### PR TITLE
fix(sandbox): normalize run_python serialization

### DIFF
--- a/tests/registry/test_core_python.py
+++ b/tests/registry/test_core_python.py
@@ -352,6 +352,28 @@ def main(data_list, data_dict):
         assert result["processed"]["dict_keys"] == ["a", "b"]
 
     @pytest.mark.anyio
+    async def test_non_json_leaf_values_are_normalized(
+        self, sandbox_service: SandboxService
+    ) -> None:
+        """Test that non-JSON leaf values are normalized instead of failing."""
+        script_content = """
+from datetime import datetime
+
+def main():
+    return {
+        "all_ips": {"2.2.2.2", "1.1.1.1"},
+        "seen_at": datetime(2026, 3, 30, 13, 9, 52),
+        "nested": [{"ports": {443, 80}}],
+    }
+"""
+        result = await sandbox_service.run_python(script=script_content)
+        assert result == {
+            "all_ips": ["1.1.1.1", "2.2.2.2"],
+            "seen_at": "2026-03-30T13:09:52",
+            "nested": [{"ports": [80, 443]}],
+        }
+
+    @pytest.mark.anyio
     async def test_clean_error_messages(self, sandbox_service: SandboxService) -> None:
         """Test that error messages are clean and user-friendly without tracebacks."""
         script_with_value_error = """

--- a/tests/registry/test_core_python.py
+++ b/tests/registry/test_core_python.py
@@ -374,6 +374,30 @@ def main():
         }
 
     @pytest.mark.anyio
+    async def test_dataclass_instances_and_classes_are_normalized(
+        self, sandbox_service: SandboxService
+    ) -> None:
+        """Test dataclass instances and classes normalize without failure."""
+        script_content = """
+from dataclasses import dataclass
+
+@dataclass
+class Finding:
+    name: str
+
+def main():
+    return {
+        "instance": Finding("alert"),
+        "class": Finding,
+    }
+"""
+        result = await sandbox_service.run_python(script=script_content)
+        assert result == {
+            "instance": {"name": "alert"},
+            "class": "<class '__main__.Finding'>",
+        }
+
+    @pytest.mark.anyio
     async def test_clean_error_messages(self, sandbox_service: SandboxService) -> None:
         """Test that error messages are clean and user-friendly without tracebacks."""
         script_with_value_error = """

--- a/tests/registry/test_core_python.py
+++ b/tests/registry/test_core_python.py
@@ -374,6 +374,24 @@ def main():
         }
 
     @pytest.mark.anyio
+    async def test_mixed_sets_are_normalized_deterministically(
+        self, sandbox_service: SandboxService
+    ) -> None:
+        """Test mixed-type sets normalize in a deterministic order."""
+        script_content = """
+def main():
+    return {
+        "mixed": {1, "a"},
+        "nested": [{"values": {2, None}}],
+    }
+"""
+        result = await sandbox_service.run_python(script=script_content)
+        assert result == {
+            "mixed": ["a", 1],
+            "nested": [{"values": [2, None]}],
+        }
+
+    @pytest.mark.anyio
     async def test_dataclass_instances_and_classes_are_normalized(
         self, sandbox_service: SandboxService
     ) -> None:

--- a/tests/registry/test_core_python.py
+++ b/tests/registry/test_core_python.py
@@ -416,6 +416,31 @@ def main():
         }
 
     @pytest.mark.anyio
