### PR TITLE
[codex] Preserve 'Use latest' semantics for preset chats

### DIFF
--- a/tests/unit/test_agent_session_preset_versioning.py
+++ b/tests/unit/test_agent_session_preset_versioning.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
@@ -10,6 +11,7 @@ import pytest
 from tracecat.agent.session.schemas import AgentSessionUpdate
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
 from tracecat.db.models import AgentSession
 from tracecat.exceptions import TracecatValidationError
@@ -33,12 +35,11 @@ def _build_service() -> tuple[AgentSessionService, SimpleNamespace, Role]:
 
 
 @pytest.mark.anyio
-async def test_update_session_resolves_current_version_when_preset_changes() -> None:
+async def test_update_session_keeps_latest_unpinned_when_preset_changes() -> None:
     service, session, role = _build_service()
     old_preset_id = uuid.uuid4()
     new_preset_id = uuid.uuid4()
     old_version_id = uuid.uuid4()
-    resolved_version_id = uuid.uuid4()
     agent_session = AgentSession(
         workspace_id=role.workspace_id,
         title="Chat",
@@ -48,7 +49,7 @@ async def test_update_session_resolves_current_version_when_preset_changes() -> 
         agent_preset_id=old_preset_id,
         agent_preset_version_id=old_version_id,
     )
-    resolve_mock = AsyncMock(return_value=resolved_version_id)
+    resolve_mock = AsyncMock()
     service._resolve_preset_version_for_assignment = resolve_mock
 
     updated = await service.update_session(
@@ -56,34 +57,21 @@ async def test_update_session_resolves_current_version_when_preset_changes() -> 
         params=AgentSessionUpdate(agent_preset_id=new_preset_id),
     )
 
-    resolve_mock.assert_awaited_once_with(
-        entity_type=AgentSessionEntity.CASE,
-        entity_id=agent_session.entity_id,
-        agent_preset_id=new_preset_id,
-        agent_preset_version_id=None,
-    )
+    resolve_mock.assert_not_awaited()
     assert updated.agent_preset_id == new_preset_id
-    assert updated.agent_preset_version_id == resolved_version_id
+    assert updated.agent_preset_version_id is None
     session.commit.assert_awaited_once()
     session.refresh.assert_awaited_once_with(agent_session)
 
 
 @pytest.mark.anyio
-async def test_ensure_session_preset_version_id_uses_current_version() -> None:
-    service, session, role = _build_service()
+async def test_resolve_preset_version_for_assignment_returns_none_when_unpinned() -> (
+    None
+):
+    service, session, _role = _build_service()
     preset_id = uuid.uuid4()
-    resolved_version_id = uuid.uuid4()
-    agent_session = AgentSession(
-        workspace_id=role.workspace_id,
-        title="Chat",
-        created_by=uuid.uuid4(),
-        entity_type="case",
-        entity_id=uuid.uuid4(),
-        agent_preset_id=preset_id,
-        agent_preset_version_id=None,
-    )
     resolve_agent_preset_version = AsyncMock(
-        return_value=SimpleNamespace(id=resolved_version_id)
+        return_value=SimpleNamespace(id=uuid.uuid4())
     )
 
     preset_service = Mock()
@@ -95,15 +83,94 @@ async def test_ensure_session_preset_version_id_uses_current_version() -> None:
             Mock(return_value=preset_service),
         )
 
-        resolved = await service._ensure_session_preset_version_id(agent_session)
+        resolved = await service._resolve_preset_version_for_assignment(
+            entity_type=AgentSessionEntity.CASE,
+            entity_id=uuid.uuid4(),
+            agent_preset_id=preset_id,
+            agent_preset_version_id=None,
+        )
 
