### PR TITLE
fix(agents): drop parallel_tool_calls param for custom model providers

### DIFF
--- a/tracecat/agent/llm_proxy/provider_openai.py
+++ b/tracecat/agent/llm_proxy/provider_openai.py
@@ -146,6 +146,11 @@ def _normalize_openai_unsupported_params(
 def _normalize_custom_model_provider_payload(payload: dict[str, Any]) -> None:
     if "max_completion_tokens" in payload and "max_tokens" not in payload:
         payload["max_tokens"] = payload.pop("max_completion_tokens")
+    # parallel_tool_calls is not part of the OpenAI spec and causes LiteLLM to
+    # generate a malformed tool_choice when routing to Bedrock (missing the
+    # required `type` field).  Drop it for custom providers since we cannot
+    # control how the downstream proxy translates it.
+    payload.pop("parallel_tool_calls", None)
 
 
 def _normalize_openai_payload(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove `parallel_tool_calls` from custom model provider payloads to stop malformed `tool_choice` generation by `LiteLLM` when routing to `Bedrock`. This aligns with the OpenAI spec and prevents tool-calling errors for non-OpenAI providers.

- **Bug Fixes**
  - Drop `parallel_tool_calls` during custom provider normalization, fixing missing `type` in downstream `tool_choice`. OpenAI model payloads are unchanged.

<sup>Written for commit a4f2fe32539758ea1fba67e5403e06a6e0c28d9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

