### PR TITLE
fix(frontend): lazy-load sidebar and workflow catalog hooks

### DIFF
--- a/frontend/src/components/cases/add-case-tag-dialog.tsx
+++ b/frontend/src/components/cases/add-case-tag-dialog.tsx
@@ -52,7 +52,9 @@ export function AddCaseTagDialog({
   onOpenChange,
 }: AddCaseTagDialogProps) {
   const workspaceId = useWorkspaceId()
-  const { caseTags, createCaseTag } = useCaseTagCatalog(workspaceId)
+  const { caseTags, createCaseTag } = useCaseTagCatalog(workspaceId, {
+    enabled: open,
+  })
 
   const methods = useForm<TagCreate>({
     resolver: zodResolver(createTagSchema),

--- a/frontend/src/components/dashboard/add-workflow-tag-dialog.tsx
+++ b/frontend/src/components/dashboard/add-workflow-tag-dialog.tsx
@@ -51,7 +51,7 @@ export function AddWorkflowTagDialog({
   onOpenChange,
 }: AddWorkflowTagDialogProps) {
   const workspaceId = useWorkspaceId()
-  const { tags, createTag } = useWorkflowTags(workspaceId)
+  const { tags, createTag } = useWorkflowTags(workspaceId, { enabled: open })
 
   const methods = useForm<TagCreate>({
     resolver: zodResolver(createTagSchema),

--- a/frontend/src/components/dashboard/table-actions.tsx
+++ b/frontend/src/components/dashboard/table-actions.tsx
@@ -43,6 +43,7 @@ export function WorkflowActions({
   setActiveDialog,
   showMoveToFolder = true,
   availableTags,
+  areTagsLoading = false,
 }: {
   item: WorkflowDirectoryItem
   onDuplicateWorkflow: (item: WorkflowDirectoryItem) => void
@@ -51,6 +52,7 @@ export function WorkflowActions({
   setActiveDialog?: (activeDialog: ActiveDialog | null) => void
   showMoveToFolder?: boolean
   availableTags?: TagRead[]
+  areTagsLoading?: boolean
 }) {
   const { appSettings } = useOrgAppSettings()
   const workspaceId = useWorkspaceId()
@@ -190,6 +192,14 @@ export function WorkflowActions({
             </ContextMenuSubContent>
           </ContextMenuPortal>
         </ContextMenuSub>
+      ) : areTagsLoading ? (
+        <ContextMenuItem
+          className="!bg-transparent text-xs !text-muted-foreground"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <TagsIcon className="mr-2 size-3.5" />
+          <span>Loading tags...</span>
+        </ContextMenuItem>
       ) : (
         <ContextMenuItem
           className="!bg-transparent text-xs !text-muted-foreground hover:cursor-not-allowed"

--- a/frontend/src/components/dashboard/workflows-dashboard.tsx
+++ b/frontend/src/components/dashboard/workflows-dashboard.tsx
@@ -791,6 +791,8 @@ function WorkflowsListRow({
   setSelectedFolder,
   setActiveDialog,
   availableTags,
+  areTagsLoading = false,
+  onWorkflowContextMenuOpen,
 }: {
   item: DirectoryItem
   onOpenWorkflow: (workflowId: string) => void
@@ -801,6 +803,8 @@ function WorkflowsListRow({
   setSelectedFolder: (folder: FolderDirectoryItem | null) => void
   setActiveDialog: (activeDialog: ActiveDialog | null) => void
   availableTags?: TagRead[]
+  areTagsLoading?: boolean
+  onWorkflowContextMenuOpen?: () => void
 }) {
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false)
 
@@ -839,7 +843,14 @@ function WorkflowsListRow({
   }
 
   return (
-    <ContextMenu onOpenChange={setIsContextMenuOpen}>
+    <ContextMenu
+      onOpenChange={(open) => {
+        setIsContextMenuOpen(open)
+        if (open) {
+          onWorkflowContextMenuOpen?.()
+        }
+      }}
+    >
       <ContextMenuTrigger asChild>
         <div
           className={cn(
@@ -871,6 +882,7 @@ function WorkflowsListRow({
           onDuplicateWorkflow={onDuplicateWorkflow}
           duplicateDisabled={duplicateDisabled}
           availableTags={availableTags}
+          areTagsLoading={areTagsLoading}
           showMoveToFolder
           setSelectedWorkflow={setSelectedWorkflow}
           setActiveDialog={setActiveDialog}
@@ -910,6 +922,7 @@ export function WorkflowsDashboard() {
     useState<WorkflowReadMinimal | null>(null)
   const [selectedFolder, setSelectedFolder] =
     useState<FolderDirectoryItem | null>(null)
+  const [shouldLoadWorkflowTags, setShouldLoadWorkflowTags] = useState(false)
 
   const { createWorkflow, moveWorkflow, addWorkflowTag } = useWorkflowManager(
     undefined,
@@ -920,7 +933,15 @@ export function WorkflowsDashboard() {
   const { folders, foldersIsLoading } = useFolders(workspaceId, {
     enabled: view === "list",
   })
-  const { tags } = useWorkflowTags(workspaceId)
+  const { tags, tagsIsLoading } = useWorkflowTags(workspaceId, {
+    enabled: shouldLoadWorkflowTags,
+  })
+
+  useEffect(() => {
+    if (tagFilter.length > 0) {
+      setShouldLoadWorkflowTags(true)
+    }
+  }, [tagFilter.length])
 
   const tagNameByRef = useMemo(() => {
     const map = new Map<string, string>()
@@ -1293,6 +1314,11 @@ export function WorkflowsDashboard() {
             tags={tags}
             tagFilter={tagFilter}
             onTagChange={setTagFilter}
+            onTagFilterOpenChange={(open) => {
+              if (open) {
+                setShouldLoadWorkflowTags(true)
+              }
+            }}
             webhookFilter={webhookFilter}
             onWebhookFilterChange={setWebhookFilter}
             scheduleFilter={scheduleFilter}
@@ -1342,6 +1368,10 @@ export function WorkflowsDashboard() {
                     key={`${item.type}-${item.id}`}
                     item={item}
                     availableTags={tags}
+                    areTagsLoading={shouldLoadWorkflowTags && tagsIsLoading}
+                    onWorkflowContextMenuOpen={() => {
+                      setShouldLoadWorkflowTags(true)
+                    }}
                     onOpenWorkflow={(workflowId) => {
                       router.push(
                         `/workspaces/${workspaceId}/workflows/${workflowId}`

--- a/frontend/src/components/dashboard/workflows-header.tsx
+++ b/frontend/src/components/dashboard/workflows-header.tsx
@@ -216,14 +216,26 @@ interface TagFilterSelectProps {
   value: string[]
   options: TagRead[]
   onChange: (next: string[]) => void
+  onOpenChange?: (open: boolean) => void
 }
 
-function TagFilterSelect({ value, options, onChange }: TagFilterSelectProps) {
+function TagFilterSelect({
+  value,
+  options,
+  onChange,
+  onOpenChange,
+}: TagFilterSelectProps) {
   const [open, setOpen] = useState(false)
   const valueSet = useMemo(() => new Set(value), [value])
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen)
+        onOpenChange?.(nextOpen)
+      }}
+    >
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -474,6 +486,7 @@ interface WorkflowsHeaderProps {
   tags?: TagRead[]
   tagFilter: string[]
   onTagChange: (value: string[]) => void
+  onTagFilterOpenChange?: (open: boolean) => void
   webhookFilter: WorkflowWebhookFilterValue
   onWebhookFilterChange: (value: WorkflowWebhookFilterValue) => void
   scheduleFilter: WorkflowScheduleFilterValue
@@ -502,6 +515,7 @@ export function WorkflowsHeader({
   tags,
   tagFilter,
   onTagChange,
+  onTagFilterOpenChange,
   webhookFilter,
   onWebhookFilterChange,
   scheduleFilter,
@@ -631,6 +645,7 @@ export function WorkflowsHeader({
           value={tagFilter}
           options={tags ?? []}
           onChange={onTagChange}
+          onOpenChange={onTagFilterOpenChange}
         />
 
         <IconFilterSelect

--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -73,10 +73,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const caseId = params?.caseId
   const casesListPath = `${basePath}/cases`
   const isCasesList = pathname === casesListPath
-  const { hasEntitlement, isLoading: entitlementsIsLoading } = useEntitlements()
-  const agentAddonsEnabled = hasEntitlement("agent_addons")
+  const isAgentsRoute = pathname?.startsWith(`${basePath}/agents`) ?? false
   const [createCaseDialogOpen, setCreateCaseDialogOpen] = useState(false)
   const [lockedFeatureDialogOpen, setLockedFeatureDialogOpen] = useState(false)
+  const [agentsSectionOpen, setAgentsSectionOpen] = useState(isAgentsRoute)
 
   useEffect(() => {
     setSidebarOpenRef.current = setSidebarOpen
@@ -117,9 +117,21 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const canViewMembers = useScopeCheck("workspace:member:read")
   const canViewCases = useScopeCheck("case:read")
   const canCreateCase = useScopeCheck("case:create")
-  const { presets, presetsIsLoading } = useAgentPresets(workspaceId, {
-    enabled: agentAddonsEnabled && canViewAgents === true,
+  const shouldLoadAgentsSection =
+    canViewAgents === true && (agentsSectionOpen || isAgentsRoute)
+  const { hasEntitlement, isLoading: entitlementsIsLoading } = useEntitlements({
+    enabled: shouldLoadAgentsSection,
   })
+  const agentAddonsEnabled = hasEntitlement("agent_addons")
+  const { presets, presetsIsLoading } = useAgentPresets(workspaceId, {
+    enabled: shouldLoadAgentsSection && agentAddonsEnabled,
+  })
+
+  useEffect(() => {
+    if (isAgentsRoute) {
+      setAgentsSectionOpen(true)
+    }
+  }, [isAgentsRoute])
 
   const openNewAgentBuilder = () => {
     router.push(`${basePath}/agents/new`)
@@ -285,7 +297,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         )}
 
         {canViewAgents === true && (
-          <Collapsible defaultOpen className="group/collapsible">
+          <Collapsible
+            open={agentsSectionOpen}
+            onOpenChange={setAgentsSectionOpen}
+            className="group/collapsible"
+          >
             <SidebarGroup className="group/agents relative">
               <SidebarGroupLabel asChild>
                 <CollapsibleTrigger className="w-full">

--- a/frontend/src/hooks/use-entitlements.ts
+++ b/frontend/src/hooks/use-entitlements.ts
@@ -7,12 +7,18 @@ type EntitlementKey = keyof Awaited<
   ReturnType<typeof organizationGetOrganizationEntitlements>
 >
 
-export function useEntitlements(): {
+export function useEntitlements({
+  enabled = true,
+}: {
+  enabled?: boolean
+} = {}): {
   hasEntitlement: (key: EntitlementKey) => boolean
   isLoading: boolean
   hasEntitlementData: boolean
 } {
-  const { organization, isLoading: organizationLoading } = useOrganization()
+  const { organization, isLoading: organizationLoading } = useOrganization({
+    enabled,
+  })
   const {
     data: entitlements,
     isLoading,
@@ -20,7 +26,7 @@ export function useEntitlements(): {
   } = useQuery({
     queryKey: ["organization-entitlements", organization?.id],
     queryFn: async () => await organizationGetOrganizationEntitlements(),
-    enabled: Boolean(organization?.id),
+    enabled: enabled && Boolean(organization?.id),
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   })
@@ -29,10 +35,11 @@ export function useEntitlements(): {
 
   return {
     hasEntitlement: (key: EntitlementKey) => {
+      if (!enabled) return false
       if (organizationLoading || isLoading || error) return false
       return Boolean(entitlements?.[key])
     },
-    isLoading: organizationLoading || isLoading,
+    isLoading: enabled ? organizationLoading || isLoading : false,
     hasEntitlementData,
   }
 }

--- a/frontend/src/hooks/use-organization.ts
+++ b/frontend/src/hooks/use-organization.ts
@@ -11,7 +11,11 @@ import {
  *
  * Returns basic information about the organization the authenticated user belongs to.
  */
-export function useOrganization() {
+export function useOrganization({
+  enabled = true,
+}: {
+  enabled?: boolean
+} = {}) {
   const {
     data: organization,
     isLoading,
@@ -19,6 +23,7 @@ export function useOrganization() {
   } = useQuery<OrganizationGetOrganizationResponse>({
     queryKey: ["current-organization"],
     queryFn: organizationGetOrganization,
+    enabled,
     retry: false,
   })
 


### PR DESCRIPTION
## Summary
- lazy-load sidebar agent entitlements and presets until the Agents section is opened or an agent route is active
- lazy-load workflow tag catalogs until the tag filter, workflow context menu, or tag creation dialogs actually need them
- keep the workflow directory fetch in place for folder view because the page needs it for initial render

## Verification
- `uv run ruff check .`
- `pnpm -C frontend exec biome check src/hooks/use-organization.ts src/hooks/use-entitlements.ts src/components/sidebar/app-sidebar.tsx src/components/dashboard/workflows-header.tsx src/components/dashboard/table-actions.tsx src/components/dashboard/workflows-dashboard.tsx src/components/dashboard/add-workflow-tag-dialog.tsx src/components/cases/add-case-tag-dialog.tsx`
- `pnpm -C frontend run typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-load Agents data and workflow tag catalogs so we only fetch them when needed, reducing initial load and API calls. Folder view fetching remains unchanged.

- **New Features**
  - Sidebar: load organization entitlements and agent presets only when the Agents section opens or on Agents routes.
  - Workflows: load tag catalogs when the tag filter opens, workflow context menu opens, or Add Tag dialogs open; show “Loading tags…” in the menu while fetching.
  - Hooks: added an `enabled` option to organization and entitlements hooks and used it across dialogs and the dashboard to gate requests.
  - Context menu/list: trigger tag loading on context menu open and pass loading state to the menu; keep folder/directory fetch for initial render in folder view.

<sup>Written for commit 93f230bf9a33ffbc2bebfffa4cfe937e3cdfe136. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

