### PR TITLE
fix(schedule): preserve workspace search attrs on update

### DIFF
--- a/tests/unit/test_schedule_update_search_attributes.py
+++ b/tests/unit/test_schedule_update_search_attributes.py
@@ -1,0 +1,90 @@
+"""Regression tests for schedule update search attributes."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+import temporalio.client
+from temporalio.common import TypedSearchAttributes
+
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.identifiers import ScheduleUUID
+from tracecat.workflow.executions.enums import (
+    ExecutionType,
+    TemporalSearchAttr,
+    TriggerType,
+)
+from tracecat.workflow.schedules import bridge
+from tracecat.workflow.schedules.schemas import ScheduleUpdate
+
+
+def _build_mock_schedule_input() -> MagicMock:
+    mock_input = MagicMock()
+    mock_schedule = MagicMock()
+    mock_spec = MagicMock()
+
+    mock_spec.cron_expressions = []
+    mock_spec.intervals = []
+    mock_schedule.spec = mock_spec
+    mock_schedule.action = MagicMock(spec=temporalio.client.ScheduleActionStartWorkflow)
+    mock_schedule.action.args = [MagicMock()]
+    mock_schedule.action.args[0].dsl = MagicMock()
+    mock_schedule.action.typed_search_attributes = None
+    mock_schedule.state = MagicMock()
+    mock_input.description.schedule = mock_schedule
+    return mock_input
+
+
+@pytest.mark.anyio
+async def test_update_schedule_preserves_workspace_search_attrs_when_decode_fails():
+    """Use the caller role when rebuilding search attributes after decode failure."""
+
+    schedule_id = ScheduleUUID.new_uuid4()
+    workspace_id = uuid.uuid4()
+    role = Role(
+        type="service",
+        workspace_id=workspace_id,
+        service_id="tracecat-service",
+        scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-service"],
+    )
+
+    captured_update = None
+
+    async def capture_update(update_func):
+        nonlocal captured_update
+        result = await update_func(_build_mock_schedule_input())
+        captured_update = result.schedule
+        return result
+
+    mock_handle = MagicMock()
+    mock_handle.update = capture_update
+
+    with (
+        patch(
+            "tracecat.workflow.schedules.bridge._get_handle", return_value=mock_handle
+        ),
+        patch(
+            "tracecat.workflow.executions.common.extract_first",
+            side_effect=RuntimeError("cannot decode existing schedule args"),
+        ),
+    ):
+        await bridge.update_schedule(
+            schedule_id, ScheduleUpdate(status="offline"), role=role
+        )
+
+    assert captured_update is not None
+    search_attrs = captured_update.action.typed_search_attributes
+    assert isinstance(search_attrs, TypedSearchAttributes)
+
+    pairs = cast(list[Any], search_attrs.search_attributes)
+    values = {pair.key.name: pair.value for pair in pairs}
+    assert values[TemporalSearchAttr.TRIGGER_TYPE.value] == TriggerType.SCHEDULED.value
+    assert (
+        values[TemporalSearchAttr.EXECUTION_TYPE.value] == ExecutionType.PUBLISHED.value
+    )
+    assert values[TemporalSearchAttr.WORKSPACE_ID.value] == str(workspace_id)
+    assert captured_update.state.paused is True

--- a/tests/unit/test_workflow_schedules_service.py
+++ b/tests/unit/test_workflow_schedules_service.py
@@ -84,9 +84,10 @@ async def test_update_schedule_updates_existing_schedule(
     _, schedule = await _create_workflow_with_schedule(session, svc_role.workspace_id)
     updated_temporal_schedule_ids = []
 
-    async def _update_schedule(schedule_id, params):
+    async def _update_schedule(schedule_id, params, *, role=None):
         updated_temporal_schedule_ids.append(schedule_id)
         assert params.status == "online"
+        assert role == svc_role
 
     monkeypatch.setattr(bridge, "update_schedule", _update_schedule)
 

--- a/tracecat/workflow/schedules/bridge.py
+++ b/tracecat/workflow/schedules/bridge.py
@@ -130,7 +130,12 @@ async def delete_schedule(schedule_id: AnyScheduleID) -> None:
     return None
 
 
-async def update_schedule(schedule_id: AnyScheduleID, params: ScheduleUpdate) -> None:
+async def update_schedule(
+    schedule_id: AnyScheduleID,
+    params: ScheduleUpdate,
+    *,
+    role: Role | None = None,
+) -> None:
     async def _update_schedule(
         input: temporalio.client.ScheduleUpdateInput,
     ) -> temporalio.client.ScheduleUpdate:
@@ -148,18 +153,20 @@ async def update_schedule(schedule_id: AnyScheduleID, params: ScheduleUpdate) ->
             try:
                 raw_args = await extract_first(Payloads(payloads=[action.args[0]]))
                 run_args = DSLRunArgs.model_validate(raw_args)
-                role = run_args.role
+                effective_role = run_args.role
             except Exception as e:
                 logger.warning(
                     "Error extracting role from schedule action",
                     error=e,
                 )
-                role = Role(
+                effective_role = Role(
                     type="service",
                     service_id="tracecat-schedule-runner",
                     scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-schedule-runner"],
                 )
-            action.typed_search_attributes = build_schedule_search_attributes(role)
+            action.typed_search_attributes = build_schedule_search_attributes(
+                role or effective_role
+            )
             if "inputs" in set_fields:
                 action.args[0].dsl.trigger_inputs = set_fields["inputs"]  # type: ignore
         else:

--- a/tracecat/workflow/schedules/service.py
+++ b/tracecat/workflow/schedules/service.py
@@ -245,7 +245,7 @@ class WorkflowSchedulesService(BaseWorkspaceService):
         # After-commit callback to update Temporal schedule
         async def _update_schedule():
             try:
-                await bridge.update_schedule(schedule_id, params)
+                await bridge.update_schedule(schedule_id, params, role=self.role)
                 logger.info(
                     "Updated schedule",
                     schedule_id=schedule_id,


### PR DESCRIPTION
## Summary
- thread the caller role into schedule updates so search attributes can be rebuilt with workspace scope intact
- fall back to the caller role when decoding existing schedule args fails during `update_schedule`
- add regression coverage for both the decode-failure path and service-to-bridge role forwarding

## Testing
- `uv run ruff check tracecat/workflow/schedules/bridge.py tracecat/workflow/schedules/service.py tests/unit/test_schedule_update_search_attributes.py`
- `uv run pyright tracecat/workflow/schedules/bridge.py tracecat/workflow/schedules/service.py tests/unit/test_schedule_update_search_attributes.py`
- `TRACECAT__SERVICE_KEY=dummy uv run pytest tests/unit/test_schedule_update_search_attributes.py`
- `TRACECAT__SERVICE_KEY=dummy uv run pytest tests/unit/test_schedule_update_search_attributes.py tests/unit/test_workflow_schedules_service.py::test_update_schedule_updates_existing_schedule tests/unit/test_schedule_update_cron_clearing.py`
- `uv run ruff check tests/unit/test_workflow_schedules_service.py`
- `uv run pyright tests/unit/test_workflow_schedules_service.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves workspace-scoped Temporal search attributes when updating schedules. Prevents `WORKSPACE_ID` loss so schedule queries and filters continue to work after updates.

- **Bug Fixes**
  - Add optional `role` to `update_schedule`; rebuild search attributes using caller role, else decoded role, else `tracecat-schedule-runner`.
  - Forward the requester role from service to bridge.
  - Add tests for decode-failure and role forwarding; verify `WORKSPACE_ID`, `TRIGGER_TYPE`, `EXECUTION_TYPE`, and paused state on offline.

<sup>Written for commit 1a0d787b4cff13fb967668c06c3186b31e146149. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

