### PR TITLE
feat: Enable Claude Code tool search

### DIFF
--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -598,6 +598,7 @@ class ClaudeAgentRuntime:
                 env={
                     "ANTHROPIC_AUTH_TOKEN": payload.litellm_auth_token,
                     "ANTHROPIC_BASE_URL": get_litellm_url(),
+                    "ENABLE_TOOL_SEARCH": "true",
                 },
                 model=payload.config.model_name,
                 system_prompt=self._build_system_prompt(payload.config.instructions),


### PR DESCRIPTION
## What changed
- set `ENABLE_TOOL_SEARCH=true` in the Claude Code runtime environment passed to the agent process

## Why
- Claude Code tool search needs the feature flag enabled in the spawned runtime environment

## Impact
- Claude Code agent runs from this runtime can use tool search when the upstream SDK/runtime honors the flag

## Root cause
- the runtime was not exporting the tool-search enablement flag when launching Claude Code

## Validation
- no additional checks were run for this change
- commit hooks were intentionally skipped at user request to avoid autogenerated file churn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Claude Code tool search by setting ENABLE_TOOL_SEARCH=true in the runtime environment passed to the agent process. This allows Claude Code runs to use tool search when the upstream SDK/runtime supports the flag.

<sup>Written for commit 042695790e4458fdaee09e5bb0ca65ec1390b3c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

