### PR TITLE
[codex] fix(agents): render structured tool response sources

### DIFF
--- a/frontend/src/components/ai-elements/tool.tsx
+++ b/frontend/src/components/ai-elements/tool.tsx
@@ -31,6 +31,8 @@ import {
 } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
 import { CodeBlock, CodeBlockCopyButton } from "./code-block"
+import { Response } from "./response"
+import { Source, Sources, SourcesContent, SourcesTrigger } from "./sources"
 
 const MAX_INLINE_PAYLOAD_CHARS = 12_000
 
@@ -163,6 +165,18 @@ type SerializedPayload = {
   extension: "json" | "txt"
 }
 
+type RichToolSource = {
+  title?: string
+  url: string
+}
+
+type RichToolPayload = {
+  response: {
+    text: string
+  }
+  sources: RichToolSource[]
+}
+
 /**
  * Normalize MCP content arrays to the actual payload text when possible.
  * Example: [{ type: "text", text: "[]" }] -> []
@@ -269,6 +283,117 @@ function serializeToolPayload(payload: unknown): SerializedPayload {
   }
 
   return { text: String(payload), extension: "txt" }
+}
+
+function maybeParseJsonPayload(payload: unknown): unknown {
+  if (typeof payload !== "string") {
+    return payload
+  }
+
+  const trimmed = payload.trim()
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    return payload
+  }
+
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return payload
+  }
+}
+
+function extractRichToolPayload(payload: unknown): RichToolPayload | null {
+  const normalizedPayload = maybeParseJsonPayload(
+    extractMcpTextContent(payload)
+  )
+  if (
+    !normalizedPayload ||
+    typeof normalizedPayload !== "object" ||
+    Array.isArray(normalizedPayload) ||
+    isValidElement(normalizedPayload)
+  ) {
+    return null
+  }
+
+  const payloadRecord = normalizedPayload as Record<string, unknown>
+  const topLevelKeys = Object.keys(payloadRecord)
+  if (
+    topLevelKeys.length === 0 ||
+    topLevelKeys.some((key) => key !== "response" && key !== "sources") ||
+    !("response" in payloadRecord)
+  ) {
+    return null
+  }
+
+  const { response, sources } = payloadRecord
+  if (
+    !response ||
+    typeof response !== "object" ||
+    Array.isArray(response) ||
+    isValidElement(response)
+  ) {
+    return null
+  }
+
+  const responseRecord = response as Record<string, unknown>
+  const responseKeys = Object.keys(responseRecord)
+  if (
+    responseKeys.length !== 1 ||
+    responseKeys[0] !== "text" ||
+    typeof responseRecord.text !== "string"
+  ) {
+    return null
+  }
+  const responseText = responseRecord.text
+
+  if (sources === undefined) {
+    return {
+      response: { text: responseText },
+      sources: [],
+    }
+  }
+
+  if (!Array.isArray(sources)) {
+    return null
+  }
+
+  const parsedSources: RichToolSource[] = []
+  for (const source of sources) {
+    if (
+      !source ||
+      typeof source !== "object" ||
+      Array.isArray(source) ||
+      isValidElement(source)
+    ) {
+      return null
+    }
+
+    const sourceRecord = source as Record<string, unknown>
+    const sourceKeys = Object.keys(sourceRecord)
+    if (
+      sourceKeys.length === 0 ||
+      sourceKeys.some((key) => key !== "title" && key !== "url") ||
+      typeof sourceRecord.url !== "string" ||
+      ("title" in sourceRecord &&
+        sourceRecord.title !== undefined &&
+        typeof sourceRecord.title !== "string")
+    ) {
+      return null
+    }
+    const sourceUrl = sourceRecord.url
+    const sourceTitle =
+      typeof sourceRecord.title === "string" ? sourceRecord.title : undefined
+
+    parsedSources.push({
+      title: sourceTitle,
+      url: sourceUrl,
+    })
+  }
+
+  return {
+    response: { text: responseText },
+    sources: parsedSources,
+  }
 }
 
 function formatBytes(bytes: number): string {
@@ -389,6 +514,7 @@ export const ToolOutput = ({
   ...props
 }: ToolOutputProps) => {
   const hasOutput = output !== undefined && output !== null
+  const richOutput = hasOutput ? extractRichToolPayload(output) : null
   if (!hasOutput && !errorText) {
     return null
   }
@@ -407,6 +533,24 @@ export const ToolOutput = ({
         (isValidElement(output) ? (
           <div className="rounded-md bg-muted/50 p-1.5 text-[11px] text-foreground">
             {output}
+          </div>
+        ) : richOutput ? (
+          <div className="space-y-3 text-sm">
+            <Response>{richOutput.response.text}</Response>
+            {richOutput.sources.length > 0 && (
+              <Sources>
+                <SourcesTrigger count={richOutput.sources.length} />
+                <SourcesContent>
+                  {richOutput.sources.map((source) => (
+                    <Source
+                      key={source.url}
+                      href={source.url}
+                      title={source.title ?? source.url}
+                    />
+                  ))}
+                </SourcesContent>
+              </Sources>
+            )}
           </div>
         ) : (
           <ToolPayload payload={output} downloadName="tool-result" />

--- a/frontend/tests/tool.test.tsx
+++ b/frontend/tests/tool.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 
 jest.mock("@/components/ai-elements/code-block", () => ({
   CodeBlock: ({
@@ -16,7 +16,7 @@ jest.mock("@/components/ai-elements/code-block", () => ({
   CodeBlockCopyButton: () => null,
 }))
 
-import { ToolInput } from "@/components/ai-elements/tool"
+import { ToolInput, ToolOutput } from "@/components/ai-elements/tool"
 
 describe("Tool payload downloads", () => {
   beforeEach(() => {
@@ -31,6 +31,34 @@ describe("Tool payload downloads", () => {
       expect(
         screen.getByRole("link", { name: /download file/i })
       ).toHaveAttribute("download", "tool-parameters.json")
+    })
+  })
+
+  it("renders structured text and sources instead of raw JSON", async () => {
+    render(
+      <ToolOutput
+        output={{
+          response: { text: "Washington, DC: ⛅ +2°C" },
+          sources: [
+            {
+              title: "wttr.in Washington, DC weather",
+              url: "https://wttr.in/washington,dc?format=3",
+            },
+          ],
+        }}
+        errorText={undefined}
+      />
+    )
+
+    expect(screen.getByText("Washington, DC: ⛅ +2°C")).toBeInTheDocument()
+    expect(screen.queryByTestId("mock-code-block")).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: /used 1 sources/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /wttr\.in washington, dc weather/i })
+      ).toHaveAttribute("href", "https://wttr.in/washington,dc?format=3")
     })
   })
 })


### PR DESCRIPTION
## Summary
- render tool outputs shaped like `{ response: { text }, sources }` as rich text plus source links instead of raw JSON
- keep the existing generic tool payload renderer as the fallback for every other payload shape
- add a focused frontend test that covers the weather-style payload and asserts the raw JSON code block is not shown

## Why
Tool outputs from the weather path currently arrive as a structured object:

```json
{"response":{"text":"Washington, DC: ⛅ +2°C"},"sources":[{"title":"wttr.in Washington, DC weather","url":"https://wttr.in/washington,dc?format=3"}]}
```

The chat UI only renders rich citations for assistant `source-url` parts, so this tool payload was falling back to the generic JSON renderer. That produced a split display: plain assistant text plus a raw JSON blob in the tool result.

This change teaches `ToolOutput` to recognize that strict payload shape and render it as the result text with collapsible source links, while leaving all other tool payloads on the existing JSON/code-block path.

## Impact
Users now see weather-style tool responses as readable text with linked sources instead of a serialized JSON object.

## Validation
- `pnpm -C frontend test -- --runInBand frontend/tests/tool.test.tsx`
- `pnpm -C frontend check`
- `pnpm -C frontend typecheck`
- `uv run ruff check .`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render structured tool outputs shaped `{ response: { text }, sources }` as rich text with collapsible source links instead of a raw JSON block. Keep the JSON/code-block renderer as the fallback for other payloads, and add a focused frontend test to assert the new behavior.

<sup>Written for commit 6066e83f423e19ac6ab20301d4a8b2a19f182b89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

