### PR TITLE
Fix selector node disappearing during initial canvas hydration

### DIFF
--- a/frontend/src/components/builder/canvas/graph-layout.ts
+++ b/frontend/src/components/builder/canvas/graph-layout.ts
@@ -97,8 +97,9 @@ export function mergeHydratedNodes(
   hydratedNodes: Node[]
 ): Node[] {
   const currentNodesById = new Map(currentNodes.map((node) => [node.id, node]))
+  const hydratedNodeIds = new Set(hydratedNodes.map((node) => node.id))
 
-  return hydratedNodes.map((node) => {
+  const mergedNodes = hydratedNodes.map((node) => {
     const currentNode = currentNodesById.get(node.id)
     if (!currentNode) {
       return node
@@ -112,4 +113,10 @@ export function mergeHydratedNodes(
       height: currentNode.height ?? node.height,
     }
   })
+
+  const unhydratedEphemeralNodes = currentNodes.filter(
+    (node) => node.type === "selector" && !hydratedNodeIds.has(node.id)
+  )
+
+  return [...mergedNodes, ...unhydratedEphemeralNodes]
 }

--- a/frontend/tests/graph-layout.test.ts
+++ b/frontend/tests/graph-layout.test.ts
@@ -140,4 +140,27 @@ describe("mergeHydratedNodes", () => {
       }),
     ])
   })
+
+  it("preserves unhydrated selector nodes so an in-progress action picker is not dropped", () => {
+    const currentNodes = [
+      createNode("trigger-1", "trigger"),
+      createNode("selector-1", "selector", {
+        position: { x: 120, y: 240 },
+      }),
+    ]
+    const hydratedNodes = [
+      createNode("trigger-1", "trigger", {
+        position: { x: 10, y: 20 },
+      }),
+    ]
+
+    expect(mergeHydratedNodes(currentNodes, hydratedNodes)).toEqual([
+      createNode("trigger-1", "trigger", {
+        position: { x: 10, y: 20 },
+      }),
+      createNode("selector-1", "selector", {
+        position: { x: 120, y: 240 },
+      }),
+    ])
+  })
 })


### PR DESCRIPTION
### Motivation

- The action selector (ephemeral `selector` node) created during a drag-to-create gesture could be dropped when the backend graph hydration completed immediately after the gesture, causing the selector to briefly appear then disappear.

### Description

- Updated `mergeHydratedNodes` in `frontend/src/components/builder/canvas/graph-layout.ts` to preserve unhydrated ephemeral nodes by appending local `selector` nodes that are not yet present in the hydrated payload.
- Added a regression test in `frontend/tests/graph-layout.test.ts` verifying that unhydrated `selector` nodes are retained by `mergeHydratedNodes` so an in-progress action picker is not removed.

### Testing

- Ran the focused frontend unit tests with `pnpm -C frontend test -- graph-layout.test.ts`, and the suite passed (`1` test suite, `6` tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d51c0654d883208d2fb25958f6c0cf)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the ephemeral selector node from disappearing during initial canvas hydration. Keeps the in-progress action picker visible when drag-to-create overlaps with backend hydration.

- **Bug Fixes**
  - Updated mergeHydratedNodes to append local selector nodes not included in the hydrated payload.
  - Added a unit test in graph-layout.test.ts to ensure unhydrated selector nodes are retained.

<sup>Written for commit 68db33f60981b63b4695689dda2b554ed5310509. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

