### PR TITLE
feat(agents): new agent catalog db models

### DIFF
--- a/alembic/versions/7d23a45113ee_add_agent_catalog_tables.py
+++ b/alembic/versions/7d23a45113ee_add_agent_catalog_tables.py
@@ -1,0 +1,311 @@
+"""add agent catalog tables
+
+Revision ID: b742858f7d69
+Revises: 7e1a4d9c2b6f
+Create Date: 2026-04-08 13:17:30.844855
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+from tracecat.db.tenant_rls import (
+    disable_agent_catalog_table_rls,
+    disable_org_optional_workspace_table_rls,
+    disable_org_table_rls,
+    enable_agent_catalog_table_rls,
+    enable_org_optional_workspace_table_rls,
+    enable_org_table_rls,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "7d23a45113ee"
+down_revision: str | None = "b742858f7d69"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_custom_provider",
+        sa.Column("organization_id", sa.UUID(), nullable=False),
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("display_name", sa.String(length=200), nullable=False),
+        sa.Column("base_url", sa.String(length=500), nullable=True),
+        sa.Column(
+            "passthrough",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column("encrypted_config", sa.LargeBinary(), nullable=True),
+        sa.Column("api_key_header", sa.String(length=120), nullable=True),
+        sa.Column(
+            "discovery_status",
+            sa.Enum(
+                "never",
+                "running",
+                "succeeded",
+                "failed",
+                name="agentcustomproviderdiscoverystatus",
+                native_enum=False,
+            ),
+            server_default=sa.text("'never'"),
+            nullable=False,
+        ),
+        sa.Column("last_refreshed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("surrogate_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organization.id"],
+            name=op.f("fk_agent_custom_provider_organization_id_organization"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name=op.f("pk_agent_custom_provider")),
+        sa.UniqueConstraint(
+            "organization_id",
+            "id",
+            name=op.f("uq_agent_custom_provider_organization_id_id"),
+        ),
+    )
+    op.create_index(
+        op.f("ix_agent_custom_provider_id"),
+        "agent_custom_provider",
+        ["id"],
+        unique=True,
+    )
+
+    op.create_table(
+        "agent_catalog",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("organization_id", sa.UUID(), nullable=True),
+        sa.Column("custom_provider_id", sa.UUID(), nullable=True),
+        sa.Column("model_provider", sa.String(length=120), nullable=False),
+        sa.Column("model_name", sa.String(length=500), nullable=False),
+        sa.Column(
+            "model_metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("encrypted_config", sa.LargeBinary(), nullable=True),
+        sa.Column("last_refreshed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "custom_provider_id IS NULL OR organization_id IS NOT NULL",
+            name=op.f("custom_provider_requires_org"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id", "custom_provider_id"],
+            ["agent_custom_provider.organization_id", "agent_custom_provider.id"],
+            name="fk_agent_catalog_org_custom_provider",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organization.id"],
+            name=op.f("fk_agent_catalog_organization_id_organization"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_agent_catalog")),
+    )
+    op.create_index(
+        op.f("ix_agent_catalog_organization_id"),
+        "agent_catalog",
+        ["organization_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_agent_catalog_organization_id_custom_provider_id",
+        "agent_catalog",
+        ["organization_id", "custom_provider_id"],
+        unique=False,
+    )
+    op.create_index(
+        "uq_agent_catalog_custom_provider_model_provider_model_name",
+        "agent_catalog",
+        ["organization_id", "custom_provider_id", "model_provider", "model_name"],
+        unique=True,
+        postgresql_nulls_not_distinct=True,
+    )
+
+    op.create_table(
+        "agent_model_access",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("organization_id", sa.UUID(), nullable=False),
+        sa.Column("workspace_id", sa.UUID(), nullable=True),
+        sa.Column("catalog_id", sa.UUID(), nullable=False),
+        sa.Column("surrogate_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["catalog_id"],
+            ["agent_catalog.id"],
+            name=op.f("fk_agent_model_access_catalog_id_agent_catalog"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organization.id"],
+            name=op.f("fk_agent_model_access_organization_id_organization"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_agent_model_access_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name=op.f("pk_agent_model_access")),
+    )
+    op.create_index(
+        "ix_agent_model_access_catalog_id",
+        "agent_model_access",
+        ["catalog_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_agent_model_access_id"),
+        "agent_model_access",
+        ["id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_agent_model_access_workspace_id",
+        "agent_model_access",
+        ["workspace_id"],
+        unique=False,
+    )
+    op.create_index(
+        "uq_agent_model_access_organization_workspace_catalog",
+        "agent_model_access",
+        ["organization_id", "workspace_id", "catalog_id"],
+        unique=True,
+        postgresql_nulls_not_distinct=True,
+    )
+
+    op.add_column("agent_preset", sa.Column("catalog_id", sa.UUID(), nullable=True))
+    op.create_index(
+        op.f("ix_agent_preset_catalog_id"),
+        "agent_preset",
+        ["catalog_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        op.f("fk_agent_preset_catalog_id_agent_catalog"),
+        "agent_preset",
+        "agent_catalog",
+        ["catalog_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.add_column(
+        "agent_preset_version",
+        sa.Column("catalog_id", sa.UUID(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_agent_preset_version_catalog_id"),
+        "agent_preset_version",
+        ["catalog_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        op.f("fk_agent_preset_version_catalog_id_agent_catalog"),
+        "agent_preset_version",
+        "agent_catalog",
+        ["catalog_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.execute(enable_org_table_rls("agent_custom_provider"))
+    op.execute(enable_agent_catalog_table_rls())
+    op.execute(enable_org_optional_workspace_table_rls("agent_model_access"))
+
+
+def downgrade() -> None:
+    op.execute(disable_org_optional_workspace_table_rls("agent_model_access"))
+    op.execute(disable_agent_catalog_table_rls())
+    op.execute(disable_org_table_rls("agent_custom_provider"))
+
+    op.drop_constraint(
+        op.f("fk_agent_preset_version_catalog_id_agent_catalog"),
+        "agent_preset_version",
+        type_="foreignkey",
+    )
+    op.drop_index(
+        op.f("ix_agent_preset_version_catalog_id"),
+        table_name="agent_preset_version",
+    )
+    op.drop_column("agent_preset_version", "catalog_id")
+
+    op.drop_constraint(
+        op.f("fk_agent_preset_catalog_id_agent_catalog"),
+        "agent_preset",
+        type_="foreignkey",
+    )
+    op.drop_index(op.f("ix_agent_preset_catalog_id"), table_name="agent_preset")
+    op.drop_column("agent_preset", "catalog_id")
+
+    op.drop_index(
+        "uq_agent_model_access_organization_workspace_catalog",
+        table_name="agent_model_access",
+        postgresql_nulls_not_distinct=True,
+    )
+    op.drop_index("ix_agent_model_access_workspace_id", table_name="agent_model_access")
+    op.drop_index(op.f("ix_agent_model_access_id"), table_name="agent_model_access")
+    op.drop_index("ix_agent_model_access_catalog_id", table_name="agent_model_access")
+    op.drop_table("agent_model_access")
+
+    op.drop_index(
+        "uq_agent_catalog_custom_provider_model_provider_model_name",
+        table_name="agent_catalog",
+        postgresql_nulls_not_distinct=True,
+    )
+    op.drop_index(
+        "ix_agent_catalog_organization_id_custom_provider_id",
+        table_name="agent_catalog",
+    )
+    op.drop_index(op.f("ix_agent_catalog_organization_id"), table_name="agent_catalog")
+    op.drop_table("agent_catalog")
+
+    op.drop_index(
+        op.f("ix_agent_custom_provider_id"), table_name="agent_custom_provider"
+    )
+    op.drop_table("agent_custom_provider")

--- a/alembic/versions/7d23a45113ee_add_agent_catalog_tables.py
+++ b/alembic/versions/7d23a45113ee_add_agent_catalog_tables.py
@@ -1,7 +1,7 @@
 """add agent catalog tables
 
 Revision ID: b742858f7d69
-Revises: 7e1a4d9c2b6f
+Revises: 0c9a39e54e2f
 Create Date: 2026-04-08 13:17:30.844855
 
 """
@@ -23,7 +23,7 @@ from tracecat.db.tenant_rls import (
 
 # revision identifiers, used by Alembic.
 revision: str = "7d23a45113ee"
-down_revision: str | None = "b742858f7d69"
+down_revision: str | None = "0c9a39e54e2f"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/7d23a45113ee_add_agent_catalog_tables.py
+++ b/alembic/versions/7d23a45113ee_add_agent_catalog_tables.py
@@ -43,19 +43,6 @@ def upgrade() -> None:
         ),
         sa.Column("encrypted_config", sa.LargeBinary(), nullable=True),
         sa.Column("api_key_header", sa.String(length=120), nullable=True),
-        sa.Column(
-            "discovery_status",
-            sa.Enum(
-                "never",
-                "running",
-                "succeeded",
-                "failed",
-                name="agentcustomproviderdiscoverystatus",
-                native_enum=False,
-            ),
-            server_default=sa.text("'never'"),
-            nullable=False,
-        ),
         sa.Column("last_refreshed_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column("surrogate_id", sa.Integer(), nullable=False),
         sa.Column(

--- a/alembic/versions/7d23a45113ee_add_agent_catalog_tables.py
+++ b/alembic/versions/7d23a45113ee_add_agent_catalog_tables.py
@@ -1,7 +1,7 @@
 """add agent catalog tables
 
