### PR TITLE
feat: Add custom fields long text and url support

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5810,11 +5810,31 @@ export const $CaseFieldCreate = {
       ],
       title: "Options",
     },
+    kind: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/CaseFieldKind",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
   },
   type: "object",
   required: ["name", "type"],
   title: "CaseFieldCreate",
   description: "Create a new case field.",
+} as const
+
+export const $CaseFieldKind = {
+  type: "string",
+  enum: ["LONG_TEXT", "URL"],
+  title: "CaseFieldKind",
+  description: `Semantic kind for case custom fields.
+
+Controls how the field is rendered in the UI without changing the underlying
+SQL storage type.`,
 } as const
 
 export const $CaseFieldRead = {
@@ -5862,6 +5882,16 @@ export const $CaseFieldRead = {
         },
       ],
       title: "Options",
+    },
+    kind: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/CaseFieldKind",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     value: {
       title: "Value",
@@ -5926,6 +5956,16 @@ export const $CaseFieldReadMinimal = {
         },
       ],
       title: "Options",
+    },
+    kind: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/CaseFieldKind",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
   },
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1574,7 +1574,16 @@ export type CaseFieldCreate = {
   nullable?: boolean
   default?: unknown | null
   options?: Array<string> | null
+  kind?: CaseFieldKind | null
 }
+
+/**
+ * Semantic kind for case custom fields.
+ *
+ * Controls how the field is rendered in the UI without changing the underlying
+ * SQL storage type.
+ */
+export type CaseFieldKind = "LONG_TEXT" | "URL"
 
 /**
  * Read model for a case field.
@@ -1587,6 +1596,7 @@ export type CaseFieldRead = {
   default: string | null
   reserved: boolean
   options?: Array<string> | null
+  kind?: CaseFieldKind | null
   value: unknown
 }
 
@@ -1601,6 +1611,7 @@ export type CaseFieldReadMinimal = {
   default: string | null
   reserved: boolean
   options?: Array<string> | null
+  kind?: CaseFieldKind | null
 }
 
 /**

--- a/frontend/src/components/cases/add-custom-field-dialog.tsx
+++ b/frontend/src/components/cases/add-custom-field-dialog.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
 import { type ControllerRenderProps, useForm } from "react-hook-form"
 import { z } from "zod"
-import { ApiError, casesCreateField } from "@/client"
+import { ApiError, type CaseFieldKind, casesCreateField } from "@/client"
 import { SqlTypeDisplay } from "@/components/data-type/sql-type-display"
 import { MultiTagCommandInput } from "@/components/tags-input"
 import { Button } from "@/components/ui/button"
@@ -36,9 +36,34 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { toast } from "@/components/ui/use-toast"
+import { CASE_FIELD_KIND_CONFIG } from "@/lib/data-type"
 import type { TracecatApiError } from "@/lib/errors"
 import { type SqlTypeCreatable, SqlTypeCreatableEnum } from "@/lib/tables"
 import { useWorkspaceId } from "@/providers/workspace-id"
+
+/** Options for the case field type picker (SQL types + kind-based semantic types). */
+interface CaseFieldTypeOption {
+  value: string
+  type: SqlTypeCreatable
+  kind: CaseFieldKind | null
+}
+
+const CASE_FIELD_TYPE_OPTIONS: CaseFieldTypeOption[] = [
+  { value: "TEXT", type: "TEXT", kind: null },
+  { value: "LONG_TEXT", type: "TEXT", kind: "LONG_TEXT" },
+  { value: "INTEGER", type: "INTEGER", kind: null },
+  { value: "NUMERIC", type: "NUMERIC", kind: null },
+  { value: "BOOLEAN", type: "BOOLEAN", kind: null },
+  { value: "DATE", type: "DATE", kind: null },
+  { value: "TIMESTAMPTZ", type: "TIMESTAMPTZ", kind: null },
+  { value: "URL", type: "JSONB", kind: "URL" },
+  { value: "SELECT", type: "SELECT", kind: null },
+  { value: "MULTI_SELECT", type: "MULTI_SELECT", kind: null },
+]
+
+function findTypeOption(value: string): CaseFieldTypeOption | undefined {
+  return CASE_FIELD_TYPE_OPTIONS.find((opt) => opt.value === value)
+}
 
 const isSelectableColumnType = (type?: string) =>
   type === "SELECT" || type === "MULTI_SELECT"
@@ -69,6 +94,7 @@ const caseFieldFormSchema = z
         "Field name must start with a letter and contain only letters, numbers, and underscores"
       ),
     type: z.enum(SqlTypeCreatableEnum),
+    kind: z.enum(["LONG_TEXT", "URL"]).nullable().optional(),
     nullable: z.boolean().default(true),
     default: z.string().nullable().optional(),
     defaultMulti: z.array(z.string()).optional(), // For MULTI_SELECT defaults
