### PR TITLE
fix: normalize default port for mcp

### DIFF
--- a/tests/unit/test_mcp_oidc_endpoints.py
+++ b/tests/unit/test_mcp_oidc_endpoints.py
@@ -363,9 +363,10 @@ def test_authorize_accepts_redirect_uri_without_explicit_default_http_port(
     [
         "http://localhost:abc/auth/callback",
         "http://localhost:70000/auth/callback",
+        "http://[::1/auth/callback",
     ],
 )
-def test_authorize_rejects_redirect_uri_with_invalid_port(
+def test_authorize_rejects_malformed_redirect_uri(
     client: TestClient,
     redirect_uri: str,
 ) -> None:

--- a/tests/unit/test_mcp_oidc_endpoints.py
+++ b/tests/unit/test_mcp_oidc_endpoints.py
@@ -333,6 +333,31 @@ def test_authorize_rejects_wrong_redirect_uri(client: TestClient) -> None:
     assert response.json()["error"] == "invalid_request"
 
 
+def test_authorize_accepts_redirect_uri_without_explicit_default_http_port(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.TRACECAT__PUBLIC_APP_URL",
+        "http://localhost:80",
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.resolve_authorize_session",
+        AsyncMock(return_value=SessionNeedsAction(action=NeedsAction.LOGIN)),
+    )
+    monkeypatch.setattr(
+        "tracecat.mcp.oidc.endpoints.store_resume_transaction", AsyncMock()
+    )
+
+    response = client.get(
+        "/authorize",
+        params=_authorize_params(redirect_uri="http://localhost/auth/callback"),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+
+
 def test_authorize_rejects_missing_code_challenge(client: TestClient) -> None:
     response = client.get("/authorize", params=_authorize_params(code_challenge=""))
 

--- a/tests/unit/test_mcp_oidc_endpoints.py
+++ b/tests/unit/test_mcp_oidc_endpoints.py
@@ -358,6 +358,29 @@ def test_authorize_accepts_redirect_uri_without_explicit_default_http_port(
     assert response.status_code == 302
 
 
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "http://localhost:abc/auth/callback",
+        "http://localhost:70000/auth/callback",
+    ],
+)
+def test_authorize_rejects_redirect_uri_with_invalid_port(
+    client: TestClient,
+    redirect_uri: str,
+) -> None:
+    response = client.get(
+        "/authorize",
+        params=_authorize_params(redirect_uri=redirect_uri),
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": "invalid_request",
+        "error_description": "redirect_uri does not match the registered callback",
+    }
+
+
 def test_authorize_rejects_missing_code_challenge(client: TestClient) -> None:
     response = client.get("/authorize", params=_authorize_params(code_challenge=""))
 

--- a/tracecat/mcp/oidc/endpoints.py
+++ b/tracecat/mcp/oidc/endpoints.py
@@ -13,7 +13,7 @@ import hmac
 import secrets
 import time
 from typing import Annotated, Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import jwt
 from fastapi import APIRouter, Depends, Form, Header, Query, Request
@@ -88,6 +88,29 @@ def _allowed_redirect_uri() -> str:
     The FastMCP proxy's callback is ``{PUBLIC_APP_URL}/auth/callback``.
     """
     return f"{TRACECAT__PUBLIC_APP_URL.rstrip('/')}/auth/callback"
+
+
+def _normalize_default_port_uri(uri: str) -> str:
+    """Normalize default HTTP(S) ports so equivalent callback URIs compare equal."""
+    parts = urlsplit(uri)
+    if not parts.scheme or not parts.hostname:
+        return uri
+
+    default_port = {"http": 80, "https": 443}.get(parts.scheme.lower())
+    if default_port is None or parts.port != default_port:
+        return uri
+
+    host = parts.hostname
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if parts.username is not None:
+        userinfo = parts.username
+        if parts.password is not None:
+            userinfo = f"{userinfo}:{parts.password}"
+        netloc = f"{userinfo}@{host}"
+    else:
+        netloc = host
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 
 def _error_response(
@@ -221,7 +244,9 @@ async def _handle_authorize(
         return _error_response("unsupported_response_type", "Only 'code' is supported")
     if client_id != oidc_config.INTERNAL_CLIENT_ID:
         return _error_response("invalid_client", "Unknown client_id")
-    if redirect_uri != _allowed_redirect_uri():
+    if _normalize_default_port_uri(redirect_uri) != _normalize_default_port_uri(
+        _allowed_redirect_uri()
+    ):
         return _error_response(
             "invalid_request",
             "redirect_uri does not match the registered callback",

--- a/tracecat/mcp/oidc/endpoints.py
+++ b/tracecat/mcp/oidc/endpoints.py
@@ -97,7 +97,12 @@ def _normalize_default_port_uri(uri: str) -> str:
         return uri
 
     default_port = {"http": 80, "https": 443}.get(parts.scheme.lower())
-    if default_port is None or parts.port != default_port:
+    try:
+        parsed_port = parts.port
+    except ValueError:
+        return uri
+
+    if default_port is None or parsed_port != default_port:
         return uri
 
     host = parts.hostname

--- a/tracecat/mcp/oidc/endpoints.py
+++ b/tracecat/mcp/oidc/endpoints.py
@@ -92,7 +92,11 @@ def _allowed_redirect_uri() -> str:
 
 def _normalize_default_port_uri(uri: str) -> str:
     """Normalize default HTTP(S) ports so equivalent callback URIs compare equal."""
-    parts = urlsplit(uri)
+    try:
+        parts = urlsplit(uri)
+    except ValueError:
+        return uri
+
     if not parts.scheme or not parts.hostname:
         return uri
 


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OIDC authorize to treat callback URLs with or without default ports the same, preventing invalid_request errors when `TRACECAT__PUBLIC_APP_URL` includes :80 or :443. Also rejects malformed redirect URIs with a clear 400 invalid_request.

- **Bug Fixes**
  - Compare redirect URIs after normalizing default ports (`http` 80, `https` 443) in `tracecat.mcp.oidc.endpoints`.
  - Added `_normalize_default_port_uri` and tests; accept implicit `:80`; reject malformed URIs (non-numeric/out-of-range ports, invalid host/IPv6 formatting).

<sup>Written for commit b308c35e62d8200313ff7ab26a63e4ac84f3a11d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

