### PR TITLE
fix: Builder oauth preset validation

### DIFF
--- a/tests/unit/test_agent_internal_tools.py
+++ b/tests/unit/test_agent_internal_tools.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
+from tracecat_registry import RegistryOAuthSecret
 
 from tracecat.agent.mcp import internal_tools
 from tracecat.agent.tokens import InternalToolContext, MCPTokenClaims
+from tracecat.integrations.enums import OAuthGrantType
+from tracecat.integrations.schemas import ProviderKey
 
 
 class _AsyncContext:
@@ -50,10 +54,37 @@ def test_evaluate_configuration_prefers_workspace_secret_even_when_empty():
         requirements,
         workspace_inventory,
         org_inventory,
+        set(),
     )
 
     assert configured is False
     assert missing == ["missing key: slack.SLACK_BOT_TOKEN"]
+
+
+def test_evaluate_configuration_accepts_configured_oauth_integration():
+    requirements = [
+        {
+            "type": "oauth",
+            "provider_id": "google_docs",
+            "grant_type": "client_credentials",
+            "optional": False,
+        }
+    ]
+
+    configured, missing = internal_tools._evaluate_configuration(
+        requirements,
+        {},
+        {},
+        {
+            ProviderKey(
+                id="google_docs",
+                grant_type=OAuthGrantType.CLIENT_CREDENTIALS,
+            )
+        },
+    )
+
+    assert configured is True
+    assert missing == []
 
 
 @pytest.mark.anyio
@@ -101,6 +132,9 @@ async def test_list_available_tools_includes_configuration_fields(monkeypatch):
     async def _secret_inventory(_role):
         return {}, {}
 
+    async def _oauth_inventory(_role):
+        return set()
+
     monkeypatch.setattr(
         "tracecat.agent.preset.service.AgentPresetService.with_session",
         lambda role: _AsyncContext(preset_service),
@@ -113,6 +147,11 @@ async def test_list_available_tools_includes_configuration_fields(monkeypatch):
         internal_tools,
         "_load_secret_inventory",
         _secret_inventory,
+    )
+    monkeypatch.setattr(
+        internal_tools,
+        "_load_oauth_inventory",
+        _oauth_inventory,
     )
     monkeypatch.setattr(internal_tools, "_get_action_configuration", _config)
 
@@ -149,6 +188,9 @@ async def test_update_preset_blocks_unconfigured_tool_add(monkeypatch):
     async def _secret_inventory(_role):
         return {}, {}
 
+    async def _oauth_inventory(_role):
+        return set()
+
     monkeypatch.setattr(
         "tracecat.agent.preset.service.AgentPresetService.with_session",
         lambda role: _AsyncContext(preset_service),
@@ -162,6 +204,11 @@ async def test_update_preset_blocks_unconfigured_tool_add(monkeypatch):
         "_load_secret_inventory",
         _secret_inventory,
     )
+    monkeypatch.setattr(
+        internal_tools,
+        "_load_oauth_inventory",
+        _oauth_inventory,
+    )
     monkeypatch.setattr(internal_tools, "_get_action_configuration", _config)
 
     with pytest.raises(
@@ -171,3 +218,92 @@ async def test_update_preset_blocks_unconfigured_tool_add(monkeypatch):
             {"actions": ["tools.alpha", "tools.slack.post_message"]},
             claims,
         )
+
+
+@pytest.mark.anyio
+async def test_update_preset_allows_configured_oauth_tool_add(monkeypatch):
+    preset_id = uuid.uuid4()
+    claims = _build_claims(preset_id)
+
+    existing_preset = SimpleNamespace(actions=["tools.alpha"])
+    updated_preset = {
+        "id": preset_id,
+        "workspace_id": claims.workspace_id,
+        "name": "Builder Preset",
+        "slug": "builder-preset",
+        "description": None,
+        "current_version_id": None,
+        "created_at": datetime.now(UTC),
+        "updated_at": datetime.now(UTC),
+        "instructions": None,
+        "model_name": "gpt-5.4",
+        "model_provider": "openai",
+        "base_url": None,
+        "output_type": None,
+        "actions": ["tools.alpha", "tools.google_docs.create_document"],
+        "namespaces": None,
+        "tool_approvals": None,
+        "mcp_integrations": None,
+        "retries": 3,
+        "enable_internet_access": False,
+    }
+
+    async def _get_preset(_preset_id):
+        return existing_preset
+
+    async def _update_preset(_preset, _params):
+        return updated_preset
+
+    async def _get_action_from_index(_action_name):
+        return SimpleNamespace(manifest=object())
+
+    registry_service = SimpleNamespace(
+        get_action_from_index=_get_action_from_index,
+        aggregate_secrets_from_manifest=lambda _manifest, _action_name: [
+            RegistryOAuthSecret(
+                provider_id="google_docs",
+                grant_type="client_credentials",
+            )
+        ],
+    )
+    preset_service = SimpleNamespace(
+        get_preset=_get_preset,
+        update_preset=_update_preset,
+    )
+
+    async def _secret_inventory(_role):
+        return {}, {}
+
+    async def _oauth_inventory(_role):
+        return {
+            ProviderKey(
+                id="google_docs",
+                grant_type=OAuthGrantType.CLIENT_CREDENTIALS,
+            )
+        }
+
+    monkeypatch.setattr(
+        "tracecat.agent.preset.service.AgentPresetService.with_session",
+        lambda role: _AsyncContext(preset_service),
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.mcp.internal_tools.RegistryActionsService.with_session",
+        lambda role: _AsyncContext(registry_service),
+    )
+    monkeypatch.setattr(
+        internal_tools,
+        "_load_secret_inventory",
+        _secret_inventory,
+    )
+    monkeypatch.setattr(
+        internal_tools,
+        "_load_oauth_inventory",
+        _oauth_inventory,
+    )
+
+    result = await internal_tools.update_preset(
+        {"actions": ["tools.alpha", "tools.google_docs.create_document"]},
+        claims,
+    )
+
+    assert result["actions"] == ["tools.alpha", "tools.google_docs.create_document"]

