### PR TITLE
fix(frontend): use fixed sizing for bulk case action dialogs

### DIFF
--- a/frontend/src/components/nav/controls-header.tsx
+++ b/frontend/src/components/nav/controls-header.tsx
@@ -1192,8 +1192,8 @@ function CasesSelectionActionsBar({ enabled = true }: { enabled?: boolean }) {
           if (!open) setCommentText("")
         }}
       >
-        <DialogContent className="sm:max-w-2xl">
-          <DialogHeader>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader className="text-left">
             <DialogTitle>Add comment</DialogTitle>
             <DialogDescription>
               Add a comment to {selectedCount} selected
@@ -1206,7 +1206,7 @@ function CasesSelectionActionsBar({ enabled = true }: { enabled?: boolean }) {
             placeholder="Enter comment..."
             className="min-h-[150px]"
           />
-          <DialogFooter>
+          <DialogFooter className="flex-row justify-end space-x-2">
             <Button
               variant="outline"
               onClick={() => {
@@ -1239,8 +1239,8 @@ function CasesSelectionActionsBar({ enabled = true }: { enabled?: boolean }) {
           if (!open) setAppendText("")
         }}
       >
-        <DialogContent className="sm:max-w-2xl">
-          <DialogHeader>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader className="text-left">
             <DialogTitle>Append to description</DialogTitle>
             <DialogDescription>
               Append text to the description of {selectedCount} selected
@@ -1253,7 +1253,7 @@ function CasesSelectionActionsBar({ enabled = true }: { enabled?: boolean }) {
             placeholder="Enter text to append..."
             className="min-h-[150px]"
           />
-          <DialogFooter>
+          <DialogFooter className="flex-row justify-end space-x-2">
             <Button
               variant="outline"
               onClick={() => {


### PR DESCRIPTION
## Summary
- Remove responsive breakpoint classes (`sm:`) from the bulk "Add comment" and "Append to description" dialogs
- Use fixed `max-w-2xl` width, always left-aligned headers, and horizontal button layout to eliminate jarring layout shifts at different viewport sizes

## Test plan
- [ ] Open the cases list, select multiple cases, and open "Add comment" from the bulk actions menu — verify the dialog has a fixed width, left-aligned title, and horizontally laid out buttons
- [ ] Repeat for "Append to description"
- [ ] Resize the browser window and confirm the dialog layout remains consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use fixed sizing and layout for the bulk "Add comment" and "Append to description" dialogs to remove jarring responsive shifts. Sets a consistent max-w-2xl width, left-aligned headers, and horizontal, right-aligned buttons across all viewports.

<sup>Written for commit d78554391991a3ea0117a5f808450f499f6996b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

