### PR TITLE
fix(agents): clamp max tokens >= 1

### DIFF
--- a/tracecat/agent/llm_proxy/provider_anthropic.py
+++ b/tracecat/agent/llm_proxy/provider_anthropic.py
@@ -24,6 +24,7 @@ from tracecat.agent.llm_proxy.anthropic_compat import (
     truncate_tool_name,
 )
 from tracecat.agent.llm_proxy.requests import (
+    clamp_max_tokens,
     filter_allowed_model_settings,
     messages_request_to_anthropic_payload,
     messages_request_to_openai_payload,
@@ -205,6 +206,7 @@ class AnthropicAdapter:
             outbound_payload.update(allowed)
         outbound_payload["stream"] = True
         outbound_payload["model"] = model
+        clamp_max_tokens(outbound_payload)
 
         async with client.stream(
             "POST",

--- a/tracecat/agent/llm_proxy/requests.py
+++ b/tracecat/agent/llm_proxy/requests.py
@@ -74,6 +74,24 @@ def _allowed_model_setting_keys(provider: str | None) -> set[str]:
     return keys
 
 
+_TOKEN_LIMIT_KEYS = {"max_tokens", "max_completion_tokens"}
+
+
+def clamp_max_tokens(payload: dict[str, Any]) -> None:
+    """Clamp max_tokens / max_completion_tokens to at least 1 in-place.
+
+    The Claude Code CLI computes ``max_tokens = context_window - prompt_tokens``
+    before sending the request.  When the conversation context exceeds the
+    window the SDK may send a negative value which upstream providers reject.
+    Clamping to 1 lets the provider return a normal "context too long" error
+    instead of a confusing "max_tokens must be at least 1" 400.
+    """
+    for key in _TOKEN_LIMIT_KEYS:
+        if (val := payload.get(key)) is not None and isinstance(val, (int, float)):
+            if val < 1:
+                payload[key] = 1
+
+
 def filter_allowed_model_settings(
     model_settings: dict[str, Any],
     *,
@@ -81,7 +99,11 @@ def filter_allowed_model_settings(
 ) -> dict[str, Any]:
     """Keep only model settings supported by the selected provider family."""
     allowed_keys = _allowed_model_setting_keys(provider)
-    return {key: value for key, value in model_settings.items() if key in allowed_keys}
+    filtered = {
+        key: value for key, value in model_settings.items() if key in allowed_keys
+    }
+    clamp_max_tokens(filtered)
+    return filtered
 
 
 def _safe_dict(value: Any) -> dict[str, Any]:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clamp `max_tokens` and `max_completion_tokens` to at least 1 in outgoing LLM requests to avoid provider 400s and surface a clear "context too long" error when prompts exceed the window. Applied during model settings filtering and Anthropic stream passthrough.

- **Bug Fixes**
  - Added `clamp_max_tokens(payload)` to sanitize token limits in-place.
  - Call clamp during `filter_allowed_model_settings` and in Anthropic `passthrough_stream`.
  - Handles negative values from clients (e.g., Claude Code CLI) by setting a minimum of 1.

<sup>Written for commit 84300564f0f467f1cf84dcc16a33948c9e675635. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