-    assert resolved == resolved_version_id
-    assert agent_session.agent_preset_version_id == resolved_version_id
-    resolve_agent_preset_version.assert_awaited_once_with(
-        preset_id=preset_id,
+    assert resolved is None
+    resolve_agent_preset_version.assert_not_awaited()
+    session.add.assert_not_called()
+    session.commit.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_update_session_clears_preset_version_pin_when_latest_is_selected() -> (
+    None
+):
+    service, session, role = _build_service()
+    preset_id = uuid.uuid4()
+    agent_session = AgentSession(
+        workspace_id=role.workspace_id,
+        title="Chat",
+        created_by=uuid.uuid4(),
+        entity_type="agent_preset",
+        entity_id=preset_id,
+        agent_preset_id=None,
+        agent_preset_version_id=uuid.uuid4(),
     )
-    session.add.assert_called_with(agent_session)
+    resolve_mock = AsyncMock()
+    service._resolve_preset_version_for_assignment = resolve_mock
+
+    updated = await service.update_session(
+        agent_session,
+        params=AgentSessionUpdate(agent_preset_version_id=None),
+    )
+
+    resolve_mock.assert_not_awaited()
+    assert updated.agent_preset_id == preset_id
+    assert updated.agent_preset_version_id is None
     session.commit.assert_awaited_once()
+    session.refresh.assert_awaited_once_with(agent_session)
+
+
+@pytest.mark.anyio
+async def test_build_agent_config_preserves_unpinned_agent_preset_sessions() -> None:
+    service, session, role = _build_service()
+    preset_id = uuid.uuid4()
+    agent_session = AgentSession(
+        workspace_id=role.workspace_id,
+        title="Chat",
+        created_by=uuid.uuid4(),
+        entity_type="agent_preset",
+        entity_id=preset_id,
+        agent_preset_id=None,
+        agent_preset_version_id=None,
+    )
+    expected_config = AgentConfig(
+        model_name="claude-opus-4-5-20251101",
+        model_provider="anthropic",
+    )
+
+    @asynccontextmanager
+    async def fake_with_preset_config(
+        *,
+        preset_id: uuid.UUID | None = None,
+        slug: str | None = None,
+        preset_version_id: uuid.UUID | None = None,
+        preset_version: int | None = None,
+        use_workspace_credentials: bool = True,
+    ):
+        del slug, preset_version, use_workspace_credentials
+        assert preset_id == agent_session.entity_id
+        assert preset_version_id is None
+        yield expected_config
+
+    fake_agent_service = SimpleNamespace(with_preset_config=fake_with_preset_config)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "tracecat.agent.session.service.AgentManagementService",
+            Mock(return_value=fake_agent_service),
+        )
+
+        async with service._build_agent_config(agent_session) as config:
+            assert config == expected_config
+
+    session.add.assert_not_called()
+    session.commit.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -194,7 +194,7 @@ class AgentSessionService(BaseWorkspaceService):
         agent_preset_id: uuid.UUID | None,
         agent_preset_version_id: uuid.UUID | None,
     ) -> uuid.UUID | None:
-        """Resolve the pinned preset version for a session assignment."""
+        """Validate and normalize an explicit preset version pin for a session."""
         logical_preset_id = self._resolve_logical_preset_id(
             entity_type=entity_type,
             entity_id=entity_id,
@@ -207,40 +207,14 @@ class AgentSessionService(BaseWorkspaceService):
                 )
             return None
 
+        if agent_preset_version_id is None:
+            return None
+
         preset_service = AgentPresetService(self.session, self.role)
         version = await preset_service.resolve_agent_preset_version(
             preset_id=logical_preset_id,
             preset_version_id=agent_preset_version_id,
         )
