### PR TITLE
fix(ui): show tiers settings page regardless of multi-tenant mode

### DIFF
--- a/frontend/src/app/admin/tiers/page.tsx
+++ b/frontend/src/app/admin/tiers/page.tsx
@@ -1,35 +1,17 @@
 "use client"
 
 import { AlertTriangleIcon } from "lucide-react"
-import { useRouter } from "next/navigation"
-import { useEffect } from "react"
 import { AdminTiersTable } from "@/components/admin/admin-tiers-table"
 import { CreateTierDialog } from "@/components/admin/create-tier-dialog"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { useAdminTiers } from "@/hooks/use-admin"
-import { useAppInfo } from "@/lib/hooks"
 
 export default function AdminTiersPage() {
-  const router = useRouter()
-  const { appInfo, appInfoIsLoading } = useAppInfo()
-  const shouldRedirectToRegistry =
-    !appInfoIsLoading && appInfo?.ee_multi_tenant === false
-  const shouldLoadTiers = !appInfoIsLoading && !shouldRedirectToRegistry
-  const { isLoading, error } = useAdminTiers(true, shouldLoadTiers)
+  const { isLoading, error } = useAdminTiers(true)
 
-  useEffect(() => {
-    if (shouldRedirectToRegistry) {
-      router.replace("/admin/registry")
-    }
-  }, [router, shouldRedirectToRegistry])
-
-  if (appInfoIsLoading || isLoading) {
+  if (isLoading) {
     return <CenteredSpinner />
-  }
-
-  if (shouldRedirectToRegistry) {
-    return null
   }
 
   if (error) {

--- a/frontend/src/components/sidebar/admin-sidebar.tsx
+++ b/frontend/src/components/sidebar/admin-sidebar.tsx
@@ -60,16 +60,12 @@ export function AdminSidebar({
       icon: UsersIcon,
       isActive: pathname?.includes("/admin/users"),
     },
-    ...(multiTenantEnabled
-      ? [
-          {
-            title: "Tiers",
-            url: "/admin/tiers",
-            icon: LayersIcon,
-            isActive: pathname?.includes("/admin/tiers"),
-          },
-        ]
-      : []),
+    {
+      title: "Tiers",
+      url: "/admin/tiers",
+      icon: LayersIcon,
+      isActive: pathname?.includes("/admin/tiers"),
+    },
   ]
 
   const navRegistry = [


### PR DESCRIPTION
## Summary
- Remove `TRACECAT__EE_MULTI_TENANT` gate from the admin tiers page and sidebar nav
- The tiers page is now always accessible, even in single-tenant deployments
- Tier settings will eventually be gated by an in-app license key instead of an env var

## Changes
- `frontend/src/app/admin/tiers/page.tsx`: Removed `useAppInfo`/`useRouter`/`useEffect` and the redirect-to-registry logic when `ee_multi_tenant === false`
- `frontend/src/components/sidebar/admin-sidebar.tsx`: "Tiers" nav item is now unconditionally included in the platform nav

## Test plan
- [ ] Verify tiers page loads at `/admin/tiers` with `TRACECAT__EE_MULTI_TENANT=false`
- [ ] Verify tiers sidebar link is visible in single-tenant mode
- [ ] Verify tiers page still works correctly in multi-tenant mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Tiers admin page and sidebar link always visible by removing the `TRACECAT__EE_MULTI_TENANT` gate. Single-tenant deployments can now access /admin/tiers.

- **Bug Fixes**
  - Removed single-tenant redirect from /admin/tiers and simplified page data loading.
  - Sidebar now always renders the Tiers nav item.

<sup>Written for commit 62a51f39543b73ad3c35b33e1a27083dc779657a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