@@ -133,6 +159,7 @@ export function AddCustomFieldDialog({
     defaultValues: {
       name: "",
       type: "TEXT",
+      kind: null,
       nullable: true,
       default: null,
       defaultMulti: [],
@@ -140,7 +167,9 @@ export function AddCustomFieldDialog({
     },
   })
   const selectedType = form.watch("type")
+  const selectedKind = form.watch("kind")
   const requiresOptions = isSelectableColumnType(selectedType)
+  const pickerValue = selectedKind ?? selectedType
 
   useEffect(() => {
     form.setValue("default", "")
@@ -152,7 +181,7 @@ export function AddCustomFieldDialog({
       form.setValue("options", [])
       form.clearErrors("options")
     }
-  }, [form, selectedType])
+  }, [form, selectedType, selectedKind])
 
   const onSubmit = async (data: CaseFieldFormValues) => {
     setIsSubmitting(true)
@@ -263,6 +292,7 @@ export function AddCustomFieldDialog({
           options: isSelectableColumnType(data.type)
             ? sanitizeColumnOptions(data.options)
             : null,
+          kind: data.kind ?? null,
         },
       })
 
@@ -328,38 +358,49 @@ export function AddCustomFieldDialog({
               )}
             />
 
-            <FormField
-              control={form.control}
-              name="type"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Data type</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select a data type" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {SqlTypeCreatableEnum.filter(
-                        (type) => type !== "JSONB"
-                      ).map((type) => (
-                        <SelectItem key={type} value={type}>
-                          <SqlTypeDisplay
-                            type={type}
-                            labelClassName="text-xs"
-                          />
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormDescription>
-                    The SQL data type for this field.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <FormItem>
+              <FormLabel>Data type</FormLabel>
+              <Select
+                value={pickerValue}
+                onValueChange={(value) => {
+                  const opt = findTypeOption(value)
+                  if (opt) {
+                    form.setValue("type", opt.type)
+                    form.setValue("kind", opt.kind ?? null)
+                  }
+                }}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a data type" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {CASE_FIELD_TYPE_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.kind ? (
+                        <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                          {(() => {
+                            const Icon = CASE_FIELD_KIND_CONFIG[opt.kind].icon
+                            return <Icon className="size-4 shrink-0" />
+                          })()}
+                          <span className="text-xs font-normal leading-none whitespace-nowrap">
+                            {CASE_FIELD_KIND_CONFIG[opt.kind].label}
+                          </span>
+                        </span>
+                      ) : (
+                        <SqlTypeDisplay
+                          type={opt.type}
+                          labelClassName="text-xs"
+                        />
+                      )}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormDescription>The data type for this field.</FormDescription>
+              <FormMessage />
+            </FormItem>
 
             {requiresOptions && (
               <FormField
@@ -388,54 +429,59 @@ export function AddCustomFieldDialog({
               />
             )}
 
-            {selectedType === "MULTI_SELECT" ? (
-              <FormField
-                control={form.control}
-                name="defaultMulti"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Default values (optional)</FormLabel>
-                    <FormControl>
-                      <MultiTagCommandInput
-                        value={field.value || []}
-                        onChange={field.onChange}
-                        placeholder="Select default values..."
-                        suggestions={sanitizeColumnOptions(
-                          form.watch("options")
-                        ).map((opt) => ({ id: opt, label: opt, value: opt }))}
-                        searchKeys={["label"]}
-                        className="w-full"
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      Select default values from the options above.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            ) : (
-              <FormField
-                control={form.control}
-                name="default"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Default value (optional)</FormLabel>
-                    <FormControl>
-                      <DefaultValueInput
-                        type={selectedType}
-                        field={field}
-                        options={form.watch("options")}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {getDefaultHelperText(selectedType)}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            )}
+            {!selectedKind &&
+              (selectedType === "MULTI_SELECT" ? (
+                <FormField
+                  control={form.control}
+                  name="defaultMulti"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Default values (optional)</FormLabel>
+                      <FormControl>
+                        <MultiTagCommandInput
+                          value={field.value || []}
+                          onChange={field.onChange}
+                          placeholder="Select default values..."
+                          suggestions={sanitizeColumnOptions(
+                            form.watch("options")
+                          ).map((opt) => ({
+                            id: opt,
+                            label: opt,
+                            value: opt,
+                          }))}
+                          searchKeys={["label"]}
+                          className="w-full"
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Select default values from the options above.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              ) : (
+                <FormField
+                  control={form.control}
+                  name="default"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Default value (optional)</FormLabel>
+                      <FormControl>
+                        <DefaultValueInput
+                          type={selectedType}
+                          field={field}
+                          options={form.watch("options")}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        {getDefaultHelperText(selectedType)}
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              ))}
 
             <DialogFooter>
               <Button type="submit" disabled={isSubmitting}>

--- a/frontend/src/components/cases/case-description-editor.tsx
+++ b/frontend/src/components/cases/case-description-editor.tsx
@@ -13,6 +13,7 @@ interface CaseDescriptionEditorProps {
   className?: string
   onBlur?: () => void
   toolbarStatus?: React.ReactNode
+  autoFocus?: boolean
 }
 
 export function CaseDescriptionEditor({
@@ -21,6 +22,7 @@ export function CaseDescriptionEditor({
   className,
   onBlur,
   toolbarStatus,
+  autoFocus = false,
 }: CaseDescriptionEditorProps) {
   const [value, setValue] = React.useState(initialContent ?? "")
   const [isEditorActive, setIsEditorActive] = React.useState(false)
@@ -73,6 +75,7 @@ export function CaseDescriptionEditor({
         toolbarStatus={toolbarStatus}
         placeholder="Describe the case..."
         className="case-description-editor"
+        autoFocus={autoFocus}
       />
     </div>
   )

--- a/frontend/src/components/cases/case-field-kind-dialogs.tsx
+++ b/frontend/src/components/cases/case-field-kind-dialogs.tsx
@@ -100,7 +100,7 @@ export function UrlFieldDialog({
       setUrl(initialValue.url)
       setLabel(initialValue.label)
     }
-  }, [open, initialValue])
+  }, [open, initialValue.url, initialValue.label])
 
   const handleSave = useCallback(() => {
     onSave({ url: url.trim(), label: label.trim() })

--- a/frontend/src/components/cases/case-field-kind-dialogs.tsx
+++ b/frontend/src/components/cases/case-field-kind-dialogs.tsx
@@ -1,0 +1,247 @@
+"use client"
+
+import { ExternalLink } from "lucide-react"
+import { useCallback, useEffect, useState } from "react"
+import { CaseDescriptionEditor } from "@/components/cases/case-description-editor"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+// -- Long text dialog --
+
+interface LongTextFieldDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  fieldLabel: string
+  initialValue: string
+  onSave: (value: string) => void
+}
+
+/**
+ * Dialog for editing a LONG_TEXT case field using the rich-text editor.
+ */
+export function LongTextFieldDialog({
+  open,
+  onOpenChange,
+  fieldLabel,
+  initialValue,
+  onSave,
+}: LongTextFieldDialogProps) {
+  const [draft, setDraft] = useState(initialValue)
+
+  useEffect(() => {
+    if (open) {
+      setDraft(initialValue)
+    }
+  }, [open, initialValue])
+
+  const handleSave = useCallback(() => {
+    onSave(draft)
+    onOpenChange(false)
+  }, [draft, onSave, onOpenChange])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{fieldLabel}</DialogTitle>
+        </DialogHeader>
+        <div className="min-h-[200px]">
+          <CaseDescriptionEditor initialContent={draft} onChange={setDraft} />
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave}>Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// -- URL dialog --
+
+interface UrlFieldValue {
+  url: string
+  label: string
+}
+
+interface UrlFieldDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  fieldLabel: string
+  initialValue: UrlFieldValue
+  onSave: (value: UrlFieldValue) => void
+}
+
+/**
+ * Dialog for editing a URL case field (url + label inputs).
+ */
+export function UrlFieldDialog({
+  open,
+  onOpenChange,
+  fieldLabel,
+  initialValue,
+  onSave,
+}: UrlFieldDialogProps) {
+  const [url, setUrl] = useState(initialValue.url)
+  const [label, setLabel] = useState(initialValue.label)
+
+  useEffect(() => {
+    if (open) {
+      setUrl(initialValue.url)
+      setLabel(initialValue.label)
+    }
+  }, [open, initialValue])
+
+  const handleSave = useCallback(() => {
+    onSave({ url: url.trim(), label: label.trim() })
+    onOpenChange(false)
+  }, [url, label, onSave, onOpenChange])
+
+  const trimmedUrl = url.trim()
+  const trimmedLabel = label.trim()
+  const urlHint = getUrlHint(trimmedUrl)
+  const isEmpty = trimmedUrl.length === 0 && trimmedLabel.length === 0
+  const isValid = !urlHint && trimmedUrl.length > 0 && trimmedLabel.length > 0
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>{fieldLabel}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="url-field-label">Label</Label>
+            <Input
+              id="url-field-label"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="Display text"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="url-field-url">URL</Label>
+            <Input
+              id="url-field-url"
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://example.com"
+            />
+            {!isEmpty && urlHint && (
+              <p className="text-xs text-muted-foreground">{urlHint}</p>
+            )}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!isValid}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// -- Inline renderers for the case panel --
+
+interface LongTextFieldCellProps {
+  onClick: () => void
+  hasValue: boolean
+}
+
+/**
+ * Inline cell for a LONG_TEXT field: shows an "Expand" button.
+ */
+export function LongTextFieldCell({
+  onClick,
+  hasValue,
+}: LongTextFieldCellProps) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="h-7 w-full justify-end px-2 text-sm font-normal text-muted-foreground"
+      onClick={onClick}
+    >
+      {hasValue ? "Expand" : "Add..."}
+    </Button>
+  )
+}
+
+interface UrlFieldCellProps {
+  value: UrlFieldValue | null
+  onEdit: () => void
+}
+
+/**
+ * Inline cell for a URL field: shows label text and an external-link icon.
+ */
+export function UrlFieldCell({ value, onEdit }: UrlFieldCellProps) {
+  if (!value || !value.url) {
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 w-full justify-end px-2 text-sm font-normal text-muted-foreground"
+        onClick={onEdit}
+      >
+        Add...
+      </Button>
+    )
+  }
+
+  return (
+    <div className="flex h-7 w-full items-center justify-end gap-1">
+      <button
+        type="button"
+        className="min-w-0 truncate text-right text-sm hover:underline"
+        onClick={onEdit}
+        title={value.label}
+      >
+        {value.label}
+      </button>
+      <a
+        href={value.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="shrink-0 text-muted-foreground hover:text-foreground"
+        title={value.url}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <ExternalLink className="size-3.5" />
+      </a>
+    </div>
+  )
+}
+
+/**
+ * Return a user-friendly hint if the URL is not a valid absolute http(s) URL,
+ * or undefined if the URL is valid. Returns undefined for empty strings so
+ * the hint only shows once the user has started typing.
+ */
+function getUrlHint(url: string): string | undefined {
+  if (url.length === 0) return undefined
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return "URL must start with http:// or https://"
+    }
+    return undefined
+  } catch {
+    return "Enter a valid URL, e.g. https://example.com"
+  }
+}

