### PR TITLE
fix(agents): strip internal proxy metadata from tool args

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/service.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/service.py
@@ -23,6 +23,7 @@ from temporalio.client import WorkflowExecution, WorkflowExecutionStatus, Workfl
 
 from tracecat.agent.aliases import build_agent_alias
 from tracecat.agent.approvals.enums import ApprovalStatus
+from tracecat.agent.mcp.metadata import strip_proxy_tool_metadata
 from tracecat.agent.schemas import AgentOutput
 from tracecat.auth.types import Role
 from tracecat.common import all_activities
@@ -719,10 +720,14 @@ class ApprovalManager:
                 approval_args: dict[str, Any] | None = None
                 if payload.args is not None:
                     if isinstance(payload.args, dict):
-                        approval_args = payload.args
+                        approval_args = strip_proxy_tool_metadata(payload.args)
                     elif isinstance(payload.args, str):
                         try:
-                            approval_args = json.loads(payload.args)
+                            loaded_args = json.loads(payload.args)
+                            if isinstance(loaded_args, dict):
+                                approval_args = strip_proxy_tool_metadata(loaded_args)
+                            else:
+                                approval_args = {"raw_args": payload.args}
                         except (json.JSONDecodeError, ValueError):
                             # Store as-is if not valid JSON
                             approval_args = {"raw_args": payload.args}

--- a/packages/tracecat-ee/tracecat_ee/watchtower/service.py
+++ b/packages/tracecat-ee/tracecat_ee/watchtower/service.py
@@ -13,6 +13,7 @@ from sqlalchemy import and_, case, delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
+from tracecat.agent.mcp.metadata import strip_proxy_tool_metadata
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.models import (
     OrganizationMembership,
@@ -1146,20 +1147,21 @@ def redact_tool_call_args(
     arguments: Mapping[str, Any] | None,
 ) -> dict[str, object]:
     """Create a structural argument summary without persisting raw values."""
-    if not arguments:
+    sanitized_arguments = strip_proxy_tool_metadata(arguments)
+    if not sanitized_arguments:
         return {"arg_count": 0, "keys": [], "args": {}}
 
     truncated = False
     entries: list[tuple[str, Any]] = []
-    for key, value in arguments.items():
+    for key, value in sanitized_arguments.items():
         entries.append((str(key), value))
         if len(entries) >= WATCHTOWER_MAX_REDACTED_ITEMS:
-            truncated = len(arguments) > WATCHTOWER_MAX_REDACTED_ITEMS
+            truncated = len(sanitized_arguments) > WATCHTOWER_MAX_REDACTED_ITEMS
             break
 
     redacted: dict[str, object] = {key: _redact_value(value) for key, value in entries}
     return {
-        "arg_count": len(arguments),
+        "arg_count": len(sanitized_arguments),
         "keys": [key for key, _ in entries],
         "truncated": truncated,
         "args": redacted,

--- a/tests/unit/test_agent_mcp_metadata.py
+++ b/tests/unit/test_agent_mcp_metadata.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from tracecat.agent.mcp.metadata import (
+    PROXY_TOOL_CALL_ID_KEY,
+    PROXY_TOOL_METADATA_KEY,
+    sanitize_message_tool_inputs,
+    strip_proxy_tool_metadata,
+)
+
+
+def test_strip_proxy_tool_metadata_removes_internal_key() -> None:
+    assert strip_proxy_tool_metadata(
+        {
+            "url": "https://example.com",
+            PROXY_TOOL_METADATA_KEY: {
+                PROXY_TOOL_CALL_ID_KEY: "toolu_123",
+            },
+        }
+    ) == {"url": "https://example.com"}
+
+
+def test_sanitize_message_tool_inputs_strips_claude_tool_use_metadata() -> None:
+    message = {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_123",
+                "name": "mcp__tracecat-registry__core__http_request",
+                "input": {
+                    "url": "https://example.com",
+                    PROXY_TOOL_METADATA_KEY: {
+                        PROXY_TOOL_CALL_ID_KEY: "toolu_123",
+                    },
+                },
+            }
+        ],
+    }
+
+    sanitized = sanitize_message_tool_inputs(message)
+
+    assert sanitized["content"][0]["input"] == {"url": "https://example.com"}
+    assert message["content"][0]["input"][PROXY_TOOL_METADATA_KEY] == {
+        PROXY_TOOL_CALL_ID_KEY: "toolu_123"
+    }
+
+
+def test_sanitize_message_tool_inputs_strips_pydantic_tool_call_metadata() -> None:
+    message = {
+        "kind": "response",
+        "parts": [
+            {
+                "part_kind": "tool-call",
+                "tool_name": "core.http_request",
+                "tool_call_id": "call_123",
+                "args": {
+                    "url": "https://example.com",
+                    PROXY_TOOL_METADATA_KEY: {
+                        PROXY_TOOL_CALL_ID_KEY: "call_123",
+                    },
+                },
+            }
+        ],
+    }
+
+    sanitized = sanitize_message_tool_inputs(message)
+
+    assert sanitized["parts"][0]["args"] == {"url": "https://example.com"}
+    assert message["parts"][0]["args"][PROXY_TOOL_METADATA_KEY] == {
+        PROXY_TOOL_CALL_ID_KEY: "call_123"
+    }

