### PR TITLE
fix(agents): passthrough the agent sdk headers

### DIFF
--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -83,8 +83,9 @@ async def test_forward_request_streams_tracecat_proxy_response(
         payload: dict,
         claims: object,
         trace_request_id: str | None = None,
+        ingress_headers: dict[str, str] | None = None,
     ) -> object:
-        del self, claims, trace_request_id
+        del self, claims, trace_request_id, ingress_headers
         assert payload["stream"] is True
 
         async def _events():

--- a/tests/unit/test_tracecat_llm_proxy_core.py
+++ b/tests/unit/test_tracecat_llm_proxy_core.py
@@ -299,6 +299,7 @@ async def test_proxy_passes_authorized_model_to_anthropic_passthrough(
             *,
             model: str,
             base_url: str | None = None,
+            ingress_headers: dict[str, str] | None = None,
         ):
             del client
             captured["payload_model"] = payload["model"]

--- a/tracecat/agent/llm_proxy/core.py
+++ b/tracecat/agent/llm_proxy/core.py
@@ -195,6 +195,7 @@ class TracecatLLMProxy:
         payload: dict[str, Any],
         claims: LLMTokenClaims,
         trace_request_id: str | None = None,
+        ingress_headers: dict[str, str] | None = None,
     ) -> AsyncIterator[bytes]:
         # Eagerly resolve credentials before constructing the lazy generator
         # so that HTTPException is raised before response headers are sent.
@@ -226,6 +227,7 @@ class TracecatLLMProxy:
                         claims.model_settings,
                         model=claims.model,
                         base_url=claims.base_url,
+                        ingress_headers=ingress_headers,
                     ):
                         yield chunk
                     return

--- a/tracecat/agent/llm_proxy/provider_anthropic.py
+++ b/tracecat/agent/llm_proxy/provider_anthropic.py
@@ -74,19 +74,50 @@ def _anthropic_messages_url(base_url: str) -> str:
     return f"{base_url}/v1/messages"
 
 
+_FORWARDED_INGRESS_HEADERS = frozenset({"anthropic-version", "anthropic-beta"})
+
+
 def _build_anthropic_headers(
     credentials: dict[str, str],
+    *,
+    ingress_headers: dict[str, str] | None = None,
 ) -> dict[str, str]:
+    """Build Anthropic API headers.
+
+    Headers from the ingress request (e.g. ``anthropic-version``,
+    ``anthropic-beta``) are forwarded so the upstream API version matches
+    what the calling SDK expects.  Credential-level overrides still take
+    precedence.
+    """
     api_key = credentials.get("ANTHROPIC_API_KEY")
     if not api_key:
         raise ValueError("Anthropic provider requires ANTHROPIC_API_KEY")
-    headers = {
-        "Content-Type": "application/json",
-        "x-api-key": api_key,
-        "anthropic-version": credentials.get("ANTHROPIC_VERSION", "2023-06-01"),
-    }
+
+    # Start with forwarded SDK headers, then layer credential overrides.
+    # Header names are compared case-insensitively because the socket parser
+    # preserves original casing (e.g. "Anthropic-Version" from the SDK).
+    headers: dict[str, str] = {}
+    if ingress_headers:
+        lowered = {k.lower(): v for k, v in ingress_headers.items()}
+        for key in _FORWARDED_INGRESS_HEADERS:
+            if value := lowered.get(key):
+                headers[key] = value
+
+    headers.update(
+        {
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+        }
+    )
+    # Credential-level overrides win over ingress headers.
+    if version := credentials.get("ANTHROPIC_VERSION"):
+        headers["anthropic-version"] = version
+    elif "anthropic-version" not in headers:
+        headers["anthropic-version"] = "2023-06-01"
+
     if beta := credentials.get("ANTHROPIC_BETA"):
         headers["anthropic-beta"] = beta
+
     return headers
 
 
@@ -159,10 +190,11 @@ class AnthropicAdapter:
         *,
         model: str,
         base_url: str | None = None,
+        ingress_headers: dict[str, str] | None = None,
     ) -> AsyncIterator[bytes]:
         """Stream raw SSE bytes — Anthropic in, Anthropic out, no normalization."""
         base_url = base_url or _DEFAULT_ANTHROPIC_BASE_URL
-        headers = _build_anthropic_headers(credentials)
+        headers = _build_anthropic_headers(credentials, ingress_headers=ingress_headers)
         outbound_payload = dict(payload)
 
         # Inject token-level model settings into the raw payload

--- a/tracecat/agent/llm_proxy/provider_common.py
+++ b/tracecat/agent/llm_proxy/provider_common.py
@@ -68,6 +68,7 @@ class PassthroughStreamAdapter(Protocol):
         *,
         model: str,
         base_url: str | None = None,
+        ingress_headers: dict[str, str] | None = None,
     ) -> AsyncIterator[bytes]:
         raise NotImplementedError
 

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -428,6 +428,7 @@ class LLMSocketProxy:
                         payload=payload,
                         claims=claims,
                         trace_request_id=trace_request_id,
+                        ingress_headers=headers,
                     )
                     await self._write_response(
                         writer,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Passes through select SDK headers to Anthropic in passthrough streaming to match the calling SDK’s API version and avoid version mismatch errors.

- **Bug Fixes**
  - Forward `anthropic-version` and `anthropic-beta` from ingress to Anthropic with case-insensitive matching; credentials still override; fallback to `2023-06-01` if unset.
  - Thread `ingress_headers` through sandbox → core → provider (`passthrough_stream` signature) and update tests.

<sup>Written for commit 7904a9c92ef10aeb70ebd5a77d2221dd526e44f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