-Revision ID: b742858f7d69
-Revises: 0c9a39e54e2f
+Revision ID: 7d23a45113ee
+Revises: aa5951a3373f
 Create Date: 2026-04-08 13:17:30.844855
 
 """
@@ -23,7 +23,7 @@ from tracecat.db.tenant_rls import (
 
 # revision identifiers, used by Alembic.
 revision: str = "7d23a45113ee"
-down_revision: str | None = "0c9a39e54e2f"
+down_revision: str | None = "aa5951a3373f"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
@@ -105,7 +105,7 @@ def upgrade() -> None:
         ),
         sa.CheckConstraint(
             "custom_provider_id IS NULL OR organization_id IS NOT NULL",
-            name=op.f("custom_provider_requires_org"),
+            name="custom_provider_requires_org",
         ),
         sa.ForeignKeyConstraint(
             ["organization_id", "custom_provider_id"],

--- a/tracecat/agent/platform_catalog.json
+++ b/tracecat/agent/platform_catalog.json
@@ -1,0 +1,2623 @@
+{
+  "models": [
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5-2025-08-07",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5-mini-2025-08-07",
+      "metadata": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "input_cost_per_token": 2.5e-07,
+        "provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2e-06,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.1",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.2",
+      "metadata": {
+        "cache_read_input_token_cost": 1.75e-07,
+        "input_cost_per_token": 1.75e-06,
+        "provider": "openai",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.4",
+      "metadata": {
+        "cache_read_input_token_cost": 2.5e-07,
+        "input_cost_per_token": 2.5e-06,
+        "provider": "openai",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-opus-4-6",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "provider": "anthropic",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-opus-4-5-20251101",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "provider": "anthropic",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-sonnet-4-6",
+      "metadata": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "provider": "anthropic",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-sonnet-4-20250514",
+      "metadata": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "provider": "anthropic",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-haiku-4-5-20251001",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.25e-06,
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 1e-06,
+        "provider": "anthropic",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-06,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-2.0-flash-001",
+      "metadata": {
+        "cache_read_input_token_cost": 3.75e-08,
+        "input_cost_per_token": 1.5e-07,
+        "provider": "vertex_ai-language-models",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-2.5-flash",
+      "metadata": {
+        "cache_read_input_token_cost": 3e-08,
+        "input_cost_per_token": 3e-07,
+        "provider": "vertex_ai-language-models",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-2.5-pro",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "provider": "vertex_ai-language-models",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-3-pro-preview",
+      "metadata": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 2e-06,
+        "provider": "vertex_ai-language-models",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/ai21.j2-mid-v1",
+      "metadata": {
+        "input_cost_per_token": 1.25e-05,
+        "provider": "bedrock",
+        "max_input_tokens": 8191,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 1.25e-05
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/ai21.j2-ultra-v1",
+      "metadata": {
+        "input_cost_per_token": 1.88e-05,
+        "provider": "bedrock",
+        "max_input_tokens": 8191,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 1.88e-05
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/ai21.jamba-1-5-large-v1:0",
+      "metadata": {
+        "input_cost_per_token": 2e-06,
+        "provider": "bedrock",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 8e-06
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/ai21.jamba-1-5-mini-v1:0",
+      "metadata": {
+        "input_cost_per_token": 2e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/ai21.jamba-instruct-v1:0",
+      "metadata": {
+        "input_cost_per_token": 5e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 70000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 7e-07,
+        "supports_system_messages": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/amazon.nova-2-lite-v1:0",
+      "metadata": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_token": 3e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_video_input": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/amazon.nova-2-multimodal-embeddings-v1:0",
+      "metadata": {
+        "provider": "bedrock",
+        "max_input_tokens": 8172,
+        "max_tokens": 8172,
+        "mode": "embedding",
+        "input_cost_per_token": 1.35e-07,
+        "input_cost_per_image": 6e-05,
+        "input_cost_per_video_per_second": 0.0007,
+        "input_cost_per_audio_per_second": 0.00014,
+        "output_cost_per_token": 0.0,
+        "output_vector_size": 3072,
+        "supports_embedding_image_input": true,
+        "supports_image_input": true,
+        "supports_video_input": true,
+        "supports_audio_input": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/amazon.nova-2-pro-preview-20251202-v1:0",
+      "metadata": {
+        "cache_read_input_token_cost": 5.46875e-07,
+        "input_cost_per_token": 2.1875e-06,
+        "input_cost_per_image_token": 2.1875e-06,
+        "input_cost_per_audio_token": 2.1875e-06,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.75e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_video_input": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/amazon.nova-lite-v1:0",
+      "metadata": {
+        "input_cost_per_token": 6e-08,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 300000,
+        "max_output_tokens": 10000,
+        "max_tokens": 10000,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-07,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/amazon.nova-micro-v1:0",
+      "metadata": {
+        "input_cost_per_token": 3.5e-08,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 10000,
+        "max_tokens": 10000,
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-07,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/amazon.nova-pro-v1:0",
+      "metadata": {
+        "input_cost_per_token": 8e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 300000,
+        "max_output_tokens": 10000,
+        "max_tokens": 10000,
+        "mode": "chat",
+        "output_cost_per_token": 3.2e-06,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/amazon.rerank-v1:0",
+      "metadata": {
+        "input_cost_per_query": 0.001,
+        "input_cost_per_token": 0.0,
+        "provider": "bedrock",
+        "max_document_chunks_per_query": 100,
+        "max_input_tokens": 32000,
+        "max_output_tokens": 32000,
+        "max_query_tokens": 32000,
+        "max_tokens": 32000,
+        "max_tokens_per_document_chunk": 512,
+        "mode": "rerank",
+        "output_cost_per_token": 0.0
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/amazon.titan-embed-image-v1",
+      "metadata": {
+        "input_cost_per_image": 6e-05,
+        "input_cost_per_token": 8e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 128,
+        "max_tokens": 128,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_vector_size": 1024,
+        "supports_embedding_image_input": true,
+        "supports_image_input": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/amazon.titan-embed-text-v1",
+      "metadata": {
+        "input_cost_per_token": 1e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_vector_size": 1536
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/amazon.titan-embed-text-v2:0",
+      "metadata": {
+        "input_cost_per_token": 2e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_vector_size": 1024
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/amazon.titan-text-express-v1",
+      "metadata": {
+        "input_cost_per_token": 1.3e-06,
+        "provider": "bedrock",
+        "max_input_tokens": 42000,
+        "max_output_tokens": 8000,
+        "max_tokens": 8000,
+        "mode": "chat",
+        "output_cost_per_token": 1.7e-06
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/amazon.titan-text-lite-v1",
+      "metadata": {
+        "input_cost_per_token": 3e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 42000,
+        "max_output_tokens": 4000,
+        "max_tokens": 4000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/amazon.titan-text-premier-v1:0",
+      "metadata": {
+        "input_cost_per_token": 5e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 42000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/anthropic.claude-haiku-4-5",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.25e-06,
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 1e-06,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-06,
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346,
+        "supports_native_streaming": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/anthropic.claude-haiku-4-5-20251001-v1:0",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.25e-06,
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 1e-06,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-06,
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/anthropic.claude-opus-4-1-20250805-v1:0",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.875e-05,
+        "cache_read_input_token_cost": 1.5e-06,
+        "input_cost_per_token": 1.5e-05,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/anthropic.claude-opus-4-20250514-v1:0",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.875e-05,
+        "cache_read_input_token_cost": 1.5e-06,
+        "input_cost_per_token": 1.5e-05,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/anthropic.claude-opus-4-5-20251101-v1:0",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/anthropic.claude-opus-4-6-v1",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
+      "metadata": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "input_cost_per_token_above_200k_tokens": 6e-06,
+        "output_cost_per_token_above_200k_tokens": 2.25e-05,
+        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "metadata": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "input_cost_per_token_above_200k_tokens": 6e-06,
+        "output_cost_per_token_above_200k_tokens": 2.25e-05,
+        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/anthropic.claude-sonnet-4-6",
+      "metadata": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/cohere.command-light-text-v14",
+      "metadata": {
+        "input_cost_per_token": 3e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 4096,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/cohere.command-r-plus-v1:0",
+      "metadata": {
+        "input_cost_per_token": 3e-06,
+        "provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/cohere.command-r-v1:0",
+      "metadata": {
+        "input_cost_per_token": 5e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/cohere.command-text-v14",
+      "metadata": {
+        "input_cost_per_token": 1.5e-06,
+        "provider": "bedrock",
+        "max_input_tokens": 4096,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 2e-06,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/cohere.embed-english-v3",
+      "metadata": {
+        "input_cost_per_token": 1e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 512,
+        "max_tokens": 512,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "supports_embedding_image_input": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/cohere.embed-multilingual-v3",
+      "metadata": {
+        "input_cost_per_token": 1e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 512,
+        "max_tokens": 512,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "supports_embedding_image_input": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/cohere.embed-v4:0",
+      "metadata": {
+        "input_cost_per_token": 1.2e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_vector_size": 1536,
+        "supports_embedding_image_input": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/cohere.rerank-v3-5:0",
+      "metadata": {
+        "input_cost_per_query": 0.002,
+        "input_cost_per_token": 0.0,
+        "provider": "bedrock",
+        "max_document_chunks_per_query": 100,
+        "max_input_tokens": 32000,
+        "max_output_tokens": 32000,
+        "max_query_tokens": 32000,
+        "max_tokens": 32000,
+        "max_tokens_per_document_chunk": 512,
+        "mode": "rerank",
+        "output_cost_per_token": 0.0
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/deepseek.v3-v1:0",
+      "metadata": {
+        "input_cost_per_token": 5.8e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 81920,
+        "max_tokens": 81920,
+        "mode": "chat",
+        "output_cost_per_token": 1.68e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/deepseek.v3.2",
+      "metadata": {
+        "input_cost_per_token": 6.2e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 163840,
+        "max_tokens": 163840,
+        "mode": "chat",
+        "output_cost_per_token": 1.85e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/google.gemma-3-12b-it",
+      "metadata": {
+        "input_cost_per_token": 9e-08,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.9e-07,
+        "supports_system_messages": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/google.gemma-3-27b-it",
+      "metadata": {
+        "input_cost_per_token": 2.3e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 3.8e-07,
+        "supports_system_messages": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/google.gemma-3-4b-it",
+      "metadata": {
+        "input_cost_per_token": 4e-08,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 8e-08,
+        "supports_system_messages": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama2-13b-chat-v1",
+      "metadata": {
+        "input_cost_per_token": 7.5e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 4096,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 1e-06
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama2-70b-chat-v1",
+      "metadata": {
+        "input_cost_per_token": 1.95e-06,
+        "provider": "bedrock",
+        "max_input_tokens": 4096,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 2.56e-06
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama3-1-405b-instruct-v1:0",
+      "metadata": {
+        "input_cost_per_token": 5.32e-06,
+        "provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 1.6e-05,
+        "supports_function_calling": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama3-1-70b-instruct-v1:0",
+      "metadata": {
+        "input_cost_per_token": 9.9e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "max_tokens": 2048,
+        "mode": "chat",
+        "output_cost_per_token": 9.9e-07,
+        "supports_function_calling": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama3-1-8b-instruct-v1:0",
+      "metadata": {
+        "input_cost_per_token": 2.2e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "max_tokens": 2048,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-07,
+        "supports_function_calling": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama3-2-11b-instruct-v1:0",
+      "metadata": {
+        "input_cost_per_token": 3.5e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 3.5e-07,
+        "supports_function_calling": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama3-2-1b-instruct-v1:0",
+      "metadata": {
+        "input_cost_per_token": 1e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07,
+        "supports_function_calling": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama3-2-3b-instruct-v1:0",
+      "metadata": {
+        "input_cost_per_token": 1.5e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-07,
+        "supports_function_calling": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama3-2-90b-instruct-v1:0",
+      "metadata": {
+        "input_cost_per_token": 2e-06,
+        "provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 2e-06,
+        "supports_function_calling": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama3-3-70b-instruct-v1:0",
+      "metadata": {
+        "input_cost_per_token": 7.2e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 7.2e-07,
+        "supports_function_calling": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama3-70b-instruct-v1:0",
+      "metadata": {
+        "input_cost_per_token": 2.65e-06,
+        "provider": "bedrock",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 3.5e-06
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama3-8b-instruct-v1:0",
+      "metadata": {
+        "input_cost_per_token": 3e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama4-maverick-17b-instruct-v1:0",
+      "metadata": {
+        "input_cost_per_token": 2.4e-07,
+        "input_cost_per_token_batches": 1.2e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 9.7e-07,
+        "output_cost_per_token_batches": 4.85e-07,
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text",
+          "code"
+        ],
+        "supports_function_calling": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/meta.llama4-scout-17b-instruct-v1:0",
+      "metadata": {
+        "input_cost_per_token": 1.7e-07,
+        "input_cost_per_token_batches": 8.5e-08,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 6.6e-07,
+        "output_cost_per_token_batches": 3.3e-07,
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text",
+          "code"
+        ],
+        "supports_function_calling": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/minimax.minimax-m2",
+      "metadata": {
+        "input_cost_per_token": 3e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "supports_system_messages": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/minimax.minimax-m2.1",
+      "metadata": {
+        "input_cost_per_token": 3e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 196000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/minimax.minimax-m2.5",
+      "metadata": {
+        "input_cost_per_token": 3e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/mistral.devstral-2-123b",
+      "metadata": {
+        "input_cost_per_token": 4e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/mistral.magistral-small-2509",
+      "metadata": {
+        "input_cost_per_token": 5e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/mistral.ministral-3-14b-instruct",
+      "metadata": {
+        "input_cost_per_token": 2e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/mistral.ministral-3-3b-instruct",
+      "metadata": {
+        "input_cost_per_token": 1e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/mistral.ministral-3-8b-instruct",
+      "metadata": {
+        "input_cost_per_token": 1.5e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/mistral.mistral-7b-instruct-v0:2",
+      "metadata": {
+        "input_cost_per_token": 1.5e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/mistral.mistral-large-2402-v1:0",
+      "metadata": {
+        "input_cost_per_token": 8e-06,
+        "provider": "bedrock",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-05,
+        "supports_function_calling": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/mistral.mistral-large-2407-v1:0",
+      "metadata": {
+        "input_cost_per_token": 3e-06,
+        "provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 9e-06,
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/mistral.mistral-large-3-675b-instruct",
+      "metadata": {
+        "input_cost_per_token": 5e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/mistral.mistral-small-2402-v1:0",
+      "metadata": {
+        "input_cost_per_token": 1e-06,
+        "provider": "bedrock",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "supports_function_calling": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/mistral.mixtral-8x7b-instruct-v0:1",
+      "metadata": {
+        "input_cost_per_token": 4.5e-07,
+        "provider": "bedrock",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 7e-07,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/mistral.voxtral-mini-3b-2507",
+      "metadata": {
+        "input_cost_per_token": 4e-08,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 4e-08,
+        "supports_audio_input": true,
+        "supports_system_messages": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/mistral.voxtral-small-24b-2507",
+      "metadata": {
+        "input_cost_per_token": 1e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 3e-07,
+        "supports_audio_input": true,
+        "supports_system_messages": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/moonshot.kimi-k2-thinking",
+      "metadata": {
+        "input_cost_per_token": 6e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/moonshotai.kimi-k2.5",
+      "metadata": {
+        "input_cost_per_token": 6e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/nvidia.nemotron-nano-12b-v2",
+      "metadata": {
+        "input_cost_per_token": 2e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "supports_system_messages": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/nvidia.nemotron-nano-3-30b",
+      "metadata": {
+        "input_cost_per_token": 6e-08,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/nvidia.nemotron-nano-9b-v2",
+      "metadata": {
+        "input_cost_per_token": 6e-08,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.3e-07,
+        "supports_system_messages": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/nvidia.nemotron-super-3-120b",
+      "metadata": {
+        "input_cost_per_token": 1.5e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 6.5e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/openai.gpt-oss-120b-1:0",
+      "metadata": {
+        "input_cost_per_token": 1.5e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/openai.gpt-oss-20b-1:0",
+      "metadata": {
+        "input_cost_per_token": 7e-08,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/openai.gpt-oss-safeguard-120b",
+      "metadata": {
+        "input_cost_per_token": 1.5e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "supports_system_messages": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/openai.gpt-oss-safeguard-20b",
+      "metadata": {
+        "input_cost_per_token": 7e-08,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "supports_system_messages": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/qwen.qwen3-235b-a22b-2507-v1:0",
+      "metadata": {
+        "input_cost_per_token": 2.2e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 8.8e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/qwen.qwen3-32b-v1:0",
+      "metadata": {
+        "input_cost_per_token": 1.5e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/qwen.qwen3-coder-30b-a3b-v1:0",
+      "metadata": {
+        "input_cost_per_token": 1.5e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/qwen.qwen3-coder-480b-a35b-v1:0",
+      "metadata": {
+        "input_cost_per_token": 2.2e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.8e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/qwen.qwen3-coder-next",
+      "metadata": {
+        "input_cost_per_token": 5e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/qwen.qwen3-next-80b-a3b",
+      "metadata": {
+        "input_cost_per_token": 1.5e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/qwen.qwen3-vl-235b-a22b",
+      "metadata": {
+        "input_cost_per_token": 5.3e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.66e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_native_structured_output": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/twelvelabs.marengo-embed-2-7-v1:0",
+      "metadata": {
+        "input_cost_per_token": 7e-05,
+        "provider": "bedrock",
+        "max_input_tokens": 77,
+        "max_tokens": 77,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_vector_size": 1024,
+        "supports_embedding_image_input": true,
+        "supports_image_input": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/twelvelabs.pegasus-1-2-v1:0",
+      "metadata": {
+        "input_cost_per_video_per_second": 0.00049,
+        "output_cost_per_token": 7.5e-06,
+        "provider": "bedrock",
+        "mode": "chat",
+        "supports_video_input": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/writer.palmyra-x4-v1:0",
+      "metadata": {
+        "input_cost_per_token": 2.5e-06,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/writer.palmyra-x5-v1:0",
+      "metadata": {
+        "input_cost_per_token": 6e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "supports_function_calling": true,
+        "supports_pdf_input": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/zai.glm-4.7",
+      "metadata": {
+        "input_cost_per_token": 6e-07,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/zai.glm-4.7-flash",
+      "metadata": {
+        "input_cost_per_token": 7e-08,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "bedrock",
+      "model_name": "bedrock/zai.glm-5",
+      "metadata": {
+        "input_cost_per_token": 1e-06,
+        "provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3.2e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "azure_openai",
+      "model_name": "azure/gpt-5-2025-08-07",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "provider": "azure",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_openai",
+      "model_name": "azure/gpt-5-mini-2025-08-07",
+      "metadata": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "input_cost_per_token": 2.5e-07,
+        "provider": "azure",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2e-06,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_openai",
+      "model_name": "azure/gpt-5-nano-2025-08-07",
+      "metadata": {
+        "cache_read_input_token_cost": 5e-09,
+        "input_cost_per_token": 5e-08,
+        "provider": "azure",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_openai",
+      "model_name": "azure/gpt-5.1",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "provider": "azure",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_openai",
+      "model_name": "azure/gpt-5.2",
+      "metadata": {
+        "cache_read_input_token_cost": 1.75e-07,
+        "input_cost_per_token": 1.75e-06,
+        "provider": "azure",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_openai",
+      "model_name": "azure/gpt-5.4",
+      "metadata": {
+        "cache_read_input_token_cost": 2.5e-07,
+        "input_cost_per_token": 2.5e-06,
+        "provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_openai",
+      "model_name": "azure/gpt-4o-2024-11-20",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_token": 2.75e-06,
+        "provider": "azure",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1.1e-05,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_openai",
+      "model_name": "azure/gpt-4o-2024-08-06",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_token": 2.5e-06,
+        "provider": "azure",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_openai",
+      "model_name": "azure/gpt-4o-mini-2024-07-18",
+      "metadata": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_token": 1.65e-07,
+        "provider": "azure",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 6.6e-07,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/claude-opus-4-6",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/claude-opus-4-5",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/claude-opus-4-1",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.875e-05,
+        "cache_read_input_token_cost": 1.5e-06,
+        "input_cost_per_token": 1.5e-05,
+        "provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/claude-sonnet-4-6",
+      "metadata": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/claude-sonnet-4-5",
+      "metadata": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/claude-haiku-4-5",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.25e-06,
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 1e-06,
+        "provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-06,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/mistral-large",
+      "metadata": {
+        "input_cost_per_token": 4e-06,
+        "provider": "azure_ai",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-05,
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/mistral-large-2407",
+      "metadata": {
+        "input_cost_per_token": 2e-06,
+        "provider": "azure_ai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/mistral-large-latest",
+      "metadata": {
+        "input_cost_per_token": 2e-06,
+        "provider": "azure_ai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/mistral-small",
+      "metadata": {
+        "input_cost_per_token": 1e-06,
+        "provider": "azure_ai",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/Meta-Llama-3.1-405B-Instruct",
+      "metadata": {
+        "input_cost_per_token": 5.33e-06,
+        "provider": "azure_ai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "max_tokens": 2048,
+        "mode": "chat",
+        "output_cost_per_token": 1.6e-05,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/Meta-Llama-3.1-70B-Instruct",
+      "metadata": {
+        "input_cost_per_token": 2.68e-06,
+        "provider": "azure_ai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "max_tokens": 2048,
+        "mode": "chat",
+        "output_cost_per_token": 3.54e-06,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/deepseek-v3",
+      "metadata": {
+        "input_cost_per_token": 1.14e-06,
+        "provider": "azure_ai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 4.56e-06,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "azure_ai",
+      "model_name": "azure_ai/deepseek-r1",
+      "metadata": {
+        "input_cost_per_token": 1.35e-06,
+        "provider": "azure_ai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 5.4e-06,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/claude-opus-4-6@default",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "provider": "vertex_ai-anthropic_models",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/claude-opus-4-5@20251101",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "provider": "vertex_ai-anthropic_models",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/claude-opus-4@20250514",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.875e-05,
+        "cache_read_input_token_cost": 1.5e-06,
+        "input_cost_per_token": 1.5e-05,
+        "provider": "vertex_ai-anthropic_models",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/claude-sonnet-4-6@default",
+      "metadata": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "provider": "vertex_ai-anthropic_models",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/claude-sonnet-4-5@20250929",
+      "metadata": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "provider": "vertex_ai-anthropic_models",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/claude-haiku-4-5@20251001",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.25e-06,
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 1e-06,
+        "provider": "vertex_ai-anthropic_models",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 5e-06,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/gemini-3-pro-preview",
+      "metadata": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 2e-06,
+        "provider": "vertex_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/gemini-3.1-pro-preview",
+      "metadata": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 2e-06,
+        "provider": "vertex_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/mistral-large@latest",
+      "metadata": {
+        "input_cost_per_token": 2e-06,
+        "provider": "vertex_ai-mistral_models",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/mistral-large@2411-001",
+      "metadata": {
+        "input_cost_per_token": 2e-06,
+        "provider": "vertex_ai-mistral_models",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/mistral-small-2503@001",
+      "metadata": {
+        "input_cost_per_token": 1e-06,
+        "provider": "vertex_ai-mistral_models",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/meta/llama-3.1-405b-instruct-maas",
+      "metadata": {
+        "input_cost_per_token": 5e-06,
+        "provider": "vertex_ai-llama_models",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "max_tokens": 2048,
+        "mode": "chat",
+        "output_cost_per_token": 1.6e-05,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/meta/llama-3.1-70b-instruct-maas",
+      "metadata": {
+        "input_cost_per_token": 0.0,
+        "provider": "vertex_ai-llama_models",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "max_tokens": 2048,
+        "mode": "chat",
+        "output_cost_per_token": 0.0,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/deepseek-ai/deepseek-v3.2-maas",
+      "metadata": {
+        "input_cost_per_token": 5.6e-07,
+        "provider": "vertex_ai-deepseek_models",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1.68e-06,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+      }
+    },
+    {
+      "model_provider": "vertex_ai",
+      "model_name": "vertex_ai/deepseek-ai/deepseek-r1-0528-maas",
+      "metadata": {
+        "input_cost_per_token": 1.35e-06,
+        "provider": "vertex_ai-deepseek_models",
+        "max_input_tokens": 65336,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 5.4e-06,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+      }
+    }
+  ]
+}

--- a/tracecat/agent/platform_catalog.json
+++ b/tracecat/agent/platform_catalog.json
@@ -1,135 +1,313 @@
 {
   "models": [
     {
-      "model_provider": "openai",
-      "model_name": "gpt-5-2025-08-07",
+      "model_provider": "anthropic",
+      "model_name": "claude-3-7-sonnet-20250219",
       "metadata": {
-        "cache_read_input_token_cost": 1.25e-07,
-        "input_cost_per_token": 1.25e-06,
-        "provider": "openai",
-        "max_input_tokens": 272000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-5-mini-2025-08-07",
-      "metadata": {
-        "cache_read_input_token_cost": 2.5e-08,
-        "input_cost_per_token": 2.5e-07,
-        "provider": "openai",
-        "max_input_tokens": 272000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 2e-06,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-5.1",
-      "metadata": {
-        "cache_read_input_token_cost": 1.25e-07,
-        "input_cost_per_token": 1.25e-06,
-        "provider": "openai",
-        "max_input_tokens": 272000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-5.2",
-      "metadata": {
-        "cache_read_input_token_cost": 1.75e-07,
-        "input_cost_per_token": 1.75e-06,
-        "provider": "openai",
-        "max_input_tokens": 272000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 1.4e-05,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-5.4",
-      "metadata": {
-        "cache_read_input_token_cost": 2.5e-07,
-        "input_cost_per_token": 2.5e-06,
-        "provider": "openai",
-        "max_input_tokens": 1050000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-02-19",
+        "input_cost_per_token": 3e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
         "supports_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
-        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tool_use_system_prompt_tokens": 159,
+        "provider": "anthropic"
       }
     },
     {
       "model_provider": "anthropic",
-      "model_name": "claude-opus-4-6",
+      "model_name": "claude-3-haiku-20240307",
       "metadata": {
-        "cache_creation_input_token_cost": 6.25e-06,
-        "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 5e-06,
-        "provider": "anthropic",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 2.5e-05,
+        "cache_creation_input_token_cost": 3e-07,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
+        "cache_read_input_token_cost": 3e-08,
+        "input_cost_per_token": 2.5e-07,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 1.25e-06,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 264,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-3-opus-20240229",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.875e-05,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
+        "cache_read_input_token_cost": 1.5e-06,
+        "deprecation_date": "2026-05-01",
+        "input_cost_per_token": 1.5e-05,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 7.5e-05,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 395,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-4-opus-20250514",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.875e-05,
+        "cache_read_input_token_cost": 1.5e-06,
+        "input_cost_per_token": 1.5e-05,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "output_cost_per_token": 7.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
         "supports_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-4-sonnet-20250514",
+      "metadata": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "input_cost_per_token": 3e-06,
+        "input_cost_per_token_above_200k_tokens": 6e-06,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 1.5e-05,
+        "output_cost_per_token_above_200k_tokens": 2.25e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tool_use_system_prompt_tokens": 159,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-haiku-4-5",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 2e-06,
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 1e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 5e-06,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_computer_use": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-haiku-4-5-20251001",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 2e-06,
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 1e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 5e-06,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_computer_use": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-opus-4-1",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.875e-05,
+        "cache_creation_input_token_cost_above_1hr": 3e-05,
+        "cache_read_input_token_cost": 1.5e-06,
+        "input_cost_per_token": 1.5e-05,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "output_cost_per_token": 7.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-opus-4-1-20250805",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.875e-05,
+        "cache_creation_input_token_cost_above_1hr": 3e-05,
+        "cache_read_input_token_cost": 1.5e-06,
+        "input_cost_per_token": 1.5e-05,
+        "deprecation_date": "2026-08-05",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "output_cost_per_token": 7.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-opus-4-20250514",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.875e-05,
+        "cache_creation_input_token_cost_above_1hr": 3e-05,
+        "cache_read_input_token_cost": 1.5e-06,
+        "input_cost_per_token": 1.5e-05,
+        "deprecation_date": "2026-05-14",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "output_cost_per_token": 7.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-opus-4-5",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159,
+        "provider": "anthropic"
       }
     },
     {
@@ -137,21 +315,271 @@
       "model_name": "claude-opus-4-5-20251101",
       "metadata": {
         "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
-        "provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
-        "mode": "chat",
         "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
         "supports_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-opus-4-6",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346,
+        "provider_specific_entry": {
+          "us": 1.1,
+          "fast": 6.0
+        },
+        "supports_max_reasoning_effort": true,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-opus-4-6-20260205",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346,
+        "provider_specific_entry": {
+          "us": 1.1,
+          "fast": 6.0
+        },
+        "supports_max_reasoning_effort": true,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-opus-4-7",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "tool_use_system_prompt_tokens": 346,
+        "provider_specific_entry": {
+          "us": 1.1,
+          "fast": 6.0
+        },
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-opus-4-7-20260416",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "tool_use_system_prompt_tokens": 346,
+        "provider_specific_entry": {
+          "us": 1.1,
+          "fast": 6.0
+        },
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-sonnet-4-20250514",
+      "metadata": {
+        "deprecation_date": "2026-05-14",
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "input_cost_per_token_above_200k_tokens": 6e-06,
+        "output_cost_per_token_above_200k_tokens": 2.25e-05,
+        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-sonnet-4-5",
+      "metadata": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "input_cost_per_token_above_200k_tokens": 6e-06,
+        "output_cost_per_token_above_200k_tokens": 2.25e-05,
+        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-sonnet-4-5-20250929",
+      "metadata": {
+        "cache_creation_input_token_cost": 3.75e-06,
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "input_cost_per_token_above_200k_tokens": 6e-06,
+        "output_cost_per_token_above_200k_tokens": 2.25e-05,
+        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tool_use_system_prompt_tokens": 346,
+        "provider": "anthropic"
       }
     },
     {
@@ -161,83 +589,226 @@
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
-        "provider": "anthropic",
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
-        "mode": "chat",
         "output_cost_per_token": 1.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
         "supports_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346,
+        "provider": "anthropic"
       }
     },
     {
-      "model_provider": "anthropic",
-      "model_name": "claude-sonnet-4-20250514",
+      "model_provider": "google",
+      "model_name": "gemini-2.0-flash",
       "metadata": {
-        "cache_creation_input_token_cost": 3.75e-06,
-        "cache_read_input_token_cost": 3e-07,
-        "input_cost_per_token": 3e-06,
-        "provider": "anthropic",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
+        "cache_read_input_token_cost": 2.5e-08,
+        "deprecation_date": "2026-06-01",
+        "input_cost_per_audio_token": 7e-07,
+        "input_cost_per_token": 1e-07,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 8192,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 8192,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_token": 4e-07,
+        "rpm": 10000,
+        "source": "https://ai.google.dev/pricing#2_0flash",
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text",
+          "image"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
         "supports_function_calling": true,
-        "supports_pdf_input": true,
         "supports_prompt_caching": true,
-        "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "anthropic",
-      "model_name": "claude-haiku-4-5-20251001",
-      "metadata": {
-        "cache_creation_input_token_cost": 1.25e-06,
-        "cache_read_input_token_cost": 1e-07,
-        "input_cost_per_token": 1e-06,
-        "provider": "anthropic",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 5e-06,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 10000000,
+        "provider": "gemini"
       }
     },
     {
       "model_provider": "google",
       "model_name": "gemini-2.0-flash-001",
       "metadata": {
-        "cache_read_input_token_cost": 3.75e-08,
-        "input_cost_per_token": 1.5e-07,
-        "provider": "vertex_ai-language-models",
+        "cache_read_input_token_cost": 2.5e-08,
+        "deprecation_date": "2026-06-01",
+        "input_cost_per_audio_token": 7e-07,
+        "input_cost_per_token": 1e-07,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
+        "max_pdf_size_mb": 30,
         "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 6e-07,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_token": 4e-07,
+        "rpm": 10000,
+        "source": "https://ai.google.dev/pricing#2_0flash",
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text",
+          "image"
+        ],
+        "supports_audio_output": false,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 10000000,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-2.0-flash-lite",
+      "metadata": {
+        "cache_read_input_token_cost": 1.875e-08,
+        "deprecation_date": "2026-06-01",
+        "input_cost_per_audio_token": 7.5e-08,
+        "input_cost_per_token": 7.5e-08,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 8192,
+        "max_pdf_size_mb": 50,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_token": 3e-07,
+        "rpm": 4000,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-2.0-flash-lite",
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 4000000,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-2.0-flash-lite-001",
+      "metadata": {
+        "cache_read_input_token_cost": 1.875e-08,
+        "deprecation_date": "2026-06-01",
+        "input_cost_per_audio_token": 7.5e-08,
+        "input_cost_per_token": 7.5e-08,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 8192,
+        "max_pdf_size_mb": 50,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_token": 3e-07,
+        "rpm": 4000,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-2.0-flash-lite",
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 4000000,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-2.5-computer-use-preview-10-2025",
+      "metadata": {
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_above_200k_tokens": 1.5e-05,
+        "rpm": 2000,
+        "source": "https://ai.google.dev/gemini-api/docs/computer-use",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tpm": 800000,
+        "provider": "gemini"
       }
     },
     {
@@ -245,21 +816,252 @@
       "model_name": "gemini-2.5-flash",
       "metadata": {
         "cache_read_input_token_cost": 3e-08,
+        "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
-        "provider": "vertex_ai-language-models",
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
         "max_tokens": 65535,
-        "mode": "chat",
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_reasoning_token": 2.5e-06,
         "output_cost_per_token": 2.5e-06,
+        "rpm": 100000,
+        "source": "https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-preview",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_output": false,
         "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 8000000,
+        "supports_service_tier": true,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-2.5-flash-lite",
+      "metadata": {
+        "cache_read_input_token_cost": 1e-08,
+        "input_cost_per_audio_token": 3e-07,
+        "input_cost_per_token": 1e-07,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65535,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_reasoning_token": 4e-07,
+        "output_cost_per_token": 4e-07,
+        "rpm": 15,
+        "source": "https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-lite",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_output": false,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 250000,
+        "supports_service_tier": true,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-2.5-flash-lite-preview-06-17",
+      "metadata": {
+        "deprecation_date": "2025-11-18",
+        "cache_read_input_token_cost": 2.5e-08,
+        "input_cost_per_audio_token": 5e-07,
+        "input_cost_per_token": 1e-07,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65535,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_reasoning_token": 4e-07,
+        "output_cost_per_token": 4e-07,
+        "rpm": 15,
+        "source": "https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-lite",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_output": false,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 250000,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-2.5-flash-lite-preview-09-2025",
+      "metadata": {
+        "cache_read_input_token_cost": 1e-08,
+        "input_cost_per_audio_token": 3e-07,
+        "input_cost_per_token": 1e-07,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65535,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_reasoning_token": 4e-07,
+        "output_cost_per_token": 4e-07,
+        "rpm": 15,
+        "source": "https://developers.googleblog.com/en/continuing-to-bring-you-our-latest-models-with-an-improved-gemini-2-5-flash-and-flash-lite-release/",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_output": false,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 250000,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-2.5-flash-preview-09-2025",
+      "metadata": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_audio_token": 1e-06,
+        "input_cost_per_token": 3e-07,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65535,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_reasoning_token": 2.5e-06,
+        "output_cost_per_token": 2.5e-06,
+        "rpm": 15,
+        "source": "https://developers.googleblog.com/en/continuing-to-bring-you-our-latest-models-with-an-improved-gemini-2-5-flash-and-flash-lite-release/",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_output": false,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 250000,
+        "provider": "gemini"
       }
     },
     {
@@ -267,13 +1069,41 @@
       "model_name": "gemini-2.5-pro",
       "metadata": {
         "cache_read_input_token_cost": 1.25e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 2.5e-07,
         "input_cost_per_token": 1.25e-06,
-        "provider": "vertex_ai-language-models",
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "input_cost_per_token_priority": 1.25e-06,
+        "input_cost_per_token_above_200k_tokens_priority": 2.5e-06,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
         "max_tokens": 65535,
-        "mode": "chat",
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
         "output_cost_per_token": 1e-05,
+        "output_cost_per_token_above_200k_tokens": 1.5e-05,
+        "output_cost_per_token_priority": 1e-05,
+        "output_cost_per_token_above_200k_tokens_priority": 1.5e-05,
+        "rpm": 2000,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supports_service_tier": true,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_input": true,
         "supports_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
@@ -281,1631 +1111,108 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 800000,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-3-flash-preview",
+      "metadata": {
+        "cache_read_input_token_cost": 5e-08,
+        "input_cost_per_audio_token": 1e-06,
+        "input_cost_per_token": 5e-07,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65535,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_reasoning_token": 3e-06,
+        "output_cost_per_token": 3e-06,
+        "rpm": 2000,
+        "source": "https://ai.google.dev/pricing/gemini-3",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_output": false,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_native_streaming": true,
+        "tpm": 800000,
+        "input_cost_per_token_priority": 9e-07,
+        "input_cost_per_audio_token_priority": 1.8e-06,
+        "output_cost_per_token_priority": 5.4e-06,
+        "cache_read_input_token_cost_priority": 9e-08,
+        "supports_service_tier": true,
+        "provider": "gemini"
       }
     },
     {
       "model_provider": "google",
       "model_name": "gemini-3-pro-preview",
       "metadata": {
+        "deprecation_date": "2026-03-09",
         "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
         "input_cost_per_token": 2e-06,
-        "provider": "vertex_ai-language-models",
+        "input_cost_per_token_above_200k_tokens": 4e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
         "max_tokens": 65535,
-        "mode": "chat",
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
         "output_cost_per_token": 1.2e-05,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/ai21.j2-mid-v1",
-      "metadata": {
-        "input_cost_per_token": 1.25e-05,
-        "provider": "bedrock",
-        "max_input_tokens": 8191,
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 1.25e-05
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/ai21.j2-ultra-v1",
-      "metadata": {
-        "input_cost_per_token": 1.88e-05,
-        "provider": "bedrock",
-        "max_input_tokens": 8191,
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 1.88e-05
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/ai21.jamba-1-5-large-v1:0",
-      "metadata": {
-        "input_cost_per_token": 2e-06,
-        "provider": "bedrock",
-        "max_input_tokens": 256000,
-        "max_output_tokens": 256000,
-        "max_tokens": 256000,
-        "mode": "chat",
-        "output_cost_per_token": 8e-06
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/ai21.jamba-1-5-mini-v1:0",
-      "metadata": {
-        "input_cost_per_token": 2e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 256000,
-        "max_output_tokens": 256000,
-        "max_tokens": 256000,
-        "mode": "chat",
-        "output_cost_per_token": 4e-07
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/ai21.jamba-instruct-v1:0",
-      "metadata": {
-        "input_cost_per_token": 5e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 70000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 7e-07,
-        "supports_system_messages": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/amazon.nova-2-lite-v1:0",
-      "metadata": {
-        "cache_read_input_token_cost": 7.5e-08,
-        "input_cost_per_token": 3e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_video_input": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/amazon.nova-2-multimodal-embeddings-v1:0",
-      "metadata": {
-        "provider": "bedrock",
-        "max_input_tokens": 8172,
-        "max_tokens": 8172,
-        "mode": "embedding",
-        "input_cost_per_token": 1.35e-07,
-        "input_cost_per_image": 6e-05,
-        "input_cost_per_video_per_second": 0.0007,
-        "input_cost_per_audio_per_second": 0.00014,
-        "output_cost_per_token": 0.0,
-        "output_vector_size": 3072,
-        "supports_embedding_image_input": true,
-        "supports_image_input": true,
-        "supports_video_input": true,
-        "supports_audio_input": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/amazon.nova-2-pro-preview-20251202-v1:0",
-      "metadata": {
-        "cache_read_input_token_cost": 5.46875e-07,
-        "input_cost_per_token": 2.1875e-06,
-        "input_cost_per_image_token": 2.1875e-06,
-        "input_cost_per_audio_token": 2.1875e-06,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 1.75e-05,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_video_input": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/amazon.nova-lite-v1:0",
-      "metadata": {
-        "input_cost_per_token": 6e-08,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 300000,
-        "max_output_tokens": 10000,
-        "max_tokens": 10000,
-        "mode": "chat",
-        "output_cost_per_token": 2.4e-07,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/amazon.nova-micro-v1:0",
-      "metadata": {
-        "input_cost_per_token": 3.5e-08,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 10000,
-        "max_tokens": 10000,
-        "mode": "chat",
-        "output_cost_per_token": 1.4e-07,
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/amazon.nova-pro-v1:0",
-      "metadata": {
-        "input_cost_per_token": 8e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 300000,
-        "max_output_tokens": 10000,
-        "max_tokens": 10000,
-        "mode": "chat",
-        "output_cost_per_token": 3.2e-06,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/amazon.rerank-v1:0",
-      "metadata": {
-        "input_cost_per_query": 0.001,
-        "input_cost_per_token": 0.0,
-        "provider": "bedrock",
-        "max_document_chunks_per_query": 100,
-        "max_input_tokens": 32000,
-        "max_output_tokens": 32000,
-        "max_query_tokens": 32000,
-        "max_tokens": 32000,
-        "max_tokens_per_document_chunk": 512,
-        "mode": "rerank",
-        "output_cost_per_token": 0.0
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/amazon.titan-embed-image-v1",
-      "metadata": {
-        "input_cost_per_image": 6e-05,
-        "input_cost_per_token": 8e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 128,
-        "max_tokens": 128,
-        "mode": "embedding",
-        "output_cost_per_token": 0.0,
-        "output_vector_size": 1024,
-        "supports_embedding_image_input": true,
-        "supports_image_input": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/amazon.titan-embed-text-v1",
-      "metadata": {
-        "input_cost_per_token": 1e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "embedding",
-        "output_cost_per_token": 0.0,
-        "output_vector_size": 1536
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/amazon.titan-embed-text-v2:0",
-      "metadata": {
-        "input_cost_per_token": 2e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "embedding",
-        "output_cost_per_token": 0.0,
-        "output_vector_size": 1024
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/amazon.titan-text-express-v1",
-      "metadata": {
-        "input_cost_per_token": 1.3e-06,
-        "provider": "bedrock",
-        "max_input_tokens": 42000,
-        "max_output_tokens": 8000,
-        "max_tokens": 8000,
-        "mode": "chat",
-        "output_cost_per_token": 1.7e-06
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/amazon.titan-text-lite-v1",
-      "metadata": {
-        "input_cost_per_token": 3e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 42000,
-        "max_output_tokens": 4000,
-        "max_tokens": 4000,
-        "mode": "chat",
-        "output_cost_per_token": 4e-07
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/amazon.titan-text-premier-v1:0",
-      "metadata": {
-        "input_cost_per_token": 5e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 42000,
-        "max_output_tokens": 32000,
-        "max_tokens": 32000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-06
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/anthropic.claude-haiku-4-5",
-      "metadata": {
-        "cache_creation_input_token_cost": 1.25e-06,
-        "cache_read_input_token_cost": 1e-07,
-        "input_cost_per_token": 1e-06,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 5e-06,
-        "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_native_streaming": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/anthropic.claude-haiku-4-5-20251001-v1:0",
-      "metadata": {
-        "cache_creation_input_token_cost": 1.25e-06,
-        "cache_read_input_token_cost": 1e-07,
-        "input_cost_per_token": 1e-06,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 5e-06,
-        "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/anthropic.claude-opus-4-1-20250805-v1:0",
-      "metadata": {
-        "cache_creation_input_token_cost": 1.875e-05,
-        "cache_read_input_token_cost": 1.5e-06,
-        "input_cost_per_token": 1.5e-05,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 32000,
-        "max_tokens": 32000,
-        "mode": "chat",
-        "output_cost_per_token": 7.5e-05,
-        "search_context_cost_per_query": {
-          "search_context_size_high": 0.01,
-          "search_context_size_low": 0.01,
-          "search_context_size_medium": 0.01
-        },
-        "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/anthropic.claude-opus-4-20250514-v1:0",
-      "metadata": {
-        "cache_creation_input_token_cost": 1.875e-05,
-        "cache_read_input_token_cost": 1.5e-06,
-        "input_cost_per_token": 1.5e-05,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 32000,
-        "max_tokens": 32000,
-        "mode": "chat",
-        "output_cost_per_token": 7.5e-05,
-        "search_context_cost_per_query": {
-          "search_context_size_high": 0.01,
-          "search_context_size_low": 0.01,
-          "search_context_size_medium": 0.01
-        },
-        "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/anthropic.claude-opus-4-5-20251101-v1:0",
-      "metadata": {
-        "cache_creation_input_token_cost": 6.25e-06,
-        "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 5e-06,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 2.5e-05,
-        "search_context_cost_per_query": {
-          "search_context_size_high": 0.01,
-          "search_context_size_low": 0.01,
-          "search_context_size_medium": 0.01
-        },
-        "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/anthropic.claude-opus-4-6-v1",
-      "metadata": {
-        "cache_creation_input_token_cost": 6.25e-06,
-        "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 5e-06,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 2.5e-05,
-        "search_context_cost_per_query": {
-          "search_context_size_high": 0.01,
-          "search_context_size_low": 0.01,
-          "search_context_size_medium": 0.01
-        },
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
-      "metadata": {
-        "cache_creation_input_token_cost": 3.75e-06,
-        "cache_read_input_token_cost": 3e-07,
-        "input_cost_per_token": 3e-06,
-        "input_cost_per_token_above_200k_tokens": 6e-06,
-        "output_cost_per_token_above_200k_tokens": 2.25e-05,
-        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
-        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "search_context_cost_per_query": {
-          "search_context_size_high": 0.01,
-          "search_context_size_low": 0.01,
-          "search_context_size_medium": 0.01
-        },
-        "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0",
-      "metadata": {
-        "cache_creation_input_token_cost": 3.75e-06,
-        "cache_read_input_token_cost": 3e-07,
-        "input_cost_per_token": 3e-06,
-        "input_cost_per_token_above_200k_tokens": 6e-06,
-        "output_cost_per_token_above_200k_tokens": 2.25e-05,
-        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
-        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "search_context_cost_per_query": {
-          "search_context_size_high": 0.01,
-          "search_context_size_low": 0.01,
-          "search_context_size_medium": 0.01
-        },
-        "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/anthropic.claude-sonnet-4-6",
-      "metadata": {
-        "cache_creation_input_token_cost": 3.75e-06,
-        "cache_read_input_token_cost": 3e-07,
-        "input_cost_per_token": 3e-06,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "search_context_cost_per_query": {
-          "search_context_size_high": 0.01,
-          "search_context_size_low": 0.01,
-          "search_context_size_medium": 0.01
-        },
-        "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 346,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/cohere.command-light-text-v14",
-      "metadata": {
-        "input_cost_per_token": 3e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 6e-07,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/cohere.command-r-plus-v1:0",
-      "metadata": {
-        "input_cost_per_token": 3e-06,
-        "provider": "bedrock",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/cohere.command-r-v1:0",
-      "metadata": {
-        "input_cost_per_token": 5e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-06,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/cohere.command-text-v14",
-      "metadata": {
-        "input_cost_per_token": 1.5e-06,
-        "provider": "bedrock",
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 2e-06,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/cohere.embed-english-v3",
-      "metadata": {
-        "input_cost_per_token": 1e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 512,
-        "max_tokens": 512,
-        "mode": "embedding",
-        "output_cost_per_token": 0.0,
-        "supports_embedding_image_input": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/cohere.embed-multilingual-v3",
-      "metadata": {
-        "input_cost_per_token": 1e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 512,
-        "max_tokens": 512,
-        "mode": "embedding",
-        "output_cost_per_token": 0.0,
-        "supports_embedding_image_input": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/cohere.embed-v4:0",
-      "metadata": {
-        "input_cost_per_token": 1.2e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "embedding",
-        "output_cost_per_token": 0.0,
-        "output_vector_size": 1536,
-        "supports_embedding_image_input": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/cohere.rerank-v3-5:0",
-      "metadata": {
-        "input_cost_per_query": 0.002,
-        "input_cost_per_token": 0.0,
-        "provider": "bedrock",
-        "max_document_chunks_per_query": 100,
-        "max_input_tokens": 32000,
-        "max_output_tokens": 32000,
-        "max_query_tokens": 32000,
-        "max_tokens": 32000,
-        "max_tokens_per_document_chunk": 512,
-        "mode": "rerank",
-        "output_cost_per_token": 0.0
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/deepseek.v3-v1:0",
-      "metadata": {
-        "input_cost_per_token": 5.8e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 163840,
-        "max_output_tokens": 81920,
-        "max_tokens": 81920,
-        "mode": "chat",
-        "output_cost_per_token": 1.68e-06,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/deepseek.v3.2",
-      "metadata": {
-        "input_cost_per_token": 6.2e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 163840,
-        "max_output_tokens": 163840,
-        "max_tokens": 163840,
-        "mode": "chat",
-        "output_cost_per_token": 1.85e-06,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/google.gemma-3-12b-it",
-      "metadata": {
-        "input_cost_per_token": 9e-08,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 2.9e-07,
-        "supports_system_messages": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/google.gemma-3-27b-it",
-      "metadata": {
-        "input_cost_per_token": 2.3e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 3.8e-07,
-        "supports_system_messages": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/google.gemma-3-4b-it",
-      "metadata": {
-        "input_cost_per_token": 4e-08,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 8e-08,
-        "supports_system_messages": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama2-13b-chat-v1",
-      "metadata": {
-        "input_cost_per_token": 7.5e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1e-06
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama2-70b-chat-v1",
-      "metadata": {
-        "input_cost_per_token": 1.95e-06,
-        "provider": "bedrock",
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 2.56e-06
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama3-1-405b-instruct-v1:0",
-      "metadata": {
-        "input_cost_per_token": 5.32e-06,
-        "provider": "bedrock",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1.6e-05,
-        "supports_function_calling": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama3-1-70b-instruct-v1:0",
-      "metadata": {
-        "input_cost_per_token": 9.9e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 2048,
-        "max_tokens": 2048,
-        "mode": "chat",
-        "output_cost_per_token": 9.9e-07,
-        "supports_function_calling": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama3-1-8b-instruct-v1:0",
-      "metadata": {
-        "input_cost_per_token": 2.2e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 2048,
-        "max_tokens": 2048,
-        "mode": "chat",
-        "output_cost_per_token": 2.2e-07,
-        "supports_function_calling": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama3-2-11b-instruct-v1:0",
-      "metadata": {
-        "input_cost_per_token": 3.5e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 3.5e-07,
-        "supports_function_calling": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama3-2-1b-instruct-v1:0",
-      "metadata": {
-        "input_cost_per_token": 1e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1e-07,
-        "supports_function_calling": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama3-2-3b-instruct-v1:0",
-      "metadata": {
-        "input_cost_per_token": 1.5e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-07,
-        "supports_function_calling": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama3-2-90b-instruct-v1:0",
-      "metadata": {
-        "input_cost_per_token": 2e-06,
-        "provider": "bedrock",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 2e-06,
-        "supports_function_calling": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama3-3-70b-instruct-v1:0",
-      "metadata": {
-        "input_cost_per_token": 7.2e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 7.2e-07,
-        "supports_function_calling": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama3-70b-instruct-v1:0",
-      "metadata": {
-        "input_cost_per_token": 2.65e-06,
-        "provider": "bedrock",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 3.5e-06
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama3-8b-instruct-v1:0",
-      "metadata": {
-        "input_cost_per_token": 3e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 6e-07
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama4-maverick-17b-instruct-v1:0",
-      "metadata": {
-        "input_cost_per_token": 2.4e-07,
-        "input_cost_per_token_batches": 1.2e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 9.7e-07,
-        "output_cost_per_token_batches": 4.85e-07,
+        "output_cost_per_token_above_200k_tokens": 1.8e-05,
+        "output_cost_per_token_batches": 6e-06,
+        "rpm": 2000,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
         "supported_modalities": [
           "text",
-          "image"
+          "image",
+          "audio",
+          "video"
         ],
         "supported_output_modalities": [
-          "text",
-          "code"
+          "text"
         ],
-        "supports_function_calling": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/meta.llama4-scout-17b-instruct-v1:0",
-      "metadata": {
-        "input_cost_per_token": 1.7e-07,
-        "input_cost_per_token_batches": 8.5e-08,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 6.6e-07,
-        "output_cost_per_token_batches": 3.3e-07,
-        "supported_modalities": [
-          "text",
-          "image"
-        ],
-        "supported_output_modalities": [
-          "text",
-          "code"
-        ],
-        "supports_function_calling": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/minimax.minimax-m2",
-      "metadata": {
-        "input_cost_per_token": 3e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.2e-06,
-        "supports_system_messages": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/minimax.minimax-m2.1",
-      "metadata": {
-        "input_cost_per_token": 3e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 196000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.2e-06,
-        "supports_function_calling": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/minimax.minimax-m2.5",
-      "metadata": {
-        "input_cost_per_token": 3e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.2e-06,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/mistral.devstral-2-123b",
-      "metadata": {
-        "input_cost_per_token": 4e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 256000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 2e-06,
-        "supports_function_calling": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/mistral.magistral-small-2509",
-      "metadata": {
-        "input_cost_per_token": 5e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-06,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_system_messages": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/mistral.ministral-3-14b-instruct",
-      "metadata": {
-        "input_cost_per_token": 2e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 2e-07,
-        "supports_function_calling": true,
-        "supports_system_messages": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/mistral.ministral-3-3b-instruct",
-      "metadata": {
-        "input_cost_per_token": 1e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1e-07,
-        "supports_function_calling": true,
-        "supports_system_messages": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/mistral.ministral-3-8b-instruct",
-      "metadata": {
-        "input_cost_per_token": 1.5e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-07,
-        "supports_function_calling": true,
-        "supports_system_messages": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/mistral.mistral-7b-instruct-v0:2",
-      "metadata": {
-        "input_cost_per_token": 1.5e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 32000,
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 2e-07,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/mistral.mistral-large-2402-v1:0",
-      "metadata": {
-        "input_cost_per_token": 8e-06,
-        "provider": "bedrock",
-        "max_input_tokens": 32000,
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 2.4e-05,
-        "supports_function_calling": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/mistral.mistral-large-2407-v1:0",
-      "metadata": {
-        "input_cost_per_token": 3e-06,
-        "provider": "bedrock",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 9e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/mistral.mistral-large-3-675b-instruct",
-      "metadata": {
-        "input_cost_per_token": 5e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-06,
-        "supports_function_calling": true,
-        "supports_system_messages": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/mistral.mistral-small-2402-v1:0",
-      "metadata": {
-        "input_cost_per_token": 1e-06,
-        "provider": "bedrock",
-        "max_input_tokens": 32000,
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 3e-06,
-        "supports_function_calling": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/mistral.mixtral-8x7b-instruct-v0:1",
-      "metadata": {
-        "input_cost_per_token": 4.5e-07,
-        "provider": "bedrock",
-        "max_input_tokens": 32000,
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 7e-07,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/mistral.voxtral-mini-3b-2507",
-      "metadata": {
-        "input_cost_per_token": 4e-08,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 4e-08,
         "supports_audio_input": true,
-        "supports_system_messages": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/mistral.voxtral-small-24b-2507",
-      "metadata": {
-        "input_cost_per_token": 1e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 3e-07,
-        "supports_audio_input": true,
-        "supports_system_messages": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/moonshot.kimi-k2-thinking",
-      "metadata": {
-        "input_cost_per_token": 6e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "supports_reasoning": true,
-        "supports_system_messages": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/moonshotai.kimi-k2.5",
-      "metadata": {
-        "input_cost_per_token": 6e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
-        "mode": "chat",
-        "output_cost_per_token": 3e-06,
-        "supports_function_calling": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/nvidia.nemotron-nano-12b-v2",
-      "metadata": {
-        "input_cost_per_token": 2e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 6e-07,
-        "supports_system_messages": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/nvidia.nemotron-nano-3-30b",
-      "metadata": {
-        "input_cost_per_token": 6e-08,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 262144,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 2.4e-07,
-        "supports_function_calling": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/nvidia.nemotron-nano-9b-v2",
-      "metadata": {
-        "input_cost_per_token": 6e-08,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 2.3e-07,
-        "supports_system_messages": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/nvidia.nemotron-super-3-120b",
-      "metadata": {
-        "input_cost_per_token": 1.5e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 256000,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 6.5e-07,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/openai.gpt-oss-120b-1:0",
-      "metadata": {
-        "input_cost_per_token": 1.5e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 6e-07,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/openai.gpt-oss-20b-1:0",
-      "metadata": {
-        "input_cost_per_token": 7e-08,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 3e-07,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/openai.gpt-oss-safeguard-120b",
-      "metadata": {
-        "input_cost_per_token": 1.5e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 6e-07,
-        "supports_system_messages": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/openai.gpt-oss-safeguard-20b",
-      "metadata": {
-        "input_cost_per_token": 7e-08,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 2e-07,
-        "supports_system_messages": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/qwen.qwen3-235b-a22b-2507-v1:0",
-      "metadata": {
-        "input_cost_per_token": 2.2e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 262144,
-        "max_output_tokens": 131072,
-        "max_tokens": 131072,
-        "mode": "chat",
-        "output_cost_per_token": 8.8e-07,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/qwen.qwen3-32b-v1:0",
-      "metadata": {
-        "input_cost_per_token": 1.5e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "output_cost_per_token": 6e-07,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/qwen.qwen3-coder-30b-a3b-v1:0",
-      "metadata": {
-        "input_cost_per_token": 1.5e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 262144,
-        "max_output_tokens": 131072,
-        "max_tokens": 131072,
-        "mode": "chat",
-        "output_cost_per_token": 6e-07,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/qwen.qwen3-coder-480b-a35b-v1:0",
-      "metadata": {
-        "input_cost_per_token": 2.2e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 262000,
-        "max_output_tokens": 65536,
-        "max_tokens": 65536,
-        "mode": "chat",
-        "output_cost_per_token": 1.8e-06,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/qwen.qwen3-coder-next",
-      "metadata": {
-        "input_cost_per_token": 5e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 262144,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.2e-06,
-        "supports_function_calling": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/qwen.qwen3-next-80b-a3b",
-      "metadata": {
-        "input_cost_per_token": 1.5e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.2e-06,
-        "supports_function_calling": true,
-        "supports_system_messages": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/qwen.qwen3-vl-235b-a22b",
-      "metadata": {
-        "input_cost_per_token": 5.3e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 2.66e-06,
-        "supports_function_calling": true,
-        "supports_system_messages": true,
-        "supports_vision": true,
-        "supports_native_structured_output": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/twelvelabs.marengo-embed-2-7-v1:0",
-      "metadata": {
-        "input_cost_per_token": 7e-05,
-        "provider": "bedrock",
-        "max_input_tokens": 77,
-        "max_tokens": 77,
-        "mode": "embedding",
-        "output_cost_per_token": 0.0,
-        "output_vector_size": 1024,
-        "supports_embedding_image_input": true,
-        "supports_image_input": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/twelvelabs.pegasus-1-2-v1:0",
-      "metadata": {
-        "input_cost_per_video_per_second": 0.00049,
-        "output_cost_per_token": 7.5e-06,
-        "provider": "bedrock",
-        "mode": "chat",
-        "supports_video_input": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/writer.palmyra-x4-v1:0",
-      "metadata": {
-        "input_cost_per_token": 2.5e-06,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_pdf_input": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/writer.palmyra-x5-v1:0",
-      "metadata": {
-        "input_cost_per_token": 6e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 6e-06,
-        "supports_function_calling": true,
-        "supports_pdf_input": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/zai.glm-4.7",
-      "metadata": {
-        "input_cost_per_token": 6e-07,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 2.2e-06,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/zai.glm-4.7-flash",
-      "metadata": {
-        "input_cost_per_token": 7e-08,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 4e-07,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "bedrock",
-      "model_name": "bedrock/zai.glm-5",
-      "metadata": {
-        "input_cost_per_token": 1e-06,
-        "provider": "bedrock_converse",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 3.2e-06,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "azure_openai",
-      "model_name": "azure/gpt-5-2025-08-07",
-      "metadata": {
-        "cache_read_input_token_cost": 1.25e-07,
-        "input_cost_per_token": 1.25e-06,
-        "provider": "azure",
-        "max_input_tokens": 272000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
         "supports_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
@@ -1913,710 +1220,2710 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 800000,
+        "input_cost_per_token_priority": 3.6e-06,
+        "input_cost_per_token_above_200k_tokens_priority": 7.2e-06,
+        "output_cost_per_token_priority": 2.16e-05,
+        "output_cost_per_token_above_200k_tokens_priority": 3.24e-05,
+        "cache_read_input_token_cost_priority": 3.6e-07,
+        "cache_read_input_token_cost_above_200k_tokens_priority": 7.2e-07,
+        "supports_service_tier": true,
+        "provider": "gemini"
       }
     },
     {
-      "model_provider": "azure_openai",
-      "model_name": "azure/gpt-5-mini-2025-08-07",
+      "model_provider": "google",
+      "model_name": "gemini-3.1-flash-lite-preview",
       "metadata": {
         "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost_per_audio_token": 5e-08,
+        "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 2.5e-07,
-        "provider": "azure",
-        "max_input_tokens": 272000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65536,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_reasoning_token": 1.5e-06,
+        "output_cost_per_token": 1.5e-06,
+        "rpm": 15,
+        "source": "https://ai.google.dev/gemini-api/docs/models",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": false,
+        "supports_code_execution": true,
+        "supports_file_search": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_native_streaming": true,
+        "tpm": 250000,
+        "supports_service_tier": true,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-3.1-flash-live-preview",
+      "metadata": {
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_image_token": 1e-06,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_video_per_second": 3.3333333333333335e-05,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 4.5e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_endpoints": [
+          "/v1/realtime"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text",
+          "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-3.1-pro-preview",
+      "metadata": {
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_200k_tokens": 4e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65536,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_above_200k_tokens": 1.8e-05,
+        "output_cost_per_token_batches": 6e-06,
+        "rpm": 2000,
+        "source": "https://ai.google.dev/gemini-api/docs/models#gemini-3.1-pro-preview",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_url_context": true,
+        "supports_native_streaming": true,
+        "tpm": 800000,
+        "input_cost_per_token_priority": 3.6e-06,
+        "input_cost_per_token_above_200k_tokens_priority": 7.2e-06,
+        "output_cost_per_token_priority": 2.16e-05,
+        "output_cost_per_token_above_200k_tokens_priority": 3.24e-05,
+        "cache_read_input_token_cost_priority": 3.6e-07,
+        "cache_read_input_token_cost_above_200k_tokens_priority": 7.2e-07,
+        "supports_service_tier": true,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-3.1-pro-preview-customtools",
+      "metadata": {
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_200k_tokens": 4e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65536,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_above_200k_tokens": 1.8e-05,
+        "output_cost_per_token_batches": 6e-06,
+        "rpm": 2000,
+        "source": "https://ai.google.dev/gemini-api/docs/models#gemini-3.1-pro-preview",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_url_context": true,
+        "supports_native_streaming": true,
+        "tpm": 800000,
+        "input_cost_per_token_priority": 3.6e-06,
+        "input_cost_per_token_above_200k_tokens_priority": 7.2e-06,
+        "output_cost_per_token_priority": 2.16e-05,
+        "output_cost_per_token_above_200k_tokens_priority": 3.24e-05,
+        "cache_read_input_token_cost_priority": 3.6e-07,
+        "cache_read_input_token_cost_above_200k_tokens_priority": 7.2e-07,
+        "supports_service_tier": true,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-exp-1206",
+      "metadata": {
+        "cache_read_input_token_cost": 3e-08,
+        "input_cost_per_audio_token": 1e-06,
+        "input_cost_per_token": 3e-07,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65535,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_reasoning_token": 2.5e-06,
+        "output_cost_per_token": 2.5e-06,
+        "rpm": 100000,
+        "source": "https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-preview",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_output": false,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 8000000,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-flash-latest",
+      "metadata": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_audio_token": 1e-06,
+        "input_cost_per_token": 3e-07,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65535,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_reasoning_token": 2.5e-06,
+        "output_cost_per_token": 2.5e-06,
+        "rpm": 15,
+        "source": "https://developers.googleblog.com/en/continuing-to-bring-you-our-latest-models-with-an-improved-gemini-2-5-flash-and-flash-lite-release/",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_output": false,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 250000,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-flash-lite-latest",
+      "metadata": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "input_cost_per_audio_token": 3e-07,
+        "input_cost_per_token": 1e-07,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65535,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_reasoning_token": 4e-07,
+        "output_cost_per_token": 4e-07,
+        "rpm": 15,
+        "source": "https://developers.googleblog.com/en/continuing-to-bring-you-our-latest-models-with-an-improved-gemini-2-5-flash-and-flash-lite-release/",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_output": false,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 250000,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "google",
+      "model_name": "gemini-pro-latest",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 2.5e-07,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65535,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_above_200k_tokens": 1.5e-05,
+        "rpm": 2000,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "tpm": 800000,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "chatgpt-4o-latest",
+      "metadata": {
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 1.5e-05,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-3.5-turbo",
+      "metadata": {
+        "input_cost_per_token": 5e-07,
+        "max_input_tokens": 16385,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 1.5e-06,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-3.5-turbo-0125",
+      "metadata": {
+        "input_cost_per_token": 5e-07,
+        "max_input_tokens": 16385,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 1.5e-06,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-3.5-turbo-1106",
+      "metadata": {
+        "deprecation_date": "2026-09-28",
+        "input_cost_per_token": 1e-06,
+        "max_input_tokens": 16385,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
         "output_cost_per_token": 2e-06,
         "supports_function_calling": true,
-        "supports_pdf_input": true,
+        "supports_parallel_function_calling": true,
         "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "azure_openai",
-      "model_name": "azure/gpt-5-nano-2025-08-07",
+      "model_provider": "openai",
+      "model_name": "gpt-3.5-turbo-16k",
       "metadata": {
-        "cache_read_input_token_cost": 5e-09,
-        "input_cost_per_token": 5e-08,
-        "provider": "azure",
+        "input_cost_per_token": 3e-06,
+        "max_input_tokens": 16385,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 4e-06,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4",
+      "metadata": {
+        "input_cost_per_token": 3e-05,
+        "max_input_tokens": 8192,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 6e-05,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4-0125-preview",
+      "metadata": {
+        "deprecation_date": "2026-03-26",
+        "input_cost_per_token": 1e-05,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 3e-05,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4-0314",
+      "metadata": {
+        "deprecation_date": "2026-03-26",
+        "input_cost_per_token": 3e-05,
+        "max_input_tokens": 8192,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 6e-05,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4-0613",
+      "metadata": {
+        "deprecation_date": "2025-06-06",
+        "input_cost_per_token": 3e-05,
+        "max_input_tokens": 8192,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 6e-05,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4-1106-preview",
+      "metadata": {
+        "deprecation_date": "2026-03-26",
+        "input_cost_per_token": 1e-05,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 3e-05,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4-turbo",
+      "metadata": {
+        "input_cost_per_token": 1e-05,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 3e-05,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4-turbo-2024-04-09",
+      "metadata": {
+        "input_cost_per_token": 1e-05,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 3e-05,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4-turbo-preview",
+      "metadata": {
+        "input_cost_per_token": 1e-05,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 3e-05,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4.1",
+      "metadata": {
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_priority": 8.75e-07,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "input_cost_per_token_priority": 3.5e-06,
+        "max_input_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "output_cost_per_token": 8e-06,
+        "output_cost_per_token_batches": 4e-06,
+        "output_cost_per_token_priority": 1.4e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4.1-2025-04-14",
+      "metadata": {
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "max_input_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "output_cost_per_token": 8e-06,
+        "output_cost_per_token_batches": 4e-06,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4.1-mini",
+      "metadata": {
+        "cache_read_input_token_cost": 1e-07,
+        "cache_read_input_token_cost_priority": 1.75e-07,
+        "input_cost_per_token": 4e-07,
+        "input_cost_per_token_batches": 2e-07,
+        "input_cost_per_token_priority": 7e-07,
+        "max_input_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "output_cost_per_token": 1.6e-06,
+        "output_cost_per_token_batches": 8e-07,
+        "output_cost_per_token_priority": 2.8e-06,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4.1-mini-2025-04-14",
+      "metadata": {
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 4e-07,
+        "input_cost_per_token_batches": 2e-07,
+        "max_input_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "output_cost_per_token": 1.6e-06,
+        "output_cost_per_token_batches": 8e-07,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4.1-nano",
+      "metadata": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost_priority": 5e-08,
+        "input_cost_per_token": 1e-07,
+        "input_cost_per_token_batches": 5e-08,
+        "input_cost_per_token_priority": 2e-07,
+        "max_input_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "output_cost_per_token": 4e-07,
+        "output_cost_per_token_batches": 2e-07,
+        "output_cost_per_token_priority": 8e-07,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4.1-nano-2025-04-14",
+      "metadata": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "input_cost_per_token": 1e-07,
+        "input_cost_per_token_batches": 5e-08,
+        "max_input_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "output_cost_per_token": 4e-07,
+        "output_cost_per_token_batches": 2e-07,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4o",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-06,
+        "cache_read_input_token_cost_priority": 2.125e-06,
+        "input_cost_per_token": 2.5e-06,
+        "input_cost_per_token_batches": 1.25e-06,
+        "input_cost_per_token_priority": 4.25e-06,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_batches": 5e-06,
+        "output_cost_per_token_priority": 1.7e-05,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4o-2024-05-13",
+      "metadata": {
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_batches": 2.5e-06,
+        "input_cost_per_token_priority": 8.75e-06,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "output_cost_per_token": 1.5e-05,
+        "output_cost_per_token_batches": 7.5e-06,
+        "output_cost_per_token_priority": 2.625e-05,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4o-2024-08-06",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_token": 2.5e-06,
+        "input_cost_per_token_batches": 1.25e-06,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_batches": 5e-06,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4o-2024-11-20",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-06,
+        "input_cost_per_token": 2.5e-06,
+        "input_cost_per_token_batches": 1.25e-06,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_batches": 5e-06,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4o-mini",
+      "metadata": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_priority": 1.25e-07,
+        "input_cost_per_token": 1.5e-07,
+        "input_cost_per_token_batches": 7.5e-08,
+        "input_cost_per_token_priority": 2.5e-07,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "output_cost_per_token": 6e-07,
+        "output_cost_per_token_batches": 3e-07,
+        "output_cost_per_token_priority": 1e-06,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-4o-mini-2024-07-18",
+      "metadata": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_token": 1.5e-07,
+        "input_cost_per_token_batches": 7.5e-08,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "output_cost_per_token": 6e-07,
+        "output_cost_per_token_batches": 3e-07,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.03,
+          "search_context_size_low": 0.025,
+          "search_context_size_medium": 0.0275
+        },
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "cache_read_input_token_cost_flex": 6.25e-08,
+        "cache_read_input_token_cost_priority": 2.5e-07,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_flex": 6.25e-07,
+        "input_cost_per_token_priority": 2.5e-06,
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 4e-07,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_flex": 5e-06,
+        "output_cost_per_token_priority": 2e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "azure_openai",
-      "model_name": "azure/gpt-5.1",
+      "model_provider": "openai",
+      "model_name": "gpt-5-2025-08-07",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "cache_read_input_token_cost_flex": 6.25e-08,
+        "cache_read_input_token_cost_priority": 2.5e-07,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_flex": 6.25e-07,
+        "input_cost_per_token_priority": 2.5e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_flex": 5e-06,
+        "output_cost_per_token_priority": 2e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5-chat",
       "metadata": {
         "cache_read_input_token_cost": 1.25e-07,
         "input_cost_per_token": 1.25e-06,
-        "provider": "azure",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "output_cost_per_token": 1e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": false,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": false,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": false,
+        "supports_vision": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5-chat-latest",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "output_cost_per_token": 1e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": false,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": false,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": false,
+        "supports_vision": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5-codex",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
         "output_cost_per_token": 1e-05,
+        "supported_endpoints": [
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5-mini",
+      "metadata": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost_flex": 1.25e-08,
+        "cache_read_input_token_cost_priority": 4.5e-08,
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_flex": 1.25e-07,
+        "input_cost_per_token_priority": 4.5e-07,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2e-06,
+        "output_cost_per_token_flex": 1e-06,
+        "output_cost_per_token_priority": 3.6e-06,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "azure_openai",
-      "model_name": "azure/gpt-5.2",
+      "model_provider": "openai",
+      "model_name": "gpt-5-mini-2025-08-07",
+      "metadata": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost_flex": 1.25e-08,
+        "cache_read_input_token_cost_priority": 4.5e-08,
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_flex": 1.25e-07,
+        "input_cost_per_token_priority": 4.5e-07,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2e-06,
+        "output_cost_per_token_flex": 1e-06,
+        "output_cost_per_token_priority": 3.6e-06,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5-nano",
+      "metadata": {
+        "cache_read_input_token_cost": 5e-09,
+        "cache_read_input_token_cost_flex": 2.5e-09,
+        "input_cost_per_token": 5e-08,
+        "input_cost_per_token_flex": 2.5e-08,
+        "input_cost_per_token_priority": 2.5e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 4e-07,
+        "output_cost_per_token_flex": 2e-07,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5-nano-2025-08-07",
+      "metadata": {
+        "cache_read_input_token_cost": 5e-09,
+        "cache_read_input_token_cost_flex": 2.5e-09,
+        "input_cost_per_token": 5e-08,
+        "input_cost_per_token_flex": 2.5e-08,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 4e-07,
+        "output_cost_per_token_flex": 2e-07,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5-pro",
+      "metadata": {
+        "input_cost_per_token": 1.5e-05,
+        "input_cost_per_token_batches": 7.5e-06,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 272000,
+        "max_tokens": 272000,
+        "output_cost_per_token": 0.00012,
+        "output_cost_per_token_batches": 6e-05,
+        "supported_endpoints": [
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": false,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5-pro-2025-10-06",
+      "metadata": {
+        "input_cost_per_token": 1.5e-05,
+        "input_cost_per_token_batches": 7.5e-06,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 272000,
+        "max_tokens": 272000,
+        "output_cost_per_token": 0.00012,
+        "output_cost_per_token_batches": 6e-05,
+        "supported_endpoints": [
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": false,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.1",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "cache_read_input_token_cost_priority": 2.5e-07,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_priority": 2.5e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_priority": 2e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text",
+          "image"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.1-2025-11-13",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "cache_read_input_token_cost_priority": 2.5e-07,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_priority": 2.5e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_priority": 2e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text",
+          "image"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.1-chat-latest",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "cache_read_input_token_cost_priority": 2.5e-07,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_priority": 2.5e-06,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_priority": 2e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text",
+          "image"
+        ],
+        "supports_function_calling": false,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": false,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": false,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.1-codex",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "cache_read_input_token_cost_priority": 2.5e-07,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_priority": 2.5e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_priority": 2e-05,
+        "supported_endpoints": [
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.1-codex-max",
+      "metadata": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "input_cost_per_token": 1.25e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1e-05,
+        "supported_endpoints": [
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.1-codex-mini",
+      "metadata": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost_priority": 4.5e-08,
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_priority": 4.5e-07,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2e-06,
+        "output_cost_per_token_priority": 3.6e-06,
+        "supported_endpoints": [
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.2",
       "metadata": {
         "cache_read_input_token_cost": 1.75e-07,
+        "cache_read_input_token_cost_priority": 3.5e-07,
         "input_cost_per_token": 1.75e-06,
-        "provider": "azure",
+        "input_cost_per_token_priority": 3.5e-06,
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
         "output_cost_per_token": 1.4e-05,
+        "output_cost_per_token_priority": 2.8e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text",
+          "image"
+        ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "azure_openai",
-      "model_name": "azure/gpt-5.4",
+      "model_provider": "openai",
+      "model_name": "gpt-5.2-2025-12-11",
+      "metadata": {
+        "cache_read_input_token_cost": 1.75e-07,
+        "cache_read_input_token_cost_priority": 3.5e-07,
+        "input_cost_per_token": 1.75e-06,
+        "input_cost_per_token_priority": 3.5e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1.4e-05,
+        "output_cost_per_token_priority": 2.8e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text",
+          "image"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.2-chat-latest",
+      "metadata": {
+        "cache_read_input_token_cost": 1.75e-07,
+        "cache_read_input_token_cost_priority": 3.5e-07,
+        "input_cost_per_token": 1.75e-06,
+        "input_cost_per_token_priority": 3.5e-06,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "output_cost_per_token": 1.4e-05,
+        "output_cost_per_token_priority": 2.8e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.2-codex",
+      "metadata": {
+        "cache_read_input_token_cost": 1.75e-07,
+        "cache_read_input_token_cost_priority": 3.5e-07,
+        "input_cost_per_token": 1.75e-06,
+        "input_cost_per_token_priority": 3.5e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1.4e-05,
+        "output_cost_per_token_priority": 2.8e-05,
+        "supported_endpoints": [
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.2-pro",
+      "metadata": {
+        "input_cost_per_token": 2.1e-05,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 0.000168,
+        "supported_endpoints": [
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.2-pro-2025-12-11",
+      "metadata": {
+        "input_cost_per_token": 2.1e-05,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 0.000168,
+        "supported_endpoints": [
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.3-chat-latest",
+      "metadata": {
+        "cache_read_input_token_cost": 1.75e-07,
+        "cache_read_input_token_cost_priority": 3.5e-07,
+        "input_cost_per_token": 1.75e-06,
+        "input_cost_per_token_priority": 3.5e-06,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "output_cost_per_token": 1.4e-05,
+        "output_cost_per_token_priority": 2.8e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.3-codex",
+      "metadata": {
+        "cache_read_input_token_cost": 1.75e-07,
+        "cache_read_input_token_cost_priority": 3.5e-07,
+        "input_cost_per_token": 1.75e-06,
+        "input_cost_per_token_priority": 3.5e-06,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1.4e-05,
+        "output_cost_per_token_priority": 2.8e-05,
+        "supported_endpoints": [
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": false,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "gpt-5.4",
       "metadata": {
         "cache_read_input_token_cost": 2.5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 5e-07,
+        "cache_read_input_token_cost_flex": 1.3e-07,
+        "cache_read_input_token_cost_priority": 5e-07,
         "input_cost_per_token": 2.5e-06,
-        "provider": "azure",
+        "input_cost_per_token_above_272k_tokens": 5e-06,
+        "input_cost_per_token_flex": 1.25e-06,
+        "input_cost_per_token_batches": 1.25e-06,
+        "input_cost_per_token_priority": 5e-06,
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
         "output_cost_per_token": 1.5e-05,
+        "output_cost_per_token_above_272k_tokens": 2.25e-05,
+        "output_cost_per_token_flex": 7.5e-06,
+        "output_cost_per_token_batches": 7.5e-06,
+        "output_cost_per_token_priority": 3e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "azure_openai",
-      "model_name": "azure/gpt-4o-2024-11-20",
+      "model_provider": "openai",
+      "model_name": "gpt-5.4-2026-03-05",
       "metadata": {
-        "cache_read_input_token_cost": 1.25e-06,
-        "input_cost_per_token": 2.75e-06,
-        "provider": "azure",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "output_cost_per_token": 1.1e-05,
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "azure_openai",
-      "model_name": "azure/gpt-4o-2024-08-06",
-      "metadata": {
-        "cache_read_input_token_cost": 1.25e-06,
+        "cache_read_input_token_cost": 2.5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 5e-07,
+        "cache_read_input_token_cost_flex": 1.3e-07,
+        "cache_read_input_token_cost_priority": 5e-07,
         "input_cost_per_token": 2.5e-06,
-        "provider": "azure",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
+        "input_cost_per_token_above_272k_tokens": 5e-06,
+        "input_cost_per_token_flex": 1.25e-06,
+        "input_cost_per_token_batches": 1.25e-06,
+        "input_cost_per_token_priority": 5e-06,
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 1.5e-05,
+        "output_cost_per_token_above_272k_tokens": 2.25e-05,
+        "output_cost_per_token_flex": 7.5e-06,
+        "output_cost_per_token_batches": 7.5e-06,
+        "output_cost_per_token_priority": 3e-05,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
         "supports_prompt_caching": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "azure_openai",
-      "model_name": "azure/gpt-4o-mini-2024-07-18",
+      "model_provider": "openai",
+      "model_name": "gpt-5.4-mini",
       "metadata": {
         "cache_read_input_token_cost": 7.5e-08,
-        "input_cost_per_token": 1.65e-07,
-        "provider": "azure",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "output_cost_per_token": 6.6e-07,
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/claude-opus-4-6",
-      "metadata": {
-        "cache_creation_input_token_cost": 6.25e-06,
-        "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 5e-06,
-        "provider": "azure_ai",
-        "max_input_tokens": 200000,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "cache_read_input_token_cost_batches": 3.75e-08,
+        "cache_read_input_token_cost_priority": 1.5e-07,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_flex": 3.75e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_priority": 1.5e-06,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 2.5e-05,
+        "output_cost_per_token": 4.5e-06,
+        "output_cost_per_token_flex": 2.25e-06,
+        "output_cost_per_token_batches": 2.25e-06,
+        "output_cost_per_token_priority": 9e-06,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false,
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/claude-opus-4-5",
+      "model_provider": "openai",
+      "model_name": "gpt-5.4-nano",
       "metadata": {
-        "cache_creation_input_token_cost": 6.25e-06,
-        "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 5e-06,
-        "provider": "azure_ai",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 2.5e-05,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/claude-opus-4-1",
-      "metadata": {
-        "cache_creation_input_token_cost": 1.875e-05,
-        "cache_read_input_token_cost": 1.5e-06,
-        "input_cost_per_token": 1.5e-05,
-        "provider": "azure_ai",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 32000,
-        "max_tokens": 32000,
-        "mode": "chat",
-        "output_cost_per_token": 7.5e-05,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/claude-sonnet-4-6",
-      "metadata": {
-        "cache_creation_input_token_cost": 3.75e-06,
-        "cache_read_input_token_cost": 3e-07,
-        "input_cost_per_token": 3e-06,
-        "provider": "azure_ai",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/claude-sonnet-4-5",
-      "metadata": {
-        "cache_creation_input_token_cost": 3.75e-06,
-        "cache_read_input_token_cost": 3e-07,
-        "input_cost_per_token": 3e-06,
-        "provider": "azure_ai",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/claude-haiku-4-5",
-      "metadata": {
-        "cache_creation_input_token_cost": 1.25e-06,
-        "cache_read_input_token_cost": 1e-07,
-        "input_cost_per_token": 1e-06,
-        "provider": "azure_ai",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 5e-06,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/mistral-large",
-      "metadata": {
-        "input_cost_per_token": 4e-06,
-        "provider": "azure_ai",
-        "max_input_tokens": 32000,
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 1.2e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/mistral-large-2407",
-      "metadata": {
-        "input_cost_per_token": 2e-06,
-        "provider": "azure_ai",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 6e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/mistral-large-latest",
-      "metadata": {
-        "input_cost_per_token": 2e-06,
-        "provider": "azure_ai",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "output_cost_per_token": 6e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/mistral-small",
-      "metadata": {
-        "input_cost_per_token": 1e-06,
-        "provider": "azure_ai",
-        "max_input_tokens": 32000,
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 3e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/Meta-Llama-3.1-405B-Instruct",
-      "metadata": {
-        "input_cost_per_token": 5.33e-06,
-        "provider": "azure_ai",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 2048,
-        "max_tokens": 2048,
-        "mode": "chat",
-        "output_cost_per_token": 1.6e-05,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/Meta-Llama-3.1-70B-Instruct",
-      "metadata": {
-        "input_cost_per_token": 2.68e-06,
-        "provider": "azure_ai",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 2048,
-        "max_tokens": 2048,
-        "mode": "chat",
-        "output_cost_per_token": 3.54e-06,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/deepseek-v3",
-      "metadata": {
-        "input_cost_per_token": 1.14e-06,
-        "provider": "azure_ai",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 4.56e-06,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "azure_ai",
-      "model_name": "azure_ai/deepseek-r1",
-      "metadata": {
-        "input_cost_per_token": 1.35e-06,
-        "provider": "azure_ai",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 5.4e-06,
-        "supports_reasoning": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/claude-opus-4-6@default",
-      "metadata": {
-        "cache_creation_input_token_cost": 6.25e-06,
-        "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 5e-06,
-        "provider": "vertex_ai-anthropic_models",
-        "max_input_tokens": 1000000,
+        "cache_read_input_token_cost": 2e-08,
+        "cache_read_input_token_cost_flex": 1e-08,
+        "cache_read_input_token_cost_batches": 1e-08,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_flex": 1e-07,
+        "input_cost_per_token_batches": 1e-07,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
-        "mode": "chat",
-        "output_cost_per_token": 2.5e-05,
+        "output_cost_per_token": 1.25e-06,
+        "output_cost_per_token_flex": 6.25e-07,
+        "output_cost_per_token_batches": 6.25e-07,
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/batch",
+          "/v1/responses"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false,
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/claude-opus-4-5@20251101",
+      "model_provider": "openai",
+      "model_name": "gpt-5.4-pro",
       "metadata": {
-        "cache_creation_input_token_cost": 6.25e-06,
-        "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 5e-06,
-        "provider": "vertex_ai-anthropic_models",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 2.5e-05,
+        "cache_read_input_token_cost": 3e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 6e-06,
+        "input_cost_per_token": 3e-05,
+        "input_cost_per_token_above_272k_tokens": 6e-05,
+        "input_cost_per_token_flex": 1.5e-05,
+        "input_cost_per_token_batches": 1.5e-05,
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 0.00018,
+        "output_cost_per_token_above_272k_tokens": 0.00027,
+        "output_cost_per_token_flex": 9e-05,
+        "output_cost_per_token_batches": 9e-05,
+        "supported_endpoints": [
+          "/v1/responses",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
         "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_response_schema": true,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/claude-opus-4@20250514",
+      "model_provider": "openai",
+      "model_name": "gpt-5.4-pro-2026-03-05",
       "metadata": {
-        "cache_creation_input_token_cost": 1.875e-05,
-        "cache_read_input_token_cost": 1.5e-06,
+        "cache_read_input_token_cost": 3e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 6e-06,
+        "input_cost_per_token": 3e-05,
+        "input_cost_per_token_above_272k_tokens": 6e-05,
+        "input_cost_per_token_flex": 1.5e-05,
+        "input_cost_per_token_batches": 1.5e-05,
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 0.00018,
+        "output_cost_per_token_above_272k_tokens": 0.00027,
+        "output_cost_per_token_flex": 9e-05,
+        "output_cost_per_token_batches": 9e-05,
+        "supported_endpoints": [
+          "/v1/responses",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "o1",
+      "metadata": {
+        "cache_read_input_token_cost": 7.5e-06,
         "input_cost_per_token": 1.5e-05,
-        "provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
-        "max_output_tokens": 32000,
-        "max_tokens": 32000,
-        "mode": "chat",
-        "output_cost_per_token": 7.5e-05,
+        "max_output_tokens": 100000,
+        "max_tokens": 100000,
+        "output_cost_per_token": 6e-05,
         "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/claude-sonnet-4-6@default",
+      "model_provider": "openai",
+      "model_name": "o1-2024-12-17",
       "metadata": {
-        "cache_creation_input_token_cost": 3.75e-06,
-        "cache_read_input_token_cost": 3e-07,
-        "input_cost_per_token": 3e-06,
-        "provider": "vertex_ai-anthropic_models",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/claude-sonnet-4-5@20250929",
-      "metadata": {
-        "cache_creation_input_token_cost": 3.75e-06,
-        "cache_read_input_token_cost": 3e-07,
-        "input_cost_per_token": 3e-06,
-        "provider": "vertex_ai-anthropic_models",
+        "cache_read_input_token_cost": 7.5e-06,
+        "input_cost_per_token": 1.5e-05,
         "max_input_tokens": 200000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
+        "max_output_tokens": 100000,
+        "max_tokens": 100000,
+        "output_cost_per_token": 6e-05,
         "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/claude-haiku-4-5@20251001",
+      "model_provider": "openai",
+      "model_name": "o1-pro",
       "metadata": {
-        "cache_creation_input_token_cost": 1.25e-06,
-        "cache_read_input_token_cost": 1e-07,
-        "input_cost_per_token": 1e-06,
-        "provider": "vertex_ai-anthropic_models",
+        "input_cost_per_token": 0.00015,
+        "input_cost_per_token_batches": 7.5e-05,
         "max_input_tokens": 200000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 5e-06,
+        "max_output_tokens": 100000,
+        "max_tokens": 100000,
+        "output_cost_per_token": 0.0006,
+        "output_cost_per_token_batches": 0.0003,
+        "supported_endpoints": [
+          "/v1/responses",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
         "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/gemini-3-pro-preview",
-      "metadata": {
-        "cache_read_input_token_cost": 2e-07,
-        "input_cost_per_token": 2e-06,
-        "provider": "vertex_ai",
-        "max_input_tokens": 1048576,
-        "max_output_tokens": 65535,
-        "max_tokens": 65535,
-        "mode": "chat",
-        "output_cost_per_token": 1.2e-05,
-        "supports_function_calling": true,
+        "supports_native_streaming": false,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/gemini-3.1-pro-preview",
+      "model_provider": "openai",
+      "model_name": "o1-pro-2025-03-19",
       "metadata": {
-        "cache_read_input_token_cost": 2e-07,
-        "input_cost_per_token": 2e-06,
-        "provider": "vertex_ai",
-        "max_input_tokens": 1048576,
-        "max_output_tokens": 65536,
-        "max_tokens": 65536,
-        "mode": "chat",
-        "output_cost_per_token": 1.2e-05,
+        "input_cost_per_token": 0.00015,
+        "input_cost_per_token_batches": 7.5e-05,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000,
+        "max_tokens": 100000,
+        "output_cost_per_token": 0.0006,
+        "output_cost_per_token_batches": 0.0003,
+        "supported_endpoints": [
+          "/v1/responses",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
         "supports_function_calling": true,
+        "supports_native_streaming": false,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/mistral-large@latest",
+      "model_provider": "openai",
+      "model_name": "o3",
       "metadata": {
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_flex": 2.5e-07,
+        "cache_read_input_token_cost_priority": 8.75e-07,
         "input_cost_per_token": 2e-06,
-        "provider": "vertex_ai-mistral_models",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 6e-06,
+        "input_cost_per_token_flex": 1e-06,
+        "input_cost_per_token_priority": 3.5e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000,
+        "max_tokens": 100000,
+        "output_cost_per_token": 8e-06,
+        "output_cost_per_token_flex": 4e-06,
+        "output_cost_per_token_priority": 1.4e-05,
+        "supported_endpoints": [
+          "/v1/responses",
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
         "supports_function_calling": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/mistral-large@2411-001",
-      "metadata": {
-        "input_cost_per_token": 2e-06,
-        "provider": "vertex_ai-mistral_models",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 6e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/mistral-small-2503@001",
-      "metadata": {
-        "input_cost_per_token": 1e-06,
-        "provider": "vertex_ai-mistral_models",
-        "max_input_tokens": 32000,
-        "max_output_tokens": 8191,
-        "max_tokens": 8191,
-        "mode": "chat",
-        "output_cost_per_token": 3e-06,
-        "supports_function_calling": true,
-        "supports_tool_choice": true
-      }
-    },
-    {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/meta/llama-3.1-405b-instruct-maas",
-      "metadata": {
-        "input_cost_per_token": 5e-06,
-        "provider": "vertex_ai-llama_models",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 2048,
-        "max_tokens": 2048,
-        "mode": "chat",
-        "output_cost_per_token": 1.6e-05,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/meta/llama-3.1-70b-instruct-maas",
-      "metadata": {
-        "input_cost_per_token": 0.0,
-        "provider": "vertex_ai-llama_models",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 2048,
-        "max_tokens": 2048,
-        "mode": "chat",
-        "output_cost_per_token": 0.0,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-      }
-    },
-    {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/deepseek-ai/deepseek-v3.2-maas",
-      "metadata": {
-        "input_cost_per_token": 5.6e-07,
-        "provider": "vertex_ai-deepseek_models",
-        "max_input_tokens": 163840,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 1.68e-06,
-        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "provider": "openai"
       }
     },
     {
-      "model_provider": "vertex_ai",
-      "model_name": "vertex_ai/deepseek-ai/deepseek-r1-0528-maas",
+      "model_provider": "openai",
+      "model_name": "o3-2025-04-16",
       "metadata": {
-        "input_cost_per_token": 1.35e-06,
-        "provider": "vertex_ai-deepseek_models",
-        "max_input_tokens": 65336,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 5.4e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 2e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000,
+        "max_tokens": 100000,
+        "output_cost_per_token": 8e-06,
+        "supported_endpoints": [
+          "/v1/responses",
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
         "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "o3-mini",
+      "metadata": {
+        "cache_read_input_token_cost": 5.5e-07,
+        "input_cost_per_token": 1.1e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000,
+        "max_tokens": 100000,
+        "output_cost_per_token": 4.4e-06,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": false,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "o3-mini-2025-01-31",
+      "metadata": {
+        "cache_read_input_token_cost": 5.5e-07,
+        "input_cost_per_token": 1.1e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000,
+        "max_tokens": 100000,
+        "output_cost_per_token": 4.4e-06,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": false,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "o3-pro",
+      "metadata": {
+        "input_cost_per_token": 2e-05,
+        "input_cost_per_token_batches": 1e-05,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000,
+        "max_tokens": 100000,
+        "output_cost_per_token": 8e-05,
+        "output_cost_per_token_batches": 4e-05,
+        "supported_endpoints": [
+          "/v1/responses",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "o3-pro-2025-06-10",
+      "metadata": {
+        "input_cost_per_token": 2e-05,
+        "input_cost_per_token_batches": 1e-05,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000,
+        "max_tokens": 100000,
+        "output_cost_per_token": 8e-05,
+        "output_cost_per_token_batches": 4e-05,
+        "supported_endpoints": [
+          "/v1/responses",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "o4-mini",
+      "metadata": {
+        "cache_read_input_token_cost": 2.75e-07,
+        "cache_read_input_token_cost_flex": 1.375e-07,
+        "cache_read_input_token_cost_priority": 5e-07,
+        "input_cost_per_token": 1.1e-06,
+        "input_cost_per_token_flex": 5.5e-07,
+        "input_cost_per_token_priority": 2e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000,
+        "max_tokens": 100000,
+        "output_cost_per_token": 4.4e-06,
+        "output_cost_per_token_flex": 2.2e-06,
+        "output_cost_per_token_priority": 8e-06,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "provider": "openai"
+      }
+    },
+    {
+      "model_provider": "openai",
+      "model_name": "o4-mini-2025-04-16",
+      "metadata": {
+        "cache_read_input_token_cost": 2.75e-07,
+        "input_cost_per_token": 1.1e-06,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000,
+        "max_tokens": 100000,
+        "output_cost_per_token": 4.4e-06,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "provider": "openai"
       }
     }
   ]

--- a/tracecat/agent/platform_catalog.json
+++ b/tracecat/agent/platform_catalog.json
@@ -2,83 +2,6 @@
   "models": [
     {
       "model_provider": "anthropic",
-      "model_name": "claude-3-7-sonnet-20250219",
-      "metadata": {
-        "cache_creation_input_token_cost": 3.75e-06,
-        "cache_creation_input_token_cost_above_1hr": 6e-06,
-        "cache_read_input_token_cost": 3e-07,
-        "deprecation_date": "2026-02-19",
-        "input_cost_per_token": 3e-06,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "output_cost_per_token": 1.5e-05,
-        "search_context_cost_per_query": {
-          "search_context_size_high": 0.01,
-          "search_context_size_low": 0.01,
-          "search_context_size_medium": 0.01
-        },
-        "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "tool_use_system_prompt_tokens": 159,
-        "provider": "anthropic"
-      }
-    },
-    {
-      "model_provider": "anthropic",
-      "model_name": "claude-3-haiku-20240307",
-      "metadata": {
-        "cache_creation_input_token_cost": 3e-07,
-        "cache_creation_input_token_cost_above_1hr": 6e-06,
-        "cache_read_input_token_cost": 3e-08,
-        "input_cost_per_token": 2.5e-07,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 1.25e-06,
-        "supports_assistant_prefill": true,
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 264,
-        "provider": "anthropic"
-      }
-    },
-    {
-      "model_provider": "anthropic",
-      "model_name": "claude-3-opus-20240229",
-      "metadata": {
-        "cache_creation_input_token_cost": 1.875e-05,
-        "cache_creation_input_token_cost_above_1hr": 6e-06,
-        "cache_read_input_token_cost": 1.5e-06,
-        "deprecation_date": "2026-05-01",
-        "input_cost_per_token": 1.5e-05,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 7.5e-05,
-        "supports_assistant_prefill": true,
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 395,
-        "provider": "anthropic"
-      }
-    },
-    {
-      "model_provider": "anthropic",
       "model_name": "claude-4-opus-20250514",
       "metadata": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -196,68 +119,6 @@
         "cache_creation_input_token_cost_above_1hr": 3e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "input_cost_per_token": 1.5e-05,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 32000,
-        "max_tokens": 32000,
-        "output_cost_per_token": 7.5e-05,
-        "search_context_cost_per_query": {
-          "search_context_size_high": 0.01,
-          "search_context_size_low": 0.01,
-          "search_context_size_medium": 0.01
-        },
-        "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
-        "provider": "anthropic"
-      }
-    },
-    {
-      "model_provider": "anthropic",
-      "model_name": "claude-opus-4-1-20250805",
-      "metadata": {
-        "cache_creation_input_token_cost": 1.875e-05,
-        "cache_creation_input_token_cost_above_1hr": 3e-05,
-        "cache_read_input_token_cost": 1.5e-06,
-        "input_cost_per_token": 1.5e-05,
-        "deprecation_date": "2026-08-05",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 32000,
-        "max_tokens": 32000,
-        "output_cost_per_token": 7.5e-05,
-        "search_context_cost_per_query": {
-          "search_context_size_high": 0.01,
-          "search_context_size_low": 0.01,
-          "search_context_size_medium": 0.01
-        },
-        "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
-        "provider": "anthropic"
-      }
-    },
-    {
-      "model_provider": "anthropic",
-      "model_name": "claude-opus-4-20250514",
-      "metadata": {
-        "cache_creation_input_token_cost": 1.875e-05,
-        "cache_creation_input_token_cost_above_1hr": 3e-05,
-        "cache_read_input_token_cost": 1.5e-06,
-        "input_cost_per_token": 1.5e-05,
-        "deprecation_date": "2026-05-14",
         "max_input_tokens": 200000,
         "max_output_tokens": 32000,
         "max_tokens": 32000,
@@ -442,6 +303,8 @@
           "us": 1.1,
           "fast": 6.0
         },
+        "supports_max_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
         "provider": "anthropic"
       }
     },
@@ -477,41 +340,8 @@
           "us": 1.1,
           "fast": 6.0
         },
-        "provider": "anthropic"
-      }
-    },
-    {
-      "model_provider": "anthropic",
-      "model_name": "claude-sonnet-4-20250514",
-      "metadata": {
-        "deprecation_date": "2026-05-14",
-        "cache_creation_input_token_cost": 3.75e-06,
-        "cache_creation_input_token_cost_above_1hr": 6e-06,
-        "cache_read_input_token_cost": 3e-07,
-        "input_cost_per_token": 3e-06,
-        "input_cost_per_token_above_200k_tokens": 6e-06,
-        "output_cost_per_token_above_200k_tokens": 2.25e-05,
-        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
-        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "output_cost_per_token": 1.5e-05,
-        "search_context_cost_per_query": {
-          "search_context_size_high": 0.01,
-          "search_context_size_low": 0.01,
-          "search_context_size_medium": 0.01
-        },
-        "supports_assistant_prefill": true,
-        "supports_computer_use": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "tool_use_system_prompt_tokens": 159,
+        "supports_max_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
         "provider": "anthropic"
       }
     },
@@ -609,172 +439,6 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346,
         "provider": "anthropic"
-      }
-    },
-    {
-      "model_provider": "gemini",
-      "model_name": "gemini-2.0-flash",
-      "metadata": {
-        "cache_read_input_token_cost": 2.5e-08,
-        "deprecation_date": "2026-06-01",
-        "input_cost_per_audio_token": 7e-07,
-        "input_cost_per_token": 1e-07,
-        "max_audio_length_hours": 8.4,
-        "max_audio_per_prompt": 1,
-        "max_images_per_prompt": 3000,
-        "max_input_tokens": 1048576,
-        "max_output_tokens": 8192,
-        "max_pdf_size_mb": 30,
-        "max_tokens": 8192,
-        "max_video_length": 1,
-        "max_videos_per_prompt": 10,
-        "output_cost_per_token": 4e-07,
-        "rpm": 10000,
-        "source": "https://ai.google.dev/pricing#2_0flash",
-        "supported_modalities": [
-          "text",
-          "image",
-          "audio",
-          "video"
-        ],
-        "supported_output_modalities": [
-          "text",
-          "image"
-        ],
-        "supports_audio_input": true,
-        "supports_audio_output": true,
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_url_context": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "tpm": 10000000,
-        "provider": "gemini"
-      }
-    },
-    {
-      "model_provider": "gemini",
-      "model_name": "gemini-2.0-flash-001",
-      "metadata": {
-        "cache_read_input_token_cost": 2.5e-08,
-        "deprecation_date": "2026-06-01",
-        "input_cost_per_audio_token": 7e-07,
-        "input_cost_per_token": 1e-07,
-        "max_audio_length_hours": 8.4,
-        "max_audio_per_prompt": 1,
-        "max_images_per_prompt": 3000,
-        "max_input_tokens": 1048576,
-        "max_output_tokens": 8192,
-        "max_pdf_size_mb": 30,
-        "max_tokens": 8192,
-        "max_video_length": 1,
-        "max_videos_per_prompt": 10,
-        "output_cost_per_token": 4e-07,
-        "rpm": 10000,
-        "source": "https://ai.google.dev/pricing#2_0flash",
-        "supported_modalities": [
-          "text",
-          "image",
-          "audio",
-          "video"
-        ],
-        "supported_output_modalities": [
-          "text",
-          "image"
-        ],
-        "supports_audio_output": false,
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "tpm": 10000000,
-        "provider": "gemini"
-      }
-    },
-    {
-      "model_provider": "gemini",
-      "model_name": "gemini-2.0-flash-lite",
-      "metadata": {
-        "cache_read_input_token_cost": 1.875e-08,
-        "deprecation_date": "2026-06-01",
-        "input_cost_per_audio_token": 7.5e-08,
-        "input_cost_per_token": 7.5e-08,
-        "max_audio_length_hours": 8.4,
-        "max_audio_per_prompt": 1,
-        "max_images_per_prompt": 3000,
-        "max_input_tokens": 1048576,
-        "max_output_tokens": 8192,
-        "max_pdf_size_mb": 50,
-        "max_video_length": 1,
-        "max_videos_per_prompt": 10,
-        "output_cost_per_token": 3e-07,
-        "rpm": 4000,
-        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-2.0-flash-lite",
-        "supported_modalities": [
-          "text",
-          "image",
-          "audio",
-          "video"
-        ],
-        "supported_output_modalities": [
-          "text"
-        ],
-        "supports_audio_output": true,
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "tpm": 4000000,
-        "provider": "gemini"
-      }
-    },
-    {
-      "model_provider": "gemini",
-      "model_name": "gemini-2.0-flash-lite-001",
-      "metadata": {
-        "cache_read_input_token_cost": 1.875e-08,
-        "deprecation_date": "2026-06-01",
-        "input_cost_per_audio_token": 7.5e-08,
-        "input_cost_per_token": 7.5e-08,
-        "max_audio_length_hours": 8.4,
-        "max_audio_per_prompt": 1,
-        "max_images_per_prompt": 3000,
-        "max_input_tokens": 1048576,
-        "max_output_tokens": 8192,
-        "max_pdf_size_mb": 50,
-        "max_video_length": 1,
-        "max_videos_per_prompt": 10,
-        "output_cost_per_token": 3e-07,
-        "rpm": 4000,
-        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-2.0-flash-lite",
-        "supported_modalities": [
-          "text",
-          "image",
-          "audio",
-          "video"
-        ],
-        "supported_output_modalities": [
-          "text"
-        ],
-        "supports_audio_output": true,
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "tpm": 4000000,
-        "provider": "gemini"
       }
     },
     {
@@ -910,57 +574,6 @@
         "supports_web_search": true,
         "tpm": 250000,
         "supports_service_tier": true,
-        "provider": "gemini"
-      }
-    },
-    {
-      "model_provider": "gemini",
-      "model_name": "gemini-2.5-flash-lite-preview-06-17",
-      "metadata": {
-        "deprecation_date": "2025-11-18",
-        "cache_read_input_token_cost": 2.5e-08,
-        "input_cost_per_audio_token": 5e-07,
-        "input_cost_per_token": 1e-07,
-        "max_audio_length_hours": 8.4,
-        "max_audio_per_prompt": 1,
-        "max_images_per_prompt": 3000,
-        "max_input_tokens": 1048576,
-        "max_output_tokens": 65535,
-        "max_pdf_size_mb": 30,
-        "max_tokens": 65535,
-        "max_video_length": 1,
-        "max_videos_per_prompt": 10,
-        "output_cost_per_reasoning_token": 4e-07,
-        "output_cost_per_token": 4e-07,
-        "rpm": 15,
-        "source": "https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-lite",
-        "supported_endpoints": [
-          "/v1/chat/completions",
-          "/v1/completions",
-          "/v1/batch"
-        ],
-        "supported_modalities": [
-          "text",
-          "image",
-          "audio",
-          "video"
-        ],
-        "supported_output_modalities": [
-          "text"
-        ],
-        "supports_audio_output": false,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_url_context": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "tpm": 250000,
         "provider": "gemini"
       }
     },
@@ -1170,66 +783,6 @@
         "input_cost_per_audio_token_priority": 1.8e-06,
         "output_cost_per_token_priority": 5.4e-06,
         "cache_read_input_token_cost_priority": 9e-08,
-        "supports_service_tier": true,
-        "provider": "gemini"
-      }
-    },
-    {
-      "model_provider": "gemini",
-      "model_name": "gemini-3-pro-preview",
-      "metadata": {
-        "deprecation_date": "2026-03-09",
-        "cache_read_input_token_cost": 2e-07,
-        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
-        "input_cost_per_token": 2e-06,
-        "input_cost_per_token_above_200k_tokens": 4e-06,
-        "input_cost_per_token_batches": 1e-06,
-        "max_audio_length_hours": 8.4,
-        "max_audio_per_prompt": 1,
-        "max_images_per_prompt": 3000,
-        "max_input_tokens": 1048576,
-        "max_output_tokens": 65535,
-        "max_pdf_size_mb": 30,
-        "max_tokens": 65535,
-        "max_video_length": 1,
-        "max_videos_per_prompt": 10,
-        "output_cost_per_token": 1.2e-05,
-        "output_cost_per_token_above_200k_tokens": 1.8e-05,
-        "output_cost_per_token_batches": 6e-06,
-        "rpm": 2000,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
-        "supported_endpoints": [
-          "/v1/chat/completions",
-          "/v1/completions",
-          "/v1/batch"
-        ],
-        "supported_modalities": [
-          "text",
-          "image",
-          "audio",
-          "video"
-        ],
-        "supported_output_modalities": [
-          "text"
-        ],
-        "supports_audio_input": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_video_input": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "tpm": 800000,
-        "input_cost_per_token_priority": 3.6e-06,
-        "input_cost_per_token_above_200k_tokens_priority": 7.2e-06,
-        "output_cost_per_token_priority": 2.16e-05,
-        "output_cost_per_token_above_200k_tokens_priority": 3.24e-05,
-        "cache_read_input_token_cost_priority": 3.6e-07,
-        "cache_read_input_token_cost_above_200k_tokens_priority": 7.2e-07,
         "supports_service_tier": true,
         "provider": "gemini"
       }
@@ -1645,620 +1198,6 @@
         "supports_web_search": true,
         "tpm": 800000,
         "provider": "gemini"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "chatgpt-4o-latest",
-      "metadata": {
-        "input_cost_per_token": 5e-06,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 1.5e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-3.5-turbo",
-      "metadata": {
-        "input_cost_per_token": 5e-07,
-        "max_input_tokens": 16385,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 1.5e-06,
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-3.5-turbo-0125",
-      "metadata": {
-        "input_cost_per_token": 5e-07,
-        "max_input_tokens": 16385,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 1.5e-06,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-3.5-turbo-1106",
-      "metadata": {
-        "deprecation_date": "2026-09-28",
-        "input_cost_per_token": 1e-06,
-        "max_input_tokens": 16385,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 2e-06,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-3.5-turbo-16k",
-      "metadata": {
-        "input_cost_per_token": 3e-06,
-        "max_input_tokens": 16385,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 4e-06,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4",
-      "metadata": {
-        "input_cost_per_token": 3e-05,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 6e-05,
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4-0125-preview",
-      "metadata": {
-        "deprecation_date": "2026-03-26",
-        "input_cost_per_token": 1e-05,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 3e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4-0314",
-      "metadata": {
-        "deprecation_date": "2026-03-26",
-        "input_cost_per_token": 3e-05,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 6e-05,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4-0613",
-      "metadata": {
-        "deprecation_date": "2025-06-06",
-        "input_cost_per_token": 3e-05,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 6e-05,
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4-1106-preview",
-      "metadata": {
-        "deprecation_date": "2026-03-26",
-        "input_cost_per_token": 1e-05,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 3e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4-turbo",
-      "metadata": {
-        "input_cost_per_token": 1e-05,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 3e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4-turbo-2024-04-09",
-      "metadata": {
-        "input_cost_per_token": 1e-05,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 3e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4-turbo-preview",
-      "metadata": {
-        "input_cost_per_token": 1e-05,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 3e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4.1",
-      "metadata": {
-        "cache_read_input_token_cost": 5e-07,
-        "cache_read_input_token_cost_priority": 8.75e-07,
-        "input_cost_per_token": 2e-06,
-        "input_cost_per_token_batches": 1e-06,
-        "input_cost_per_token_priority": 3.5e-06,
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "output_cost_per_token": 8e-06,
-        "output_cost_per_token_batches": 4e-06,
-        "output_cost_per_token_priority": 1.4e-05,
-        "supported_endpoints": [
-          "/v1/chat/completions",
-          "/v1/batch",
-          "/v1/responses"
-        ],
-        "supported_modalities": [
-          "text",
-          "image"
-        ],
-        "supported_output_modalities": [
-          "text"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_service_tier": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4.1-2025-04-14",
-      "metadata": {
-        "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 2e-06,
-        "input_cost_per_token_batches": 1e-06,
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "output_cost_per_token": 8e-06,
-        "output_cost_per_token_batches": 4e-06,
-        "supported_endpoints": [
-          "/v1/chat/completions",
-          "/v1/batch",
-          "/v1/responses"
-        ],
-        "supported_modalities": [
-          "text",
-          "image"
-        ],
-        "supported_output_modalities": [
-          "text"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_service_tier": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4.1-mini",
-      "metadata": {
-        "cache_read_input_token_cost": 1e-07,
-        "cache_read_input_token_cost_priority": 1.75e-07,
-        "input_cost_per_token": 4e-07,
-        "input_cost_per_token_batches": 2e-07,
-        "input_cost_per_token_priority": 7e-07,
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "output_cost_per_token": 1.6e-06,
-        "output_cost_per_token_batches": 8e-07,
-        "output_cost_per_token_priority": 2.8e-06,
-        "supported_endpoints": [
-          "/v1/chat/completions",
-          "/v1/batch",
-          "/v1/responses"
-        ],
-        "supported_modalities": [
-          "text",
-          "image"
-        ],
-        "supported_output_modalities": [
-          "text"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_service_tier": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4.1-mini-2025-04-14",
-      "metadata": {
-        "cache_read_input_token_cost": 1e-07,
-        "input_cost_per_token": 4e-07,
-        "input_cost_per_token_batches": 2e-07,
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "output_cost_per_token": 1.6e-06,
-        "output_cost_per_token_batches": 8e-07,
-        "supported_endpoints": [
-          "/v1/chat/completions",
-          "/v1/batch",
-          "/v1/responses"
-        ],
-        "supported_modalities": [
-          "text",
-          "image"
-        ],
-        "supported_output_modalities": [
-          "text"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_service_tier": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4.1-nano",
-      "metadata": {
-        "cache_read_input_token_cost": 2.5e-08,
-        "cache_read_input_token_cost_priority": 5e-08,
-        "input_cost_per_token": 1e-07,
-        "input_cost_per_token_batches": 5e-08,
-        "input_cost_per_token_priority": 2e-07,
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "output_cost_per_token": 4e-07,
-        "output_cost_per_token_batches": 2e-07,
-        "output_cost_per_token_priority": 8e-07,
-        "supported_endpoints": [
-          "/v1/chat/completions",
-          "/v1/batch",
-          "/v1/responses"
-        ],
-        "supported_modalities": [
-          "text",
-          "image"
-        ],
-        "supported_output_modalities": [
-          "text"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_service_tier": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4.1-nano-2025-04-14",
-      "metadata": {
-        "cache_read_input_token_cost": 2.5e-08,
-        "input_cost_per_token": 1e-07,
-        "input_cost_per_token_batches": 5e-08,
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "output_cost_per_token": 4e-07,
-        "output_cost_per_token_batches": 2e-07,
-        "supported_endpoints": [
-          "/v1/chat/completions",
-          "/v1/batch",
-          "/v1/responses"
-        ],
-        "supported_modalities": [
-          "text",
-          "image"
-        ],
-        "supported_output_modalities": [
-          "text"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_service_tier": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4o",
-      "metadata": {
-        "cache_read_input_token_cost": 1.25e-06,
-        "cache_read_input_token_cost_priority": 2.125e-06,
-        "input_cost_per_token": 2.5e-06,
-        "input_cost_per_token_batches": 1.25e-06,
-        "input_cost_per_token_priority": 4.25e-06,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "output_cost_per_token": 1e-05,
-        "output_cost_per_token_batches": 5e-06,
-        "output_cost_per_token_priority": 1.7e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_service_tier": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4o-2024-05-13",
-      "metadata": {
-        "input_cost_per_token": 5e-06,
-        "input_cost_per_token_batches": 2.5e-06,
-        "input_cost_per_token_priority": 8.75e-06,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "output_cost_per_token": 1.5e-05,
-        "output_cost_per_token_batches": 7.5e-06,
-        "output_cost_per_token_priority": 2.625e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4o-2024-08-06",
-      "metadata": {
-        "cache_read_input_token_cost": 1.25e-06,
-        "input_cost_per_token": 2.5e-06,
-        "input_cost_per_token_batches": 1.25e-06,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "output_cost_per_token": 1e-05,
-        "output_cost_per_token_batches": 5e-06,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_service_tier": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4o-2024-11-20",
-      "metadata": {
-        "cache_read_input_token_cost": 1.25e-06,
-        "input_cost_per_token": 2.5e-06,
-        "input_cost_per_token_batches": 1.25e-06,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "output_cost_per_token": 1e-05,
-        "output_cost_per_token_batches": 5e-06,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_service_tier": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4o-mini",
-      "metadata": {
-        "cache_read_input_token_cost": 7.5e-08,
-        "cache_read_input_token_cost_priority": 1.25e-07,
-        "input_cost_per_token": 1.5e-07,
-        "input_cost_per_token_batches": 7.5e-08,
-        "input_cost_per_token_priority": 2.5e-07,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "output_cost_per_token": 6e-07,
-        "output_cost_per_token_batches": 3e-07,
-        "output_cost_per_token_priority": 1e-06,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_service_tier": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "gpt-4o-mini-2024-07-18",
-      "metadata": {
-        "cache_read_input_token_cost": 7.5e-08,
-        "input_cost_per_token": 1.5e-07,
-        "input_cost_per_token_batches": 7.5e-08,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "output_cost_per_token": 6e-07,
-        "output_cost_per_token_batches": 3e-07,
-        "search_context_cost_per_query": {
-          "search_context_size_high": 0.03,
-          "search_context_size_low": 0.025,
-          "search_context_size_medium": 0.0275
-        },
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_service_tier": true,
-        "supports_vision": true,
-        "provider": "openai"
       }
     },
     {
@@ -3576,139 +2515,29 @@
     },
     {
       "model_provider": "openai",
-      "model_name": "o1",
-      "metadata": {
-        "cache_read_input_token_cost": 7.5e-06,
-        "input_cost_per_token": 1.5e-05,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 100000,
-        "max_tokens": 100000,
-        "output_cost_per_token": 6e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": false,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "o1-2024-12-17",
-      "metadata": {
-        "cache_read_input_token_cost": 7.5e-06,
-        "input_cost_per_token": 1.5e-05,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 100000,
-        "max_tokens": 100000,
-        "output_cost_per_token": 6e-05,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "o1-pro",
-      "metadata": {
-        "input_cost_per_token": 0.00015,
-        "input_cost_per_token_batches": 7.5e-05,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 100000,
-        "max_tokens": 100000,
-        "output_cost_per_token": 0.0006,
-        "output_cost_per_token_batches": 0.0003,
-        "supported_endpoints": [
-          "/v1/responses",
-          "/v1/batch"
-        ],
-        "supported_modalities": [
-          "text",
-          "image"
-        ],
-        "supported_output_modalities": [
-          "text"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": false,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "o1-pro-2025-03-19",
-      "metadata": {
-        "input_cost_per_token": 0.00015,
-        "input_cost_per_token_batches": 7.5e-05,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 100000,
-        "max_tokens": 100000,
-        "output_cost_per_token": 0.0006,
-        "output_cost_per_token_batches": 0.0003,
-        "supported_endpoints": [
-          "/v1/responses",
-          "/v1/batch"
-        ],
-        "supported_modalities": [
-          "text",
-          "image"
-        ],
-        "supported_output_modalities": [
-          "text"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": false,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "o3",
+      "model_name": "gpt-5.5",
       "metadata": {
         "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
         "cache_read_input_token_cost_flex": 2.5e-07,
-        "cache_read_input_token_cost_priority": 8.75e-07,
-        "input_cost_per_token": 2e-06,
-        "input_cost_per_token_flex": 1e-06,
-        "input_cost_per_token_priority": 3.5e-06,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 100000,
-        "max_tokens": 100000,
-        "output_cost_per_token": 8e-06,
-        "output_cost_per_token_flex": 4e-06,
-        "output_cost_per_token_priority": 1.4e-05,
+        "cache_read_input_token_cost_priority": 1e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "input_cost_per_token_flex": 2.5e-06,
+        "input_cost_per_token_batches": 2.5e-06,
+        "input_cost_per_token_priority": 1e-05,
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "output_cost_per_token_flex": 1.5e-05,
+        "output_cost_per_token_batches": 1.5e-05,
+        "output_cost_per_token_priority": 6e-05,
         "supported_endpoints": [
-          "/v1/responses",
           "/v1/chat/completions",
-          "/v1/completions",
-          "/v1/batch"
+          "/v1/batch",
+          "/v1/responses"
         ],
         "supported_modalities": [
           "text",
@@ -3718,33 +2547,48 @@
           "text"
         ],
         "supports_function_calling": true,
-        "supports_parallel_function_calling": false,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_service_tier": true,
         "supports_vision": true,
         "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
         "provider": "openai"
       }
     },
     {
       "model_provider": "openai",
-      "model_name": "o3-2025-04-16",
+      "model_name": "gpt-5.5-2026-04-23",
       "metadata": {
         "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 2e-06,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 100000,
-        "max_tokens": 100000,
-        "output_cost_per_token": 8e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "cache_read_input_token_cost_flex": 2.5e-07,
+        "cache_read_input_token_cost_priority": 1e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "input_cost_per_token_flex": 2.5e-06,
+        "input_cost_per_token_batches": 2.5e-06,
+        "input_cost_per_token_priority": 1e-05,
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "output_cost_per_token_flex": 1.5e-05,
+        "output_cost_per_token_batches": 1.5e-05,
+        "output_cost_per_token_priority": 6e-05,
         "supported_endpoints": [
-          "/v1/responses",
           "/v1/chat/completions",
-          "/v1/completions",
-          "/v1/batch"
+          "/v1/batch",
+          "/v1/responses"
         ],
         "supported_modalities": [
           "text",
@@ -3754,69 +2598,40 @@
           "text"
         ],
         "supports_function_calling": true,
-        "supports_parallel_function_calling": false,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_service_tier": true,
         "supports_vision": true,
         "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
         "provider": "openai"
       }
     },
     {
       "model_provider": "openai",
-      "model_name": "o3-mini",
+      "model_name": "gpt-5.5-pro",
       "metadata": {
-        "cache_read_input_token_cost": 5.5e-07,
-        "input_cost_per_token": 1.1e-06,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 100000,
-        "max_tokens": 100000,
-        "output_cost_per_token": 4.4e-06,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": false,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": false,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "o3-mini-2025-01-31",
-      "metadata": {
-        "cache_read_input_token_cost": 5.5e-07,
-        "input_cost_per_token": 1.1e-06,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 100000,
-        "max_tokens": 100000,
-        "output_cost_per_token": 4.4e-06,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": false,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": false,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "o3-pro",
-      "metadata": {
-        "input_cost_per_token": 2e-05,
-        "input_cost_per_token_batches": 1e-05,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 100000,
-        "max_tokens": 100000,
-        "output_cost_per_token": 8e-05,
-        "output_cost_per_token_batches": 4e-05,
+        "cache_read_input_token_cost": 6e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 1.2e-05,
+        "input_cost_per_token": 6e-05,
+        "input_cost_per_token_above_272k_tokens": 0.00012,
+        "input_cost_per_token_flex": 3e-05,
+        "input_cost_per_token_batches": 3e-05,
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 0.00036,
+        "output_cost_per_token_above_272k_tokens": 0.00054,
+        "output_cost_per_token_flex": 0.00018,
+        "output_cost_per_token_batches": 0.00018,
         "supported_endpoints": [
           "/v1/responses",
           "/v1/batch"
@@ -3829,28 +2644,40 @@
           "text"
         ],
         "supports_function_calling": true,
-        "supports_parallel_function_calling": false,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_response_schema": true,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
+        "supports_service_tier": true,
         "supports_vision": true,
         "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
         "provider": "openai"
       }
     },
     {
       "model_provider": "openai",
-      "model_name": "o3-pro-2025-06-10",
+      "model_name": "gpt-5.5-pro-2026-04-23",
       "metadata": {
-        "input_cost_per_token": 2e-05,
-        "input_cost_per_token_batches": 1e-05,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 100000,
-        "max_tokens": 100000,
-        "output_cost_per_token": 8e-05,
-        "output_cost_per_token_batches": 4e-05,
+        "cache_read_input_token_cost": 6e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 1.2e-05,
+        "input_cost_per_token": 6e-05,
+        "input_cost_per_token_above_272k_tokens": 0.00012,
+        "input_cost_per_token_flex": 3e-05,
+        "input_cost_per_token_batches": 3e-05,
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 0.00036,
+        "output_cost_per_token_above_272k_tokens": 0.00054,
+        "output_cost_per_token_flex": 0.00018,
+        "output_cost_per_token_batches": 0.00018,
         "supported_endpoints": [
           "/v1/responses",
           "/v1/batch"
@@ -3863,66 +2690,20 @@
           "text"
         ],
         "supports_function_calling": true,
-        "supports_parallel_function_calling": false,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "o4-mini",
-      "metadata": {
-        "cache_read_input_token_cost": 2.75e-07,
-        "cache_read_input_token_cost_flex": 1.375e-07,
-        "cache_read_input_token_cost_priority": 5e-07,
-        "input_cost_per_token": 1.1e-06,
-        "input_cost_per_token_flex": 5.5e-07,
-        "input_cost_per_token_priority": 2e-06,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 100000,
-        "max_tokens": 100000,
-        "output_cost_per_token": 4.4e-06,
-        "output_cost_per_token_flex": 2.2e-06,
-        "output_cost_per_token_priority": 8e-06,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": false,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_service_tier": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "provider": "openai"
-      }
-    },
-    {
-      "model_provider": "openai",
-      "model_name": "o4-mini-2025-04-16",
-      "metadata": {
-        "cache_read_input_token_cost": 2.75e-07,
-        "input_cost_per_token": 1.1e-06,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 100000,
-        "max_tokens": 100000,
-        "output_cost_per_token": 4.4e-06,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": false,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_service_tier": true,
-        "supports_vision": true,
-        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true,
         "provider": "openai"
       }
     }

--- a/tracecat/agent/platform_catalog.json
+++ b/tracecat/agent/platform_catalog.json
@@ -612,7 +612,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-2.0-flash",
       "metadata": {
         "cache_read_input_token_cost": 2.5e-08,
@@ -656,7 +656,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-2.0-flash-001",
       "metadata": {
         "cache_read_input_token_cost": 2.5e-08,
@@ -698,7 +698,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-2.0-flash-lite",
       "metadata": {
         "cache_read_input_token_cost": 1.875e-08,
@@ -738,7 +738,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-2.0-flash-lite-001",
       "metadata": {
         "cache_read_input_token_cost": 1.875e-08,
@@ -778,7 +778,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-2.5-computer-use-preview-10-2025",
       "metadata": {
         "input_cost_per_token": 1.25e-06,
@@ -812,7 +812,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-2.5-flash",
       "metadata": {
         "cache_read_input_token_cost": 3e-08,
@@ -863,7 +863,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-2.5-flash-lite",
       "metadata": {
         "cache_read_input_token_cost": 1e-08,
@@ -914,7 +914,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-2.5-flash-lite-preview-06-17",
       "metadata": {
         "deprecation_date": "2025-11-18",
@@ -965,7 +965,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-2.5-flash-lite-preview-09-2025",
       "metadata": {
         "cache_read_input_token_cost": 1e-08,
@@ -1015,7 +1015,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-2.5-flash-preview-09-2025",
       "metadata": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -1065,7 +1065,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-2.5-pro",
       "metadata": {
         "cache_read_input_token_cost": 1.25e-07,
@@ -1119,7 +1119,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-3-flash-preview",
       "metadata": {
         "cache_read_input_token_cost": 5e-08,
@@ -1175,7 +1175,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-3-pro-preview",
       "metadata": {
         "deprecation_date": "2026-03-09",
@@ -1235,7 +1235,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-3.1-flash-lite-preview",
       "metadata": {
         "cache_read_input_token_cost": 2.5e-08,
@@ -1292,7 +1292,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-3.1-flash-live-preview",
       "metadata": {
         "input_cost_per_audio_token": 3e-06,
@@ -1327,7 +1327,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-3.1-pro-preview",
       "metadata": {
         "cache_read_input_token_cost": 2e-07,
@@ -1388,7 +1388,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-3.1-pro-preview-customtools",
       "metadata": {
         "cache_read_input_token_cost": 2e-07,
@@ -1449,7 +1449,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-exp-1206",
       "metadata": {
         "cache_read_input_token_cost": 3e-08,
@@ -1499,7 +1499,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-flash-latest",
       "metadata": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -1549,7 +1549,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-flash-lite-latest",
       "metadata": {
         "cache_read_input_token_cost": 2.5e-08,
@@ -1599,7 +1599,7 @@
       }
     },
     {
-      "model_provider": "google",
+      "model_provider": "gemini",
       "model_name": "gemini-pro-latest",
       "metadata": {
         "cache_read_input_token_cost": 1.25e-07,

--- a/tracecat/agent/types.py
+++ b/tracecat/agent/types.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from enum import StrEnum
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -32,15 +31,6 @@ else:
     # Runtime fallbacks for types only used in annotations
     ModelMessage = Any
     CustomToolList = list[Any]
-
-
-class AgentCustomProviderDiscoveryStatus(StrEnum):
-    """Discovery lifecycle states for custom provider catalog refreshes."""
-
-    NEVER = "never"
-    RUNNING = "running"
-    SUCCEEDED = "succeeded"
-    FAILED = "failed"
 
 
 class StreamKey(str):

--- a/tracecat/agent/types.py
+++ b/tracecat/agent/types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -31,6 +32,15 @@ else:
     # Runtime fallbacks for types only used in annotations
     ModelMessage = Any
     CustomToolList = list[Any]
+
+
+class AgentCustomProviderDiscoveryStatus(StrEnum):
+    """Discovery lifecycle states for custom provider catalog refreshes."""
+
+    NEVER = "never"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
 
 
 class StreamKey(str):

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -47,6 +47,7 @@ from sqlalchemy.orm import (
 
 from tracecat import config
 from tracecat.agent.approvals.enums import ApprovalStatus
+from tracecat.agent.types import AgentCustomProviderDiscoveryStatus
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.secrets import get_signing_secret
 from tracecat.authz.enums import ScopeSource
@@ -81,6 +82,13 @@ CASE_TASK_STATUS_ENUM = Enum(CaseTaskStatus, name="casetaskstatus")
 INTERACTION_STATUS_ENUM = Enum(InteractionStatus, name="interactionstatus")
 APPROVAL_STATUS_ENUM = Enum(ApprovalStatus, name="approvalstatus")
 INVITATION_STATUS_ENUM = Enum(InvitationStatus, name="invitationstatus")
+AGENT_CUSTOM_PROVIDER_DISCOVERY_STATUS_ENUM = Enum(
+    AgentCustomProviderDiscoveryStatus,
+    name="agentcustomproviderdiscoverystatus",
+    native_enum=False,
+    values_callable=lambda statuses: [status.value for status in statuses],
+    validate_strings=True,
+)
 
 
 # Naming convention for constraints so Alembic can generate deterministic names
@@ -2549,6 +2557,152 @@ class Approval(WorkspaceModel):
     )
 
 
+class AgentCustomProvider(OrganizationModel):
+    """Organization-scoped custom LLM provider configuration."""
+
+    __tablename__ = "agent_custom_provider"
+    __table_args__ = (UniqueConstraint("organization_id", "id"),)
+
+    organization_id: Mapped[OrganizationID] = mapped_column(
+        UUID,
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    display_name: Mapped[str] = mapped_column(String(200), nullable=False)
+    base_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    passthrough: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+    encrypted_config: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    api_key_header: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    discovery_status: Mapped[AgentCustomProviderDiscoveryStatus] = mapped_column(
+        AGENT_CUSTOM_PROVIDER_DISCOVERY_STATUS_ENUM,
+        nullable=False,
+        default=AgentCustomProviderDiscoveryStatus.NEVER,
+        server_default=text("'never'"),
+    )
+    last_refreshed_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+
+    catalog_rows: Mapped[list[AgentCatalog]] = relationship(
+        "AgentCatalog",
+        back_populates="custom_provider",
+        cascade="all, delete-orphan",
+        foreign_keys="[AgentCatalog.organization_id, AgentCatalog.custom_provider_id]",
+    )
+
+
+class AgentCatalog(Base, TimestampMixin):
+    """Normalized agent catalog entries."""
+
+    __tablename__ = "agent_catalog"
+    __table_args__ = (
+        CheckConstraint(
+            "custom_provider_id IS NULL OR organization_id IS NOT NULL",
+            name="custom_provider_requires_org",
+        ),
+        ForeignKeyConstraint(
+            ["organization_id", "custom_provider_id"],
+            ["agent_custom_provider.organization_id", "agent_custom_provider.id"],
+            name="fk_agent_catalog_org_custom_provider",
+            ondelete="CASCADE",
+        ),
+        Index(
+            "ix_agent_catalog_organization_id_custom_provider_id",
+            "organization_id",
+            "custom_provider_id",
+        ),
+        Index(
+            "uq_agent_catalog_custom_provider_model_provider_model_name",
+            "organization_id",
+            "custom_provider_id",
+            "model_provider",
+            "model_name",
+            unique=True,
+            postgresql_nulls_not_distinct=True,
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[OrganizationID | None] = mapped_column(
+        UUID,
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    custom_provider_id: Mapped[uuid.UUID | None] = mapped_column(UUID, nullable=True)
+    model_provider: Mapped[str] = mapped_column(String(120), nullable=False)
+    model_name: Mapped[str] = mapped_column(String(500), nullable=False)
+    model_metadata: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    encrypted_config: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    last_refreshed_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+
+    custom_provider: Mapped[AgentCustomProvider | None] = relationship(
+        "AgentCustomProvider",
+        back_populates="catalog_rows",
+        foreign_keys=[organization_id, custom_provider_id],
+    )
+    model_access: Mapped[list[AgentModelAccess]] = relationship(
+        "AgentModelAccess",
+        back_populates="catalog",
+        cascade="all, delete-orphan",
+    )
+
+
+class AgentModelAccess(OrganizationModel):
+    """Organization- and workspace-scoped access to catalog models."""
+
+    __tablename__ = "agent_model_access"
+    __table_args__ = (
+        Index("ix_agent_model_access_workspace_id", "workspace_id"),
+        Index("ix_agent_model_access_catalog_id", "catalog_id"),
+        Index(
+            "uq_agent_model_access_organization_workspace_catalog",
+            "organization_id",
+            "workspace_id",
+            "catalog_id",
+            unique=True,
+            postgresql_nulls_not_distinct=True,
+        ),
+    )
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    organization_id: Mapped[OrganizationID] = mapped_column(
+        UUID,
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    workspace_id: Mapped[WorkspaceID | None] = mapped_column(
+        UUID,
+        ForeignKey("workspace.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    catalog_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("agent_catalog.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    catalog: Mapped[AgentCatalog] = relationship(
+        "AgentCatalog",
+        back_populates="model_access",
+    )
+
+
 class AgentSession(WorkspaceModel):
     """Generic agent session/thread entity (harness-agnostic).
 
