### PR TITLE
feat(ui+api): Rename inbox to approvals

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/approvals/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/approvals/layout.tsx
@@ -3,39 +3,41 @@
 import { XIcon } from "lucide-react"
 import type React from "react"
 import { createContext, useCallback, useContext, useRef, useState } from "react"
-import { InboxChat } from "@/components/inbox/inbox-chat"
+import { ApprovalsChat } from "@/components/approvals/approvals-chat"
 import { ControlsHeader } from "@/components/nav/controls-header"
 import { AppSidebar } from "@/components/sidebar/app-sidebar"
 import { Button } from "@/components/ui/button"
 import { ResizableSidebar } from "@/components/ui/resizable-sidebar"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
-import type { InboxSessionItem } from "@/lib/agents"
+import type { ApprovalSessionItem } from "@/lib/agents"
 
-interface InboxChatContextValue {
-  selectedSession: InboxSessionItem | null
-  setSelectedSession: (session: InboxSessionItem | null) => void
+interface ApprovalsChatContextValue {
+  selectedSession: ApprovalSessionItem | null
+  setSelectedSession: (session: ApprovalSessionItem | null) => void
   chatOpen: boolean
   setChatOpen: (open: boolean) => void
   registerOnClose: (callback: () => void) => void
 }
 
-const InboxChatContext = createContext<InboxChatContextValue | null>(null)
+const ApprovalsChatContext = createContext<ApprovalsChatContextValue | null>(
+  null
+)
 
-export function useInboxChat() {
-  const context = useContext(InboxChatContext)
+export function useApprovalsChat() {
+  const context = useContext(ApprovalsChatContext)
   if (!context) {
-    throw new Error("useInboxChat must be used within InboxLayout")
+    throw new Error("useApprovalsChat must be used within ApprovalsLayout")
   }
   return context
 }
 
-export default function InboxLayout({
+export default function ApprovalsLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
   const [selectedSession, setSelectedSession] =
-    useState<InboxSessionItem | null>(null)
+    useState<ApprovalSessionItem | null>(null)
   const [chatOpen, setChatOpen] = useState(false)
   const onCloseCallbackRef = useRef<(() => void) | null>(null)
 
@@ -50,7 +52,7 @@ export default function InboxLayout({
   }
 
   return (
-    <InboxChatContext.Provider
+    <ApprovalsChatContext.Provider
       value={{
         selectedSession,
         setSelectedSession,
@@ -101,12 +103,12 @@ export default function InboxLayout({
 
               {/* Chat content */}
               <div className="min-h-0 flex-1">
-                <InboxChat session={selectedSession} />
+                <ApprovalsChat session={selectedSession} />
               </div>
             </div>
           </ResizableSidebar>
         )}
       </SidebarProvider>
-    </InboxChatContext.Provider>
+    </ApprovalsChatContext.Provider>
   )
 }

--- a/frontend/src/app/workspaces/[workspaceId]/approvals/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/approvals/page.tsx
@@ -1,41 +1,41 @@
 "use client"
 
 import { useEffect } from "react"
+import { ActivityLayout } from "@/components/approvals"
 import { useScopeCheck } from "@/components/auth/scope-guard"
 import { EntitlementRequiredEmptyState } from "@/components/entitlement-required-empty-state"
-import { ActivityLayout } from "@/components/inbox"
 import { CenteredSpinner } from "@/components/loading/spinner"
+import { useApprovals } from "@/hooks/use-approvals"
 import { useEntitlements } from "@/hooks/use-entitlements"
-import { useInbox } from "@/hooks/use-inbox"
 
-export default function InboxPage() {
+export default function ApprovalsPage() {
   const { hasEntitlement, isLoading: entitlementsLoading } = useEntitlements()
   const agentAddonsEnabled = hasEntitlement("agent_addons")
-  const canReadInbox = useScopeCheck("inbox:read")
+  const canReadApprovals = useScopeCheck("approval:read")
 
   const {
     sessions,
     selectedId,
     setSelectedId,
-    isLoading: inboxIsLoading,
-    error: inboxError,
+    isLoading: approvalsIsLoading,
+    error: approvalsError,
     filters,
     setSearchQuery,
     setEntityType,
     setLimit,
     setUpdatedAfter,
     setCreatedAfter,
-  } = useInbox({ enabled: agentAddonsEnabled && canReadInbox })
+  } = useApprovals({ enabled: agentAddonsEnabled && canReadApprovals })
 
   useEffect(() => {
-    document.title = "Inbox"
+    document.title = "Approvals"
   }, [])
 
   if (entitlementsLoading) {
     return <CenteredSpinner />
   }
 
-  if (!canReadInbox) {
+  if (!canReadApprovals) {
     return null
   }
 
@@ -57,8 +57,8 @@ export default function InboxPage() {
       sessions={sessions}
       selectedId={selectedId}
       onSelect={setSelectedId}
-      isLoading={inboxIsLoading}
-      error={inboxError ?? null}
+      isLoading={approvalsIsLoading}
+      error={approvalsError ?? null}
       filters={filters}
       onSearchChange={setSearchQuery}
       onEntityTypeChange={setEntityType}

--- a/frontend/src/app/workspaces/[workspaceId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/page.tsx
@@ -41,7 +41,7 @@ export default function WorkspacePage() {
   const canViewSecrets = useScopeCheck("secret:read")
   const canViewIntegrations = useScopeCheck("integration:read")
   const canViewMembers = useScopeCheck("workspace:member:read")
-  const canViewInbox = useScopeCheck("inbox:read")
+  const canViewApprovals = useScopeCheck("approval:read")
 
   const { hasEntitlement, isLoading: entitlementsLoading } = useEntitlements()
   const agentAddonsEnabled = hasEntitlement("agent_addons")
@@ -57,7 +57,7 @@ export default function WorkspacePage() {
       canViewSecrets,
       canViewIntegrations,
       canViewMembers,
-      canViewInbox,
+      canViewApprovals,
     ].some((value) => value === undefined)
 
   const landingPath = useMemo(() => {
@@ -89,15 +89,15 @@ export default function WorkspacePage() {
     if (canViewMembers === true) {
       return `${basePath}/members`
     }
-    if (canViewInbox === true) {
-      return `${basePath}/inbox`
+    if (canViewApprovals === true) {
+      return `${basePath}/approvals`
     }
     return null
   }, [
     agentAddonsEnabled,
     canViewAgents,
     canViewCases,
-    canViewInbox,
+    canViewApprovals,
     canViewIntegrations,
     canViewMembers,
     canViewSecrets,

--- a/frontend/src/app/workspaces/layout.tsx
+++ b/frontend/src/app/workspaces/layout.tsx
@@ -172,7 +172,7 @@ function WorkspaceChildren({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   const isWorkflowBuilder = !!params?.workflowId
   const isCasesPage = Boolean(pathname?.match(/\/cases(\/|$)/))
-  const isInboxPage = pathname?.includes("/inbox")
+  const isApprovalsPage = pathname?.includes("/approvals")
   const isTablesPage = Boolean(pathname?.match(/\/tables(\/|$)/))
   const isSettingsPage = pathname?.includes("/settings")
   const isOrganizationPage = pathname?.includes("/organization")
@@ -205,8 +205,8 @@ function WorkspaceChildren({ children }: { children: React.ReactNode }) {
     return <>{children}</>
   }
 
-  // Inbox pages have their own layout with chat sidebar
-  if (isInboxPage) {
+  // Approvals pages have their own layout with chat sidebar
+  if (isApprovalsPage) {
     return <>{children}</>
   }
 

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -2248,7 +2248,7 @@ Determines the context and behavior of the session:
 - AGENT_PRESET_BUILDER: Builder chat for editing/configuring a preset
 - COPILOT: Workspace-level copilot assistant
 - WORKFLOW: Workflow-initiated agent run (from action)
-- APPROVAL: Inbox approval continuation (hidden from main chat list)
+- APPROVAL: Approval continuation (hidden from main chat list)
 - EXTERNAL_CHANNEL: External channel session (e.g. Slack thread)`,
 } as const
 
@@ -2264,7 +2264,7 @@ export const $AgentSessionForkRequest = {
         },
       ],
       description:
-        "Override entity type for the forked session. Use 'approval' for inbox forks to hide from main chat list.",
+        "Override entity type for the forked session. Use 'approval' for approval forks to hide from main chat list.",
     },
   },
   type: "object",
@@ -3107,6 +3107,116 @@ export const $ApprovalInteraction = {
   required: ["type"],
   title: "ApprovalInteraction",
   description: "Configuration for an approval interaction.",
+} as const
+
+export const $ApprovalItemRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+      description: "Unique approval item ID",
+    },
+    type: {
+      $ref: "#/components/schemas/ApprovalItemType",
+      description: "Type of approval item",
+    },
+    title: {
+      type: "string",
+      title: "Title",
+      description: "Display title",
+    },
+    preview: {
+      type: "string",
+      title: "Preview",
+      description: "Preview text",
+    },
+    status: {
+      $ref: "#/components/schemas/ApprovalItemStatus",
+      description: "Item status",
+    },
+    unread: {
+      type: "boolean",
+      title: "Unread",
+      description: "Whether the item is unread",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+      description: "Creation timestamp",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+      description: "Last update timestamp",
+    },
+    workflow: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/WorkflowSummary",
+        },
+        {
+          type: "null",
+        },
+      ],
+      description: "Associated workflow",
+    },
+    source_id: {
+      type: "string",
+      format: "uuid",
+      title: "Source Id",
+      description: "ID of the source entity",
+    },
+    source_type: {
+      type: "string",
+      title: "Source Type",
+      description: "Type of source entity (e.g., agent_session)",
+    },
+    metadata: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Metadata",
+      description: "Type-specific metadata",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "type",
+    "title",
+    "preview",
+    "status",
+    "unread",
+    "created_at",
+    "updated_at",
+    "source_id",
+    "source_type",
+  ],
+  title: "ApprovalItemRead",
+  description: "Read model for approval items.",
+} as const
+
+export const $ApprovalItemStatus = {
+  type: "string",
+  enum: ["pending", "completed", "failed"],
+  title: "ApprovalItemStatus",
+  description: "Status of approval items.",
+} as const
+
+export const $ApprovalItemType = {
+  type: "string",
+  enum: ["approval"],
+  title: "ApprovalItemType",
+  description: "Types of approval items.",
 } as const
 
 export const $ApprovalMap = {
@@ -8134,11 +8244,11 @@ export const $ContinueRunRequest = {
     },
     source: {
       type: "string",
-      enum: ["inbox", "slack"],
+      enum: ["approval", "slack"],
       title: "Source",
       description:
-        "Origin of the approval decision submission. Use 'inbox' for Tracecat UI/API and 'slack' for Slack actions.",
-      default: "inbox",
+        "Origin of the approval decision submission. Use 'approval' for Tracecat UI/API and 'slack' for Slack actions.",
+      default: "approval",
     },
   },
   type: "object",
@@ -8254,6 +8364,69 @@ export const $CursorPaginatedResponse_AgentPresetVersionReadMinimal_ = {
   type: "object",
   required: ["items"],
   title: "CursorPaginatedResponse[AgentPresetVersionReadMinimal]",
+} as const
+
+export const $CursorPaginatedResponse_ApprovalItemRead_ = {
+  properties: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/ApprovalItemRead",
+      },
+      type: "array",
+      title: "Items",
+    },
+    next_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Cursor",
+      description: "Cursor for next page",
+    },
+    prev_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Prev Cursor",
+      description: "Cursor for previous page",
+    },
+    has_more: {
+      type: "boolean",
+      title: "Has More",
+      description: "Whether more items exist",
+      default: false,
+    },
+    has_previous: {
+      type: "boolean",
+      title: "Has Previous",
+      description: "Whether previous items exist",
+      default: false,
+    },
+    total_estimate: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Estimate",
+      description: "Estimated total count from table statistics",
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "CursorPaginatedResponse[ApprovalItemRead]",
 } as const
 
 export const $CursorPaginatedResponse_CaseReadMinimal_ = {
@@ -8380,69 +8553,6 @@ export const $CursorPaginatedResponse_CaseTableRowRead_ = {
   type: "object",
   required: ["items"],
   title: "CursorPaginatedResponse[CaseTableRowRead]",
-} as const
-
-export const $CursorPaginatedResponse_InboxItemRead_ = {
-  properties: {
-    items: {
-      items: {
-        $ref: "#/components/schemas/InboxItemRead",
-      },
-      type: "array",
-      title: "Items",
-    },
-    next_cursor: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Next Cursor",
-      description: "Cursor for next page",
-    },
-    prev_cursor: {
-      anyOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Prev Cursor",
-      description: "Cursor for previous page",
-    },
-    has_more: {
-      type: "boolean",
-      title: "Has More",
-      description: "Whether more items exist",
-      default: false,
-    },
-    has_previous: {
-      type: "boolean",
-      title: "Has Previous",
-      description: "Whether previous items exist",
-      default: false,
-    },
-    total_estimate: {
-      anyOf: [
-        {
-          type: "integer",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Total Estimate",
-      description: "Estimated total count from table statistics",
-    },
-  },
-  type: "object",
-  required: ["items"],
-  title: "CursorPaginatedResponse[InboxItemRead]",
 } as const
 
 export const $CursorPaginatedResponse_TableRowRead_ = {
@@ -11413,116 +11523,6 @@ distinguish multiple files.`,
   required: ["url", "media_type", "identifier"],
   title: "ImageUrl",
   description: "A URL to an image.",
-} as const
-
-export const $InboxItemRead = {
-  properties: {
-    id: {
-      type: "string",
-      format: "uuid",
-      title: "Id",
-      description: "Unique inbox item ID",
-    },
-    type: {
-      $ref: "#/components/schemas/InboxItemType",
-      description: "Type of inbox item",
-    },
-    title: {
-      type: "string",
-      title: "Title",
-      description: "Display title",
-    },
-    preview: {
-      type: "string",
-      title: "Preview",
-      description: "Preview text",
-    },
-    status: {
-      $ref: "#/components/schemas/InboxItemStatus",
-      description: "Item status",
-    },
-    unread: {
-      type: "boolean",
-      title: "Unread",
-      description: "Whether the item is unread",
-    },
-    created_at: {
-      type: "string",
-      format: "date-time",
-      title: "Created At",
-      description: "Creation timestamp",
-    },
-    updated_at: {
-      type: "string",
-      format: "date-time",
-      title: "Updated At",
-      description: "Last update timestamp",
-    },
-    workflow: {
-      anyOf: [
-        {
-          $ref: "#/components/schemas/WorkflowSummary",
-        },
-        {
-          type: "null",
-        },
-      ],
-      description: "Associated workflow",
-    },
-    source_id: {
-      type: "string",
-      format: "uuid",
-      title: "Source Id",
-      description: "ID of the source entity",
-    },
-    source_type: {
-      type: "string",
-      title: "Source Type",
-      description: "Type of source entity (e.g., agent_session)",
-    },
-    metadata: {
-      anyOf: [
-        {
-          additionalProperties: true,
-          type: "object",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Metadata",
-      description: "Type-specific metadata",
-    },
-  },
-  type: "object",
-  required: [
-    "id",
-    "type",
-    "title",
-    "preview",
-    "status",
-    "unread",
-    "created_at",
-    "updated_at",
-    "source_id",
-    "source_type",
-  ],
-  title: "InboxItemRead",
-  description: "Read model for inbox items.",
-} as const
-
-export const $InboxItemStatus = {
-  type: "string",
-  enum: ["pending", "completed", "failed"],
-  title: "InboxItemStatus",
-  description: "Status of inbox items.",
-} as const
-
-export const $InboxItemType = {
-  type: "string",
-  enum: ["approval"],
-  title: "InboxItemType",
-  description: "Types of inbox items.",
 } as const
 
 export const $InferredColumn = {
@@ -25068,7 +25068,7 @@ export const $WorkflowSummary = {
   type: "object",
   required: ["id", "title"],
   title: "WorkflowSummary",
-  description: "Summary of a workflow for inbox item context.",
+  description: "Summary of a workflow for approval item context.",
 } as const
 
 export const $WorkflowSyncPullRequest = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -148,6 +148,8 @@ import type {
   AgentSetDefaultModelResponse,
   AgentUpdateProviderCredentialsData,
   AgentUpdateProviderCredentialsResponse,
+  ApprovalsListApprovalsData,
+  ApprovalsListApprovalsResponse,
   ApprovalsSubmitApprovalsData,
   ApprovalsSubmitApprovalsResponse,
   AuthAuthDatabaseLoginData,
@@ -314,8 +316,6 @@ import type {
   GraphApplyGraphOperationsResponse,
   GraphGetGraphData,
   GraphGetGraphResponse,
-  InboxListItemsData,
-  InboxListItemsResponse,
   IntegrationsConnectProviderData,
   IntegrationsConnectProviderResponse,
   IntegrationsDeleteIntegrationData,
@@ -4719,7 +4719,7 @@ export const agentSessionsStreamSessionEvents = (
  * Creates a new session linked to the parent session, allowing users
  * to ask the agent for context after making approval decisions.
  *
- * Set entity_type to 'approval' for inbox forks to hide from main chat list.
+ * Set entity_type to 'approval' for approval forks to hide from main chat list.
  * @param data The data for the request.
  * @param data.sessionId
  * @param data.workspaceId
@@ -4775,7 +4775,7 @@ export const approvalsSubmitApprovals = (
   data: ApprovalsSubmitApprovalsData
 ): CancelablePromise<ApprovalsSubmitApprovalsResponse> => {
   return __request(OpenAPI, {
-    method: "POST",
+    method: "PATCH",
     url: "/approvals/{session_id}",
     path: {
       session_id: data.sessionId,
@@ -5751,8 +5751,8 @@ export const adminRegistryPromoteRegistryVersion = (
 }
 
 /**
- * List Items
- * List inbox items with cursor-based pagination.
+ * List Approvals
+ * List approval items with cursor-based pagination.
  *
  * Supports sorting by created_at, updated_at, or status.
  * Default sort is by created_at descending.
@@ -5763,15 +5763,15 @@ export const adminRegistryPromoteRegistryVersion = (
  * @param data.reverse
  * @param data.orderBy Column name to order by (created_at, updated_at, status)
  * @param data.sort Sort direction (asc or desc)
- * @returns CursorPaginatedResponse_InboxItemRead_ Successful Response
+ * @returns CursorPaginatedResponse_ApprovalItemRead_ Successful Response
  * @throws ApiError
  */
-export const inboxListItems = (
-  data: InboxListItemsData
-): CancelablePromise<InboxListItemsResponse> => {
+export const approvalsListApprovals = (
+  data: ApprovalsListApprovalsData
+): CancelablePromise<ApprovalsListApprovalsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/inbox/items",
+    url: "/approvals",
     query: {
       limit: data.limit,
       cursor: data.cursor,

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -518,7 +518,7 @@ export type AgentSessionCreate = {
  * - AGENT_PRESET_BUILDER: Builder chat for editing/configuring a preset
  * - COPILOT: Workspace-level copilot assistant
  * - WORKFLOW: Workflow-initiated agent run (from action)
- * - APPROVAL: Inbox approval continuation (hidden from main chat list)
+ * - APPROVAL: Approval continuation (hidden from main chat list)
  * - EXTERNAL_CHANNEL: External channel session (e.g. Slack thread)
  */
 export type AgentSessionEntity =
@@ -535,7 +535,7 @@ export type AgentSessionEntity =
  */
 export type AgentSessionForkRequest = {
   /**
-   * Override entity type for the forked session. Use 'approval' for inbox forks to hide from main chat list.
+   * Override entity type for the forked session. Use 'approval' for approval forks to hide from main chat list.
    */
   entity_type?: AgentSessionEntity | null
 }
@@ -757,6 +757,72 @@ export type ApprovalInteraction = {
    */
   approve_if?: string | null
 }
+
+/**
+ * Read model for approval items.
+ */
+export type ApprovalItemRead = {
+  /**
+   * Unique approval item ID
+   */
+  id: string
+  /**
+   * Type of approval item
+   */
+  type: ApprovalItemType
+  /**
+   * Display title
+   */
+  title: string
+  /**
+   * Preview text
+   */
+  preview: string
+  /**
+   * Item status
+   */
+  status: ApprovalItemStatus
+  /**
+   * Whether the item is unread
+   */
+  unread: boolean
+  /**
+   * Creation timestamp
+   */
+  created_at: string
+  /**
+   * Last update timestamp
+   */
+  updated_at: string
+  /**
+   * Associated workflow
+   */
+  workflow?: WorkflowSummary | null
+  /**
+   * ID of the source entity
+   */
+  source_id: string
+  /**
+   * Type of source entity (e.g., agent_session)
+   */
+  source_type: string
+  /**
+   * Type-specific metadata
+   */
+  metadata?: {
+    [key: string]: unknown
+  } | null
+}
+
+/**
+ * Status of approval items.
+ */
+export type ApprovalItemStatus = "pending" | "completed" | "failed"
+
+/**
+ * Types of approval items.
+ */
+export type ApprovalItemType = "approval"
 
 export type ApprovalMap = {
   [key: string]: boolean | ToolApproved | ToolDenied
@@ -2328,15 +2394,15 @@ export type ContinueRunRequest = {
   kind?: "continue"
   decisions: Array<ApprovalDecision>
   /**
-   * Origin of the approval decision submission. Use 'inbox' for Tracecat UI/API and 'slack' for Slack actions.
+   * Origin of the approval decision submission. Use 'approval' for Tracecat UI/API and 'slack' for Slack actions.
    */
-  source?: "inbox" | "slack"
+  source?: "approval" | "slack"
 }
 
 /**
- * Origin of the approval decision submission. Use 'inbox' for Tracecat UI/API and 'slack' for Slack actions.
+ * Origin of the approval decision submission. Use 'approval' for Tracecat UI/API and 'slack' for Slack actions.
  */
-export type source = "inbox" | "slack"
+export type source = "approval" | "slack"
 
 /**
  * Event for when a case is created.
@@ -2359,6 +2425,30 @@ export type CreatedEventRead = {
 
 export type CursorPaginatedResponse_AgentPresetVersionReadMinimal_ = {
   items: Array<AgentPresetVersionReadMinimal>
+  /**
+   * Cursor for next page
+   */
+  next_cursor?: string | null
+  /**
+   * Cursor for previous page
+   */
+  prev_cursor?: string | null
+  /**
+   * Whether more items exist
+   */
+  has_more?: boolean
+  /**
+   * Whether previous items exist
+   */
+  has_previous?: boolean
+  /**
+   * Estimated total count from table statistics
+   */
+  total_estimate?: number | null
+}
+
+export type CursorPaginatedResponse_ApprovalItemRead_ = {
+  items: Array<ApprovalItemRead>
   /**
    * Cursor for next page
    */
@@ -2407,30 +2497,6 @@ export type CursorPaginatedResponse_CaseReadMinimal_ = {
 
 export type CursorPaginatedResponse_CaseTableRowRead_ = {
   items: Array<CaseTableRowRead>
-  /**
-   * Cursor for next page
-   */
-  next_cursor?: string | null
-  /**
-   * Cursor for previous page
-   */
-  prev_cursor?: string | null
-  /**
-   * Whether more items exist
-   */
-  has_more?: boolean
-  /**
-   * Whether previous items exist
-   */
-  has_previous?: boolean
-  /**
-   * Estimated total count from table statistics
-   */
-  total_estimate?: number | null
-}
-
-export type CursorPaginatedResponse_InboxItemRead_ = {
-  items: Array<InboxItemRead>
   /**
    * Cursor for next page
    */
@@ -3513,72 +3579,6 @@ export type ImageUrl = {
    */
   readonly identifier: string
 }
-
-/**
- * Read model for inbox items.
- */
-export type InboxItemRead = {
-  /**
-   * Unique inbox item ID
-   */
-  id: string
-  /**
-   * Type of inbox item
-   */
-  type: InboxItemType
-  /**
-   * Display title
-   */
-  title: string
-  /**
-   * Preview text
-   */
-  preview: string
-  /**
-   * Item status
-   */
-  status: InboxItemStatus
-  /**
-   * Whether the item is unread
-   */
-  unread: boolean
-  /**
-   * Creation timestamp
-   */
-  created_at: string
-  /**
-   * Last update timestamp
-   */
-  updated_at: string
-  /**
-   * Associated workflow
-   */
-  workflow?: WorkflowSummary | null
-  /**
-   * ID of the source entity
-   */
-  source_id: string
-  /**
-   * Type of source entity (e.g., agent_session)
-   */
-  source_type: string
-  /**
-   * Type-specific metadata
-   */
-  metadata?: {
-    [key: string]: unknown
-  } | null
-}
-
-/**
- * Status of inbox items.
- */
-export type InboxItemStatus = "pending" | "completed" | "failed"
-
-/**
- * Types of inbox items.
- */
-export type InboxItemType = "approval"
 
 /**
  * Inferred column mapping between CSV headers and table columns.
@@ -7645,7 +7645,7 @@ export type WorkflowRunReadMinimal = {
 }
 
 /**
- * Summary of a workflow for inbox item context.
+ * Summary of a workflow for approval item context.
  */
 export type WorkflowSummary = {
   /**
@@ -9428,7 +9428,7 @@ export type AdminRegistryPromoteRegistryVersionData = {
 export type AdminRegistryPromoteRegistryVersionResponse =
   tracecat__admin__registry__schemas__RegistryVersionPromoteResponse
 
-export type InboxListItemsData = {
+export type ApprovalsListApprovalsData = {
   cursor?: string | null
   limit?: number
   /**
@@ -9443,7 +9443,8 @@ export type InboxListItemsData = {
   workspaceId: string
 }
 
-export type InboxListItemsResponse = CursorPaginatedResponse_InboxItemRead_
+export type ApprovalsListApprovalsResponse =
+  CursorPaginatedResponse_ApprovalItemRead_
 
 export type EditorListFunctionsData = {
   workspaceId: string
@@ -13019,7 +13020,7 @@ export type $OpenApiTs = {
     }
   }
   "/approvals/{session_id}": {
-    post: {
+    patch: {
       req: ApprovalsSubmitApprovalsData
       res: {
         /**
@@ -13601,14 +13602,14 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/inbox/items": {
+  "/approvals": {
     get: {
-      req: InboxListItemsData
+      req: ApprovalsListApprovalsData
       res: {
         /**
          * Successful Response
          */
-        200: CursorPaginatedResponse_InboxItemRead_
+        200: CursorPaginatedResponse_ApprovalItemRead_
         /**
          * Validation Error
          */

--- a/frontend/src/components/approvals/activity-accordion.tsx
+++ b/frontend/src/components/approvals/activity-accordion.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react"
 import { useMemo } from "react"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import type { AgentDerivedStatus, InboxSessionItem } from "@/lib/agents"
+import type { AgentDerivedStatus, ApprovalSessionItem } from "@/lib/agents"
 import { cn } from "@/lib/utils"
 import { ActivityItem } from "./activity-item"
 
@@ -60,7 +60,7 @@ const GROUP_ORDER: StatusGroup[] = [
 ]
 
 interface ActivityAccordionProps {
-  sessions: InboxSessionItem[]
+  sessions: ApprovalSessionItem[]
   selectedId: string | null
   onSelect: (id: string) => void
 }
@@ -72,7 +72,7 @@ export function ActivityAccordion({
 }: ActivityAccordionProps) {
   // Group sessions by status category
   const groupedSessions = useMemo(() => {
-    const groups: Record<StatusGroup, InboxSessionItem[]> = {
+    const groups: Record<StatusGroup, ApprovalSessionItem[]> = {
       review_required: [],
       running: [],
       error: [],

--- a/frontend/src/components/approvals/activity-item.tsx
+++ b/frontend/src/components/approvals/activity-item.tsx
@@ -10,11 +10,11 @@ import {
   EventUpdatedAt,
 } from "@/components/cases/cases-feed-event"
 import { Badge } from "@/components/ui/badge"
-import type { InboxSessionItem } from "@/lib/agents"
+import type { ApprovalSessionItem } from "@/lib/agents"
 import { cn } from "@/lib/utils"
 
 interface ActivityItemProps {
-  session: InboxSessionItem
+  session: ApprovalSessionItem
   isSelected: boolean
   onClick: () => void
 }

--- a/frontend/src/components/approvals/approvals-chat.tsx
+++ b/frontend/src/components/approvals/approvals-chat.tsx
@@ -2,15 +2,15 @@
 
 import { useEffect, useState } from "react"
 import { agentSessionsListSessions } from "@/client"
-import type { InboxSessionItem } from "@/lib/agents"
+import type { ApprovalSessionItem } from "@/lib/agents"
 import { useWorkspaceId } from "@/providers/workspace-id"
-import { InboxDetail } from "./inbox-detail"
+import { ApprovalsDetail } from "./approvals-detail"
 
-interface InboxChatProps {
-  session: InboxSessionItem
+interface ApprovalsChatProps {
+  session: ApprovalSessionItem
 }
 
-export function InboxChat({ session }: InboxChatProps) {
+export function ApprovalsChat({ session }: ApprovalsChatProps) {
   const workspaceId = useWorkspaceId()
 
   // Track the forked session ID and pending message
@@ -71,7 +71,7 @@ export function InboxChat({ session }: InboxChatProps) {
   }
 
   return (
-    <InboxDetail
+    <ApprovalsDetail
       key={activeSessionId}
       sessionId={activeSessionId}
       parentSessionId={session.id}

--- a/frontend/src/components/approvals/approvals-detail.tsx
+++ b/frontend/src/components/approvals/approvals-detail.tsx
@@ -9,15 +9,15 @@ import { NoMessages } from "@/components/chat/messages"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { toast } from "@/components/ui/use-toast"
 import { useGetChatVercel } from "@/hooks/use-chat"
-import type { InboxSessionItem } from "@/lib/agents"
+import type { ApprovalSessionItem } from "@/lib/agents"
 import { useChatReadiness } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
-interface InboxDetailProps {
+interface ApprovalsDetailProps {
   sessionId: string
   /** The original parent session ID - used for forking */
   parentSessionId: string
-  session: InboxSessionItem
+  session: ApprovalSessionItem
   /** Called after successfully forking, passes the forked session ID and the message to send */
   onForked?: (forkedSessionId: string, pendingMessage: string) => void
   /** Message to send immediately (passed from parent after fork) */
@@ -26,14 +26,14 @@ interface InboxDetailProps {
   onPendingMessageSent?: () => void
 }
 
-export function InboxDetail({
+export function ApprovalsDetail({
   sessionId,
   parentSessionId,
   session,
   onForked,
   pendingMessage,
   onPendingMessageSent,
-}: InboxDetailProps) {
+}: ApprovalsDetailProps) {
   const workspaceId = useWorkspaceId()
   const [isForking, setIsForking] = useState(false)
   const forkingRef = useRef(false)

--- a/frontend/src/components/approvals/approvals-header.tsx
+++ b/frontend/src/components/approvals/approvals-header.tsx
@@ -21,7 +21,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
-import type { DateFilterValue } from "@/hooks/use-inbox"
+import type { DateFilterValue } from "@/hooks/use-approvals"
 import { cn } from "@/lib/utils"
 
 const ENTITY_TYPE_OPTIONS: Array<{
@@ -52,7 +52,7 @@ const DATE_FILTER_OPTIONS: Array<{
   { value: "1m", label: "1 month ago" },
 ]
 
-interface InboxHeaderProps {
+interface ApprovalsHeaderProps {
   searchQuery: string
   onSearchChange: (query: string) => void
   entityType: AgentSessionEntity | "all"
@@ -65,7 +65,7 @@ interface InboxHeaderProps {
   onCreatedAfterChange: (value: DateFilterValue) => void
 }
 
-export function InboxHeader({
+export function ApprovalsHeader({
   searchQuery,
   onSearchChange,
   entityType,
@@ -76,7 +76,7 @@ export function InboxHeader({
   onUpdatedAfterChange,
   createdAfter,
   onCreatedAfterChange,
-}: InboxHeaderProps) {
+}: ApprovalsHeaderProps) {
   // Count only non-default filters (don't count limit since it always has a value)
   const activeFilterCount =
     (entityType !== "all" ? 1 : 0) +

--- a/frontend/src/components/approvals/index.tsx
+++ b/frontend/src/components/approvals/index.tsx
@@ -1,21 +1,21 @@
 "use client"
 
 import { useEffect } from "react"
-import { useInboxChat } from "@/app/workspaces/[workspaceId]/inbox/layout"
+import { useApprovalsChat } from "@/app/workspaces/[workspaceId]/approvals/layout"
 import type { AgentSessionEntity } from "@/client"
 import { CenteredSpinner } from "@/components/loading/spinner"
-import type { DateFilterValue, UseInboxFilters } from "@/hooks/use-inbox"
-import type { InboxSessionItem } from "@/lib/agents"
+import type { DateFilterValue, UseApprovalFilters } from "@/hooks/use-approvals"
+import type { ApprovalSessionItem } from "@/lib/agents"
 import { ActivityAccordion } from "./activity-accordion"
-import { InboxHeader } from "./inbox-header"
+import { ApprovalsHeader } from "./approvals-header"
 
 interface ActivityLayoutProps {
-  sessions: InboxSessionItem[]
+  sessions: ApprovalSessionItem[]
   selectedId: string | null
   onSelect: (id: string | null) => void
   isLoading: boolean
   error: Error | null
-  filters: UseInboxFilters
+  filters: UseApprovalFilters
   onSearchChange: (query: string) => void
   onEntityTypeChange: (type: AgentSessionEntity | "all") => void
   onLimitChange: (limit: number) => void
@@ -36,7 +36,8 @@ export function ActivityLayout({
   onUpdatedAfterChange,
   onCreatedAfterChange,
 }: ActivityLayoutProps) {
-  const { setSelectedSession, setChatOpen, registerOnClose } = useInboxChat()
+  const { setSelectedSession, setChatOpen, registerOnClose } =
+    useApprovalsChat()
 
   // Sync selected session with layout context
   const selectedSession = sessions.find((s) => s.id === selectedId) ?? null
@@ -58,7 +59,7 @@ export function ActivityLayout({
   if (isLoading) {
     return (
       <div className="flex size-full flex-col">
-        <InboxHeader
+        <ApprovalsHeader
           searchQuery={filters.searchQuery}
           onSearchChange={onSearchChange}
           entityType={filters.entityType}
@@ -80,7 +81,7 @@ export function ActivityLayout({
   if (error) {
     return (
       <div className="flex size-full flex-col">
-        <InboxHeader
+        <ApprovalsHeader
           searchQuery={filters.searchQuery}
           onSearchChange={onSearchChange}
           entityType={filters.entityType}
@@ -103,7 +104,7 @@ export function ActivityLayout({
 
   return (
     <div className="flex size-full flex-col">
-      <InboxHeader
+      <ApprovalsHeader
         searchQuery={filters.searchQuery}
         onSearchChange={onSearchChange}
         entityType={filters.entityType}

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -198,7 +198,7 @@ export interface ChatSessionPaneProps {
    * Called before sending a message. If provided, receives the message text
    * and should handle sending it (e.g., to a forked session). Returns the
    * new session ID to switch to, or null to cancel.
-   * Used for inbox fork-on-send behavior.
+   * Used for approval fork-on-send behavior.
    */
   onBeforeSend?: (
     messageText: string,

--- a/frontend/src/components/nav/controls-header.tsx
+++ b/frontend/src/components/nav/controls-header.tsx
@@ -1733,12 +1733,6 @@ function getPageConfig(
     }
   }
 
-  if (pagePath.startsWith("/inbox")) {
-    return {
-      title: "Inbox",
-    }
-  }
-
   return null
 }
 

--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -4,10 +4,8 @@ import {
   BlocksIcon,
   BoxIcon,
   ChevronDown,
-  InboxIcon,
   KeyRound,
   LayersIcon,
-  LayersPlus,
   ListVideoIcon,
   type LucideIcon,
   Plus,
@@ -22,7 +20,6 @@ import type * as React from "react"
 import { useEffect, useRef, useState } from "react"
 import type { AgentPresetReadMinimal } from "@/client"
 import { useScopeCheck } from "@/components/auth/scope-guard"
-import { CreateCaseDialog } from "@/components/cases/case-create-dialog"
 import {
   LockedFeatureChip,
   LockedFeatureModal,
@@ -74,7 +71,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const casesListPath = `${basePath}/cases`
   const isCasesList = pathname === casesListPath
   const isAgentsRoute = pathname?.startsWith(`${basePath}/agents`) ?? false
-  const [createCaseDialogOpen, setCreateCaseDialogOpen] = useState(false)
   const [lockedFeatureDialogOpen, setLockedFeatureDialogOpen] = useState(false)
   const [agentsSectionOpen, setAgentsSectionOpen] = useState(isAgentsRoute)
 
@@ -116,7 +112,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const canViewInbox = useScopeCheck("inbox:read")
   const canViewMembers = useScopeCheck("workspace:member:read")
   const canViewCases = useScopeCheck("case:read")
-  const canCreateCase = useScopeCheck("case:create")
   const shouldLoadAgentsSection =
     canViewAgents === true && (agentsSectionOpen || isAgentsRoute)
   const { hasEntitlement, isLoading: entitlementsIsLoading } = useEntitlements({
@@ -189,10 +184,31 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     },
     {
       title: "Actions",
-      url: `${basePath}/actions`,
       icon: BoxIcon,
-      isActive: pathname?.startsWith(`${basePath}/actions`),
-      visible: canViewActions === true,
+      isActive:
+        pathname?.startsWith(`${basePath}/actions`) ||
+        pathname?.startsWith(`${basePath}/inbox`),
+      visible: canViewActions === true || canViewInbox === true,
+      items: [
+        ...(canViewActions === true
+          ? [
+              {
+                title: "Registry",
+                url: `${basePath}/actions`,
+                isActive: pathname?.startsWith(`${basePath}/actions`),
+              },
+            ]
+          : []),
+        ...(canViewInbox === true
+          ? [
+              {
+                title: "Approvals",
+                url: `${basePath}/inbox`,
+                isActive: pathname?.startsWith(`${basePath}/inbox`),
+              },
+            ]
+          : []),
+      ],
     },
   ]
 
@@ -206,39 +222,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           open={lockedFeatureDialogOpen}
           onOpenChange={setLockedFeatureDialogOpen}
         />
-        <SidebarGroup>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {canCreateCase === true && (
-                <SidebarMenuItem>
-                  <SidebarMenuButton
-                    onClick={() => setCreateCaseDialogOpen(true)}
-                  >
-                    <LayersPlus />
-                    <span>Add case</span>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              )}
-              {canViewInbox === true && (
-                <SidebarMenuItem>
-                  <SidebarMenuButton
-                    asChild
-                    isActive={pathname?.startsWith(`${basePath}/inbox`)}
-                  >
-                    <Link href={`${basePath}/inbox`}>
-                      <InboxIcon />
-                      <span>Inbox</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              )}
-            </SidebarMenu>
-            <CreateCaseDialog
-              open={createCaseDialogOpen}
-              onOpenChange={setCreateCaseDialogOpen}
-            />
-          </SidebarGroupContent>
-        </SidebarGroup>
         {navWorkspace.some((item) => item.visible === true) && (
           <Collapsible defaultOpen className="group/collapsible">
             <SidebarGroup>

--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -109,7 +109,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const canViewSecrets = useScopeCheck("secret:read")
   const canViewIntegrations = useScopeCheck("integration:read")
   const canViewActions = useScopeCheck("org:registry:read")
-  const canViewInbox = useScopeCheck("inbox:read")
+  const canViewApprovals = useScopeCheck("approval:read")
   const canViewMembers = useScopeCheck("workspace:member:read")
   const canViewCases = useScopeCheck("case:read")
   const shouldLoadAgentsSection =
@@ -187,8 +187,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       icon: BoxIcon,
       isActive:
         pathname?.startsWith(`${basePath}/actions`) ||
-        pathname?.startsWith(`${basePath}/inbox`),
-      visible: canViewActions === true || canViewInbox === true,
+        pathname?.startsWith(`${basePath}/approvals`),
+      visible: canViewActions === true || canViewApprovals === true,
       items: [
         ...(canViewActions === true
           ? [
@@ -199,12 +199,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               },
             ]
           : []),
-        ...(canViewInbox === true
+        ...(canViewApprovals === true
           ? [
               {
                 title: "Approvals",
-                url: `${basePath}/inbox`,
-                isActive: pathname?.startsWith(`${basePath}/inbox`),
+                url: `${basePath}/approvals`,
+                isActive: pathname?.startsWith(`${basePath}/approvals`),
               },
             ]
           : []),

--- a/frontend/src/hooks/use-approvals.ts
+++ b/frontend/src/hooks/use-approvals.ts
@@ -4,28 +4,28 @@ import { type Query, useQuery } from "@tanstack/react-query"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import {
   type AgentSessionEntity,
-  type InboxItemRead,
-  type InboxItemStatus,
-  type InboxListItemsResponse,
-  inboxListItems,
+  type ApprovalItemRead,
+  type ApprovalItemStatus,
+  type ApprovalsListApprovalsResponse,
+  approvalsListApprovals,
 } from "@/client"
 import {
   type AgentDerivedStatus,
   type AgentStatusTone,
+  type ApprovalSessionItem,
   getAgentStatusMetadata,
-  type InboxSessionItem,
 } from "@/lib/agents"
 import { retryHandler, type TracecatApiError } from "@/lib/errors"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
-export interface UseInboxOptions {
+export interface UseApprovalOptions {
   enabled?: boolean
   autoRefresh?: boolean
 }
 
 export type DateFilterValue = "1d" | "3d" | "1w" | "1m" | null
 
-export interface UseInboxFilters {
+export interface UseApprovalFilters {
   searchQuery: string
   entityType: AgentSessionEntity | "all"
   limit: number
@@ -33,14 +33,14 @@ export interface UseInboxFilters {
   createdAfter: DateFilterValue
 }
 
-export interface UseInboxResult {
-  sessions: InboxSessionItem[]
+export interface UseApprovalResult {
+  sessions: ApprovalSessionItem[]
   selectedId: string | null
   setSelectedId: (id: string | null) => void
   isLoading: boolean
   error: Error | null
   refetch: () => void
-  filters: UseInboxFilters
+  filters: UseApprovalFilters
   setSearchQuery: (query: string) => void
   setEntityType: (type: AgentSessionEntity | "all") => void
   setLimit: (limit: number) => void
@@ -49,7 +49,7 @@ export interface UseInboxResult {
 }
 
 /**
- * Maps InboxItemStatus to the derived status and display properties used by the UI.
+ * Maps ApprovalItemStatus to the derived status and display properties used by the UI.
  */
 const TEMPORAL_DERIVED_STATUSES = new Set<AgentDerivedStatus>([
   "RUNNING",
@@ -62,11 +62,11 @@ const TEMPORAL_DERIVED_STATUSES = new Set<AgentDerivedStatus>([
   "UNKNOWN",
 ])
 
-function mapInboxStatusToAgentStatus(
-  status: InboxItemStatus,
+function mapApprovalStatusToAgentStatus(
+  status: ApprovalItemStatus,
   temporalStatusRaw: string | null
 ): {
-  derivedStatus: InboxSessionItem["derivedStatus"]
+  derivedStatus: ApprovalSessionItem["derivedStatus"]
   statusLabel: string
   statusPriority: number
   statusTone: AgentStatusTone
@@ -118,15 +118,20 @@ function mapInboxStatusToAgentStatus(
 }
 
 /**
- * Converts an InboxItemRead to the InboxSessionItem format expected by UI components.
- * This bridges the inbox API with inbox UI components.
+ * Converts an ApprovalItemRead to the ApprovalSessionItem format expected by UI components.
+ * This bridges the approvals API with approvals UI components.
  */
-function inboxItemToSessionItem(item: InboxItemRead): InboxSessionItem {
+function approvalItemToSessionItem(
+  item: ApprovalItemRead
+): ApprovalSessionItem {
   const temporalStatusRaw =
     typeof item.metadata?.temporal_status === "string"
       ? item.metadata.temporal_status
       : null
-  const statusInfo = mapInboxStatusToAgentStatus(item.status, temporalStatusRaw)
+  const statusInfo = mapApprovalStatusToAgentStatus(
+    item.status,
+    temporalStatusRaw
+  )
 
   return {
     // Core session fields - use source_id as the session identifier
@@ -137,7 +142,7 @@ function inboxItemToSessionItem(item: InboxItemRead): InboxSessionItem {
     created_at: item.created_at,
     updated_at: item.updated_at,
 
-    // Workflow metadata from inbox item
+    // Workflow metadata from approval item
     parent_workflow: item.workflow
       ? {
           id: item.workflow.id,
@@ -146,7 +151,7 @@ function inboxItemToSessionItem(item: InboxItemRead): InboxSessionItem {
         }
       : null,
 
-    // Status fields derived from inbox status
+    // Status fields derived from approval status
     ...statusInfo,
     pendingApprovalCount:
       (item.metadata?.pending_count as number) ??
@@ -171,7 +176,9 @@ function getDateFromFilter(filter: DateFilterValue): Date | null {
   }
 }
 
-export function useInbox(options: UseInboxOptions = {}): UseInboxResult {
+export function useApprovals(
+  options: UseApprovalOptions = {}
+): UseApprovalResult {
   const { enabled = true, autoRefresh = true } = options
   const workspaceId = useWorkspaceId()
   const [selectedId, setSelectedId] = useState<string | null>(null)
@@ -184,7 +191,7 @@ export function useInbox(options: UseInboxOptions = {}): UseInboxResult {
   const [createdAfter, setCreatedAfter] = useState<DateFilterValue>(null)
 
   /**
-   * Computes the refetch interval for inbox items based on current state.
+   * Computes the refetch interval for approval items based on current state.
    *
    * Returns `false` to disable polling when:
    * - Auto-refresh is disabled
@@ -197,9 +204,9 @@ export function useInbox(options: UseInboxOptions = {}): UseInboxResult {
   const computeRefetchInterval = useCallback(
     (
       query: Query<
-        InboxListItemsResponse,
+        ApprovalsListApprovalsResponse,
         TracecatApiError,
-        InboxListItemsResponse,
+        ApprovalsListApprovalsResponse,
         readonly unknown[]
       >
     ) => {
@@ -238,23 +245,27 @@ export function useInbox(options: UseInboxOptions = {}): UseInboxResult {
     [autoRefresh]
   )
 
-  // Fetch inbox items from the unified inbox endpoint
+  // Fetch approval items from the unified approvals endpoint.
   // This endpoint properly aggregates approval status from the backend
   const {
     data: sessions,
     isLoading,
     error,
     refetch,
-  } = useQuery<InboxListItemsResponse, TracecatApiError, InboxSessionItem[]>({
-    queryKey: ["inbox-items", workspaceId, limit],
+  } = useQuery<
+    ApprovalsListApprovalsResponse,
+    TracecatApiError,
+    ApprovalSessionItem[]
+  >({
+    queryKey: ["approval-items", workspaceId, limit],
     queryFn: () =>
-      inboxListItems({
+      approvalsListApprovals({
         workspaceId,
         limit,
       }),
     select: (data) => {
-      // Convert inbox items to session format and sort by priority
-      const converted = data.items.map(inboxItemToSessionItem)
+      // Convert approval items to session format and sort by priority
+      const converted = data.items.map(approvalItemToSessionItem)
       // Sort by status priority (pending approvals first), then by updated_at (most recent first)
       return converted.sort((a, b) => {
         if (a.statusPriority !== b.statusPriority) {

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -414,7 +414,7 @@ export function useVercelChat({
           const body: ContinueRunRequest = {
             kind: "continue",
             decisions: dataPart.data.decisions,
-            source: dataPart.data.source ?? "inbox",
+            source: dataPart.data.source ?? "approval",
           }
           return { body }
         }
@@ -470,7 +470,7 @@ export type ApprovalCard = {
  */
 export function makeContinueMessage(
   decisions: ContinueRunRequest["decisions"],
-  source: ContinueRunRequest["source"] = "inbox"
+  source: ContinueRunRequest["source"] = "approval"
 ): UIMessage {
   return {
     id: `continue-${Date.now()}`,

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -138,12 +138,12 @@ export type AgentSessionWithStatus = AgentSessionReadWithMeta & {
 }
 
 /**
- * Minimal inbox item type for the inbox list view.
- * This is a simpler type that works with the unified inbox API
- * while maintaining compatibility with inbox UI components.
+ * Minimal approval item type for the approvals list view.
+ * This is a simpler type that works with the unified approvals API
+ * while maintaining compatibility with approvals UI components.
  */
-export interface InboxSessionItem {
-  /** The agent session ID (source_id from inbox API) */
+export interface ApprovalSessionItem {
+  /** The agent session ID (source_id from approvals API) */
   id: string
   title: string
   entity_type: string

--- a/frontend/src/lib/approvals.ts
+++ b/frontend/src/lib/approvals.ts
@@ -1,13 +1,13 @@
 /**
- * Inbox utilities for the Linear-style inbox UI.
+ * Approval queue utilities for the approvals UI.
  */
 
-import type { InboxItemStatus } from "@/client"
+import type { ApprovalItemStatus } from "@/client"
 
 /**
  * Get display color class for status badge.
  */
-export function getStatusBadgeClass(status: InboxItemStatus): string {
+export function getStatusBadgeClass(status: ApprovalItemStatus): string {
   switch (status) {
     case "pending":
       return "border-amber-500/50 text-amber-600"

--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
@@ -69,7 +69,7 @@ def _to_approval_decisions(approvals: ApprovalMap) -> list[ApprovalDecision]:
     return decisions
 
 
-@router.post("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.patch("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def submit_approvals(
     *,
     role: WorkspaceUserRole,
@@ -114,7 +114,7 @@ async def submit_approvals(
         decisions = _to_approval_decisions(payload.approvals)
         continuation = ContinueRunRequest(
             decisions=decisions,
-            source="inbox",
+            source="approval",
         )
         await session_service.run_turn(session_id, continuation)
     except TracecatNotFoundError as exc:

--- a/packages/tracecat-ee/tracecat_ee/agent/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/router.py
@@ -69,7 +69,7 @@ def _to_approval_decisions(approvals: ApprovalMap) -> list[ApprovalDecision]:
     return decisions
 
 
-@router.post("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.patch("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def submit_approvals(
     *,
     role: WorkspaceUserRole,
@@ -114,7 +114,7 @@ async def submit_approvals(
         decisions = _to_approval_decisions(payload.approvals)
         continuation = ContinueRunRequest(
             decisions=decisions,
-            source="inbox",
+            source="approval",
         )
         await session_service.run_turn(session_id, continuation)
     except TracecatNotFoundError as exc:

--- a/packages/tracecat-ee/tracecat_ee/approvals/__init__.py
+++ b/packages/tracecat-ee/tracecat_ee/approvals/__init__.py
@@ -1,0 +1,1 @@
+"""EE approvals module for enterprise notification features."""

--- a/packages/tracecat-ee/tracecat_ee/approvals/providers/__init__.py
+++ b/packages/tracecat-ee/tracecat_ee/approvals/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Approvals providers for EE features."""

--- a/packages/tracecat-ee/tracecat_ee/approvals/providers/approvals.py
+++ b/packages/tracecat-ee/tracecat_ee/approvals/providers/approvals.py
@@ -1,4 +1,4 @@
-"""Approvals inbox provider for workflow-initiated agent sessions."""
+"""Approvals provider for workflow-initiated agent sessions."""
 
 from __future__ import annotations
 
@@ -11,11 +11,11 @@ from sqlalchemy import and_, or_, select
 from temporalio.client import WorkflowExecutionStatus
 
 from tracecat.agent.approvals.enums import ApprovalStatus
+from tracecat.approvals.schemas import ApprovalItemRead, WorkflowSummary
+from tracecat.approvals.types import ApprovalItemStatus, ApprovalItemType
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.models import AgentSession, Approval, Workflow
 from tracecat.dsl.client import get_temporal_client
-from tracecat.inbox.schemas import InboxItemRead, WorkflowSummary
-from tracecat.inbox.types import InboxItemStatus, InboxItemType
 from tracecat.logger import logger
 from tracecat.pagination import BaseCursorPaginator, CursorPaginatedResponse
 from tracecat_ee.agent.types import AgentWorkflowID
@@ -34,8 +34,8 @@ if TYPE_CHECKING:
     from tracecat.auth.types import Role
 
 
-class ApprovalsInboxProvider(BaseCursorPaginator):
-    """Provides approval items for the inbox.
+class ApprovalsProvider(BaseCursorPaginator):
+    """Provides approval items for the approvals queue.
 
     Filters to workflow-initiated sessions only and enriches with workflow metadata.
     """
@@ -77,7 +77,7 @@ class ApprovalsInboxProvider(BaseCursorPaginator):
                 return session_id, description.status
             except Exception as exc:
                 logger.warning(
-                    "Failed to describe agent workflow for inbox status",
+                    "Failed to describe agent workflow for approval status",
                     session_id=str(session_id),
                     run_id=str(run_id),
                     error=str(exc),
@@ -96,7 +96,7 @@ class ApprovalsInboxProvider(BaseCursorPaginator):
                 statuses[session_id] = status
         return statuses
 
-    async def list_items(
+    async def list_approvals(
         self,
         *,
         limit: int = 20,
@@ -104,7 +104,7 @@ class ApprovalsInboxProvider(BaseCursorPaginator):
         reverse: bool = False,
         order_by: str | None = None,
         sort: Literal["asc", "desc"] | None = None,
-    ) -> CursorPaginatedResponse[InboxItemRead]:
+    ) -> CursorPaginatedResponse[ApprovalItemRead]:
         """List workflow approval items with cursor pagination."""
         # Base query for workflow-initiated sessions with approvals
         base_stmt = (
@@ -272,8 +272,8 @@ class ApprovalsInboxProvider(BaseCursorPaginator):
     async def _enrich_sessions(
         self,
         sessions: Sequence[AgentSession],
-    ) -> list[InboxItemRead]:
-        """Transform sessions to inbox items with workflow metadata."""
+    ) -> list[ApprovalItemRead]:
+        """Transform sessions to approval items with workflow metadata."""
         if not sessions:
             return []
 
@@ -306,8 +306,8 @@ class ApprovalsInboxProvider(BaseCursorPaginator):
             workflows = workflow_result.scalars().all()
             workflows_by_id = {w.id: w for w in workflows}
 
-        # Transform to InboxItemRead
-        items: list[InboxItemRead] = []
+        # Transform to ApprovalItemRead
+        items: list[ApprovalItemRead] = []
         for session in sessions:
             session_approvals = approvals_by_session.get(session.id, [])
 
@@ -322,13 +322,13 @@ class ApprovalsInboxProvider(BaseCursorPaginator):
             temporal_status_name = temporal_status.name if temporal_status else None
 
             if pending_count > 0:
-                status = InboxItemStatus.PENDING
+                status = ApprovalItemStatus.PENDING
             elif temporal_status in FAILED_STATUSES:
-                status = InboxItemStatus.FAILED
+                status = ApprovalItemStatus.FAILED
             elif failed_count > 0:
-                status = InboxItemStatus.FAILED
+                status = ApprovalItemStatus.FAILED
             else:
-                status = InboxItemStatus.COMPLETED
+                status = ApprovalItemStatus.COMPLETED
 
             # Build preview text
             if pending_count > 0:
@@ -353,7 +353,7 @@ class ApprovalsInboxProvider(BaseCursorPaginator):
                     title=workflow.title or "Untitled workflow",
                     alias=workflow.alias,
                 )
-                # Use workflow alias or title as the inbox item title
+                # Use workflow alias or title as the approval item title
                 title = workflow.alias or workflow.title or title
 
             # Build metadata
@@ -374,9 +374,9 @@ class ApprovalsInboxProvider(BaseCursorPaginator):
             }
 
             items.append(
-                InboxItemRead(
+                ApprovalItemRead(
                     id=session.id,
-                    type=InboxItemType.APPROVAL,
+                    type=ApprovalItemType.APPROVAL,
                     title=title,
                     preview=preview,
                     status=status,

--- a/packages/tracecat-ee/tracecat_ee/inbox/__init__.py
+++ b/packages/tracecat-ee/tracecat_ee/inbox/__init__.py
@@ -1,1 +1,0 @@
-"""EE Inbox module for enterprise notification features."""

--- a/packages/tracecat-ee/tracecat_ee/inbox/providers/__init__.py
+++ b/packages/tracecat-ee/tracecat_ee/inbox/providers/__init__.py
@@ -1,1 +1,0 @@
-"""Inbox providers for EE features."""

--- a/tests/unit/api/test_api_workflow_execution_search.py
+++ b/tests/unit/api/test_api_workflow_execution_search.py
@@ -64,10 +64,17 @@ async def test_list_workflow_executions_excludes_agent_workflow_types(
     mock_service = AsyncMock()
     mock_service.list_executions = AsyncMock(return_value=[])
 
-    with patch.object(
-        executions_router.WorkflowExecutionsService,
-        "connect",
-        AsyncMock(return_value=mock_service),
+    with (
+        patch.object(
+            executions_router.WorkflowExecutionsService,
+            "connect",
+            AsyncMock(return_value=mock_service),
+        ),
+        patch.object(
+            executions_router,
+            "get_setting",
+            AsyncMock(return_value=None),
+        ),
     ):
         response = client.get("/workflow-executions")
 

--- a/tests/unit/test_agent_channel_handler.py
+++ b/tests/unit/test_agent_channel_handler.py
@@ -531,7 +531,7 @@ async def test_handle_clears_dedup_key_after_processing_failure() -> None:
 
 
 @pytest.mark.anyio
-async def test_handle_app_mention_allows_session_when_inbox_was_previous_source() -> (
+async def test_handle_app_mention_allows_session_when_approval_was_previous_source() -> (
     None
 ):
     workspace_id = uuid.uuid4()
@@ -591,7 +591,7 @@ async def test_handle_app_mention_allows_session_when_inbox_was_previous_source(
         patch(
             "tracecat.agent.channels.handlers.slack.AgentSessionService.get_session",
             new_callable=AsyncMock,
-            return_value=SimpleNamespace(channel_context={"active_sink": "inbox"}),
+            return_value=SimpleNamespace(channel_context={"active_sink": "approval"}),
         ),
         patch(
             "tracecat.agent.channels.handlers.slack.AgentSessionService.has_pending_approvals",

--- a/tests/unit/test_agent_session_approval_sink.py
+++ b/tests/unit/test_agent_session_approval_sink.py
@@ -80,10 +80,10 @@ async def test_claim_external_channel_approval_sink_allows_source_switch(
 
     switched = await service.claim_external_channel_approval_sink(
         session_id=external_agent_session.id,
-        source="inbox",
+        source="approval",
     )
 
-    assert switched == "inbox"
+    assert switched == "approval"
 
 
 @pytest.mark.anyio
@@ -96,15 +96,15 @@ async def test_claim_external_channel_approval_sink_is_idempotent(
 
     first = await service.claim_external_channel_approval_sink(
         session_id=external_agent_session.id,
-        source="inbox",
+        source="approval",
     )
     second = await service.claim_external_channel_approval_sink(
         session_id=external_agent_session.id,
-        source="inbox",
+        source="approval",
     )
 
-    assert first == "inbox"
-    assert second == "inbox"
+    assert first == "approval"
+    assert second == "approval"
 
 
 @pytest.mark.anyio
@@ -181,7 +181,7 @@ async def test_list_messages_preserves_compaction_metadata(
 
 
 @pytest.mark.anyio
-async def test_run_turn_continue_with_inbox_source_for_non_external_session(
+async def test_run_turn_continue_with_approval_source_for_non_external_session(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
@@ -215,7 +215,7 @@ async def test_run_turn_continue_with_inbox_source_for_non_external_session(
                 action="approve",
             )
         ],
-        source="inbox",
+        source="approval",
     )
 
     fake_handle = SimpleNamespace(execute_update=AsyncMock(return_value=None))
@@ -266,7 +266,7 @@ async def test_run_turn_continue_without_pending_approvals_is_noop(
                 action="approve",
             )
         ],
-        source="inbox",
+        source="approval",
     )
 
     fake_handle = SimpleNamespace(execute_update=AsyncMock(return_value=None))
@@ -318,7 +318,7 @@ async def test_run_turn_continue_duplicate_submission_is_noop(
                 action="approve",
             )
         ],
-        source="inbox",
+        source="approval",
     )
 
     fake_redis = SimpleNamespace(

--- a/tests/unit/test_agent_session_router.py
+++ b/tests/unit/test_agent_session_router.py
@@ -44,7 +44,7 @@ async def test_send_message_continue_uses_path_session_id_for_stream_key() -> No
                 action="approve",
             )
         ],
-        source="inbox",
+        source="approval",
     )
 
     fake_svc = SimpleNamespace(
@@ -169,7 +169,7 @@ async def test_send_message_does_not_reset_stream_when_validation_fails() -> Non
                 action="approve",
             )
         ],
-        source="inbox",
+        source="approval",
     )
 
     fake_svc = SimpleNamespace(

--- a/tests/unit/test_rbac_scopes.py
+++ b/tests/unit/test_rbac_scopes.py
@@ -247,8 +247,8 @@ class TestGetMissingScopes:
 class TestSystemRoleScopes:
     """Tests for system role scope definitions."""
 
-    def test_viewer_includes_inbox_read(self):
-        assert "inbox:read" in VIEWER_SCOPES
+    def test_viewer_includes_approval_read(self):
+        assert "approval:read" in VIEWER_SCOPES
 
     def test_viewer_scopes_are_read_only(self):
         for scope in VIEWER_SCOPES:

--- a/tests/unit/test_route_scope_guards.py
+++ b/tests/unit/test_route_scope_guards.py
@@ -5,10 +5,10 @@ from collections.abc import Awaitable, Callable, Sequence
 import pytest
 
 from tracecat.agent.preset import router as agent_preset_router
+from tracecat.approvals import router as approvals_router
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
 from tracecat.exceptions import ScopeDeniedError
-from tracecat.inbox import router as inbox_router
 from tracecat.integrations import router as integrations_router
 from tracecat.organization import router as organization_router
 from tracecat.registry.actions import router as registry_actions_router
@@ -123,10 +123,12 @@ async def test_table_update_row_requires_table_update_scope() -> None:
 @pytest.mark.parametrize(
     ("endpoint", "required_scope"),
     [
-        (inbox_router.list_items, "inbox:read"),
+        (approvals_router.list_approvals, "approval:read"),
     ],
 )
-async def test_inbox_scope_guards(endpoint: AsyncEndpoint, required_scope: str) -> None:
+async def test_approval_scope_guards(
+    endpoint: AsyncEndpoint, required_scope: str
+) -> None:
     await _assert_endpoint_requires_scope(endpoint, required_scope)
 
 

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -165,7 +165,7 @@ class FanoutStreamSink:
     """Broadcasts stream events to multiple sinks.
 
     Used for external-channel sessions where we need Slack thread updates and
-    Redis stream updates (for inbox/UI) in parallel.
+    Redis stream updates (for approval/UI) in parallel.
     """
 
     sinks: tuple[LoopbackEventSink, ...]

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -457,7 +457,7 @@ async def fork_session(
     Creates a new session linked to the parent session, allowing users
     to ask the agent for context after making approval decisions.
 
-    Set entity_type to 'approval' for inbox forks to hide from main chat list.
+    Set entity_type to 'approval' for approval forks to hide from main chat list.
     """
     try:
         svc = AgentSessionService(session, role)

--- a/tracecat/agent/session/schemas.py
+++ b/tracecat/agent/session/schemas.py
@@ -144,5 +144,5 @@ class AgentSessionForkRequest(BaseModel):
     entity_type: AgentSessionEntity | None = Field(
         default=None,
         description="Override entity type for the forked session. "
-        "Use 'approval' for inbox forks to hide from main chat list.",
+        "Use 'approval' for approval forks to hide from main chat list.",
     )

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -672,12 +672,12 @@ class AgentSessionService(BaseWorkspaceService):
         self,
         *,
         session_id: uuid.UUID,
-        source: Literal["inbox", "slack"],
-    ) -> Literal["inbox", "slack"]:
+        source: Literal["approval", "slack"],
+    ) -> Literal["approval", "slack"]:
         """Legacy no-op sink claim kept for backwards compatibility.
 
         External-channel approvals are no longer source-locked. Decisions can be
-        submitted from Slack or inbox; first accepted continuation wins.
+        submitted from Slack or approval; first accepted continuation wins.
         """
         stmt = select(AgentSession).where(
             AgentSession.id == session_id,
@@ -1106,10 +1106,10 @@ class AgentSessionService(BaseWorkspaceService):
                 f"No active workflow run for session {session_id}"
             )
 
-        source: Literal["inbox", "slack"] = request.source
+        source: Literal["approval", "slack"] = request.source
 
         # Idempotency path: if approvals are already resolved, accept duplicate
-        # submissions as a no-op (cross-surface races Slack <-> inbox).
+        # submissions as a no-op (cross-surface races Slack <-> approval).
         if not await self.has_pending_approvals(session_id):
             logger.info(
                 "Ignoring approval continuation without pending approvals",
@@ -1819,7 +1819,7 @@ class AgentSessionService(BaseWorkspaceService):
         Args:
             parent_session_id: The ID of the session to fork.
             entity_type: Override entity type for the forked session. If None,
-                inherits from parent. Use APPROVAL for inbox forks to hide
+                inherits from parent. Use APPROVAL for approval forks to hide
                 from main chat list.
 
         Returns:

--- a/tracecat/agent/session/types.py
+++ b/tracecat/agent/session/types.py
@@ -12,7 +12,7 @@ class AgentSessionEntity(StrEnum):
     - AGENT_PRESET_BUILDER: Builder chat for editing/configuring a preset
     - COPILOT: Workspace-level copilot assistant
     - WORKFLOW: Workflow-initiated agent run (from action)
-    - APPROVAL: Inbox approval continuation (hidden from main chat list)
+    - APPROVAL: Approval continuation (hidden from main chat list)
     - EXTERNAL_CHANNEL: External channel session (e.g. Slack thread)
     """
 

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -36,6 +36,7 @@ from tracecat.api.common import (
     generic_exception_handler,
     tracecat_exception_handler,
 )
+from tracecat.approvals.router import router as approvals_queue_router
 from tracecat.auth.credentials import authenticated_user_only
 from tracecat.auth.dependencies import (
     require_any_auth_type_enabled,
@@ -101,7 +102,6 @@ from tracecat.editor.router import router as editor_router
 from tracecat.exceptions import EntitlementRequired, ScopeDeniedError, TracecatException
 from tracecat.feature_flags import FlagLike, is_feature_enabled
 from tracecat.feature_flags.router import router as feature_flags_router
-from tracecat.inbox.router import router as inbox_router
 from tracecat.integrations.router import (
     integrations_router,
     mcp_router,
@@ -447,7 +447,7 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(watchtower_router)
     app.include_router(admin_router)
     app.include_router(admin_registry_router, prefix="/admin")
-    app.include_router(inbox_router)
+    app.include_router(approvals_queue_router)
     app.include_router(editor_router)
     app.include_router(registry_repos_router)
     app.include_router(registry_actions_router)

--- a/tracecat/approvals/__init__.py
+++ b/tracecat/approvals/__init__.py
@@ -1,0 +1,1 @@
+"""Approvals module for unified approval queue aggregation."""

--- a/tracecat/approvals/dependencies.py
+++ b/tracecat/approvals/dependencies.py
@@ -1,4 +1,4 @@
-"""Inbox provider dependencies."""
+"""Approval provider dependencies."""
 
 from __future__ import annotations
 
@@ -9,28 +9,28 @@ from tracecat.logger import logger
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
+    from tracecat.approvals.types import ApprovalProvider
     from tracecat.auth.types import Role
-    from tracecat.inbox.types import InboxProvider
 
 
-def get_inbox_providers(
+def get_approval_providers(
     session: AsyncSession,
     role: Role,
-) -> list[InboxProvider]:
-    """Get list of inbox providers.
+) -> list[ApprovalProvider]:
+    """Get list of approval providers.
 
     Providers are registered dynamically based on available features.
     EE features (like approvals) are loaded if the tracecat_ee package is available.
     """
-    providers: list[InboxProvider] = []
+    providers: list[ApprovalProvider] = []
 
     # EE: Add approvals provider if available
     try:
-        from tracecat_ee.inbox.providers.approvals import ApprovalsInboxProvider
+        from tracecat_ee.approvals.providers.approvals import ApprovalsProvider
 
-        providers.append(ApprovalsInboxProvider(session, role))
-        logger.debug("Loaded ApprovalsInboxProvider")
+        providers.append(ApprovalsProvider(session, role))
+        logger.debug("Loaded ApprovalsProvider")
     except ImportError:
-        logger.debug("ApprovalsInboxProvider not available (EE feature)")
+        logger.debug("ApprovalsProvider not available (EE feature)")
 
     return providers

--- a/tracecat/approvals/router.py
+++ b/tracecat/approvals/router.py
@@ -1,21 +1,21 @@
-"""Inbox API router."""
+"""Approvals API router."""
 
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, HTTPException, Query, status
 
 from tracecat import config
+from tracecat.approvals.dependencies import get_approval_providers
+from tracecat.approvals.schemas import ApprovalItemRead
+from tracecat.approvals.service import ApprovalService
 from tracecat.auth.credentials import RoleACL
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
-from tracecat.inbox.dependencies import get_inbox_providers
-from tracecat.inbox.schemas import InboxItemRead
-from tracecat.inbox.service import InboxService
 from tracecat.logger import logger
 from tracecat.pagination import CursorPaginatedResponse
 
-router = APIRouter(prefix="/inbox", tags=["inbox"])
+router = APIRouter(prefix="/approvals", tags=["approvals"])
 
 WorkspaceUser = Annotated[
     Role,
@@ -27,9 +27,9 @@ WorkspaceUser = Annotated[
 ]
 
 
-@router.get("/items")
-@require_scope("inbox:read")
-async def list_items(
+@router.get("")
+@require_scope("approval:read")
+async def list_approvals(
     role: WorkspaceUser,
     session: AsyncDBSession,
     limit: int = Query(
@@ -46,17 +46,17 @@ async def list_items(
     sort: Literal["asc", "desc"] | None = Query(
         default=None, description="Sort direction (asc or desc)"
     ),
-) -> CursorPaginatedResponse[InboxItemRead]:
-    """List inbox items with cursor-based pagination.
+) -> CursorPaginatedResponse[ApprovalItemRead]:
+    """List approval items with cursor-based pagination.
 
     Supports sorting by created_at, updated_at, or status.
     Default sort is by created_at descending.
     """
-    providers = get_inbox_providers(session, role)
-    service = InboxService(session, role, providers)
+    providers = get_approval_providers(session, role)
+    service = ApprovalService(session, role, providers)
 
     try:
-        return await service.list_items(
+        return await service.list_approvals(
             limit=limit,
             cursor=cursor,
             reverse=reverse,
@@ -64,7 +64,7 @@ async def list_items(
             sort=sort,
         )
     except ValueError as e:
-        logger.warning(f"Invalid request for list inbox items: {e}")
+        logger.warning(f"Invalid request for list approval items: {e}")
 
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tracecat/approvals/schemas.py
+++ b/tracecat/approvals/schemas.py
@@ -1,4 +1,4 @@
-"""Inbox API schemas."""
+"""Approvals API schemas."""
 
 from __future__ import annotations
 
@@ -8,25 +8,25 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from tracecat.inbox.types import InboxItemStatus, InboxItemType
+from tracecat.approvals.types import ApprovalItemStatus, ApprovalItemType
 
 
 class WorkflowSummary(BaseModel):
-    """Summary of a workflow for inbox item context."""
+    """Summary of a workflow for approval item context."""
 
     id: uuid.UUID = Field(..., description="Workflow ID")
     title: str = Field(..., description="Workflow title")
     alias: str | None = Field(default=None, description="Workflow alias")
 
 
-class InboxItemRead(BaseModel):
-    """Read model for inbox items."""
+class ApprovalItemRead(BaseModel):
+    """Read model for approval items."""
 
-    id: uuid.UUID = Field(..., description="Unique inbox item ID")
-    type: InboxItemType = Field(..., description="Type of inbox item")
+    id: uuid.UUID = Field(..., description="Unique approval item ID")
+    type: ApprovalItemType = Field(..., description="Type of approval item")
     title: str = Field(..., description="Display title")
     preview: str = Field(..., description="Preview text")
-    status: InboxItemStatus = Field(..., description="Item status")
+    status: ApprovalItemStatus = Field(..., description="Item status")
     unread: bool = Field(..., description="Whether the item is unread")
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")

--- a/tracecat/approvals/service.py
+++ b/tracecat/approvals/service.py
@@ -1,37 +1,37 @@
-"""Inbox service for aggregating notification items from multiple providers."""
+"""Approvals service for aggregating notification items from multiple providers."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
-from tracecat.inbox.schemas import InboxItemRead
-from tracecat.inbox.types import InboxItemStatus
+from tracecat.approvals.schemas import ApprovalItemRead
+from tracecat.approvals.types import ApprovalItemStatus
 from tracecat.pagination import BaseCursorPaginator, CursorPaginatedResponse
 from tracecat.service import BaseWorkspaceService
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
+    from tracecat.approvals.types import ApprovalProvider
     from tracecat.auth.types import Role
-    from tracecat.inbox.types import InboxProvider
 
 
-class InboxService(BaseWorkspaceService, BaseCursorPaginator):
-    """Service for aggregating inbox items from multiple providers."""
+class ApprovalService(BaseWorkspaceService, BaseCursorPaginator):
+    """Service for aggregating approval items from multiple providers."""
 
-    service_name = "inbox"
+    service_name = "approvals"
 
     def __init__(
         self,
         session: AsyncSession,
         role: Role,
-        providers: list[InboxProvider] | None = None,
+        providers: list[ApprovalProvider] | None = None,
     ):
         BaseWorkspaceService.__init__(self, session, role)
         BaseCursorPaginator.__init__(self, session)
         self.providers = providers or []
 
-    async def list_items(
+    async def list_approvals(
         self,
         *,
         limit: int = 20,
@@ -39,18 +39,18 @@ class InboxService(BaseWorkspaceService, BaseCursorPaginator):
         reverse: bool = False,
         order_by: str | None = None,
         sort: Literal["asc", "desc"] | None = None,
-    ) -> CursorPaginatedResponse[InboxItemRead]:
-        """List inbox items with cursor-based pagination.
+    ) -> CursorPaginatedResponse[ApprovalItemRead]:
+        """List approval items with cursor-based pagination.
 
         For the initial implementation, this delegates pagination to providers
         and merges results. Future optimization could use a materialized view
         or unified table for more efficient cross-provider pagination.
         """
         # For now, use simple aggregation with in-memory pagination
-        # This works well for small-medium inbox sizes
-        # TODO: Optimize for large inboxes with cross-provider cursor pagination
+        # This works well for small-medium approval queue sizes.
+        # TODO: Optimize for large queues with cross-provider cursor pagination.
 
-        all_items: list[InboxItemRead] = []
+        all_items: list[ApprovalItemRead] = []
 
         # Decode cursor to get target item ID if present
         cursor_id: str | None = None
@@ -61,13 +61,13 @@ class InboxService(BaseWorkspaceService, BaseCursorPaginator):
         # Initial fetch - get enough items to likely include cursor position.
         # For cross-provider aggregation, we fetch a larger window to increase
         # the likelihood of including the cursor item. This is a known limitation
-        # of in-memory aggregation; very large inboxes may need a unified table.
+        # of in-memory aggregation; very large queues may need a unified table.
         # Fetch more when we have a cursor to search for.
         initial_fetch_limit = limit * 10 if cursor_id else limit * 2
 
         for provider in self.providers:
             # Fetch items without cursor - handle pagination at aggregate level
-            provider_response = await provider.list_items(
+            provider_response = await provider.list_approvals(
                 limit=initial_fetch_limit,
                 cursor=None,
                 reverse=reverse,
@@ -93,7 +93,7 @@ class InboxService(BaseWorkspaceService, BaseCursorPaginator):
             # Secondary sort by created_at in the same direction
             all_items.sort(
                 key=lambda x: (
-                    x.status != InboxItemStatus.PENDING,
+                    x.status != ApprovalItemStatus.PENDING,
                     x.created_at.timestamp()
                     if sort_desc
                     else -x.created_at.timestamp(),

--- a/tracecat/approvals/types.py
+++ b/tracecat/approvals/types.py
@@ -1,4 +1,4 @@
-"""Inbox domain types and protocols."""
+"""Approval queue domain types and protocols."""
 
 from __future__ import annotations
 
@@ -6,12 +6,12 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Literal, Protocol
 
 if TYPE_CHECKING:
-    from tracecat.inbox.schemas import InboxItemRead
+    from tracecat.approvals.schemas import ApprovalItemRead
     from tracecat.pagination import CursorPaginatedResponse
 
 
-class InboxItemType(StrEnum):
-    """Types of inbox items."""
+class ApprovalItemType(StrEnum):
+    """Types of approval items."""
 
     APPROVAL = "approval"
     # Future types:
@@ -19,23 +19,23 @@ class InboxItemType(StrEnum):
     # ASSIGNMENT = "assignment"
 
 
-class InboxItemStatus(StrEnum):
-    """Status of inbox items."""
+class ApprovalItemStatus(StrEnum):
+    """Status of approval items."""
 
     PENDING = "pending"
     COMPLETED = "completed"
     FAILED = "failed"
 
 
-class InboxProvider(Protocol):
-    """Protocol for inbox item providers.
+class ApprovalProvider(Protocol):
+    """Protocol for approval item providers.
 
-    Providers are responsible for fetching inbox items from their respective
+    Providers are responsible for fetching approval items from their respective
     domains (approvals, mentions, etc.) and transforming them into the unified
-    InboxItemRead format.
+    ApprovalItemRead format.
     """
 
-    async def list_items(
+    async def list_approvals(
         self,
         *,
         limit: int = 20,
@@ -43,6 +43,6 @@ class InboxProvider(Protocol):
         reverse: bool = False,
         order_by: str | None = None,
         sort: Literal["asc", "desc"] | None = None,
-    ) -> CursorPaginatedResponse[InboxItemRead]:
-        """List inbox items with cursor-based pagination."""
+    ) -> CursorPaginatedResponse[ApprovalItemRead]:
+        """List approval items with cursor-based pagination."""
         ...

--- a/tracecat/authz/scopes.py
+++ b/tracecat/authz/scopes.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 VIEWER_SCOPES: frozenset[str] = frozenset(
     {
-        "inbox:read",
+        "approval:read",
         "workflow:read",
         "integration:read",
         "case:read",
@@ -147,7 +147,7 @@ ORG_OWNER_SCOPES: frozenset[str] = frozenset(
         "workspace:rbac:read",
         "workspace:rbac:manage",
         # Full resource control
-        "inbox:read",
+        "approval:read",
         "workflow:read",
         "workflow:sync",
         "workflow:create",
@@ -239,7 +239,7 @@ ORG_ADMIN_SCOPES: frozenset[str] = frozenset(
         "workspace:rbac:read",
         "workspace:rbac:manage",
         # Full resource control
-        "inbox:read",
+        "approval:read",
         "workflow:read",
         "workflow:sync",
         "workflow:create",
@@ -322,7 +322,7 @@ PRESET_ROLE_SCOPES: dict[str, frozenset[str]] = {
 
 WORKSPACE_OPERATIONAL_SCOPES: frozenset[str] = frozenset(
     {
-        "inbox:read",
+        "approval:read",
         "workflow:read",
         "workflow:sync",
         "workflow:create",

--- a/tracecat/authz/seeding.py
+++ b/tracecat/authz/seeding.py
@@ -231,8 +231,8 @@ SYSTEM_SCOPE_DEFINITIONS: list[ScopeDefinition] = [
     ScopeDefinition("case:create", "case", "create", "Create new cases"),
     ScopeDefinition("case:update", "case", "update", "Modify existing cases"),
     ScopeDefinition("case:delete", "case", "delete", "Delete cases"),
-    # Inbox scopes
-    ScopeDefinition("inbox:read", "inbox", "read", "View inbox items"),
+    # Approval scopes
+    ScopeDefinition("approval:read", "approval", "read", "View approval items"),
     # Table scopes
     ScopeDefinition("table:read", "table", "read", "View tables"),
     ScopeDefinition("table:create", "table", "create", "Create new tables"),

--- a/tracecat/chat/schemas.py
+++ b/tracecat/chat/schemas.py
@@ -280,11 +280,11 @@ class ContinueRunRequest(BaseModel):
 
     kind: Literal["continue"] = Field(default="continue", frozen=True)
     decisions: list[ApprovalDecision]
-    source: Literal["inbox", "slack"] = Field(
-        default="inbox",
+    source: Literal["approval", "slack"] = Field(
+        default="approval",
         description=(
             "Origin of the approval decision submission. "
-            "Use 'inbox' for Tracecat UI/API and 'slack' for Slack actions."
+            "Use 'approval' for Tracecat UI/API and 'slack' for Slack actions."
         ),
     )
 

--- a/tracecat/inbox/__init__.py
+++ b/tracecat/inbox/__init__.py
@@ -1,1 +1,0 @@
-"""Inbox module for unified notification aggregation."""


### PR DESCRIPTION
## Summary
This changes the workspace sidebar so approval work is grouped under the existing `Actions` section instead of appearing as a separate top-level inbox entry. It also removes the standalone `Add case` button from the sidebar.

## User impact
Before this change, the sidebar exposed `Inbox` as its own top-level item and also showed `Add case` as a global action. That made the workspace navigation feel split between top-level shortcuts and accordion content, even though approvals belong with other action-oriented workspace tools.

After this change, users find approvals under `Workspace` -> `Actions` as `Approvals`, alongside the existing actions registry entry when that scope is available. The redundant top-level case creation entry is removed.

## Root cause
The sidebar defined inbox and case creation in a separate group above the workspace accordion, while the rest of the workspace navigation lived inside `navWorkspace`. That structure prevented approvals from being organized with related workspace tools.

## Fix
The sidebar now models `Actions` as a grouped navigation item with sub-items:
- `Registry` for the existing actions page when the registry scope is available.
- `Approvals` for the inbox route when inbox access is available.

The obsolete top-level `Add case` button and its unused dialog wiring were removed from the sidebar component.

## Validation
I validated the changed file with:
- `pnpm -C frontend exec biome check src/components/sidebar/app-sidebar.tsx`

I also installed frontend dependencies in this worktree so the packaged frontend tooling was available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved approvals into the Sidebar’s Actions group, replaced the old Inbox surface with Approvals across UI and API, and removed the Add case button. This tidies navigation and standardizes the approvals flow.

- **Refactors**
  - UI: Added nested Actions items “Registry” and “Approvals”; routes/pages renamed to `/approvals`; removed Inbox and the sidebar “Add case” wiring.
  - API/scopes: `inbox:read` -> `approval:read`; `GET /inbox/items` -> `GET /approvals`; submit approvals is now `PATCH /approvals/{session_id}`; `ContinueRunRequest.source` default is `"approval"`.

<sup>Written for commit 965103812cd1cd5003a256863ac066fa222ee10e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

