### PR TITLE
fix(agents): inject tool results as user messages for custom model pa…

### DIFF
--- a/tests/unit/test_tracecat_llm_proxy.py
+++ b/tests/unit/test_tracecat_llm_proxy.py
@@ -861,10 +861,67 @@ def test_openai_family_adapter_uses_responses_for_reasoning_history() -> None:
         },
         {
             "type": "message",
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": '[Tool result] call_1: {"status":"ok"}',
+                }
+            ],
+        },
+    ]
+
+
+def test_custom_model_provider_formats_tool_results_as_user_history() -> None:
+    request = NormalizedMessagesRequest(
+        provider="custom-model-provider",
+        model="claude-4-6-sonnet",
+        messages=(
+            NormalizedMessage(
+                role="assistant",
+                content=[
+                    {
+                        "type": "tool_use",
+                        "id": "call_1",
+                        "name": "lookup",
+                        "input": {"query": "status"},
+                    },
+                ],
+            ),
+            NormalizedMessage(
+                role="tool",
+                tool_call_id="call_1",
+                content={"status": "ok"},
+            ),
+        ),
+        output_format=IngressFormat.ANTHROPIC,
+        stream=True,
+    )
+
+    custom_request = OpenAIFamilyAdapter("custom-model-provider").prepare_request(
+        request,
+        {"CUSTOM_MODEL_PROVIDER_BASE_URL": "https://custom.example"},
+    )
+
+    assert custom_request.url == "https://custom.example/v1/responses"
+    assert custom_request.json_body is not None
+    assert custom_request.json_body["input"] == [
+        {
+            "type": "message",
             "role": "assistant",
             "content": [
                 {
                     "type": "output_text",
+                    "text": '[Tool call] lookup: {"query":"status"}',
+                }
+            ],
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
                     "text": '[Tool result] call_1: {"status":"ok"}',
                 }
             ],

--- a/tracecat/agent/llm_proxy/provider_openai.py
+++ b/tracecat/agent/llm_proxy/provider_openai.py
@@ -167,7 +167,11 @@ def _text_message(parts: list[str], *, role: str) -> dict[str, Any]:
     }
 
 
-def _responses_input_items_from_message(message: Any) -> list[dict[str, Any]]:
+def _responses_input_items_from_message(
+    message: Any,
+    *,
+    provider: str,
+) -> list[dict[str, Any]]:
     """Convert a NormalizedMessage into Responses API input items."""
     if message.role == "tool":
         content = _stringify(message.content).strip()
@@ -175,7 +179,10 @@ def _responses_input_items_from_message(message: Any) -> list[dict[str, Any]]:
             return []
         tool_name = message.name or message.tool_call_id or "tool"
         return [
-            _text_message([f"[Tool result] {tool_name}: {content}"], role="assistant")
+            _text_message(
+                [f"[Tool result] {tool_name}: {content}"],
+                role="user",
+            )
         ]
 
     if message.role == "assistant":
@@ -292,7 +299,10 @@ def _openai_responses_payload(request: NormalizedMessagesRequest) -> dict[str, A
             item
             for message in request.messages
             if message.role != "system"
-            for item in _responses_input_items_from_message(message)
+            for item in _responses_input_items_from_message(
+                message,
+                provider=request.provider,
+            )
         ],
         "stream": request.stream,
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes tool result injection in the LLM proxy by sending tool outputs as user messages in the OpenAI-family `responses` payload. This ensures custom model providers process tool results correctly and keeps reasoning history consistent.

- **Bug Fixes**
  - Convert `tool` role outputs to `user` messages with `[Tool result] ...` in `responses` input.
  - Ensure custom providers use `/v1/responses` and receive tool results as user history after a tool call.
  - Added unit tests for custom provider formatting and reasoning history.

<sup>Written for commit 406bcf9ec129c4b6a195fd2f1b79832d577641e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