@@ -3162,6 +3316,13 @@ class AgentPreset(WorkspaceModel):
     model_provider: Mapped[str] = mapped_column(
         String(120), nullable=False, doc="LLM provider identifier"
     )
+    catalog_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID,
+        ForeignKey("agent_catalog.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+        doc="Canonical catalog row backing this model selection",
+    )
     base_url: Mapped[str | None] = mapped_column(
         String(500),
         nullable=True,
@@ -3271,6 +3432,13 @@ class AgentPresetVersion(WorkspaceModel):
     )
     model_provider: Mapped[str] = mapped_column(
         String(120), nullable=False, doc="LLM provider identifier"
+    )
+    catalog_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID,
+        ForeignKey("agent_catalog.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+        doc="Canonical catalog row backing this model selection",
     )
     base_url: Mapped[str | None] = mapped_column(
         String(500),

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -47,7 +47,6 @@ from sqlalchemy.orm import (
 
 from tracecat import config
 from tracecat.agent.approvals.enums import ApprovalStatus
-from tracecat.agent.types import AgentCustomProviderDiscoveryStatus
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.secrets import get_signing_secret
 from tracecat.authz.enums import ScopeSource
@@ -82,15 +81,6 @@ CASE_TASK_STATUS_ENUM = Enum(CaseTaskStatus, name="casetaskstatus")
 INTERACTION_STATUS_ENUM = Enum(InteractionStatus, name="interactionstatus")
 APPROVAL_STATUS_ENUM = Enum(ApprovalStatus, name="approvalstatus")
 INVITATION_STATUS_ENUM = Enum(InvitationStatus, name="invitationstatus")
-AGENT_CUSTOM_PROVIDER_DISCOVERY_STATUS_ENUM = Enum(
-    AgentCustomProviderDiscoveryStatus,
-    name="agentcustomproviderdiscoverystatus",
-    native_enum=False,
-    values_callable=lambda statuses: [status.value for status in statuses],
-    validate_strings=True,
-)
-
-
 # Naming convention for constraints so Alembic can generate deterministic names
 # See: https://alembic.sqlalchemy.org/en/latest/naming.html
 NAMING_CONVENTION: dict[str, str] = {
@@ -2582,12 +2572,6 @@ class AgentCustomProvider(OrganizationModel):
     )
     encrypted_config: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     api_key_header: Mapped[str | None] = mapped_column(String(120), nullable=True)
-    discovery_status: Mapped[AgentCustomProviderDiscoveryStatus] = mapped_column(
-        AGENT_CUSTOM_PROVIDER_DISCOVERY_STATUS_ENUM,
-        nullable=False,
-        default=AgentCustomProviderDiscoveryStatus.NEVER,
-        server_default=text("'never'"),
-    )
     last_refreshed_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True), nullable=True
     )

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -308,8 +308,16 @@ def enable_service_account_child_table_rls(table: str) -> str:
                       )
                 )
     """
+def _agent_catalog_platform_read_policy() -> str:
+    return f"{policy_name('agent_catalog')}_platform_read"
+
 
 def enable_agent_catalog_table_rls() -> str:
+    # Split policy so platform rows (organization_id IS NULL) are readable by
+    # every org but cannot be written or deleted by an org-scoped session.
+    # Writes/deletes are gated by the FOR ALL policy, which only matches
+    # rows owned by the current org; platform-row read access is granted
+    # additively via a FOR SELECT policy (permissive policies OR together).
     return f"""
         ALTER TABLE "agent_catalog" ENABLE ROW LEVEL SECURITY;
 