--- a/tests/unit/test_approvals_manager.py
+++ b/tests/unit/test_approvals_manager.py
@@ -406,6 +406,40 @@ class TestRecordApprovalRequestsActivity:
             assert approval is not None
             assert approval.tool_call_args == {"json": "string"}
 
+    async def test_record_approvals_strips_internal_proxy_metadata(
+        self,
+        session: AsyncSession,
+        svc_role: Role,
+        mock_agent_session: AgentSession,
+    ) -> None:
+        """Test recording approval args removes Tracecat-internal metadata."""
+        approvals = [
+            ToolApprovalPayload(
+                tool_call_id="call_123",
+                tool_name="test_tool",
+                args={
+                    "url": "https://example.com",
+                    "__tracecat": {"tool_call_id": "call_123"},
+                },
+            ),
+        ]
+
+        input_data = PersistApprovalsActivityInputs(
+            role=svc_role,
+            session_id=mock_agent_session.id,
+            approvals=approvals,
+        )
+
+        await ApprovalManager.record_approval_requests(input_data)
+
+        async with ApprovalService.with_session(role=svc_role) as service:
+            approval = await service.get_approval_by_session_and_tool(
+                session_id=mock_agent_session.id,
+                tool_call_id="call_123",
+            )
+            assert approval is not None
+            assert approval.tool_call_args == {"url": "https://example.com"}
+
 
 @pytest.mark.anyio
 class TestApplyApprovalDecisionsActivity:

--- a/tests/unit/test_watchtower_service.py
+++ b/tests/unit/test_watchtower_service.py
@@ -130,6 +130,21 @@ def test_redact_tool_call_args_summarizes_nested_objects() -> None:
     assert filters_meta["keys"] == ["status", "limit"]
 
 
+def test_redact_tool_call_args_ignores_internal_proxy_metadata() -> None:
+    result = redact_tool_call_args(
+        {
+            "query": "find me",
+            "__tracecat": {"tool_call_id": "toolu_123"},
+        }
+    )
+
+    assert result["arg_count"] == 1
+    assert result["keys"] == ["query"]
+    args = result["args"]
+    assert isinstance(args, dict)
+    assert "__tracecat" not in args
+
+
 def test_sanitize_error_redacted_truncates_long_values() -> None:
     long_message = "x" * 2100
     sanitized = _sanitize_error_redacted(long_message)