-        return version.id
-
-    async def _ensure_session_preset_version_id(
-        self, agent_session: AgentSession
-    ) -> uuid.UUID | None:
-        """Backfill a pinned preset version for unexpected unpinned sessions."""
-        if agent_session.agent_preset_version_id is not None:
-            return agent_session.agent_preset_version_id
-
-        try:
-            entity_type = AgentSessionEntity(agent_session.entity_type)
-        except ValueError:
-            return None
-
-        logical_preset_id = self._resolve_logical_preset_id(
-            entity_type=entity_type,
-            entity_id=agent_session.entity_id,
-            agent_preset_id=agent_session.agent_preset_id,
-        )
-        if logical_preset_id is None:
-            return None
-
-        preset_service = AgentPresetService(self.session, self.role)
-        version = await preset_service.resolve_agent_preset_version(
-            preset_id=logical_preset_id,
-        )
-        agent_session.agent_preset_version_id = version.id
-        self.session.add(agent_session)
-        await self.session.commit()
         return version.id
 
     async def get_session(
@@ -449,25 +423,19 @@ class AgentSessionService(BaseWorkspaceService):
                 if preset_id_updated and (
                     requested_preset_id != agent_session.agent_preset_id
                 ):
-                    resolved_version_id = (
-                        await self._resolve_preset_version_for_assignment(
-                            entity_type=entity_type,
-                            entity_id=agent_session.entity_id,
-                            agent_preset_id=requested_preset_id,
-                            agent_preset_version_id=(
-                                requested_version_id if version_id_updated else None
-                            ),
+                    if requested_version_id is None:
+                        resolved_version_id = None
+                    else:
+                        resolved_version_id = (
+                            await self._resolve_preset_version_for_assignment(
+                                entity_type=entity_type,
+                                entity_id=agent_session.entity_id,
+                                agent_preset_id=requested_preset_id,
+                                agent_preset_version_id=requested_version_id,
+                            )
                         )
-                    )
                 elif version_id_updated and requested_version_id is None:
-                    resolved_version_id = (
-                        await self._resolve_preset_version_for_assignment(
-                            entity_type=entity_type,
-                            entity_id=agent_session.entity_id,
-                            agent_preset_id=requested_preset_id,
-                            agent_preset_version_id=None,
-                        )
-                    )
+                    resolved_version_id = None
                 elif version_id_updated:
                     resolved_version_id = (
                         await self._resolve_preset_version_for_assignment(
@@ -1250,16 +1218,13 @@ class AgentSessionService(BaseWorkspaceService):
             return
 
         session_entity = AgentSessionEntity(agent_session.entity_type)
-        pinned_preset_version_id = await self._ensure_session_preset_version_id(
-            agent_session
-        )
 
         if session_entity is AgentSessionEntity.CASE:
             entity_instructions = await self._entity_to_prompt(agent_session)
             if agent_session.agent_preset_id:
                 async with agent_svc.with_preset_config(
                     preset_id=agent_session.agent_preset_id,
-                    preset_version_id=pinned_preset_version_id,
+                    preset_version_id=agent_session.agent_preset_version_id,
                 ) as preset_config:
                     combined_instructions = (
                         f"{preset_config.instructions}\n\n{entity_instructions}"
@@ -1283,7 +1248,7 @@ class AgentSessionService(BaseWorkspaceService):
             # Live chat uses workspace-level credentials
             async with agent_svc.with_preset_config(
                 preset_id=agent_session.entity_id,
-                preset_version_id=pinned_preset_version_id,
+                preset_version_id=agent_session.agent_preset_version_id,
                 use_workspace_credentials=True,
             ) as preset_config:
                 yield preset_config
@@ -1292,7 +1257,7 @@ class AgentSessionService(BaseWorkspaceService):
             preset_id = agent_session.agent_preset_id or agent_session.entity_id
             async with agent_svc.with_preset_config(
                 preset_id=preset_id,
-                preset_version_id=pinned_preset_version_id,
+                preset_version_id=agent_session.agent_preset_version_id,
                 use_workspace_credentials=True,
             ) as preset_config:
                 yield preset_config
@@ -1324,7 +1289,7 @@ class AgentSessionService(BaseWorkspaceService):
             if agent_session.agent_preset_id:
                 async with agent_svc.with_preset_config(
                     preset_id=agent_session.agent_preset_id,
-                    preset_version_id=pinned_preset_version_id,
+                    preset_version_id=agent_session.agent_preset_version_id,
                     use_workspace_credentials=False,
                 ) as preset_config:
                     combined_instructions = (
@@ -1359,13 +1324,10 @@ class AgentSessionService(BaseWorkspaceService):
                 # Get parent session to check for preset
                 parent_session = await self.get_session(agent_session.parent_session_id)
                 if parent_session and parent_session.agent_preset_id:
-                    parent_version_id = await self._ensure_session_preset_version_id(
-                        parent_session
-                    )
                     # Use parent's preset with forked context prepended
                     async with agent_svc.with_preset_config(
                         preset_id=parent_session.agent_preset_id,
-                        preset_version_id=parent_version_id,
+                        preset_version_id=parent_session.agent_preset_version_id,
                         use_workspace_credentials=True,
                     ) as preset_config:
                         combined_instructions = (
@@ -1394,7 +1356,7 @@ class AgentSessionService(BaseWorkspaceService):
                 # Workflow sessions with preset use the preset config
                 async with agent_svc.with_preset_config(
                     preset_id=agent_session.agent_preset_id,
-                    preset_version_id=pinned_preset_version_id,
+                    preset_version_id=agent_session.agent_preset_version_id,
                     use_workspace_credentials=True,
                 ) as preset_config:
                     yield preset_config


### PR DESCRIPTION
## Summary
- preserve `agent_preset_version_id = null` as an unpinned "follow latest" state instead of resolving it to the current immutable preset version
- stop runtime config loading from backfilling and persisting a concrete preset version ID for unpinned sessions
- update session versioning tests to cover unpinned create/update/runtime behavior

## Root cause
The UI already sends `null` when a user selects `Use latest`, but the backend normalized that `null` into a concrete preset version ID during session create/update and again during runtime config resolution. That made unpinned preset chats impossible in practice: saving a preset created a new immutable version, but existing chats stayed stuck on the older pinned version.

## User impact
- preset chats that are set to `Use latest` now continue following the preset head after future saves
- explicit version pins still resolve and remain stable

## Validation
- `uv run ruff check tracecat/agent/session/service.py tests/unit/test_agent_session_preset_versioning.py`
- `uv run ruff format --check tracecat/agent/session/service.py tests/unit/test_agent_session_preset_versioning.py`
- `uv run basedpyright tracecat/agent/session/service.py tests/unit/test_agent_session_preset_versioning.py`
- Attempted: `PG_PORT=5532 uv run pytest tests/unit/test_agent_session_preset_versioning.py` using the existing local Tracecat Postgres stack on port `5532`; the run did not complete cleanly in this environment because session-scoped test setup stalled outside the changed assertions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves “Use latest” for preset chats by keeping `agent_preset_version_id = null` unpinned. Unpinned sessions now follow the preset head after future saves; explicit pins remain stable.

- **Bug Fixes**
  - Stop resolving/persisting a concrete version when `agent_preset_version_id` is `null` (removed backfill).
  - Update session updates to clear the pin when “Use latest” is selected and only resolve versions when explicitly provided.
  - Pass `agent_preset_version_id` directly to runtime config (allowing `None`) and add tests for unpinned create/update/runtime behavior.

<sup>Written for commit 07c6c5574ec50846f2572698157cf52cc92acaf7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