--- a/tracecat/agent/mcp/internal_tools.py
+++ b/tracecat/agent/mcp/internal_tools.py
@@ -13,8 +13,8 @@ configure agent presets through natural language.
 from __future__ import annotations
 
 import uuid
-from collections.abc import Awaitable, Callable
-from typing import Any, TypedDict
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any, Literal, TypedDict, cast
 
 from pydantic import BaseModel, Field
 from tracecat_registry import RegistryOAuthSecret, RegistrySecret
@@ -33,6 +33,9 @@ from tracecat.contexts import ctx_role
 from tracecat.exceptions import (
     TracecatValidationError,
 )
+from tracecat.integrations.enums import OAuthGrantType
+from tracecat.integrations.schemas import ProviderKey
+from tracecat.integrations.service import IntegrationService
 from tracecat.logger import logger
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
@@ -80,13 +83,35 @@ class InternalToolError(Exception):
     """Raised when an internal tool execution fails."""
 
 
-def _secrets_to_requirements(secrets: list[Any]) -> list[dict[str, Any]]:
+class SecretRequirement(TypedDict):
+    """Configuration requirement for a regular secret."""
+
+    type: Literal["secret"]
+    name: str
+    required_keys: list[str]
+    optional: bool
+
+
+class OAuthRequirement(TypedDict):
+    """Configuration requirement for a workspace OAuth integration."""
+
+    type: Literal["oauth"]
+    provider_id: str
+    grant_type: str
+    optional: bool
+
+
+Requirement = SecretRequirement | OAuthRequirement
+
+
+def _secrets_to_requirements(secrets: list[Any]) -> list[Requirement]:
     """Convert registry secret objects to simple requirement metadata."""
