### PR TITLE
fix: match status_changed across close and reopen

### DIFF
--- a/frontend/src/components/cases/add-case-duration-dialog.tsx
+++ b/frontend/src/components/cases/add-case-duration-dialog.tsx
@@ -30,11 +30,13 @@ export function AddCaseDurationDialog({
 
       const startFieldFilters = buildFieldFilters(
         values.start.eventType,
-        values.start.filterValues
+        values.start.filterValues,
+        values.start
       )
       const endFieldFilters = buildFieldFilters(
         values.end.eventType,
-        values.end.filterValues
+        values.end.filterValues,
+        values.end
       )
 
       const payload = {

--- a/frontend/src/components/cases/case-duration-dialog.tsx
+++ b/frontend/src/components/cases/case-duration-dialog.tsx
@@ -97,9 +97,6 @@ const getFilterLabel = (
   if (isCaseFieldEventType(eventType)) {
     return "Field"
   }
-  if (isCaseDropdownEventType(eventType)) {
-    return "Dropdown"
-  }
   return null
 }
 
@@ -437,55 +434,65 @@ export function CaseDurationDialog({
     [endEventType, tagFilterOptions, fieldFilterOptions]
   )
 
-  const startDropdownOptions = useMemo<CaseFilterOption[]>(() => {
-    if (!startDropdownDefId || !dropdownDefinitions) return []
-    const def = dropdownDefinitions.find((d) => d.id === startDropdownDefId)
+  const getDropdownOptions = (
+    defId: string | undefined
+  ): CaseFilterOption[] => {
+    if (!defId || !dropdownDefinitions) return []
+    const def = dropdownDefinitions.find((d) => d.id === defId)
     return def?.options?.map((o) => ({ value: o.id, label: o.label })) ?? []
-  }, [startDropdownDefId, dropdownDefinitions])
+  }
 
-  const endDropdownOptions = useMemo<CaseFilterOption[]>(() => {
-    if (!endDropdownDefId || !dropdownDefinitions) return []
-    const def = dropdownDefinitions.find((d) => d.id === endDropdownDefId)
-    return def?.options?.map((o) => ({ value: o.id, label: o.label })) ?? []
-  }, [endDropdownDefId, dropdownDefinitions])
+  const startDropdownOptions = useMemo(
+    () => getDropdownOptions(startDropdownDefId),
+    [startDropdownDefId, dropdownDefinitions]
+  )
+  const endDropdownOptions = useMemo(
+    () => getDropdownOptions(endDropdownDefId),
+    [endDropdownDefId, dropdownDefinitions]
+  )
 
   const startFilterLabel = startEventType
     ? getFilterLabel(startEventType)
     : null
   const endFilterLabel = endEventType ? getFilterLabel(endEventType) : null
 
-  const hasStartFilters = (eventType: CaseDurationEventTypeValue): boolean => {
-    if (isCaseDropdownEventType(eventType)) {
-      return !!startDropdownDefId && startDropdownOptionCount > 0
-    }
-    return startFilterCount > 0
-  }
-
-  const hasEndFilters = (eventType: CaseDurationEventTypeValue): boolean => {
-    if (isCaseDropdownEventType(eventType)) {
-      return !!endDropdownDefId && endDropdownOptionCount > 0
-    }
-    return endFilterCount > 0
-  }
-
   const isSubmitDisabled = useMemo(() => {
-    if (isSubmitting) {
-      return true
+    if (isSubmitting) return true
+    if (!nameValue?.trim()) return true
+    if (!startEventType || !endEventType) return true
+
+    const hasFilters = (
+      eventType: CaseDurationEventTypeValue,
+      filterCount: number,
+      dropdownDefId: string | undefined,
+      dropdownOptionCount: number
+    ): boolean => {
+      if (isCaseDropdownEventType(eventType)) {
+        return !!dropdownDefId && dropdownOptionCount > 0
+      }
+      return filterCount > 0
     }
-    const trimmedName = nameValue?.trim() ?? ""
-    if (!trimmedName) {
-      return true
-    }
-    if (!startEventType || !endEventType) {
-      return true
-    }
+
     if (
       requiresFilterSelection(startEventType) &&
-      !hasStartFilters(startEventType)
+      !hasFilters(
+        startEventType,
+        startFilterCount,
+        startDropdownDefId,
+        startDropdownOptionCount
+      )
     ) {
       return true
     }
-    if (requiresFilterSelection(endEventType) && !hasEndFilters(endEventType)) {
+    if (
+      requiresFilterSelection(endEventType) &&
+      !hasFilters(
+        endEventType,
+        endFilterCount,
+        endDropdownDefId,
+        endDropdownOptionCount
+      )
+    ) {
       return true
     }
     return false

--- a/frontend/src/components/cases/case-duration-dialog.tsx
+++ b/frontend/src/components/cases/case-duration-dialog.tsx
@@ -178,7 +178,7 @@ const formSchema = z
       })
     }
 
-    // Overlap validation — skip for dropdown events (definition_id distinguishes)
+    // Overlap validation for filterValues-based events
     if (
       startRequiresFilter &&
       endRequiresFilter &&
@@ -199,6 +199,31 @@ const formSchema = z
           path: ["end", "filterValues"],
           code: z.ZodIssueCode.custom,
           message: `Choose ${label.toLowerCase()} values that differ from the "From event".`,
+        })
+      }
+    }
+
+    // Overlap validation for dropdown events
+    if (
+      isCaseDropdownEventType(startEventType) &&
+      isCaseDropdownEventType(endEventType) &&
+      values.start.dropdownDefinitionId &&
+      values.start.dropdownDefinitionId === values.end.dropdownDefinitionId
+    ) {
+      const startOpts = values.start.dropdownOptionIds ?? []
+      const endOpts = values.end.dropdownOptionIds ?? []
+      const overlapping = startOpts.filter((id) => endOpts.includes(id))
+      if (overlapping.length > 0) {
+        ctx.addIssue({
+          path: ["start", "dropdownOptionIds"],
+          code: z.ZodIssueCode.custom,
+          message:
+            'Remove duplicate option selections shared with the "To event".',
+        })
+        ctx.addIssue({
+          path: ["end", "dropdownOptionIds"],
+          code: z.ZodIssueCode.custom,
+          message: 'Choose options that differ from the "From event".',
         })
       }
     }

--- a/frontend/src/components/cases/case-duration-dialog.tsx
+++ b/frontend/src/components/cases/case-duration-dialog.tsx
@@ -15,7 +15,9 @@ import {
   CASE_EVENT_FILTER_OPTIONS,
   CASE_EVENT_OPTIONS,
   CASE_EVENT_VALUES,
+  isCaseDropdownEventType,
   isCaseEventFilterType,
+  isCaseFieldEventType,
   isCaseTagEventType,
 } from "@/components/cases/case-duration-options"
 import {
@@ -49,13 +51,19 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
-import { useCaseTagCatalog } from "@/lib/hooks"
+import {
+  useCaseDropdownDefinitions,
+  useCaseFields,
+  useCaseTagCatalog,
+} from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 const anchorSchema = z.object({
   selection: z.enum(["first", "last"]),
   eventType: z.enum(CASE_EVENT_VALUES),
   filterValues: z.array(z.string()).optional(),
+  dropdownDefinitionId: z.string().optional(),
+  dropdownOptionIds: z.array(z.string()).optional(),
 })
 
 const CATEGORY_OPTIONS = {
@@ -69,7 +77,12 @@ type CaseDurationEventTypeValue = (typeof CASE_EVENT_VALUES)[number]
 const requiresFilterSelection = (
   eventType: CaseDurationEventTypeValue
 ): boolean => {
-  return isCaseEventFilterType(eventType) || isCaseTagEventType(eventType)
+  return (
+    isCaseEventFilterType(eventType) ||
+    isCaseTagEventType(eventType) ||
+    isCaseFieldEventType(eventType) ||
+    isCaseDropdownEventType(eventType)
+  )
 }
 
 const getFilterLabel = (
@@ -80,6 +93,12 @@ const getFilterLabel = (
   }
   if (isCaseTagEventType(eventType)) {
     return "Tag"
+  }
+  if (isCaseFieldEventType(eventType)) {
+    return "Field"
+  }
+  if (isCaseDropdownEventType(eventType)) {
+    return "Dropdown"
   }
   return null
 }
@@ -110,7 +129,23 @@ const formSchema = z
     const startRequiresFilter = requiresFilterSelection(startEventType)
     const endRequiresFilter = requiresFilterSelection(endEventType)
 
-    if (startRequiresFilter && startFilterValues.length === 0) {
+    // Dropdown validation uses its own fields
+    if (isCaseDropdownEventType(startEventType)) {
+      if (!values.start.dropdownDefinitionId) {
+        ctx.addIssue({
+          path: ["start", "dropdownDefinitionId"],
+          code: z.ZodIssueCode.custom,
+          message: "Select a dropdown.",
+        })
+      }
+      if (!values.start.dropdownOptionIds?.length) {
+        ctx.addIssue({
+          path: ["start", "dropdownOptionIds"],
+          code: z.ZodIssueCode.custom,
+          message: "Select at least one option.",
+        })
+      }
+    } else if (startRequiresFilter && startFilterValues.length === 0) {
       const label = getFilterLabel(startEventType) ?? "value"
       ctx.addIssue({
         path: ["start", "filterValues"],
@@ -119,7 +154,22 @@ const formSchema = z
       })
     }
 
-    if (endRequiresFilter && endFilterValues.length === 0) {
+    if (isCaseDropdownEventType(endEventType)) {
+      if (!values.end.dropdownDefinitionId) {
+        ctx.addIssue({
+          path: ["end", "dropdownDefinitionId"],
+          code: z.ZodIssueCode.custom,
+          message: "Select a dropdown.",
+        })
+      }
+      if (!values.end.dropdownOptionIds?.length) {
+        ctx.addIssue({
+          path: ["end", "dropdownOptionIds"],
+          code: z.ZodIssueCode.custom,
+          message: "Select at least one option.",
+        })
+      }
+    } else if (endRequiresFilter && endFilterValues.length === 0) {
       const label = getFilterLabel(endEventType) ?? "value"
       ctx.addIssue({
         path: ["end", "filterValues"],
@@ -128,10 +178,12 @@ const formSchema = z
       })
     }
 
+    // Overlap validation — skip for dropdown events (definition_id distinguishes)
     if (
       startRequiresFilter &&
       endRequiresFilter &&
-      startEventType === endEventType
+      startEventType === endEventType &&
+      !isCaseDropdownEventType(startEventType)
     ) {
       const overlappingValues = startFilterValues.filter((value) =>
         endFilterValues.includes(value)
@@ -156,7 +208,8 @@ export type CaseDurationFormValues = z.infer<typeof formSchema>
 
 const buildFilterOptions = (
   eventType: CaseDurationFormValues["start"]["eventType"] | undefined,
-  tagOptions: CaseFilterOption[]
+  tagOptions: CaseFilterOption[],
+  fieldOptions?: CaseFilterOption[]
 ): CaseFilterOption[] => {
   if (!eventType) {
     return []
@@ -183,6 +236,10 @@ const buildFilterOptions = (
     return tagOptions
   }
 
+  if (isCaseFieldEventType(eventType)) {
+    return fieldOptions ?? []
+  }
+
   return []
 }
 
@@ -205,11 +262,15 @@ export const createEmptyCaseDurationFormValues =
       selection: "first",
       eventType: "case_created",
       filterValues: [],
+      dropdownDefinitionId: undefined,
+      dropdownOptionIds: [],
     },
     end: {
       selection: "first",
       eventType: "case_closed",
       filterValues: [],
+      dropdownDefinitionId: undefined,
+      dropdownOptionIds: [],
     },
   })
 
@@ -243,13 +304,28 @@ export const getFilterFieldKey = (
   if (isCaseTagEventType(eventType)) {
     return "data.tag_ref"
   }
+  if (isCaseFieldEventType(eventType)) {
+    return "data.changes.field"
+  }
   return null
 }
 
 export const buildFieldFilters = (
   eventType: CaseDurationFormValues["start"]["eventType"],
-  filterValues: CaseDurationFormValues["start"]["filterValues"]
+  filterValues: CaseDurationFormValues["start"]["filterValues"],
+  anchor?: CaseDurationFormValues["start"]
 ): Record<string, unknown> | null => {
+  if (isCaseDropdownEventType(eventType) && anchor) {
+    const { dropdownDefinitionId, dropdownOptionIds } = anchor
+    if (!dropdownDefinitionId || !dropdownOptionIds?.length) {
+      return null
+    }
+    return {
+      "data.definition_id": dropdownDefinitionId,
+      "data.new_option_id": dropdownOptionIds,
+    }
+  }
+
   const fieldKey = getFilterFieldKey(eventType)
   if (!fieldKey || !filterValues || filterValues.length === 0) {
     return null
@@ -283,6 +359,11 @@ export function CaseDurationDialog({
   const { caseTags } = useCaseTagCatalog(workspaceId ?? "", {
     enabled: Boolean(workspaceId),
   })
+  const { caseFields } = useCaseFields(workspaceId ?? "", Boolean(workspaceId))
+  const { dropdownDefinitions } = useCaseDropdownDefinitions(
+    workspaceId ?? "",
+    Boolean(workspaceId)
+  )
 
   const tagFilterOptions = useMemo<CaseFilterOption[]>(() => {
     if (!caseTags) {
@@ -296,25 +377,72 @@ export function CaseDurationDialog({
     }))
   }, [caseTags])
 
+  const fieldFilterOptions = useMemo<CaseFilterOption[]>(() => {
+    if (!caseFields) {
+      return []
+    }
+    return caseFields
+      .filter((f) => !f.reserved)
+      .map((f) => ({
+        value: f.id,
+        label: f.id,
+      }))
+  }, [caseFields])
+
   const startEventType = form.watch("start.eventType")
   const endEventType = form.watch("end.eventType")
   const nameValue = form.watch("name")
   const startFilterCount = form.watch("start.filterValues")?.length ?? 0
   const endFilterCount = form.watch("end.filterValues")?.length ?? 0
+  const startDropdownDefId = form.watch("start.dropdownDefinitionId")
+  const endDropdownDefId = form.watch("end.dropdownDefinitionId")
+  const startDropdownOptionCount =
+    form.watch("start.dropdownOptionIds")?.length ?? 0
+  const endDropdownOptionCount =
+    form.watch("end.dropdownOptionIds")?.length ?? 0
 
   const startFilterOptions = useMemo(
-    () => buildFilterOptions(startEventType, tagFilterOptions),
-    [startEventType, tagFilterOptions]
+    () =>
+      buildFilterOptions(startEventType, tagFilterOptions, fieldFilterOptions),
+    [startEventType, tagFilterOptions, fieldFilterOptions]
   )
   const endFilterOptions = useMemo(
-    () => buildFilterOptions(endEventType, tagFilterOptions),
-    [endEventType, tagFilterOptions]
+    () =>
+      buildFilterOptions(endEventType, tagFilterOptions, fieldFilterOptions),
+    [endEventType, tagFilterOptions, fieldFilterOptions]
   )
+
+  const startDropdownOptions = useMemo<CaseFilterOption[]>(() => {
+    if (!startDropdownDefId || !dropdownDefinitions) return []
+    const def = dropdownDefinitions.find((d) => d.id === startDropdownDefId)
+    return def?.options?.map((o) => ({ value: o.id, label: o.label })) ?? []
+  }, [startDropdownDefId, dropdownDefinitions])
+
+  const endDropdownOptions = useMemo<CaseFilterOption[]>(() => {
+    if (!endDropdownDefId || !dropdownDefinitions) return []
+    const def = dropdownDefinitions.find((d) => d.id === endDropdownDefId)
+    return def?.options?.map((o) => ({ value: o.id, label: o.label })) ?? []
+  }, [endDropdownDefId, dropdownDefinitions])
 
   const startFilterLabel = startEventType
     ? getFilterLabel(startEventType)
     : null
   const endFilterLabel = endEventType ? getFilterLabel(endEventType) : null
+
+  const hasStartFilters = (eventType: CaseDurationEventTypeValue): boolean => {
+    if (isCaseDropdownEventType(eventType)) {
+      return !!startDropdownDefId && startDropdownOptionCount > 0
+    }
+    return startFilterCount > 0
+  }
+
+  const hasEndFilters = (eventType: CaseDurationEventTypeValue): boolean => {
+    if (isCaseDropdownEventType(eventType)) {
+      return !!endDropdownDefId && endDropdownOptionCount > 0
+    }
+    return endFilterCount > 0
+  }
+
   const isSubmitDisabled = useMemo(() => {
     if (isSubmitting) {
       return true
@@ -326,10 +454,13 @@ export function CaseDurationDialog({
     if (!startEventType || !endEventType) {
       return true
     }
-    if (requiresFilterSelection(startEventType) && startFilterCount === 0) {
+    if (
+      requiresFilterSelection(startEventType) &&
+      !hasStartFilters(startEventType)
+    ) {
       return true
     }
-    if (requiresFilterSelection(endEventType) && endFilterCount === 0) {
+    if (requiresFilterSelection(endEventType) && !hasEndFilters(endEventType)) {
       return true
     }
     return false
@@ -340,6 +471,10 @@ export function CaseDurationDialog({
     endEventType,
     startFilterCount,
     endFilterCount,
+    startDropdownDefId,
+    startDropdownOptionCount,
+    endDropdownDefId,
+    endDropdownOptionCount,
   ])
 
   return (
@@ -432,6 +567,8 @@ export function CaseDurationDialog({
                         value={field.value}
                         onValueChange={(value) => {
                           form.setValue("start.filterValues", [])
+                          form.setValue("start.dropdownDefinitionId", undefined)
+                          form.setValue("start.dropdownOptionIds", [])
                           field.onChange(value)
                         }}
                       >
@@ -455,29 +592,86 @@ export function CaseDurationDialog({
                     </FormItem>
                   )}
                 />
-                {startFilterLabel && (
-                  <FormField
-                    control={form.control}
-                    name="start.filterValues"
-                    render={({ field }) => (
-                      <FormItem className="space-y-2">
-                        <FormLabel className="text-xs">
-                          {startFilterLabel}
-                        </FormLabel>
-                        <FormControl className="w-full">
-                          <CaseFilterMultiSelect
-                            placeholder={`Select ${startFilterLabel.toLowerCase()}`}
-                            value={field.value ?? []}
-                            options={startFilterOptions}
-                            onChange={(nextValue) => {
-                              field.onChange(nextValue)
+                {startFilterLabel &&
+                  !isCaseDropdownEventType(startEventType) && (
+                    <FormField
+                      control={form.control}
+                      name="start.filterValues"
+                      render={({ field }) => (
+                        <FormItem className="space-y-2">
+                          <FormLabel className="text-xs">
+                            {startFilterLabel}
+                          </FormLabel>
+                          <FormControl className="w-full">
+                            <CaseFilterMultiSelect
+                              placeholder={`Select ${startFilterLabel.toLowerCase()}`}
+                              value={field.value ?? []}
+                              options={startFilterOptions}
+                              onChange={(nextValue) => {
+                                field.onChange(nextValue)
+                              }}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  )}
+                {isCaseDropdownEventType(startEventType) && (
+                  <>
+                    <FormField
+                      control={form.control}
+                      name="start.dropdownDefinitionId"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-xs">Dropdown</FormLabel>
+                          <Select
+                            value={field.value ?? ""}
+                            onValueChange={(value) => {
+                              form.setValue("start.dropdownOptionIds", [])
+                              field.onChange(value)
                             }}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
+                          >
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select dropdown" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {dropdownDefinitions?.map((def) => (
+                                <SelectItem key={def.id} value={def.id}>
+                                  {def.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    {startDropdownDefId && (
+                      <FormField
+                        control={form.control}
+                        name="start.dropdownOptionIds"
+                        render={({ field }) => (
+                          <FormItem className="space-y-2">
+                            <FormLabel className="text-xs">Option</FormLabel>
+                            <FormControl className="w-full">
+                              <CaseFilterMultiSelect
+                                placeholder="Select option"
+                                value={field.value ?? []}
+                                options={startDropdownOptions}
+                                onChange={(nextValue) => {
+                                  field.onChange(nextValue)
+                                }}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
                     )}
-                  />
+                  </>
                 )}
               </div>
 
@@ -523,6 +717,8 @@ export function CaseDurationDialog({
                         value={field.value}
                         onValueChange={(value) => {
                           form.setValue("end.filterValues", [])
+                          form.setValue("end.dropdownDefinitionId", undefined)
+                          form.setValue("end.dropdownOptionIds", [])
                           field.onChange(value)
                         }}
                       >
@@ -546,7 +742,7 @@ export function CaseDurationDialog({
                     </FormItem>
                   )}
                 />
-                {endFilterLabel && (
+                {endFilterLabel && !isCaseDropdownEventType(endEventType) && (
                   <FormField
                     control={form.control}
                     name="end.filterValues"
@@ -569,6 +765,62 @@ export function CaseDurationDialog({
                       </FormItem>
                     )}
                   />
+                )}
+                {isCaseDropdownEventType(endEventType) && (
+                  <>
+                    <FormField
+                      control={form.control}
+                      name="end.dropdownDefinitionId"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-xs">Dropdown</FormLabel>
+                          <Select
+                            value={field.value ?? ""}
+                            onValueChange={(value) => {
+                              form.setValue("end.dropdownOptionIds", [])
+                              field.onChange(value)
+                            }}
+                          >
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select dropdown" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {dropdownDefinitions?.map((def) => (
+                                <SelectItem key={def.id} value={def.id}>
+                                  {def.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    {endDropdownDefId && (
+                      <FormField
+                        control={form.control}
+                        name="end.dropdownOptionIds"
+                        render={({ field }) => (
+                          <FormItem className="space-y-2">
+                            <FormLabel className="text-xs">Option</FormLabel>
+                            <FormControl className="w-full">
+                              <CaseFilterMultiSelect
+                                placeholder="Select option"
+                                value={field.value ?? []}
+                                options={endDropdownOptions}
+                                onChange={(nextValue) => {
+                                  field.onChange(nextValue)
+                                }}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    )}
+                  </>
                 )}
               </div>
             </div>

--- a/frontend/src/components/cases/case-duration-options.ts
+++ b/frontend/src/components/cases/case-duration-options.ts
@@ -5,7 +5,11 @@ import {
   FilePlus2,
   Flag,
   Flame,
+  FormInput,
   GitCompare,
+  List,
+  MessageSquarePlus,
+  MessageSquareX,
   PenSquare,
   RotateCcw,
   Tag,
@@ -79,6 +83,36 @@ export const CASE_EVENT_OPTIONS: CaseEventOption[] = [
     label: "Tag removed",
     icon: Tag,
   },
+  {
+    value: "fields_changed",
+    label: "Custom field changed",
+    icon: FormInput,
+  },
+  {
+    value: "dropdown_value_changed",
+    label: "Dropdown value changed",
+    icon: List,
+  },
+  {
+    value: "comment_created",
+    label: "Comment added",
+    icon: MessageSquarePlus,
+  },
+  {
+    value: "comment_deleted",
+    label: "Comment deleted",
+    icon: MessageSquareX,
+  },
+  {
+    value: "comment_reply_created",
+    label: "Comment reply added",
+    icon: MessageSquarePlus,
+  },
+  {
+    value: "comment_reply_deleted",
+    label: "Comment reply deleted",
+    icon: MessageSquareX,
+  },
 ]
 
 export const CASE_EVENT_VALUES = CASE_EVENT_OPTIONS.map(
@@ -150,6 +184,14 @@ export function isCaseTagEventType(
   value: CaseEventType
 ): value is CaseTagEventType {
   return (CASE_TAG_EVENT_TYPES as readonly CaseEventType[]).includes(value)
+}
+
+export function isCaseFieldEventType(value: CaseEventType): boolean {
+  return value === "fields_changed"
+}
+
+export function isCaseDropdownEventType(value: CaseEventType): boolean {
+  return value === "dropdown_value_changed"
 }
 
 export function getCaseEventOption(value: CaseEventType): CaseEventOption {

--- a/frontend/src/components/cases/cases-feed-event.tsx
+++ b/frontend/src/components/cases/cases-feed-event.tsx
@@ -8,6 +8,7 @@ import {
   PencilIcon,
   PencilLineIcon,
   PlusIcon,
+  TagIcon,
   TrashIcon,
   UserIcon,
   UserXIcon,
@@ -31,6 +32,8 @@ import type {
   ReopenedEventRead,
   SeverityChangedEventRead,
   StatusChangedEventRead,
+  TagAddedEventRead,
+  TagRemovedEventRead,
   TaskAssigneeChangedEventRead,
   TaskCreatedEventRead,
   TaskDeletedEventRead,
@@ -790,6 +793,44 @@ export function TaskWorkflowChangedEvent({
         <span className="font-medium max-w-32 inline-block truncate align-bottom">
           {event.title}
         </span>
+      </span>
+    </div>
+  )
+}
+
+// Tag events
+
+export function TagAddedEvent({
+  event,
+  actor,
+}: {
+  event: TagAddedEventRead
+  actor: User
+}) {
+  return (
+    <div className="flex items-center space-x-2 text-xs">
+      <EventIcon icon={TagIcon} />
+      <span>
+        <EventActor user={actor} /> added tag{" "}
+        <span className="font-medium">{event.tag_name}</span>
+      </span>
+    </div>
+  )
+}
+
+export function TagRemovedEvent({
+  event,
+  actor,
+}: {
+  event: TagRemovedEventRead
+  actor: User
+}) {
+  return (
+    <div className="flex items-center space-x-2 text-xs">
+      <EventIcon icon={TagIcon} className="text-red-600 bg-red-50" />
+      <span>
+        <EventActor user={actor} /> removed tag{" "}
+        <span className="font-medium">{event.tag_name}</span>
       </span>
     </div>
   )

--- a/frontend/src/components/cases/cases-feed.tsx
+++ b/frontend/src/components/cases/cases-feed.tsx
@@ -34,6 +34,8 @@ import {
   PriorityChangedEvent,
   SeverityChangedEvent,
   StatusChangedEvent,
+  TagAddedEvent,
+  TagRemovedEvent,
   TaskAssigneeChangedEvent,
   TaskCreatedEvent,
   TaskDeletedEvent,
@@ -61,6 +63,39 @@ import { useAppInfo, useCaseEvents } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 import { InlineDotSeparator } from "../separator"
+
+const HANDLED_FEED_EVENT_TYPES = new Set([
+  "case_created",
+  "case_closed",
+  "case_reopened",
+  "case_viewed",
+  "case_updated",
+  "status_changed",
+  "priority_changed",
+  "severity_changed",
+  "fields_changed",
+  "assignee_changed",
+  "task_created",
+  "task_deleted",
+  "task_status_changed",
+  "task_priority_changed",
+  "task_workflow_changed",
+  "task_assignee_changed",
+  "attachment_created",
+  "attachment_deleted",
+  "payload_changed",
+  "comment_created",
+  "comment_reply_created",
+  "comment_updated",
+  "comment_reply_updated",
+  "comment_deleted",
+  "comment_reply_deleted",
+  "dropdown_value_changed",
+  "table_row_linked",
+  "table_row_unlinked",
+  "tag_added",
+  "tag_removed",
+])
 
 function CaseFeedEvent({
   event,
@@ -206,6 +241,23 @@ function CaseFeedEvent({
             <span>
               <EventActor user={actor} /> unlinked a row from{" "}
               {(event as { table_name?: string }).table_name || "a table"}
+            </span>
+          </div>
+        )}
+
+        {event.type === "tag_added" && (
+          <TagAddedEvent event={event} actor={actor} />
+        )}
+
+        {event.type === "tag_removed" && (
+          <TagRemovedEvent event={event} actor={actor} />
+        )}
+
+        {event.type && !HANDLED_FEED_EVENT_TYPES.has(event.type) && (
+          <div className="flex items-center space-x-2 text-xs">
+            <EventIcon icon={PlusIcon} />
+            <span>
+              <EventActor user={actor} /> {event.type.replace(/_/g, " ")}
             </span>
           </div>
         )}

--- a/frontend/src/components/cases/update-case-duration-dialog.tsx
+++ b/frontend/src/components/cases/update-case-duration-dialog.tsx
@@ -13,6 +13,7 @@ import {
   getFilterFieldKey,
   normalizeFilterValues,
 } from "@/components/cases/case-duration-dialog"
+import { isCaseDropdownEventType } from "@/components/cases/case-duration-options"
 
 interface UpdateCaseDurationDialogProps {
   open: boolean
@@ -25,6 +26,36 @@ interface UpdateCaseDurationDialogProps {
   isUpdating?: boolean
 }
 
+function extractAnchorFormValues(
+  anchor: CaseDurationDefinitionRead["start_anchor"]
+): CaseDurationFormValues["start"] {
+  if (isCaseDropdownEventType(anchor.event_type)) {
+    const defId = anchor.field_filters?.["data.definition_id"]
+    const optionIds = normalizeFilterValues(
+      anchor.field_filters?.["data.new_option_id"]
+    )
+    return {
+      selection: anchor.selection ?? "first",
+      eventType: anchor.event_type,
+      filterValues: [],
+      dropdownDefinitionId: typeof defId === "string" ? defId : undefined,
+      dropdownOptionIds: optionIds,
+    }
+  }
+
+  const fieldKey = getFilterFieldKey(anchor.event_type)
+  const filterValues = normalizeFilterValues(
+    fieldKey ? anchor.field_filters?.[fieldKey] : undefined
+  )
+  return {
+    selection: anchor.selection ?? "first",
+    eventType: anchor.event_type,
+    filterValues,
+    dropdownDefinitionId: undefined,
+    dropdownOptionIds: [],
+  }
+}
+
 const getInitialValues = (
   duration: CaseDurationDefinitionRead | null
 ): CaseDurationFormValues | undefined => {
@@ -32,31 +63,11 @@ const getInitialValues = (
     return undefined
   }
 
-  const startFieldKey = getFilterFieldKey(duration.start_anchor.event_type)
-  const endFieldKey = getFilterFieldKey(duration.end_anchor.event_type)
-
-  const startFilters = normalizeFilterValues(
-    startFieldKey
-      ? duration.start_anchor.field_filters?.[startFieldKey]
-      : undefined
-  )
-  const endFilters = normalizeFilterValues(
-    endFieldKey ? duration.end_anchor.field_filters?.[endFieldKey] : undefined
-  )
-
   return {
     name: duration.name,
     description: duration.description ?? "",
-    start: {
-      selection: duration.start_anchor.selection ?? "first",
-      eventType: duration.start_anchor.event_type,
-      filterValues: startFilters,
-    },
-    end: {
-      selection: duration.end_anchor.selection ?? "first",
-      eventType: duration.end_anchor.event_type,
-      filterValues: endFilters,
-    },
+    start: extractAnchorFormValues(duration.start_anchor),
+    end: extractAnchorFormValues(duration.end_anchor),
   }
 }
 
@@ -80,11 +91,13 @@ export function UpdateCaseDurationDialog({
 
       const startFieldFilters = buildFieldFilters(
         values.start.eventType,
-        values.start.filterValues
+        values.start.filterValues,
+        values.start
       )
       const endFieldFilters = buildFieldFilters(
         values.end.eventType,
-        values.end.filterValues
+        values.end.filterValues,
+        values.end
       )
 
       const payload: CaseDurationDefinitionUpdate = {

--- a/frontend/tests/cases-feed-event.test.tsx
+++ b/frontend/tests/cases-feed-event.test.tsx
@@ -94,7 +94,7 @@ describe("case feed comment events", () => {
     expect(screen.getByText("deleted a reply")).toBeInTheDocument()
   })
 
-  it("offers comment events in trigger suggestions only", () => {
+  it("offers comment events in both trigger suggestions and duration options", () => {
     const suggestionValues = new Set(
       CASE_EVENT_SUGGESTIONS.map(({ value }) => value)
     )
@@ -102,8 +102,8 @@ describe("case feed comment events", () => {
 
     expect(suggestionValues).toContain("comment_created")
     expect(suggestionValues).toContain("comment_reply_deleted")
-    expect(durationValues).not.toContain("comment_created")
-    expect(durationValues).not.toContain("comment_reply_deleted")
+    expect(durationValues).toContain("comment_created")
+    expect(durationValues).toContain("comment_reply_deleted")
     expect(getCaseEventOption("comment_reply_updated").label).toBe(
       "Comment Reply Updated"
     )

--- a/tests/unit/test_case_duration_service.py
+++ b/tests/unit/test_case_duration_service.py
@@ -1,5 +1,7 @@
 import uuid
+from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy import select
@@ -24,6 +26,28 @@ from tracecat.db.models import CaseDuration
 from tracecat.tags.schemas import TagCreate
 
 pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture(autouse=True)
+def stub_case_duration_entitlements() -> Iterator[None]:
+    with (
+        patch.object(
+            CaseDurationDefinitionService,
+            "has_entitlement",
+            new=AsyncMock(return_value=True),
+        ),
+        patch.object(
+            CaseDurationService,
+            "has_entitlement",
+            new=AsyncMock(return_value=True),
+        ),
+        patch.object(
+            CasesService,
+            "has_entitlement",
+            new=AsyncMock(return_value=False),
+        ),
+    ):
+        yield
 
 
 def make_case_create(
@@ -191,6 +215,85 @@ async def test_duration_filters_support_multiple_values(
     updated_value = values[0]
     assert updated_value.end_event_id is not None
     assert updated_value.duration is not None
+
+
+@pytest.mark.anyio
+async def test_duration_filters_match_closed_under_status_changed(
+    session: AsyncSession, svc_role
+) -> None:
+    cases_service = CasesService(session=session, role=svc_role)
+    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    await definition_service.create_definition(
+        CaseDurationDefinitionCreate(
+            name="Time to closed status",
+            start_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.CASE_CREATED,
+            ),
+            end_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.STATUS_CHANGED,
+                field_filters={"data.new": CaseStatus.CLOSED},
+            ),
+        )
+    )
+
+    case = await cases_service.create_case(make_case_create())
+
+    values = await duration_service.compute_duration(case)
+    assert len(values) == 1
+    assert values[0].end_event_id is None
+
+    case = await cases_service.update_case(case, CaseUpdate(status=CaseStatus.CLOSED))
+
+    values = await duration_service.compute_duration(case)
+    assert len(values) == 1
+    value = values[0]
+    assert value.end_event_id is not None
+    assert value.ended_at is not None
+    assert value.duration is not None
+
+
+@pytest.mark.anyio
+async def test_duration_filters_match_reopened_under_status_changed(
+    session: AsyncSession, svc_role
+) -> None:
+    cases_service = CasesService(session=session, role=svc_role)
+    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    await definition_service.create_definition(
+        CaseDurationDefinitionCreate(
+            name="Time to resume work",
+            start_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.CASE_CLOSED,
+            ),
+            end_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.STATUS_CHANGED,
+                field_filters={"data.new": CaseStatus.IN_PROGRESS},
+            ),
+        )
+    )
+
+    case = await cases_service.create_case(make_case_create())
+    case = await cases_service.update_case(case, CaseUpdate(status=CaseStatus.CLOSED))
+
+    values = await duration_service.compute_duration(case)
+    assert len(values) == 1
+    assert values[0].start_event_id is not None
+    assert values[0].end_event_id is None
+
+    case = await cases_service.update_case(
+        case,
+        CaseUpdate(status=CaseStatus.IN_PROGRESS),
+    )
+
+    values = await duration_service.compute_duration(case)
+    assert len(values) == 1
+    value = values[0]
+    assert value.start_event_id is not None
+    assert value.end_event_id is not None
+    assert value.duration is not None
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_case_duration_service.py
+++ b/tests/unit/test_case_duration_service.py
@@ -811,3 +811,88 @@ async def test_compute_durations_empty_cases_list(
     durations = await duration_service.compute_durations([])
 
     assert durations == {}
+
+
+# --- _resolve_field array traversal tests ---
+
+
+@pytest.mark.anyio
+async def test_resolve_field_traverses_array_of_dicts(
+    session: AsyncSession, svc_role
+) -> None:
+    """_resolve_field should collect values from each item in a list."""
+    from tracecat.db.models import CaseEvent
+
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    event = CaseEvent(
+        workspace_id=uuid.uuid4(),
+        case_id=uuid.uuid4(),
+        type=CaseEventType.FIELDS_CHANGED,
+        data={
+            "changes": [
+                {"field": "severity_score", "old": 3, "new": 8},
+                {"field": "team", "old": "alpha", "new": "beta"},
+            ]
+        },
+    )
+
+    result = duration_service._resolve_field(event, "data.changes.field")
+    assert result == ["severity_score", "team"]
+
+
+@pytest.mark.anyio
+async def test_resolve_field_array_returns_none_when_no_items_have_key(
+    session: AsyncSession, svc_role
+) -> None:
+    """_resolve_field should return None if no array items have the target key."""
+    from tracecat.db.models import CaseEvent
+
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    event = CaseEvent(
+        workspace_id=uuid.uuid4(),
+        case_id=uuid.uuid4(),
+        type=CaseEventType.FIELDS_CHANGED,
+        data={"changes": [{"other": "value"}, {"other": "value2"}]},
+    )
+
+    result = duration_service._resolve_field(event, "data.changes.field")
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_matches_filters_with_array_resolved_values(
+    session: AsyncSession, svc_role
+) -> None:
+    """_matches_filters should work when _resolve_field returns a list from array traversal."""
+    from tracecat.db.models import CaseEvent
+
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    event = CaseEvent(
+        workspace_id=uuid.uuid4(),
+        case_id=uuid.uuid4(),
+        type=CaseEventType.FIELDS_CHANGED,
+        data={
+            "changes": [
+                {"field": "severity_score", "old": 3, "new": 8},
+                {"field": "team", "old": "alpha", "new": "beta"},
+            ]
+        },
+    )
+
+    # Should match when filter value is in the resolved list
+    assert duration_service._matches_filters(
+        event, {"data.changes.field": ["severity_score"]}
+    )
+
+    # Should match when multiple filter values overlap
+    assert duration_service._matches_filters(
+        event, {"data.changes.field": ["severity_score", "unrelated"]}
+    )
+
+    # Should NOT match when filter value is not in the resolved list
+    assert not duration_service._matches_filters(
+        event, {"data.changes.field": ["nonexistent_field"]}
+    )

--- a/tests/unit/test_case_trigger_consumer.py
+++ b/tests/unit/test_case_trigger_consumer.py
@@ -58,6 +58,77 @@ async def test_case_trigger_consumer_matches_event_type(
     assert unmatched == []
 
 
+@pytest.mark.anyio
+async def test_case_trigger_consumer_matches_status_changed_aliases(
+    session: AsyncSession, svc_role
+):
+    status_workflow = Workflow(
+        title="Status Trigger Alias",
+        description="Test workflow",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+    )
+    closed_workflow = Workflow(
+        title="Closed Trigger Alias",
+        description="Test workflow",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+    )
+    reopened_workflow = Workflow(
+        title="Reopened Trigger Alias",
+        description="Test workflow",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+    )
+    session.add_all([status_workflow, closed_workflow, reopened_workflow])
+    await session.flush()
+
+    status_trigger = CaseTrigger(
+        workspace_id=svc_role.workspace_id,
+        workflow_id=status_workflow.id,
+        status="online",
+        event_types=["status_changed"],
+        tag_filters=[],
+    )
+    closed_trigger = CaseTrigger(
+        workspace_id=svc_role.workspace_id,
+        workflow_id=closed_workflow.id,
+        status="online",
+        event_types=["case_closed"],
+        tag_filters=[],
+    )
+    reopened_trigger = CaseTrigger(
+        workspace_id=svc_role.workspace_id,
+        workflow_id=reopened_workflow.id,
+        status="online",
+        event_types=["case_reopened"],
+        tag_filters=[],
+    )
+    session.add_all([status_trigger, closed_trigger, reopened_trigger])
+    await session.commit()
+
+    closed_matches = await CaseTriggerConsumer(client=AsyncMock())._load_triggers(
+        session, svc_role.workspace_id, "case_closed"
+    )
+    assert {trigger.id for trigger in closed_matches} == {
+        status_trigger.id,
+        closed_trigger.id,
+    }
+
+    reopened_matches = await CaseTriggerConsumer(client=AsyncMock())._load_triggers(
+        session, svc_role.workspace_id, "case_reopened"
+    )
+    assert {trigger.id for trigger in reopened_matches} == {
+        status_trigger.id,
+        reopened_trigger.id,
+    }
+
+    status_matches = await CaseTriggerConsumer(client=AsyncMock())._load_triggers(
+        session, svc_role.workspace_id, "status_changed"
+    )
+    assert {trigger.id for trigger in status_matches} == {status_trigger.id}
+
+
 def _build_role(workspace_id: uuid.UUID) -> Role:
     return Role(
         type="service",

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -1,5 +1,6 @@
 import uuid  # noqa: I001
 import asyncio
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from typing import Literal
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -19,7 +20,12 @@ from tracecat.cases.dropdowns.service import (
     CaseDropdownDefinitionsService,
     CaseDropdownValuesService,
 )
-from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.enums import (
+    CaseEventType,
+    CasePriority,
+    CaseSeverity,
+    CaseStatus,
+)
 from tracecat.cases.schemas import (
     CaseCreate,
     CaseFieldCreate,
@@ -35,6 +41,25 @@ from tracecat.pagination import CursorPaginationParams
 from tracecat.tables.enums import SqlType
 
 pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture(autouse=True)
+def stub_case_duration_sync() -> Iterator[None]:
+    with patch(
+        "tracecat.cases.service.CaseDurationService.sync_case_durations",
+        new=AsyncMock(return_value=None),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def stub_case_addons_entitlement() -> Iterator[None]:
+    with patch.object(
+        CasesService,
+        "has_entitlement",
+        new=AsyncMock(return_value=True),
+    ):
+        yield
 
 
 @pytest.mark.anyio
@@ -645,6 +670,23 @@ class TestCasesService:
         assert retrieved_case.summary == update_params.summary
         assert retrieved_case.status == update_params.status
         assert retrieved_case.priority == update_params.priority
+
+    async def test_update_case_close_emits_case_closed_event(
+        self, cases_service: CasesService, case_create_params: CaseCreate
+    ) -> None:
+        """Closing a case should persist a specialized close event."""
+        created_case = await cases_service.create_case(case_create_params)
+
+        await cases_service.update_case(
+            created_case,
+            CaseUpdate(status=CaseStatus.CLOSED),
+        )
+
+        events = await cases_service.events.list_events(created_case)
+        assert len(events) >= 2
+        assert events[0].type == CaseEventType.CASE_CLOSED
+        assert events[0].data["old"] == CaseStatus.NEW.value
+        assert events[0].data["new"] == CaseStatus.CLOSED.value
 
     async def test_update_case_with_assignee(
         self,

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -688,7 +688,9 @@ class CaseDurationService(BaseWorkspaceService):
                         resolved = getattr(item, part, None)
                     if resolved is not None:
                         collected.append(resolved)
-                return collected if collected else None
+                if not collected:
+                    return None
+                value = collected
             elif isinstance(value, dict):
                 value = value.get(part)
             else:

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -611,6 +611,10 @@ class CaseDurationService(BaseWorkspaceService):
     ) -> tuple[CaseEvent, datetime] | None:
         candidates: list[tuple[CaseEvent, datetime]] = []
         for event in events:
+            # A transition to `closed` is emitted as `case_closed` (and reopening
+            # as `case_reopened`), so exact matching on `status_changed` would
+            # otherwise miss those transitions. Expand the match here so duration
+            # definitions filtered on `status_changed` still see close/reopen.
             if anchor.event_type is CaseEventType.STATUS_CHANGED:
                 if event.type not in (
                     CaseEventType.STATUS_CHANGED,

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -678,7 +678,18 @@ class CaseDurationService(BaseWorkspaceService):
     def _resolve_field(self, event: CaseEvent, path: str) -> Any:
         value: Any = event
         for part in path.split("."):
-            if isinstance(value, dict):
+            if isinstance(value, list):
+                # Traverse into each list item and collect the resolved values
+                collected = []
+                for item in value:
+                    if isinstance(item, dict):
+                        resolved = item.get(part)
+                    else:
+                        resolved = getattr(item, part, None)
+                    if resolved is not None:
+                        collected.append(resolved)
+                return collected if collected else None
+            elif isinstance(value, dict):
                 value = value.get(part)
             else:
                 value = getattr(value, part, None)

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -25,7 +25,7 @@ from tracecat.cases.durations.schemas import (
     CaseDurationRead,
     CaseDurationUpdate,
 )
-from tracecat.cases.enums import case_event_type_matches
+from tracecat.cases.enums import CaseEventType
 from tracecat.db.models import Case, CaseDuration, CaseEvent
 from tracecat.db.models import CaseDurationDefinition as CaseDurationDefinitionDB
 from tracecat.exceptions import (
@@ -611,7 +611,14 @@ class CaseDurationService(BaseWorkspaceService):
     ) -> tuple[CaseEvent, datetime] | None:
         candidates: list[tuple[CaseEvent, datetime]] = []
         for event in events:
-            if not case_event_type_matches(event.type, anchor.event_type):
+            if anchor.event_type is CaseEventType.STATUS_CHANGED:
+                if event.type not in (
+                    CaseEventType.STATUS_CHANGED,
+                    CaseEventType.CASE_CLOSED,
+                    CaseEventType.CASE_REOPENED,
+                ):
+                    continue
+            elif event.type != anchor.event_type:
                 continue
             if not self._matches_filters(event, anchor.field_filters):
                 continue

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -25,6 +25,7 @@ from tracecat.cases.durations.schemas import (
     CaseDurationRead,
     CaseDurationUpdate,
 )
+from tracecat.cases.enums import case_event_type_matches
 from tracecat.db.models import Case, CaseDuration, CaseEvent
 from tracecat.db.models import CaseDurationDefinition as CaseDurationDefinitionDB
 from tracecat.exceptions import (
@@ -610,7 +611,7 @@ class CaseDurationService(BaseWorkspaceService):
     ) -> tuple[CaseEvent, datetime] | None:
         candidates: list[tuple[CaseEvent, datetime]] = []
         for event in events:
-            if event.type != anchor.event_type:
+            if not case_event_type_matches(event.type, anchor.event_type):
                 continue
             if not self._matches_filters(event, anchor.field_filters):
                 continue

--- a/tracecat/cases/enums.py
+++ b/tracecat/cases/enums.py
@@ -92,39 +92,6 @@ class CaseEventType(StrEnum):
     COMMENT_REPLY_DELETED = "comment_reply_deleted"
 
 
-_STATUS_CHANGED_MATCH_VALUES = (
-    CaseEventType.STATUS_CHANGED.value,
-    CaseEventType.CASE_CLOSED.value,
-    CaseEventType.CASE_REOPENED.value,
-)
-
-
-def get_case_event_match_values(event_type: CaseEventType | str) -> tuple[str, ...]:
-    """Expand event types that should match compatibility aliases."""
-    normalized = CaseEventType(event_type)
-    if normalized is CaseEventType.STATUS_CHANGED:
-        return _STATUS_CHANGED_MATCH_VALUES
-    return (normalized.value,)
-
-
-def case_event_type_matches(
-    actual_event_type: CaseEventType | str,
-    expected_event_type: CaseEventType | str,
-) -> bool:
-    """Return whether an event should satisfy an expected case event type."""
-    return CaseEventType(actual_event_type).value in get_case_event_match_values(
-        expected_event_type
-    )
-
-
-def get_case_trigger_match_values(event_type: CaseEventType | str) -> tuple[str, ...]:
-    """Return trigger subscriptions that should fire for an incoming event."""
-    normalized = CaseEventType(event_type)
-    if normalized in (CaseEventType.CASE_CLOSED, CaseEventType.CASE_REOPENED):
-        return (normalized.value, CaseEventType.STATUS_CHANGED.value)
-    return (normalized.value,)
-
-
 class CaseTaskStatus(StrEnum):
     """Case task status values."""
 

--- a/tracecat/cases/enums.py
+++ b/tracecat/cases/enums.py
@@ -92,6 +92,39 @@ class CaseEventType(StrEnum):
     COMMENT_REPLY_DELETED = "comment_reply_deleted"
 
 
+_STATUS_CHANGED_MATCH_VALUES = (
+    CaseEventType.STATUS_CHANGED.value,
+    CaseEventType.CASE_CLOSED.value,
+    CaseEventType.CASE_REOPENED.value,
+)
+
+
+def get_case_event_match_values(event_type: CaseEventType | str) -> tuple[str, ...]:
+    """Expand event types that should match compatibility aliases."""
+    normalized = CaseEventType(event_type)
+    if normalized is CaseEventType.STATUS_CHANGED:
+        return _STATUS_CHANGED_MATCH_VALUES
+    return (normalized.value,)
+
+
+def case_event_type_matches(
+    actual_event_type: CaseEventType | str,
+    expected_event_type: CaseEventType | str,
+) -> bool:
+    """Return whether an event should satisfy an expected case event type."""
+    return CaseEventType(actual_event_type).value in get_case_event_match_values(
+        expected_event_type
+    )
+
+
+def get_case_trigger_match_values(event_type: CaseEventType | str) -> tuple[str, ...]:
+    """Return trigger subscriptions that should fire for an incoming event."""
+    normalized = CaseEventType(event_type)
+    if normalized in (CaseEventType.CASE_CLOSED, CaseEventType.CASE_REOPENED):
+        return (normalized.value, CaseEventType.STATUS_CHANGED.value)
+    return (normalized.value,)
+
+
 class CaseTaskStatus(StrEnum):
     """Case task status values."""
 

--- a/tracecat/cases/triggers/consumer.py
+++ b/tracecat/cases/triggers/consumer.py
@@ -336,7 +336,11 @@ class CaseTriggerConsumer:
     async def _load_triggers(
         self, session, workspace_id: uuid.UUID, event_type: str
     ) -> list[CaseTrigger]:
-        normalized_event_type = CaseEventType(event_type)
+        try:
+            normalized_event_type = CaseEventType(event_type)
+        except ValueError:
+            logger.warning("Unknown case event type, skipping", event_type=event_type)
+            return []
         # Cases emit `case_closed` / `case_reopened` instead of `status_changed`
         # for those transitions, so exact trigger lookup would otherwise skip
         # workflows subscribed to `status_changed`. Expand the incoming event to

--- a/tracecat/cases/triggers/consumer.py
+++ b/tracecat/cases/triggers/consumer.py
@@ -19,7 +19,7 @@ from tracecat.audit.enums import AuditEventStatus
 from tracecat.audit.service import AuditService
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
-from tracecat.cases.enums import get_case_trigger_match_values
+from tracecat.cases.enums import CaseEventType
 from tracecat.cases.schemas import CaseCommentWorkflowStatus
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import Case, CaseComment, CaseEvent, CaseTrigger, Workspace
@@ -336,7 +336,17 @@ class CaseTriggerConsumer:
     async def _load_triggers(
         self, session, workspace_id: uuid.UUID, event_type: str
     ) -> list[CaseTrigger]:
-        matching_event_types = get_case_trigger_match_values(event_type)
+        normalized_event_type = CaseEventType(event_type)
+        if normalized_event_type in (
+            CaseEventType.CASE_CLOSED,
+            CaseEventType.CASE_REOPENED,
+        ):
+            matching_event_types = (
+                normalized_event_type.value,
+                CaseEventType.STATUS_CHANGED.value,
+            )
+        else:
+            matching_event_types = (normalized_event_type.value,)
         stmt = select(CaseTrigger).where(
             CaseTrigger.workspace_id == workspace_id,
             CaseTrigger.status == "online",

--- a/tracecat/cases/triggers/consumer.py
+++ b/tracecat/cases/triggers/consumer.py
@@ -9,7 +9,7 @@ from time import monotonic
 from typing import Any
 
 from redis.exceptions import ResponseError
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 from sqlalchemy.orm import selectinload
 from temporalio.exceptions import WorkflowAlreadyStartedError
 from tenacity import RetryError
@@ -19,6 +19,7 @@ from tracecat.audit.enums import AuditEventStatus
 from tracecat.audit.service import AuditService
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.cases.enums import get_case_trigger_match_values
 from tracecat.cases.schemas import CaseCommentWorkflowStatus
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import Case, CaseComment, CaseEvent, CaseTrigger, Workspace
@@ -335,10 +336,16 @@ class CaseTriggerConsumer:
     async def _load_triggers(
         self, session, workspace_id: uuid.UUID, event_type: str
     ) -> list[CaseTrigger]:
+        matching_event_types = get_case_trigger_match_values(event_type)
         stmt = select(CaseTrigger).where(
             CaseTrigger.workspace_id == workspace_id,
             CaseTrigger.status == "online",
-            CaseTrigger.event_types.contains([event_type]),
+            or_(
+                *[
+                    CaseTrigger.event_types.contains([matching_event_type])
+                    for matching_event_type in matching_event_types
+                ]
+            ),
         )
         result = await session.execute(stmt)
         return list(result.scalars().all())

--- a/tracecat/cases/triggers/consumer.py
+++ b/tracecat/cases/triggers/consumer.py
@@ -337,6 +337,10 @@ class CaseTriggerConsumer:
         self, session, workspace_id: uuid.UUID, event_type: str
     ) -> list[CaseTrigger]:
         normalized_event_type = CaseEventType(event_type)
+        # Cases emit `case_closed` / `case_reopened` instead of `status_changed`
+        # for those transitions, so exact trigger lookup would otherwise skip
+        # workflows subscribed to `status_changed`. Expand the incoming event to
+        # include that subscription without changing the stored event type.
         if normalized_event_type in (
             CaseEventType.CASE_CLOSED,
             CaseEventType.CASE_REOPENED,


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies status change handling so `status_changed` anchors and triggers correctly match `case_closed` and `case_reopened`, fixing missing durations and workflows. Adds field and dropdown filters, expands selectable events (incl. comments), renders tag events in the feed, and hardens the trigger consumer against unknown event types.

- **Bug Fixes**
  - Anchors and triggers now align: `STATUS_CHANGED` anchors match `STATUS_CHANGED`/`CASE_CLOSED`/`CASE_REOPENED`; `case_closed`/`case_reopened` also load `status_changed` triggers, while `status_changed` only matches itself.
  - Closing a case persists a `CASE_CLOSED` event; duration filter resolution handles arrays (e.g., `data.changes.field`) and continues resolving nested paths after list traversal.
  - Dropdown filters build correct payloads using `"data.definition_id"` and `"data.new_option_id"`; validation prevents start/end anchors from selecting overlapping options under the same dropdown.
  - Trigger consumer skips unknown event types to avoid stuck messages during deploys.

- **New Features**
  - Duration builder adds `fields_changed`, `dropdown_value_changed`, and all comment events, with field filters and two-step dropdown filters (definition + options) and validation in both create and update dialogs.
  - Activity feed renders `tag_added`/`tag_removed` and falls back for unmapped event types.

<sup>Written for commit 9bf9b16e77df12c2668017321a1b3b00b4a36939. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

