### PR TITLE
fix(agents): restore aws_role auth for llm_proxy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Topic :: System :: Systems Administration",
 ]
 dependencies = [
+    "aioboto3==15.5.0",
     "aiocache==0.12.3",
     "aiohttp==3.13.5",
     "alembic-postgresql-enum==1.7.0",

--- a/tests/unit/test_tracecat_llm_proxy_cloud_providers.py
+++ b/tests/unit/test_tracecat_llm_proxy_cloud_providers.py
@@ -1055,6 +1055,49 @@ def test_bedrock_request_normalizes_system_tools_and_inference_config() -> None:
     }
 
 
+def test_bedrock_request_assumes_role_and_uses_inference_profile_id(mocker) -> None:
+    request = _base_request(
+        provider="bedrock",
+        model="bedrock",
+        messages=(NormalizedMessage(role="user", content="hello"),),
+    )
+    sts_client = mocker.MagicMock()
+    sts_client.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "assumed-access",
+            "SecretAccessKey": "assumed-secret",
+            "SessionToken": "assumed-token",
+        }
+    }
+    session = mocker.MagicMock()
+    session.client.return_value = sts_client
+    mocker.patch.object(provider_bedrock.boto3, "Session", return_value=session)
+
+    request_http = BedrockAdapter().prepare_request(
+        request,
+        {
+            "AWS_REGION": "us-east-1",
+            "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/customer-role",
+            "AWS_ROLE_SESSION_NAME": "customer-session",
+            "AWS_INFERENCE_PROFILE_ID": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+            "TRACECAT_AWS_EXTERNAL_ID": "tracecat-ws-deadbeef",
+        },
+    )
+
+    sts_client.assume_role.assert_called_once_with(
+        RoleArn="arn:aws:iam::123456789012:role/customer-role",
+        RoleSessionName="customer-session",
+        ExternalId="tracecat-ws-deadbeef",
+    )
+    assert request_http.url.endswith(
+        "/model/us.anthropic.claude-sonnet-4-20250514-v1%3A0/converse"
+    )
+    assert request_http.headers["Authorization"].startswith(
+        "AWS4-HMAC-SHA256 Credential=assumed-access/"
+    )
+    assert request_http.headers["X-Amz-Security-Token"] == "assumed-token"
+
+
 def test_bedrock_request_uses_resolved_claude_target_for_reasoning_translation() -> (
     None
 ):
@@ -1683,6 +1726,70 @@ async def test_bedrock_prepare_retry_request_drops_thinking_on_tool_use_reasonin
 
     assert retried is not None
     assert retried.body is not None
+    retried_payload = orjson.loads(retried.body)
+    assert "additionalModelRequestFields" not in retried_payload
+
+
+def test_bedrock_prepare_retry_request_resigns_assumed_role_requests(mocker) -> None:
+    request = _base_request(
+        provider="bedrock",
+        model="bedrock",
+        messages=(NormalizedMessage(role="user", content="hello"),),
+    )
+    sts_client = mocker.MagicMock()
+    sts_client.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "assumed-access",
+            "SecretAccessKey": "assumed-secret",
+            "SessionToken": "assumed-token",
+        }
+    }
+    session = mocker.MagicMock()
+    session.client.return_value = sts_client
+    mocker.patch.object(provider_bedrock.boto3, "Session", return_value=session)
+
+    outbound = ProviderHTTPRequest(
+        method="POST",
+        url="https://bedrock.invalid/model/bedrock/converse",
+        headers={"Authorization": "stale", "Content-Type": "application/json"},
+        body=orjson.dumps(
+            {
+                "messages": [{"role": "user", "content": [{"text": "hello"}]}],
+                "additionalModelRequestFields": {
+                    "thinking": {"type": "enabled", "budget_tokens": 2048}
+                },
+            }
+        ),
+        stream=False,
+    )
+    response = httpx.Response(
+        400,
+        request=httpx.Request("POST", outbound.url),
+        content=(
+            b"ValidationException: Expected thinking or redacted_thinking, but found tool_use"
+        ),
+    )
+
+    retried = BedrockAdapter().prepare_retry_request(
+        response=response,
+        request=request,
+        credentials={
+            "AWS_REGION": "us-east-1",
+            "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/customer-role",
+            "AWS_ROLE_SESSION_NAME": "customer-session",
+            "TRACECAT_AWS_EXTERNAL_ID": "tracecat-ws-deadbeef",
+            "AWS_MODEL_ID": "bedrock",
+        },
+        outbound_request=outbound,
+    )
+
+    assert retried is not None
+    assert retried.body is not None
+    assert retried.headers["Authorization"].startswith(
+        "AWS4-HMAC-SHA256 Credential=assumed-access/"
+    )
+    assert retried.headers["Authorization"] != "stale"
+    assert retried.headers["X-Amz-Security-Token"] == "assumed-token"
     retried_payload = orjson.loads(retried.body)
     assert "additionalModelRequestFields" not in retried_payload
 