-    requirements: list[dict[str, Any]] = []
+    requirements: list[Requirement] = []
     for secret in secrets:
         if isinstance(secret, RegistrySecret):
             requirements.append(
                 {
+                    "type": "secret",
                     "name": secret.name,
                     "required_keys": list(secret.keys or []),
                     "optional": secret.optional,
@@ -95,8 +120,9 @@ def _secrets_to_requirements(secrets: list[Any]) -> list[dict[str, Any]]:
         elif isinstance(secret, RegistryOAuthSecret):
             requirements.append(
                 {
-                    "name": secret.name,
-                    "required_keys": [secret.token_name],
+                    "type": "oauth",
+                    "provider_id": secret.provider_id,
+                    "grant_type": secret.grant_type,
                     "optional": secret.optional,
                 }
             )
@@ -104,17 +130,33 @@ def _secrets_to_requirements(secrets: list[Any]) -> list[dict[str, Any]]:
 
 
 def _evaluate_configuration(
-    requirements: list[dict[str, Any]],
+    requirements: Sequence[Requirement | dict[str, Any]],
     workspace_inventory: dict[str, set[str]],
     org_inventory: dict[str, set[str]],
+    oauth_inventory: set[ProviderKey],
 ) -> tuple[bool, list[str]]:
     """Evaluate whether required secret names/keys are configured."""
     missing: list[str] = []
     for requirement in requirements:
-        secret_name = requirement["name"]
-        required_keys = set(requirement["required_keys"])
         if requirement.get("optional", False):
             continue
+        requirement_type = requirement.get("type", "secret")
+        if requirement_type == "oauth":
+            oauth_requirement = cast(OAuthRequirement | dict[str, Any], requirement)
+            provider_key = ProviderKey(
+                id=cast(str, oauth_requirement["provider_id"]),
+                grant_type=OAuthGrantType(cast(str, oauth_requirement["grant_type"])),
+            )
+            if provider_key not in oauth_inventory:
+                missing.append(
+                    "missing oauth integration: "
+                    f"{provider_key.id} ({provider_key.grant_type.value})"
+                )
+            continue
+
+        secret_requirement = cast(SecretRequirement | dict[str, Any], requirement)
+        secret_name = cast(str, secret_requirement["name"])
+        required_keys = set(cast(list[str], secret_requirement["required_keys"]))
         keys = workspace_inventory.get(secret_name)
         if keys is None:
             keys = org_inventory.get(secret_name)
@@ -156,6 +198,16 @@ async def _load_secret_inventory(
     return workspace_inventory, org_inventory
 
 
+async def _load_oauth_inventory(role: Role) -> set[ProviderKey]:
+    """Load configured workspace OAuth integrations."""
+    async with IntegrationService.with_session(role=role) as svc:
+        integrations = await svc.list_integrations()
+    return {
+        ProviderKey(id=integration.provider_id, grant_type=integration.grant_type)
+        for integration in integrations
+    }
+
+
 def _get_preset_id(context: InternalToolContext | None) -> uuid.UUID:
     """Extract preset_id from internal tool context."""
     if context is None or context.preset_id is None:
@@ -180,6 +232,7 @@ async def _get_action_configuration(
     action_name: str,
     workspace_inventory: dict[str, set[str]],
     org_inventory: dict[str, set[str]],
+    oauth_inventory: set[ProviderKey],
 ) -> tuple[bool, list[str]]:
     """Return (configured, missing_requirements) for an action."""
     indexed = await svc.get_action_from_index(action_name)
@@ -188,7 +241,12 @@ async def _get_action_configuration(
 
     secrets = svc.aggregate_secrets_from_manifest(indexed.manifest, action_name)
     requirements = _secrets_to_requirements(secrets)
-    return _evaluate_configuration(requirements, workspace_inventory, org_inventory)
+    return _evaluate_configuration(
+        requirements,
+        workspace_inventory,
+        org_inventory,
+        oauth_inventory,
+    )
 
 
 # -----------------------------------------------------------------------------
@@ -230,6 +288,7 @@ async def list_available_tools(
     role = _build_role(claims)
     ctx_role.set(role)
     workspace_inventory, org_inventory = await _load_secret_inventory(role)
+    oauth_inventory = await _load_oauth_inventory(role)
     preset_action_set: set[str] = set()
 
     async with AgentPresetService.with_session(role=role) as preset_service:
@@ -253,6 +312,7 @@ async def list_available_tools(
                 action_name,
                 workspace_inventory,
                 org_inventory,
+                oauth_inventory,
             )
             tools.append(
                 AgentToolSummary(
@@ -302,6 +362,7 @@ async def update_preset(args: dict[str, Any], claims: MCPTokenClaims) -> dict[st
             added_actions = sorted(proposed_actions - current_actions)
             if added_actions:
                 workspace_inventory, org_inventory = await _load_secret_inventory(role)
+                oauth_inventory = await _load_oauth_inventory(role)
                 async with RegistryActionsService.with_session(
                     role=role
                 ) as registry_svc:
@@ -312,6 +373,7 @@ async def update_preset(args: dict[str, Any], claims: MCPTokenClaims) -> dict[st
                             action_name,
                             workspace_inventory,
                             org_inventory,
+                            oauth_inventory,
                         )
                         if not configured:
                             unconfigured.append(


### PR DESCRIPTION
## Summary
- fix builder preset validation to treat OAuth-backed action secrets as workspace integrations instead of regular secrets-manager keys
- load configured OAuth integrations when listing or adding tools so `internal.builder.update_preset` no longer blocks valid template actions
- add regression coverage for OAuth integration readiness and preset updates

## Root cause
The builder-side readiness check flattened `RegistryOAuthSecret` into a synthetic secret name and token key such as `google_docs_oauth.GOOGLE_DOCS_SERVICE_TOKEN`. Those values are runtime projections of an installed OAuth integration, not normal persisted secrets, so the builder produced false "missing secret" validation errors.

## Validation
- `uv run pytest tests/unit/test_agent_internal_tools.py`
- `uv run ruff check tracecat/agent/mcp/internal_tools.py tests/unit/test_agent_internal_tools.py`
- `uv run basedpyright tracecat/agent/mcp/internal_tools.py tests/unit/test_agent_internal_tools.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix builder OAuth preset validation by treating OAuth-backed action requirements as workspace integrations, not secrets. This removes false “missing secret” errors and lets users add OAuth-backed tools in the Builder.

- **Bug Fixes**
  - Interpret `RegistryOAuthSecret` as `type: "oauth"` and validate against configured integrations.
  - Load OAuth inventory via `IntegrationService` in `list_available_tools` and `update_preset`.
  - Validate provider+grant pairs and show clear “missing oauth integration” messages.
  - Added regression tests for OAuth readiness and preset updates.

<sup>Written for commit b0a28e5418e1cfcc3a66460aa75238d790d6edb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

