### PR TITLE
fix(agents): surface tool cap as schema validation error and bump def…

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/schemas.py
@@ -1,10 +1,11 @@
 import uuid
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from tracecat import config
 from tracecat.agent.types import OutputType
+from tracecat.agent.validation import validate_actions_length
 
 
 class AgentActionArgs(BaseModel):
@@ -36,6 +37,8 @@ class AgentActionArgs(BaseModel):
         description="If True, use workspace-scoped credentials; otherwise org-level",
     )
 
+    _validate_actions = field_validator("actions")(validate_actions_length)
+
 
 class PresetAgentActionArgs(BaseModel):
     preset: str
@@ -60,3 +63,5 @@ class PresetAgentActionArgs(BaseModel):
         default=True,
         description="If True, use workspace-scoped credentials; otherwise org-level",
     )
+
+    _validate_actions = field_validator("actions")(validate_actions_length)

--- a/tests/unit/test_agent_actions_cap.py
+++ b/tests/unit/test_agent_actions_cap.py
@@ -1,9 +1,11 @@
 """Tests for the agent ``actions`` list length cap.
 
 Covers the shared ``validate_actions_length`` validator plus its wiring into
-every Pydantic schema that accepts an ``actions`` field, so that exceeding
-``TRACECAT__AGENT_MAX_TOOLS`` surfaces as a schema ``ValidationError`` rather
-than as a late runtime failure inside the agent worker.
+every write/request schema that accepts an ``actions`` field, so that
+oversized lists surface as a schema ``ValidationError`` rather than as a late
+runtime failure inside the agent worker. Also pins the invariant that read
+models must remain permissive so historical presets stay viewable after the
+cap is lowered.
 """
 
 from __future__ import annotations
@@ -52,9 +54,11 @@ class TestValidateActionsLength:
         with pytest.raises(ValueError, match="at most 3 actions, got 4"):
             validate_actions_length(_actions(small_cap + 1))
 
-    def test_error_message_mentions_env_var(self, small_cap: int) -> None:
-        with pytest.raises(ValueError, match="TRACECAT__AGENT_MAX_TOOLS"):
+    def test_error_message_hides_internal_env_var(self, small_cap: int) -> None:
+        """Client-facing error must not leak the TRACECAT__AGENT_MAX_TOOLS name."""
+        with pytest.raises(ValueError) as exc_info:
             validate_actions_length(_actions(small_cap + 1))