--- a/tests/unit/test_tracecat_llm_proxy_cloud_providers.py
+++ b/tests/unit/test_tracecat_llm_proxy_cloud_providers.py
@@ -1069,25 +1069,23 @@ def test_bedrock_request_assumes_role_and_uses_inference_profile_id(mocker) -> N
             "SessionToken": "assumed-token",
         }
     }
-    session = mocker.MagicMock()
-    session.client.return_value = sts_client
-    mocker.patch.object(provider_bedrock.boto3, "Session", return_value=session)
-
+    # AWS role assumption now happens in credential resolver, not prepare_request
+    # Pass pre-assumed credentials (as would come from resolved credentials)
     request_http = BedrockAdapter().prepare_request(
         request,
         {
             "AWS_REGION": "us-east-1",
-            "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/customer-role",
-            "AWS_ROLE_SESSION_NAME": "customer-session",
+            "AWS_ACCESS_KEY_ID": sts_client.assume_role.return_value["Credentials"][
+                "AccessKeyId"
+            ],
+            "AWS_SECRET_ACCESS_KEY": sts_client.assume_role.return_value["Credentials"][
+                "SecretAccessKey"
+            ],
+            "AWS_SESSION_TOKEN": sts_client.assume_role.return_value["Credentials"][
+                "SessionToken"
+            ],
             "AWS_INFERENCE_PROFILE_ID": "us.anthropic.claude-sonnet-4-20250514-v1:0",
-            "TRACECAT_AWS_EXTERNAL_ID": "tracecat-ws-deadbeef",
         },
-    )
-
-    sts_client.assume_role.assert_called_once_with(
-        RoleArn="arn:aws:iam::123456789012:role/customer-role",
-        RoleSessionName="customer-session",
-        ExternalId="tracecat-ws-deadbeef",
     )
     assert request_http.url.endswith(
         "/model/us.anthropic.claude-sonnet-4-20250514-v1%3A0/converse"
@@ -1744,10 +1742,7 @@ def test_bedrock_prepare_retry_request_resigns_assumed_role_requests(mocker) -> 
             "SessionToken": "assumed-token",
         }
     }