+    async def test_recursive_dataclass_uses_serialization_error_fallback(
+        self, sandbox_service: SandboxService
+    ) -> None:
+        """Test recursive dataclasses use the result fallback instead of crashing."""
+        script_content = """
+from dataclasses import dataclass
+
+@dataclass
+class Node:
+    name: str
+    child: object = None
+
+def main():
+    root = Node("root")
+    root.child = root
+    return root
+"""
+        with pytest.raises(SandboxExecutionError) as exc_info:
+            await sandbox_service.run_python(script=script_content)
+
+        error_msg = str(exc_info.value)
+        assert "Output not JSON-serializable" in error_msg
+        assert "Recursive dataclass values are not JSON-serializable" in error_msg
+
+    @pytest.mark.anyio
     async def test_clean_error_messages(self, sandbox_service: SandboxService) -> None:
         """Test that error messages are clean and user-friendly without tracebacks."""
         script_with_value_error = """

--- a/tests/unit/test_unsafe_pid_executor.py
+++ b/tests/unit/test_unsafe_pid_executor.py
@@ -103,6 +103,29 @@ def main():
         assert result.output == 42
 
     @pytest.mark.anyio
+    async def test_execute_normalizes_non_json_leaf_values(
+        self, executor: UnsafePidExecutor
+    ) -> None:
+        script = """
+from datetime import datetime
+
+def main():
+    return {
+        "all_ips": {"2.2.2.2", "1.1.1.1"},
+        "seen_at": datetime(2026, 3, 30, 13, 9, 52),
+        "nested": [{"ports": {443, 80}}],
+    }
+"""
+        result = await executor.execute(script=script)
+        assert result.success
+        assert result.error is None
+        assert result.output == {
+            "all_ips": ["1.1.1.1", "2.2.2.2"],
+            "seen_at": "2026-03-30T13:09:52",
+            "nested": [{"ports": [80, 443]}],
+        }
+
+    @pytest.mark.anyio
     @pytest.mark.integration
     async def test_execute_does_not_inherit_process_env(
         self, executor: UnsafePidExecutor, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_unsafe_pid_executor.py
+++ b/tests/unit/test_unsafe_pid_executor.py
@@ -170,6 +170,30 @@ def main():
         }
 
     @pytest.mark.anyio
+    async def test_execute_reports_recursive_dataclass_as_serialization_error(
+        self, executor: UnsafePidExecutor
+    ) -> None:
+        script = """
+from dataclasses import dataclass
+
+@dataclass
+class Node:
+    name: str
+    child: object = None
+
+def main():
+    root = Node("root")
+    root.child = root
+    return root
+"""
+        result = await executor.execute(script=script)
+        assert not result.success
+        assert result.output == "Node(name='root', child=...)"
+        assert result.error is not None
+        assert "Output not JSON-serializable" in result.error
+        assert "Recursive dataclass values are not JSON-serializable" in result.error
+
+    @pytest.mark.anyio
     @pytest.mark.integration
     async def test_execute_does_not_inherit_process_env(
         self, executor: UnsafePidExecutor, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_unsafe_pid_executor.py
+++ b/tests/unit/test_unsafe_pid_executor.py
@@ -126,6 +126,25 @@ def main():
         }
 
     @pytest.mark.anyio
+    async def test_execute_normalizes_mixed_sets_deterministically(
+        self, executor: UnsafePidExecutor
+    ) -> None:
+        script = """
+def main():
+    return {
+        "mixed": {1, "a"},
+        "nested": [{"values": {2, None}}],
+    }
+"""
+        result = await executor.execute(script=script)
+        assert result.success
+        assert result.error is None
+        assert result.output == {
+            "mixed": ["a", 1],
+            "nested": [{"values": [2, None]}],
+        }
+
+    @pytest.mark.anyio
     async def test_execute_normalizes_dataclass_instances_and_classes(
         self, executor: UnsafePidExecutor
     ) -> None:

--- a/tests/unit/test_unsafe_pid_executor.py
+++ b/tests/unit/test_unsafe_pid_executor.py
@@ -126,6 +126,31 @@ def main():
         }
 
     @pytest.mark.anyio
+    async def test_execute_normalizes_dataclass_instances_and_classes(
+        self, executor: UnsafePidExecutor
+    ) -> None:
+        script = """
+from dataclasses import dataclass
+
+@dataclass
+class Finding:
+    name: str
+
+def main():
+    return {
+        "instance": Finding("alert"),
+        "class": Finding,
+    }
+"""
+        result = await executor.execute(script=script)
+        assert result.success
+        assert result.error is None
+        assert result.output == {
+            "instance": {"name": "alert"},
+            "class": "<class '__main__.Finding'>",
+        }
+
+    @pytest.mark.anyio
     @pytest.mark.integration
     async def test_execute_does_not_inherit_process_env(
         self, executor: UnsafePidExecutor, monkeypatch: pytest.MonkeyPatch

--- a/tracecat/sandbox/unsafe_pid_executor.py
+++ b/tracecat/sandbox/unsafe_pid_executor.py
@@ -36,12 +36,17 @@ module_logger = logging.getLogger(__name__)
 
 SAFE_WRAPPER_SCRIPT = '''
 import asyncio
+import dataclasses
+import datetime
+import decimal
+import enum
 import importlib
 import inspect
 import json
 import os
 import sys
 import traceback
+import uuid
 from pathlib import Path
 
 def _install_action_gateway_sdk_transport():
@@ -122,6 +127,30 @@ def _resolve_output(value):
 
     return asyncio.run(await_value())
 
+def to_json_safe(value):
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, set | frozenset):
+        try:
+            return sorted(value)
+        except TypeError:
+            return list(value)
+    if dataclasses.is_dataclass(value):
+        return dataclasses.asdict(value)
+    if isinstance(value, datetime.datetime | datetime.date | datetime.time):
+        return value.isoformat()
+    if isinstance(value, datetime.timedelta):
+        return value.total_seconds()
+    if isinstance(value, decimal.Decimal):
+        return str(value)
+    if isinstance(value, enum.Enum):
+        return to_json_safe(value.value)
+    if isinstance(value, uuid.UUID | Path):
+        return str(value)
+    if isinstance(value, bytes | bytearray):
+        return value.decode("utf-8", errors="replace")
+    return repr(value)
+
 def main():
     """Execute user script and capture results."""
     work_dir = "{work_dir}"
@@ -191,17 +220,12 @@ def main():
     # Write result to file
     result_path = Path(work_dir) / "result.json"
     try:
-        result_path.write_text(json.dumps(result))
-    except (TypeError, ValueError):
-        # Output not JSON-serializable, convert to repr
+        result_path.write_text(json.dumps(result, default=to_json_safe))
+    except (TypeError, ValueError) as e:
         result["output"] = repr(result["output"])
-        try:
-            result_path.write_text(json.dumps(result))
-        except Exception as e:
-            result["output"] = None
-            result["error"] = f"Output not JSON-serializable: {{type(e).__name__}}: {{e}}"
-            result["success"] = False
-            result_path.write_text(json.dumps(result))
+        result["error"] = f"Output not JSON-serializable: {{type(e).__name__}}: {{e}}"
+        result["success"] = False
+        result_path.write_text(json.dumps(result))
 
     sys.exit(0 if result["success"] else 1)
 

--- a/tracecat/sandbox/unsafe_pid_executor.py
+++ b/tracecat/sandbox/unsafe_pid_executor.py
@@ -136,7 +136,10 @@ def to_json_safe(value):
         except TypeError:
             return sorted(value, key=repr)
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        return dataclasses.asdict(value)
+        try:
+            return dataclasses.asdict(value)
+        except RecursionError as e:
+            raise TypeError("Recursive dataclass values are not JSON-serializable") from e
     if isinstance(value, datetime.datetime | datetime.date | datetime.time):
         return value.isoformat()
     if isinstance(value, datetime.timedelta):
@@ -221,7 +224,7 @@ def main():
     result_path = Path(work_dir) / "result.json"
     try:
         result_path.write_text(json.dumps(result, default=to_json_safe))
-    except (TypeError, ValueError) as e:
+    except (TypeError, ValueError, RecursionError) as e:
         result["output"] = repr(result["output"])
         result["error"] = f"Output not JSON-serializable: {{type(e).__name__}}: {{e}}"
         result["success"] = False

--- a/tracecat/sandbox/unsafe_pid_executor.py
+++ b/tracecat/sandbox/unsafe_pid_executor.py
@@ -135,7 +135,7 @@ def to_json_safe(value):
             return sorted(value)
         except TypeError:
             return list(value)
-    if dataclasses.is_dataclass(value):
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
         return dataclasses.asdict(value)
     if isinstance(value, datetime.datetime | datetime.date | datetime.time):
         return value.isoformat()

--- a/tracecat/sandbox/unsafe_pid_executor.py
+++ b/tracecat/sandbox/unsafe_pid_executor.py
@@ -134,7 +134,7 @@ def to_json_safe(value):
         try:
             return sorted(value)
         except TypeError:
-            return list(value)
+            return sorted(value, key=repr)
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
         return dataclasses.asdict(value)
     if isinstance(value, datetime.datetime | datetime.date | datetime.time):

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -11,12 +11,17 @@ The wrapper script is executed inside the nsjail sandbox and handles:
 # to be written to the job directory before execution
 WRAPPER_SCRIPT = '''
 import asyncio
+import dataclasses
+import datetime
+import decimal
+import enum
 import importlib
 import inspect
 import json
 import os
 import sys
 import traceback
+import uuid
 from pathlib import Path
 
 def _install_action_gateway_sdk_transport():
@@ -97,6 +102,30 @@ def _resolve_output(value):
 
     return asyncio.run(await_value())
 
+def to_json_safe(value):
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, set | frozenset):
+        try:
+            return sorted(value)
+        except TypeError:
+            return list(value)
+    if dataclasses.is_dataclass(value):
+        return dataclasses.asdict(value)
+    if isinstance(value, datetime.datetime | datetime.date | datetime.time):
+        return value.isoformat()
+    if isinstance(value, datetime.timedelta):
+        return value.total_seconds()
+    if isinstance(value, decimal.Decimal):
+        return str(value)
+    if isinstance(value, enum.Enum):
+        return to_json_safe(value.value)
+    if isinstance(value, uuid.UUID | Path):
+        return str(value)
+    if isinstance(value, bytes | bytearray):
+        return value.decode("utf-8", errors="replace")
+    return repr(value)
+
 def main():
     """Execute user script and capture results."""
     # Read inputs from file
@@ -170,13 +199,11 @@ def main():
     # Write result to file
     result_path = Path("/work/result.json")
     try:
-        result_path.write_text(json.dumps(result))
+        result_path.write_text(json.dumps(result, default=to_json_safe))
     except (TypeError, ValueError) as e:
-        # Handle non-JSON-serializable outputs (datetime, bytes, custom classes, etc.)
-        # Convert output to string representation so we don't lose the result
-        result["output"] = repr(result["output"])
         result["error"] = f"Output not JSON-serializable: {type(e).__name__}: {e}"
         result["success"] = False
+        result["output"] = repr(result["output"])
         result_path.write_text(json.dumps(result))
 
     # Exit with appropriate code

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -109,7 +109,7 @@ def to_json_safe(value):
         try:
             return sorted(value)
         except TypeError:
-            return list(value)
+            return sorted(value, key=repr)
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
         return dataclasses.asdict(value)
     if isinstance(value, datetime.datetime | datetime.date | datetime.time):

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -111,7 +111,10 @@ def to_json_safe(value):
         except TypeError:
             return sorted(value, key=repr)
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        return dataclasses.asdict(value)
+        try:
+            return dataclasses.asdict(value)
+        except RecursionError as e:
+            raise TypeError("Recursive dataclass values are not JSON-serializable") from e
     if isinstance(value, datetime.datetime | datetime.date | datetime.time):
         return value.isoformat()
     if isinstance(value, datetime.timedelta):
@@ -200,7 +203,7 @@ def main():
     result_path = Path("/work/result.json")
     try:
         result_path.write_text(json.dumps(result, default=to_json_safe))
-    except (TypeError, ValueError) as e:
+    except (TypeError, ValueError, RecursionError) as e:
         result["error"] = f"Output not JSON-serializable: {type(e).__name__}: {e}"
         result["success"] = False
         result["output"] = repr(result["output"])

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -110,7 +110,7 @@ def to_json_safe(value):
             return sorted(value)
         except TypeError:
             return list(value)
-    if dataclasses.is_dataclass(value):
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
         return dataclasses.asdict(value)
     if isinstance(value, datetime.datetime | datetime.date | datetime.time):
         return value.isoformat()


### PR DESCRIPTION
## Summary
Normalize `core.script.run_python` result serialization so unsupported Python value types like `set` and `datetime` can be returned without collapsing the entire payload.

## Root cause
The sandbox wrappers wrote `result.json` with plain `json.dumps(...)`. When a returned value contained something non-JSON-serializable, behavior diverged by runtime:
- nsjail marked the whole action failed
- unsafe PID could return a raw Python `repr(...)` string for the entire output

## What changed
- Switched both sandbox wrappers to `json.dumps(result, default=to_json_safe)`
- Kept the fallback focused on unsupported value types rather than pre-normalizing the whole object graph
- Added regression coverage for the unsafe PID path and the nsjail-targeted path
- Trimmed unused wrapper imports

## Impact
`core.script.run_python` now preserves structured output for common unsupported value types in a consistent way across sandbox implementations. Non-string dict keys are still allowed to fail.

## Validation
- `uv run pytest tests/unit/test_unsafe_pid_executor.py`
- `uv run ruff check tracecat/sandbox/wrapper.py tracecat/sandbox/unsafe_pid_executor.py tests/unit/test_unsafe_pid_executor.py tests/registry/test_core_python.py`
- `uv run basedpyright tracecat/sandbox/wrapper.py tracecat/sandbox/unsafe_pid_executor.py tests/unit/test_unsafe_pid_executor.py tests/registry/test_core_python.py`
- `uv run pytest tests/registry/test_core_python.py -k non_json_leaf_values_are_normalized` (skipped locally because nsjail is unavailable in this environment)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize serialization of `core.script.run_python` results so non-JSON values don’t break outputs, with consistent behavior across nsjail and unsafe PID sandboxes. Adds deterministic set handling, safer dataclass serialization, and clear errors for recursive dataclasses.

- **Bug Fixes**
  - Use `json.dumps(..., default=to_json_safe)` in both sandbox wrappers.
  - `to_json_safe` normalizes sets/frozensets deterministically (sorting, falling back to `repr` for mixed types); serializes dataclass instances via `asdict` while leaving dataclass classes as `repr(...)`; handles datetime/date/time/timedelta, `decimal.Decimal`, `enum.Enum`, `uuid.UUID`, `pathlib.Path`, and bytes/bytearray; falls back to `repr(...)`.
  - Detect recursive dataclass values and surface a clear "Output not JSON-serializable" error; set `success=False`, keep `repr(output)`, and in nsjail surface a clean `SandboxExecutionError`.
  - Tests cover both sandbox paths, including mixed-type sets, dataclass instance vs class, and recursive dataclass cases.

<sup>Written for commit 5ab284ad4c2a37654f857fb3711ff1c0f031935b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

