### PR TITLE
perf(agent): use byte-offset seek for incremental session line emission

### DIFF
--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -11,8 +11,9 @@ import uuid
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import orjson
 import pytest
 from claude_agent_sdk.types import (
     HookContext,
@@ -577,3 +578,286 @@ class TestClaudeAgentRuntimePreToolUseHook:
         # Should have sent approval request and interrupted
         mock_socket_writer.send_stream_event.assert_awaited()
         runtime.client.interrupt.assert_awaited()
+
+
+def _jsonl_line(data: dict[str, Any]) -> str:
+    """Encode a dict as a single JSONL line (no trailing newline)."""
+    return orjson.dumps(data).decode("utf-8")
+
+
+def _make_session_file(
+    runtime: ClaudeAgentRuntime,
+    sdk_session_id: str,
+    lines: list[str],
+) -> Path:
+    """Write lines to the runtime's session file path and return the path."""
+    path = runtime._get_session_file_path(sdk_session_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n" if lines else "")
+    return path
+
+
+class TestEmitNewSessionLines:
+    """Tests for ClaudeAgentRuntime._emit_new_session_lines().
+
+    Validates the byte-offset incremental reader: correct lines are emitted,
+    the offset advances properly, and edge cases (empty file, incomplete
+    writes, continuation flag) are handled.
+    """
+
+    SDK_SESSION_ID = "test-emit-session-001"
+
+    @pytest.fixture
+    def runtime(self, mock_socket_writer: MagicMock) -> ClaudeAgentRuntime:
+        rt = ClaudeAgentRuntime(mock_socket_writer)
+        rt._sdk_session_id = self.SDK_SESSION_ID
+        rt._cwd = Path(tempfile.mkdtemp(prefix="tracecat-emit-test-"))
+        return rt
+
+    # -- basic emission --
+
+    @pytest.mark.anyio
+    async def test_emits_all_lines(
+        self, runtime: ClaudeAgentRuntime, mock_socket_writer: MagicMock
+    ) -> None:
+        """All complete JSONL lines are emitted on the first call."""
+        lines = [
+            _jsonl_line({"type": "user", "message": {"content": "hi"}}),
+            _jsonl_line(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "hello"}]},
+                }
+            ),
+        ]
+        _make_session_file(runtime, self.SDK_SESSION_ID, lines)
+
+        await runtime._emit_new_session_lines()
+
+        assert mock_socket_writer.send_session_line.await_count == 2
+        # Verify lines sent in order
+        sent_lines = [
+            c.args[1] for c in mock_socket_writer.send_session_line.call_args_list
+        ]
+        assert sent_lines == lines
+
+    # -- incremental reads --
+
+    @pytest.mark.anyio
+    async def test_incremental_offset_only_emits_new_lines(
+        self, runtime: ClaudeAgentRuntime, mock_socket_writer: MagicMock
+    ) -> None:
+        """After first call, appending new lines only emits the new ones."""
+        line1 = _jsonl_line({"type": "user", "message": {"content": "first"}})
+        path = _make_session_file(runtime, self.SDK_SESSION_ID, [line1])
+
+        await runtime._emit_new_session_lines()
+        assert mock_socket_writer.send_session_line.await_count == 1
+        mock_socket_writer.send_session_line.reset_mock()
+
+        # Append a second line
+        line2 = _jsonl_line(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "second"}]},
+            }
+        )
+        with open(path, "a") as f:
+            f.write(line2 + "\n")
+
+        await runtime._emit_new_session_lines()
+        assert mock_socket_writer.send_session_line.await_count == 1
+        sent = mock_socket_writer.send_session_line.call_args_list[0].args[1]
+        assert sent == line2
+
+    # -- no-op cases --
+
+    @pytest.mark.anyio
+    async def test_noop_when_no_sdk_session_id(
+        self, runtime: ClaudeAgentRuntime, mock_socket_writer: MagicMock
+    ) -> None:
+        runtime._sdk_session_id = None
+        await runtime._emit_new_session_lines()
+        mock_socket_writer.send_session_line.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_noop_when_file_missing(
+        self, runtime: ClaudeAgentRuntime, mock_socket_writer: MagicMock
+    ) -> None:
+        # Don't create a file
+        await runtime._emit_new_session_lines()
+        mock_socket_writer.send_session_line.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_noop_when_no_new_data(
+        self, runtime: ClaudeAgentRuntime, mock_socket_writer: MagicMock
+    ) -> None:
+        line = _jsonl_line({"type": "user", "message": {"content": "hi"}})
+        _make_session_file(runtime, self.SDK_SESSION_ID, [line])
+
+        await runtime._emit_new_session_lines()
+        mock_socket_writer.send_session_line.reset_mock()
+
+        # Second call with no file change
+        await runtime._emit_new_session_lines()
+        mock_socket_writer.send_session_line.assert_not_awaited()
+
+    # -- empty / whitespace lines --
+
+    @pytest.mark.anyio
+    async def test_skips_empty_lines(
+        self, runtime: ClaudeAgentRuntime, mock_socket_writer: MagicMock
+    ) -> None:
+        line = _jsonl_line({"type": "user", "message": {"content": "hi"}})
+        path = runtime._get_session_file_path(self.SDK_SESSION_ID)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Write with blank lines interspersed
+        path.write_text(f"\n\n{line}\n\n")
+
+        await runtime._emit_new_session_lines()
+        assert mock_socket_writer.send_session_line.await_count == 1
+
+    # -- incomplete writes --
+
+    @pytest.mark.anyio
+    async def test_stops_at_incomplete_line_without_newline(
+        self, runtime: ClaudeAgentRuntime, mock_socket_writer: MagicMock
+    ) -> None:
+        """A line not terminated by newline is treated as incomplete and retried."""
+        complete = _jsonl_line({"type": "user", "message": {"content": "done"}})
+        incomplete = '{"type":"assistant","message":'  # no closing brace, no newline
+        path = runtime._get_session_file_path(self.SDK_SESSION_ID)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"{complete}\n{incomplete}")
+
+        await runtime._emit_new_session_lines()
+        # Only the complete line should be emitted
+        assert mock_socket_writer.send_session_line.await_count == 1
+        mock_socket_writer.send_session_line.reset_mock()
+
+        # Now "complete" the write by finishing the line
+        finished = _jsonl_line(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "ok"}]},
+            }
+        )
+        path.write_text(f"{complete}\n{finished}\n")
+
+        await runtime._emit_new_session_lines()
+        assert mock_socket_writer.send_session_line.await_count == 1
+        sent = mock_socket_writer.send_session_line.call_args_list[0].args[1]
+        assert sent == finished
+
+    @pytest.mark.anyio
+    async def test_stops_at_invalid_json(
+        self, runtime: ClaudeAgentRuntime, mock_socket_writer: MagicMock
+    ) -> None:
+        """Malformed JSON on a newline-terminated line stops processing."""
+        good = _jsonl_line({"type": "user", "message": {"content": "hi"}})
+        bad = "{not valid json"
+        after = _jsonl_line({"type": "user", "message": {"content": "bye"}})
+        path = runtime._get_session_file_path(self.SDK_SESSION_ID)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"{good}\n{bad}\n{after}\n")
+
+        await runtime._emit_new_session_lines()
+        # Only the line before the bad one is emitted
+        assert mock_socket_writer.send_session_line.await_count == 1
+
+    # -- internal classification --
+
+    @pytest.mark.anyio
+    async def test_marks_internal_lines(
+        self, runtime: ClaudeAgentRuntime, mock_socket_writer: MagicMock
+    ) -> None:
+        """System messages and queue-operation lines are marked internal."""
+        system_line = _jsonl_line({"type": "system", "message": {"content": "init"}})
+        user_line = _jsonl_line({"type": "user", "message": {"content": "hi"}})
+        _make_session_file(runtime, self.SDK_SESSION_ID, [system_line, user_line])
+
+        await runtime._emit_new_session_lines()
+
+        calls = mock_socket_writer.send_session_line.call_args_list
+        assert len(calls) == 2
+        # System line → internal=True
+        assert calls[0] == call(self.SDK_SESSION_ID, system_line, internal=True)
+        # User line → internal=False
+        assert calls[1] == call(self.SDK_SESSION_ID, user_line, internal=False)
+
+    # -- continuation flag --
+
+    @pytest.mark.anyio
+    async def test_continuation_marks_first_user_message_internal(
+        self, runtime: ClaudeAgentRuntime, mock_socket_writer: MagicMock
+    ) -> None:
+        """When _is_continuation is set, the first user message is internal."""
+        runtime._is_continuation = True
+        user1 = _jsonl_line({"type": "user", "message": {"content": "continuation"}})
+        user2 = _jsonl_line({"type": "user", "message": {"content": "real"}})
+        _make_session_file(runtime, self.SDK_SESSION_ID, [user1, user2])
+
+        await runtime._emit_new_session_lines()
+
+        calls = mock_socket_writer.send_session_line.call_args_list
+        assert len(calls) == 2
+        # First user message marked internal
+        assert calls[0] == call(self.SDK_SESSION_ID, user1, internal=True)
+        # Second user message is visible
+        assert calls[1] == call(self.SDK_SESSION_ID, user2, internal=False)
+        # Flag consumed
+        assert runtime._is_continuation is False
+
+    # -- byte offset correctness --
+
+    @pytest.mark.anyio
+    async def test_byte_offset_tracks_exact_bytes(
+        self, runtime: ClaudeAgentRuntime, mock_socket_writer: MagicMock
+    ) -> None:
+        """Byte offset matches the exact bytes consumed (including newlines)."""
+        line = _jsonl_line({"type": "user", "message": {"content": "test"}})
+        _make_session_file(runtime, self.SDK_SESSION_ID, [line])
+
+        await runtime._emit_new_session_lines()
+
+        expected_offset = len(line.encode("utf-8")) + 1  # +1 for \n
+        assert runtime._last_seen_byte_offset == expected_offset
+
+    @pytest.mark.anyio
+    async def test_byte_offset_with_multibyte_utf8(
+        self, runtime: ClaudeAgentRuntime, mock_socket_writer: MagicMock
+    ) -> None:
+        """Byte offset is correct for content with multibyte UTF-8 characters."""
+        line = _jsonl_line({"type": "user", "message": {"content": "hello 🔥 world"}})
+        _make_session_file(runtime, self.SDK_SESSION_ID, [line])
+
+        await runtime._emit_new_session_lines()
+
+        expected_offset = len(line.encode("utf-8")) + 1
+        assert runtime._last_seen_byte_offset == expected_offset
+        mock_socket_writer.send_session_line.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_preseeded_offset_skips_existing_lines(
+        self, runtime: ClaudeAgentRuntime, mock_socket_writer: MagicMock
+    ) -> None:
+        """Pre-seeding _last_seen_byte_offset skips already-persisted data."""
+        old_line = _jsonl_line({"type": "user", "message": {"content": "old"}})
+        new_line = _jsonl_line(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "new"}]},
+            }
+        )
+        path = runtime._get_session_file_path(self.SDK_SESSION_ID)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"{old_line}\n{new_line}\n")
+
+        # Pre-seed offset past the old line
+        runtime._last_seen_byte_offset = len(old_line.encode("utf-8")) + 1
+
+        await runtime._emit_new_session_lines()
+
+        assert mock_socket_writer.send_session_line.await_count == 1
+        sent = mock_socket_writer.send_session_line.call_args_list[0].args[1]
+        assert sent == new_line

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -137,7 +137,7 @@ class ClaudeAgentRuntime:
         self._was_interrupted: bool = False
         # For incremental JSONL line tracking
         self._sdk_session_id: str | None = None
