### PR TITLE
fix(agents): flush session jsonl at turn end

### DIFF
--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -26,14 +26,12 @@ from claude_agent_sdk import (
     SandboxSettings,
 )
 from claude_agent_sdk.types import (
-    AssistantMessage,
     HookContext,
     HookInput,
     PreToolUseHookSpecificOutput,
     ResultMessage,
     StreamEvent,
     SyncHookJSONOutput,
-    SystemMessage,
     ToolResultBlock,
     UserMessage,
 )
@@ -686,47 +684,6 @@ class ClaudeAgentRuntime:
                             unified = self._stream_adapter.to_unified_event(message)
                             await self._socket_writer.send_stream_event(unified)
 
-                        elif isinstance(message, AssistantMessage):
-                            # Emit new JSONL lines for persistence (with full envelope)
-                            await self._emit_new_session_lines()
-
-                            # Also stream tool results for UI
-                            # (keep send_message for backward compat / UI events)
-                            await self._socket_writer.send_message(message)
-
-                        elif isinstance(message, UserMessage):
-                            # Emit new JSONL lines for persistence (with full envelope)
-                            await self._emit_new_session_lines()
-
-                            # Also send message for UI events
-                            await self._socket_writer.send_message(message)
-
-                            # Stream tool results for UI
-                            if isinstance(message.content, list):
-                                for block in message.content:
-                                    if isinstance(block, ToolResultBlock):
-                                        # Skip denial results for pending approvals
-                                        if (
-                                            block.tool_use_id
-                                            in self._pending_approval_tool_ids
-                                        ):
-                                            continue
-                                        await self._socket_writer.send_stream_event(
-                                            UnifiedStreamEvent(
-                                                type=StreamEventType.TOOL_RESULT,
-                                                tool_call_id=block.tool_use_id,
-                                                tool_output=block.content,
-                                                is_error=block.is_error or False,
-                                            )
-                                        )
-
-                        elif isinstance(message, SystemMessage):
-                            # Emit new JSONL lines for persistence (with full envelope)
-                            await self._emit_new_session_lines()
-
-                            # Also send message for backward compat
-                            await self._socket_writer.send_message(message)
-
                         elif isinstance(message, ResultMessage):
                             # Final result - emit any remaining lines
                             await self._emit_new_session_lines()
@@ -748,12 +705,39 @@ class ClaudeAgentRuntime:
                                 duration_ms=message.duration_ms,
                                 output=result_output,
                             )
+
+                        else:
+                            # AssistantMessage, UserMessage, SystemMessage, etc.
+                            await self._emit_new_session_lines()
+
+                            # Stream tool results for UI
+                            if isinstance(message, UserMessage) and isinstance(
+                                message.content, list
+                            ):
+                                for block in message.content:
+                                    if isinstance(block, ToolResultBlock):
+                                        if (
+                                            block.tool_use_id
+                                            in self._pending_approval_tool_ids
+                                        ):
+                                            continue
+                                        await self._socket_writer.send_stream_event(
+                                            UnifiedStreamEvent(
+                                                type=StreamEventType.TOOL_RESULT,
+                                                tool_call_id=block.tool_use_id,
+                                                tool_output=block.content,
+                                                is_error=block.is_error or False,
+                                            )
+                                        )
                 finally:
                     stderr_task.cancel()
                     try:
                         await stderr_task
                     except asyncio.CancelledError:
                         pass
+
+            # CLI has exited — session file is fully flushed.
+            await self._emit_new_session_lines()
 
         except Exception as e:
             await self._socket_writer.send_log(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Flushes agent session JSONL at the end of each turn and after the CLI exits to prevent missing or delayed persisted events.

- **Bug Fixes**
  - Emit new session JSONL lines for all non-result messages via a single generic branch.
  - Perform a final flush after CLI exit to ensure the session file is fully persisted.
  - Continue streaming `TOOL_RESULT` events for user tool outputs while skipping pending approvals.

- **Refactors**
  - Consolidated per-message handling into one path and removed unused type imports.

<sup>Written for commit a8d152b84c1e2fc4f1fd7117ed1c6456b7f5b442. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

