### PR TITLE
fix(ui): restore autoHeight for inline AG Grid in case linked rows

### DIFF
--- a/frontend/src/components/tables/ag-grid-table.tsx
+++ b/frontend/src/components/tables/ag-grid-table.tsx
@@ -115,6 +115,7 @@ export function AgGridTable({
   hidePagination?: boolean
 }) {
   const isReadOnly = readOnly || rowsOverride !== undefined
+  const useAutoHeight = rowsOverride !== undefined
   const workspaceId = useWorkspaceId()
   const [pageSize, setPageSize] = useState(20)
   const [gridApi, setGridApi] = useState<GridApi | null>(null)
@@ -307,14 +308,17 @@ export function AgGridTable({
   }
 
   return (
-    <div className="flex h-full flex-col gap-2 pb-2">
+    <div
+      className={`flex flex-col gap-2 pb-2 ${useAutoHeight ? "" : "h-full"}`}
+    >
       {isReadOnly ? (
         <div
-          className="flex-1 min-h-0"
+          className={useAutoHeight ? "" : "flex-1 min-h-0"}
           onKeyDown={(e) => handleGridKeyDown(e, gridApi)}
         >
           <AgGridReact
             theme={tracecatTheme}
+            domLayout={useAutoHeight ? "autoHeight" : undefined}
             rowData={rowData}
             columnDefs={columnDefs}
             getRowId={(params) => params.data.id}
@@ -330,11 +334,12 @@ export function AgGridTable({
       ) : (
         <AgGridContextMenu gridApi={gridApi} columns={columns}>
           <div
-            className="flex-1 min-h-0"
+            className={useAutoHeight ? "" : "flex-1 min-h-0"}
             onKeyDown={(e) => handleGridKeyDown(e, gridApi)}
           >
             <AgGridReact
               theme={tracecatTheme}
+              domLayout={useAutoHeight ? "autoHeight" : undefined}
               rowData={rowData}
               columnDefs={columnDefs}
               getRowId={(params) => params.data.id}


### PR DESCRIPTION
## Summary
- Restore `domLayout="autoHeight"` for inline AG Grid tables in case linked rows
- Commit `e91a06af0` removed `autoHeight`, causing the grid to collapse to zero height when embedded in the case panel's `ScrollArea` (no fixed-height ancestor)
- Conditionally apply `autoHeight` only when `rowsOverride` is provided (inline mode), preserving the flex layout for full-page tables

## Test plan
- [ ] Open a case with linked table rows → Tables tab shows column headers and row data
- [ ] Open full-page tables view → Grid fills viewport with pagination, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore `domLayout="autoHeight"` for inline `AgGridReact` tables to prevent zero-height collapse in the case panel `ScrollArea`. Apply auto-height only when `rowsOverride` is provided (inline/linked rows), preserving the flex layout for full-page tables.

<sup>Written for commit b4b3145018d3eb092e0b0960bbf7b9030a3086cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

