### PR TITLE
fix(ui): polish case assignee UI and add assignee to case rows

### DIFF
--- a/frontend/src/components/cases/case-item.tsx
+++ b/frontend/src/components/cases/case-item.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import {
   Check,
   CircleIcon,
+  CircleSlashIcon,
   Copy,
   ExternalLink,
   ListIcon,
@@ -37,6 +38,7 @@ import {
   SEVERITIES,
   STATUSES,
 } from "@/components/cases/case-categories"
+import { CaseUserAvatar } from "@/components/cases/case-panel-common"
 import { UNASSIGNED } from "@/components/cases/case-panel-selectors"
 import {
   EventCreatedAt,
@@ -58,7 +60,7 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
 import { toast } from "@/components/ui/use-toast"
-import { getDisplayName } from "@/lib/auth"
+import { User } from "@/lib/auth"
 import { cn } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
@@ -415,6 +417,17 @@ export function CaseItem({
               </div>
             )}
 
+            {/* Assignee */}
+            {caseData.assignee && (
+              <div className="flex shrink-0 items-center gap-1">
+                <CaseUserAvatar user={new User(caseData.assignee)} size="sm" />
+                <span className="max-w-[80px] truncate text-xs text-muted-foreground">
+                  {caseData.assignee.first_name?.split(/\s/)[0] ||
+                    caseData.assignee.email.split("@")[0]}
+                </span>
+              </div>
+            )}
+
             {/* Timestamps */}
             <div className="flex shrink-0 items-center gap-2">
               <EventCreatedAt createdAt={caseData.created_at} />
@@ -526,25 +539,18 @@ export function CaseItem({
             <UserIcon className="mr-2 size-3.5" />
             Assignee
           </ContextMenuSubTrigger>
-          <ContextMenuSubContent className="w-48">
+          <ContextMenuSubContent className="w-56">
             <ContextMenuRadioGroup value={caseData.assignee?.id ?? UNASSIGNED}>
               <ContextMenuRadioItem
                 value={UNASSIGNED}
                 className="text-xs"
                 onClick={() => handleAssigneeChange(UNASSIGNED)}
               >
-                <UserIcon className="mr-2 size-3.5 text-muted-foreground" />
+                <CircleSlashIcon className="mr-2 size-3 text-muted-foreground/50" />
                 Unassigned
               </ContextMenuRadioItem>
               {members?.map((member) => {
-                const displayName = getDisplayName({
-                  first_name: member.first_name,
-                  last_name: member.last_name,
-                  email: member.email,
-                })
-                const initials = member.first_name
-                  ? member.first_name[0].toUpperCase()
-                  : member.email[0].toUpperCase()
+                const initials = member.email[0].toUpperCase()
                 return (
                   <ContextMenuRadioItem
                     key={member.user_id}
@@ -557,7 +563,7 @@ export function CaseItem({
                         {initials}
                       </AvatarFallback>
                     </Avatar>
-                    <span className="truncate">{displayName}</span>
+                    <span className="truncate">{member.email}</span>
                   </ContextMenuRadioItem>
                 )
               })}

--- a/frontend/src/components/cases/case-panel-common.tsx
+++ b/frontend/src/components/cases/case-panel-common.tsx
@@ -28,24 +28,22 @@ export function UserHoverCard({
 }) {
   const displayName = user.getDisplayName()
   const avatarText = displayName.substring(0, 1).toUpperCase()
-  const username = user.email.split("@")[0]
 
   return (
     <HoverCard>
       <HoverCardTrigger asChild>{children}</HoverCardTrigger>
-      <HoverCardContent className="w-auto" side="top">
-        <div className="flex items-center gap-4">
-          <Avatar className="size-16">
-            <AvatarFallback className="bg-primary/10 text-lg text-primary">
+      <HoverCardContent className="w-auto max-w-xs" side="top">
+        <div className="flex items-center gap-3">
+          <Avatar className="size-8 shrink-0">
+            <AvatarFallback className="text-sm font-medium">
               {avatarText}
             </AvatarFallback>
           </Avatar>
-          <div className="flex flex-col gap-1">
-            <div className="flex items-center gap-2">
-              <span className="text-base font-medium">{displayName}</span>
-              <span className="text-muted-foreground">({username})</span>
-            </div>
-            <span className="text-xs text-muted-foreground">{user.email}</span>
+          <div className="flex min-w-0 flex-col">
+            <span className="truncate text-sm font-medium">{displayName}</span>
+            <span className="truncate text-xs text-muted-foreground">
+              {user.email}
+            </span>
           </div>
         </div>
       </HoverCardContent>
@@ -69,15 +67,15 @@ export function CaseUserAvatar({
         className={cn(
           "cursor-default",
           className,
-          size === "sm" && "size-4",
+          size === "sm" && "size-5",
           size === "md" && "size-8",
           size === "lg" && "size-12"
         )}
       >
         <AvatarFallback
           className={cn(
-            "bg-primary/10 text-primary",
-            size === "sm" && "text-xs",
+            "text-sm font-medium",
+            size === "sm" && "text-[10px]",
             size === "md" && "text-sm",
             size === "lg" && "text-lg"
           )}

--- a/frontend/src/components/cases/case-panel-selectors.tsx
+++ b/frontend/src/components/cases/case-panel-selectors.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CircleIcon, ListIcon, UserIcon } from "lucide-react"
+import { CircleIcon, CircleSlashIcon, ListIcon } from "lucide-react"
 import type {
   CaseDropdownDefinitionRead,
   CaseDropdownValueRead,
@@ -24,7 +24,6 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import UserAvatar from "@/components/user-avatar"
-import { getDisplayName } from "@/lib/auth"
 import { cn, linearStyles } from "@/lib/utils"
 
 /**
@@ -335,8 +334,8 @@ export function AssigneeSelect({
                   firstName={assignee.first_name}
                   className="size-5 text-xs text-foreground"
                 />
-                <span className={cn("font-medium", valueClassName)}>
-                  {assignee.first_name || assignee.email.split("@")[0]}
+                <span className={cn("truncate", valueClassName)}>
+                  {assignee.email}
                 </span>
               </div>
             ) : (
@@ -367,6 +366,7 @@ export function AssigneeSelect({
                 email={member.email}
                 firstName={member.first_name}
                 lastName={member.last_name}
+                className={valueClassName}
               />
             </SelectItem>
           ))
@@ -388,8 +388,8 @@ export function NoAssignee({
   const baseClass = "flex items-center gap-1.5 text-xs leading-4"
   return (
     <div className={cn(baseClass, "text-muted-foreground", className)}>
-      <div className="flex size-4 items-center justify-center rounded-full border border-dashed border-muted-foreground/50">
-        <UserIcon className="size-3 text-muted-foreground" />
+      <div className="flex size-4 items-center justify-center">
+        <CircleSlashIcon className="size-2.5 text-muted-foreground/50" />
       </div>
       <span className={cn("text-xs text-muted-foreground", labelClassName)}>
         {text ?? "Unassigned"}
@@ -409,11 +409,6 @@ export function AssignedUser({
   lastName?: string | null
   className?: string
 }) {
-  const displayName = getDisplayName({
-    email,
-    first_name: firstName,
-    last_name: lastName,
-  })
   return (
     <div
       className={cn(
@@ -422,14 +417,14 @@ export function AssignedUser({
       )}
     >
       <UserAvatar
-        alt={displayName}
+        alt={email}
         email={email}
         firstName={firstName}
         className="size-4 text-foreground"
         fallbackClassName="text-[10px]"
       />
-      <span className="truncate text-xs" title={displayName}>
-        {displayName}
+      <span className="truncate" title={email}>
+        {email}
       </span>
     </div>
   )

--- a/frontend/src/components/cases/case-task-dialog.tsx
+++ b/frontend/src/components/cases/case-task-dialog.tsx
@@ -33,7 +33,6 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { useWorkspaceMembers } from "@/hooks/use-workspace"
-import { getDisplayName } from "@/lib/auth"
 import {
   useCreateCaseTask,
   useUpdateCaseTask,
@@ -268,21 +267,14 @@ export function CaseTaskDialog({
                         </SelectTrigger>
                         <SelectContent>
                           <SelectItem value={UNASSIGNED}>Unassigned</SelectItem>
-                          {members?.map((member) => {
-                            const displayName = getDisplayName({
-                              email: member.email,
-                              first_name: member.first_name,
-                              last_name: member.last_name,
-                            })
-                            return (
-                              <SelectItem
-                                key={member.user_id}
-                                value={member.user_id}
-                              >
-                                {displayName}
-                              </SelectItem>
-                            )
-                          })}
+                          {members?.map((member) => (
+                            <SelectItem
+                              key={member.user_id}
+                              value={member.user_id}
+                            >
+                              {member.email}
+                            </SelectItem>
+                          ))}
                         </SelectContent>
                       </Select>
                     </FormControl>

--- a/frontend/src/components/cases/cases-header.tsx
+++ b/frontend/src/components/cases/cases-header.tsx
@@ -9,6 +9,7 @@ import {
   Check,
   ChevronDown,
   CircleIcon,
+  CircleSlashIcon,
   ClockIcon,
   ListIcon,
   SearchIcon,
@@ -66,7 +67,6 @@ import type {
   DropdownFilterState,
 } from "@/hooks/use-cases"
 import { DEFAULT_CREATED_PRESET } from "@/hooks/use-cases"
-import { getDisplayName } from "@/lib/auth"
 import { cn } from "@/lib/utils"
 
 const getIconTextClass = (color?: string) =>
@@ -477,18 +477,11 @@ export function CasesHeader({
 
   const assigneeOptions = useMemo<FilterOption<string>[]>(() => {
     const workspaceMembers = members?.map((member) => {
-      const displayName = getDisplayName({
-        first_name: member.first_name,
-        last_name: member.last_name,
-        email: member.email,
-      })
-      const initials = member.first_name
-        ? member.first_name[0].toUpperCase()
-        : member.email[0].toUpperCase()
+      const initials = member.email[0].toUpperCase()
 
       return {
         value: member.user_id,
-        label: displayName,
+        label: member.email,
         renderIcon: () => (
           <Avatar className="size-5">
             <AvatarFallback className="text-[10px] font-medium">
@@ -502,10 +495,10 @@ export function CasesHeader({
     return [
       {
         value: UNASSIGNED,
-        label: "Not assigned",
+        label: "Unassigned",
         renderIcon: () => (
           <div className="flex size-5 items-center justify-center">
-            <UserIcon className="size-3.5 text-muted-foreground" />
+            <CircleSlashIcon className="size-3 text-muted-foreground/50" />
           </div>
         ),
       },

--- a/frontend/src/components/nav/controls-header.tsx
+++ b/frontend/src/components/nav/controls-header.tsx
@@ -144,7 +144,6 @@ import { CreateCredentialDialog } from "@/components/workspaces/create-credentia
 import { useAgentPreset } from "@/hooks/use-agent-presets"
 import { useEntitlements } from "@/hooks/use-entitlements"
 import { useWorkspaceDetails, useWorkspaceMembers } from "@/hooks/use-workspace"
-import { getDisplayName } from "@/lib/auth"
 import {
   useCaseDropdownDefinitions,
   useCaseDurationDefinitions,
@@ -666,11 +665,7 @@ function CasesSelectionActionsBar({ enabled = true }: { enabled?: boolean }) {
     },
     ...(members?.map((member) => ({
       value: member.user_id,
-      label: getDisplayName({
-        first_name: member.first_name,
-        last_name: member.last_name,
-        email: member.email,
-      }),
+      label: member.email,
     })) ?? []),
   ]
 


### PR DESCRIPTION
## Summary
- Standardize assignee terminology to "Unassigned" everywhere (was "Not assigned" in filter dropdown)
- Show user email instead of first name in all assignee selectors for better differentiation
- Fix font size/weight mismatch between AssigneeSelect trigger and dropdown items
- Replace `UserIcon` with `CircleSlashIcon` for unassigned state across all assignee UIs
- Add assignee avatar + first name to case list rows (between tags and timestamps) with hover card showing full name and email
- Add text overflow protection (`truncate`, `max-w`) to `UserHoverCard` and case row assignee label

## Test plan
- [ ] `/cases` list: verify assignee avatar + first name appears between tags and timestamps for assigned cases
- [ ] `/cases` list: hover over assignee avatar shows hover card with name and email (no overflow)
- [ ] `/cases` filter dropdown: verify "Unassigned" label and `CircleSlashIcon`, user emails shown
- [ ] `/cases/{id}` detail: verify assignee selector shows emails, font sizes match between trigger and dropdown
- [ ] Context menu assignee submenu: verify emails, `CircleSlashIcon` for unassigned
- [ ] Bulk assignee update: verify emails shown
- [ ] Case task dialog: verify emails shown

Generated with [Claude Code](https://claude.com/claude-code)