### PR TITLE
feat(integrations): use workspace variable as default CrowdStrike base_url with parameter override

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/integrations/crowdstrike_falconpy.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/crowdstrike_falconpy.py
@@ -6,6 +6,7 @@ from falconpy import APIHarnessV2
 from pydantic import Field
 
 from tracecat_registry import RegistrySecret, registry, secrets
+from tracecat_registry.context import get_context
 
 crowdstrike_secret = RegistrySecret(
     name="crowdstrike",
@@ -55,8 +56,16 @@ async def call_command(
 ) -> Any:
     params = params or {}
     extra_kwargs = extra_kwargs or {}
+
+    # Resolve base_url: parameter takes precedence, then workspace variable
+    resolved_base_url = base_url
+    if not resolved_base_url:
+        resolved_base_url = await get_context().variables.get_or_default(
+            "crowdstrike", "base_url", None
+        )
+
     falcon = APIHarnessV2(
-        base_url=base_url,
+        base_url=resolved_base_url,
         client_id=secrets.get("CROWDSTRIKE_CLIENT_ID"),
         client_secret=secrets.get("CROWDSTRIKE_CLIENT_SECRET"),
         member_cid=member_cid,


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

In #1838 the `base_url` parameter was added to the FalconPy integration, but the default value is None, meaning our workflows using this action are failing with `InvalidBaseURL: Invalid base URL address specified.` Instead of touching every step in those workflows, we went looking for a workspace variable to set and found there wasn't one.

## Related Issues

Follow-up to #1838 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the CrowdStrike FalconPy `base_url` to the workspace variable `crowdstrike.base_url` when not provided, while still letting an explicit `base_url` parameter override. Avoids `InvalidBaseURL` errors in existing workflows after #1838.

<sup>Written for commit 19dfd106d38e84875f3840b393552b4cb377465b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