-        self._last_seen_line_index: int = 0
+        self._last_seen_byte_offset: int = 0
         # Flag to mark continuation prompt as internal (consumed after first use)
         self._is_continuation: bool = False
         # Adapter for converting Claude SDK events - must be reused to track state
@@ -304,13 +304,11 @@ class ClaudeAgentRuntime:
     async def _emit_new_session_lines(self) -> None:
         """Read and emit new JSONL lines from the SDK session file.
 
-        This reads the session file written by Claude SDK and emits any new lines
-        (past _last_seen_line_index) to the orchestrator for persistence.
-        The lines contain the full JSONL envelope (uuid, timestamp, parentUuid, etc.)
-        needed for proper resume.
+        Uses a byte offset to seek directly to unread data, making each call
+        O(new bytes) instead of O(total file size).
 
         If a line fails to parse (e.g., incomplete write by SDK), we stop processing
-        at that point and keep the index there. The incomplete line will be retried
+        at that point and keep the offset there. The incomplete line will be retried
         on the next call once the SDK finishes writing it.
 
         Race condition handling: If called before _sdk_session_id is set (i.e., before
@@ -321,29 +319,53 @@ class ClaudeAgentRuntime:
             return
 
         session_file = self._get_session_file_path(self._sdk_session_id)
-        if not session_file.exists():
+
+        try:
+            file_size = session_file.stat().st_size
+        except FileNotFoundError:
+            return
+
+        if file_size <= self._last_seen_byte_offset:
             return
 
         try:
-            file_content = await asyncio.to_thread(session_file.read_text)
-            lines = file_content.splitlines()
-            new_lines = lines[self._last_seen_line_index :]
 
-            for line in new_lines:
-                if not line.strip():
-                    # Empty line - advance index and continue
-                    self._last_seen_line_index += 1
+            def _read_tail() -> bytes:
+                with open(session_file, "rb") as f:
+                    f.seek(self._last_seen_byte_offset)
+                    return f.read()
+
+            tail_bytes = await asyncio.to_thread(_read_tail)
+            if not tail_bytes:
+                return
+
+            # Walk complete newline-terminated lines in the tail
+            pos = 0
+            while pos < len(tail_bytes):
+                newline_idx = tail_bytes.find(b"\n", pos)
+                if newline_idx == -1:
+                    # No newline found — incomplete line, stop and retry next call
+                    logger.debug(
+                        "Stopping at incomplete session line, will retry",
+                        byte_offset=self._last_seen_byte_offset + pos,
+                    )
+                    break
+
+                line_bytes = tail_bytes[pos:newline_idx]
+                line_end = newline_idx + 1  # past the \n
+
+                if not line_bytes.strip():
+                    pos = line_end
                     continue
 
                 # Parse to determine visibility, but send raw line for SDK resume
                 try:
-                    line_data = orjson.loads(line)
+                    line_data = orjson.loads(line_bytes)
                 except orjson.JSONDecodeError:
-                    # Stop at the first decode failure - this line may be incomplete
-                    # because the SDK is still writing it. We'll retry on the next pass.
+                    # Incomplete JSON — stop here, will retry next call
                     logger.debug(
-                        "Stopping at incomplete session line, will retry",
-                        line_index=self._last_seen_line_index,
+                        "Stopping at unparseable session line, will retry",
+                        byte_offset=self._last_seen_byte_offset + pos,
                     )
                     break
 
@@ -355,11 +377,15 @@ class ClaudeAgentRuntime:
                     self._is_continuation = False
 
                 await self._socket_writer.send_session_line(
-                    self._sdk_session_id, line, internal=internal
+                    self._sdk_session_id,
+                    line_bytes.decode("utf-8"),
+                    internal=internal,
                 )
 
-                # Only advance the index after successfully processing the line
-                self._last_seen_line_index += 1
+                pos = line_end
+
+            # Advance offset by the bytes we fully consumed
+            self._last_seen_byte_offset += pos
 
         except Exception as e:
             logger.warning("Failed to read session file", error=str(e))
@@ -506,15 +532,17 @@ class ClaudeAgentRuntime:
             resume_session_id = payload.sdk_session_id
             # If forking, tell the SDK to create a new session from the parent's history
             fork_session = payload.is_fork
-            # For a normal resume (non-fork), seed line tracking *before* we send the
-            # new query. The CLI can append new JSONL lines for this turn before the
-            # first StreamEvent arrives; if we only set `_last_seen_line_index` after
-            # the first StreamEvent, we can permanently skip those lines and corrupt
-            # persisted history (leading to flaky resume crashes).
+            # For a normal resume (non-fork), seed byte tracking *before* we send
+            # the new query. The CLI can append new JSONL lines for this turn
+            # before the first StreamEvent arrives; if we only set the offset
+            # after the first StreamEvent, we can permanently skip those lines
+            # and corrupt persisted history (leading to flaky resume crashes).
             if not fork_session:
                 self._sdk_session_id = resume_session_id
-                # Count lines from the session data we just wrote to disk (avoid I/O).
-                self._last_seen_line_index = len(payload.sdk_session_data.splitlines())
+                # Byte length of the data we just wrote to disk (avoids extra I/O).
+                self._last_seen_byte_offset = len(
+                    payload.sdk_session_data.encode("utf-8")
+                )
 
         try:
             # Build MCP servers config for registry actions and stdio servers
@@ -657,8 +685,8 @@ class ClaudeAgentRuntime:
                                 previous = self._sdk_session_id
                                 self._sdk_session_id = message.session_id
                                 # If the CLI started a different session (e.g. fork), avoid
-                                # re-persisting old history by jumping to current file length.
-                                # For normal resumes we pre-seed `_last_seen_line_index` above.
+                                # re-persisting old history by jumping to current file size.
+                                # For normal resumes we pre-seed the byte offset above.
                                 if (
                                     previous is None
                                     and resume_session_id
@@ -667,13 +695,12 @@ class ClaudeAgentRuntime:
                                     session_file = self._get_session_file_path(
                                         self._sdk_session_id
                                     )
-                                    if session_file.exists():
-                                        file_content = await asyncio.to_thread(
-                                            session_file.read_text
+                                    try:
+                                        self._last_seen_byte_offset = (
+                                            session_file.stat().st_size
                                         )
-                                        self._last_seen_line_index = len(
-                                            file_content.splitlines()
-                                        )
+                                    except FileNotFoundError:
+                                        pass
                                 logger.debug(
                                     "Captured SDK session ID",
                                     sdk_session_id=self._sdk_session_id,


### PR DESCRIPTION
## Summary
- Replace O(total file) `read_text` + `splitlines` with O(new bytes) `seek` + `read` in `_emit_new_session_lines` by tracking `_last_seen_byte_offset` instead of `_last_seen_line_index`
- Defer `decode("utf-8")` to only when the line is non-empty, valid JSON, and about to be sent
- Add 13 unit tests covering basic emission, incremental reads, no-op cases, incomplete writes, internal classification, continuation flag, and byte offset correctness (including multibyte UTF-8)

## Test plan
- [x] All 25 tests in `test_agent_runtime.py` pass (12 existing + 13 new)
- [ ] Verify agent session resume works end-to-end with approval flow
- [ ] Verify session history is correctly persisted for multi-turn agent conversations


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch session line emission to a byte-offset reader so we only read new bytes, not the whole file. This cuts I/O on large sessions and keeps offsets accurate across resumes and forks.

- **Refactors**
  - Track `\_last_seen_byte_offset` instead of `\_last_seen_line_index`.
  - Seek to the offset and read newline-terminated chunks; stop on incomplete or invalid JSON and retry next call.
  - Defer UTF-8 decode until a line is emitted; send raw text of the JSONL line.
  - Pre-seed the offset on resume from `payload.sdk_session_data`; on CLI session switch, jump to current file size to avoid duplicating history.
  - Add 13 tests for emission, incremental reads, no-ops, incomplete writes, invalid JSON, internal classification, continuation, and multibyte UTF-8 byte-accurate offsets.

<sup>Written for commit b32a1d9e1b1a6b7077b2131775c0dad0b50a75da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