@@ -317,12 +325,17 @@ def enable_agent_catalog_table_rls() -> str:
             FOR ALL
             USING (
                 current_setting('{RLS_BYPASS_VAR}', true) = '{RLS_BYPASS_ON}'
-                OR organization_id IS NULL
                 OR organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid
             )
             WITH CHECK (
                 current_setting('{RLS_BYPASS_VAR}', true) = '{RLS_BYPASS_ON}'
                 OR organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid
+            );
+
+        CREATE POLICY {_agent_catalog_platform_read_policy()} ON "agent_catalog"
+            FOR SELECT
+            USING (
+                organization_id IS NULL
             );
     """
 
@@ -335,6 +348,7 @@ def disable_service_account_child_table_rls(table: str) -> str:
 
 def disable_agent_catalog_table_rls() -> str:
     return f"""
+        DROP POLICY IF EXISTS {_agent_catalog_platform_read_policy()} ON "agent_catalog";
         DROP POLICY IF EXISTS {policy_name("agent_catalog")} ON "agent_catalog";
         ALTER TABLE "agent_catalog" DISABLE ROW LEVEL SECURITY;
     """

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -87,22 +87,24 @@ POST_RLS_WORKSPACE_SCOPED_TABLES = (
 POST_RLS_ORG_SCOPED_TABLES = (
     "watchtower_agent",
     "mcp_refresh_token",
+    "agent_custom_provider",
 )
 
 POST_RLS_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES = (
     "watchtower_agent_session",
     "watchtower_agent_tool_call",
     "service_account",
+    "agent_model_access",
 )
 
 SPECIAL_TENANT_POLICY_TABLES = frozenset(
     {"service_account_api_key", "service_account_scope"}
 )
 
-# Workspace and oauth_state carry custom policy SQL, and scope allows shared
-# platform-owned rows.
+# Workspace and oauth_state carry custom policy SQL. scope and agent_catalog
+# both have nullable organization_id and allow shared platform-owned rows.
 SPECIAL_WORKSPACE_POLICY_TABLES = frozenset({"oauth_state"})
-SPECIAL_ORG_POLICY_TABLES = frozenset({"workspace", "scope"})
+SPECIAL_ORG_POLICY_TABLES = frozenset({"workspace", "scope", "agent_catalog"})
 
 CURRENT_WORKSPACE_SCOPED_TABLES = (
     *INITIAL_WORKSPACE_SCOPED_TABLES,
@@ -305,6 +307,22 @@ def enable_service_account_child_table_rls(table: str) -> str:
                           OR NULLIF(current_setting('app.current_workspace_id', true), '')::uuid IS NULL
                       )
                 )
+    """
+
+def enable_agent_catalog_table_rls() -> str:
+    return f"""
+        ALTER TABLE "agent_catalog" ENABLE ROW LEVEL SECURITY;
+
+        CREATE POLICY {policy_name("agent_catalog")} ON "agent_catalog"
+            FOR ALL
+            USING (
+                current_setting('{RLS_BYPASS_VAR}', true) = '{RLS_BYPASS_ON}'
+                OR organization_id IS NULL
+                OR organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid
+            )
+            WITH CHECK (
+                current_setting('{RLS_BYPASS_VAR}', true) = '{RLS_BYPASS_ON}'
+                OR organization_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid
             );
     """
 
