### PR TITLE
feat(mcp): add refresh token support to internal OIDC flow

### DIFF
--- a/alembic/versions/b742858f7d69_add_mcp_refresh_token_table.py
+++ b/alembic/versions/b742858f7d69_add_mcp_refresh_token_table.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 
 from alembic import op
+from tracecat.db.tenant_rls import disable_org_table_rls, enable_org_table_rls
 
 # revision identifiers, used by Alembic.
 revision: str = "b742858f7d69"
@@ -91,9 +92,11 @@ def upgrade() -> None:
         ["user_id"],
         unique=False,
     )
+    op.execute(enable_org_table_rls("mcp_refresh_token"))
 
 
 def downgrade() -> None:
+    op.execute(disable_org_table_rls("mcp_refresh_token"))
     op.drop_index(op.f("ix_mcp_refresh_token_user_id"), table_name="mcp_refresh_token")
     op.drop_index(
         op.f("ix_mcp_refresh_token_token_hash"), table_name="mcp_refresh_token"

--- a/alembic/versions/b742858f7d69_add_mcp_refresh_token_table.py
+++ b/alembic/versions/b742858f7d69_add_mcp_refresh_token_table.py
@@ -1,0 +1,105 @@
+"""add mcp_refresh_token table
+
+Revision ID: b742858f7d69
+Revises: 7e1a4d9c2b6f
+Create Date: 2026-04-06 18:22:03.384450
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b742858f7d69"
+down_revision: str | None = "7e1a4d9c2b6f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mcp_refresh_token",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("family_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("client_id", sa.String(), nullable=False),
+        sa.Column("encrypted_metadata", sa.LargeBinary(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("organization_id", sa.UUID(), nullable=False),
+        sa.Column("surrogate_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organization.id"],
+            name=op.f("fk_mcp_refresh_token_organization_id_organization"),
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+            name=op.f("fk_mcp_refresh_token_user_id_user"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name=op.f("pk_mcp_refresh_token")),
+    )
+    op.create_index(
+        "ix_mcp_refresh_token_expires_at",
+        "mcp_refresh_token",
+        ["expires_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_mcp_refresh_token_family_id",
+        "mcp_refresh_token",
+        ["family_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_mcp_refresh_token_id"), "mcp_refresh_token", ["id"], unique=True
+    )
+    op.create_index(
+        op.f("ix_mcp_refresh_token_status"),
+        "mcp_refresh_token",
+        ["status"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_mcp_refresh_token_token_hash"),
+        "mcp_refresh_token",
+        ["token_hash"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_mcp_refresh_token_user_id"),
+        "mcp_refresh_token",
+        ["user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_mcp_refresh_token_user_id"), table_name="mcp_refresh_token")
+    op.drop_index(
+        op.f("ix_mcp_refresh_token_token_hash"), table_name="mcp_refresh_token"
+    )
+    op.drop_index(op.f("ix_mcp_refresh_token_status"), table_name="mcp_refresh_token")
+    op.drop_index(op.f("ix_mcp_refresh_token_id"), table_name="mcp_refresh_token")
+    op.drop_index("ix_mcp_refresh_token_family_id", table_name="mcp_refresh_token")
+    op.drop_index("ix_mcp_refresh_token_expires_at", table_name="mcp_refresh_token")
+    op.drop_table("mcp_refresh_token")

--- a/tests/integration/test_mcp_oidc_flow.py
+++ b/tests/integration/test_mcp_oidc_flow.py
@@ -11,6 +11,7 @@ parameter validation) use real implementations.
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
 import secrets
 import time
@@ -168,6 +169,26 @@ class _InMemoryOIDCStorage:
             metadata=row.metadata,
         )
 
+    async def rotate_refresh_token(
+        self,
+        session: Any,
+        *,
+        token: str,
+        client_id: str,
+    ) -> tuple[RefreshTokenContext, str]:
+        ctx = await self.consume_refresh_token(
+            session, token=token, client_id=client_id
+        )
+        new_token = await self.issue_refresh_token(
+            session,
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            client_id=client_id,
+            metadata=ctx.metadata,
+            family_id=ctx.family_id,
+        )
+        return ctx, new_token
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -202,6 +223,7 @@ def _setup_config(monkeypatch: pytest.MonkeyPatch):  # pyright: ignore[reportUnu
     monkeypatch.setattr(
         "tracecat.mcp.oidc.endpoints.TRACECAT__PUBLIC_APP_URL", _TEST_APP_URL
     )
+    monkeypatch.setattr("tracecat.config.TRACECAT__DB_ENCRYPTION_KEY", "enabled")
     signing.get_signing_key.cache_clear()
     signing.get_public_jwk.cache_clear()
     yield
@@ -223,9 +245,24 @@ def mock_user() -> SimpleNamespace:
     )
 
 
+class _StubSession:
+    """Stand-in for the DB session when refresh-token storage is mocked."""
+
+    async def commit(self) -> None:
+        return None
+
+    async def rollback(self) -> None:
+        return None
+
+
 async def _stub_session_dependency():
     """Stand-in for the DB session — refresh tokens are mocked in-memory."""
-    yield None
+    yield _StubSession()
+
+
+@contextlib.asynccontextmanager
+async def _stub_bypass_session_context_manager():
+    yield _StubSession()
 
 
 @pytest.fixture()
@@ -242,6 +279,10 @@ def app(
     test_app.dependency_overrides[optional_current_active_user] = lambda: mock_user
     test_app.dependency_overrides[get_async_session_bypass_rls] = (
         _stub_session_dependency
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.get_async_session_bypass_rls_context_manager",
+        _stub_bypass_session_context_manager,
     )
 
     # Wire in-memory storage
@@ -274,8 +315,8 @@ def app(
         mem_storage.issue_refresh_token,
     )
     monkeypatch.setattr(
-        "tracecat.mcp.oidc.endpoints.consume_refresh_token",
-        mem_storage.consume_refresh_token,
+        "tracecat.mcp.oidc.endpoints.rotate_refresh_token",
+        mem_storage.rotate_refresh_token,
     )
 
     # Mock session resolution to return the test user + org

--- a/tests/integration/test_mcp_oidc_flow.py
+++ b/tests/integration/test_mcp_oidc_flow.py
@@ -26,11 +26,18 @@ from fastapi import FastAPI
 from starlette.testclient import TestClient
 
 from tracecat.auth.users import optional_current_active_user
+from tracecat.db.engine import get_async_session_bypass_rls
 from tracecat.db.models import User
 from tracecat.mcp.oidc import config as oidc_config
 from tracecat.mcp.oidc import signing
 from tracecat.mcp.oidc.endpoints import router
-from tracecat.mcp.oidc.schemas import AuthCodeData, ResumeTransaction
+from tracecat.mcp.oidc.refresh_tokens import RefreshTokenError
+from tracecat.mcp.oidc.schemas import (
+    AuthCodeData,
+    RefreshTokenContext,
+    RefreshTokenMetadata,
+    ResumeTransaction,
+)
 from tracecat.mcp.oidc.session import SessionResult
 
 # ---------------------------------------------------------------------------
@@ -48,6 +55,26 @@ _REDIRECT_URI = f"{_TEST_APP_URL}/auth/callback"
 # ---------------------------------------------------------------------------
 
 
+class _InMemoryRefreshTokenRow:
+    """Holds the persisted state for one refresh token in the in-memory store."""
+
+    def __init__(
+        self,
+        *,
+        family_id: uuid.UUID,
+        user_id: uuid.UUID,
+        organization_id: uuid.UUID,
+        client_id: str,
+        metadata: RefreshTokenMetadata,
+    ) -> None:
+        self.family_id = family_id
+        self.user_id = user_id
+        self.organization_id = organization_id
+        self.client_id = client_id
+        self.metadata = metadata
+        self.status = "active"
+
+
 class _InMemoryOIDCStorage:
     """In-memory replacements for the storage module functions."""
 
@@ -56,6 +83,8 @@ class _InMemoryOIDCStorage:
         self.resume_txns: dict[str, ResumeTransaction] = {}
         self.jtis: set[str] = set()
         self.rate_counters: dict[str, int] = {}
+        # Refresh tokens are keyed by plaintext (test-only — production hashes them).
+        self.refresh_tokens: dict[str, _InMemoryRefreshTokenRow] = {}
 
     async def store_auth_code(self, data: AuthCodeData) -> None:
         self.codes[data.code] = data
@@ -78,6 +107,66 @@ class _InMemoryOIDCStorage:
         count = self.rate_counters.get(source_ip, 0) + 1
         self.rate_counters[source_ip] = count
         return count <= oidc_config.TOKEN_RATE_LIMIT_PER_SOURCE_PER_MINUTE
+
+    # --- Refresh token operations ---
+
+    async def issue_refresh_token(
+        self,
+        _session: Any,
+        *,
+        user_id: uuid.UUID,
+        organization_id: uuid.UUID,
+        client_id: str,
+        metadata: RefreshTokenMetadata,
+        family_id: uuid.UUID | None = None,
+    ) -> str:
+        token = secrets.token_urlsafe(32)
+        self.refresh_tokens[token] = _InMemoryRefreshTokenRow(
+            family_id=family_id or uuid.uuid4(),
+            user_id=user_id,
+            organization_id=organization_id,
+            client_id=client_id,
+            metadata=metadata,
+        )
+        return token
+
+    async def consume_refresh_token(
+        self,
+        _session: Any,
+        *,
+        token: str,
+        client_id: str,
+    ) -> RefreshTokenContext:
+        row = self.refresh_tokens.get(token)
+        if row is None:
+            raise RefreshTokenError(
+                "invalid_grant", "Refresh token is invalid or expired"
+            )
+        if row.status == "used":
+            # Replay: revoke the entire family.
+            for r in self.refresh_tokens.values():
+                if r.family_id == row.family_id:
+                    r.status = "revoked"
+            raise RefreshTokenError(
+                "invalid_grant", "Refresh token replay detected; family revoked"
+            )
+        if row.status != "active":
+            raise RefreshTokenError(
+                "invalid_grant", "Refresh token is invalid or expired"
+            )
+        if row.client_id != client_id:
+            for r in self.refresh_tokens.values():
+                if r.family_id == row.family_id:
+                    r.status = "revoked"
+            raise RefreshTokenError("invalid_grant", "client_id mismatch")
+        row.status = "used"
+        return RefreshTokenContext(
+            family_id=row.family_id,
+            user_id=row.user_id,
+            organization_id=row.organization_id,
+            client_id=row.client_id,
+            metadata=row.metadata,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -134,6 +223,11 @@ def mock_user() -> SimpleNamespace:
     )
 
 
+async def _stub_session_dependency():
+    """Stand-in for the DB session — refresh tokens are mocked in-memory."""
+    yield None
+
+
 @pytest.fixture()
 def app(
     monkeypatch: pytest.MonkeyPatch,
@@ -146,6 +240,9 @@ def app(
     test_app = FastAPI()
     test_app.include_router(router)
     test_app.dependency_overrides[optional_current_active_user] = lambda: mock_user
+    test_app.dependency_overrides[get_async_session_bypass_rls] = (
+        _stub_session_dependency
+    )
 
     # Wire in-memory storage
     monkeypatch.setattr(
@@ -171,6 +268,14 @@ def app(
     monkeypatch.setattr(
         "tracecat.mcp.oidc.endpoints.check_token_rate_limit",
         mem_storage.check_token_rate_limit,
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.issue_refresh_token",
+        mem_storage.issue_refresh_token,
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.consume_refresh_token",
+        mem_storage.consume_refresh_token,
     )
 
     # Mock session resolution to return the test user + org
@@ -323,6 +428,200 @@ async def test_full_flow_code_reuse_rejected(
     )
     assert second.status_code == 400
     assert second.json()["error"] == "invalid_grant"
+
+
+@pytest.mark.anyio
+async def test_full_flow_without_offline_access_omits_refresh_token(
+    client: TestClient,
+) -> None:
+    """An auth code without offline_access scope must not yield a refresh token."""
+    verifier, challenge = _pkce_pair()
+
+    auth_response = client.get(
+        "/authorize",
+        params={
+            "response_type": "code",
+            "client_id": oidc_config.INTERNAL_CLIENT_ID,
+            "redirect_uri": _REDIRECT_URI,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "scope": "openid profile email",
+            "state": "no-offline",
+            "resource": f"{_TEST_APP_URL}/mcp",
+        },
+        follow_redirects=False,
+    )
+    code = parse_qs(urlparse(auth_response.headers["location"]).query)["code"][0]
+
+    tokens = _exchange_code(client, code, verifier)
+    assert "refresh_token" not in tokens
+    assert tokens["expires_in"] == 3600
+
+
+@pytest.mark.anyio
+async def test_full_flow_with_offline_access_yields_refresh_token(
+    client: TestClient,
+    mem_storage: _InMemoryOIDCStorage,
+) -> None:
+    """offline_access scope must yield a refresh token alongside the access token."""
+    verifier, challenge = _pkce_pair()
+
+    auth_response = client.get(
+        "/authorize",
+        params={
+            "response_type": "code",
+            "client_id": oidc_config.INTERNAL_CLIENT_ID,
+            "redirect_uri": _REDIRECT_URI,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "scope": "openid profile email offline_access",
+            "state": "with-offline",
+            "resource": f"{_TEST_APP_URL}/mcp",
+        },
+        follow_redirects=False,
+    )
+    code = parse_qs(urlparse(auth_response.headers["location"]).query)["code"][0]
+
+    tokens = _exchange_code(client, code, verifier)
+
+    assert "refresh_token" in tokens
+    assert tokens["expires_in"] == 3600
+    assert tokens["scope"] == "openid profile email offline_access"
+
+    # The issued refresh token should be tracked in storage as 'active'.
+    refresh_token = tokens["refresh_token"]
+    row = mem_storage.refresh_tokens[refresh_token]
+    assert row.status == "active"
+
+
+def _refresh_with_token(client: TestClient, refresh_token: str) -> dict[str, Any]:
+    secret = oidc_config.get_internal_client_secret()
+    response = client.post(
+        "/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": oidc_config.INTERNAL_CLIENT_ID,
+            "client_secret": secret,
+        },
+    )
+    assert response.status_code == 200, response.json()
+    return response.json()
+
+
+@pytest.mark.anyio
+async def test_full_flow_refresh_token_rotation(
+    client: TestClient,
+    app: FastAPI,
+    mock_user: SimpleNamespace,
+    mem_storage: _InMemoryOIDCStorage,
+) -> None:
+    """End-to-end refresh: authorize → tokens → rotate → verify new pair."""
+    verifier, challenge = _pkce_pair()
+
+    auth_response = client.get(
+        "/authorize",
+        params={
+            "response_type": "code",
+            "client_id": oidc_config.INTERNAL_CLIENT_ID,
+            "redirect_uri": _REDIRECT_URI,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "scope": "openid profile email offline_access",
+            "state": "rot",
+            "resource": f"{_TEST_APP_URL}/mcp",
+        },
+        follow_redirects=False,
+    )
+    code = parse_qs(urlparse(auth_response.headers["location"]).query)["code"][0]
+    initial = _exchange_code(client, code, verifier)
+    refresh_a = initial["refresh_token"]
+
+    # Rotate.
+    rotated = _refresh_with_token(client, refresh_a)
+
+    assert rotated["access_token"] != initial["access_token"]
+    assert rotated["refresh_token"] != refresh_a
+    assert rotated["token_type"] == "Bearer"
+    assert rotated["expires_in"] == 3600
+    # No id_token on refresh per OIDC spec.
+    assert "id_token" not in rotated
+
+    # Access token claims preserved.
+    claims = signing.verify_jwt(rotated["access_token"])
+    assert claims["sub"] == str(mock_user.id)
+    assert claims["organization_id"] == str(app.state.org_id)
+    assert claims["email"] == mock_user.email
+
+    # Old token is now consumed; new token is active.
+    assert mem_storage.refresh_tokens[refresh_a].status == "used"
+    new_row = mem_storage.refresh_tokens[rotated["refresh_token"]]
+    assert new_row.status == "active"
+    # Same family.
+    assert new_row.family_id == mem_storage.refresh_tokens[refresh_a].family_id
+
+
+@pytest.mark.anyio
+async def test_full_flow_refresh_token_replay_revokes_family(
+    client: TestClient,
+    mem_storage: _InMemoryOIDCStorage,
+) -> None:
+    """Reusing a consumed refresh token revokes both itself and its successor."""
+    verifier, challenge = _pkce_pair()
+
+    auth_response = client.get(
+        "/authorize",
+        params={
+            "response_type": "code",
+            "client_id": oidc_config.INTERNAL_CLIENT_ID,
+            "redirect_uri": _REDIRECT_URI,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "scope": "openid profile email offline_access",
+            "state": "replay",
+            "resource": f"{_TEST_APP_URL}/mcp",
+        },
+        follow_redirects=False,
+    )
+    code = parse_qs(urlparse(auth_response.headers["location"]).query)["code"][0]
+    initial = _exchange_code(client, code, verifier)
+    refresh_a = initial["refresh_token"]
+
+    # Legitimate rotation A -> B.
+    rotated = _refresh_with_token(client, refresh_a)
+    refresh_b = rotated["refresh_token"]
+
+    # Attacker presents A again — replay.
+    secret = oidc_config.get_internal_client_secret()
+    replay_response = client.post(
+        "/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_a,
+            "client_id": oidc_config.INTERNAL_CLIENT_ID,
+            "client_secret": secret,
+        },
+    )
+    assert replay_response.status_code == 400
+    assert replay_response.json()["error"] == "invalid_grant"
+    assert "replay" in replay_response.json()["error_description"].lower()
+
+    # Both A and B are now revoked.
+    assert mem_storage.refresh_tokens[refresh_a].status == "revoked"
+    assert mem_storage.refresh_tokens[refresh_b].status == "revoked"
+
+    # Legitimate user tries to use B — must also fail.
+    legit_response = client.post(
+        "/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_b,
+            "client_id": oidc_config.INTERNAL_CLIENT_ID,
+            "client_secret": secret,
+        },
+    )
+    assert legit_response.status_code == 400
+    assert legit_response.json()["error"] == "invalid_grant"
 
 
 def test_discovery_and_jwks_verify_minted_token(client: TestClient) -> None:

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -133,6 +133,7 @@ def test_create_mcp_auth_metadata_advertises_public_client_auth(
         "openid",
         "profile",
         "email",
+        "offline_access",
     ]
     assert "none" in payload["token_endpoint_auth_methods_supported"]
 
@@ -179,6 +180,7 @@ def test_create_mcp_auth_protected_resource_metadata_uses_mcp_path(
         "openid",
         "profile",
         "email",
+        "offline_access",
     ]
 
 
@@ -206,7 +208,7 @@ def test_create_mcp_auth_metadata_matches_public_client_registration(
     registration = registration_response.json()
     assert registration["token_endpoint_auth_method"] == "none"
     assert registration.get("client_secret") is None
-    assert registration["scope"] == "openid profile email"
+    assert registration["scope"] == "openid profile email offline_access"
     assert (
         registration["token_endpoint_auth_method"]
         in metadata["token_endpoint_auth_methods_supported"]
@@ -226,13 +228,13 @@ def test_create_mcp_auth_registration_accepts_platform_oidc_scopes(
             "grant_types": ["authorization_code", "refresh_token"],
             "response_types": ["code"],
             "token_endpoint_auth_method": "none",
-            "scope": "openid profile email",
+            "scope": "openid profile email offline_access",
         },
     )
 
     assert registration_response.status_code == 201
     registration = registration_response.json()
-    assert registration["scope"] == "openid profile email"
+    assert registration["scope"] == "openid profile email offline_access"
 
 
 def test_create_mcp_auth_registration_merges_oidc_scopes_into_partial_scope(
@@ -445,6 +447,32 @@ async def test_create_mcp_auth_get_client_merges_required_scopes_for_partial_dcr
     assert client is not None
     assert client.scope == "openid profile email"
     assert client.validate_scope("openid") == ["openid"]
+
+
+@pytest.mark.anyio
+async def test_create_mcp_auth_get_client_defaults_cimd_scope_with_offline_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth = _build_test_auth(monkeypatch)
+    client_id = "https://client.example.com/.well-known/oauth-client.json"
+
+    async def _fetch(_client_id_url: str) -> CIMDDocument:
+        return CIMDDocument(
+            client_id=AnyHttpUrl(client_id),
+            client_name="Claude Code",
+            redirect_uris=["http://localhost/callback"],
+            token_endpoint_auth_method="none",
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+        )
+
+    assert auth._cimd_manager is not None
+    monkeypatch.setattr(auth._cimd_manager._fetcher, "fetch", _fetch)
+
+    client = await auth.get_client(client_id)
+
+    assert client is not None
+    assert client.scope == "openid profile email offline_access"
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -7,6 +7,7 @@ from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+from cryptography.fernet import Fernet
 from fastmcp import FastMCP
 from fastmcp.server.auth import AccessToken
 from fastmcp.server.auth.cimd import CIMDDocument
@@ -38,7 +39,11 @@ def _mock_oidc_discovery_config(
     return config
 
 
-def _build_test_auth(monkeypatch: pytest.MonkeyPatch) -> mcp_auth.OIDCProxy:
+def _build_test_auth(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    enable_refresh_tokens: bool = True,
+) -> mcp_auth.OIDCProxy:
     monkeypatch.setattr(mcp_auth, "TRACECAT__PUBLIC_APP_URL", "https://mcp.example.com")
     # Mock the internal OIDC issuer config used by _create_oidc_auth
     monkeypatch.setattr(mcp_auth, "INTERNAL_CLIENT_ID", "tracecat-mcp-oidc-internal")
@@ -54,7 +59,10 @@ def _build_test_auth(monkeypatch: pytest.MonkeyPatch) -> mcp_auth.OIDCProxy:
     )
     # Use in-memory store instead of Redis for tests
     monkeypatch.setattr(mcp_auth, "REDIS_URL", "redis://localhost:6379/0")
-    monkeypatch.setattr(mcp_auth, "TRACECAT__DB_ENCRYPTION_KEY", "")
+    monkeypatch.setattr(
+        "tracecat.config.TRACECAT__DB_ENCRYPTION_KEY",
+        Fernet.generate_key().decode() if enable_refresh_tokens else "",
+    )
     monkeypatch.setattr(mcp_auth.AsyncRedis, "from_url", lambda *a, **kw: MagicMock())
 
     def _patched_create_oidc_auth(
@@ -83,8 +91,12 @@ def _build_test_auth(monkeypatch: pytest.MonkeyPatch) -> mcp_auth.OIDCProxy:
     return auth
 
 
-def _build_test_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
-    auth = _build_test_auth(monkeypatch)
+def _build_test_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    enable_refresh_tokens: bool = True,
+) -> TestClient:
+    auth = _build_test_auth(monkeypatch, enable_refresh_tokens=enable_refresh_tokens)
     mcp = FastMCP("test", auth=auth)
     app = mcp.http_app(path="/mcp", transport="streamable-http")
     return TestClient(app)
@@ -165,6 +177,18 @@ def test_create_mcp_auth_metadata_preserves_upstream_fields(
     }
 
 
+def test_create_mcp_auth_metadata_omits_refresh_scope_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_test_client(monkeypatch, enable_refresh_tokens=False)
+
+    response = client.get("/.well-known/oauth-authorization-server")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["scopes_supported"] == ["openid", "profile", "email"]
+
+
 def test_create_mcp_auth_protected_resource_metadata_uses_mcp_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -182,6 +206,27 @@ def test_create_mcp_auth_protected_resource_metadata_uses_mcp_path(
         "email",
         "offline_access",
     ]
+
+
+def test_create_mcp_auth_registration_defaults_scope_without_refresh_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_test_client(monkeypatch, enable_refresh_tokens=False)
+
+    registration_response = client.post(
+        "/register",
+        json={
+            "client_name": "codex-test",
+            "redirect_uris": ["http://localhost:3333/callback"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+        },
+    )
+
+    assert registration_response.status_code == 201
+    registration = registration_response.json()
+    assert registration["scope"] == "openid profile email"
 
 
 def test_create_mcp_auth_metadata_matches_public_client_registration(

--- a/tests/unit/test_mcp_oidc_endpoints.py
+++ b/tests/unit/test_mcp_oidc_endpoints.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
 import secrets
 import time
@@ -108,6 +109,7 @@ def _setup_config(monkeypatch: pytest.MonkeyPatch):  # pyright: ignore[reportUnu
     monkeypatch.setattr(
         "tracecat.mcp.oidc.endpoints.TRACECAT__PUBLIC_APP_URL", _TEST_APP_URL
     )
+    monkeypatch.setattr("tracecat.config.TRACECAT__DB_ENCRYPTION_KEY", "enabled")
     signing.get_signing_key.cache_clear()
     signing.get_public_jwk.cache_clear()
     yield
@@ -129,7 +131,7 @@ class _StubSession:
     """Stand-in for AsyncSession used by tests that mock all DB calls.
 
     The token endpoint depends on a session for refresh-token persistence,
-    but tests that mock ``issue_refresh_token`` / ``consume_refresh_token``
+    but tests that mock ``issue_refresh_token`` / ``rotate_refresh_token``
     never touch the underlying session. This stub satisfies the dependency
     without opening a real DB connection.
     """
@@ -140,11 +142,19 @@ class _StubSession:
     def add(self, *_args, **_kwargs) -> None:  # pragma: no cover - defensive
         raise AssertionError("_StubSession.add should not be called in unit tests")
 
-    async def commit(self) -> None:  # pragma: no cover - defensive
-        raise AssertionError("_StubSession.commit should not be called in unit tests")
+    async def commit(self) -> None:
+        return None
+
+    async def rollback(self) -> None:
+        return None
 
 
 async def _stub_session_dependency():
+    yield _StubSession()
+
+
+@contextlib.asynccontextmanager
+async def _stub_bypass_session_context_manager():
     yield _StubSession()
 
 
@@ -159,6 +169,10 @@ def app(monkeypatch: pytest.MonkeyPatch):
     test_app.dependency_overrides[optional_current_active_user] = lambda: None
     test_app.dependency_overrides[get_async_session_bypass_rls] = (
         _stub_session_dependency
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.get_async_session_bypass_rls_context_manager",
+        _stub_bypass_session_context_manager,
     )
     return test_app
 
@@ -226,6 +240,20 @@ def test_openid_configuration_includes_root_path_when_proxied(
     assert payload["token_endpoint"] == f"{request_issuer}/token"
     assert payload["userinfo_endpoint"] == f"{request_issuer}/userinfo"
     assert payload["jwks_uri"] == f"{request_issuer}/.well-known/jwks.json"
+
+
+def test_openid_configuration_omits_refresh_support_when_disabled(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("tracecat.config.TRACECAT__DB_ENCRYPTION_KEY", "")
+
+    response = client.get("/.well-known/openid-configuration")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["scopes_supported"] == ["openid", "profile", "email"]
+    assert payload["grant_types_supported"] == ["authorization_code"]
 
 
 def test_jwks_returns_valid_ed25519_key(client: TestClient) -> None:
@@ -842,6 +870,47 @@ async def test_token_auth_code_grant_includes_refresh_with_offline_access(
     assert call_kwargs["metadata"].scope == code_data.scope
 
 
+@pytest.mark.anyio
+async def test_token_auth_code_grant_strips_offline_access_when_disabled(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verifier, challenge = _pkce_pair()
+    code_data = _make_auth_code_data(challenge=challenge).model_copy(
+        update={"scope": "openid profile email offline_access"}
+    )
+
+    issued = AsyncMock(return_value="should-not-be-called")
+    monkeypatch.setattr("tracecat.config.TRACECAT__DB_ENCRYPTION_KEY", "")
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.check_token_rate_limit",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.load_and_delete_auth_code",
+        AsyncMock(return_value=code_data),
+    )
+    monkeypatch.setattr("tracecat.mcp.oidc.endpoints.store_jti", AsyncMock())
+    monkeypatch.setattr("tracecat.mcp.oidc.endpoints.issue_refresh_token", issued)
+    secret = oidc_config.get_internal_client_secret()
+
+    response = client.post(
+        "/token",
+        data=_token_form(
+            code=code_data.code,
+            verifier=verifier,
+            client_id=oidc_config.INTERNAL_CLIENT_ID,
+            client_secret=secret,
+        ),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "refresh_token" not in body
+    assert body["scope"] == "openid profile email"
+    issued.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Token endpoint — refresh_token grant
 # ---------------------------------------------------------------------------
@@ -899,12 +968,8 @@ async def test_token_refresh_grant_returns_new_tokens_without_id_token(
         AsyncMock(return_value=True),
     )
     monkeypatch.setattr(
-        "tracecat.mcp.oidc.endpoints.consume_refresh_token",
-        AsyncMock(return_value=ctx),
-    )
-    monkeypatch.setattr(
-        "tracecat.mcp.oidc.endpoints.issue_refresh_token",
-        AsyncMock(return_value="new-rotated-refresh-token"),
+        "tracecat.mcp.oidc.endpoints.rotate_refresh_token",
+        AsyncMock(return_value=(ctx, "new-rotated-refresh-token")),
     )
     monkeypatch.setattr("tracecat.mcp.oidc.endpoints.store_jti", AsyncMock())
     secret = oidc_config.get_internal_client_secret()
@@ -938,21 +1003,20 @@ async def test_token_refresh_grant_returns_new_tokens_without_id_token(
 
 
 @pytest.mark.anyio
-async def test_token_refresh_grant_carries_family_to_rotated_token(
+async def test_token_refresh_grant_passes_token_and_client_to_rotation_helper(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     ctx = _make_refresh_context()
-    issued = AsyncMock(return_value="rotated-token")
+    rotated = AsyncMock(return_value=(ctx, "rotated-token"))
     monkeypatch.setattr(
         "tracecat.mcp.oidc.endpoints.check_token_rate_limit",
         AsyncMock(return_value=True),
     )
     monkeypatch.setattr(
-        "tracecat.mcp.oidc.endpoints.consume_refresh_token",
-        AsyncMock(return_value=ctx),
+        "tracecat.mcp.oidc.endpoints.rotate_refresh_token",
+        rotated,
     )
-    monkeypatch.setattr("tracecat.mcp.oidc.endpoints.issue_refresh_token", issued)
     monkeypatch.setattr("tracecat.mcp.oidc.endpoints.store_jti", AsyncMock())
     secret = oidc_config.get_internal_client_secret()
 
@@ -967,10 +1031,11 @@ async def test_token_refresh_grant_carries_family_to_rotated_token(
     )
 
     assert response.status_code == 200
-    issued.assert_awaited_once()
-    assert issued.await_args is not None
-    call_kwargs = issued.await_args.kwargs
-    assert call_kwargs["family_id"] == ctx.family_id
+    rotated.assert_awaited_once()
+    assert rotated.await_args is not None
+    call_kwargs = rotated.await_args.kwargs
+    assert call_kwargs["token"] == "any"
+    assert call_kwargs["client_id"] == oidc_config.INTERNAL_CLIENT_ID
 
 
 @pytest.mark.anyio
@@ -983,7 +1048,7 @@ async def test_token_refresh_grant_maps_invalid_grant_error(
         AsyncMock(return_value=True),
     )
     monkeypatch.setattr(
-        "tracecat.mcp.oidc.endpoints.consume_refresh_token",
+        "tracecat.mcp.oidc.endpoints.rotate_refresh_token",
         AsyncMock(
             side_effect=RefreshTokenError(
                 "invalid_grant", "Refresh token is invalid or expired"
@@ -1018,7 +1083,7 @@ async def test_token_refresh_grant_maps_replay_error(
         AsyncMock(return_value=True),
     )
     monkeypatch.setattr(
-        "tracecat.mcp.oidc.endpoints.consume_refresh_token",
+        "tracecat.mcp.oidc.endpoints.rotate_refresh_token",
         AsyncMock(
             side_effect=RefreshTokenError(
                 "invalid_grant",
@@ -1042,6 +1107,34 @@ async def test_token_refresh_grant_maps_replay_error(
     body = response.json()
     assert body["error"] == "invalid_grant"
     assert "replay" in body["error_description"]
+
+
+@pytest.mark.anyio
+async def test_token_refresh_grant_rejects_when_refresh_tokens_disabled(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("tracecat.config.TRACECAT__DB_ENCRYPTION_KEY", "")
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.check_token_rate_limit",
+        AsyncMock(return_value=True),
+    )
+    secret = oidc_config.get_internal_client_secret()
+
+    response = client.post(
+        "/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "old-refresh-token",
+            "client_id": oidc_config.INTERNAL_CLIENT_ID,
+            "client_secret": secret,
+        },
+    )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"] == "invalid_grant"
+    assert "disabled" in body["error_description"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_oidc_endpoints.py
+++ b/tests/unit/test_mcp_oidc_endpoints.py
@@ -16,11 +16,18 @@ from fastapi import FastAPI
 from starlette.testclient import TestClient
 
 from tracecat.auth.users import optional_current_active_user
+from tracecat.db.engine import get_async_session_bypass_rls
 from tracecat.db.models import User
 from tracecat.mcp.oidc import config as oidc_config
 from tracecat.mcp.oidc import signing
 from tracecat.mcp.oidc.endpoints import router
-from tracecat.mcp.oidc.schemas import AuthCodeData, ResumeTransaction
+from tracecat.mcp.oidc.refresh_tokens import RefreshTokenError
+from tracecat.mcp.oidc.schemas import (
+    AuthCodeData,
+    RefreshTokenContext,
+    RefreshTokenMetadata,
+    ResumeTransaction,
+)
 from tracecat.mcp.oidc.session import NeedsAction, SessionNeedsAction, SessionResult
 
 # ---------------------------------------------------------------------------
@@ -118,6 +125,29 @@ def mock_user():
     )
 
 
+class _StubSession:
+    """Stand-in for AsyncSession used by tests that mock all DB calls.
+
+    The token endpoint depends on a session for refresh-token persistence,
+    but tests that mock ``issue_refresh_token`` / ``consume_refresh_token``
+    never touch the underlying session. This stub satisfies the dependency
+    without opening a real DB connection.
+    """
+
+    async def execute(self, *_args, **_kwargs):  # pragma: no cover - defensive
+        raise AssertionError("_StubSession.execute should not be called in unit tests")
+
+    def add(self, *_args, **_kwargs) -> None:  # pragma: no cover - defensive
+        raise AssertionError("_StubSession.add should not be called in unit tests")
+
+    async def commit(self) -> None:  # pragma: no cover - defensive
+        raise AssertionError("_StubSession.commit should not be called in unit tests")
+
+
+async def _stub_session_dependency():
+    yield _StubSession()
+
+
 @pytest.fixture()
 def app(monkeypatch: pytest.MonkeyPatch):
     """Create a FastAPI test app with the OIDC router."""
@@ -127,6 +157,9 @@ def app(monkeypatch: pytest.MonkeyPatch):
     # Override the user dependency to return None by default
     # (individual tests can override to return a mock user).
     test_app.dependency_overrides[optional_current_active_user] = lambda: None
+    test_app.dependency_overrides[get_async_session_bypass_rls] = (
+        _stub_session_dependency
+    )
     return test_app
 
 
@@ -155,9 +188,17 @@ def test_openid_configuration_returns_correct_fields(client: TestClient) -> None
     assert payload["userinfo_endpoint"] == f"{request_issuer}/userinfo"
     assert payload["jwks_uri"] == f"{request_issuer}/.well-known/jwks.json"
     assert payload["response_types_supported"] == ["code"]
-    assert payload["scopes_supported"] == ["openid", "profile", "email"]
+    assert payload["scopes_supported"] == [
+        "openid",
+        "profile",
+        "email",
+        "offline_access",
+    ]
     assert payload["code_challenge_methods_supported"] == ["S256"]
-    assert payload["grant_types_supported"] == ["authorization_code"]
+    assert payload["grant_types_supported"] == [
+        "authorization_code",
+        "refresh_token",
+    ]
 
 
 def test_openid_configuration_includes_root_path_when_proxied(
@@ -453,10 +494,21 @@ def test_token_rejects_wrong_grant_type(
         AsyncMock(return_value=True),
     )
 
-    response = client.post("/token", data=_token_form(grant_type="client_credentials"))
+    secret = oidc_config.get_internal_client_secret()
+    response = client.post(
+        "/token",
+        data=_token_form(
+            grant_type="client_credentials",
+            client_id=oidc_config.INTERNAL_CLIENT_ID,
+            client_secret=secret,
+        ),
+    )
 
     assert response.status_code == 400
-    assert response.json()["error"] == "unsupported_grant_type"
+    body = response.json()
+    assert body["error"] == "unsupported_grant_type"
+    assert "authorization_code" in body["error_description"]
+    assert "refresh_token" in body["error_description"]
 
 
 def test_token_rejects_invalid_client_id(
@@ -697,6 +749,299 @@ async def test_token_accepts_basic_auth(
 
     assert response.status_code == 200
     assert "access_token" in response.json()
+
+
+# ---------------------------------------------------------------------------
+# Token endpoint — refresh token issuance on offline_access
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_token_auth_code_grant_omits_refresh_without_offline_access(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verifier, challenge = _pkce_pair()
+    code_data = _make_auth_code_data(challenge=challenge)
+    assert "offline_access" not in code_data.scope.split()
+
+    issued = AsyncMock(return_value="should-not-be-called")
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.check_token_rate_limit",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.load_and_delete_auth_code",
+        AsyncMock(return_value=code_data),
+    )
+    monkeypatch.setattr("tracecat.mcp.oidc.endpoints.store_jti", AsyncMock())
+    monkeypatch.setattr("tracecat.mcp.oidc.endpoints.issue_refresh_token", issued)
+    secret = oidc_config.get_internal_client_secret()
+
+    response = client.post(
+        "/token",
+        data=_token_form(
+            code=code_data.code,
+            verifier=verifier,
+            client_id=oidc_config.INTERNAL_CLIENT_ID,
+            client_secret=secret,
+        ),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "refresh_token" not in body
+    assert body["expires_in"] == 3600
+    issued.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_token_auth_code_grant_includes_refresh_with_offline_access(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verifier, challenge = _pkce_pair()
+    code_data = _make_auth_code_data(challenge=challenge).model_copy(
+        update={"scope": "openid profile email offline_access"}
+    )
+
+    issued = AsyncMock(return_value="opaque-refresh-token-value")
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.check_token_rate_limit",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.load_and_delete_auth_code",
+        AsyncMock(return_value=code_data),
+    )
+    monkeypatch.setattr("tracecat.mcp.oidc.endpoints.store_jti", AsyncMock())
+    monkeypatch.setattr("tracecat.mcp.oidc.endpoints.issue_refresh_token", issued)
+    secret = oidc_config.get_internal_client_secret()
+
+    response = client.post(
+        "/token",
+        data=_token_form(
+            code=code_data.code,
+            verifier=verifier,
+            client_id=oidc_config.INTERNAL_CLIENT_ID,
+            client_secret=secret,
+        ),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["refresh_token"] == "opaque-refresh-token-value"
+    assert body["expires_in"] == 3600
+    assert "id_token" in body
+    issued.assert_awaited_once()
+    assert issued.await_args is not None
+    call_kwargs = issued.await_args.kwargs
+    assert call_kwargs["user_id"] == code_data.user_id
+    assert call_kwargs["organization_id"] == code_data.organization_id
+    assert call_kwargs["client_id"] == oidc_config.INTERNAL_CLIENT_ID
+    assert call_kwargs["metadata"].scope == code_data.scope
+
+
+# ---------------------------------------------------------------------------
+# Token endpoint — refresh_token grant
+# ---------------------------------------------------------------------------
+
+
+def _make_refresh_context(**overrides) -> RefreshTokenContext:
+    metadata = RefreshTokenMetadata(
+        email="user@example.com",
+        is_platform_superuser=False,
+        scope="openid profile email offline_access",
+        resource=f"{_TEST_APP_URL}/mcp",
+    )
+    defaults = {
+        "family_id": uuid.uuid4(),
+        "user_id": uuid.uuid4(),
+        "organization_id": uuid.uuid4(),
+        "client_id": oidc_config.INTERNAL_CLIENT_ID,
+        "metadata": metadata,
+    }
+    return RefreshTokenContext(**(defaults | overrides))
+
+
+@pytest.mark.anyio
+async def test_token_refresh_grant_rejects_missing_refresh_token(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.check_token_rate_limit",
+        AsyncMock(return_value=True),
+    )
+    secret = oidc_config.get_internal_client_secret()
+
+    response = client.post(
+        "/token",
+        data={
+            "grant_type": "refresh_token",
+            "client_id": oidc_config.INTERNAL_CLIENT_ID,
+            "client_secret": secret,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_request"
+
+
+@pytest.mark.anyio
+async def test_token_refresh_grant_returns_new_tokens_without_id_token(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _make_refresh_context()
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.check_token_rate_limit",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.consume_refresh_token",
+        AsyncMock(return_value=ctx),
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.issue_refresh_token",
+        AsyncMock(return_value="new-rotated-refresh-token"),
+    )
+    monkeypatch.setattr("tracecat.mcp.oidc.endpoints.store_jti", AsyncMock())
+    secret = oidc_config.get_internal_client_secret()
+
+    response = client.post(
+        "/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "old-refresh-token",
+            "client_id": oidc_config.INTERNAL_CLIENT_ID,
+            "client_secret": secret,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "access_token" in body
+    assert body["token_type"] == "Bearer"
+    assert body["expires_in"] == 3600
+    assert body["refresh_token"] == "new-rotated-refresh-token"
+    assert body["scope"] == ctx.metadata.scope
+    # Per OIDC spec, id_token is only issued at initial authorization.
+    assert "id_token" not in body
+
+    # Access token claims should match the original session context.
+    decoded = signing.verify_jwt(body["access_token"])
+    assert decoded["sub"] == str(ctx.user_id)
+    assert decoded["organization_id"] == str(ctx.organization_id)
+    assert decoded["email"] == ctx.metadata.email
+    assert decoded["scope"] == ctx.metadata.scope
+
+
+@pytest.mark.anyio
+async def test_token_refresh_grant_carries_family_to_rotated_token(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _make_refresh_context()
+    issued = AsyncMock(return_value="rotated-token")
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.check_token_rate_limit",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.consume_refresh_token",
+        AsyncMock(return_value=ctx),
+    )
+    monkeypatch.setattr("tracecat.mcp.oidc.endpoints.issue_refresh_token", issued)
+    monkeypatch.setattr("tracecat.mcp.oidc.endpoints.store_jti", AsyncMock())
+    secret = oidc_config.get_internal_client_secret()
+
+    response = client.post(
+        "/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "any",
+            "client_id": oidc_config.INTERNAL_CLIENT_ID,
+            "client_secret": secret,
+        },
+    )
+
+    assert response.status_code == 200
+    issued.assert_awaited_once()
+    assert issued.await_args is not None
+    call_kwargs = issued.await_args.kwargs
+    assert call_kwargs["family_id"] == ctx.family_id
+
+
+@pytest.mark.anyio
+async def test_token_refresh_grant_maps_invalid_grant_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.check_token_rate_limit",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.consume_refresh_token",
+        AsyncMock(
+            side_effect=RefreshTokenError(
+                "invalid_grant", "Refresh token is invalid or expired"
+            )
+        ),
+    )
+    secret = oidc_config.get_internal_client_secret()
+
+    response = client.post(
+        "/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "stale-token",
+            "client_id": oidc_config.INTERNAL_CLIENT_ID,
+            "client_secret": secret,
+        },
+    )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"] == "invalid_grant"
+    assert "invalid or expired" in body["error_description"]
+
+
+@pytest.mark.anyio
+async def test_token_refresh_grant_maps_replay_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.check_token_rate_limit",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.consume_refresh_token",
+        AsyncMock(
+            side_effect=RefreshTokenError(
+                "invalid_grant",
+                "Refresh token replay detected; family revoked",
+            )
+        ),
+    )
+    secret = oidc_config.get_internal_client_secret()
+
+    response = client.post(
+        "/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "replayed-token",
+            "client_id": oidc_config.INTERNAL_CLIENT_ID,
+            "client_secret": secret,
+        },
+    )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"] == "invalid_grant"
+    assert "replay" in body["error_description"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_oidc_endpoints.py
+++ b/tests/unit/test_mcp_oidc_endpoints.py
@@ -149,6 +149,20 @@ class _StubSession:
         return None
 
 
+class _TrackingSession(_StubSession):
+    """Session stub that records transaction calls for endpoint tests."""
+
+    def __init__(self) -> None:
+        self.commit_mock = AsyncMock()
+        self.rollback_mock = AsyncMock()
+
+    async def commit(self) -> None:
+        await self.commit_mock()
+
+    async def rollback(self) -> None:
+        await self.rollback_mock()
+
+
 async def _stub_session_dependency():
     yield _StubSession()
 
@@ -1107,6 +1121,51 @@ async def test_token_refresh_grant_maps_replay_error(
     body = response.json()
     assert body["error"] == "invalid_grant"
     assert "replay" in body["error_description"]
+
+
+@pytest.mark.anyio
+async def test_token_refresh_grant_rolls_back_if_store_jti_fails_before_commit(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracked_session = _TrackingSession()
+
+    @contextlib.asynccontextmanager
+    async def tracked_bypass_session_context_manager():
+        yield tracked_session
+
+    ctx = _make_refresh_context()
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.check_token_rate_limit",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.get_async_session_bypass_rls_context_manager",
+        tracked_bypass_session_context_manager,
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.rotate_refresh_token",
+        AsyncMock(return_value=(ctx, "new-rotated-refresh-token")),
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.store_jti",
+        AsyncMock(side_effect=RuntimeError("redis unavailable")),
+    )
+    secret = oidc_config.get_internal_client_secret()
+
+    with pytest.raises(RuntimeError, match="redis unavailable"):
+        client.post(
+            "/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": "old-refresh-token",
+                "client_id": oidc_config.INTERNAL_CLIENT_ID,
+                "client_secret": secret,
+            },
+        )
+
+    tracked_session.rollback_mock.assert_awaited_once()
+    tracked_session.commit_mock.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_mcp_oidc_endpoints.py
+++ b/tests/unit/test_mcp_oidc_endpoints.py
@@ -816,6 +816,12 @@ async def test_token_auth_code_grant_omits_refresh_without_offline_access(
         "tracecat.mcp.oidc.endpoints.load_and_delete_auth_code",
         AsyncMock(return_value=code_data),
     )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.get_async_session_bypass_rls_context_manager",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("refresh-token session should not be opened")
+        ),
+    )
     monkeypatch.setattr("tracecat.mcp.oidc.endpoints.store_jti", AsyncMock())
     monkeypatch.setattr("tracecat.mcp.oidc.endpoints.issue_refresh_token", issued)
     secret = oidc_config.get_internal_client_secret()
@@ -847,6 +853,12 @@ async def test_token_auth_code_grant_includes_refresh_with_offline_access(
         update={"scope": "openid profile email offline_access"}
     )
 
+    tracked_session = _StubSession()
+
+    @contextlib.asynccontextmanager
+    async def tracked_bypass_session_context_manager():
+        yield tracked_session
+
     issued = AsyncMock(return_value="opaque-refresh-token-value")
     monkeypatch.setattr(
         "tracecat.mcp.oidc.endpoints.check_token_rate_limit",
@@ -855,6 +867,10 @@ async def test_token_auth_code_grant_includes_refresh_with_offline_access(
     monkeypatch.setattr(
         "tracecat.mcp.oidc.endpoints.load_and_delete_auth_code",
         AsyncMock(return_value=code_data),
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.get_async_session_bypass_rls_context_manager",
+        tracked_bypass_session_context_manager,
     )
     monkeypatch.setattr("tracecat.mcp.oidc.endpoints.store_jti", AsyncMock())
     monkeypatch.setattr("tracecat.mcp.oidc.endpoints.issue_refresh_token", issued)
@@ -877,6 +893,7 @@ async def test_token_auth_code_grant_includes_refresh_with_offline_access(
     assert "id_token" in body
     issued.assert_awaited_once()
     assert issued.await_args is not None
+    assert issued.await_args.args[0] is tracked_session
     call_kwargs = issued.await_args.kwargs
     assert call_kwargs["user_id"] == code_data.user_id
     assert call_kwargs["organization_id"] == code_data.organization_id

--- a/tests/unit/test_mcp_oidc_refresh_tokens.py
+++ b/tests/unit/test_mcp_oidc_refresh_tokens.py
@@ -391,6 +391,36 @@ async def test_rotate_refresh_token_client_mismatch_revocation_survives_caller_r
 
 
 @pytest.mark.anyio
+async def test_rotate_refresh_token_maps_metadata_decode_failure_to_invalid_grant(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    token = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=_make_metadata(),
+    )
+
+    row = (
+        await session.execute(
+            select(MCPRefreshToken).where(
+                MCPRefreshToken.token_hash == _hash_token(token)
+            )
+        )
+    ).scalar_one()
+    row.encrypted_metadata = b"corrupted"
+    await session.commit()
+
+    with pytest.raises(RefreshTokenError) as exc_info:
+        await rotate_refresh_token(session, token=token, client_id=_TEST_CLIENT_ID)
+    assert exc_info.value.oauth_error == "invalid_grant"
+    assert "invalid or expired" in exc_info.value.description
+
+
+@pytest.mark.anyio
 async def test_consume_refresh_token_replay_revokes_entire_family(
     session: AsyncSession,
     svc_organization: Organization,

--- a/tests/unit/test_mcp_oidc_refresh_tokens.py
+++ b/tests/unit/test_mcp_oidc_refresh_tokens.py
@@ -318,6 +318,79 @@ async def test_rotate_refresh_token_replay_revokes_replacement_token(
 
 
 @pytest.mark.anyio
+async def test_rotate_refresh_token_replay_revocation_survives_caller_rollback(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    token_a = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=_make_metadata(),
+    )
+
+    ctx, token_b = await rotate_refresh_token(
+        session, token=token_a, client_id=_TEST_CLIENT_ID
+    )
+    await session.commit()
+
+    with pytest.raises(RefreshTokenError) as exc_info:
+        await rotate_refresh_token(session, token=token_a, client_id=_TEST_CLIENT_ID)
+    assert "replay" in exc_info.value.description.lower()
+
+    await session.rollback()
+
+    rows = (
+        (
+            await session.execute(
+                select(MCPRefreshToken).where(
+                    MCPRefreshToken.family_id == ctx.family_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    assert all(row.status == "revoked" for row in rows)
+
+    with pytest.raises(RefreshTokenError):
+        await consume_refresh_token(session, token=token_b, client_id=_TEST_CLIENT_ID)
+
+
+@pytest.mark.anyio
+async def test_rotate_refresh_token_client_mismatch_revocation_survives_caller_rollback(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    token = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=_make_metadata(),
+    )
+
+    with pytest.raises(RefreshTokenError) as exc_info:
+        await rotate_refresh_token(session, token=token, client_id="some-other-client")
+    assert "client_id mismatch" in exc_info.value.description
+
+    await session.rollback()
+
+    row = (
+        await session.execute(
+            select(MCPRefreshToken).where(
+                MCPRefreshToken.token_hash == _hash_token(token)
+            )
+        )
+    ).scalar_one()
+    assert row.status == "revoked"
+
+
+@pytest.mark.anyio
 async def test_consume_refresh_token_replay_revokes_entire_family(
     session: AsyncSession,
     svc_organization: Organization,

--- a/tests/unit/test_mcp_oidc_refresh_tokens.py
+++ b/tests/unit/test_mcp_oidc_refresh_tokens.py
@@ -278,6 +278,46 @@ async def test_rotate_refresh_token_issues_replacement_and_marks_old_used(
 
 
 @pytest.mark.anyio
+async def test_rotate_refresh_token_renews_expiry_window(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    token_a = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=_make_metadata(),
+    )
+
+    row_a = (
+        await session.execute(
+            select(MCPRefreshToken).where(
+                MCPRefreshToken.token_hash == _hash_token(token_a)
+            )
+        )
+    ).scalar_one()
+    original_expiry = datetime.now(UTC) + timedelta(minutes=5)
+    row_a.expires_at = original_expiry
+    await session.commit()
+
+    ctx, token_b = await rotate_refresh_token(
+        session, token=token_a, client_id=_TEST_CLIENT_ID
+    )
+
+    row_b = (
+        await session.execute(
+            select(MCPRefreshToken).where(
+                MCPRefreshToken.family_id == ctx.family_id,
+                MCPRefreshToken.token_hash == _hash_token(token_b),
+            )
+        )
+    ).scalar_one()
+    assert row_b.expires_at > original_expiry + timedelta(days=29)
+
+
+@pytest.mark.anyio
 async def test_rotate_refresh_token_replay_revokes_replacement_token(
     session: AsyncSession,
     svc_organization: Organization,

--- a/tests/unit/test_mcp_oidc_refresh_tokens.py
+++ b/tests/unit/test_mcp_oidc_refresh_tokens.py
@@ -1,0 +1,406 @@
+"""Tests for tracecat.mcp.oidc.refresh_tokens — Postgres-backed refresh tokens."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat import config
+from tracecat.db.models import MCPRefreshToken, Organization, User
+from tracecat.mcp.oidc.refresh_tokens import (
+    RefreshTokenError,
+    _hash_token,
+    consume_refresh_token,
+    issue_refresh_token,
+    revoke_family,
+)
+from tracecat.mcp.oidc.schemas import RefreshTokenMetadata
+
+pytestmark = pytest.mark.usefixtures("db")
+
+_TEST_CLIENT_ID = "tracecat-mcp-oidc-internal"
+
+
+@pytest.fixture(autouse=True)
+def encryption_key(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Set up Fernet encryption key for the metadata blob."""
+    key = Fernet.generate_key().decode()
+    monkeypatch.setattr(config, "TRACECAT__DB_ENCRYPTION_KEY", key)
+    return key
+
+
+@pytest.fixture
+async def test_user(session: AsyncSession, svc_organization: Organization) -> User:
+    """Create a test user for refresh token tests."""
+    user = User(
+        id=uuid.uuid4(),
+        email="refresh-test@example.com",
+        hashed_password="hashed_password_placeholder",
+        last_login_at=None,
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+def _make_metadata(**overrides) -> RefreshTokenMetadata:
+    defaults = {
+        "email": "refresh-test@example.com",
+        "is_platform_superuser": False,
+        "scope": "openid profile email offline_access",
+        "resource": "https://app.example.com/mcp",
+    }
+    return RefreshTokenMetadata(**(defaults | overrides))
+
+
+# ---------------------------------------------------------------------------
+# issue_refresh_token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_issue_refresh_token_creates_active_row(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    metadata = _make_metadata()
+
+    token = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=metadata,
+    )
+
+    assert token  # opaque, non-empty
+    row = (
+        await session.execute(
+            select(MCPRefreshToken).where(
+                MCPRefreshToken.token_hash == _hash_token(token)
+            )
+        )
+    ).scalar_one()
+    assert row.status == "active"
+    assert row.user_id == test_user.id
+    assert row.organization_id == svc_organization.id
+    assert row.client_id == _TEST_CLIENT_ID
+    assert row.expires_at > datetime.now(UTC) + timedelta(days=29)
+
+
+@pytest.mark.anyio
+async def test_issue_refresh_token_does_not_store_plaintext(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    """The plaintext token must never be persisted — only its hash."""
+    token = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=_make_metadata(),
+    )
+
+    rows = (await session.execute(select(MCPRefreshToken))).scalars().all()
+    for row in rows:
+        assert row.token_hash != token
+        assert token.encode() not in row.encrypted_metadata
+
+
+# ---------------------------------------------------------------------------
+# consume_refresh_token — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_consume_refresh_token_returns_context_and_marks_used(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    metadata = _make_metadata()
+    token = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=metadata,
+    )
+
+    ctx = await consume_refresh_token(session, token=token, client_id=_TEST_CLIENT_ID)
+
+    assert ctx.user_id == test_user.id
+    assert ctx.organization_id == svc_organization.id
+    assert ctx.client_id == _TEST_CLIENT_ID
+    assert ctx.metadata.email == metadata.email
+    assert ctx.metadata.scope == metadata.scope
+
+    # Underlying row should now be 'used'.
+    row = (
+        await session.execute(
+            select(MCPRefreshToken).where(
+                MCPRefreshToken.token_hash == _hash_token(token)
+            )
+        )
+    ).scalar_one()
+    assert row.status == "used"
+
+
+# ---------------------------------------------------------------------------
+# consume_refresh_token — failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_consume_refresh_token_rejects_unknown(
+    session: AsyncSession,
+) -> None:
+    with pytest.raises(RefreshTokenError) as exc_info:
+        await consume_refresh_token(
+            session, token="never-issued-token", client_id=_TEST_CLIENT_ID
+        )
+    assert exc_info.value.oauth_error == "invalid_grant"
+
+
+@pytest.mark.anyio
+async def test_consume_refresh_token_rejects_expired(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    token = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=_make_metadata(),
+    )
+
+    # Backdate expiry by hand.
+    row = (
+        await session.execute(
+            select(MCPRefreshToken).where(
+                MCPRefreshToken.token_hash == _hash_token(token)
+            )
+        )
+    ).scalar_one()
+    row.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    await session.commit()
+
+    with pytest.raises(RefreshTokenError) as exc_info:
+        await consume_refresh_token(session, token=token, client_id=_TEST_CLIENT_ID)
+    assert exc_info.value.oauth_error == "invalid_grant"
+    assert "expired" in exc_info.value.description.lower()
+
+
+@pytest.mark.anyio
+async def test_consume_refresh_token_rejects_client_id_mismatch_and_revokes_family(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    token = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=_make_metadata(),
+    )
+
+    with pytest.raises(RefreshTokenError) as exc_info:
+        await consume_refresh_token(session, token=token, client_id="some-other-client")
+    assert exc_info.value.oauth_error == "invalid_grant"
+
+    # The token's family should now be revoked.
+    row = (
+        await session.execute(
+            select(MCPRefreshToken).where(
+                MCPRefreshToken.token_hash == _hash_token(token)
+            )
+        )
+    ).scalar_one()
+    assert row.status == "revoked"
+
+
+# ---------------------------------------------------------------------------
+# Replay detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_consume_refresh_token_replay_revokes_entire_family(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    """Reusing an already-consumed token revokes the whole family."""
+    metadata = _make_metadata()
+    token_a = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=metadata,
+    )
+
+    # Normal rotation: A -> B
+    ctx_a = await consume_refresh_token(
+        session, token=token_a, client_id=_TEST_CLIENT_ID
+    )
+    token_b = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=metadata,
+        family_id=ctx_a.family_id,
+    )
+
+    # Attacker presents A again — replay.
+    with pytest.raises(RefreshTokenError) as exc_info:
+        await consume_refresh_token(session, token=token_a, client_id=_TEST_CLIENT_ID)
+    assert "replay" in exc_info.value.description.lower()
+
+    # Both A and B should now be revoked.
+    rows = (
+        (
+            await session.execute(
+                select(MCPRefreshToken).where(
+                    MCPRefreshToken.family_id == ctx_a.family_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    assert all(row.status == "revoked" for row in rows)
+
+    # B is no longer usable even by the legitimate client.
+    with pytest.raises(RefreshTokenError):
+        await consume_refresh_token(session, token=token_b, client_id=_TEST_CLIENT_ID)
+
+
+@pytest.mark.anyio
+async def test_consume_refresh_token_rejects_already_revoked(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    token = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=_make_metadata(),
+    )
+
+    row = (
+        await session.execute(
+            select(MCPRefreshToken).where(
+                MCPRefreshToken.token_hash == _hash_token(token)
+            )
+        )
+    ).scalar_one()
+    await revoke_family(session, row.family_id)
+
+    with pytest.raises(RefreshTokenError) as exc_info:
+        await consume_refresh_token(session, token=token, client_id=_TEST_CLIENT_ID)
+    assert exc_info.value.oauth_error == "invalid_grant"
+
+
+# ---------------------------------------------------------------------------
+# revoke_family
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_revoke_family_marks_all_family_tokens(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    metadata = _make_metadata()
+    family_id = uuid.uuid4()
+    for _ in range(3):
+        await issue_refresh_token(
+            session,
+            user_id=test_user.id,
+            organization_id=svc_organization.id,
+            client_id=_TEST_CLIENT_ID,
+            metadata=metadata,
+            family_id=family_id,
+        )
+
+    await revoke_family(session, family_id)
+
+    rows = (
+        (
+            await session.execute(
+                select(MCPRefreshToken).where(MCPRefreshToken.family_id == family_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 3
+    assert all(row.status == "revoked" for row in rows)
+
+
+@pytest.mark.anyio
+async def test_revoke_family_does_not_touch_other_families(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    metadata = _make_metadata()
+    family_a = uuid.uuid4()
+    family_b = uuid.uuid4()
+
+    token_a = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=metadata,
+        family_id=family_a,
+    )
+    token_b = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=metadata,
+        family_id=family_b,
+    )
+
+    await revoke_family(session, family_a)
+
+    row_a = (
+        await session.execute(
+            select(MCPRefreshToken).where(
+                MCPRefreshToken.token_hash == _hash_token(token_a)
+            )
+        )
+    ).scalar_one()
+    row_b = (
+        await session.execute(
+            select(MCPRefreshToken).where(
+                MCPRefreshToken.token_hash == _hash_token(token_b)
+            )
+        )
+    ).scalar_one()
+    assert row_a.status == "revoked"
+    assert row_b.status == "active"

--- a/tests/unit/test_mcp_oidc_refresh_tokens.py
+++ b/tests/unit/test_mcp_oidc_refresh_tokens.py
@@ -18,6 +18,7 @@ from tracecat.mcp.oidc.refresh_tokens import (
     consume_refresh_token,
     issue_refresh_token,
     revoke_family,
+    rotate_refresh_token,
 )
 from tracecat.mcp.oidc.schemas import RefreshTokenMetadata
 
@@ -237,6 +238,83 @@ async def test_consume_refresh_token_rejects_client_id_mismatch_and_revokes_fami
 # ---------------------------------------------------------------------------
 # Replay detection
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rotate_refresh_token_issues_replacement_and_marks_old_used(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    token_a = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=_make_metadata(),
+    )
+
+    ctx, token_b = await rotate_refresh_token(
+        session, token=token_a, client_id=_TEST_CLIENT_ID
+    )
+
+    assert token_b
+    assert token_b != token_a
+    rows = (
+        (
+            await session.execute(
+                select(MCPRefreshToken).where(
+                    MCPRefreshToken.family_id == ctx.family_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    status_by_hash = {row.token_hash: row.status for row in rows}
+    assert status_by_hash[_hash_token(token_a)] == "used"
+    assert status_by_hash[_hash_token(token_b)] == "active"
+
+
+@pytest.mark.anyio
+async def test_rotate_refresh_token_replay_revokes_replacement_token(
+    session: AsyncSession,
+    svc_organization: Organization,
+    test_user: User,
+) -> None:
+    token_a = await issue_refresh_token(
+        session,
+        user_id=test_user.id,
+        organization_id=svc_organization.id,
+        client_id=_TEST_CLIENT_ID,
+        metadata=_make_metadata(),
+    )
+
+    ctx, token_b = await rotate_refresh_token(
+        session, token=token_a, client_id=_TEST_CLIENT_ID
+    )
+
+    with pytest.raises(RefreshTokenError) as exc_info:
+        await rotate_refresh_token(session, token=token_a, client_id=_TEST_CLIENT_ID)
+    assert "replay" in exc_info.value.description.lower()
+
+    rows = (
+        (
+            await session.execute(
+                select(MCPRefreshToken).where(
+                    MCPRefreshToken.family_id == ctx.family_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    assert all(row.status == "revoked" for row in rows)
+
+    with pytest.raises(RefreshTokenError):
+        await consume_refresh_token(session, token=token_b, client_id=_TEST_CLIENT_ID)
 
 
 @pytest.mark.anyio

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3577,6 +3577,66 @@ class MCPIntegration(TimestampMixin, Base):
     )
 
 
+class MCPRefreshToken(OrganizationModel):
+    """Refresh tokens issued by the internal MCP OIDC IdP."""
+
+    __tablename__ = "mcp_refresh_token"
+    __table_args__ = (
+        Index("ix_mcp_refresh_token_family_id", "family_id"),
+        Index("ix_mcp_refresh_token_expires_at", "expires_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        nullable=False,
+        unique=True,
+        index=True,
+        doc="Unique refresh token identifier",
+    )
+    token_hash: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        unique=True,
+        index=True,
+        doc="SHA-256 hex digest of the opaque refresh token. Plaintext is never stored so a DB leak yields hashes only.",
+    )
+    family_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        nullable=False,
+        doc="Groups all tokens descended from one auth code exchange. Used for replay-detection revocation.",
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        doc="User the refresh token was issued to",
+    )
+    client_id: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        doc="OAuth client_id the token was issued to",
+    )
+    encrypted_metadata: Mapped[bytes] = mapped_column(
+        LargeBinary,
+        nullable=False,
+        doc="Encrypted JSON blob with session context (email, scope, resource, is_platform_superuser). Encrypted via secrets.encryption.encrypt_bytes with TRACECAT__DB_ENCRYPTION_KEY.",
+    )
+    status: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        default="active",
+        index=True,
+        doc="State machine: 'active' -> 'used' (rotated normally) or 'revoked' (family revoked).",
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        doc="Absolute expiry timestamp for this refresh token",
+    )
+
+
 class OAuthStateDB(TimestampMixin, Base):
     """Store OAuth state parameters for CSRF protection during OAuth flows."""
 

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -76,7 +76,10 @@ POST_RLS_WORKSPACE_SCOPED_TABLES = (
     "agent_preset_version",
 )
 
-POST_RLS_ORG_SCOPED_TABLES = ("watchtower_agent",)
+POST_RLS_ORG_SCOPED_TABLES = (
+    "watchtower_agent",
+    "mcp_refresh_token",
+)
 
 POST_RLS_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES = (
     "watchtower_agent_session",

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -46,7 +46,6 @@ from tracecat.authz.controls import has_scope
 from tracecat.authz.enums import OrgRole, WorkspaceRole
 from tracecat.config import (
     REDIS_URL,
-    TRACECAT__DB_ENCRYPTION_KEY,
     TRACECAT__PUBLIC_APP_URL,
 )
 from tracecat.contexts import ctx_role
@@ -66,6 +65,10 @@ from tracecat.mcp.oidc.config import (
     get_internal_client_secret,
     get_internal_discovery_url,
 )
+from tracecat.mcp.oidc.features import (
+    OFFLINE_ACCESS_SCOPE,
+    get_supported_scopes,
+)
 
 
 class MCPTokenIdentity(BaseModel):
@@ -84,7 +87,6 @@ _UUID_SCOPE_PATTERNS: dict[str, re.Pattern[str]] = {
     "workspace": re.compile(r"^(?:workspace|workspace_id):(?P<uuid>[0-9a-fA-F-]{36})$"),
 }
 
-_MCP_REFRESH_SCOPE = "offline_access"
 _MCP_ACCESS_TOKEN_FALLBACK_EXPIRY_SECONDS = 24 * 60 * 60
 _MCP_OAUTH_TRANSACTION_TTL_SECONDS = 15 * 60
 _MCP_TOKEN_ENDPOINT_AUTH_METHODS = ["none", "client_secret_post", "client_secret_basic"]
@@ -129,7 +131,7 @@ def supports_refresh_scope(scopes_supported: Sequence[str] | None) -> bool:
     if scopes_supported is None:
         # If provider metadata omits scopes_supported, optimistically request.
         return True
-    return _MCP_REFRESH_SCOPE in scopes_supported
+    return OFFLINE_ACCESS_SCOPE in scopes_supported
 
 
 def _patch_oauth_metadata_route(app: ASGIApp) -> ASGIApp:
@@ -656,11 +658,11 @@ def _create_oidc_auth() -> OIDCProxy:
     # The internal OIDC issuer lives on the API server. The MCP server
     # uses it as the upstream identity provider instead of an external BYO
     # OIDC IdP. Keep ``offline_access`` out of ``_required_scopes`` so
-    # validated tool tokens do not require it, but advertise and default it
-    # for DCR so browser clients that omit ``scope`` still receive refresh
-    # tokens after re-authentication.
+    # validated tool tokens do not require it. Advertise and default the
+    # refresh scope only when refresh-token support is enabled for this
+    # deployment.
     _required_scopes = ["openid", "profile", "email"]
-    _supported_scopes = [*_required_scopes, _MCP_REFRESH_SCOPE]
+    _supported_scopes = get_supported_scopes()
 
     class TracecatProxyDCRClient(ProxyDCRClient):
         """Relax CIMD loopback callback validation to allow ephemeral local ports."""
@@ -744,11 +746,11 @@ def _create_oidc_auth() -> OIDCProxy:
                 return None
 
             scopes = list(txn_model.scopes or [])
-            if _MCP_REFRESH_SCOPE not in scopes:
+            if OFFLINE_ACCESS_SCOPE not in scopes:
                 # We already retried (or refresh scope was never requested).
                 return None
 
-            updated_scopes = remove_scope(scopes, _MCP_REFRESH_SCOPE)
+            updated_scopes = remove_scope(scopes, OFFLINE_ACCESS_SCOPE)
             updated_txn = txn_model.model_copy(update={"scopes": updated_scopes})
 
             age_seconds = max(0.0, time.time() - float(txn_model.created_at))
@@ -763,7 +765,7 @@ def _create_oidc_auth() -> OIDCProxy:
 
             logger.warning(
                 "OIDC provider rejected refresh scope; retrying authorization without refresh scope",
-                scope=_MCP_REFRESH_SCOPE,
+                scope=OFFLINE_ACCESS_SCOPE,
                 transaction_id=txn_id,
             )
 
@@ -1017,9 +1019,9 @@ def _create_oidc_auth() -> OIDCProxy:
     redis_client = AsyncRedis.from_url(REDIS_URL, decode_responses=True)
     redis_store = RedisStore(client=redis_client)
     prefixed_store = PrefixCollectionsWrapper(redis_store, prefix="mcp")
-    if TRACECAT__DB_ENCRYPTION_KEY:
+    if config.TRACECAT__DB_ENCRYPTION_KEY:
         client_storage = FernetEncryptionWrapper(
-            prefixed_store, fernet=Fernet(TRACECAT__DB_ENCRYPTION_KEY)
+            prefixed_store, fernet=Fernet(config.TRACECAT__DB_ENCRYPTION_KEY)
         )
     else:
         logger.warning(

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -653,10 +653,14 @@ def _create_oidc_auth() -> OIDCProxy:
     """Build the OIDC auth provider for external MCP."""
     base_url = TRACECAT__PUBLIC_APP_URL.rstrip("/")
 
-    # The internal OIDC issuer lives on the API server.  The MCP server
+    # The internal OIDC issuer lives on the API server. The MCP server
     # uses it as the upstream identity provider instead of an external BYO
-    # OIDC IdP.  No refresh tokens in v1, so offline_access is omitted.
+    # OIDC IdP. Keep ``offline_access`` out of ``_required_scopes`` so
+    # validated tool tokens do not require it, but advertise and default it
+    # for DCR so browser clients that omit ``scope`` still receive refresh
+    # tokens after re-authentication.
     _required_scopes = ["openid", "profile", "email"]
+    _supported_scopes = [*_required_scopes, _MCP_REFRESH_SCOPE]
 
     class TracecatProxyDCRClient(ProxyDCRClient):
         """Relax CIMD loopback callback validation to allow ephemeral local ports."""
@@ -1041,8 +1045,11 @@ def _create_oidc_auth() -> OIDCProxy:
     # required_scopes to the constructor — it flows into the JWT
     # verifier which then rejects any token missing those scopes.
     if auth.client_registration_options is not None:
-        auth.client_registration_options.valid_scopes = _required_scopes
-        auth.client_registration_options.default_scopes = _required_scopes
+        auth.client_registration_options.valid_scopes = _supported_scopes
+        auth.client_registration_options.default_scopes = _supported_scopes
+    auth._default_scope_str = " ".join(_supported_scopes)
+    if auth._cimd_manager is not None:
+        auth._cimd_manager.default_scope = auth._default_scope_str
     return auth
 
 

--- a/tracecat/mcp/oidc/config.py
+++ b/tracecat/mcp/oidc/config.py
@@ -61,8 +61,20 @@ def get_internal_discovery_url() -> str:
 
 # --- Lifetimes ---
 
-ACCESS_TOKEN_LIFETIME_SECONDS = 24 * 60 * 60
-"""Access token lifetime: 24 hours."""
+ACCESS_TOKEN_LIFETIME_SECONDS = 60 * 60
+"""Access token lifetime: 1 hour.
+
+Short-lived access tokens limit blast radius of token compromise.
+Clients use refresh tokens (when ``offline_access`` is requested) to
+obtain new access tokens transparently.
+"""
+
+REFRESH_TOKEN_LIFETIME_SECONDS = 30 * 24 * 60 * 60
+"""Refresh token lifetime: 30 days.
+
+Refresh tokens rotate on every use; the maximum session length without
+re-authentication is bounded by this value.
+"""
 
 AUTH_CODE_LIFETIME_SECONDS = 5 * 60
 """Authorization code lifetime: 5 minutes."""

--- a/tracecat/mcp/oidc/config.py
+++ b/tracecat/mcp/oidc/config.py
@@ -72,8 +72,10 @@ obtain new access tokens transparently.
 REFRESH_TOKEN_LIFETIME_SECONDS = 30 * 24 * 60 * 60
 """Refresh token lifetime: 30 days.
 
-Refresh tokens rotate on every use; the maximum session length without
-re-authentication is bounded by this value.
+Refresh tokens rotate on every use and renew this lifetime window on
+successful refresh. Active clients therefore keep a rolling session,
+while inactive clients must re-authenticate once a refresh token has
+been idle longer than this value.
 """
 
 AUTH_CODE_LIFETIME_SECONDS = 5 * 60

--- a/tracecat/mcp/oidc/endpoints.py
+++ b/tracecat/mcp/oidc/endpoints.py
@@ -18,14 +18,25 @@ from urllib.parse import urlencode
 import jwt
 from fastapi import APIRouter, Depends, Form, Header, Query, Request
 from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import RedirectResponse, Response
 
 from tracecat.auth.users import optional_current_active_user
 from tracecat.config import TRACECAT__PUBLIC_APP_URL
+from tracecat.db.dependencies import AsyncDBSessionBypass
 from tracecat.db.models import User
 from tracecat.logger import logger
 from tracecat.mcp.oidc import config as oidc_config
-from tracecat.mcp.oidc.schemas import AuthCodeData, ResumeTransaction
+from tracecat.mcp.oidc.refresh_tokens import (
+    RefreshTokenError,
+    consume_refresh_token,
+    issue_refresh_token,
+)
+from tracecat.mcp.oidc.schemas import (
+    AuthCodeData,
+    RefreshTokenMetadata,
+    ResumeTransaction,
+)
 from tracecat.mcp.oidc.session import (
     NeedsAction,
     SessionNeedsAction,
@@ -41,6 +52,8 @@ from tracecat.mcp.oidc.storage import (
     store_jti,
     store_resume_transaction,
 )
+
+_OFFLINE_ACCESS_SCOPE = "offline_access"
 
 router = APIRouter()
 
@@ -152,13 +165,13 @@ async def openid_configuration(request: Request) -> dict[str, Any]:
         "response_types_supported": ["code"],
         "subject_types_supported": ["public"],
         "id_token_signing_alg_values_supported": ["ES256"],
-        "scopes_supported": ["openid", "profile", "email"],
+        "scopes_supported": ["openid", "profile", "email", "offline_access"],
         "token_endpoint_auth_methods_supported": [
             "client_secret_basic",
             "client_secret_post",
         ],
         "code_challenge_methods_supported": ["S256"],
-        "grant_types_supported": ["authorization_code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
         "claims_supported": [
             "sub",
             "email",
@@ -410,18 +423,52 @@ async def authorize_resume(
 # ---------------------------------------------------------------------------
 
 
+def _success_headers() -> dict[str, str]:
+    return {"Cache-Control": "no-store", "Pragma": "no-cache"}
+
+
+def _mint_access_token(
+    *,
+    user_id: str,
+    organization_id: str,
+    email: str,
+    is_platform_superuser: bool,
+    scope: str,
+    resource: str,
+) -> tuple[str, str, int]:
+    """Mint an access token JWT. Returns (token, jti, exp)."""
+    issuer = oidc_config.get_issuer_url()
+    now = int(time.time())
+    jti = secrets.token_urlsafe(16)
+    claims = {
+        "iss": issuer,
+        "sub": user_id,
+        "aud": resource,
+        "exp": now + oidc_config.ACCESS_TOKEN_LIFETIME_SECONDS,
+        "iat": now,
+        "jti": jti,
+        "scope": scope,
+        "email": email,
+        "organization_id": organization_id,
+        "is_platform_superuser": is_platform_superuser,
+    }
+    return mint_jwt(claims), jti, now
+
+
 @router.post("/token")
 async def token(
     request: Request,
+    session: AsyncDBSessionBypass,
     grant_type: str = Form(...),
-    code: str = Form(...),
-    redirect_uri: str = Form(...),
-    code_verifier: str = Form(...),
+    code: str | None = Form(default=None),
+    redirect_uri: str | None = Form(default=None),
+    code_verifier: str | None = Form(default=None),
+    refresh_token: str | None = Form(default=None),
     client_id: str = Form(default=""),
     client_secret: str = Form(default=""),
     authorization: Annotated[str | None, Header()] = None,
 ) -> Response:
-    """OIDC token endpoint — exchanges an authorization code for tokens."""
+    """OIDC token endpoint — supports authorization_code and refresh_token grants."""
     # --- Content-Type enforcement ---
     content_type = request.headers.get("content-type", "")
     if "application/x-www-form-urlencoded" not in content_type:
@@ -429,13 +476,6 @@ async def token(
             "invalid_request",
             "Content-Type must be application/x-www-form-urlencoded",
             status_code=415,
-        )
-
-    # --- Grant type ---
-    if grant_type != "authorization_code":
-        return _error_response(
-            "unsupported_grant_type",
-            "Only authorization_code is supported",
         )
 
     # --- Client authentication ---
@@ -482,14 +522,46 @@ async def token(
             status_code=429,
         )
 
+    # --- Grant type dispatch ---
+    if grant_type == "authorization_code":
+        return await _handle_authorization_code_grant(
+            session=session,
+            code=code,
+            redirect_uri=redirect_uri,
+            code_verifier=code_verifier,
+            auth_client_id=auth_client_id,
+        )
+    if grant_type == "refresh_token":
+        return await _handle_refresh_token_grant(
+            session=session,
+            refresh_token=refresh_token,
+            auth_client_id=auth_client_id,
+        )
+    return _error_response(
+        "unsupported_grant_type",
+        "Only authorization_code and refresh_token are supported",
+    )
+
+
+async def _handle_authorization_code_grant(
+    *,
+    session: AsyncSession,
+    code: str | None,
+    redirect_uri: str | None,
+    code_verifier: str | None,
+    auth_client_id: str,
+) -> Response:
+    """Exchange an authorization code for access (+ id, + refresh) tokens."""
+    if not code or not redirect_uri or not code_verifier:
+        return _error_response(
+            "invalid_request",
+            "code, redirect_uri, and code_verifier are required",
+        )
+
     # --- Load and validate auth code ---
     code_data = await load_and_delete_auth_code(code)
     if code_data is None:
-        client_ip = _get_client_ip(request)
-        logger.warning(
-            "MCP OIDC: unknown or reused auth code",
-            client_ip=client_ip,
-        )
+        logger.warning("MCP OIDC: unknown or reused auth code")
         return _error_response(
             "invalid_grant",
             "Authorization code is invalid, expired, or already used",
@@ -523,29 +595,21 @@ async def token(
     if not _validate_pkce_s256(code_verifier, code_data.code_challenge):
         return _error_response("invalid_grant", "PKCE verification failed")
 
-    # --- Mint tokens ---
-    issuer = oidc_config.get_issuer_url()
-    now = int(time.time())
-    jti = secrets.token_urlsafe(16)
+    # --- Mint access token ---
+    access_token, jti, now = _mint_access_token(
+        user_id=str(code_data.user_id),
+        organization_id=str(code_data.organization_id),
+        email=code_data.email,
+        is_platform_superuser=code_data.is_platform_superuser,
+        scope=code_data.scope,
+        resource=code_data.resource,
+    )
 
-    access_token_claims = {
-        "iss": issuer,
-        "sub": str(code_data.user_id),
-        "aud": code_data.resource,
-        "exp": now + oidc_config.ACCESS_TOKEN_LIFETIME_SECONDS,
-        "iat": now,
-        "jti": jti,
-        "scope": code_data.scope,
-        "email": code_data.email,
-        "organization_id": str(code_data.organization_id),
-        "is_platform_superuser": code_data.is_platform_superuser,
-    }
-    access_token = mint_jwt(access_token_claims)
-
-    # Store JTI for future revocation support
     await store_jti(jti)
 
-    id_token_claims = {
+    # --- Mint id token ---
+    issuer = oidc_config.get_issuer_url()
+    id_token_claims: dict[str, Any] = {
         "iss": issuer,
         "sub": str(code_data.user_id),
         "aud": auth_client_id,
@@ -559,23 +623,100 @@ async def token(
         id_token_claims["nonce"] = code_data.nonce
     id_token = mint_jwt(id_token_claims)
 
+    response_body: dict[str, Any] = {
+        "access_token": access_token,
+        "token_type": "Bearer",
+        "expires_in": oidc_config.ACCESS_TOKEN_LIFETIME_SECONDS,
+        "id_token": id_token,
+        "scope": code_data.scope,
+    }
+
+    # --- Issue refresh token if offline_access was requested ---
+    if _OFFLINE_ACCESS_SCOPE in code_data.scope.split():
+        metadata = RefreshTokenMetadata(
+            email=code_data.email,
+            is_platform_superuser=code_data.is_platform_superuser,
+            scope=code_data.scope,
+            resource=code_data.resource,
+        )
+        refresh_token_value = await issue_refresh_token(
+            session,
+            user_id=code_data.user_id,
+            organization_id=code_data.organization_id,
+            client_id=auth_client_id,
+            metadata=metadata,
+        )
+        response_body["refresh_token"] = refresh_token_value
+
     logger.info(
         "MCP OIDC: issued tokens",
         user_id=str(code_data.user_id),
         organization_id=str(code_data.organization_id),
         jti=jti,
         client_id=auth_client_id,
+        with_refresh="refresh_token" in response_body,
     )
 
+    return JSONResponse(response_body, headers=_success_headers())
+
+
+async def _handle_refresh_token_grant(
+    *,
+    session: AsyncSession,
+    refresh_token: str | None,
+    auth_client_id: str,
+) -> Response:
+    """Rotate a refresh token: validate, mint a new access + refresh pair."""
+    if not refresh_token:
+        return _error_response(
+            "invalid_request", "refresh_token is required for refresh_token grant"
+        )
+
+    try:
+        ctx = await consume_refresh_token(
+            session, token=refresh_token, client_id=auth_client_id
+        )
+    except RefreshTokenError as exc:
+        return _error_response(exc.oauth_error, exc.description)
+
+    access_token, jti, _ = _mint_access_token(
+        user_id=str(ctx.user_id),
+        organization_id=str(ctx.organization_id),
+        email=ctx.metadata.email,
+        is_platform_superuser=ctx.metadata.is_platform_superuser,
+        scope=ctx.metadata.scope,
+        resource=ctx.metadata.resource,
+    )
+
+    await store_jti(jti)
+
+    new_refresh_token = await issue_refresh_token(
+        session,
+        user_id=ctx.user_id,
+        organization_id=ctx.organization_id,
+        client_id=auth_client_id,
+        metadata=ctx.metadata,
+        family_id=ctx.family_id,
+    )
+
+    logger.info(
+        "MCP OIDC: rotated refresh token",
+        user_id=str(ctx.user_id),
+        organization_id=str(ctx.organization_id),
+        jti=jti,
+        family_id=str(ctx.family_id),
+    )
+
+    # Per OIDC spec, id_token is not re-issued on refresh — only access + refresh.
     return JSONResponse(
         {
             "access_token": access_token,
             "token_type": "Bearer",
             "expires_in": oidc_config.ACCESS_TOKEN_LIFETIME_SECONDS,
-            "id_token": id_token,
-            "scope": code_data.scope,
+            "refresh_token": new_refresh_token,
+            "scope": ctx.metadata.scope,
         },
-        headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
+        headers=_success_headers(),
     )
 
 

--- a/tracecat/mcp/oidc/endpoints.py
+++ b/tracecat/mcp/oidc/endpoints.py
@@ -18,12 +18,10 @@ from urllib.parse import urlencode
 import jwt
 from fastapi import APIRouter, Depends, Form, Header, Query, Request
 from fastapi.responses import JSONResponse
-from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import RedirectResponse, Response
 
 from tracecat.auth.users import optional_current_active_user
 from tracecat.config import TRACECAT__PUBLIC_APP_URL
-from tracecat.db.dependencies import AsyncDBSessionBypass
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import User
 from tracecat.logger import logger
@@ -472,7 +470,6 @@ def _mint_access_token(
 @router.post("/token")
 async def token(
     request: Request,
-    session: AsyncDBSessionBypass,
     grant_type: str = Form(...),
     code: str | None = Form(default=None),
     redirect_uri: str | None = Form(default=None),
@@ -539,7 +536,6 @@ async def token(
     # --- Grant type dispatch ---
     if grant_type == "authorization_code":
         return await _handle_authorization_code_grant(
-            session=session,
             code=code,
             redirect_uri=redirect_uri,
             code_verifier=code_verifier,
@@ -558,7 +554,6 @@ async def token(
 
 async def _handle_authorization_code_grant(
     *,
-    session: AsyncSession,
     code: str | None,
     redirect_uri: str | None,
     code_verifier: str | None,
@@ -654,13 +649,14 @@ async def _handle_authorization_code_grant(
             scope=granted_scope,
             resource=code_data.resource,
         )
-        refresh_token_value = await issue_refresh_token(
-            session,
-            user_id=code_data.user_id,
-            organization_id=code_data.organization_id,
-            client_id=auth_client_id,
-            metadata=metadata,
-        )
+        async with get_async_session_bypass_rls_context_manager() as session:
+            refresh_token_value = await issue_refresh_token(
+                session,
+                user_id=code_data.user_id,
+                organization_id=code_data.organization_id,
+                client_id=auth_client_id,
+                metadata=metadata,
+            )
         response_body["refresh_token"] = refresh_token_value
 
     logger.info(

--- a/tracecat/mcp/oidc/endpoints.py
+++ b/tracecat/mcp/oidc/endpoints.py
@@ -24,13 +24,21 @@ from starlette.responses import RedirectResponse, Response
 from tracecat.auth.users import optional_current_active_user
 from tracecat.config import TRACECAT__PUBLIC_APP_URL
 from tracecat.db.dependencies import AsyncDBSessionBypass
+from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import User
 from tracecat.logger import logger
 from tracecat.mcp.oidc import config as oidc_config
+from tracecat.mcp.oidc.features import (
+    OFFLINE_ACCESS_SCOPE,
+    get_supported_grant_types,
+    get_supported_scopes,
+    refresh_tokens_enabled,
+    strip_refresh_scope,
+)
 from tracecat.mcp.oidc.refresh_tokens import (
     RefreshTokenError,
-    consume_refresh_token,
     issue_refresh_token,
+    rotate_refresh_token,
 )
 from tracecat.mcp.oidc.schemas import (
     AuthCodeData,
@@ -52,8 +60,6 @@ from tracecat.mcp.oidc.storage import (
     store_jti,
     store_resume_transaction,
 )
-
-_OFFLINE_ACCESS_SCOPE = "offline_access"
 
 router = APIRouter()
 
@@ -165,13 +171,13 @@ async def openid_configuration(request: Request) -> dict[str, Any]:
         "response_types_supported": ["code"],
         "subject_types_supported": ["public"],
         "id_token_signing_alg_values_supported": ["ES256"],
-        "scopes_supported": ["openid", "profile", "email", "offline_access"],
+        "scopes_supported": get_supported_scopes(),
         "token_endpoint_auth_methods_supported": [
             "client_secret_basic",
             "client_secret_post",
         ],
         "code_challenge_methods_supported": ["S256"],
-        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "grant_types_supported": get_supported_grant_types(),
         "claims_supported": [
             "sub",
             "email",
@@ -229,6 +235,14 @@ async def _handle_authorize(
         )
     if not code_challenge:
         return _error_response("invalid_request", "code_challenge is required")
+
+    normalized_scope = strip_refresh_scope(scope)
+    if normalized_scope != scope:
+        logger.warning(
+            "MCP OIDC: stripping offline_access because refresh tokens are disabled",
+            client_id=client_id,
+        )
+        scope = normalized_scope
 
     # Default resource to the MCP endpoint URL when not provided
     # (FastMCP's OIDCProxy does not forward the RFC 8707 resource parameter).
@@ -533,7 +547,6 @@ async def token(
         )
     if grant_type == "refresh_token":
         return await _handle_refresh_token_grant(
-            session=session,
             refresh_token=refresh_token,
             auth_client_id=auth_client_id,
         )
@@ -596,12 +609,14 @@ async def _handle_authorization_code_grant(
         return _error_response("invalid_grant", "PKCE verification failed")
 
     # --- Mint access token ---
+    granted_scope = strip_refresh_scope(code_data.scope)
+
     access_token, jti, now = _mint_access_token(
         user_id=str(code_data.user_id),
         organization_id=str(code_data.organization_id),
         email=code_data.email,
         is_platform_superuser=code_data.is_platform_superuser,
-        scope=code_data.scope,
+        scope=granted_scope,
         resource=code_data.resource,
     )
 
@@ -628,15 +643,15 @@ async def _handle_authorization_code_grant(
         "token_type": "Bearer",
         "expires_in": oidc_config.ACCESS_TOKEN_LIFETIME_SECONDS,
         "id_token": id_token,
-        "scope": code_data.scope,
+        "scope": granted_scope,
     }
 
     # --- Issue refresh token if offline_access was requested ---
-    if _OFFLINE_ACCESS_SCOPE in code_data.scope.split():
+    if OFFLINE_ACCESS_SCOPE in granted_scope.split() and refresh_tokens_enabled():
         metadata = RefreshTokenMetadata(
             email=code_data.email,
             is_platform_superuser=code_data.is_platform_superuser,
-            scope=code_data.scope,
+            scope=granted_scope,
             resource=code_data.resource,
         )
         refresh_token_value = await issue_refresh_token(
@@ -662,7 +677,6 @@ async def _handle_authorization_code_grant(
 
 async def _handle_refresh_token_grant(
     *,
-    session: AsyncSession,
     refresh_token: str | None,
     auth_client_id: str,
 ) -> Response:
@@ -671,11 +685,25 @@ async def _handle_refresh_token_grant(
         return _error_response(
             "invalid_request", "refresh_token is required for refresh_token grant"
         )
+    if not refresh_tokens_enabled():
+        logger.warning(
+            "MCP OIDC: refresh_token grant rejected because refresh tokens are disabled",
+            client_id=auth_client_id,
+        )
+        return _error_response(
+            "invalid_grant", "Refresh tokens are disabled on this deployment"
+        )
 
     try:
-        ctx = await consume_refresh_token(
-            session, token=refresh_token, client_id=auth_client_id
-        )
+        async with get_async_session_bypass_rls_context_manager() as refresh_session:
+            try:
+                ctx, new_refresh_token = await rotate_refresh_token(
+                    refresh_session, token=refresh_token, client_id=auth_client_id
+                )
+            except RefreshTokenError:
+                await refresh_session.rollback()
+                raise
+            await refresh_session.commit()
     except RefreshTokenError as exc:
         return _error_response(exc.oauth_error, exc.description)
 
@@ -689,15 +717,6 @@ async def _handle_refresh_token_grant(
     )
 
     await store_jti(jti)
-
-    new_refresh_token = await issue_refresh_token(
-        session,
-        user_id=ctx.user_id,
-        organization_id=ctx.organization_id,
-        client_id=auth_client_id,
-        metadata=ctx.metadata,
-        family_id=ctx.family_id,
-    )
 
     logger.info(
         "MCP OIDC: rotated refresh token",

--- a/tracecat/mcp/oidc/endpoints.py
+++ b/tracecat/mcp/oidc/endpoints.py
@@ -700,23 +700,22 @@ async def _handle_refresh_token_grant(
                 ctx, new_refresh_token = await rotate_refresh_token(
                     refresh_session, token=refresh_token, client_id=auth_client_id
                 )
-            except RefreshTokenError:
+                access_token, jti, _ = _mint_access_token(
+                    user_id=str(ctx.user_id),
+                    organization_id=str(ctx.organization_id),
+                    email=ctx.metadata.email,
+                    is_platform_superuser=ctx.metadata.is_platform_superuser,
+                    scope=ctx.metadata.scope,
+                    resource=ctx.metadata.resource,
+                )
+
+                await store_jti(jti)
+                await refresh_session.commit()
+            except Exception:
                 await refresh_session.rollback()
                 raise
-            await refresh_session.commit()
     except RefreshTokenError as exc:
         return _error_response(exc.oauth_error, exc.description)
-
-    access_token, jti, _ = _mint_access_token(
-        user_id=str(ctx.user_id),
-        organization_id=str(ctx.organization_id),
-        email=ctx.metadata.email,
-        is_platform_superuser=ctx.metadata.is_platform_superuser,
-        scope=ctx.metadata.scope,
-        resource=ctx.metadata.resource,
-    )
-
-    await store_jti(jti)
 
     logger.info(
         "MCP OIDC: rotated refresh token",

--- a/tracecat/mcp/oidc/features.py
+++ b/tracecat/mcp/oidc/features.py
@@ -1,0 +1,36 @@
+"""Feature gating helpers for the internal MCP OIDC issuer."""
+
+from __future__ import annotations
+
+from tracecat import config
+
+OFFLINE_ACCESS_SCOPE = "offline_access"
+_BASE_OIDC_SCOPES: tuple[str, ...] = ("openid", "profile", "email")
+
+
+def refresh_tokens_enabled() -> bool:
+    """Return whether refresh-token support is enabled for this deployment."""
+    return bool(config.TRACECAT__DB_ENCRYPTION_KEY)
+
+
+def get_supported_scopes() -> list[str]:
+    """Return the OIDC scopes this deployment currently supports."""
+    scopes: list[str] = list(_BASE_OIDC_SCOPES)
+    if refresh_tokens_enabled():
+        scopes.append(OFFLINE_ACCESS_SCOPE)
+    return scopes
+
+
+def get_supported_grant_types() -> list[str]:
+    """Return the OAuth grant types this deployment currently supports."""
+    grant_types = ["authorization_code"]
+    if refresh_tokens_enabled():
+        grant_types.append("refresh_token")
+    return grant_types
+
+
+def strip_refresh_scope(scope: str) -> str:
+    """Remove ``offline_access`` when refresh tokens are disabled."""
+    if refresh_tokens_enabled():
+        return scope
+    return " ".join(part for part in scope.split() if part != OFFLINE_ACCESS_SCOPE)

--- a/tracecat/mcp/oidc/refresh_tokens.py
+++ b/tracecat/mcp/oidc/refresh_tokens.py
@@ -18,6 +18,8 @@ import uuid
 from datetime import UTC, datetime, timedelta
 
 import orjson
+from cryptography.fernet import InvalidToken
+from pydantic import ValidationError
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -160,7 +162,18 @@ async def rotate_refresh_token(
         )
         raise RefreshTokenError("invalid_grant", "client_id mismatch")
 
-    metadata = _decode_metadata(row.encrypted_metadata)
+    try:
+        metadata = _decode_metadata(row.encrypted_metadata)
+    except (InvalidToken, ValidationError, ValueError) as exc:
+        logger.warning(
+            "MCP OIDC: refresh token metadata decode failed",
+            error=str(exc),
+            family_id=str(row.family_id),
+            user_id=str(row.user_id),
+        )
+        raise RefreshTokenError(
+            "invalid_grant", "Refresh token is invalid or expired"
+        ) from exc
     row.status = "used"
     new_refresh_token = secrets.token_urlsafe(32)
     session.add(

--- a/tracecat/mcp/oidc/refresh_tokens.py
+++ b/tracecat/mcp/oidc/refresh_tokens.py
@@ -1,0 +1,187 @@
+"""Persistence and rotation logic for MCP OIDC refresh tokens.
+
+Refresh tokens are stored in Postgres (table ``mcp_refresh_token``) so they
+survive Redis flushes and admin restarts. Lookups are by SHA-256 hash of the
+opaque token — the plaintext token never lives at rest.
+
+Rotation is single-use: every successful exchange transitions the consumed
+token to ``status='used'`` and issues a fresh one. Replay of a consumed
+token revokes the entire family (all tokens descended from the same
+authorization-code exchange).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import orjson
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.secrets import get_db_encryption_key
+from tracecat.db.models import MCPRefreshToken
+from tracecat.logger import logger
+from tracecat.mcp.oidc import config as oidc_config
+from tracecat.mcp.oidc.schemas import RefreshTokenContext, RefreshTokenMetadata
+from tracecat.secrets.encryption import decrypt_value, encrypt_value
+
+
+class RefreshTokenError(Exception):
+    """Raised when a refresh token operation fails.
+
+    Carries the OAuth 2.0 error code and human-readable description so the
+    token endpoint can translate the failure into the standard JSON response.
+    """
+
+    def __init__(self, oauth_error: str, description: str) -> None:
+        super().__init__(f"{oauth_error}: {description}")
+        self.oauth_error = oauth_error
+        self.description = description
+
+
+def _hash_token(token: str) -> str:
+    """SHA-256 hex digest of the opaque refresh token."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _encode_metadata(metadata: RefreshTokenMetadata) -> bytes:
+    """Fernet-encrypt the metadata JSON blob."""
+    payload = orjson.dumps(metadata.model_dump(mode="json"))
+    return encrypt_value(payload, key=get_db_encryption_key())
+
+
+def _decode_metadata(blob: bytes) -> RefreshTokenMetadata:
+    """Decrypt and parse the metadata JSON blob."""
+    payload = decrypt_value(blob, key=get_db_encryption_key())
+    return RefreshTokenMetadata.model_validate_json(payload)
+
+
+async def issue_refresh_token(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    client_id: str,
+    metadata: RefreshTokenMetadata,
+    family_id: uuid.UUID | None = None,
+) -> str:
+    """Mint a new refresh token and persist it to the database.
+
+    Returns the plaintext opaque token. This is the only place the plaintext
+    exists in memory at the API — only its SHA-256 hash is stored.
+    """
+    token = secrets.token_urlsafe(32)
+    row = MCPRefreshToken(
+        token_hash=_hash_token(token),
+        family_id=family_id or uuid.uuid4(),
+        user_id=user_id,
+        organization_id=organization_id,
+        client_id=client_id,
+        encrypted_metadata=_encode_metadata(metadata),
+        status="active",
+        expires_at=datetime.now(UTC)
+        + timedelta(seconds=oidc_config.REFRESH_TOKEN_LIFETIME_SECONDS),
+    )
+    session.add(row)
+    await session.commit()
+    return token
+
+
+async def consume_refresh_token(
+    session: AsyncSession,
+    *,
+    token: str,
+    client_id: str,
+) -> RefreshTokenContext:
+    """Atomically consume a refresh token, returning its session context.
+
+    Raises:
+        RefreshTokenError: token is unknown, expired, already consumed,
+            revoked, or bound to a different client. On replay (presenting
+            an already-consumed token) the entire token family is revoked
+            before the error is raised.
+    """
+    token_hash = _hash_token(token)
+
+    stmt = select(MCPRefreshToken).where(MCPRefreshToken.token_hash == token_hash)
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        raise RefreshTokenError("invalid_grant", "Refresh token is invalid or expired")
+
+    # Replay: a token already marked 'used' is being presented again.
+    # Revoke the whole family — both the original chain and any rotated
+    # successors — and reject this request.
+    if row.status == "used":
+        await revoke_family(session, row.family_id)
+        logger.warning(
+            "MCP OIDC: refresh token replay detected, revoking family",
+            family_id=str(row.family_id),
+            user_id=str(row.user_id),
+        )
+        raise RefreshTokenError(
+            "invalid_grant", "Refresh token replay detected; family revoked"
+        )
+
+    if row.status != "active":
+        raise RefreshTokenError("invalid_grant", "Refresh token is invalid or expired")
+
+    if datetime.now(UTC) >= row.expires_at:
+        raise RefreshTokenError("invalid_grant", "Refresh token has expired")
+
+    if row.client_id != client_id:
+        # Treat client mismatch as a hostile reuse attempt — revoke the
+        # family rather than just refusing this one request.
+        await revoke_family(session, row.family_id)
+        logger.warning(
+            "MCP OIDC: refresh token client_id mismatch, revoking family",
+            family_id=str(row.family_id),
+            expected=row.client_id,
+            actual=client_id,
+        )
+        raise RefreshTokenError("invalid_grant", "client_id mismatch")
+
+    # Atomic compare-and-swap from 'active' -> 'used'. If two requests
+    # present the same token simultaneously, exactly one wins. Keep expiry
+    # in the WHERE clause so a token cannot be consumed after its deadline.
+    now = datetime.now(UTC)
+    consumed_token_id = await session.scalar(
+        update(MCPRefreshToken)
+        .where(
+            MCPRefreshToken.id == row.id,
+            MCPRefreshToken.status == "active",
+            MCPRefreshToken.client_id == client_id,
+            MCPRefreshToken.expires_at > now,
+        )
+        .values(status="used")
+        .returning(MCPRefreshToken.id)
+    )
+    if consumed_token_id is None:
+        raise RefreshTokenError(
+            "invalid_grant", "Refresh token was concurrently consumed"
+        )
+    await session.commit()
+
+    return RefreshTokenContext(
+        family_id=row.family_id,
+        user_id=row.user_id,
+        organization_id=row.organization_id,
+        client_id=row.client_id,
+        metadata=_decode_metadata(row.encrypted_metadata),
+    )
+
+
+async def revoke_family(session: AsyncSession, family_id: uuid.UUID) -> None:
+    """Mark every non-revoked token in a family as revoked."""
+    stmt = (
+        update(MCPRefreshToken)
+        .where(
+            MCPRefreshToken.family_id == family_id,
+            MCPRefreshToken.status != "revoked",
+        )
+        .values(status="revoked")
+    )
+    await session.execute(stmt)
+    await session.commit()

--- a/tracecat/mcp/oidc/refresh_tokens.py
+++ b/tracecat/mcp/oidc/refresh_tokens.py
@@ -185,6 +185,8 @@ async def rotate_refresh_token(
             client_id=row.client_id,
             encrypted_metadata=row.encrypted_metadata,
             status="active",
+            # Rotation uses a rolling expiry window: each successful refresh
+            # renews the family for another REFRESH_TOKEN_LIFETIME_SECONDS.
             expires_at=datetime.now(UTC)
             + timedelta(seconds=oidc_config.REFRESH_TOKEN_LIFETIME_SECONDS),
         )

--- a/tracecat/mcp/oidc/refresh_tokens.py
+++ b/tracecat/mcp/oidc/refresh_tokens.py
@@ -113,7 +113,10 @@ async def rotate_refresh_token(
     This keeps the replay-detection transition and replacement-token insertion
     in a single database transaction so concurrent replays cannot slip a fresh
     descendant token into the family after revocation. The caller owns the
-    transaction boundary and is responsible for commit/rollback.
+    transaction boundary for successful rotations and is responsible for the
+    final commit/rollback. Hostile replay and client-mismatch paths commit
+    family revocation before raising so the security side effect survives any
+    caller rollback.
     """
     token_hash = _hash_token(token)
     row = (
@@ -127,11 +130,13 @@ async def rotate_refresh_token(
         raise RefreshTokenError("invalid_grant", "Refresh token is invalid or expired")
 
     if row.status == "used":
-        await _revoke_family_rows(session, row.family_id)
+        family_id = row.family_id
+        user_id = row.user_id
+        await revoke_family(session, family_id)
         logger.warning(
             "MCP OIDC: refresh token replay detected, revoking family",
-            family_id=str(row.family_id),
-            user_id=str(row.user_id),
+            family_id=str(family_id),
+            user_id=str(user_id),
         )
         raise RefreshTokenError(
             "invalid_grant", "Refresh token replay detected; family revoked"
@@ -144,11 +149,13 @@ async def rotate_refresh_token(
         raise RefreshTokenError("invalid_grant", "Refresh token has expired")
 
     if row.client_id != client_id:
-        await _revoke_family_rows(session, row.family_id)
+        family_id = row.family_id
+        expected_client_id = row.client_id
+        await revoke_family(session, family_id)
         logger.warning(
             "MCP OIDC: refresh token client_id mismatch, revoking family",
-            family_id=str(row.family_id),
-            expected=row.client_id,
+            family_id=str(family_id),
+            expected=expected_client_id,
             actual=client_id,
         )
         raise RefreshTokenError("invalid_grant", "client_id mismatch")

--- a/tracecat/mcp/oidc/refresh_tokens.py
+++ b/tracecat/mcp/oidc/refresh_tokens.py
@@ -59,6 +59,18 @@ def _decode_metadata(blob: bytes) -> RefreshTokenMetadata:
     return RefreshTokenMetadata.model_validate_json(payload)
 
 
+async def _revoke_family_rows(session: AsyncSession, family_id: uuid.UUID) -> None:
+    """Mark every non-revoked token in a family as revoked within a transaction."""
+    await session.execute(
+        update(MCPRefreshToken)
+        .where(
+            MCPRefreshToken.family_id == family_id,
+            MCPRefreshToken.status != "revoked",
+        )
+        .values(status="revoked")
+    )
+
+
 async def issue_refresh_token(
     session: AsyncSession,
     *,
@@ -88,6 +100,86 @@ async def issue_refresh_token(
     session.add(row)
     await session.commit()
     return token
+
+
+async def rotate_refresh_token(
+    session: AsyncSession,
+    *,
+    token: str,
+    client_id: str,
+) -> tuple[RefreshTokenContext, str]:
+    """Atomically consume and replace a refresh token.
+
+    This keeps the replay-detection transition and replacement-token insertion
+    in a single database transaction so concurrent replays cannot slip a fresh
+    descendant token into the family after revocation. The caller owns the
+    transaction boundary and is responsible for commit/rollback.
+    """
+    token_hash = _hash_token(token)
+    row = (
+        await session.execute(
+            select(MCPRefreshToken)
+            .where(MCPRefreshToken.token_hash == token_hash)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise RefreshTokenError("invalid_grant", "Refresh token is invalid or expired")
+
+    if row.status == "used":
+        await _revoke_family_rows(session, row.family_id)
+        logger.warning(
+            "MCP OIDC: refresh token replay detected, revoking family",
+            family_id=str(row.family_id),
+            user_id=str(row.user_id),
+        )
+        raise RefreshTokenError(
+            "invalid_grant", "Refresh token replay detected; family revoked"
+        )
+
+    if row.status != "active":
+        raise RefreshTokenError("invalid_grant", "Refresh token is invalid or expired")
+
+    if datetime.now(UTC) >= row.expires_at:
+        raise RefreshTokenError("invalid_grant", "Refresh token has expired")
+
+    if row.client_id != client_id:
+        await _revoke_family_rows(session, row.family_id)
+        logger.warning(
+            "MCP OIDC: refresh token client_id mismatch, revoking family",
+            family_id=str(row.family_id),
+            expected=row.client_id,
+            actual=client_id,
+        )
+        raise RefreshTokenError("invalid_grant", "client_id mismatch")
+
+    metadata = _decode_metadata(row.encrypted_metadata)
+    row.status = "used"
+    new_refresh_token = secrets.token_urlsafe(32)
+    session.add(
+        MCPRefreshToken(
+            token_hash=_hash_token(new_refresh_token),
+            family_id=row.family_id,
+            user_id=row.user_id,
+            organization_id=row.organization_id,
+            client_id=row.client_id,
+            encrypted_metadata=row.encrypted_metadata,
+            status="active",
+            expires_at=datetime.now(UTC)
+            + timedelta(seconds=oidc_config.REFRESH_TOKEN_LIFETIME_SECONDS),
+        )
+    )
+
+    ctx = RefreshTokenContext(
+        family_id=row.family_id,
+        user_id=row.user_id,
+        organization_id=row.organization_id,
+        client_id=row.client_id,
+        metadata=metadata,
+    )
+    if new_refresh_token is None:  # pragma: no cover - defensive
+        raise RuntimeError("Refresh token rotation completed without a result")
+    return ctx, new_refresh_token
 
 
 async def consume_refresh_token(
@@ -175,13 +267,5 @@ async def consume_refresh_token(
 
 async def revoke_family(session: AsyncSession, family_id: uuid.UUID) -> None:
     """Mark every non-revoked token in a family as revoked."""
-    stmt = (
-        update(MCPRefreshToken)
-        .where(
-            MCPRefreshToken.family_id == family_id,
-            MCPRefreshToken.status != "revoked",
-        )
-        .values(status="revoked")
-    )
-    await session.execute(stmt)
+    await _revoke_family_rows(session, family_id)
     await session.commit()

--- a/tracecat/mcp/oidc/schemas.py
+++ b/tracecat/mcp/oidc/schemas.py
@@ -37,3 +37,28 @@ class ResumeTransaction(BaseModel):
     created_at: float
     bound_ip: str
     """SHA-256 hex digest of the requester's IP at transaction creation."""
+
+
+class RefreshTokenMetadata(BaseModel):
+    """Encrypted metadata blob persisted with each refresh token.
+
+    Holds the session context required to mint new access tokens on rotation
+    without re-resolving the user/org. Stored as a Fernet-encrypted JSON blob
+    in the ``mcp_refresh_token.encrypted_metadata`` column.
+    """
+
+    email: str
+    is_platform_superuser: bool
+    scope: str
+    resource: str
+    """OAuth ``resource`` parameter — becomes the access token ``aud``."""
+
+
+class RefreshTokenContext(BaseModel):
+    """Hydrated refresh token returned from the rotation flow."""
+
+    family_id: uuid.UUID
+    user_id: uuid.UUID
+    organization_id: uuid.UUID
+    client_id: str
+    metadata: RefreshTokenMetadata


### PR DESCRIPTION
## Summary

This PR adds refresh-token support to the internal MCP OIDC flow and wires the MCP proxy so MCP clients can actually request and receive that capability.

It includes:
- refresh-token persistence, rotation, and family revocation support for the internal OIDC issuer
- discovery and token endpoint updates for `offline_access` and `refresh_token`
- proxy-side scope defaults so MCP dynamic client registration and CIMD clients include `offline_access`
- unit and integration coverage for issuance, exchange, rotation, and replay handling

## Root Cause

The internal issuer changes alone were not enough for a real Claude Code client.

The remaining gap was in the MCP proxy layer: it still defaulted dynamic client registration and client metadata discovery to `openid profile email`, so Claude's registered client was not eligible for `offline_access` and the auth flow failed with `invalid_scope` when Claude requested it.

## Validation

Ran locally:
- `uv run ruff check tracecat/mcp/auth.py tracecat/mcp/oidc/config.py tracecat/mcp/oidc/endpoints.py tracecat/mcp/oidc/schemas.py tracecat/mcp/oidc/refresh_tokens.py tracecat/db/models.py tests/unit/test_mcp_auth.py tests/unit/test_mcp_oidc_endpoints.py tests/unit/test_mcp_oidc_refresh_tokens.py tests/integration/test_mcp_oidc_flow.py`
- `uv run basedpyright tracecat/mcp/auth.py tracecat/mcp/oidc/config.py tracecat/mcp/oidc/endpoints.py tracecat/mcp/oidc/schemas.py tracecat/mcp/oidc/refresh_tokens.py tracecat/db/models.py tests/unit/test_mcp_auth.py tests/unit/test_mcp_oidc_endpoints.py tests/unit/test_mcp_oidc_refresh_tokens.py tests/integration/test_mcp_oidc_flow.py`
- `uv run pytest tests/unit/test_mcp_auth.py -q`
- `uv run pytest tests/unit/test_mcp_oidc_endpoints.py tests/unit/test_mcp_oidc_refresh_tokens.py tests/integration/test_mcp_oidc_flow.py -q`

Also verified locally with Claude Code after restarting the cluster and reconnecting `tracecat-mcp`:

For `tracecat-mcp`:
- Key: `tracecat-mcp|21e400ae867de6cb`
- Server URL: `http://localhost:180/mcp`
- Access token: present, expired
- Refresh token: present (JWT)
- `iss`: `http://localhost:180/`
- `aud`: `http://localhost:180/mcp`
- `scope`: `openid profile email offline_access`
- `token_use`: `refresh`
- `iat`: `2026-04-04`
- `exp`: `1778123426` (`2026-05-04`)
- `upstream_claims.email`: `test@tracecat.com`
- `upstream_claims.organization_id`: `45a55f16-014a-41d9-b287-01fa9a4b6d98`
- Client ID: `https://claude.ai/oauth/claude-code-client-metadata`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds refresh-token support to the internal MCP OIDC flow with conditional enablement. Access tokens now expire in 1 hour; refresh tokens have a 30‑day rolling TTL, are persisted in Postgres, and rotate with replay protection.

- **New Features**
  - Persist refresh tokens in Postgres (`mcp_refresh_token`): SHA-256 token hash only, encrypted metadata, 30‑day rolling TTL; tenant RLS for org isolation.
  - Conditional refresh: enabled only when `TRACECAT__DB_ENCRYPTION_KEY` is set. Discovery/metadata advertise `offline_access` and the `refresh_token` grant only then; `/authorize` and `/token` strip `offline_access` when disabled; `/token` rejects the `refresh_token` grant with `invalid_grant` when disabled.
  - Rotation and replay safety: single-use rotation with row locks and atomic updates; replays and `client_id` mismatches revoke the family; revocation persists even if callers roll back.
  - `/token` supports `authorization_code` and `refresh_token`; `id_token` only on code; `expires_in` set to 3600. Stricter parameter validation and no-store caching headers.
  - MCP proxy DCR/CIMD valid/default scopes follow supported scopes and include `offline_access` only when enabled.

- **Migration**
  - Run DB migrations to create `mcp_refresh_token` and enable RLS.
  - Set `TRACECAT__DB_ENCRYPTION_KEY` for metadata encryption (refresh tokens are disabled without it).
  - Clients needing long-lived sessions should request `offline_access` (the proxy defaults this when available).

<sup>Written for commit 25beeef8066c97e98645b2592f663eddc181eccd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

