### PR TITLE
Add workflow version selector for export

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -1563,7 +1563,7 @@ export const workflowsExportWorkflow = (
  * @param data The data for the request.
  * @param data.workflowId
  * @param data.workspaceId
- * @returns WorkflowDefinitionRead Successful Response
+ * @returns WorkflowDefinitionReadMinimal Successful Response
  * @throws ApiError
  */
 export const workflowsListWorkflowDefinitions = (

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -8194,7 +8194,7 @@ export type WorkflowsListWorkflowDefinitionsData = {
 }
 
 export type WorkflowsListWorkflowDefinitionsResponse =
-  Array<WorkflowDefinitionRead>
+  Array<WorkflowDefinitionReadMinimal>
 
 export type WorkflowsGetWorkflowDefinitionData = {
   version?: number | null
@@ -11342,7 +11342,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: Array<WorkflowDefinitionRead>
+        200: Array<WorkflowDefinitionReadMinimal>
         /**
          * Validation Error
          */

--- a/frontend/src/components/export-workflow-dropdown-item.tsx
+++ b/frontend/src/components/export-workflow-dropdown-item.tsx
@@ -7,6 +7,7 @@ export function ExportMenuItem({
   format,
   workspaceId,
   workflowId,
+  version,
   icon,
   draft = false,
   label,
@@ -15,6 +16,7 @@ export function ExportMenuItem({
   format: "json" | "yaml"
   workspaceId: string
   workflowId: string
+  version?: number
   icon?: React.ReactNode
   draft?: boolean
   label?: string
@@ -30,6 +32,7 @@ export function ExportMenuItem({
             workspaceId,
             workflowId,
             format,
+            version,
             draft,
           })
         } catch (error) {

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -24,9 +24,14 @@ import type {
   GitBranchInfo,
   ValidationDetail,
   ValidationResult,
+  WorkflowDefinitionRead,
   WorkflowDslPublish,
 } from "@/client"
-import { ApiError, workflowsListWorkflowBranches } from "@/client"
+import {
+  ApiError,
+  workflowsListWorkflowBranches,
+  workflowsListWorkflowDefinitions,
+} from "@/client"
 import { ExportMenuItem } from "@/components/export-workflow-dropdown-item"
 import { Spinner } from "@/components/loading/spinner"
 import {
@@ -53,7 +58,11 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {
@@ -919,6 +928,22 @@ function BuilderNavOptions({
     listEnabled: false,
   })
   const enabledExport = appSettings?.app_workflow_export_enabled
+  const { data: workflowDefinitions, isLoading: definitionsLoading } = useQuery<
+    WorkflowDefinitionRead[]
+  >({
+    queryKey: ["workflow-definitions", workflowId],
+    queryFn: async () =>
+      workflowsListWorkflowDefinitions({
+        workspaceId,
+        workflowId,
+      }),
+    enabled: Boolean(enabledExport),
+  })
+  const olderWorkflowDefinitions =
+    workflowDefinitions
+      ?.filter((definition) => definition.version > 0)
+      .sort((left, right) => right.version - left.version)
+      .slice(1, 11) ?? []
 
   const handleDelete = async () => {
     await deleteWorkflow(workflowId)
@@ -953,6 +978,38 @@ function BuilderNavOptions({
             label="Export saved"
             icon={<DownloadIcon className="mr-2 size-3.5" />}
           />
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <DownloadIcon className="mr-2 size-3.5" />
+              Export older version
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuLabel>Select version</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {definitionsLoading ? (
+                <DropdownMenuItem disabled>
+                  Loading versions...
+                </DropdownMenuItem>
+              ) : olderWorkflowDefinitions.length > 0 ? (
+                olderWorkflowDefinitions.map((definition) => (
+                  <ExportMenuItem
+                    key={definition.id}
+                    enabledExport={enabledExport}
+                    format="yaml"
+                    workspaceId={workspaceId}
+                    workflowId={workflowId}
+                    version={definition.version}
+                    label={`Download v${definition.version}`}
+                    icon={<DownloadIcon className="mr-2 size-3.5" />}
+                  />
+                ))
+              ) : (
+                <DropdownMenuItem disabled>
+                  No older versions found
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
           <DropdownMenuItem
             onClick={() =>
               copyToClipboard({

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -2,6 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useQuery } from "@tanstack/react-query"
+import { format } from "date-fns"
 import {
   AlertTriangleIcon,
   ChevronDownIcon,
@@ -943,7 +944,7 @@ function BuilderNavOptions({
     workflowDefinitions
       ?.filter((definition) => definition.version > 0)
       .sort((left, right) => right.version - left.version)
-      .slice(1, 11) ?? []
+      .slice(1) ?? []
 
   const handleDelete = async () => {
     await deleteWorkflow(workflowId)
@@ -981,33 +982,37 @@ function BuilderNavOptions({
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
               <DownloadIcon className="mr-2 size-3.5" />
-              Export older version
+              Export version
             </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
-              <DropdownMenuLabel>Select version</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {definitionsLoading ? (
-                <DropdownMenuItem disabled>
-                  Loading versions...
-                </DropdownMenuItem>
-              ) : olderWorkflowDefinitions.length > 0 ? (
-                olderWorkflowDefinitions.map((definition) => (
-                  <ExportMenuItem
-                    key={definition.id}
-                    enabledExport={enabledExport}
-                    format="yaml"
-                    workspaceId={workspaceId}
-                    workflowId={workflowId}
-                    version={definition.version}
-                    label={`Download v${definition.version}`}
-                    icon={<DownloadIcon className="mr-2 size-3.5" />}
-                  />
-                ))
-              ) : (
-                <DropdownMenuItem disabled>
-                  No older versions found
-                </DropdownMenuItem>
-              )}
+            <DropdownMenuSubContent className="max-h-80 overflow-y-auto overscroll-none p-0">
+              <div className="sticky top-0 z-10 bg-popover pt-1">
+                <DropdownMenuLabel>Select version</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+              </div>
+              <div className="p-1 pt-0">
+                {definitionsLoading ? (
+                  <DropdownMenuItem disabled>
+                    Loading versions...
+                  </DropdownMenuItem>
+                ) : olderWorkflowDefinitions.length > 0 ? (
+                  olderWorkflowDefinitions.map((definition) => (
+                    <ExportMenuItem
+                      key={definition.id}
+                      enabledExport={enabledExport}
+                      format="yaml"
+                      workspaceId={workspaceId}
+                      workflowId={workflowId}
+                      version={definition.version}
+                      label={`v${definition.version} · ${format(new Date(definition.created_at), "MMM d, yyyy h:mm a")}`}
+                      icon={<DownloadIcon className="mr-2 size-3.5" />}
+                    />
+                  ))
+                ) : (
+                  <DropdownMenuItem disabled>
+                    No older versions found
+                  </DropdownMenuItem>
+                )}
+              </div>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
           <DropdownMenuItem

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -25,7 +25,7 @@ import type {
   GitBranchInfo,
   ValidationDetail,
   ValidationResult,
-  WorkflowDefinitionRead,
+  WorkflowDefinitionReadMinimal,
   WorkflowDslPublish,
 } from "@/client"
 import {
@@ -929,16 +929,19 @@ function BuilderNavOptions({
     listEnabled: false,
   })
   const enabledExport = appSettings?.app_workflow_export_enabled
-  const { data: workflowDefinitions, isLoading: definitionsLoading } = useQuery<
-    WorkflowDefinitionRead[]
-  >({
+  const [versionSubMenuOpen, setVersionSubMenuOpen] = React.useState(false)
+  const {
+    data: workflowDefinitions,
+    isLoading: definitionsLoading,
+    isError: definitionsError,
+  } = useQuery<WorkflowDefinitionReadMinimal[]>({
     queryKey: ["workflow-definitions", workflowId],
     queryFn: async () =>
       workflowsListWorkflowDefinitions({
         workspaceId,
         workflowId,
       }),
-    enabled: Boolean(enabledExport),
+    enabled: Boolean(enabledExport) && versionSubMenuOpen,
   })
   const olderWorkflowDefinitions =
     workflowDefinitions
@@ -979,8 +982,11 @@ function BuilderNavOptions({
             label="Export saved"
             icon={<DownloadIcon className="mr-2 size-3.5" />}
           />
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
+          <DropdownMenuSub
+            open={versionSubMenuOpen}
+            onOpenChange={setVersionSubMenuOpen}
+          >
+            <DropdownMenuSubTrigger disabled={!enabledExport}>
               <DownloadIcon className="mr-2 size-3.5" />
               Export version
             </DropdownMenuSubTrigger>
@@ -993,6 +999,10 @@ function BuilderNavOptions({
                 {definitionsLoading ? (
                   <DropdownMenuItem disabled>
                     Loading versions...
+                  </DropdownMenuItem>
+                ) : definitionsError ? (
+                  <DropdownMenuItem disabled>
+                    Failed to load versions
                   </DropdownMenuItem>
                 ) : olderWorkflowDefinitions.length > 0 ? (
                   olderWorkflowDefinitions.map((definition) => (

--- a/frontend/src/providers/workflow.tsx
+++ b/frontend/src/providers/workflow.tsx
@@ -106,6 +106,9 @@ export function WorkflowProvider({
     onSuccess: (response) => {
       if (response.status === "success") {
         queryClient.invalidateQueries({ queryKey: ["workflow", workflowId] })
+        queryClient.invalidateQueries({
+          queryKey: ["workflow-definitions", workflowId],
+        })
         toast({
           title: "Saved changes to workflow",
           description: "New workflow version saved successfully.",
@@ -172,6 +175,9 @@ export function WorkflowProvider({
         ) : undefined,
       })
       queryClient.invalidateQueries({ queryKey: ["workflow", workflowId] })
+      queryClient.invalidateQueries({
+        queryKey: ["workflow-definitions", workflowId],
+      })
     },
     onError: (error: ApiError) => {
       console.warn("Failed to publish workflow:", error)

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -659,11 +659,11 @@ async def list_workflow_definitions(
     role: WorkspaceUserRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
-) -> list[WorkflowDefinitionRead]:
+) -> list[WorkflowDefinitionReadMinimal]:
     """List all workflow definitions for a Workflow."""
     service = WorkflowDefinitionsService(session, role=role)
     defns = await service.list_workflow_defitinions(workflow_id=workflow_id)
-    return WorkflowDefinitionRead.list_adapter().validate_python(defns)
+    return WorkflowDefinitionReadMinimal.list_adapter().validate_python(defns)
 
 
 @router.get("/{workflow_id}/definition", tags=["workflows"])


### PR DESCRIPTION
### Motivation
- Provide an easy UI to download historical workflow definition versions from the builder so users can retrieve older saved states without manual API calls.

### Description
- Extend `ExportMenuItem` to accept an optional `version` prop and forward it to the `exportWorkflow` API call so exports can request a specific workflow definition version.
- Fetch saved definitions in the builder options using `workflowsListWorkflowDefinitions` via a `useQuery` and derive an `olderWorkflowDefinitions` list (exclude the latest) for selection.
- Add an `Export older version` submenu in the builder "More" menu that shows a loading state, an empty-state message, and per-version `Download v{n}` items that call `ExportMenuItem` with `version` set.
- Keep existing `Export draft` and `Export saved` actions unchanged and only add the explicit historical-version selector in the submenu.

### Testing
- Ran `pnpm -C frontend exec biome check --write src/components/export-workflow-dropdown-item.tsx src/components/nav/builder-nav.tsx` which completed successfully.
- Ran `pnpm -C frontend run typecheck` (`tsc --noEmit`) which completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7eec8c1c483209fea99eb95c074a2)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "Export version" submenu in the builder so users can download specific historical workflow definitions with timestamped labels. The list is lazy-loaded and uses a minimal API response to keep the nav fast, and it auto-refreshes after save or publish.

- **New Features**
  - `ExportMenuItem` accepts an optional `version` and forwards it to the export call.
  - Lazy-loaded "Export version" submenu: fetch on open via `workflowsListWorkflowDefinitions`, exclude the latest, sort desc, scrollable with a sticky "Select version" header; shows loading, error, and empty states; disabled when export is off.
  - Invalidates the `workflow-definitions` query on commit and publish to refresh the list.

- **Refactors**
  - Return `WorkflowDefinitionReadMinimal` from `workflowsListWorkflowDefinitions` (API and client types) to avoid sending full workflow content on nav render.

<sup>Written for commit 8c3907e9784a71da6f976e73536d045f203e855f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