@@ -313,6 +331,12 @@ def disable_service_account_child_table_rls(table: str) -> str:
     return f"""
         DROP POLICY IF EXISTS {policy_name(table)} ON "{table}";
         ALTER TABLE "{table}" DISABLE ROW LEVEL SECURITY;
+    """
+
+def disable_agent_catalog_table_rls() -> str:
+    return f"""
+        DROP POLICY IF EXISTS {policy_name("agent_catalog")} ON "agent_catalog";
+        ALTER TABLE "agent_catalog" DISABLE ROW LEVEL SECURITY;
     """
 
 

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -307,7 +307,10 @@ def enable_service_account_child_table_rls(table: str) -> str:
                           OR NULLIF(current_setting('app.current_workspace_id', true), '')::uuid IS NULL
                       )
                 )
+            );
     """
+
+
 def _agent_catalog_platform_read_policy() -> str:
     return f"{policy_name('agent_catalog')}_platform_read"
 
@@ -345,6 +348,7 @@ def disable_service_account_child_table_rls(table: str) -> str:
         DROP POLICY IF EXISTS {policy_name(table)} ON "{table}";
         ALTER TABLE "{table}" DISABLE ROW LEVEL SECURITY;
     """
+
 
 def disable_agent_catalog_table_rls() -> str:
     return f"""


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds database models and tenant RLS for an agent model catalog, custom LLM providers, and model access to support LLM Providers v2 and custom provider onboarding. Refreshes the platform catalog (standardizes the `gemini` slug, prunes deprecated models, bumps versions), links presets to catalog entries, and removes the custom provider discovery status.

- **New Features**
  - Tables: `agent_catalog` (platform or org), `agent_custom_provider` (`base_url`, `passthrough`, `encrypted_config`, `api_key_header`), `agent_model_access` (org/workspace).
  - Presets: optional `catalog_id` on `agent_preset` and `agent_preset_version` (FK to `agent_catalog`).
  - Catalog: new `platform_catalog.json` with updated models, capabilities, limits, pricing; standardized `gemini`; pruned deprecated; version bumps.
  - RLS: split `agent_catalog` policies (platform rows world-readable; org rows tenant-scoped). Added tenant policies for `agent_custom_provider` and `agent_model_access`.

- **Migration**
  - Run database migrations.

<sup>Written for commit 79607d1536eb9a35c231fc63c7624e9c10ac2449. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2506?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

