### PR TITLE
fix(agent): add missing signature field to thinking blocks and condit…

### DIFF
--- a/tests/unit/test_tracecat_llm_proxy.py
+++ b/tests/unit/test_tracecat_llm_proxy.py
@@ -1047,7 +1047,7 @@ async def test_openai_family_parse_response_preserves_reasoning_blocks() -> None
     assert isinstance(parsed.content, list)
     assert parsed.content[0]["type"] == "thinking"
     assert parsed.content[0]["thinking"] == "I should inspect the record first."
-    assert "signature" not in parsed.content[0]
+    assert parsed.content[0]["signature"] == ""
     assert parsed.tool_calls == (
         NormalizedToolCall(
             id="call_1",

--- a/tracecat/agent/llm_proxy/provider_azure_openai.py
+++ b/tracecat/agent/llm_proxy/provider_azure_openai.py
@@ -135,7 +135,9 @@ def _normalized_chat_response_content(message: dict[str, Any]) -> Any:
     if not (reasoning := _chat_reasoning_text(message)):
         return content
 
-    blocks: list[dict[str, Any]] = [{"type": "thinking", "thinking": reasoning}]
+    blocks: list[dict[str, Any]] = [
+        {"type": "thinking", "thinking": reasoning, "signature": ""}
+    ]
     if content:
         if isinstance(content, list):
             for item in content:

--- a/tracecat/agent/llm_proxy/provider_openai.py
+++ b/tracecat/agent/llm_proxy/provider_openai.py
@@ -400,7 +400,11 @@ def _normalized_responses_content(payload: dict[str, Any]) -> Any:
                     for part in summary
                     if isinstance(part, dict)
                 )
-            content_blocks.append({"type": "thinking", "thinking": thinking})
+            # OpenAI reasoning responses may include a signature field for the encrypted blob
+            signature = item.get("signature", "")
+            content_blocks.append(
+                {"type": "thinking", "thinking": thinking, "signature": signature}
+            )
         elif item_type == "message":
             for part in item.get("content", []):
                 if not isinstance(part, dict):
@@ -662,6 +666,7 @@ class OpenAIFamilyAdapter(ProviderAdapter, AnthropicStreamingAdapter):
                                 "content_block": {
                                     "type": "thinking",
                                     "thinking": "",
+                                    "signature": "",
                                 },
                             },
                         )
@@ -705,6 +710,7 @@ class OpenAIFamilyAdapter(ProviderAdapter, AnthropicStreamingAdapter):
                                 "content_block": {
                                     "type": "thinking",
                                     "thinking": "",
+                                    "signature": "",
                                 },
                             },
                         )

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -457,15 +457,20 @@ class ClaudeAgentRuntime:
             "hookSpecificOutput": hook_output,
         }
 
-    def _build_system_prompt(self, instructions: str | None) -> str:
+    def _build_system_prompt(
+        self, instructions: str | None, output_type: str | dict[str, Any] | None = None
+    ) -> str:
         """Build the system prompt for the agent."""
-        base = (
-            "If asked about your identity, you are a Tracecat automation assistant.\n\n"
-            "If a structured output schema is configured, you MUST produce structured"
-            " output as the very last thing in EVERY turn — including follow-up turns."
-            " Do not add any commentary, explanation, or text after the structured"
-            " output. This applies to every response, not just the first one."
-        )
+        base = "If asked about your identity, you are a Tracecat automation assistant."
+
+        # Only include structured output instruction if output_type is configured (not None)
+        if output_type is not None:
+            base += (
+                "\n\nYou MUST produce structured output as the very last thing in EVERY turn"
+                " — including follow-up turns. Do not add any commentary, explanation, or text"
+                " after the structured output. This applies to every response, not just the first one."
+            )
+
         return f"{base}\n\n{instructions}" if instructions else base
 
     async def run(self, payload: RuntimeInitPayload) -> None:
@@ -592,7 +597,9 @@ class ClaudeAgentRuntime:
                     "ANTHROPIC_BASE_URL": get_llm_proxy_url(),
                 },
                 model=payload.config.model_name,
-                system_prompt=self._build_system_prompt(payload.config.instructions),
+                system_prompt=self._build_system_prompt(
+                    payload.config.instructions, payload.config.output_type
+                ),
                 mcp_servers=mcp_servers,
                 disallowed_tools=disallowed_tools,
                 stderr=handle_claude_stderr,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add the missing `signature` field to "thinking" blocks for OpenAI/Azure reasoning responses and only include structured-output instructions when an `output_type` is configured. This prevents downstream key errors and avoids forcing structured output when no schema is set.

- **Bug Fixes**
  - OpenAI/Azure: always include `signature` in "thinking" blocks (use `item.get("signature", "")`), and add empty `signature` placeholders during content allocation to keep block shape consistent.
  - Claude code runtime: system prompt only adds structured-output instructions when `output_type` is provided; the call site now passes `output_type` to `_build_system_prompt`.

<sup>Written for commit fe453692faadd0e07e75482f1578748f01ba5575. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