-    session = mocker.MagicMock()
-    session.client.return_value = sts_client
-    mocker.patch.object(provider_bedrock.boto3, "Session", return_value=session)
-
+    # AWS role assumption now happens in credential resolver, not prepare_retry_request
     outbound = ProviderHTTPRequest(
         method="POST",
         url="https://bedrock.invalid/model/bedrock/converse",
@@ -1775,9 +1770,15 @@ def test_bedrock_prepare_retry_request_resigns_assumed_role_requests(mocker) -> 
         request=request,
         credentials={
             "AWS_REGION": "us-east-1",
-            "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/customer-role",
-            "AWS_ROLE_SESSION_NAME": "customer-session",
-            "TRACECAT_AWS_EXTERNAL_ID": "tracecat-ws-deadbeef",
+            "AWS_ACCESS_KEY_ID": sts_client.assume_role.return_value["Credentials"][
+                "AccessKeyId"
+            ],
+            "AWS_SECRET_ACCESS_KEY": sts_client.assume_role.return_value["Credentials"][
+                "SecretAccessKey"
+            ],
+            "AWS_SESSION_TOKEN": sts_client.assume_role.return_value["Credentials"][
+                "SessionToken"
+            ],
             "AWS_MODEL_ID": "bedrock",
         },
         outbound_request=outbound,

--- a/tracecat/agent/llm_proxy/credentials.py
+++ b/tracecat/agent/llm_proxy/credentials.py
@@ -95,7 +95,8 @@ async def _resolve_credentials_cached(
         )
     if creds is None:
         return None
-    if provider == "bedrock":
+    #  Assume role for Bedrock if bearer token is not available
+    if provider == "bedrock" and not creds.get("AWS_BEARER_TOKEN_BEDROCK"):
         creds = await assume_bedrock_aws_role(creds)
     return creds
 

--- a/tracecat/agent/llm_proxy/credentials.py
+++ b/tracecat/agent/llm_proxy/credentials.py
@@ -93,10 +93,10 @@ async def _resolve_credentials_cached(
             provider,
             use_workspace_credentials=use_workspace_credentials,
         )
-    # For Bedrock, resolve role assumption upfront so prepare_request stays sync
+    if creds is None:
+        return None
     if provider == "bedrock":
-        creds = await assume_bedrock_aws_role(creds or {})
-
+        creds = await assume_bedrock_aws_role(creds)
     return creds
 
 

--- a/tracecat/agent/llm_proxy/credentials.py
+++ b/tracecat/agent/llm_proxy/credentials.py
@@ -8,6 +8,7 @@ from typing import Any, Protocol
 from aiocache import Cache, cached
 
 from tracecat import config
+from tracecat.agent.llm_proxy.provider_bedrock import assume_bedrock_aws_role
 from tracecat.agent.service import AgentManagementService
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
@@ -74,7 +75,11 @@ async def _resolve_credentials_cached(
     *,
     service_id: InternalServiceID = "tracecat-llm-gateway",
 ) -> dict[str, str] | None:
-    """Resolve credentials through AgentManagementService with aiocache TTL."""
+    """Resolve credentials through AgentManagementService with aiocache TTL.
+
+    For Bedrock with AWS_ROLE_ARN, assumes the role and returns credentials
+    with the assumed role's access key, secret key, and session token.
+    """
     role = Role(
         type="service",
         user_id=None,
@@ -84,10 +89,15 @@ async def _resolve_credentials_cached(
         scopes=SERVICE_PRINCIPAL_SCOPES[service_id],
     )
     async with AgentManagementService.with_session(role=role) as service:
-        return await service.get_runtime_provider_credentials(
+        creds = await service.get_runtime_provider_credentials(
             provider,
             use_workspace_credentials=use_workspace_credentials,
         )
+    # For Bedrock, resolve role assumption upfront so prepare_request stays sync
+    if provider == "bedrock":
+        creds = await assume_bedrock_aws_role(creds or {})
+
+    return creds
 
 
 @dataclass(slots=True)

--- a/tracecat/agent/llm_proxy/provider_bedrock.py
+++ b/tracecat/agent/llm_proxy/provider_bedrock.py
@@ -111,12 +111,19 @@ async def assume_bedrock_aws_role(
 
     session = AIOSession()
     async with session.client("sts") as sts_client:
-        kwargs = {"RoleArn": role_arn, "RoleSessionName": role_session_name}
+        # Build assume_role kwargs with proper typing
         if external_id:
-            kwargs["ExternalId"] = external_id
-
-        response = await sts_client.assume_role(**kwargs)  # type: ignore[arg-type]
-        assumed_creds = response["Credentials"]  # type: ignore[return-value]
+            response = await sts_client.assume_role(
+                RoleArn=role_arn,
+                RoleSessionName=role_session_name,
+                ExternalId=external_id,
+            )
+        else:
+            response = await sts_client.assume_role(
+                RoleArn=role_arn,
+                RoleSessionName=role_session_name,
+            )
+        assumed_creds = response["Credentials"]
 
     # Return new dict with assumed role credentials (immutable)
     result = dict(credentials)

--- a/tracecat/agent/llm_proxy/provider_bedrock.py
+++ b/tracecat/agent/llm_proxy/provider_bedrock.py
@@ -15,9 +15,9 @@ from dataclasses import dataclass
 from typing import Any, TypedDict
 from urllib.parse import quote
 
-import boto3
 import httpx
 import orjson
+from aioboto3 import Session as AIOSession
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from botocore.credentials import Credentials
@@ -83,6 +83,47 @@ _BEDROCK_STREAM_EVENT_KEYS = frozenset(
         "messageStop",
     }
 )
+
+
+async def assume_bedrock_aws_role(
+    credentials: dict[str, str],
+) -> dict[str, str]:
+    """Assume an AWS role for Bedrock if AWS_ROLE_ARN is configured.
+
+    Returns a new credentials dict with assumed role credentials,
+    or a copy of the original dict if no role assumption needed.
+    Credentials are immutable - never modifies the input dict.
+
+    Args:
+        credentials: AWS credentials dict that may contain AWS_ROLE_ARN.
+
+    Returns:
+        New dict with AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and
+        AWS_SESSION_TOKEN set to the assumed role credentials if role assumption
+        occurred, otherwise a copy of the input dict.
+    """
+    if not credentials.get("AWS_ROLE_ARN"):
+        return dict(credentials)
+
+    role_arn = credentials["AWS_ROLE_ARN"]
+    external_id = credentials.get(_TRACECAT_AWS_EXTERNAL_ID_SECRET_KEY)
+    role_session_name = credentials.get("AWS_ROLE_SESSION_NAME") or "tracecat-bedrock"
+
+    session = AIOSession()
+    async with session.client("sts") as sts_client:
+        kwargs = {"RoleArn": role_arn, "RoleSessionName": role_session_name}
+        if external_id:
+            kwargs["ExternalId"] = external_id
+
+        response = await sts_client.assume_role(**kwargs)  # type: ignore[arg-type]
+        assumed_creds = response["Credentials"]  # type: ignore[return-value]
+
+    # Return new dict with assumed role credentials (immutable)
+    result = dict(credentials)
+    result["AWS_ACCESS_KEY_ID"] = assumed_creds["AccessKeyId"]
+    result["AWS_SECRET_ACCESS_KEY"] = assumed_creds["SecretAccessKey"]
+    result["AWS_SESSION_TOKEN"] = assumed_creds["SessionToken"]
+    return result
 
 
 @dataclass(slots=True)
@@ -882,36 +923,32 @@ def _signed_bedrock_request(
     url: str,
     body: bytes,
 ) -> ProviderHTTPRequest:
+    """Create a signed Bedrock request with AWS SigV4 authentication.
+
+    AWS role assumption (if AWS_ROLE_ARN is configured) is handled upfront
+    by the credential resolver, so credentials here are ready to use.
+
+    Checks credentials in priority order:
+    1. Bearer token (AWS_BEARER_TOKEN_BEDROCK) - explicit auth
+    2. Static/assumed credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY)
+
+    Args:
+        request: The normalized LLM request.
+        credentials: AWS credentials (with role already assumed if needed).
+        url: Bedrock endpoint URL.
+        body: Request body as bytes.
+
+    Returns:
+        ProviderHTTPRequest with SigV4-signed headers.
+
+    Raises:
+        ValueError: If AWS_REGION is missing or no valid credentials provided.
+    """
     region = credentials.get("AWS_REGION")
     if not region:
         raise ValueError("Bedrock requires AWS_REGION")
 
-    if role_arn := credentials.get("AWS_ROLE_ARN"):
-        sts_client = boto3.Session().client("sts")
-        role_session_name = _bedrock_role_session_name(request, credentials)
-        if external_id := credentials.get(_TRACECAT_AWS_EXTERNAL_ID_SECRET_KEY):
-            assumed_role = sts_client.assume_role(
-                RoleArn=role_arn,
-                RoleSessionName=role_session_name,
-                ExternalId=external_id,
-            )["Credentials"]
-        else:
-            assumed_role = sts_client.assume_role(
-                RoleArn=role_arn,
-                RoleSessionName=role_session_name,
-            )["Credentials"]
-        return _sigv4_bedrock_request(
-            request=request,
-            credentials=Credentials(
-                assumed_role["AccessKeyId"],
-                assumed_role["SecretAccessKey"],
-                assumed_role["SessionToken"],
-            ),
-            url=url,
-            body=body,
-            region=region,
-        )
-
+    # Check bearer token first
     if api_key := credentials.get("AWS_BEARER_TOKEN_BEDROCK"):
         return ProviderHTTPRequest(
             method="POST",
@@ -924,11 +961,12 @@ def _signed_bedrock_request(
             stream=request.stream,
         )
 
+    # Use static or assumed credentials (credential resolver handles role assumption)
     access_key = credentials.get("AWS_ACCESS_KEY_ID")
     secret_key = credentials.get("AWS_SECRET_ACCESS_KEY")
     if not access_key or not secret_key:
         raise ValueError(
-            "Bedrock requires AWS_ROLE_ARN, AWS_BEARER_TOKEN_BEDROCK, or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY"
+            "Bedrock requires AWS_BEARER_TOKEN_BEDROCK or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY"
         )
 
     return _sigv4_bedrock_request(
@@ -968,23 +1006,6 @@ def _sigv4_bedrock_request(
         body=body,
         stream=request.stream,
     )
-
-
-def _bedrock_role_session_name(
-    request: NormalizedMessagesRequest,
-    credentials: dict[str, str],
-) -> str:
-    if session_name := credentials.get("AWS_ROLE_SESSION_NAME"):
-        stripped_session_name = session_name.strip()
-        if stripped_session_name:
-            return stripped_session_name[:64]
-
-    parts = ["tracecat"]
-    if request.workspace_id is not None:
-        parts.extend(["ws", str(request.workspace_id).replace("-", "")[:8]])
-    if request.session_id is not None:
-        parts.extend(["session", str(request.session_id).replace("-", "")[:8]])
-    return "-".join(parts)[:64]
 
 
 def _load_request_body(request: ProviderHTTPRequest) -> dict[str, Any]:
@@ -1336,6 +1357,8 @@ class BedrockAdapter:
             credentials,
             stream=True,
         )
+        # AWS role assumption is handled upfront by credential resolver,
+        # so credentials here are ready to use
         stream_request = _signed_bedrock_request(
             request=request,
             credentials=credentials,

--- a/tracecat/agent/llm_proxy/provider_bedrock.py
+++ b/tracecat/agent/llm_proxy/provider_bedrock.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from typing import Any, TypedDict
 from urllib.parse import quote
 
+import boto3
 import httpx
 import orjson
 from botocore.auth import SigV4Auth
@@ -71,6 +72,7 @@ _BEDROCK_FORCED_TOOL_CHOICE_THINKING_ERROR = (
 _BEDROCK_UNSUPPORTED_REASONING_EFFORT_ERROR = (
     "reasoning_effort: Extra inputs are not permitted"
 )
+_TRACECAT_AWS_EXTERNAL_ID_SECRET_KEY = "TRACECAT_AWS_EXTERNAL_ID"
 _BEDROCK_STREAM_EVENT_KEYS = frozenset(
     {
         "messageStart",
@@ -884,6 +886,32 @@ def _signed_bedrock_request(
     if not region:
         raise ValueError("Bedrock requires AWS_REGION")
 
+    if role_arn := credentials.get("AWS_ROLE_ARN"):
+        sts_client = boto3.Session().client("sts")
+        role_session_name = _bedrock_role_session_name(request, credentials)
+        if external_id := credentials.get(_TRACECAT_AWS_EXTERNAL_ID_SECRET_KEY):
+            assumed_role = sts_client.assume_role(
+                RoleArn=role_arn,
+                RoleSessionName=role_session_name,
+                ExternalId=external_id,
+            )["Credentials"]
+        else:
+            assumed_role = sts_client.assume_role(
+                RoleArn=role_arn,
+                RoleSessionName=role_session_name,
+            )["Credentials"]
+        return _sigv4_bedrock_request(
+            request=request,
+            credentials=Credentials(
+                assumed_role["AccessKeyId"],
+                assumed_role["SecretAccessKey"],
+                assumed_role["SessionToken"],
+            ),
+            url=url,
+            body=body,
+            region=region,
+        )
+
     if api_key := credentials.get("AWS_BEARER_TOKEN_BEDROCK"):
         return ProviderHTTPRequest(
             method="POST",
@@ -900,21 +928,37 @@ def _signed_bedrock_request(
     secret_key = credentials.get("AWS_SECRET_ACCESS_KEY")
     if not access_key or not secret_key:
         raise ValueError(
-            "Bedrock requires AWS_BEARER_TOKEN_BEDROCK or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY"
+            "Bedrock requires AWS_ROLE_ARN, AWS_BEARER_TOKEN_BEDROCK, or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY"
         )
 
+    return _sigv4_bedrock_request(
+        request=request,
+        credentials=Credentials(
+            access_key,
+            secret_key,
+            credentials.get("AWS_SESSION_TOKEN"),
+        ),
+        url=url,
+        body=body,
+        region=region,
+    )
+
+
+def _sigv4_bedrock_request(
+    *,
+    request: NormalizedMessagesRequest,
+    credentials: Credentials,
+    url: str,
+    body: bytes,
+    region: str,
+) -> ProviderHTTPRequest:
     aws_request = AWSRequest(
         method="POST",
         url=url,
         data=body,
         headers={"Content-Type": "application/json"},
     )
-    credentials_obj = Credentials(
-        access_key,
-        secret_key,
-        credentials.get("AWS_SESSION_TOKEN"),
-    )
-    SigV4Auth(credentials_obj, "bedrock", region).add_auth(aws_request)
+    SigV4Auth(credentials, "bedrock", region).add_auth(aws_request)
     headers = dict(aws_request.headers.items())
     headers["Content-Type"] = "application/json"
     return ProviderHTTPRequest(
@@ -924,6 +968,23 @@ def _signed_bedrock_request(
         body=body,
         stream=request.stream,
     )
+
+
+def _bedrock_role_session_name(
+    request: NormalizedMessagesRequest,
+    credentials: dict[str, str],
+) -> str:
+    if session_name := credentials.get("AWS_ROLE_SESSION_NAME"):
+        stripped_session_name = session_name.strip()
+        if stripped_session_name:
+            return stripped_session_name[:64]
+
+    parts = ["tracecat"]
+    if request.workspace_id is not None:
+        parts.extend(["ws", str(request.workspace_id).replace("-", "")[:8]])
+    if request.session_id is not None:
+        parts.extend(["session", str(request.session_id).replace("-", "")[:8]])
+    return "-".join(parts)[:64]
 
 
 def _load_request_body(request: ProviderHTTPRequest) -> dict[str, Any]:
@@ -1246,7 +1307,6 @@ class BedrockAdapter:
         credentials: dict[str, str],
         outbound_request: ProviderHTTPRequest,
     ) -> ProviderHTTPRequest | None:
-        del credentials, request
         payload = _load_request_body(outbound_request)
         rewritten = payload
         if (
@@ -1258,12 +1318,11 @@ class BedrockAdapter:
             rewritten = _remove_reasoning_effort_from_payload(rewritten)
         if rewritten == payload:
             return None
-        return ProviderHTTPRequest(
-            method=outbound_request.method,
+        return _signed_bedrock_request(
+            request=request,
+            credentials=credentials,
             url=outbound_request.url,
-            headers=outbound_request.headers,
             body=_json_bytes(rewritten),
-            stream=outbound_request.stream,
         )
 
     async def stream_anthropic(

--- a/uv.lock
+++ b/uv.lock
@@ -4163,6 +4163,7 @@ wheels = [
 name = "tracecat"
 source = { editable = "." }
 dependencies = [
+    { name = "aioboto3" },
     { name = "aiocache" },
     { name = "aiohttp" },
     { name = "alembic" },
@@ -4241,6 +4242,7 @@ lint = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aioboto3", specifier = "==15.5.0" },
     { name = "aiocache", specifier = "==0.12.3" },
     { name = "aiohttp", specifier = "==3.13.5" },
     { name = "alembic", specifier = "==1.13.2" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restore AWS role-based auth in the Bedrock LLM proxy. We now assume the configured role up front (skip if a bearer token is set) and sign initial, streaming, and retried requests with fresh temporary credentials.

- **Bug Fixes**
  - Assume role via STS in the credential resolver when `AWS_ROLE_ARN` is set; support `TRACECAT_AWS_EXTERNAL_ID`; derive or fallback `AWS_ROLE_SESSION_NAME`; never mutate input creds; skip role assumption when `AWS_BEARER_TOKEN_BEDROCK` is present.
  - Prefer `AWS_BEARER_TOKEN_BEDROCK`; otherwise sign via a shared SigV4 helper; re-sign retry requests to refresh `Authorization`/`X-Amz-Security-Token`; honor `AWS_INFERENCE_PROFILE_ID`; clearer errors when `AWS_REGION` or creds are missing; streaming uses the same signer.

- **Dependencies**
  - Add `aioboto3==15.5.0` for async STS role assumption.

<sup>Written for commit 77571f0e5c2e27be0698eb3af462b98f6922a5af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