+        assert "TRACECAT__AGENT_MAX_TOOLS" not in str(exc_info.value)
 
     def test_zero_cap_disables_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``max_tools == 0`` means "no limit" — keep parity with build_agent_tools."""
@@ -113,15 +117,23 @@ class TestAgentConfigSchemaCap:
 
 
 class TestPresetSchemasCap:
-    """Preset write/read schemas reject oversized action lists."""
+    """Preset write schemas reject oversized action lists; reads remain permissive."""
 
-    def test_execution_config_rejects_over_cap(self, small_cap: int) -> None:
-        with pytest.raises(ValidationError):
-            AgentPresetExecutionConfig(
-                model_name="gpt-4o-mini",
-                model_provider="openai",
-                actions=_actions(small_cap + 1),
-            )
+    def test_execution_config_allows_over_cap_for_reads(self, small_cap: int) -> None:
+        """Read-path base must not enforce the cap.
+
+        Historical presets stored under a larger cap need to remain loadable
+        so users can view and shrink them after the cap is lowered. Regression
+        guard: ``AgentPresetRead`` / ``AgentPresetVersionReadMinimal`` inherit
+        from this class.
+        """
+        payload = AgentPresetExecutionConfig(
+            model_name="gpt-4o-mini",
+            model_provider="openai",
+            actions=_actions(small_cap + 1),
+        )
+        assert payload.actions is not None
+        assert len(payload.actions) == small_cap + 1
 
     def test_execution_config_write_rejects_over_cap(self, small_cap: int) -> None:
         with pytest.raises(ValidationError):

--- a/tests/unit/test_agent_actions_cap.py
+++ b/tests/unit/test_agent_actions_cap.py
@@ -1,0 +1,146 @@
+"""Tests for the agent ``actions`` list length cap.
+
+Covers the shared ``validate_actions_length`` validator plus its wiring into
+every Pydantic schema that accepts an ``actions`` field, so that exceeding
+``TRACECAT__AGENT_MAX_TOOLS`` surfaces as a schema ``ValidationError`` rather
+than as a late runtime failure inside the agent worker.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+from tracecat_ee.agent.schemas import AgentActionArgs, PresetAgentActionArgs
+
+from tracecat import config
+from tracecat.agent.preset.schemas import (
+    AgentPresetCreate,
+    AgentPresetExecutionConfig,
+    AgentPresetExecutionConfigWrite,
+    AgentPresetUpdate,
+)
+from tracecat.agent.schemas import AgentConfigSchema
+from tracecat.agent.validation import validate_actions_length
+
+
+@pytest.fixture
+def small_cap(monkeypatch: pytest.MonkeyPatch) -> int:
+    """Lower the tool cap so tests don't need huge lists."""
+    cap = 3
+    monkeypatch.setattr(config, "TRACECAT__AGENT_MAX_TOOLS", cap)
+    return cap
+
+
+def _actions(n: int) -> list[str]:
+    return [f"tools.pkg.action_{i}" for i in range(n)]
+
+
+class TestValidateActionsLength:
+    """Pure tests for the shared validator function."""
+
+    def test_none_passes_through(self, small_cap: int) -> None:
+        assert validate_actions_length(None) is None
+
+    def test_empty_list_passes(self, small_cap: int) -> None:
+        assert validate_actions_length([]) == []
+
+    def test_at_cap_passes(self, small_cap: int) -> None:
+        value = _actions(small_cap)
+        assert validate_actions_length(value) == value
+
+    def test_over_cap_raises(self, small_cap: int) -> None:
+        with pytest.raises(ValueError, match="at most 3 actions, got 4"):
+            validate_actions_length(_actions(small_cap + 1))
+
+    def test_error_message_mentions_env_var(self, small_cap: int) -> None:
+        with pytest.raises(ValueError, match="TRACECAT__AGENT_MAX_TOOLS"):
+            validate_actions_length(_actions(small_cap + 1))
+
+    def test_zero_cap_disables_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``max_tools == 0`` means "no limit" — keep parity with build_agent_tools."""
+        monkeypatch.setattr(config, "TRACECAT__AGENT_MAX_TOOLS", 0)
+        value = _actions(500)
+        assert validate_actions_length(value) == value
+
+
+class TestAgentActionArgsCap:
+    """``ai.agent`` action args reject oversized action lists."""
+
+    def test_accepts_list_at_cap(self, small_cap: int) -> None:
+        args = AgentActionArgs(
+            user_prompt="hi",
+            model_name="gpt-4o-mini",
+            model_provider="openai",
+            actions=_actions(small_cap),
+        )
+        assert args.actions is not None
+        assert len(args.actions) == small_cap
+
+    def test_rejects_list_over_cap(self, small_cap: int) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            AgentActionArgs(
+                user_prompt="hi",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                actions=_actions(small_cap + 1),
+            )
+        assert "at most 3 actions" in str(exc_info.value)
+
+
+class TestPresetAgentActionArgsCap:
+    """``ai.preset_agent`` action args reject oversized action lists."""
+
+    def test_rejects_list_over_cap(self, small_cap: int) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            PresetAgentActionArgs(
+                preset="triage",
+                user_prompt="hi",
+                actions=_actions(small_cap + 1),
+            )
+        assert "at most 3 actions" in str(exc_info.value)
+
+
+class TestAgentConfigSchemaCap:
+    """Internal ``/agent/run`` config request rejects oversized action lists."""
+
+    def test_rejects_list_over_cap(self, small_cap: int) -> None:
+        with pytest.raises(ValidationError):
+            AgentConfigSchema(
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                actions=_actions(small_cap + 1),
+            )
+
+
+class TestPresetSchemasCap:
+    """Preset write/read schemas reject oversized action lists."""
+
+    def test_execution_config_rejects_over_cap(self, small_cap: int) -> None:
+        with pytest.raises(ValidationError):
+            AgentPresetExecutionConfig(
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                actions=_actions(small_cap + 1),
+            )
+
+    def test_execution_config_write_rejects_over_cap(self, small_cap: int) -> None:
+        with pytest.raises(ValidationError):
+            AgentPresetExecutionConfigWrite(
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                actions=_actions(small_cap + 1),
+            )
+
+    def test_preset_create_rejects_over_cap(self, small_cap: int) -> None:
+        with pytest.raises(ValidationError):
+            AgentPresetCreate(
+                name="Triage",
+                slug="triage",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                actions=_actions(small_cap + 1),
+            )
+
+    def test_preset_update_rejects_over_cap(self, small_cap: int) -> None:
+        with pytest.raises(ValidationError):
+            AgentPresetUpdate(actions=_actions(small_cap + 1))

--- a/tracecat/agent/preset/schemas.py
+++ b/tracecat/agent/preset/schemas.py
@@ -32,7 +32,15 @@ PresetModelWriteField = Annotated[
 
 
 class AgentPresetExecutionConfig(Schema):
-    """Execution fields that define a preset version."""
+    """Execution fields that define a preset version.
+
+    Used as the base for read models (``AgentPresetRead``,
+    ``AgentPresetVersionReadMinimal``). Deliberately does **not** enforce
+    ``TRACECAT__AGENT_MAX_TOOLS`` on ``actions`` — historical presets created
+    under a higher cap must remain readable so users can view and fix them
+    after lowering the cap. Write-time enforcement lives on
+    ``AgentPresetExecutionConfigWrite`` and ``AgentPresetUpdate``.
+    """
 
     instructions: str | None = Field(default=None)
     model_name: PresetModelField
@@ -45,8 +53,6 @@ class AgentPresetExecutionConfig(Schema):
     mcp_integrations: list[str] | None = Field(default=None)
     retries: int = Field(default=3, ge=0)
     enable_internet_access: bool = Field(default=False)
-
-    _validate_actions = field_validator("actions")(validate_actions_length)
 
 
 class AgentPresetExecutionConfigWrite(Schema):

--- a/tracecat/agent/preset/schemas.py
+++ b/tracecat/agent/preset/schemas.py
@@ -6,9 +6,10 @@ import uuid
 from datetime import datetime
 from typing import Annotated, Any
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator
 
 from tracecat.agent.types import AgentConfig, OutputType
+from tracecat.agent.validation import validate_actions_length
 from tracecat.core.schemas import Schema
 from tracecat.identifiers import WorkspaceID
 
@@ -45,6 +46,8 @@ class AgentPresetExecutionConfig(Schema):
     retries: int = Field(default=3, ge=0)
     enable_internet_access: bool = Field(default=False)
 
+    _validate_actions = field_validator("actions")(validate_actions_length)
+
 
 class AgentPresetExecutionConfigWrite(Schema):
     """Write-time execution validation for mutable preset fields."""
@@ -60,6 +63,8 @@ class AgentPresetExecutionConfigWrite(Schema):
     mcp_integrations: list[str] | None = Field(default=None)
     retries: int = Field(default=3, ge=0)
     enable_internet_access: bool = Field(default=False)
+
+    _validate_actions = field_validator("actions")(validate_actions_length)
 
 
 class AgentPresetBase(AgentPresetExecutionConfigWrite):
@@ -92,6 +97,8 @@ class AgentPresetUpdate(BaseModel):
     mcp_integrations: list[str] | None = Field(default=None)
     retries: int | None = Field(default=None, ge=0)
     enable_internet_access: bool | None = Field(default=None)
+
+    _validate_actions = field_validator("actions")(validate_actions_length)
 
 
 class AgentPresetReadMinimal(Schema):

--- a/tracecat/agent/schemas.py
+++ b/tracecat/agent/schemas.py
@@ -10,13 +10,14 @@ from typing import (
     TypedDict,
 )
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic_ai.messages import ModelMessage, ModelResponse
 from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import DeferredToolResults
 
 from tracecat.agent.types import AgentConfig
+from tracecat.agent.validation import validate_actions_length
 from tracecat.auth.types import Role
 from tracecat.chat.schemas import ChatMessage
 
@@ -257,6 +258,8 @@ class AgentConfigSchema(BaseModel):
     model_settings: dict[str, Any] | None = None
     mcp_servers: list[MCPServerConfigSchema] | None = None
     retries: int = Field(default=20)
+
+    _validate_actions = field_validator("actions")(validate_actions_length)
 
 
 class RankableItemSchema(TypedDict):

--- a/tracecat/agent/tools.py
+++ b/tracecat/agent/tools.py
@@ -336,9 +336,8 @@ async def build_agent_tools(
 
     if max_tools > 0 and len(tools) > max_tools:
         raise ValueError(
-            f"An agent can reference at most {max_tools} actions, got {len(tools)}. "
-            "Reduce the number of tools attached to the agent or raise "
-            "TRACECAT__AGENT_MAX_TOOLS."
+            f"An agent can reference at most {max_tools} actions, "
+            f"got {len(tools)}. Reduce the number of tools attached to the agent."
         )
 
     return BuildToolsResult(tools=tools, collected_secrets=collected_secrets)

--- a/tracecat/agent/tools.py
+++ b/tracecat/agent/tools.py
@@ -335,7 +335,11 @@ async def build_agent_tools(
         )
 
     if max_tools > 0 and len(tools) > max_tools:
-        raise ValueError(f"Cannot request more than {max_tools} tools")
+        raise ValueError(
+            f"An agent can reference at most {max_tools} actions, got {len(tools)}. "
+            "Reduce the number of tools attached to the agent or raise "
+            "TRACECAT__AGENT_MAX_TOOLS."
+        )
 
     return BuildToolsResult(tools=tools, collected_secrets=collected_secrets)
 

--- a/tracecat/agent/validation.py
+++ b/tracecat/agent/validation.py
@@ -17,8 +17,7 @@ def validate_actions_length(value: list[str] | None) -> list[str] | None:
     max_tools = config.TRACECAT__AGENT_MAX_TOOLS
     if max_tools > 0 and len(value) > max_tools:
         raise ValueError(
-            f"An agent can reference at most {max_tools} actions, got {len(value)}. "
-            "Reduce the number of tools attached to the agent or raise "
-            "TRACECAT__AGENT_MAX_TOOLS."
+            f"An agent can reference at most {max_tools} actions, "
+            f"got {len(value)}. Reduce the number of tools attached to the agent."
         )
     return value

--- a/tracecat/agent/validation.py
+++ b/tracecat/agent/validation.py
@@ -1,0 +1,24 @@
+"""Shared schema-level validators for agent configuration."""
+
+from __future__ import annotations
+
+from tracecat import config
+
+
+def validate_actions_length(value: list[str] | None) -> list[str] | None:
+    """Ensure the ``actions`` list does not exceed the configured tool cap.
+
+    Raised as a ``ValueError`` so it surfaces as a Pydantic ``ValidationError``
+    at schema validation time, instead of failing later inside the agent
+    worker when tools are materialized.
+    """
+    if value is None:
+        return value
+    max_tools = config.TRACECAT__AGENT_MAX_TOOLS
+    if max_tools > 0 and len(value) > max_tools:
+        raise ValueError(
+            f"An agent can reference at most {max_tools} actions, got {len(value)}. "
+            "Reduce the number of tools attached to the agent or raise "
+            "TRACECAT__AGENT_MAX_TOOLS."
+        )
+    return value

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -1024,7 +1024,7 @@ TRACECAT__UNIFIED_AGENT_STREAMING_ENABLED = os.environ.get(
 ).lower() in ("true", "1")
 """Whether to enable unified streaming for agent execution."""
 
-TRACECAT__AGENT_MAX_TOOLS = int(os.environ.get("TRACECAT__AGENT_MAX_TOOLS") or 30)
+TRACECAT__AGENT_MAX_TOOLS = int(os.environ.get("TRACECAT__AGENT_MAX_TOOLS") or 100)
 """The maximum number of tools that can be used in an agent."""
 
 TRACECAT__AGENT_MAX_TOOL_CALLS = int(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate and cap agent action lists at schema time, and bump the default cap from 30 to 100. Write-time schemas fail fast with clear errors; read models remain permissive so old presets still load.

- **Bug Fixes**
  - Added shared `validate_actions_length`; wired into `AgentActionArgs`, `PresetAgentActionArgs`, `AgentConfigSchema`, `AgentPresetExecutionConfigWrite`, and `AgentPresetUpdate` (not the `AgentPresetExecutionConfig` read base).
  - Over-cap now surfaces as a Pydantic `ValidationError` with a clear message; `0` disables the cap.
  - Updated `build_agent_tools` over-cap error text for consistency.

<sup>Written for commit fa78098206714b3dc222caeb674faa327ca78676. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