--- a/frontend/src/components/cases/case-field-kind-dialogs.tsx
+++ b/frontend/src/components/cases/case-field-kind-dialogs.tsx
@@ -304,39 +304,15 @@ export function JsonFieldDialog({
 
 // -- Inline renderers for the case panel --
 
-interface LongTextFieldCellProps {
+interface ExpandFieldCellProps {
   onClick: () => void
   hasValue: boolean
 }
 
 /**
- * Inline cell for a LONG_TEXT field: shows an "Expand" button.
+ * Inline cell for expandable fields (LONG_TEXT, JSONB): shows "Expand" or "Add..." button.
  */
-export function LongTextFieldCell({
-  onClick,
-  hasValue,
-}: LongTextFieldCellProps) {
-  return (
-    <Button
-      variant="ghost"
-      size="sm"
-      className="h-7 w-full justify-end px-2 text-sm font-normal text-muted-foreground"
-      onClick={onClick}
-    >
-      {hasValue ? "Expand" : "Add..."}
-    </Button>
-  )
-}
-
-interface JsonFieldCellProps {
-  onClick: () => void
-  hasValue: boolean
-}
-
-/**
- * Inline cell for a JSONB field: shows "Expand" or "Add..." button.
- */
-export function JsonFieldCell({ onClick, hasValue }: JsonFieldCellProps) {
+export function ExpandFieldCell({ onClick, hasValue }: ExpandFieldCellProps) {
   return (
     <Button
       variant="ghost"

--- a/frontend/src/components/cases/case-field-kind-dialogs.tsx
+++ b/frontend/src/components/cases/case-field-kind-dialogs.tsx
@@ -1,7 +1,14 @@
 "use client"
 
+import { closeBrackets } from "@codemirror/autocomplete"
+import { history } from "@codemirror/commands"
+import { json } from "@codemirror/lang-json"
+import { bracketMatching } from "@codemirror/language"
+import { type Diagnostic, linter, lintGutter } from "@codemirror/lint"
+import { EditorView } from "@codemirror/view"
+import CodeMirror from "@uiw/react-codemirror"
 import { ExternalLink } from "lucide-react"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { CaseDescriptionEditor } from "@/components/cases/case-description-editor"
 import { Button } from "@/components/ui/button"
 import {
@@ -54,13 +61,19 @@ export function LongTextFieldDialog({
           <DialogTitle>{fieldLabel}</DialogTitle>
         </DialogHeader>
         <div className="min-h-[200px]">
-          <CaseDescriptionEditor initialContent={draft} onChange={setDraft} />
+          <CaseDescriptionEditor
+            initialContent={draft}
+            onChange={setDraft}
+            autoFocus
+          />
         </div>
         <DialogFooter>
           <Button variant="ghost" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={handleSave}>Save</Button>
+          <Button variant="outline" onClick={handleSave}>
+            Save
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
@@ -147,7 +160,141 @@ export function UrlFieldDialog({
           <Button variant="ghost" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={!isValid}>
+          <Button variant="outline" onClick={handleSave} disabled={!isValid}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// -- JSON dialog --
+
+function jsonLinter(view: EditorView): Diagnostic[] {
+  const content = view.state.doc.toString()
+  if (!content.trim()) return []
+  try {
+    JSON.parse(content)
+    return []
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Invalid JSON"
+    const posMatch = msg.match(/position (\d+)/)
+    const pos = posMatch ? Number.parseInt(posMatch[1], 10) : 0
+    const from = Math.min(pos, content.length)
+    const to = Math.min(from + 1, content.length)
+    return [{ from, to, severity: "error", message: msg, source: "json" }]
+  }
+}
+
+interface JsonFieldDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  fieldLabel: string
+  initialValue: unknown
+  onSave: (value: unknown) => void
+}
+
+/**
+ * Dialog for editing a JSONB case field using a CodeMirror JSON editor
+ * with syntax highlighting, linting, and validation.
+ */
+export function JsonFieldDialog({
+  open,
+  onOpenChange,
+  fieldLabel,
+  initialValue,
+  onSave,
+}: JsonFieldDialogProps) {
+  const serialized =
+    initialValue === null || initialValue === undefined
+      ? ""
+      : typeof initialValue === "string"
+        ? initialValue
+        : JSON.stringify(initialValue, null, 2)
+
+  const [draft, setDraft] = useState(serialized)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (open) {
+      setDraft(serialized)
+      setError(null)
+    }
+  }, [open, serialized])
+
+  const validate = useCallback((val: string): boolean => {
+    if (val.trim() === "") return true
+    try {
+      JSON.parse(val)
+      return true
+    } catch {
+      return false
+    }
+  }, [])
+
+  const handleSave = useCallback(() => {
+    if (!validate(draft)) {
+      setError("Invalid JSON")
+      return
+    }
+    const trimmed = draft.trim()
+    onSave(trimmed === "" ? null : JSON.parse(trimmed))
+    onOpenChange(false)
+  }, [draft, validate, onSave, onOpenChange])
+
+  const extensions = useMemo(
+    () => [
+      json(),
+      lintGutter(),
+      linter(jsonLinter),
+      history(),
+      bracketMatching(),
+      closeBrackets(),
+      EditorView.theme({
+        ".cm-content": { fontFamily: "monospace", fontSize: "13px" },
+        ".cm-scroller": { maxHeight: "400px", overflow: "auto" },
+      }),
+    ],
+    []
+  )
+
+  const isValid = validate(draft)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{fieldLabel}</DialogTitle>
+        </DialogHeader>
+        <CodeMirror
+          value={draft}
+          onChange={(val) => {
+            setDraft(val)
+            if (error) setError(validate(val) ? null : "Invalid JSON")
+          }}
+          height="300px"
+          extensions={extensions}
+          autoFocus
+          basicSetup={{
+            lineNumbers: true,
+            foldGutter: true,
+            highlightActiveLine: true,
+            bracketMatching: false,
+            closeBrackets: false,
+            history: false,
+            defaultKeymap: true,
+            syntaxHighlighting: true,
+            autocompletion: false,
+          }}
+          className="overflow-auto rounded-md border font-mono text-sm"
+        />
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button variant="outline" onClick={handleSave} disabled={!isValid}>
             Save
           </Button>
         </DialogFooter>
@@ -170,6 +317,27 @@ export function LongTextFieldCell({
   onClick,
   hasValue,
 }: LongTextFieldCellProps) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="h-7 w-full justify-end px-2 text-sm font-normal text-muted-foreground"
+      onClick={onClick}
+    >
+      {hasValue ? "Expand" : "Add..."}
+    </Button>
+  )
+}
+
+interface JsonFieldCellProps {
+  onClick: () => void
+  hasValue: boolean
+}
+
+/**
+ * Inline cell for a JSONB field: shows "Expand" or "Add..." button.
+ */
+export function JsonFieldCell({ onClick, hasValue }: JsonFieldCellProps) {
   return (
     <Button
       variant="ghost"

--- a/frontend/src/components/cases/case-field-kind-dialogs.tsx
+++ b/frontend/src/components/cases/case-field-kind-dialogs.tsx
@@ -124,7 +124,8 @@ export function UrlFieldDialog({
   const trimmedLabel = label.trim()
   const urlHint = getUrlHint(trimmedUrl)
   const isEmpty = trimmedUrl.length === 0 && trimmedLabel.length === 0
-  const isValid = !urlHint && trimmedUrl.length > 0 && trimmedLabel.length > 0
+  const isValid =
+    isEmpty || (!urlHint && trimmedUrl.length > 0 && trimmedLabel.length > 0)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -209,9 +210,7 @@ export function JsonFieldDialog({
   const serialized =
     initialValue === null || initialValue === undefined
       ? ""
-      : typeof initialValue === "string"
-        ? initialValue
-        : JSON.stringify(initialValue, null, 2)
+      : JSON.stringify(initialValue, null, 2)
 
   const [draft, setDraft] = useState(serialized)
   const [error, setError] = useState<string | null>(null)

--- a/frontend/src/components/cases/case-field-kind-dialogs.tsx
+++ b/frontend/src/components/cases/case-field-kind-dialogs.tsx
@@ -214,18 +214,34 @@ export function UrlFieldCell({ value, onEdit }: UrlFieldCellProps) {
       >
         {value.label}
       </button>
-      <a
-        href={value.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="shrink-0 text-muted-foreground hover:text-foreground"
-        title={value.url}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <ExternalLink className="size-3.5" />
-      </a>
+      {isSafeUrl(value.url) && (
+        <a
+          href={value.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+          title={value.url}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <ExternalLink className="size-3.5" />
+        </a>
+      )}
     </div>
   )
+}
+
+/**
+ * Return true when the URL is a valid absolute http or https URL.
+ * Used to gate the rendered anchor so non-http(s) schemes (e.g. javascript:)
+ * are never placed in an href attribute.
+ */
+function isSafeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/frontend/src/components/cases/case-panel-custom-fields.tsx
+++ b/frontend/src/components/cases/case-panel-custom-fields.tsx
@@ -311,7 +311,7 @@ function MultiSelectBadges({ values }: { values: string[] }) {
 
   return (
     <div ref={containerRef} className="flex items-center gap-1 overflow-hidden">
-      {values.map((value) => (
+      {values.slice(0, visibleCount).map((value) => (
         <Badge
           key={value}
           variant="secondary"

--- a/frontend/src/components/cases/case-panel-custom-fields.tsx
+++ b/frontend/src/components/cases/case-panel-custom-fields.tsx
@@ -1,9 +1,21 @@
 import { format, isValid as isValidDate } from "date-fns"
-import { Check, Clock3, X } from "lucide-react"
-import type { CSSProperties } from "react"
+import { Check } from "lucide-react"
+import {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import { FormProvider, useForm, useFormContext } from "react-hook-form"
 import { z } from "zod"
 import type { CaseFieldRead, CaseUpdate } from "@/client"
+import {
+  LongTextFieldCell,
+  LongTextFieldDialog,
+  UrlFieldCell,
+  UrlFieldDialog,
+} from "@/components/cases/case-field-kind-dialogs"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -21,6 +33,11 @@ import {
   FormItem,
   FormMessage,
 } from "@/components/ui/form"
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card"
 import { Input } from "@/components/ui/input"
 import {
   Popover,
@@ -34,6 +51,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { toast } from "@/components/ui/use-toast"
 import { cn, linearStyles } from "@/lib/utils"
 
 const customFieldFormSchema = z.object({
@@ -43,8 +61,8 @@ const customFieldFormSchema = z.object({
 
 type CustomFieldFormSchema = z.infer<typeof customFieldFormSchema>
 
-const DATE_TIME_DISPLAY_FORMAT = "MMM d yyyy '·' p"
-const DATE_DISPLAY_FORMAT = "MMM d yyyy"
+const DATE_TIME_DISPLAY_FORMAT = "yyyy-MM-dd HH:mm"
+const DATE_DISPLAY_FORMAT = "yyyy-MM-dd"
 
 const formatDateFieldValue = (
   date: Date,
@@ -68,6 +86,44 @@ const toDateValue = (value: unknown): Date | null => {
 }
 
 export function CustomField({
+  customField,
+  updateCase,
+  inputClassName,
+  inputStyle,
+  onValueChange,
+  formClassName,
+}: {
+  customField: CaseFieldRead
+  updateCase: (caseUpdate: Partial<CaseUpdate>) => Promise<void>
+  inputClassName?: string
+  inputStyle?: CSSProperties
+  onValueChange?: (id: string, value: unknown) => void
+  formClassName?: string
+}) {
+  // Kind-specific fields use dialog-based editing, not inline blur-to-save
+  if (customField.kind === "LONG_TEXT") {
+    return (
+      <LongTextCustomField customField={customField} updateCase={updateCase} />
+    )
+  }
+  if (customField.kind === "URL") {
+    return <UrlCustomField customField={customField} updateCase={updateCase} />
+  }
+
+  return (
+    <InlineCustomField
+      customField={customField}
+      updateCase={updateCase}
+      inputClassName={inputClassName}
+      inputStyle={inputStyle}
+      onValueChange={onValueChange}
+      formClassName={formClassName}
+    />
+  )
+}
+
+/** Standard inline-edit custom field (blur-to-save via form). */
+function InlineCustomField({
   customField,
   updateCase,
   inputClassName,
@@ -118,6 +174,100 @@ export function CustomField({
     </FormProvider>
   )
 }
+
+function LongTextCustomField({
+  customField,
+  updateCase,
+}: {
+  customField: CaseFieldRead
+  updateCase: (caseUpdate: Partial<CaseUpdate>) => Promise<void>
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const currentValue =
+    typeof customField.value === "string" ? customField.value : ""
+
+  const handleSave = useCallback(
+    async (value: string) => {
+      try {
+        await updateCase({
+          fields: { [customField.id]: value || null },
+        })
+      } catch (error) {
+        console.error(error)
+      }
+    },
+    [customField.id, updateCase]
+  )
+
+  return (
+    <>
+      <LongTextFieldCell
+        onClick={() => setDialogOpen(true)}
+        hasValue={currentValue.length > 0}
+      />
+      <LongTextFieldDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        fieldLabel={customField.id}
+        initialValue={currentValue}
+        onSave={handleSave}
+      />
+    </>
+  )
+}
+
+function UrlCustomField({
+  customField,
+  updateCase,
+}: {
+  customField: CaseFieldRead
+  updateCase: (caseUpdate: Partial<CaseUpdate>) => Promise<void>
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const parsed =
+    customField.value &&
+    typeof customField.value === "object" &&
+    !Array.isArray(customField.value)
+      ? (customField.value as { url?: string; label?: string })
+      : null
+  const urlValue = {
+    url: parsed?.url ?? "",
+    label: parsed?.label ?? "",
+  }
+
+  const handleSave = useCallback(
+    async (value: { url: string; label: string }) => {
+      try {
+        await updateCase({
+          fields: {
+            [customField.id]: value.url && value.label ? value : null,
+          },
+        })
+      } catch (error) {
+        console.error(error)
+      }
+    },
+    [customField.id, updateCase]
+  )
+
+  return (
+    <>
+      <UrlFieldCell
+        value={urlValue.url ? urlValue : null}
+        onEdit={() => setDialogOpen(true)}
+      />
+      <UrlFieldDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        fieldLabel={customField.id}
+        initialValue={urlValue}
+        onSave={handleSave}
+      />
+    </>
+  )
+}
+
 interface CustomFieldProps {
   customField: CaseFieldRead
   onBlur?: (id: string, value: unknown) => void
@@ -126,9 +276,64 @@ interface CustomFieldProps {
 }
 
 /**
- * We wnat to dispatch a form field
- * @param param0
- * @returns
+ * Renders badges in a single-line container with overflow detection.
+ * When badges overflow, shows only those that fit plus a "+N" indicator.
+ */
+function MultiSelectBadges({ values }: { values: string[] }) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [visibleCount, setVisibleCount] = useState(values.length)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const measure = () => {
+      const children = Array.from(container.children) as HTMLElement[]
+      // Exclude the +N indicator from measurement (it has data-overflow attribute)
+      const badges = children.filter((c) => !c.dataset.overflow)
+      let count = 0
+      for (const child of badges) {
+        if (child.offsetLeft + child.offsetWidth > container.clientWidth) {
+          break
+        }
+        count++
+      }
+      setVisibleCount(count > 0 ? count : 1)
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [values])
+
+  const hiddenCount = values.length - visibleCount
+
+  return (
+    <div ref={containerRef} className="flex items-center gap-1 overflow-hidden">
+      {values.map((value) => (
+        <Badge
+          key={value}
+          variant="secondary"
+          className="shrink-0 px-1.5 py-0 text-[11px]"
+        >
+          {value}
+        </Badge>
+      ))}
+      {hiddenCount > 0 && (
+        <span
+          data-overflow=""
+          className="shrink-0 text-[11px] text-muted-foreground"
+        >
+          +{hiddenCount}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Core renderer that dispatches on field type.
  */
 export function CustomFieldInner({
   customField,
@@ -194,45 +399,44 @@ export function CustomFieldInner({
                     field.onBlur()
                     const raw = String(field.value ?? "").trim()
                     if (!raw) {
-                      form.clearErrors("value")
                       onBlur?.(customField.id, null)
                       return
                     }
 
                     if (customField.type === "INTEGER") {
                       if (!/^-?\d+$/.test(raw)) {
-                        form.setError("value", {
-                          type: "validate",
-                          message: "Must be a valid integer",
+                        toast({
+                          title: "Validation error",
+                          description: "Must be a valid integer",
+                          variant: "destructive",
                         })
                         return
                       }
-                      form.clearErrors("value")
                       onBlur?.(customField.id, Number.parseInt(raw, 10))
                       return
                     }
 
                     if (!/^-?(?:\d+|\d*\.\d+)$/.test(raw)) {
-                      form.setError("value", {
-                        type: "validate",
-                        message: "Must be a valid number",
+                      toast({
+                        title: "Validation error",
+                        description: "Must be a valid number",
+                        variant: "destructive",
                       })
                       return
                     }
                     const parsed = Number(raw)
                     if (!Number.isFinite(parsed)) {
-                      form.setError("value", {
-                        type: "validate",
-                        message: "Must be a valid number",
+                      toast({
+                        title: "Validation error",
+                        description: "Must be a valid number",
+                        variant: "destructive",
                       })
                       return
                     }
-                    form.clearErrors("value")
                     onBlur?.(customField.id, parsed)
                   }}
                 />
               </FormControl>
-              <FormMessage />
             </FormItem>
           )}
         />
@@ -307,10 +511,25 @@ export function CustomFieldInner({
                   value={String(field.value || "")}
                   className={baseInputClassName}
                   style={inputStyle}
-                  onBlur={() => onBlur && onBlur(customField.id, field.value)}
+                  onBlur={() => {
+                    const raw = String(field.value ?? "").trim()
+                    if (!raw) {
+                      onBlur?.(customField.id, null)
+                      return
+                    }
+                    try {
+                      const parsed = JSON.parse(raw)
+                      onBlur?.(customField.id, parsed)
+                    } catch {
+                      toast({
+                        title: "Validation error",
+                        description: "Must be valid JSON",
+                        variant: "destructive",
+                      })
+                    }
+                  }}
                 />
               </FormControl>
-              <FormMessage />
             </FormItem>
           )}
         />
@@ -342,6 +561,7 @@ export function CustomFieldInner({
                     formatDisplay={(date) =>
                       format(date, DATE_TIME_DISPLAY_FORMAT)
                     }
+                    icon={<></>}
                     buttonProps={{
                       variant: "ghost",
                       className: cn(
@@ -387,7 +607,7 @@ export function CustomFieldInner({
                     hideTime
                     placeholder="Select date"
                     formatDisplay={(date) => format(date, DATE_DISPLAY_FORMAT)}
-                    icon={<Clock3 className="mr-2 size-4" />}
+                    icon={<></>}
                     buttonProps={{
                       variant: "ghost",
                       className: cn(
@@ -521,37 +741,54 @@ export function CustomFieldInner({
               onBlur?.(customField.id, newValues)
             }
 
-            const removeOption = (option: string) => {
-              const newValues = currentValues.filter((v) => v !== option)
-              field.onChange(newValues)
-              onBlur?.(customField.id, newValues)
-            }
-
-            const displayValue =
-              currentValues.length === 0
-                ? "Select..."
-                : currentValues.join(", ")
-
             return (
               <FormItem>
                 <Popover>
-                  <PopoverTrigger asChild>
-                    <FormControl>
-                      <Button
-                        variant="ghost"
-                        role="combobox"
-                        className={cn(
-                          linearStyles.input.full,
-                          "inline-flex h-7 w-full min-w-0 justify-end gap-1 whitespace-nowrap rounded-sm border-none px-2 text-right text-sm font-normal shadow-none",
-                          currentValues.length === 0 && "text-muted-foreground",
-                          inputClassName
-                        )}
-                        style={inputStyle}
+                  <HoverCard openDelay={300}>
+                    <HoverCardTrigger asChild>
+                      <PopoverTrigger asChild>
+                        <FormControl>
+                          <Button
+                            variant="ghost"
+                            role="combobox"
+                            className={cn(
+                              linearStyles.input.full,
+                              "inline-flex h-7 w-full min-w-0 justify-end gap-1 overflow-hidden whitespace-nowrap rounded-sm border-none px-2 text-right text-sm font-normal shadow-none",
+                              currentValues.length === 0 &&
+                                "text-muted-foreground",
+                              inputClassName
+                            )}
+                            style={inputStyle}
+                          >
+                            {currentValues.length === 0 ? (
+                              <span className="truncate">Select...</span>
+                            ) : (
+                              <MultiSelectBadges values={currentValues} />
+                            )}
+                          </Button>
+                        </FormControl>
+                      </PopoverTrigger>
+                    </HoverCardTrigger>
+                    {currentValues.length > 0 && (
+                      <HoverCardContent
+                        className="w-auto max-w-xs p-2"
+                        side="top"
+                        align="end"
                       >
-                        <span className="truncate">{displayValue}</span>
-                      </Button>
-                    </FormControl>
-                  </PopoverTrigger>
+                        <div className="flex flex-wrap gap-1">
+                          {currentValues.map((value) => (
+                            <Badge
+                              key={value}
+                              variant="secondary"
+                              className="text-[11px]"
+                            >
+                              {value}
+                            </Badge>
+                          ))}
+                        </div>
+                      </HoverCardContent>
+                    )}
+                  </HoverCard>
                   <PopoverContent className="w-56 p-0" align="end">
                     <Command>
                       <CommandInput
@@ -586,27 +823,6 @@ export function CustomFieldInner({
                     </Command>
                   </PopoverContent>
                 </Popover>
-                {currentValues.length > 0 && (
-                  <div className="mt-1 flex flex-wrap justify-end gap-1">
-                    {currentValues.map((value) => (
-                      <Badge
-                        key={value}
-                        variant="secondary"
-                        className="gap-1 text-[11px]"
-                      >
-                        {value}
-                        <button
-                          type="button"
-                          className="ml-0.5 rounded-full outline-none hover:bg-muted-foreground/20"
-                          onClick={() => removeOption(value)}
-                        >
-                          <X className="h-2.5 w-2.5" />
-                          <span className="sr-only">Remove {value}</span>
-                        </button>
-                      </Badge>
-                    ))}
-                  </div>
-                )}
                 <FormMessage />
               </FormItem>
             )

--- a/frontend/src/components/cases/case-panel-custom-fields.tsx
+++ b/frontend/src/components/cases/case-panel-custom-fields.tsx
@@ -11,6 +11,8 @@ import { FormProvider, useForm, useFormContext } from "react-hook-form"
 import { z } from "zod"
 import type { CaseFieldRead, CaseUpdate } from "@/client"
 import {
+  JsonFieldCell,
+  JsonFieldDialog,
   LongTextFieldCell,
   LongTextFieldDialog,
   UrlFieldCell,
@@ -61,14 +63,6 @@ const customFieldFormSchema = z.object({
 
 type CustomFieldFormSchema = z.infer<typeof customFieldFormSchema>
 
-/** Serialize JSONB object values to a JSON string for text input display. */
-function serializeFormValue(type: string, value: unknown): unknown {
-  if (type === "JSONB" && typeof value === "object" && value !== null) {
-    return JSON.stringify(value)
-  }
-  return value
-}
-
 const DATE_TIME_DISPLAY_FORMAT = "yyyy-MM-dd HH:mm"
 const DATE_DISPLAY_FORMAT = "yyyy-MM-dd"
 
@@ -117,6 +111,10 @@ export function CustomField({
   if (customField.kind === "URL") {
     return <UrlCustomField customField={customField} updateCase={updateCase} />
   }
+  // Plain JSONB fields (no kind) use a JSON editor dialog
+  if (customField.type === "JSONB") {
+    return <JsonCustomField customField={customField} updateCase={updateCase} />
+  }
 
   return (
     <InlineCustomField
@@ -150,26 +148,13 @@ function InlineCustomField({
   const form = useForm<CustomFieldFormSchema>({
     defaultValues: {
       id: customField.id,
-      value: serializeFormValue(customField.type, customField.value),
+      value: customField.value,
     },
   })
 
   const onSubmit = async (data: CustomFieldFormSchema) => {
-    // JSONB values are stored as JSON strings in the form — parse back for the API
-    let submitValue = data.value
-    if (
-      customField.type === "JSONB" &&
-      typeof submitValue === "string" &&
-      submitValue.trim()
-    ) {
-      try {
-        submitValue = JSON.parse(submitValue)
-      } catch {
-        // keep as string if invalid JSON
-      }
-    }
     try {
-      await updateCase({ fields: { [customField.id]: submitValue } })
+      await updateCase({ fields: { [customField.id]: data.value } })
     } catch (error) {
       console.error(error)
     }
@@ -177,12 +162,10 @@ function InlineCustomField({
   const onBlur = useCallback(
     (id: string, value: unknown) => {
       onValueChange?.(id, value)
-      // Serialize for display (prevents [object Object] flash on JSONB fields)
-      form.setValue("value", serializeFormValue(customField.type, value))
-      // Submit the raw value directly to the API (objects stay as objects)
-      updateCase({ fields: { [id]: value } }).catch(console.error)
+      form.setValue("value", value)
+      form.handleSubmit(onSubmit)()
     },
-    [customField.type, form, onValueChange, updateCase]
+    [form, onSubmit, onValueChange]
   )
   return (
     <FormProvider {...form}>
@@ -285,6 +268,43 @@ function UrlCustomField({
         onOpenChange={setDialogOpen}
         fieldLabel={customField.id}
         initialValue={urlValue}
+        onSave={handleSave}
+      />
+    </>
+  )
+}
+
+function JsonCustomField({
+  customField,
+  updateCase,
+}: {
+  customField: CaseFieldRead
+  updateCase: (caseUpdate: Partial<CaseUpdate>) => Promise<void>
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const hasValue = customField.value !== null && customField.value !== undefined
+
+  const handleSave = useCallback(
+    async (value: unknown) => {
+      try {
+        await updateCase({
+          fields: { [customField.id]: value },
+        })
+      } catch (error) {
+        console.error(error)
+      }
+    },
+    [customField.id, updateCase]
+  )
+
+  return (
+    <>
+      <JsonFieldCell onClick={() => setDialogOpen(true)} hasValue={hasValue} />
+      <JsonFieldDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        fieldLabel={customField.id}
+        initialValue={customField.value}
         onSave={handleSave}
       />
     </>
@@ -544,43 +564,7 @@ export function CustomFieldInner({
           )}
         />
       )
-    case "JSONB":
-      return (
-        <FormField
-          control={form.control}
-          name="value"
-          render={({ field }) => (
-            <FormItem>
-              <FormControl>
-                <Input
-                  type="text"
-                  {...field}
-                  value={String(field.value || "")}
-                  className={baseInputClassName}
-                  style={inputStyle}
-                  onBlur={() => {
-                    const raw = String(field.value ?? "").trim()
-                    if (!raw) {
-                      onBlur?.(customField.id, null)
-                      return
-                    }
-                    try {
-                      const parsed = JSON.parse(raw)
-                      onBlur?.(customField.id, parsed)
-                    } catch {
-                      toast({
-                        title: "Validation error",
-                        description: "Must be valid JSON",
-                        variant: "default",
-                      })
-                    }
-                  }}
-                />
-              </FormControl>
-            </FormItem>
-          )}
-        />
-      )
+    // JSONB fields are handled by JsonCustomField before reaching this switch
     case "TIMESTAMP":
     case "TIMESTAMPTZ": {
       const fieldType =

--- a/frontend/src/components/cases/case-panel-custom-fields.tsx
+++ b/frontend/src/components/cases/case-panel-custom-fields.tsx
@@ -141,7 +141,14 @@ function InlineCustomField({
   const form = useForm<CustomFieldFormSchema>({
     defaultValues: {
       id: customField.id,
-      value: customField.value,
+      // JSONB values arrive as parsed objects from the API — serialize to a
+      // JSON string so the text input displays and round-trips correctly.
+      value:
+        customField.type === "JSONB" &&
+        typeof customField.value === "object" &&
+        customField.value !== null
+          ? JSON.stringify(customField.value)
+          : customField.value,
     },
   })
   const onSubmit = async (data: CustomFieldFormSchema) => {
@@ -432,7 +439,7 @@ export function CustomFieldInner({
                         toast({
                           title: "Validation error",
                           description: "Must be a valid integer",
-                          variant: "destructive",
+                          variant: "default",
                         })
                         return
                       }
@@ -444,7 +451,7 @@ export function CustomFieldInner({
                       toast({
                         title: "Validation error",
                         description: "Must be a valid number",
-                        variant: "destructive",
+                        variant: "default",
                       })
                       return
                     }
@@ -453,7 +460,7 @@ export function CustomFieldInner({
                       toast({
                         title: "Validation error",
                         description: "Must be a valid number",
-                        variant: "destructive",
+                        variant: "default",
                       })
                       return
                     }
@@ -548,7 +555,7 @@ export function CustomFieldInner({
                       toast({
                         title: "Validation error",
                         description: "Must be valid JSON",
-                        variant: "destructive",
+                        variant: "default",
                       })
                     }
                   }}

--- a/frontend/src/components/cases/case-panel-custom-fields.tsx
+++ b/frontend/src/components/cases/case-panel-custom-fields.tsx
@@ -11,9 +11,8 @@ import { FormProvider, useForm, useFormContext } from "react-hook-form"
 import { z } from "zod"
 import type { CaseFieldRead, CaseUpdate } from "@/client"
 import {
-  JsonFieldCell,
+  ExpandFieldCell,
   JsonFieldDialog,
-  LongTextFieldCell,
   LongTextFieldDialog,
   UrlFieldCell,
   UrlFieldDialog,
@@ -207,7 +206,7 @@ function LongTextCustomField({
 
   return (
     <>
-      <LongTextFieldCell
+      <ExpandFieldCell
         onClick={() => setDialogOpen(true)}
         hasValue={currentValue.length > 0}
       />
@@ -299,7 +298,10 @@ function JsonCustomField({
 
   return (
     <>
-      <JsonFieldCell onClick={() => setDialogOpen(true)} hasValue={hasValue} />
+      <ExpandFieldCell
+        onClick={() => setDialogOpen(true)}
+        hasValue={hasValue}
+      />
       <JsonFieldDialog
         open={dialogOpen}
         onOpenChange={setDialogOpen}
@@ -334,7 +336,13 @@ function MultiSelectBadges({ values }: { values: string[] }) {
     if (!container) return
 
     const measure = () => {
-      const badges = Array.from(container.children) as HTMLElement[]
+      const children = Array.from(container.children) as HTMLElement[]
+      // Last child is the +N indicator placeholder
+      const indicatorEl = children[children.length - 1]
+      const badges = children.slice(0, -1)
+      const indicatorWidth = indicatorEl ? indicatorEl.offsetWidth : 0
+      const gap = 4 // gap-1 = 0.25rem = 4px
+
       let count = 0
       for (const child of badges) {
         if (child.offsetLeft + child.offsetWidth > container.clientWidth) {
@@ -342,6 +350,21 @@ function MultiSelectBadges({ values }: { values: string[] }) {
         }
         count++
       }
+
+      // If there are hidden badges, reserve space for the +N indicator
+      if (count > 1 && count < badges.length) {
+        const lastVisible = badges[count - 1]
+        if (
+          lastVisible.offsetLeft +
+            lastVisible.offsetWidth +
+            gap +
+            indicatorWidth >
+          container.clientWidth
+        ) {
+          count--
+        }
+      }
+
       setVisibleCount(count > 0 ? count : 1)
     }
 
@@ -355,7 +378,7 @@ function MultiSelectBadges({ values }: { values: string[] }) {
 
   return (
     <div className="relative overflow-hidden">
-      {/* Hidden measurement layer — always contains every badge */}
+      {/* Hidden measurement layer — all badges + a +N placeholder for width calculation */}
       <div
         ref={measureRef}
         aria-hidden
@@ -377,6 +400,7 @@ function MultiSelectBadges({ values }: { values: string[] }) {
             {value}
           </Badge>
         ))}
+        <span className="shrink-0 text-[11px]">+{values.length}</span>
       </div>
       {/* Visible layer — only the badges that fit plus the +N indicator */}
       <div className="flex items-center gap-1">

--- a/frontend/src/components/cases/case-panel-custom-fields.tsx
+++ b/frontend/src/components/cases/case-panel-custom-fields.tsx
@@ -61,6 +61,14 @@ const customFieldFormSchema = z.object({
 
 type CustomFieldFormSchema = z.infer<typeof customFieldFormSchema>
 
+/** Serialize JSONB object values to a JSON string for text input display. */
+function serializeFormValue(type: string, value: unknown): unknown {
+  if (type === "JSONB" && typeof value === "object" && value !== null) {
+    return JSON.stringify(value)
+  }
+  return value
+}
+
 const DATE_TIME_DISPLAY_FORMAT = "yyyy-MM-dd HH:mm"
 const DATE_DISPLAY_FORMAT = "yyyy-MM-dd"
 
@@ -112,6 +120,7 @@ export function CustomField({
 
   return (
     <InlineCustomField
+      key={`${customField.id}-${JSON.stringify(customField.value)}`}
       customField={customField}
       updateCase={updateCase}
       inputClassName={inputClassName}
@@ -141,33 +150,40 @@ function InlineCustomField({
   const form = useForm<CustomFieldFormSchema>({
     defaultValues: {
       id: customField.id,
-      // JSONB values arrive as parsed objects from the API — serialize to a
-      // JSON string so the text input displays and round-trips correctly.
-      value:
-        customField.type === "JSONB" &&
-        typeof customField.value === "object" &&
-        customField.value !== null
-          ? JSON.stringify(customField.value)
-          : customField.value,
+      value: serializeFormValue(customField.type, customField.value),
     },
   })
+
   const onSubmit = async (data: CustomFieldFormSchema) => {
-    const caseUpdate: Partial<CaseUpdate> = {
-      fields: {
-        [customField.id]: data.value,
-      },
+    // JSONB values are stored as JSON strings in the form — parse back for the API
+    let submitValue = data.value
+    if (
+      customField.type === "JSONB" &&
+      typeof submitValue === "string" &&
+      submitValue.trim()
+    ) {
+      try {
+        submitValue = JSON.parse(submitValue)
+      } catch {
+        // keep as string if invalid JSON
+      }
     }
     try {
-      await updateCase(caseUpdate)
+      await updateCase({ fields: { [customField.id]: submitValue } })
     } catch (error) {
       console.error(error)
     }
   }
-  const onBlur = (id: string, value: unknown) => {
-    onValueChange?.(id, value)
-    form.setValue("value", value)
-    form.handleSubmit(onSubmit)()
-  }
+  const onBlur = useCallback(
+    (id: string, value: unknown) => {
+      onValueChange?.(id, value)
+      // Serialize for display (prevents [object Object] flash on JSONB fields)
+      form.setValue("value", serializeFormValue(customField.type, value))
+      // Submit the raw value directly to the API (objects stay as objects)
+      updateCase({ fields: { [id]: value } }).catch(console.error)
+    },
+    [customField.type, form, onValueChange, updateCase]
+  )
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className={formClassName}>

--- a/frontend/src/components/cases/case-panel-custom-fields.tsx
+++ b/frontend/src/components/cases/case-panel-custom-fields.tsx
@@ -278,19 +278,20 @@ interface CustomFieldProps {
 /**
  * Renders badges in a single-line container with overflow detection.
  * When badges overflow, shows only those that fit plus a "+N" indicator.
+ *
+ * A hidden measurement div always renders every badge so the
+ * ResizeObserver can re-expand the visible set when the container grows.
  */
 function MultiSelectBadges({ values }: { values: string[] }) {
-  const containerRef = useRef<HTMLDivElement>(null)
+  const measureRef = useRef<HTMLDivElement>(null)
   const [visibleCount, setVisibleCount] = useState(values.length)
 
   useEffect(() => {
-    const container = containerRef.current
+    const container = measureRef.current
     if (!container) return
 
     const measure = () => {
-      const children = Array.from(container.children) as HTMLElement[]
-      // Exclude the +N indicator from measurement (it has data-overflow attribute)
-      const badges = children.filter((c) => !c.dataset.overflow)
+      const badges = Array.from(container.children) as HTMLElement[]
       let count = 0
       for (const child of badges) {
         if (child.offsetLeft + child.offsetWidth > container.clientWidth) {
@@ -310,24 +311,47 @@ function MultiSelectBadges({ values }: { values: string[] }) {
   const hiddenCount = values.length - visibleCount
 
   return (
-    <div ref={containerRef} className="flex items-center gap-1 overflow-hidden">
-      {values.slice(0, visibleCount).map((value) => (
-        <Badge
-          key={value}
-          variant="secondary"
-          className="shrink-0 px-1.5 py-0 text-[11px]"
-        >
-          {value}
-        </Badge>
-      ))}
-      {hiddenCount > 0 && (
-        <span
-          data-overflow=""
-          className="shrink-0 text-[11px] text-muted-foreground"
-        >
-          +{hiddenCount}
-        </span>
-      )}
+    <div className="relative overflow-hidden">
+      {/* Hidden measurement layer — always contains every badge */}
+      <div
+        ref={measureRef}
+        aria-hidden
+        className="pointer-events-none flex items-center gap-1"
+        style={{
+          visibility: "hidden",
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+        }}
+      >
+        {values.map((value) => (
+          <Badge
+            key={value}
+            variant="secondary"
+            className="shrink-0 px-1.5 py-0 text-[11px]"
+          >
+            {value}
+          </Badge>
+        ))}
+      </div>
+      {/* Visible layer — only the badges that fit plus the +N indicator */}
+      <div className="flex items-center gap-1">
+        {values.slice(0, visibleCount).map((value) => (
+          <Badge
+            key={value}
+            variant="secondary"
+            className="shrink-0 px-1.5 py-0 text-[11px]"
+          >
+            {value}
+          </Badge>
+        ))}
+        {hiddenCount > 0 && (
+          <span className="shrink-0 text-[11px] text-muted-foreground">
+            +{hiddenCount}
+          </span>
+        )}
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/cases/custom-fields-table.tsx
+++ b/frontend/src/components/cases/custom-fields-table.tsx
@@ -31,6 +31,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import type { SqlType } from "@/lib/data-type"
+import { getCaseFieldTypeConfig } from "@/lib/data-type"
 
 interface CustomFieldsTableProps {
   fields: CaseFieldReadMinimal[]
@@ -87,15 +88,30 @@ export function CustomFieldsTable({
                   title="Data type"
                 />
               ),
-              cell: ({ row }) => (
-                <SqlTypeBadge
-                  type={
-                    row.getValue<CaseFieldReadMinimal["type"]>(
-                      "type"
-                    ) as SqlType
-                  }
-                />
-              ),
+              cell: ({ row }) => {
+                const fieldType = row.getValue<CaseFieldReadMinimal["type"]>(
+                  "type"
+                ) as SqlType
+                const fieldKind = row.original.kind
+                const config = getCaseFieldTypeConfig(fieldType, fieldKind)
+                if (fieldKind && config) {
+                  const Icon = config.icon
+                  return (
+                    <Badge
+                      variant="secondary"
+                      className="text-xs whitespace-nowrap"
+                    >
+                      <span className="inline-flex items-center gap-1.5">
+                        <Icon className="size-3 shrink-0" />
+                        <span className="text-xs font-medium whitespace-nowrap">
+                          {config.label}
+                        </span>
+                      </span>
+                    </Badge>
+                  )
+                }
+                return <SqlTypeBadge type={fieldType} />
+              },
               enableSorting: true,
               enableHiding: false,
             },

--- a/frontend/src/components/cases/edit-custom-field-dialog.tsx
+++ b/frontend/src/components/cases/edit-custom-field-dialog.tsx
@@ -36,6 +36,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { toast } from "@/components/ui/use-toast"
+import { getCaseFieldTypeConfig } from "@/lib/data-type"
 import type { TracecatApiError } from "@/lib/errors"
 import { type SqlTypeCreatable, SqlTypeCreatableEnum } from "@/lib/tables"
 import { useWorkspaceId } from "@/providers/workspace-id"
@@ -400,23 +401,39 @@ export function EditCustomFieldDialog({
             <FormField
               control={form.control}
               name="type"
-              render={({ field: fieldInput }) => (
-                <FormItem>
-                  <FormLabel>Data type</FormLabel>
-                  <FormControl>
-                    <div className="flex h-10 items-center rounded-md border border-input px-3 text-xs">
-                      <SqlTypeDisplay
-                        type={fieldInput.value}
-                        labelClassName="text-xs"
-                      />
-                    </div>
-                  </FormControl>
-                  <FormDescription>
-                    Data type is fixed after field creation.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
+              render={({ field: fieldInput }) => {
+                const typeConfig = getCaseFieldTypeConfig(
+                  fieldInput.value,
+                  field?.kind
+                )
+                const Icon = typeConfig?.icon
+                return (
+                  <FormItem>
+                    <FormLabel>Data type</FormLabel>
+                    <FormControl>
+                      <div className="flex h-10 items-center rounded-md border border-input px-3 text-xs">
+                        {field?.kind && Icon ? (
+                          <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                            <Icon className="size-4 shrink-0" />
+                            <span className="text-xs font-normal leading-none whitespace-nowrap">
+                              {typeConfig?.label}
+                            </span>
+                          </span>
+                        ) : (
+                          <SqlTypeDisplay
+                            type={fieldInput.value}
+                            labelClassName="text-xs"
+                          />
+                        )}
+                      </div>
+                    </FormControl>
+                    <FormDescription>
+                      Data type is fixed after field creation.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )
+              }}
             />
 
             {requiresOptions && (

--- a/frontend/src/lib/data-type.ts
+++ b/frontend/src/lib/data-type.ts
@@ -6,11 +6,14 @@ import {
   CircleDot,
   Fingerprint,
   Hash,
+  Link,
   ListTodo,
+  ScrollText,
   SquareCheck,
   ToggleLeft,
   Type,
 } from "lucide-react"
+import type { CaseFieldKind } from "@/client"
 import type { SqlTypeEnum } from "@/lib/tables"
 
 export type SqlType = (typeof SqlTypeEnum)[number]
@@ -32,6 +35,24 @@ export const SQL_TYPE_CONFIG: Record<SqlType, TypeConfig> = {
   UUID: { label: "UUID", icon: Fingerprint },
   SELECT: { label: "Select", icon: SquareCheck },
   MULTI_SELECT: { label: "Multi-select", icon: ListTodo },
+}
+
+/** Display config overrides for case field kinds. */
+export const CASE_FIELD_KIND_CONFIG: Record<CaseFieldKind, TypeConfig> = {
+  LONG_TEXT: { label: "Long text", icon: ScrollText },
+  URL: { label: "URL", icon: Link },
+}
+
+/**
+ * Get the display config for a field, preferring kind-specific config when available.
+ */
+export function getCaseFieldTypeConfig(
+  type?: SqlType | null,
+  kind?: CaseFieldKind | null
+): TypeConfig | undefined {
+  if (kind) return CASE_FIELD_KIND_CONFIG[kind]
+  if (!type) return undefined
+  return SQL_TYPE_CONFIG[type]
 }
 
 export function getSqlTypeConfig(type?: SqlType | null) {

--- a/tracecat/cases/enums.py
+++ b/tracecat/cases/enums.py
@@ -99,3 +99,14 @@ class CaseTaskStatus(StrEnum):
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
     BLOCKED = "blocked"
+
+
+class CaseFieldKind(StrEnum):
+    """Semantic kind for case custom fields.
+
+    Controls how the field is rendered in the UI without changing the underlying
+    SQL storage type.
+    """
+
+    LONG_TEXT = "LONG_TEXT"
+    URL = "URL"

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -338,13 +338,7 @@ async def get_case(
         f = CaseFieldReadMinimal.from_sa(defn, field_schema=field_schema)
         final_fields.append(
             CaseFieldRead(
-                id=f.id,
-                type=f.type,
-                description=f.description,
-                nullable=f.nullable,
-                default=f.default,
-                reserved=f.reserved,
-                options=f.options,
+                **f.model_dump(),
                 value=fields.get(f.id),
             )
         )
@@ -408,13 +402,7 @@ async def create_case(
         f = CaseFieldReadMinimal.from_sa(defn, field_schema=field_schema)
         final_fields.append(
             CaseFieldRead(
-                id=f.id,
-                type=f.type,
-                description=f.description,
-                nullable=f.nullable,
-                default=f.default,
-                reserved=f.reserved,
-                options=f.options,
+                **f.model_dump(),
                 value=fields.get(f.id),
             )
         )
@@ -485,13 +473,7 @@ async def update_case(
         f = CaseFieldReadMinimal.from_sa(defn, field_schema=field_schema)
         final_fields.append(
             CaseFieldRead(
-                id=f.id,
-                type=f.type,
-                description=f.description,
-                nullable=f.nullable,
-                default=f.default,
-                reserved=f.reserved,
-                options=f.options,
+                **f.model_dump(),
                 value=fields.get(f.id),
             )
         )
@@ -831,13 +813,7 @@ async def get_case_metrics(
         fields = await cases_service.fields.get_fields(case) or {}
         field_reads = [
             CaseFieldRead(
-                id=f.id,
-                type=f.type,
-                description=f.description,
-                nullable=f.nullable,
-                default=f.default,
-                reserved=f.reserved,
-                options=f.options,
+                **f.model_dump(),
                 value=fields.get(f.id),
             )
             for f in field_templates

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -466,13 +466,7 @@ async def get_case(
         f = CaseFieldReadMinimal.from_sa(defn, field_schema=field_schema)
         final_fields.append(
             CaseFieldRead(
-                id=f.id,
-                type=f.type,
-                description=f.description,
-                nullable=f.nullable,
-                default=f.default,
-                reserved=f.reserved,
-                options=f.options,
+                **f.model_dump(),
                 value=fields.get(f.id),
             )
         )

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -16,6 +16,7 @@ from tracecat.cases.dropdowns.schemas import (
 )
 from tracecat.cases.enums import (
     CaseEventType,
+    CaseFieldKind,
     CasePriority,
     CaseSeverity,
     CaseStatus,
@@ -120,6 +121,8 @@ class CaseUpdate(Schema):
 class CaseFieldReadMinimal(CustomFieldRead):
     """Minimal read model for a case field."""
 
+    kind: CaseFieldKind | None = Field(default=None)
+
     @classmethod
     def from_sa(
         cls,
@@ -138,17 +141,22 @@ class CaseFieldReadMinimal(CustomFieldRead):
         Returns:
             A CaseFieldReadMinimal instance populated from the column data.
         """
-        return cls.model_validate(
-            super().from_sa(
-                column,
-                reserved_fields=set(RESERVED_CASE_FIELDS),
-                field_schema=field_schema,
-            )
+        base = super().from_sa(
+            column,
+            reserved_fields=set(RESERVED_CASE_FIELDS),
+            field_schema=field_schema,
         )
+        kind: CaseFieldKind | None = None
+        if field_schema and (meta := field_schema.get(column["name"])):
+            if kind_str := meta.get("kind"):
+                kind = CaseFieldKind(kind_str)
+        return cls.model_validate({**base.model_dump(), "kind": kind})
 
 
 class CaseFieldCreate(CustomFieldCreate):
     """Create a new case field."""
+
+    kind: CaseFieldKind | None = Field(default=None)
 
 
 class CaseFieldUpdate(CustomFieldUpdate):

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -46,6 +46,7 @@ from tracecat.cases.schemas import (
     CaseCommentWorkflowStatus,
     CaseCreate,
     CaseEventVariant,
+    CaseFieldCreate,
     CaseReadMinimal,
     CaseSearchAggregateRead,
     CaseStatusGroupCounts,
@@ -81,7 +82,7 @@ from tracecat.cases.tags.service import CaseTagsService
 from tracecat.cases.triggers.publisher import publish_case_event_payload
 from tracecat.contexts import ctx_run
 from tracecat.custom_fields import CustomFieldsService
-from tracecat.custom_fields.schemas import CustomFieldCreate, CustomFieldUpdate
+from tracecat.custom_fields.schemas import CustomFieldUpdate
 from tracecat.db.models import (
     Case,
     CaseComment,
@@ -1017,6 +1018,28 @@ class CaseFieldsService(CustomFieldsService):
     _table = "case_fields"
     _reserved_columns = {"id", "case_id", "created_at", "updated_at", "workspace_id"}
 
+    @require_scope("case:create")
+    async def create_field(self, params: CaseFieldCreate) -> None:  # type: ignore[override]
+        """Create a new case field column and update the schema.
+
+        Extends the parent to persist the optional ``kind`` metadata
+        (e.g. LONG_TEXT, URL) that controls UI rendering.
+        """
+        await self._ensure_schema_ready()
+        params.nullable = True
+        await self.editor.create_column(params)
+
+        field_def: dict[str, Any] = {"type": params.type.value}
+
+        if params.type in (SqlType.SELECT, SqlType.MULTI_SELECT) and params.options:
+            field_def["options"] = normalize_column_options(params.options)
+
+        if params.kind is not None:
+            field_def["kind"] = params.kind.value
+
+        await self._update_field_schema(params.name, field_def)
+        await self.session.commit()
+
     def _table_definition(self) -> sa.Table:
         """Return the SQLAlchemy Table definition for the case_fields workspace table."""
         return sa.Table(
@@ -1087,26 +1110,6 @@ class CaseFieldsService(CustomFieldsService):
         flag_modified(definition, "schema")
         await self.session.flush()
 
-    @require_scope("case:create")
-    async def create_field(self, params: CustomFieldCreate) -> None:
-        """Create a new custom field column and update the schema."""
-
-        await self._ensure_schema_ready()
-        params.nullable = True  # Custom fields remain nullable by default
-        await self.editor.create_column(params)
-
-        # Store field metadata in schema
-        # Schema structure: {field_name: {type, options (only for SELECT/MULTI_SELECT)}}
-        field_def: dict[str, Any] = {"type": params.type.value}
-
-        # Only include options for SELECT/MULTI_SELECT types
-        if params.type in (SqlType.SELECT, SqlType.MULTI_SELECT) and params.options:
-            field_def["options"] = normalize_column_options(params.options)
-
-        await self._update_field_schema(params.name, field_def)
-
-        await self.session.commit()
-
     @require_scope("case:update")
     async def update_field(self, field_id: str, params: CustomFieldUpdate) -> None:
         """Update a custom field column and update the schema if needed."""
@@ -1136,6 +1139,10 @@ class CaseFieldsService(CustomFieldsService):
             elif "options" in current_field_def:
                 # Preserve existing options if not being updated
                 new_field_def["options"] = current_field_def["options"]
+
+            # Preserve kind metadata across updates
+            if "kind" in current_field_def:
+                new_field_def["kind"] = current_field_def["kind"]
 
             # If field was renamed, remove old entry
             if new_field_id != field_id:


### PR DESCRIPTION
## Summary
- Replace inline `FormMessage` validation errors for integer/number fields with toast notifications to prevent layout shifts in the fixed-height panel row
- Simplify date/datetime display to ISO format (`yyyy-MM-dd`) and remove calendar/clock icons
- Add JSON validation on blur for JSONB fields — invalid JSON shows a destructive toast and prevents submission
- Fix multiselect to show only badges (removing duplicate comma-joined text), with `ResizeObserver`-based overflow detection (`+N` indicator) and `HoverCard` for viewing all selected values on hover

## Test plan
- [ ] INTEGER: type "abc", blur → toast appears, value not saved; type "42" → saved
- [ ] NUMERIC: type "1.2.3" → toast; type "3.14" → saved
- [ ] JSONB: type `{"hello": "wer` → toast; type `{"hello": "world"}` → saved
- [ ] DATE: displays as "2026-03-28", no icon
- [ ] DATETIME: displays as "2026-03-28 14:30", no icon
- [ ] MULTI_SELECT with 2 values: 2 badges inline, no +N
- [ ] MULTI_SELECT with 5 values: badges + "+N", no wrap/spillover
- [ ] Hover on truncated multiselect → HoverCard shows all badges
- [ ] Click multiselect → Popover opens for toggling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds semantic kinds (LONG_TEXT, URL) and dialog-based editors for long text, URL, and JSONB fields to case custom fields. Improves validation and display, and ensures `kind` metadata flows through the API and UI.

- **New Features**
  - Added `CaseFieldKind` (`LONG_TEXT`, `URL`) end-to-end: set on create, included on read, persisted in `field_schema`, and preserved on updates.
  - Type picker now offers “Long text” (TEXT + kind) and “URL” (JSONB + kind); LONG_TEXT/URL use dialogs; edit dialog and fields table show semantic labels/icons.
  - JSONB fields open a CodeMirror editor dialog with syntax highlighting and linting; Save is disabled on invalid JSON; cells show “Expand”/“Add…”.
  - Numbers validate on blur with toasts; dates use ISO formats (`yyyy-MM-dd`, `yyyy-MM-dd HH:mm`) with no icons; multiselect shows inline badges with `+N` overflow and a `HoverCard` for full values.

- **Bug Fixes**
  - Sanitized URL links (http/https only) and allow clearing URL fields by saving an empty value.
  - Fixed multiselect overflow using a two-layer measurement and reserved `+N` width to prevent clipping; expands/recedes correctly on resize.
  - JSONB editor consistently serializes values (including top-level strings) so content displays correctly; no “[object Object]” flash.
  - Routers now forward `kind` via `model_dump()` so kind-based rendering is consistent across API responses and UI.

<sup>Written for commit 924318d7963eb217308e45d98633ffc50093e7ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

