### PR TITLE
docs: Registry OAuth/secrets snippet and Custom OAuth guidance

### DIFF
--- a/docs/automations/core-concepts/secrets.mdx
+++ b/docs/automations/core-concepts/secrets.mdx
@@ -114,6 +114,10 @@ Do not print secret values in the final answer.
 ```
 </CodeGroup>
 
+## Custom registry actions
+
+Authors of [Python UDFs](/custom-actions/python-udf) and [YAML templates](/custom-actions/yaml-template) declare required secrets in the registry (including OAuth and structured secret types). The same `${{ SECRETS... }}` syntax applies; see [Use OAuth tokens in expressions](/automations/integrations/oauth-integrations#use-oauth-tokens-in-expressions) on the OAuth page for token paths, `RegistryOAuthSecret` and YAML `type: oauth`, and Custom OAuth `provider_id` rules.
+
 ## Related pages
 
 - See [Pre-built credentials](/automations/integrations/prebuilt-credentials) for provider-specific credential templates for built-in integrations.

--- a/docs/automations/integrations/oauth-integrations.mdx
+++ b/docs/automations/integrations/oauth-integrations.mdx
@@ -3,6 +3,8 @@ title: "OAuth"
 description: "Connect OAuth providers and use managed OAuth tokens in expressions."
 ---
 
+import RegistrySecretsAndOAuth from "/snippets/registry-secrets-and-oauth.mdx";
+
 ## Overview
 
 Tracecat supports built-in OAuth integrations and custom OAuth providers. OAuth integrations expose tokens through secret expressions.
@@ -18,7 +20,7 @@ OAuth grant types:
 
 ## Configure a provider
 
-Built-in providers already exist in the Integrations page. Add custom providers from `Add integration` -> `OAuth provider`.
+Built-in OAuth integrations are listed on the Integrations page. For **Custom OAuth**, use **Add integration** → **OAuth provider** (or **Add custom OAuth provider** under **Custom OAuth**).
 
 Most providers require these fields:
 
@@ -28,31 +30,15 @@ Most providers require these fields:
 - Token endpoint
 - Scopes
 
+After you save a custom provider, **connect** it (complete the OAuth flow) when using delegated access so Tracecat can issue tokens.
+
 ## Use OAuth tokens in expressions
 
-Tracecat exposes OAuth tokens under the secret name `<provider_id>_oauth`.
-The token key depends on the grant type:
-
-- Delegated access: `${{ SECRETS.<provider_id>_oauth.<PROVIDER>_USER_TOKEN }}`
-- Client credentials: `${{ SECRETS.<provider_id>_oauth.<PROVIDER>_SERVICE_TOKEN }}`
-
-Examples:
-
-```yaml
-${{ SECRETS.slack_oauth.SLACK_USER_TOKEN }}
-${{ SECRETS.microsoft_entra_oauth.MICROSOFT_ENTRA_SERVICE_TOKEN }}
-```
-
-Some templates support either grant type.
-In that case, use a fallback:
-
-```yaml
-${{ SECRETS.microsoft_entra_oauth.MICROSOFT_ENTRA_USER_TOKEN || SECRETS.microsoft_entra_oauth.MICROSOFT_ENTRA_SERVICE_TOKEN }}
-```
+<RegistrySecretsAndOAuth />
 
 ## OAuth and actions
 
-Registry actions can require an OAuth integration directly. Actions can also reference OAuth tokens in expressions.
+Registry actions **reference** OAuth integrations but do not create them. Configure a built-in or custom provider in Integrations first, then declare `RegistryOAuthSecret` (Python) or `type: oauth` (YAML) so the action requires that integration at runtime. Syntax and examples are in **Use OAuth tokens in expressions** above.
 
 ## OAuth and MCP
 
@@ -62,8 +48,31 @@ Remote MCP integrations can use an existing OAuth integration. For custom remote
 2. Connect that provider.
 3. Create an MCP integration and attach the connected OAuth integration.
 
+## FAQ
+
+### Why is my custom OAuth `provider_id` prefixed with `custom_`?
+
+This applies to **Custom OAuth** integrations you create from the Integrations page (**Add integration** → **OAuth provider**, or the **Add custom OAuth provider** dialog under **Custom OAuth**). It does **not** apply to built-in OAuth integrations (for example Slack or Google Drive), which use stable ids from the product.
+
+When you save a custom provider, Tracecat derives a **provider id** from the display name or the id you enter (slugified). If that value does not already start with `custom_`, the server **prepends** `custom_` so it does not collide with [built-in providers](https://github.com/TracecatHQ/tracecat/blob/main/tracecat/integrations/providers/__init__.py). If the id is already taken, a numeric suffix is added.
+
+Use the **exact** `provider_id` from Integrations everywhere: expressions (`${{ SECRETS.custom_my_api_oauth.CUSTOM_MY_API_USER_TOKEN }}`), `RegistryOAuthSecret(provider_id="custom_my_api", ...)`, and YAML `provider_id: custom_my_api`. Token environment keys use the full provider id in uppercase (including the `CUSTOM_` segment).
+
+### Can my custom action create an OAuth integration?
+
+No. `RegistryOAuthSecret` and YAML `type: oauth` entries declare that the action *requires* an existing OAuth integration — they do not register one. Create the integration from [Configure a provider](#configure-a-provider) (or [contribute a built-in provider](#how-do-i-contribute-a-built-in-oauth-provider)). Once it exists, your action can reference its tokens via `${{ SECRETS.<provider_id>_oauth... }}`.
+
+### How do I contribute a built-in OAuth provider?
+
+Shipped providers are implemented in the Tracecat app and get **stable** ids (for example `slack`, `google_drive`) without the UI `custom_` rule.
+
+1. Subclass `AuthorizationCodeOAuthProvider` or `ClientCredentialsOAuthProvider` under [`tracecat/integrations/providers/`](https://github.com/TracecatHQ/tracecat/tree/main/tracecat/integrations/providers). See [`slack/oauth.py`](https://github.com/TracecatHQ/tracecat/blob/main/tracecat/integrations/providers/slack/oauth.py) for a full example.
+2. Register the class in [`_PROVIDER_CLASSES`](https://github.com/TracecatHQ/tracecat/blob/main/tracecat/integrations/providers/__init__.py).
+3. Keep the [registry package](https://github.com/TracecatHQ/tracecat/tree/main/packages/tracecat-registry) aligned: same `provider_id` and `grant_type` in `RegistryOAuthSecret` (Python) and `type: oauth` entries (YAML) so actions resolve the same integration as the UI.
+
 ## Related pages
 
 - See [Prebuilt credentials](/automations/integrations/prebuilt-credentials) for static credentials such as API keys and bot tokens.
 - See [Secrets](/automations/core-concepts/secrets) for how secret expressions are resolved at runtime.
+- See [Python UDFs](/custom-actions/python-udf) and [YAML templates](/custom-actions/yaml-template) for custom registry actions.
 - See [MCP servers](/automations/integrations/mcp-integrations) for remote and `stdio` MCP setup.

--- a/docs/automations/integrations/prebuilt-credentials.mdx
+++ b/docs/automations/integrations/prebuilt-credentials.mdx
@@ -39,5 +39,5 @@ In `/Credentials`, click `Configure` for the credential. Tracecat pre-fills the 
 ## Related pages
 
 - See [Secrets](/automations/core-concepts/secrets) for the core secret model and secret expression syntax.
-- See [OAuth](/automations/integrations/oauth-integrations) for integrations that issue managed OAuth tokens instead of static keys.
+- See [OAuth](/automations/integrations/oauth-integrations) for integrations that issue managed OAuth tokens instead of static keys, and for the same `${{ SECRETS... }}` patterns in custom registry actions.
 - See [MCP servers](/automations/integrations/mcp-integrations) for MCP-specific integration setup and secret-backed `stdio` configuration.

--- a/docs/custom-actions/python-udf.mdx
+++ b/docs/custom-actions/python-udf.mdx
@@ -3,6 +3,8 @@ title: "Python UDFs"
 description: "Build custom Python actions in Tracecat."
 ---
 
+import RegistrySecretsAndOAuth from "/snippets/registry-secrets-and-oauth.mdx";
+
 Tracecat makes it easy to turn your Python scripts into actions for agents and workflows. All you need is:
 
 - A single Python decorator, `@registry.register`
@@ -109,8 +111,20 @@ api_secret = RegistrySecret(
 `secret_type` uses snake_case everywhere — Python declarations, the API, and the UI all use the same values (`ssh_key`, `ca_cert`, `mtls`, `custom`).
 </Note>
 
+<RegistrySecretsAndOAuth />
+
 ## Example actions
 
 You can browse all open-source integrations in Tracecat in [tools actions](https://github.com/TracecatHQ/tracecat/tree/main/packages/tracecat-registry/tracecat_registry/integrations). Use [template actions](https://github.com/TracecatHQ/tracecat/tree/main/packages/tracecat-registry/tracecat_registry/templates/tools) to see how actions are composed, and use [core actions](https://github.com/TracecatHQ/tracecat/tree/main/packages/tracecat-registry/tracecat_registry/core) to inspect built-in implementations.
 
 For concrete examples, browse the [Slack](https://github.com/TracecatHQ/tracecat/blob/main/packages/tracecat-registry/tracecat_registry/integrations/slack_sdk.py), [AWS Boto3](https://github.com/TracecatHQ/tracecat/blob/main/packages/tracecat-registry/tracecat_registry/integrations/aws_boto3.py), and [FalconPy](https://github.com/TracecatHQ/tracecat/blob/main/packages/tracecat-registry/tracecat_registry/integrations/crowdstrike_falconpy.py) integrations.
+
+## FAQ
+
+### Why does `secrets.get` use names like `GOOGLE_DRIVE_USER_TOKEN`?
+
+UDFs read **injected key names**, not `${{ SECRETS... }}` strings. Those keys match the token names for your declared secrets (for OAuth, the uppercase `provider_id` plus `_USER_TOKEN` or `_SERVICE_TOKEN`). See the imported section above (OAuth token paths and **Python UDFs**), and the [OAuth FAQ](/automations/integrations/oauth-integrations#faq) for custom `provider_id` values.
+
+### Where are example UDFs for OAuth and structured secrets?
+
+See **Repo examples** in the registry section above, or browse [tools integrations](https://github.com/TracecatHQ/tracecat/tree/main/packages/tracecat-registry/tracecat_registry/integrations) on GitHub.

--- a/docs/custom-actions/yaml-template.mdx
+++ b/docs/custom-actions/yaml-template.mdx
@@ -3,6 +3,8 @@ title: "YAML templates"
 description: "Build custom YAML actions in Tracecat."
 ---
 
+import RegistrySecretsAndOAuth from "/snippets/registry-secrets-and-oauth.mdx";
+
 Use a YAML action template to compose existing actions into a reusable action.
 
 ## Template shape
@@ -81,6 +83,12 @@ You can use:
 - `VARS`
 - `FN.*`
 
+## Secrets
+
+Declare what each template needs under `definition.secrets` (API keys, structured types, or OAuth). That list drives which credentials must exist for the action when the workflow runs. Use the same `${{ SECRETS... }}` paths in `args` as in any other expression.
+
+<RegistrySecretsAndOAuth />
+
 ## Limitations
 
 - Template steps only support `ref`, `action`, and `args`.
@@ -94,3 +102,13 @@ You can use:
 All integrations in Tracecat are open source. Browse [template actions](https://github.com/TracecatHQ/tracecat/tree/main/packages/tracecat-registry/tracecat_registry/templates/tools) for more examples.
 
 For concrete examples, browse the [Slack templates](https://github.com/TracecatHQ/tracecat/tree/main/packages/tracecat-registry/tracecat_registry/templates/tools/slack) and [CrowdStrike templates](https://github.com/TracecatHQ/tracecat/tree/main/packages/tracecat-registry/tracecat_registry/templates/tools/crowdstrike).
+
+## FAQ
+
+### How do `definition.secrets` and `${{ SECRETS... }}` work together?
+
+`definition.secrets` declares which credentials the template needs at runtime. Use `SECRETS` in `args` to pass values into steps (see the **Secrets** and **Expressions** sections above). OAuth entries use `type: oauth` with `provider_id` and `grant_type` matching an integration in your workspace.
+
+### Why does my custom OAuth `provider_id` in YAML not match what I typed?
+
+UI-created **Custom OAuth** providers often get a `custom_` prefix. Use the exact id from Integrations; see the [OAuth FAQ](/automations/integrations/oauth-integrations#faq).

--- a/docs/snippets/registry-secrets-and-oauth.mdx
+++ b/docs/snippets/registry-secrets-and-oauth.mdx
@@ -1,0 +1,87 @@
+Use the same `${{ SECRETS... }}` syntax as workflow actions.
+
+**Custom secrets** (API keys, SSH, mTLS, CA bundles, and so on):
+
+```yaml
+${{ SECRETS.<secret_name>.<KEY> }}
+```
+
+**OAuth** tokens live under `<provider_id>_oauth`. The key is the provider id in uppercase plus `_USER_TOKEN` or `_SERVICE_TOKEN`:
+
+- `authorization_code`: `${{ SECRETS.<provider_id>_oauth.<PROVIDER_ID_UPPER>_USER_TOKEN }}`
+- `client_credentials`: `${{ SECRETS.<provider_id>_oauth.<PROVIDER_ID_UPPER>_SERVICE_TOKEN }}`
+
+```yaml
+${{ SECRETS.slack_oauth.SLACK_USER_TOKEN }}
+${{ SECRETS.google_docs_oauth.GOOGLE_DOCS_SERVICE_TOKEN }}
+```
+
+Optional fallback when either grant type is allowed:
+
+```yaml
+${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}
+```
+
+**Custom OAuth** providers you add from the UI (**Add integration** → **OAuth provider**, or **Add custom OAuth provider** under **Custom OAuth**) receive a `custom_`-prefixed `provider_id` when the slug does not already start with `custom_`. That flow creates the integration in Tracecat only — it does **not** define anything in your registry package; use the **exact** `provider_id` from Integrations in expressions and declarations. See the [OAuth FAQ](/automations/integrations/oauth-integrations#faq) for more detail.
+
+<Note>
+Registry actions **reference** existing OAuth integrations — they do not create them.
+Configure the integration in [Integrations](/automations/integrations/oauth-integrations#configure-a-provider) first (pick a built-in OAuth integration or add a **Custom OAuth** provider). For delegated access (`authorization_code`), **connect** the integration so Tracecat can store tokens before workflows run.
+Declaring `RegistryOAuthSecret` (Python) or `type: oauth` (YAML) tells Tracecat your action needs that integration at runtime. To ship a new built-in provider in the product, see [How do I contribute a built-in OAuth provider?](/automations/integrations/oauth-integrations#how-do-i-contribute-a-built-in-oauth-provider) (that is separate from using OAuth in registry actions).
+</Note>
+
+## Python UDFs
+
+Declare credentials in `@registry.register(..., secrets=[...])`.
+
+- **`RegistrySecret`**: static keys; set `secret_type` to `ssh_key`, `mtls`, or `ca_cert` when needed ([secret types](/automations/core-concepts/secrets)). Optional: `optional`, `optional_keys`.
+- **`RegistryOAuthSecret`**: declares a dependency on an existing OAuth integration. Pass the `provider_id` and `grant_type` that match the integration in your workspace (a mismatch — for example declaring `authorization_code` when the integration uses `client_credentials` — will not resolve).
+
+Read values with `secrets.get("<KEY>")` (key only, e.g. `GOOGLE_DRIVE_USER_TOKEN`), not a `SECRETS.` path.
+
+```python
+from tracecat_registry import RegistryOAuthSecret, RegistrySecret, registry, secrets
+
+api = RegistrySecret(name="exa", keys=["EXA_API_KEY"])
+
+oauth = RegistryOAuthSecret(
+    provider_id="google_drive",
+    grant_type="authorization_code",
+)
+```
+
+## YAML
+
+Under `definition`, set a `secrets` list (same validator as Python).
+
+**Custom** (optional `secret_type` for structured secrets):
+
+```yaml
+definition:
+  secrets:
+    - name: exa
+      keys: ["EXA_API_KEY"]
+    - name: ansible
+      keys: ["PRIVATE_KEY"]
+      secret_type: ssh_key
+```
+
+**OAuth**:
+
+```yaml
+definition:
+  secrets:
+    - type: oauth
+      provider_id: microsoft_teams
+      grant_type: authorization_code
+```
+
+The `provider_id` and `grant_type` must match an integration already configured in your workspace. Use `${{ SECRETS.<provider_id>_oauth.<TOKEN_KEY> }}` in `args`. Set `optional: true` on an OAuth entry when it is not always required.
+
+## Repo examples
+
+- **SSH / `ssh_key`:** [`tracecat_registry/core/ssh.py`](https://github.com/TracecatHQ/tracecat/blob/main/packages/tracecat-registry/tracecat_registry/core/ssh.py)
+- **OAuth UDFs:** [`integrations/google_drive.py`](https://github.com/TracecatHQ/tracecat/blob/main/packages/tracecat-registry/tracecat_registry/integrations/google_drive.py), [`integrations/slack_sdk.py`](https://github.com/TracecatHQ/tracecat/blob/main/packages/tracecat-registry/tracecat_registry/integrations/slack_sdk.py)
+- **YAML (API key):** [`templates/tools/exa/search.yml`](https://github.com/TracecatHQ/tracecat/blob/main/packages/tracecat-registry/tracecat_registry/templates/tools/exa/search.yml)
+- **YAML OAuth:** [`microsoft_teams/send_message.yml`](https://github.com/TracecatHQ/tracecat/blob/main/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_teams/send_message.yml) (`authorization_code`), [`google_docs/create_document.yml`](https://github.com/TracecatHQ/tracecat/blob/main/packages/tracecat-registry/tracecat_registry/templates/tools/google_docs/create_document.yml) (`client_credentials`), [`microsoft_sentinel/.../get_alert_rule_template.yml`](https://github.com/TracecatHQ/tracecat/blob/main/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/get_alert_rule_template.yml) (optional dual grant)
+- **Built-in provider ids:** [`tracecat/integrations/providers/__init__.py`](https://github.com/TracecatHQ/tracecat/blob/main/tracecat/integrations/providers/__init__.py)


### PR DESCRIPTION
## Summary

Adds a reusable Mintlify snippet (`docs/snippets/registry-secrets-and-oauth.mdx`) documenting how to declare `RegistrySecret`, structured secret types, and `RegistryOAuthSecret` in Python UDFs and YAML templates, including `SECRETS` expression paths.

Clarifies that registry actions **reference** existing OAuth integrations (they do not create them), documents Custom OAuth `custom_` `provider_id` behavior, connect/delegated access, and `grant_type` matching.

## Pages updated

- OAuth integrations: **Use OAuth tokens in expressions**, FAQ, Configure a provider
- Python UDFs / YAML templates: import snippet, FAQs
- Secrets / prebuilt credentials: cross-links

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable docs snippet for registry secrets and OAuth that standardizes `${{ SECRETS... }}` token paths and shows `RegistrySecret` (including structured types) and `RegistryOAuthSecret` usage in Python UDFs and YAML templates. Clarifies Custom OAuth behavior (`custom_`-prefixed `provider_id`, connect flow for delegated access, and `grant_type` matching) and that registry actions reference existing OAuth integrations; updates OAuth, Secrets, Prebuilt credentials, and UDF/YAML pages with examples, FAQs, and cross-links.

<sup>Written for commit 5c83a98e7ca7b03eece85383fc706b0d337a3160. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