--- a/tracecat/agent/adapter/vercel.py
+++ b/tracecat/agent/adapter/vercel.py
@@ -60,6 +60,7 @@ from pydantic_ai.messages import (
 from pydantic_core import to_json
 
 from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
+from tracecat.agent.mcp.metadata import strip_proxy_tool_metadata
 from tracecat.agent.mcp.utils import normalize_mcp_tool_name
 from tracecat.agent.stream.events import (
     StreamDelta,
@@ -671,6 +672,10 @@ class ToolInputAvailableEventPayload:
     toolName: str
     input: Any
 
+    def __post_init__(self) -> None:
+        if isinstance(self.input, dict):
+            self.input = strip_proxy_tool_metadata(self.input)
+
 
 @dataclasses.dataclass(slots=True, kw_only=True)
 class ToolOutputAvailableEventPayload:
@@ -908,7 +913,7 @@ class VercelStreamContext:
                 tool_call = ToolCallPart(
                     tool_name=tool_name,
                     tool_call_id=tool_call_id,
-                    args=event.tool_input or {},
+                    args=strip_proxy_tool_metadata(event.tool_input or {}),
                 )
                 state = self._create_part_state(
                     event.part_id or 0, "tool", tool_call=tool_call
@@ -935,13 +940,11 @@ class VercelStreamContext:
                         tool_call_id = state.tool_call.tool_call_id
                         if not self.tool_input_emitted.get(tool_call_id, False):
                             # Emit final tool input
-                            tool_input = (
-                                event.tool_input or state.tool_call.args_as_dict()
-                            )
                             yield ToolInputAvailableEventPayload(
                                 toolCallId=tool_call_id,
                                 toolName=event.tool_name or state.tool_call.tool_name,
-                                input=tool_input,
+                                input=event.tool_input
+                                or state.tool_call.args_as_dict(),
                             )
                             self.tool_input_emitted[tool_call_id] = True
                     for message in self._finalize_part(event.part_id):
@@ -961,11 +964,10 @@ class VercelStreamContext:
                     tool_name = self.approval_tool_name.get(
                         tool_call_id, event.tool_name or "tool"
                     )
-                    input_payload: Any = self.approval_input.get(tool_call_id, {})
                     yield ToolInputAvailableEventPayload(
                         toolCallId=tool_call_id,
                         toolName=str(tool_name),
-                        input=input_payload,
+                        input=self.approval_input.get(tool_call_id, {}),
                     )
                     self.tool_input_emitted[tool_call_id] = True
 
@@ -1216,6 +1218,10 @@ class MutableToolPart:
     output: Any | None = None
     error_text: str | None = None
 
+    def __post_init__(self) -> None:
+        if isinstance(self.input, dict):
+            self.input = strip_proxy_tool_metadata(self.input)
+
     def set_result(
         self,
         content: Any,
@@ -1334,7 +1340,7 @@ def _extract_approval_payload_from_message(
                             ToolCallPart(
                                 tool_name=part.tool_name,
                                 tool_call_id=part.tool_call_id,
-                                args=part.args_as_dict(),
+                                args=strip_proxy_tool_metadata(part.args_as_dict()),
                             )
                         )
                 return approvals if approvals else None
@@ -1360,7 +1366,7 @@ def _extract_approval_payload_from_message(
                     ToolCallPart(
                         tool_name=block.name,
                         tool_call_id=block.id,
-                        args=block.input or {},
+                        args=strip_proxy_tool_metadata(block.input or {}),
                     )
                 )
         return approvals if approvals else None

--- a/tracecat/agent/mcp/metadata.py
+++ b/tracecat/agent/mcp/metadata.py
@@ -1,0 +1,93 @@
+"""Helpers for Tracecat-internal proxy tool metadata."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from typing import Any
+
+from tracecat.logger import logger
+
+PROXY_TOOL_METADATA_KEY = "__tracecat"
+PROXY_TOOL_CALL_ID_KEY = "tool_call_id"
+
+
+def strip_proxy_tool_metadata(args: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return tool arguments without Tracecat-internal proxy metadata.
+
+    Args:
+        args: Tool arguments that may include Tracecat proxy metadata.
+
+    Returns:
+        A shallow-copied dict with the internal metadata removed.
+    """
+    if not args:
+        return {}
+
+    cleaned = dict(args)
+    cleaned.pop(PROXY_TOOL_METADATA_KEY, None)
+    return cleaned
+
+
+def extract_proxy_tool_call_id(args: dict[str, Any]) -> str | None:
+    """Pop internal Tracecat metadata from proxy tool args and return tool_call_id.
+
+    Args:
+        args: Mutable tool arguments sent through the registry proxy.
+
+    Returns:
+        The extracted tool call ID if present and well-formed, else ``None``.
+    """
+    raw_metadata = args.pop(PROXY_TOOL_METADATA_KEY, None)
+    if raw_metadata is None:
+        return None
+    if not isinstance(raw_metadata, dict):
+        logger.warning(
+            "Ignoring malformed proxy tool metadata",
+            metadata_type=type(raw_metadata).__name__,
+        )
+        return None
+
+    raw_tool_call_id = raw_metadata.get(PROXY_TOOL_CALL_ID_KEY)
+    if raw_tool_call_id is None:
+        return None
+    if not isinstance(raw_tool_call_id, str) or not raw_tool_call_id:
+        logger.warning(
+            "Ignoring malformed proxy tool call ID",
+            tool_call_id_type=type(raw_tool_call_id).__name__,
+        )
+        return None
+    return raw_tool_call_id
+
+
+def sanitize_message_tool_inputs(message: dict[str, Any]) -> dict[str, Any]:
+    """Remove proxy-only metadata from tool inputs in a persisted message payload.
+
+    Args:
+        message: Raw persisted message payload.
+
+    Returns:
+        A deep-copied message with internal proxy metadata stripped from any
+        tool-call input payloads.
+    """
+    sanitized = copy.deepcopy(message)
+
+    if isinstance(parts := sanitized.get("parts"), list):
+        for part in parts:
+            if (
+                isinstance(part, dict)
+                and part.get("part_kind") in {"tool-call", "builtin-tool-call"}
+                and isinstance(raw_args := part.get("args"), Mapping)
+            ):
+                part["args"] = strip_proxy_tool_metadata(raw_args)
+
+    if isinstance(content := sanitized.get("content"), list):
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and isinstance(raw_input := block.get("input"), Mapping)
+            ):
+                block["input"] = strip_proxy_tool_metadata(raw_input)
+
+    return sanitized

--- a/tracecat/agent/mcp/proxy_server.py
+++ b/tracecat/agent/mcp/proxy_server.py
@@ -21,13 +21,15 @@ from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
 
 from tracecat.agent.common.types import MCPToolDefinition
+from tracecat.agent.mcp.metadata import (
+    PROXY_TOOL_CALL_ID_KEY,
+    PROXY_TOOL_METADATA_KEY,
+    extract_proxy_tool_call_id,
+)
 from tracecat.agent.mcp.user_client import UserMCPClient
 from tracecat.agent.mcp.utils import action_name_to_mcp_tool_name
 from tracecat.agent.sandbox.config import TRUSTED_MCP_SOCKET_PATH
 from tracecat.logger import logger
-
-PROXY_TOOL_METADATA_KEY = "__tracecat"
-PROXY_TOOL_CALL_ID_KEY = "tool_call_id"
 
 
 class _UDSClientFactory:
@@ -109,30 +111,6 @@ def build_registry_proxy_tool_schema(
     schema.setdefault("type", "object")
     properties[PROXY_TOOL_METADATA_KEY] = _build_proxy_tool_metadata_schema()
     return schema
-
-
-def extract_proxy_tool_call_id(args: dict[str, Any]) -> str | None:
-    """Pop internal Tracecat metadata from proxy tool args and return tool_call_id."""
-    raw_metadata = args.pop(PROXY_TOOL_METADATA_KEY, None)
-    if raw_metadata is None:
-        return None
-    if not isinstance(raw_metadata, dict):
-        logger.warning(
-            "Ignoring malformed proxy tool metadata",
-            metadata_type=type(raw_metadata).__name__,
-        )
-        return None
-
-    raw_tool_call_id = raw_metadata.get(PROXY_TOOL_CALL_ID_KEY)
-    if raw_tool_call_id is None:
-        return None
-    if not isinstance(raw_tool_call_id, str) or not raw_tool_call_id:
-        logger.warning(
-            "Ignoring malformed proxy tool call ID",
-            tool_call_id_type=type(raw_tool_call_id).__name__,
-        )
-        return None
-    return raw_tool_call_id
 
 
 def _make_tool_handler(

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -25,6 +25,7 @@ from tracecat_registry._internal.exceptions import SecretNotFoundError
 import tracecat.agent.adapter.vercel
 from tracecat import config
 from tracecat.agent.approvals.enums import ApprovalStatus
+from tracecat.agent.mcp.metadata import sanitize_message_tool_inputs
 from tracecat.agent.preset.prompts import AgentPresetBuilderPrompt
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.schemas import RunAgentArgs
@@ -1523,13 +1524,16 @@ class AgentSessionService(BaseWorkspaceService):
             if not inner_message:
                 inner_message = content
 
+            # Strip internal proxy metadata before returning persisted tool inputs.
+            sanitized_message = sanitize_message_tool_inputs(inner_message)
+
             # Deserialize the content using Claude SDK TypeAdapter
-            message = ClaudeSDKMessageTA.validate_python(inner_message)
+            message = ClaudeSDKMessageTA.validate_python(sanitized_message)
             messages.append(ChatMessage(id=str(entry.id), message=message))
 
             # For assistant messages, check for tool calls needing approval bubbles
             if msg_type == "assistant":
-                tool_uses = self._extract_tool_uses_from_message(inner_message)
+                tool_uses = self._extract_tool_uses_from_message(sanitized_message)
                 for tool_use in tool_uses:
                     tool_use_id = tool_use.get("id")
                     if tool_use_id and (

--- a/tracecat/chat/schemas.py
+++ b/tracecat/chat/schemas.py
@@ -12,6 +12,7 @@ from pydantic_ai.tools import ToolApproved, ToolDenied
 from tracecat.agent.adapter import vercel
 from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.common.stream_types import HarnessType
+from tracecat.agent.mcp.metadata import sanitize_message_tool_inputs
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import ClaudeSDKMessageTA, ModelMessageTA, UnifiedMessage
 from tracecat.chat.enums import MessageKind
@@ -216,10 +217,11 @@ class ChatMessage(BaseModel):
     @classmethod
     def from_db(cls, db_msg: models.ChatMessage) -> ChatMessage:
         """Deserialize a database message into a typed ChatMessage."""
+        sanitized_data = sanitize_message_tool_inputs(db_msg.data)
         if db_msg.harness == HarnessType.CLAUDE_CODE.value:
-            message = ClaudeSDKMessageTA.validate_python(db_msg.data)
+            message = ClaudeSDKMessageTA.validate_python(sanitized_data)
         else:
-            message = ModelMessageTA.validate_python(db_msg.data)
+            message = ModelMessageTA.validate_python(sanitized_data)
         return cls(id=str(db_msg.id), message=message)
 
 


### PR DESCRIPTION
## Summary
- Extract proxy tool metadata helpers (`strip_proxy_tool_metadata`, `extract_proxy_tool_call_id`, `sanitize_message_tool_inputs`) into `tracecat/agent/mcp/metadata.py`
- Centralize `__tracecat` metadata stripping in `ToolInputAvailableEventPayload` and `MutableToolPart` via `__post_init__`, removing ~10 scattered strip calls in `vercel.py`
- Strip metadata in approvals persistence, watchtower redaction, session history, and chat deserialization

## Test plan
- [x] `test_agent_mcp_metadata.py` — unit tests for `strip_proxy_tool_metadata` and `sanitize_message_tool_inputs`
- [x] `test_approvals_manager.py` — verifies approval args strip internal metadata
- [x] `test_watchtower_service.py` — verifies redacted args exclude internal metadata


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops leaking Tracecat-internal proxy metadata by stripping `__tracecat` from tool args across UI events, persistence, and redaction. Centralizes the logic so tool inputs shown to users and saved to the DB no longer include internal IDs.

- **Bug Fixes**
  - Strip `__tracecat` from tool inputs at emission (`ToolInputAvailableEventPayload`, `MutableToolPart`).
  - Remove metadata in approvals storage, watchtower redaction, session history, and chat deserialization.
  - Redaction summaries now exclude internal metadata in counts and keys.

- **Refactors**
  - Added `tracecat/agent/mcp/metadata.py` with `strip_proxy_tool_metadata`, `extract_proxy_tool_call_id`, `sanitize_message_tool_inputs`.
  - Replaced scattered strip calls in `tracecat/agent/adapter/vercel.py` and `tracecat/agent/mcp/proxy_server.py` with centralized helpers.
  - Added unit tests for helpers, approvals, and watchtower paths.

<sup>Written for commit 855dc849c3f8e95175c0a8a6f56e0ce75a14a969. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

