### PR TITLE
feat: Display dropdowns, fields, and metrics in case rows

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo } from "react"
+import { useEffect } from "react"
 import { CasesLayout } from "@/components/cases/cases-layout"
 import { useCaseColumnVisibility } from "@/hooks/use-case-column-visibility"
 import { useCases } from "@/hooks/use-cases"
@@ -31,38 +31,8 @@ export default function CasesPage() {
     caseAddonsEnabled
   )
 
-  // Build the set of valid column IDs from loaded definitions so the hook
-  // can prune stale persisted selections (e.g. deleted definitions).
-  // undefined while any definition list is still loading → skip pruning.
-  const validColumnIds = useMemo(() => {
-    const dropdowns = caseAddonsEnabled ? dropdownDefinitions : undefined
-    const durations = caseAddonsEnabled ? caseDurationDefinitions : undefined
-    // Fields are not gated by case_addons
-    if (!caseFields || (caseAddonsEnabled && (!dropdowns || !durations))) {
-      return undefined
-    }
-    const ids = new Set<string>()
-    if (dropdowns) {
-      for (const d of dropdowns) ids.add(`dropdown:${d.ref}`)
-    }
-    for (const f of caseFields) {
-      if (!f.reserved) ids.add(`field:${f.id}`)
-    }
-    if (durations) {
-      for (const d of durations) ids.add(`duration:${d.id}`)
-    }
-    return ids
-  }, [
-    dropdownDefinitions,
-    caseFields,
-    caseDurationDefinitions,
-    caseAddonsEnabled,
-  ])
-
-  const { visibleColumnIds, toggleColumn } = useCaseColumnVisibility(
-    workspaceId,
-    validColumnIds
-  )
+  const { visibleColumnIds, toggleColumn } =
+    useCaseColumnVisibility(workspaceId)
 
   const includeFields = visibleColumnIds.some((id) => id.startsWith("field:"))
 

--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -21,29 +21,33 @@ export default function CasesPage() {
 
   const { members } = useWorkspaceMembers(workspaceId)
   const { caseTags } = useCaseTagCatalog(workspaceId)
-  const { dropdownDefinitions } = useCaseDropdownDefinitions(
-    workspaceId,
-    caseAddonsEnabled
-  )
-  const { caseFields } = useCaseFields(workspaceId)
-  const { caseDurationDefinitions } = useCaseDurationDefinitions(
-    workspaceId,
-    caseAddonsEnabled
-  )
+  const { dropdownDefinitions, dropdownDefinitionsIsFetching } =
+    useCaseDropdownDefinitions(workspaceId, caseAddonsEnabled)
+  const { caseFields, caseFieldsIsFetching } = useCaseFields(workspaceId)
+  const { caseDurationDefinitions, caseDurationDefinitionsIsFetching } =
+    useCaseDurationDefinitions(workspaceId, caseAddonsEnabled)
 
   // Avoid pruning persisted selections until entitlement and field metadata
-  // have both resolved; a partial Set during loading would erase stored choices.
+  // have both resolved from the current fetch; stale cached definitions during
+  // a refetch could otherwise erase still-valid stored choices.
   const knownColumnIds = useMemo<Set<string> | undefined>(() => {
     if (!hasEntitlementData) {
       return undefined
     }
-    if (caseFields === undefined) {
+    if (caseFields === undefined || caseFieldsIsFetching) {
       return undefined
     }
-    if (caseAddonsEnabled && dropdownDefinitions === undefined) {
+    if (
+      caseAddonsEnabled &&
+      (dropdownDefinitions === undefined || dropdownDefinitionsIsFetching)
+    ) {
       return undefined
     }
-    if (caseAddonsEnabled && caseDurationDefinitions === undefined) {
+    if (
+      caseAddonsEnabled &&
+      (caseDurationDefinitions === undefined ||
+        caseDurationDefinitionsIsFetching)
+    ) {
       return undefined
     }
 
@@ -63,8 +67,11 @@ export default function CasesPage() {
   }, [
     hasEntitlementData,
     dropdownDefinitions,
+    dropdownDefinitionsIsFetching,
     caseFields,
+    caseFieldsIsFetching,
     caseDurationDefinitions,
+    caseDurationDefinitionsIsFetching,
     caseAddonsEnabled,
   ])
 

--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -22,7 +22,8 @@ export default function CasesPage() {
   const { visibleColumnIds, toggleColumn } =
     useCaseColumnVisibility(workspaceId)
 
-  const includeFields = visibleColumnIds.some((id) => id.startsWith("field:"))
+  const includeFields =
+    caseAddonsEnabled && visibleColumnIds.some((id) => id.startsWith("field:"))
 
   const {
     cases,

--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -31,9 +31,19 @@ export default function CasesPage() {
     caseAddonsEnabled
   )
 
-  // Build stable set of known column IDs for the hook's cap enforcement.
-  // Keyed on definition arrays — only rebuilds when definitions actually change.
-  const knownColumnIds = useMemo(() => {
+  // Avoid pruning persisted selections until the relevant definitions have
+  // resolved; an empty Set during loading would erase stored choices.
+  const knownColumnIds = useMemo<Set<string> | undefined>(() => {
+    if (caseFields === undefined) {
+      return undefined
+    }
+    if (caseAddonsEnabled && dropdownDefinitions === undefined) {
+      return undefined
+    }
+    if (caseAddonsEnabled && caseDurationDefinitions === undefined) {
+      return undefined
+    }
+
     const ids = new Set<string>()
     if (caseAddonsEnabled && dropdownDefinitions) {
       for (const d of dropdownDefinitions) ids.add(`dropdown:${d.ref}`)
@@ -59,7 +69,27 @@ export default function CasesPage() {
     knownColumnIds
   )
 
-  const includeFields = visibleColumnIds.some((id) => id.startsWith("field:"))
+  const selectedFieldIds = useMemo(() => {
+    const validFieldIds = new Set(
+      (caseFields ?? [])
+        .filter((field) => !field.reserved)
+        .map((field) => field.id)
+    )
+    return visibleColumnIds
+      .filter((columnId) => columnId.startsWith("field:"))
+      .map((columnId) => columnId.slice("field:".length))
+      .filter((fieldId) => validFieldIds.has(fieldId))
+  }, [caseFields, visibleColumnIds])
+
+  const includeDurations = useMemo(() => {
+    if (!caseAddonsEnabled || !caseDurationDefinitions) {
+      return false
+    }
+    const durationColumnIds = new Set(
+      caseDurationDefinitions.map((definition) => `duration:${definition.id}`)
+    )
+    return visibleColumnIds.some((columnId) => durationColumnIds.has(columnId))
+  }, [caseAddonsEnabled, caseDurationDefinitions, visibleColumnIds])
 
   const {
     cases,
@@ -95,7 +125,7 @@ export default function CasesPage() {
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
-  } = useCases({ includeFields })
+  } = useCases({ fieldIds: selectedFieldIds, includeDurations })
 
   useEffect(() => {
     if (typeof window !== "undefined") {

--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useMemo } from "react"
 import { CasesLayout } from "@/components/cases/cases-layout"
 import { useCaseColumnVisibility } from "@/hooks/use-case-column-visibility"
 import { useCases } from "@/hooks/use-cases"
@@ -31,8 +31,33 @@ export default function CasesPage() {
     caseAddonsEnabled
   )
 
-  const { visibleColumnIds, toggleColumn } =
-    useCaseColumnVisibility(workspaceId)
+  // Build stable set of known column IDs for the hook's cap enforcement.
+  // Keyed on definition arrays — only rebuilds when definitions actually change.
+  const knownColumnIds = useMemo(() => {
+    const ids = new Set<string>()
+    if (caseAddonsEnabled && dropdownDefinitions) {
+      for (const d of dropdownDefinitions) ids.add(`dropdown:${d.ref}`)
+    }
+    if (caseFields) {
+      for (const f of caseFields) {
+        if (!f.reserved) ids.add(`field:${f.id}`)
+      }
+    }
+    if (caseAddonsEnabled && caseDurationDefinitions) {
+      for (const d of caseDurationDefinitions) ids.add(`duration:${d.id}`)
+    }
+    return ids
+  }, [
+    dropdownDefinitions,
+    caseFields,
+    caseDurationDefinitions,
+    caseAddonsEnabled,
+  ])
+
+  const { visibleColumnIds, toggleColumn } = useCaseColumnVisibility(
+    workspaceId,
+    knownColumnIds
+  )
 
   const includeFields = visibleColumnIds.some((id) => id.startsWith("field:"))
 

--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useMemo } from "react"
 import { CasesLayout } from "@/components/cases/cases-layout"
 import { useCaseColumnVisibility } from "@/hooks/use-case-column-visibility"
 import { useCases } from "@/hooks/use-cases"
@@ -19,11 +19,52 @@ export default function CasesPage() {
   const { hasEntitlement } = useEntitlements()
   const caseAddonsEnabled = hasEntitlement("case_addons")
 
-  const { visibleColumnIds, toggleColumn } =
-    useCaseColumnVisibility(workspaceId)
+  const { members } = useWorkspaceMembers(workspaceId)
+  const { caseTags } = useCaseTagCatalog(workspaceId)
+  const { dropdownDefinitions } = useCaseDropdownDefinitions(
+    workspaceId,
+    caseAddonsEnabled
+  )
+  const { caseFields } = useCaseFields(workspaceId)
+  const { caseDurationDefinitions } = useCaseDurationDefinitions(
+    workspaceId,
+    caseAddonsEnabled
+  )
 
-  const includeFields =
-    caseAddonsEnabled && visibleColumnIds.some((id) => id.startsWith("field:"))
+  // Build the set of valid column IDs from loaded definitions so the hook
+  // can prune stale persisted selections (e.g. deleted definitions).
+  // undefined while any definition list is still loading → skip pruning.
+  const validColumnIds = useMemo(() => {
+    const dropdowns = caseAddonsEnabled ? dropdownDefinitions : undefined
+    const durations = caseAddonsEnabled ? caseDurationDefinitions : undefined
+    // Fields are not gated by case_addons
+    if (!caseFields || (caseAddonsEnabled && (!dropdowns || !durations))) {
+      return undefined
+    }
+    const ids = new Set<string>()
+    if (dropdowns) {
+      for (const d of dropdowns) ids.add(`dropdown:${d.ref}`)
+    }
+    for (const f of caseFields) {
+      if (!f.reserved) ids.add(`field:${f.id}`)
+    }
+    if (durations) {
+      for (const d of durations) ids.add(`duration:${d.id}`)
+    }
+    return ids
+  }, [
+    dropdownDefinitions,
+    caseFields,
+    caseDurationDefinitions,
+    caseAddonsEnabled,
+  ])
+
+  const { visibleColumnIds, toggleColumn } = useCaseColumnVisibility(
+    workspaceId,
+    validColumnIds
+  )
+
+  const includeFields = visibleColumnIds.some((id) => id.startsWith("field:"))
 
   const {
     cases,
@@ -61,18 +102,6 @@ export default function CasesPage() {
     fetchNextPage,
   } = useCases({ includeFields })
 
-  const { members } = useWorkspaceMembers(workspaceId)
-  const { caseTags } = useCaseTagCatalog(workspaceId)
-  const { dropdownDefinitions } = useCaseDropdownDefinitions(
-    workspaceId,
-    caseAddonsEnabled
-  )
-  const { caseFields } = useCaseFields(workspaceId, caseAddonsEnabled)
-  const { caseDurationDefinitions } = useCaseDurationDefinitions(
-    workspaceId,
-    caseAddonsEnabled
-  )
-
   useEffect(() => {
     if (typeof window !== "undefined") {
       document.title = "Cases"
@@ -109,7 +138,7 @@ export default function CasesPage() {
         dropdownDefinitions={
           caseAddonsEnabled ? dropdownDefinitions : undefined
         }
-        fieldDefinitions={caseAddonsEnabled ? caseFields : undefined}
+        fieldDefinitions={caseFields}
         durationDefinitions={
           caseAddonsEnabled ? caseDurationDefinitions : undefined
         }

--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -2,14 +2,27 @@
 
 import { useEffect } from "react"
 import { CasesLayout } from "@/components/cases/cases-layout"
+import { useCaseColumnVisibility } from "@/hooks/use-case-column-visibility"
 import { useCases } from "@/hooks/use-cases"
 import { useEntitlements } from "@/hooks/use-entitlements"
 import { useWorkspaceMembers } from "@/hooks/use-workspace"
-import { useCaseDropdownDefinitions, useCaseTagCatalog } from "@/lib/hooks"
+import {
+  useCaseDropdownDefinitions,
+  useCaseDurationDefinitions,
+  useCaseFields,
+  useCaseTagCatalog,
+} from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 export default function CasesPage() {
   const workspaceId = useWorkspaceId()
+  const { hasEntitlement } = useEntitlements()
+  const caseAddonsEnabled = hasEntitlement("case_addons")
+
+  const { visibleColumnIds, toggleColumn } =
+    useCaseColumnVisibility(workspaceId)
+
+  const includeFields = visibleColumnIds.some((id) => id.startsWith("field:"))
 
   const {
     cases,
@@ -45,13 +58,16 @@ export default function CasesPage() {
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
-  } = useCases()
+  } = useCases({ includeFields })
 
   const { members } = useWorkspaceMembers(workspaceId)
   const { caseTags } = useCaseTagCatalog(workspaceId)
-  const { hasEntitlement } = useEntitlements()
-  const caseAddonsEnabled = hasEntitlement("case_addons")
   const { dropdownDefinitions } = useCaseDropdownDefinitions(
+    workspaceId,
+    caseAddonsEnabled
+  )
+  const { caseFields } = useCaseFields(workspaceId, caseAddonsEnabled)
+  const { caseDurationDefinitions } = useCaseDurationDefinitions(
     workspaceId,
     caseAddonsEnabled
   )
@@ -92,6 +108,12 @@ export default function CasesPage() {
         dropdownDefinitions={
           caseAddonsEnabled ? dropdownDefinitions : undefined
         }
+        fieldDefinitions={caseAddonsEnabled ? caseFields : undefined}
+        durationDefinitions={
+          caseAddonsEnabled ? caseDurationDefinitions : undefined
+        }
+        visibleColumnIds={visibleColumnIds}
+        onToggleColumn={toggleColumn}
         onDropdownFilterChange={setDropdownFilter}
         onDropdownModeChange={setDropdownMode}
         onDropdownSortDirectionChange={setDropdownSortDirection}

--- a/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/cases/page.tsx
@@ -16,7 +16,7 @@ import { useWorkspaceId } from "@/providers/workspace-id"
 
 export default function CasesPage() {
   const workspaceId = useWorkspaceId()
-  const { hasEntitlement } = useEntitlements()
+  const { hasEntitlement, hasEntitlementData } = useEntitlements()
   const caseAddonsEnabled = hasEntitlement("case_addons")
 
   const { members } = useWorkspaceMembers(workspaceId)
@@ -31,9 +31,12 @@ export default function CasesPage() {
     caseAddonsEnabled
   )
 
-  // Avoid pruning persisted selections until the relevant definitions have
-  // resolved; an empty Set during loading would erase stored choices.
+  // Avoid pruning persisted selections until entitlement and field metadata
+  // have both resolved; a partial Set during loading would erase stored choices.
   const knownColumnIds = useMemo<Set<string> | undefined>(() => {
+    if (!hasEntitlementData) {
+      return undefined
+    }
     if (caseFields === undefined) {
       return undefined
     }
@@ -58,6 +61,7 @@ export default function CasesPage() {
     }
     return ids
   }, [
+    hasEntitlementData,
     dropdownDefinitions,
     caseFields,
     caseDurationDefinitions,

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -6315,6 +6315,32 @@ export const $CaseReadMinimal = {
       type: "array",
       title: "Rows",
     },
+    durations: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/CaseDurationRead",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Durations",
+    },
+    field_values: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Field Values",
+    },
     num_tasks_completed: {
       type: "integer",
       title: "Num Tasks Completed",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -7098,6 +7098,8 @@ export const tablesImportCsv = (
  * @param data.orderBy Column name to order by (e.g. created_at, updated_at, priority, severity, status, tasks). Default: created_at
  * @param data.sort Direction to sort (asc or desc)
  * @param data.includeRows Include linked table rows
+ * @param data.fieldIds Include only the requested custom field IDs
+ * @param data.includeDurations Include case duration values
  * @returns CursorPaginatedResponse_CaseReadMinimal_ Successful Response
  * @throws ApiError
  */
@@ -7114,6 +7116,8 @@ export const casesListCases = (
       order_by: data.orderBy,
       sort: data.sort,
       include_rows: data.includeRows,
+      field_ids: data.fieldIds,
+      include_durations: data.includeDurations,
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -7171,7 +7175,8 @@ export const casesCreateCase = (
  * @param data.orderBy Column name to order by (e.g. created_at, updated_at, priority, severity, status, tasks). Default: created_at
  * @param data.sort Direction to sort (asc or desc)
  * @param data.includeRows Include linked table rows
- * @param data.includeFields Include custom field values
+ * @param data.fieldIds Include only the requested custom field IDs
+ * @param data.includeDurations Include case duration values
  * @returns CursorPaginatedResponse_CaseReadMinimal_ Successful Response
  * @throws ApiError
  */
@@ -7200,7 +7205,8 @@ export const casesSearchCases = (
       order_by: data.orderBy,
       sort: data.sort,
       include_rows: data.includeRows,
-      include_fields: data.includeFields,
+      field_ids: data.fieldIds,
+      include_durations: data.includeDurations,
       workspace_id: data.workspaceId,
     },
     errors: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -7171,6 +7171,7 @@ export const casesCreateCase = (
  * @param data.orderBy Column name to order by (e.g. created_at, updated_at, priority, severity, status, tasks). Default: created_at
  * @param data.sort Direction to sort (asc or desc)
  * @param data.includeRows Include linked table rows
+ * @param data.includeFields Include custom field values
  * @returns CursorPaginatedResponse_CaseReadMinimal_ Successful Response
  * @throws ApiError
  */
@@ -7199,6 +7200,7 @@ export const casesSearchCases = (
       order_by: data.orderBy,
       sort: data.sort,
       include_rows: data.includeRows,
+      include_fields: data.includeFields,
       workspace_id: data.workspaceId,
     },
     errors: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -9805,6 +9805,14 @@ export type CasesListCasesData = {
    */
   cursor?: string | null
   /**
+   * Include only the requested custom field IDs
+   */
+  fieldIds?: Array<string> | null
+  /**
+   * Include case duration values
+   */
+  includeDurations?: boolean
+  /**
    * Include linked table rows
    */
   includeRows?: boolean
@@ -9861,9 +9869,13 @@ export type CasesSearchCasesData = {
    */
   endTime?: string | null
   /**
-   * Include custom field values
+   * Include only the requested custom field IDs
    */
-  includeFields?: boolean
+  fieldIds?: Array<string> | null
+  /**
+   * Include case duration values
+   */
+  includeDurations?: boolean
   /**
    * Include linked table rows
    */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1715,6 +1715,10 @@ export type CaseReadMinimal = {
   tags?: Array<CaseTagRead>
   dropdown_values: Array<CaseDropdownValueRead>
   rows?: Array<CaseTableRowRead>
+  durations?: Array<CaseDurationRead> | null
+  field_values?: {
+    [key: string]: unknown
+  } | null
   num_tasks_completed?: number
   num_tasks_total?: number
 }
@@ -9856,6 +9860,10 @@ export type CasesSearchCasesData = {
    * Return cases created at or before this timestamp
    */
   endTime?: string | null
+  /**
+   * Include custom field values
+   */
+  includeFields?: boolean
   /**
    * Include linked table rows
    */

--- a/frontend/src/components/cases/case-badge.tsx
+++ b/frontend/src/components/cases/case-badge.tsx
@@ -1,7 +1,8 @@
-import type { LucideIcon } from "lucide-react"
+import { CircleIcon, type LucideIcon } from "lucide-react"
 import type React from "react"
 import type { PropsWithChildren } from "react"
 import type { CasePriority, CaseSeverity, CaseStatus } from "@/client"
+import { DynamicLucideIcon } from "@/components/dynamic-lucide-icon"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 
@@ -37,6 +38,52 @@ export function CaseBadge<T extends CaseBadgeValue>({
         strokeWidth={3}
       />
       <span>{label}</span>
+    </Badge>
+  )
+}
+
+export interface CaseColumnBadgeProps {
+  label: string
+  iconName?: string | null
+  color?: string | null
+  className?: string
+}
+
+/** Generic badge for custom columns (dropdowns, fields, durations). */
+export function CaseColumnBadge({
+  label,
+  iconName,
+  color,
+  className,
+}: CaseColumnBadgeProps) {
+  const fallbackIcon = (
+    <CircleIcon className="size-[0.9em] flex-none" strokeWidth={3} />
+  )
+  const colorStyle = color
+    ? ({ backgroundColor: `${color}20`, color } as React.CSSProperties)
+    : undefined
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        !color && defaultColor,
+        "max-w-[120px] items-center gap-1 border-0 leading-tight",
+        className
+      )}
+      style={colorStyle}
+    >
+      {iconName ? (
+        <DynamicLucideIcon
+          name={iconName}
+          className="size-[0.9em] flex-none"
+          strokeWidth={3}
+          fallback={fallbackIcon}
+        />
+      ) : (
+        fallbackIcon
+      )}
+      <span className="truncate">{label}</span>
     </Badge>
   )
 }

--- a/frontend/src/components/cases/case-badge.tsx
+++ b/frontend/src/components/cases/case-badge.tsx
@@ -42,38 +42,40 @@ export function CaseBadge<T extends CaseBadgeValue>({
   )
 }
 
-export interface CaseColumnBadgeProps {
+export interface CaseColumnBadgeProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "content" | "color"> {
   label?: string
   content?: React.ReactNode
   iconName?: string | null
   color?: string | null
-  className?: string
-  title?: string
 }
 
 /** Generic badge for custom columns (dropdowns, fields, durations). */
 export const CaseColumnBadge = React.forwardRef<
   HTMLDivElement,
   CaseColumnBadgeProps
->(({ label, content, iconName, color, className, title }, ref) => {
+>(({ label, content, iconName, color, className, style, ...props }, ref) => {
   const fallbackIcon = (
     <CircleIcon className="size-[0.9em] flex-none" strokeWidth={3} />
   )
   const colorStyle = color
     ? ({ backgroundColor: `${color}20`, color } as React.CSSProperties)
     : undefined
+  const mergedStyle = { ...style, ...colorStyle }
 
   return (
     <Badge
       ref={ref}
       variant="outline"
-      title={title}
+      // Keep passing DOM props through to the underlying Badge so wrappers like
+      // Radix TooltipTrigger(asChild) can attach their hover/focus handlers.
       className={cn(
         !color && "bg-secondary text-secondary-foreground",
-        "max-w-[120px] items-center gap-1 border-0 leading-tight",
+        "max-w-[120px] items-center gap-1 border-0 leading-tight transition-opacity hover:opacity-80",
         className
       )}
-      style={colorStyle}
+      style={mergedStyle}
+      {...props}
     >
       {iconName ? (
         <DynamicLucideIcon

--- a/frontend/src/components/cases/case-badge.tsx
+++ b/frontend/src/components/cases/case-badge.tsx
@@ -1,6 +1,6 @@
 import { CircleIcon, type LucideIcon } from "lucide-react"
-import type React from "react"
 import type { PropsWithChildren } from "react"
+import * as React from "react"
 import type { CasePriority, CaseSeverity, CaseStatus } from "@/client"
 import { DynamicLucideIcon } from "@/components/dynamic-lucide-icon"
 import { Badge } from "@/components/ui/badge"
@@ -43,19 +43,19 @@ export function CaseBadge<T extends CaseBadgeValue>({
 }
 
 export interface CaseColumnBadgeProps {
-  label: string
+  label?: string
+  content?: React.ReactNode
   iconName?: string | null
   color?: string | null
   className?: string
+  title?: string
 }
 
 /** Generic badge for custom columns (dropdowns, fields, durations). */
-export function CaseColumnBadge({
-  label,
-  iconName,
-  color,
-  className,
-}: CaseColumnBadgeProps) {
+export const CaseColumnBadge = React.forwardRef<
+  HTMLDivElement,
+  CaseColumnBadgeProps
+>(({ label, content, iconName, color, className, title }, ref) => {
   const fallbackIcon = (
     <CircleIcon className="size-[0.9em] flex-none" strokeWidth={3} />
   )
@@ -65,7 +65,9 @@ export function CaseColumnBadge({
 
   return (
     <Badge
+      ref={ref}
       variant="outline"
+      title={title}
       className={cn(
         !color && "bg-secondary text-secondary-foreground",
         "max-w-[120px] items-center gap-1 border-0 leading-tight",
@@ -83,7 +85,8 @@ export function CaseColumnBadge({
       ) : (
         fallbackIcon
       )}
-      <span className="truncate">{label}</span>
+      {content ?? <span className="truncate">{label}</span>}
     </Badge>
   )
-}
+})
+CaseColumnBadge.displayName = "CaseColumnBadge"

--- a/frontend/src/components/cases/case-badge.tsx
+++ b/frontend/src/components/cases/case-badge.tsx
@@ -67,7 +67,7 @@ export function CaseColumnBadge({
     <Badge
       variant="outline"
       className={cn(
-        !color && "bg-muted/50 text-muted-foreground",
+        !color && "bg-secondary text-secondary-foreground",
         "max-w-[120px] items-center gap-1 border-0 leading-tight",
         className
       )}

--- a/frontend/src/components/cases/case-badge.tsx
+++ b/frontend/src/components/cases/case-badge.tsx
@@ -67,7 +67,7 @@ export function CaseColumnBadge({
     <Badge
       variant="outline"
       className={cn(
-        !color && defaultColor,
+        !color && "bg-muted/50 text-muted-foreground",
         "max-w-[120px] items-center gap-1 border-0 leading-tight",
         className
       )}

--- a/frontend/src/components/cases/case-badge.tsx
+++ b/frontend/src/components/cases/case-badge.tsx
@@ -71,7 +71,7 @@ export const CaseColumnBadge = React.forwardRef<
       // Radix TooltipTrigger(asChild) can attach their hover/focus handlers.
       className={cn(
         !color && "bg-secondary text-secondary-foreground",
-        "max-w-[120px] items-center gap-1 border-0 leading-tight transition-opacity hover:opacity-80",
+        "min-w-0 max-w-[120px] items-center gap-1 border-0 leading-tight transition-opacity hover:opacity-80",
         className
       )}
       style={mergedStyle}
@@ -87,7 +87,7 @@ export const CaseColumnBadge = React.forwardRef<
       ) : (
         fallbackIcon
       )}
-      {content ?? <span className="truncate">{label}</span>}
+      {content ?? <span className="min-w-0 flex-1 truncate">{label}</span>}
     </Badge>
   )
 })

--- a/frontend/src/components/cases/case-closure-dialog.tsx
+++ b/frontend/src/components/cases/case-closure-dialog.tsx
@@ -308,19 +308,28 @@ function ClosureFieldInput({
         <div className="space-y-1.5">
           <Label className="text-sm">{field.id}</Label>
           <Input
-            type="number"
+            type="text"
+            inputMode={field.type === "INTEGER" ? "numeric" : "decimal"}
             value={value != null ? String(value) : ""}
             onChange={(e) => {
-              const v = e.target.value
-              if (v === "") {
+              const raw = e.target.value
+              const trimmed = raw.trim()
+              if (!trimmed) {
+                onValidationChange?.(false)
                 onChange(null)
-              } else {
-                onChange(
-                  field.type === "INTEGER"
-                    ? Number.parseInt(v)
-                    : Number.parseFloat(v)
-                )
+                return
               }
+
+              if (field.type === "INTEGER") {
+                const isValid = /^-?\d+$/.test(trimmed)
+                onValidationChange?.(!isValid)
+                onChange(trimmed)
+                return
+              }
+
+              const isValid = Number.isFinite(Number(trimmed))
+              onValidationChange?.(!isValid)
+              onChange(trimmed)
             }}
             placeholder={`Enter ${field.id}...`}
           />

--- a/frontend/src/components/cases/case-closure-dialog.tsx
+++ b/frontend/src/components/cases/case-closure-dialog.tsx
@@ -48,6 +48,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import {
+  isValidSqlIntegerInput,
+  isValidSqlNumericInput,
+} from "@/lib/sql-value-validation"
 import { cn } from "@/lib/utils"
 
 interface CaseClosureDialogProps {
@@ -321,13 +325,13 @@ function ClosureFieldInput({
               }
 
               if (field.type === "INTEGER") {
-                const isValid = /^-?\d+$/.test(trimmed)
+                const isValid = isValidSqlIntegerInput(trimmed)
                 onValidationChange?.(!isValid)
                 onChange(trimmed)
                 return
               }
 
-              const isValid = Number.isFinite(Number(trimmed))
+              const isValid = isValidSqlNumericInput(trimmed)
               onValidationChange?.(!isValid)
               onChange(trimmed)
             }}

--- a/frontend/src/components/cases/case-column-picker.tsx
+++ b/frontend/src/components/cases/case-column-picker.tsx
@@ -131,7 +131,7 @@ export function CaseColumnPicker({
           )}
         >
           <SlidersHorizontalIcon className="size-3.5 text-muted-foreground" />
-          <span>Columns</span>
+          <span>Display</span>
           {selectedCount > 0 && (
             <span className="ml-0.5 text-[10px] font-medium text-muted-foreground">
               {selectedCount}

--- a/frontend/src/components/cases/case-column-picker.tsx
+++ b/frontend/src/components/cases/case-column-picker.tsx
@@ -102,18 +102,32 @@ export function CaseColumnPicker({
   onToggle,
 }: CaseColumnPickerProps) {
   const [open, setOpen] = useState(false)
-  const selectedCount = visibleColumnIds.length
-  const isAtLimit = selectedCount >= MAX_VISIBLE_COLUMNS
 
   const nonReservedFields = useMemo(
     () => fieldDefinitions?.filter((f) => !f.reserved) ?? [],
     [fieldDefinitions]
   )
 
-  const hasOptions =
-    (dropdownDefinitions && dropdownDefinitions.length > 0) ||
-    nonReservedFields.length > 0 ||
-    (durationDefinitions && durationDefinitions.length > 0)
+  // Build set of known column IDs so stale persisted IDs don't count
+  // toward the max-4 limit or show in the badge count.
+  const knownColumnIds = useMemo(() => {
+    const ids = new Set<string>()
+    if (dropdownDefinitions) {
+      for (const d of dropdownDefinitions) ids.add(`dropdown:${d.ref}`)
+    }
+    for (const f of nonReservedFields) ids.add(`field:${f.id}`)
+    if (durationDefinitions) {
+      for (const d of durationDefinitions) ids.add(`duration:${d.id}`)
+    }
+    return ids
+  }, [dropdownDefinitions, nonReservedFields, durationDefinitions])
+
+  const selectedCount = visibleColumnIds.filter((id) =>
+    knownColumnIds.has(id)
+  ).length
+  const isAtLimit = selectedCount >= MAX_VISIBLE_COLUMNS
+
+  const hasOptions = knownColumnIds.size > 0
 
   if (!hasOptions) {
     return null

--- a/frontend/src/components/cases/case-column-picker.tsx
+++ b/frontend/src/components/cases/case-column-picker.tsx
@@ -1,0 +1,241 @@
+"use client"
+
+import {
+  Check,
+  ChevronDown,
+  ListIcon,
+  SlidersHorizontalIcon,
+  TextIcon,
+  TimerIcon,
+} from "lucide-react"
+import { type ReactNode, useMemo, useState } from "react"
+import type {
+  CaseDropdownDefinitionRead,
+  CaseDurationDefinitionRead,
+  CaseFieldReadMinimal,
+} from "@/client"
+import { DynamicLucideIcon } from "@/components/dynamic-lucide-icon"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+
+const MAX_VISIBLE_COLUMNS = 4
+
+function ColumnCheckbox({
+  checked,
+  disabled,
+}: {
+  checked: boolean
+  disabled: boolean
+}) {
+  return (
+    <div
+      className={cn(
+        "mr-2 flex size-4 shrink-0 items-center justify-center rounded-sm border",
+        checked
+          ? "border-primary bg-primary text-primary-foreground"
+          : "border-muted-foreground/40 bg-transparent",
+        disabled && "opacity-40"
+      )}
+    >
+      {checked && <Check className="size-3" />}
+    </div>
+  )
+}
+
+function ColumnOption({
+  columnId,
+  searchValue,
+  label,
+  icon,
+  isSelected,
+  isDisabled,
+  onToggle,
+}: {
+  columnId: string
+  searchValue: string
+  label: string
+  icon: ReactNode
+  isSelected: boolean
+  isDisabled: boolean
+  onToggle: (columnId: string) => void
+}) {
+  return (
+    <CommandItem
+      key={columnId}
+      value={searchValue}
+      onSelect={() => !isDisabled && onToggle(columnId)}
+      disabled={isDisabled}
+      className="text-xs"
+    >
+      <ColumnCheckbox checked={isSelected} disabled={isDisabled} />
+      {icon}
+      <span className="truncate">{label}</span>
+    </CommandItem>
+  )
+}
+
+interface CaseColumnPickerProps {
+  dropdownDefinitions?: CaseDropdownDefinitionRead[]
+  fieldDefinitions?: CaseFieldReadMinimal[]
+  durationDefinitions?: CaseDurationDefinitionRead[]
+  visibleColumnIds: string[]
+  onToggle: (columnId: string) => void
+}
+
+export function CaseColumnPicker({
+  dropdownDefinitions,
+  fieldDefinitions,
+  durationDefinitions,
+  visibleColumnIds,
+  onToggle,
+}: CaseColumnPickerProps) {
+  const [open, setOpen] = useState(false)
+  const selectedCount = visibleColumnIds.length
+  const isAtLimit = selectedCount >= MAX_VISIBLE_COLUMNS
+
+  const nonReservedFields = useMemo(
+    () => fieldDefinitions?.filter((f) => !f.reserved) ?? [],
+    [fieldDefinitions]
+  )
+
+  const hasOptions =
+    (dropdownDefinitions && dropdownDefinitions.length > 0) ||
+    nonReservedFields.length > 0 ||
+    (durationDefinitions && durationDefinitions.length > 0)
+
+  if (!hasOptions) {
+    return null
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex h-6 items-center gap-1.5 rounded-md border border-input bg-transparent px-2 text-xs font-medium transition-colors",
+            "hover:bg-muted/50",
+            selectedCount > 0 && "border-primary/50 bg-primary/5"
+          )}
+        >
+          <SlidersHorizontalIcon className="size-3.5 text-muted-foreground" />
+          <span>Columns</span>
+          {selectedCount > 0 && (
+            <span className="ml-0.5 text-[10px] font-medium text-muted-foreground">
+              {selectedCount}
+            </span>
+          )}
+          <ChevronDown className="size-3 opacity-50" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-56 p-0 shadow-sm"
+        align="start"
+        sideOffset={4}
+      >
+        <Command>
+          <CommandInput
+            placeholder="Search columns..."
+            className="h-8 text-xs"
+          />
+          <CommandList>
+            <CommandEmpty className="py-3 text-center text-xs text-muted-foreground">
+              No columns found.
+            </CommandEmpty>
+
+            {dropdownDefinitions && dropdownDefinitions.length > 0 && (
+              <CommandGroup heading="Dropdowns">
+                {dropdownDefinitions.map((def) => {
+                  const columnId = `dropdown:${def.ref}`
+                  const isSelected = visibleColumnIds.includes(columnId)
+                  return (
+                    <ColumnOption
+                      key={columnId}
+                      columnId={columnId}
+                      searchValue={`dropdown ${def.name}`}
+                      label={def.name}
+                      icon={
+                        def.icon_name ? (
+                          <DynamicLucideIcon
+                            name={def.icon_name}
+                            className="mr-2 size-3.5 shrink-0 text-muted-foreground"
+                            fallback={
+                              <ListIcon className="mr-2 size-3.5 shrink-0 text-muted-foreground" />
+                            }
+                          />
+                        ) : (
+                          <ListIcon className="mr-2 size-3.5 shrink-0 text-muted-foreground" />
+                        )
+                      }
+                      isSelected={isSelected}
+                      isDisabled={!isSelected && isAtLimit}
+                      onToggle={onToggle}
+                    />
+                  )
+                })}
+              </CommandGroup>
+            )}
+
+            {nonReservedFields.length > 0 && (
+              <CommandGroup heading="Fields">
+                {nonReservedFields.map((field) => {
+                  const columnId = `field:${field.id}`
+                  const isSelected = visibleColumnIds.includes(columnId)
+                  return (
+                    <ColumnOption
+                      key={columnId}
+                      columnId={columnId}
+                      searchValue={`field ${field.id}`}
+                      label={field.id}
+                      icon={
+                        <TextIcon className="mr-2 size-3.5 shrink-0 text-muted-foreground" />
+                      }
+                      isSelected={isSelected}
+                      isDisabled={!isSelected && isAtLimit}
+                      onToggle={onToggle}
+                    />
+                  )
+                })}
+              </CommandGroup>
+            )}
+
+            {durationDefinitions && durationDefinitions.length > 0 && (
+              <CommandGroup heading="Durations">
+                {durationDefinitions.map((def) => {
+                  const columnId = `duration:${def.id}`
+                  const isSelected = visibleColumnIds.includes(columnId)
+                  return (
+                    <ColumnOption
+                      key={columnId}
+                      columnId={columnId}
+                      searchValue={`duration ${def.name}`}
+                      label={def.name}
+                      icon={
+                        <TimerIcon className="mr-2 size-3.5 shrink-0 text-muted-foreground" />
+                      }
+                      isSelected={isSelected}
+                      isDisabled={!isSelected && isAtLimit}
+                      onToggle={onToggle}
+                    />
+                  )
+                })}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/src/components/cases/case-item.tsx
+++ b/frontend/src/components/cases/case-item.tsx
@@ -16,9 +16,10 @@ import {
   UserIcon,
 } from "lucide-react"
 import Link from "next/link"
-import { useEffect, useMemo, useState } from "react"
+import { type ReactNode, useEffect, useMemo, useState } from "react"
 import type {
   CaseDropdownDefinitionRead,
+  CaseDurationDefinitionRead,
   CaseFieldReadMinimal,
   CasePriority,
   CaseReadMinimal,
@@ -63,23 +64,25 @@ import {
 import { toast } from "@/components/ui/use-toast"
 import { User } from "@/lib/auth"
 import { formatCaseFieldDisplayLabel } from "@/lib/case-field-display"
+import { parseISODuration } from "@/lib/time"
 import { cn } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
-/** Parse an ISO 8601 duration string (e.g. "PT2H15M30S") to a short label. */
-function formatIsoDuration(iso: string): string | null {
-  const match = iso.match(
-    /^P(?:(\d+)D)?T?(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?$/
-  )
-  if (!match) return null
-  const days = Number(match[1] || 0)
-  const hours = Number(match[2] || 0) + days * 24
-  const minutes = Number(match[3] || 0)
-  const seconds = Number(match[4] || 0)
-  const total = hours * 3600 + minutes * 60 + seconds
-  if (total < 60) return `${Math.round(total)}s`
-  if (total < 3600) return `${Math.floor(total / 60)}m`
-  return `${Math.floor(total / 3600)}h`
+function formatCompactDuration(duration: string): string | null {
+  try {
+    const parsed = parseISODuration(duration)
+    const parts: string[] = []
+    if (parsed.years) parts.push(`${parsed.years}y`)
+    if (parsed.months) parts.push(`${parsed.months}mo`)
+    if (parsed.weeks) parts.push(`${parsed.weeks}w`)
+    if (parsed.days) parts.push(`${parsed.days}d`)
+    if (parsed.hours) parts.push(`${parsed.hours}h`)
+    if (parsed.minutes) parts.push(`${parsed.minutes}m`)
+    if (parsed.seconds) parts.push(`${parsed.seconds}s`)
+    return parts.length > 0 ? parts.join("") : "0s"
+  } catch {
+    return null
+  }
 }
 
 interface CaseItemProps {
@@ -93,6 +96,7 @@ interface CaseItemProps {
   members?: WorkspaceMember[]
   dropdownDefinitions?: CaseDropdownDefinitionRead[]
   fieldTypesById?: ReadonlyMap<string, CaseFieldReadMinimal["type"]>
+  durationNamesById?: ReadonlyMap<CaseDurationDefinitionRead["id"], string>
   visibleColumnIds?: string[]
 }
 
@@ -107,6 +111,7 @@ export function CaseItem({
   members,
   dropdownDefinitions,
   fieldTypesById,
+  durationNamesById,
   visibleColumnIds,
 }: CaseItemProps) {
   const workspaceId = useWorkspaceId()
@@ -125,12 +130,11 @@ export function CaseItem({
     setOptimisticTags(null)
   }, [caseData.tags])
 
-  // Compute visible column badges
-  const columnBadges = useMemo(() => {
+  const summaryColumnBadges = useMemo(() => {
     if (!visibleColumnIds || visibleColumnIds.length === 0) {
       return null
     }
-    const badges: React.ReactNode[] = []
+    const badges: ReactNode[] = []
     for (const columnId of visibleColumnIds) {
       if (columnId.startsWith("dropdown:")) {
         const ref = columnId.slice("dropdown:".length)
@@ -138,7 +142,7 @@ export function CaseItem({
           (v) => v.definition_ref === ref
         )
         if (dv?.option_label) {
-          badges.push(
+          const badge = (
             <CaseColumnBadge
               key={columnId}
               label={dv.option_label}
@@ -147,6 +151,7 @@ export function CaseItem({
               className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
             />
           )
+          badges.push(badge)
         }
       } else if (columnId.startsWith("field:")) {
         const fieldId = columnId.slice("field:".length)
@@ -156,29 +161,15 @@ export function CaseItem({
             value,
             fieldTypesById?.get(fieldId)
           )
-          badges.push(
+          const badge = (
             <CaseColumnBadge
               key={columnId}
               label={label}
+              title={fieldId}
               className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
             />
           )
-        }
-      } else if (columnId.startsWith("duration:")) {
-        const defId = columnId.slice("duration:".length)
-        const dur = caseData.durations?.find((d) => d.definition_id === defId)
-        if (dur?.duration != null) {
-          const label = formatIsoDuration(dur.duration)
-          if (label) {
-            badges.push(
-              <CaseColumnBadge
-                key={columnId}
-                label={label}
-                iconName="timer"
-                className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
-              />
-            )
-          }
+          badges.push(badge)
         }
       }
     }
@@ -188,8 +179,50 @@ export function CaseItem({
     fieldTypesById,
     caseData.dropdown_values,
     caseData.field_values,
-    caseData.durations,
   ])
+
+  const durationBadges = useMemo(() => {
+    if (!visibleColumnIds || visibleColumnIds.length === 0) {
+      return null
+    }
+
+    const badges: ReactNode[] = []
+    for (const columnId of visibleColumnIds) {
+      if (!columnId.startsWith("duration:")) {
+        continue
+      }
+
+      const defId = columnId.slice("duration:".length)
+      const dur = caseData.durations?.find((d) => d.definition_id === defId)
+      if (dur?.duration == null) {
+        continue
+      }
+
+      const formattedValue = formatCompactDuration(dur.duration)
+      if (!formattedValue) {
+        continue
+      }
+
+      const durationName = durationNamesById?.get(defId) ?? "Duration"
+      const badge = (
+        <CaseColumnBadge
+          key={columnId}
+          iconName="timer"
+          title={durationName}
+          className="h-5 max-w-[172px] shrink-0 px-1.5 py-0 text-[10px]"
+          content={
+            <span className="flex min-w-0 items-center gap-0.5">
+              <span className="truncate">{durationName}</span>
+              <span className="shrink-0">: {formattedValue}</span>
+            </span>
+          }
+        />
+      )
+      badges.push(badge)
+    }
+
+    return badges.length > 0 ? badges : null
+  }, [visibleColumnIds, caseData.durations, durationNamesById])
 
   const handleCheckboxClick = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -474,7 +507,7 @@ export function CaseItem({
                 />
               )}
               {/* Custom column badges */}
-              {columnBadges}
+              {summaryColumnBadges}
             </div>
 
             {/* Tags - right aligned */}
@@ -504,6 +537,12 @@ export function CaseItem({
                     +{caseData.tags.length - 3}
                   </span>
                 )}
+              </div>
+            )}
+
+            {durationBadges && (
+              <div className="flex shrink-0 items-center gap-1">
+                {durationBadges}
               </div>
             )}
 

--- a/frontend/src/components/cases/case-item.tsx
+++ b/frontend/src/components/cases/case-item.tsx
@@ -102,7 +102,7 @@ function withBadgeTooltip(
   return (
     <Tooltip key={key}>
       <TooltipTrigger asChild>{badge}</TooltipTrigger>
-      <TooltipContent side="top" className="px-2 py-1">
+      <TooltipContent side="top" className="px-2 py-1 text-xs">
         {tooltip}
       </TooltipContent>
     </Tooltip>
@@ -213,7 +213,7 @@ export function CaseItem({
               label={dv.option_label}
               iconName={dv.option_icon_name}
               color={dv.option_color}
-              className="h-5 shrink-0 px-1.5 py-0 text-xs"
+              className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
             />
           )
           badges.push(
@@ -236,7 +236,7 @@ export function CaseItem({
             <CaseColumnBadge
               key={columnId}
               label={label}
-              className="h-5 shrink-0 px-1.5 py-0 text-xs"
+              className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
             />
           )
           badges.push(
@@ -286,7 +286,7 @@ export function CaseItem({
         <CaseColumnBadge
           key={columnId}
           iconName="timer"
-          className="h-5 max-w-[172px] shrink-0 px-1.5 py-0 text-xs"
+          className="h-5 max-w-[172px] shrink-0 px-1.5 py-0 text-[10px]"
           content={
             <span className="flex min-w-0 items-center gap-0.5">
               <span className="truncate">{durationName}</span>

--- a/frontend/src/components/cases/case-item.tsx
+++ b/frontend/src/components/cases/case-item.tsx
@@ -148,14 +148,19 @@ export function CaseItem({
         const fieldId = columnId.slice("field:".length)
         const value = caseData.field_values?.[fieldId]
         if (value != null) {
-          const label =
-            typeof value === "boolean"
-              ? value
-                ? "Yes"
-                : "No"
-              : typeof value === "number"
-                ? String(parseFloat(value.toFixed(2)))
-                : String(value)
+          let label: string
+          if (typeof value === "boolean") {
+            label = value ? "Yes" : "No"
+          } else if (typeof value === "number") {
+            label = String(parseFloat(value.toFixed(2)))
+          } else if (typeof value === "object") {
+            // URL-kind fields store {url, label}; JSONB stores arbitrary objects
+            const obj = value as Record<string, unknown>
+            label =
+              typeof obj.label === "string" ? obj.label : JSON.stringify(value)
+          } else {
+            label = String(value)
+          }
           badges.push(
             <CaseColumnBadge
               key={columnId}

--- a/frontend/src/components/cases/case-item.tsx
+++ b/frontend/src/components/cases/case-item.tsx
@@ -149,7 +149,13 @@ export function CaseItem({
         const value = caseData.field_values?.[fieldId]
         if (value != null) {
           const label =
-            typeof value === "boolean" ? (value ? "Yes" : "No") : String(value)
+            typeof value === "boolean"
+              ? value
+                ? "Yes"
+                : "No"
+              : typeof value === "number"
+                ? String(parseFloat(value.toFixed(2)))
+                : String(value)
           badges.push(
             <CaseColumnBadge
               key={columnId}

--- a/frontend/src/components/cases/case-item.tsx
+++ b/frontend/src/components/cases/case-item.tsx
@@ -61,28 +61,93 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
 import { User } from "@/lib/auth"
 import { formatCaseFieldDisplayLabel } from "@/lib/case-field-display"
-import { parseISODuration } from "@/lib/time"
+import { durationToHumanReadable, parseISODuration } from "@/lib/time"
 import { cn } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 function formatCompactDuration(duration: string): string | null {
   try {
     const parsed = parseISODuration(duration)
-    const parts: string[] = []
-    if (parsed.years) parts.push(`${parsed.years}y`)
-    if (parsed.months) parts.push(`${parsed.months}mo`)
-    if (parsed.weeks) parts.push(`${parsed.weeks}w`)
-    if (parsed.days) parts.push(`${parsed.days}d`)
-    if (parsed.hours) parts.push(`${parsed.hours}h`)
-    if (parsed.minutes) parts.push(`${parsed.minutes}m`)
-    if (parsed.seconds) parts.push(`${parsed.seconds}s`)
-    return parts.length > 0 ? parts.join("") : "0s"
+    if (parsed.years) return `${parsed.years}y`
+    if (parsed.months) return `${parsed.months}mo`
+    if (parsed.weeks) return `${parsed.weeks}w`
+    if (parsed.days) return `${parsed.days}d`
+    if (parsed.hours) return `${parsed.hours}h`
+    if (parsed.minutes) return `${parsed.minutes}m`
+    if (parsed.seconds) return `${parsed.seconds}s`
+    return "0s"
   } catch {
     return null
   }
+}
+
+function withBadgeTooltip(
+  badge: ReactNode,
+  tooltip: ReactNode,
+  key: string
+): ReactNode {
+  if (!tooltip) {
+    return badge
+  }
+
+  return (
+    <Tooltip key={key}>
+      <TooltipTrigger asChild>{badge}</TooltipTrigger>
+      <TooltipContent side="top" className="px-2 py-1">
+        {tooltip}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function formatFieldTooltipLabel(fieldId: string): string {
+  const normalized = fieldId.replace(/[_-]+/g, " ").trim()
+  if (!normalized) {
+    return fieldId
+  }
+
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1)
+}
+
+function formatTooltipTimestamp(timestamp?: string | null): string | null {
+  if (!timestamp) {
+    return null
+  }
+
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.toLocaleString()
+}
+
+function buildDurationTooltipContent(
+  name: string,
+  duration: string,
+  startedAt?: string | null,
+  endedAt?: string | null
+): ReactNode {
+  const startedLabel = formatTooltipTimestamp(startedAt)
+  const endedLabel = formatTooltipTimestamp(endedAt)
+
+  return (
+    <div className="space-y-1">
+      <div className="font-medium">{name}</div>
+      <div>Duration: {durationToHumanReadable(duration)}</div>
+      {startedLabel && <div>Started: {startedLabel}</div>}
+      {endedLabel && <div>Ended: {endedLabel}</div>}
+    </div>
+  )
 }
 
 interface CaseItemProps {
@@ -148,10 +213,16 @@ export function CaseItem({
               label={dv.option_label}
               iconName={dv.option_icon_name}
               color={dv.option_color}
-              className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
+              className="h-5 shrink-0 px-1.5 py-0 text-xs"
             />
           )
-          badges.push(badge)
+          badges.push(
+            withBadgeTooltip(
+              badge,
+              dv.definition_name || dv.definition_ref || ref,
+              columnId
+            )
+          )
         }
       } else if (columnId.startsWith("field:")) {
         const fieldId = columnId.slice("field:".length)
@@ -165,11 +236,12 @@ export function CaseItem({
             <CaseColumnBadge
               key={columnId}
               label={label}
-              title={fieldId}
-              className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
+              className="h-5 shrink-0 px-1.5 py-0 text-xs"
             />
           )
-          badges.push(badge)
+          badges.push(
+            withBadgeTooltip(badge, formatFieldTooltipLabel(fieldId), columnId)
+          )
         }
       }
     }
@@ -204,12 +276,17 @@ export function CaseItem({
       }
 
       const durationName = durationNamesById?.get(defId) ?? "Duration"
+      const tooltipContent = buildDurationTooltipContent(
+        durationName,
+        dur.duration,
+        dur.started_at,
+        dur.ended_at
+      )
       const badge = (
         <CaseColumnBadge
           key={columnId}
           iconName="timer"
-          title={durationName}
-          className="h-5 max-w-[172px] shrink-0 px-1.5 py-0 text-[10px]"
+          className="h-5 max-w-[172px] shrink-0 px-1.5 py-0 text-xs"
           content={
             <span className="flex min-w-0 items-center gap-0.5">
               <span className="truncate">{durationName}</span>
@@ -218,7 +295,7 @@ export function CaseItem({
           }
         />
       )
-      badges.push(badge)
+      badges.push(withBadgeTooltip(badge, tooltipContent, columnId))
     }
 
     return badges.length > 0 ? badges : null
@@ -477,92 +554,97 @@ export function CaseItem({
           </button>
 
           {/* Case ID + Summary + Badges */}
-          <button
-            type="button"
-            onClick={onClick}
-            className="flex min-w-0 flex-1 items-center gap-3 bg-transparent p-0 text-left"
-          >
-            <div className="flex min-w-0 flex-1 items-center gap-2">
-              <span className="shrink-0 text-xs font-medium text-muted-foreground">
-                {caseData.short_id}
-              </span>
-              <span className="truncate text-xs">{caseData.summary}</span>
-              {/* Badges - right next to summary */}
-              {priorityConfig && (
-                <CaseBadge
-                  value={caseData.priority}
-                  label={priorityConfig.label}
-                  icon={priorityConfig.icon}
-                  color={priorityConfig.color}
-                  className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
-                />
-              )}
-              {severityConfig && (
-                <CaseBadge
-                  value={caseData.severity}
-                  label={severityConfig.label}
-                  icon={severityConfig.icon}
-                  color={severityConfig.color}
-                  className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
-                />
-              )}
-              {/* Custom column badges */}
-              {summaryColumnBadges}
-            </div>
-
-            {/* Tags - right aligned */}
-            {caseData.tags && caseData.tags.length > 0 && (
-              <div className="flex shrink-0 items-center gap-1">
-                {caseData.tags.slice(0, 3).map((tag) => (
-                  <span
-                    key={tag.id}
-                    className={cn(
-                      "inline-flex h-5 items-center rounded-full px-2 text-[10px] font-medium",
-                      !tag.color && "bg-muted text-muted-foreground"
-                    )}
-                    style={
-                      tag.color
-                        ? {
-                            backgroundColor: `${tag.color}20`,
-                            color: tag.color,
-                          }
-                        : undefined
-                    }
-                  >
-                    {tag.name}
-                  </span>
-                ))}
-                {caseData.tags.length > 3 && (
-                  <span className="text-[10px] text-muted-foreground">
-                    +{caseData.tags.length - 3}
-                  </span>
-                )}
-              </div>
-            )}
-
-            {durationBadges && (
-              <div className="flex shrink-0 items-center gap-1">
-                {durationBadges}
-              </div>
-            )}
-
-            {/* Assignee */}
-            {caseData.assignee && (
-              <div className="flex shrink-0 items-center gap-1">
-                <CaseUserAvatar user={new User(caseData.assignee)} size="sm" />
-                <span className="max-w-[80px] truncate text-xs text-muted-foreground">
-                  {caseData.assignee.first_name?.split(/\s/)[0] ||
-                    caseData.assignee.email.split("@")[0]}
+          <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+            <button
+              type="button"
+              onClick={onClick}
+              className="flex min-w-0 flex-1 items-center gap-3 bg-transparent p-0 text-left"
+            >
+              <div className="flex min-w-0 flex-1 items-center gap-2">
+                <span className="shrink-0 text-xs font-medium text-muted-foreground">
+                  {caseData.short_id}
                 </span>
+                <span className="truncate text-xs">{caseData.summary}</span>
+                {/* Badges - right next to summary */}
+                {priorityConfig && (
+                  <CaseBadge
+                    value={caseData.priority}
+                    label={priorityConfig.label}
+                    icon={priorityConfig.icon}
+                    color={priorityConfig.color}
+                    className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
+                  />
+                )}
+                {severityConfig && (
+                  <CaseBadge
+                    value={caseData.severity}
+                    label={severityConfig.label}
+                    icon={severityConfig.icon}
+                    color={severityConfig.color}
+                    className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
+                  />
+                )}
+                {/* Custom column badges */}
+                {summaryColumnBadges}
               </div>
-            )}
 
-            {/* Timestamps */}
-            <div className="flex shrink-0 items-center gap-2">
-              <EventCreatedAt createdAt={caseData.created_at} />
-              <EventUpdatedAt updatedAt={caseData.updated_at} />
-            </div>
-          </button>
+              {/* Tags - right aligned */}
+              {caseData.tags && caseData.tags.length > 0 && (
+                <div className="flex shrink-0 items-center gap-1">
+                  {caseData.tags.slice(0, 3).map((tag) => (
+                    <span
+                      key={tag.id}
+                      className={cn(
+                        "inline-flex h-5 items-center rounded-full px-2 text-[10px] font-medium",
+                        !tag.color && "bg-muted text-muted-foreground"
+                      )}
+                      style={
+                        tag.color
+                          ? {
+                              backgroundColor: `${tag.color}20`,
+                              color: tag.color,
+                            }
+                          : undefined
+                      }
+                    >
+                      {tag.name}
+                    </span>
+                  ))}
+                  {caseData.tags.length > 3 && (
+                    <span className="text-[10px] text-muted-foreground">
+                      +{caseData.tags.length - 3}
+                    </span>
+                  )}
+                </div>
+              )}
+
+              {durationBadges && (
+                <div className="flex shrink-0 items-center gap-1">
+                  {durationBadges}
+                </div>
+              )}
+
+              {/* Assignee */}
+              {caseData.assignee && (
+                <div className="flex shrink-0 items-center gap-1">
+                  <CaseUserAvatar
+                    user={new User(caseData.assignee)}
+                    size="sm"
+                  />
+                  <span className="max-w-[80px] truncate text-xs text-muted-foreground">
+                    {caseData.assignee.first_name?.split(/\s/)[0] ||
+                      caseData.assignee.email.split("@")[0]}
+                  </span>
+                </div>
+              )}
+
+              {/* Timestamps */}
+              <div className="flex shrink-0 items-center gap-2">
+                <EventCreatedAt createdAt={caseData.created_at} />
+                <EventUpdatedAt updatedAt={caseData.updated_at} />
+              </div>
+            </button>
+          </TooltipProvider>
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent className="w-48">

--- a/frontend/src/components/cases/case-item.tsx
+++ b/frontend/src/components/cases/case-item.tsx
@@ -19,6 +19,7 @@ import Link from "next/link"
 import { useEffect, useMemo, useState } from "react"
 import type {
   CaseDropdownDefinitionRead,
+  CaseFieldReadMinimal,
   CasePriority,
   CaseReadMinimal,
   CaseSeverity,
@@ -61,6 +62,7 @@ import {
 } from "@/components/ui/context-menu"
 import { toast } from "@/components/ui/use-toast"
 import { User } from "@/lib/auth"
+import { formatCaseFieldDisplayLabel } from "@/lib/case-field-display"
 import { cn } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
@@ -90,6 +92,7 @@ interface CaseItemProps {
   tags?: CaseTagRead[]
   members?: WorkspaceMember[]
   dropdownDefinitions?: CaseDropdownDefinitionRead[]
+  fieldTypesById?: ReadonlyMap<string, CaseFieldReadMinimal["type"]>
   visibleColumnIds?: string[]
 }
 
@@ -103,6 +106,7 @@ export function CaseItem({
   tags,
   members,
   dropdownDefinitions,
+  fieldTypesById,
   visibleColumnIds,
 }: CaseItemProps) {
   const workspaceId = useWorkspaceId()
@@ -148,19 +152,10 @@ export function CaseItem({
         const fieldId = columnId.slice("field:".length)
         const value = caseData.field_values?.[fieldId]
         if (value != null) {
-          let label: string
-          if (typeof value === "boolean") {
-            label = value ? "Yes" : "No"
-          } else if (typeof value === "number") {
-            label = String(parseFloat(value.toFixed(2)))
-          } else if (typeof value === "object") {
-            // URL-kind fields store {url, label}; JSONB stores arbitrary objects
-            const obj = value as Record<string, unknown>
-            label =
-              typeof obj.label === "string" ? obj.label : JSON.stringify(value)
-          } else {
-            label = String(value)
-          }
+          const label = formatCaseFieldDisplayLabel(
+            value,
+            fieldTypesById?.get(fieldId)
+          )
           badges.push(
             <CaseColumnBadge
               key={columnId}
@@ -190,6 +185,7 @@ export function CaseItem({
     return badges.length > 0 ? badges : null
   }, [
     visibleColumnIds,
+    fieldTypesById,
     caseData.dropdown_values,
     caseData.field_values,
     caseData.durations,

--- a/frontend/src/components/cases/case-item.tsx
+++ b/frontend/src/components/cases/case-item.tsx
@@ -16,7 +16,7 @@ import {
   UserIcon,
 } from "lucide-react"
 import Link from "next/link"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import type {
   CaseDropdownDefinitionRead,
   CasePriority,
@@ -32,7 +32,7 @@ import {
   casesSetCaseDropdownValue,
   casesUpdateCase,
 } from "@/client"
-import { CaseBadge } from "@/components/cases/case-badge"
+import { CaseBadge, CaseColumnBadge } from "@/components/cases/case-badge"
 import {
   PRIORITIES,
   SEVERITIES,
@@ -64,6 +64,22 @@ import { User } from "@/lib/auth"
 import { cn } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
+/** Parse an ISO 8601 duration string (e.g. "PT2H15M30S") to a short label. */
+function formatIsoDuration(iso: string): string | null {
+  const match = iso.match(
+    /^P(?:(\d+)D)?T?(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?$/
+  )
+  if (!match) return null
+  const days = Number(match[1] || 0)
+  const hours = Number(match[2] || 0) + days * 24
+  const minutes = Number(match[3] || 0)
+  const seconds = Number(match[4] || 0)
+  const total = hours * 3600 + minutes * 60 + seconds
+  if (total < 60) return `${Math.round(total)}s`
+  if (total < 3600) return `${Math.floor(total / 60)}m`
+  return `${Math.floor(total / 3600)}h`
+}
+
 interface CaseItemProps {
   caseData: CaseReadMinimal
   isSelected: boolean
@@ -74,6 +90,7 @@ interface CaseItemProps {
   tags?: CaseTagRead[]
   members?: WorkspaceMember[]
   dropdownDefinitions?: CaseDropdownDefinitionRead[]
+  visibleColumnIds?: string[]
 }
 
 export function CaseItem({
@@ -86,6 +103,7 @@ export function CaseItem({
   tags,
   members,
   dropdownDefinitions,
+  visibleColumnIds,
 }: CaseItemProps) {
   const workspaceId = useWorkspaceId()
   const queryClient = useQueryClient()
@@ -102,6 +120,69 @@ export function CaseItem({
   useEffect(() => {
     setOptimisticTags(null)
   }, [caseData.tags])
+
+  // Compute visible column badges
+  const columnBadges = useMemo(() => {
+    if (!visibleColumnIds || visibleColumnIds.length === 0) {
+      return null
+    }
+    const badges: React.ReactNode[] = []
+    for (const columnId of visibleColumnIds) {
+      if (columnId.startsWith("dropdown:")) {
+        const ref = columnId.slice("dropdown:".length)
+        const dv = caseData.dropdown_values?.find(
+          (v) => v.definition_ref === ref
+        )
+        if (dv?.option_label) {
+          badges.push(
+            <CaseColumnBadge
+              key={columnId}
+              label={dv.option_label}
+              iconName={dv.option_icon_name}
+              color={dv.option_color}
+              className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
+            />
+          )
+        }
+      } else if (columnId.startsWith("field:")) {
+        const fieldId = columnId.slice("field:".length)
+        const value = caseData.field_values?.[fieldId]
+        if (value != null) {
+          const label =
+            typeof value === "boolean" ? (value ? "Yes" : "No") : String(value)
+          badges.push(
+            <CaseColumnBadge
+              key={columnId}
+              label={label}
+              className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
+            />
+          )
+        }
+      } else if (columnId.startsWith("duration:")) {
+        const defId = columnId.slice("duration:".length)
+        const dur = caseData.durations?.find((d) => d.definition_id === defId)
+        if (dur?.duration != null) {
+          const label = formatIsoDuration(dur.duration)
+          if (label) {
+            badges.push(
+              <CaseColumnBadge
+                key={columnId}
+                label={label}
+                iconName="timer"
+                className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
+              />
+            )
+          }
+        }
+      }
+    }
+    return badges.length > 0 ? badges : null
+  }, [
+    visibleColumnIds,
+    caseData.dropdown_values,
+    caseData.field_values,
+    caseData.durations,
+  ])
 
   const handleCheckboxClick = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -385,6 +466,8 @@ export function CaseItem({
                   className="h-5 shrink-0 px-1.5 py-0 text-[10px]"
                 />
               )}
+              {/* Custom column badges */}
+              {columnBadges}
             </div>
 
             {/* Tags - right aligned */}

--- a/frontend/src/components/cases/case-panel-custom-fields.tsx
+++ b/frontend/src/components/cases/case-panel-custom-fields.tsx
@@ -453,7 +453,10 @@ export function CustomFieldInner({
                   value={
                     field.value === null || field.value === undefined
                       ? ""
-                      : String(field.value)
+                      : typeof field.value === "number" &&
+                          customField.type === "NUMERIC"
+                        ? String(parseFloat(field.value.toFixed(2)))
+                        : String(field.value)
                   }
                   placeholder="Empty"
                   onChange={(e) => field.onChange(e.target.value)}
@@ -484,7 +487,7 @@ export function CustomFieldInner({
                       field.onChange(customField.value)
                       return
                     }
-                    onBlur?.(customField.id, parsed)
+                    onBlur?.(customField.id, parseFloat(parsed.toFixed(2)))
                   }}
                 />
               </FormControl>

--- a/frontend/src/components/cases/case-panel-custom-fields.tsx
+++ b/frontend/src/components/cases/case-panel-custom-fields.tsx
@@ -50,6 +50,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { getCaseFieldEditorValue } from "@/lib/case-field-display"
 import { cn, linearStyles } from "@/lib/utils"
 
 const customFieldFormSchema = z.object({
@@ -120,7 +121,10 @@ function InlineCustomField({
   const form = useForm<CustomFieldFormSchema>({
     defaultValues: {
       id: customField.id,
-      value: customField.value,
+      value:
+        customField.type === "NUMERIC" || customField.type === "INTEGER"
+          ? getCaseFieldEditorValue(customField.value, customField.type)
+          : customField.value,
     },
   })
 
@@ -453,10 +457,7 @@ export function CustomFieldInner({
                   value={
                     field.value === null || field.value === undefined
                       ? ""
-                      : typeof field.value === "number" &&
-                          customField.type === "NUMERIC"
-                        ? String(parseFloat(field.value.toFixed(2)))
-                        : String(field.value)
+                      : String(field.value)
                   }
                   placeholder="Empty"
                   onChange={(e) => field.onChange(e.target.value)}
@@ -473,7 +474,12 @@ export function CustomFieldInner({
                     if (customField.type === "INTEGER") {
                       if (!/^-?\d+$/.test(raw)) {
                         // Silently revert to saved value
-                        field.onChange(customField.value)
+                        field.onChange(
+                          getCaseFieldEditorValue(
+                            customField.value,
+                            customField.type
+                          )
+                        )
                         return
                       }
                       const parsed = Number.parseInt(raw, 10)
@@ -484,10 +490,15 @@ export function CustomFieldInner({
                     const parsed = Number(raw)
                     if (!Number.isFinite(parsed)) {
                       // Silently revert to saved value
-                      field.onChange(customField.value)
+                      field.onChange(
+                        getCaseFieldEditorValue(
+                          customField.value,
+                          customField.type
+                        )
+                      )
                       return
                     }
-                    onBlur?.(customField.id, parseFloat(parsed.toFixed(2)))
+                    onBlur?.(customField.id, raw)
                   }}
                 />
               </FormControl>

--- a/frontend/src/components/cases/cases-accordion.tsx
+++ b/frontend/src/components/cases/cases-accordion.tsx
@@ -16,6 +16,7 @@ import type { ComponentType } from "react"
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import type {
   CaseDropdownDefinitionRead,
+  CaseFieldReadMinimal,
   CaseReadMinimal,
   CaseSearchAggregateRead,
   CaseStatus,
@@ -122,6 +123,7 @@ interface CasesAccordionProps {
   tags?: CaseTagRead[]
   members?: WorkspaceMember[]
   dropdownDefinitions?: CaseDropdownDefinitionRead[]
+  fieldTypesById?: ReadonlyMap<string, CaseFieldReadMinimal["type"]>
   visibleColumnIds?: string[]
   prioritySortDirection?: SortDirection
   severitySortDirection?: SortDirection
@@ -150,6 +152,7 @@ interface VirtualizedGroupRowsProps {
   tags?: CaseTagRead[]
   members?: WorkspaceMember[]
   dropdownDefinitions?: CaseDropdownDefinitionRead[]
+  fieldTypesById?: ReadonlyMap<string, CaseFieldReadMinimal["type"]>
   visibleColumnIds?: string[]
 }
 
@@ -164,6 +167,7 @@ function VirtualizedGroupRows({
   tags,
   members,
   dropdownDefinitions,
+  fieldTypesById,
   visibleColumnIds,
 }: VirtualizedGroupRowsProps) {
   const groupContainerRef = useRef<HTMLDivElement | null>(null)
@@ -273,6 +277,7 @@ function VirtualizedGroupRows({
               tags={tags}
               members={members}
               dropdownDefinitions={dropdownDefinitions}
+              fieldTypesById={fieldTypesById}
               visibleColumnIds={visibleColumnIds}
             />
           </div>
@@ -292,6 +297,7 @@ export function CasesAccordion({
   tags,
   members,
   dropdownDefinitions,
+  fieldTypesById,
   visibleColumnIds,
   prioritySortDirection,
   severitySortDirection,
@@ -484,6 +490,7 @@ export function CasesAccordion({
                     tags={tags}
                     members={members}
                     dropdownDefinitions={dropdownDefinitions}
+                    fieldTypesById={fieldTypesById}
                     visibleColumnIds={visibleColumnIds}
                   />
                 </div>

--- a/frontend/src/components/cases/cases-accordion.tsx
+++ b/frontend/src/components/cases/cases-accordion.tsx
@@ -16,6 +16,7 @@ import type { ComponentType } from "react"
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import type {
   CaseDropdownDefinitionRead,
+  CaseDurationDefinitionRead,
   CaseFieldReadMinimal,
   CaseReadMinimal,
   CaseSearchAggregateRead,
@@ -124,6 +125,7 @@ interface CasesAccordionProps {
   members?: WorkspaceMember[]
   dropdownDefinitions?: CaseDropdownDefinitionRead[]
   fieldTypesById?: ReadonlyMap<string, CaseFieldReadMinimal["type"]>
+  durationNamesById?: ReadonlyMap<CaseDurationDefinitionRead["id"], string>
   visibleColumnIds?: string[]
   prioritySortDirection?: SortDirection
   severitySortDirection?: SortDirection
@@ -153,6 +155,7 @@ interface VirtualizedGroupRowsProps {
   members?: WorkspaceMember[]
   dropdownDefinitions?: CaseDropdownDefinitionRead[]
   fieldTypesById?: ReadonlyMap<string, CaseFieldReadMinimal["type"]>
+  durationNamesById?: ReadonlyMap<CaseDurationDefinitionRead["id"], string>
   visibleColumnIds?: string[]
 }
 
@@ -168,6 +171,7 @@ function VirtualizedGroupRows({
   members,
   dropdownDefinitions,
   fieldTypesById,
+  durationNamesById,
   visibleColumnIds,
 }: VirtualizedGroupRowsProps) {
   const groupContainerRef = useRef<HTMLDivElement | null>(null)
@@ -278,6 +282,7 @@ function VirtualizedGroupRows({
               members={members}
               dropdownDefinitions={dropdownDefinitions}
               fieldTypesById={fieldTypesById}
+              durationNamesById={durationNamesById}
               visibleColumnIds={visibleColumnIds}
             />
           </div>
@@ -298,6 +303,7 @@ export function CasesAccordion({
   members,
   dropdownDefinitions,
   fieldTypesById,
+  durationNamesById,
   visibleColumnIds,
   prioritySortDirection,
   severitySortDirection,
@@ -491,6 +497,7 @@ export function CasesAccordion({
                     members={members}
                     dropdownDefinitions={dropdownDefinitions}
                     fieldTypesById={fieldTypesById}
+                    durationNamesById={durationNamesById}
                     visibleColumnIds={visibleColumnIds}
                   />
                 </div>

--- a/frontend/src/components/cases/cases-accordion.tsx
+++ b/frontend/src/components/cases/cases-accordion.tsx
@@ -122,6 +122,7 @@ interface CasesAccordionProps {
   tags?: CaseTagRead[]
   members?: WorkspaceMember[]
   dropdownDefinitions?: CaseDropdownDefinitionRead[]
+  visibleColumnIds?: string[]
   prioritySortDirection?: SortDirection
   severitySortDirection?: SortDirection
   assigneeSortDirection?: SortDirection
@@ -149,6 +150,7 @@ interface VirtualizedGroupRowsProps {
   tags?: CaseTagRead[]
   members?: WorkspaceMember[]
   dropdownDefinitions?: CaseDropdownDefinitionRead[]
+  visibleColumnIds?: string[]
 }
 
 function VirtualizedGroupRows({
@@ -162,6 +164,7 @@ function VirtualizedGroupRows({
   tags,
   members,
   dropdownDefinitions,
+  visibleColumnIds,
 }: VirtualizedGroupRowsProps) {
   const groupContainerRef = useRef<HTMLDivElement | null>(null)
   const [scrollMargin, setScrollMargin] = useState(0)
@@ -270,6 +273,7 @@ function VirtualizedGroupRows({
               tags={tags}
               members={members}
               dropdownDefinitions={dropdownDefinitions}
+              visibleColumnIds={visibleColumnIds}
             />
           </div>
         )
@@ -288,6 +292,7 @@ export function CasesAccordion({
   tags,
   members,
   dropdownDefinitions,
+  visibleColumnIds,
   prioritySortDirection,
   severitySortDirection,
   assigneeSortDirection,
@@ -479,6 +484,7 @@ export function CasesAccordion({
                     tags={tags}
                     members={members}
                     dropdownDefinitions={dropdownDefinitions}
+                    visibleColumnIds={visibleColumnIds}
                   />
                 </div>
               </AccordionPrimitive.Content>

--- a/frontend/src/components/cases/cases-header.tsx
+++ b/frontend/src/components/cases/cases-header.tsx
@@ -23,6 +23,8 @@ import { type ComponentType, useEffect, useMemo, useState } from "react"
 import type { DateRange } from "react-day-picker"
 import type {
   CaseDropdownDefinitionRead,
+  CaseDurationDefinitionRead,
+  CaseFieldReadMinimal,
   CasePriority,
   CaseSeverity,
   CaseStatus,
@@ -34,6 +36,7 @@ import {
   SEVERITIES,
   STATUSES,
 } from "@/components/cases/case-categories"
+import { CaseColumnPicker } from "@/components/cases/case-column-picker"
 import { UNASSIGNED } from "@/components/cases/case-panel-selectors"
 import {
   type CaseSortField,
@@ -386,6 +389,10 @@ interface CasesHeaderProps {
   members?: WorkspaceMember[]
   tags?: CaseTagRead[]
   dropdownDefinitions?: CaseDropdownDefinitionRead[]
+  fieldDefinitions?: CaseFieldReadMinimal[]
+  durationDefinitions?: CaseDurationDefinitionRead[]
+  visibleColumnIds?: string[]
+  onToggleColumn?: (columnId: string) => void
   dropdownFilters: Record<string, DropdownFilterState>
   onDropdownFilterChange: (ref: string, values: string[]) => void
   onDropdownModeChange: (ref: string, mode: FilterMode) => void
@@ -438,6 +445,10 @@ export function CasesHeader({
   members,
   tags,
   dropdownDefinitions,
+  fieldDefinitions,
+  durationDefinitions,
+  visibleColumnIds,
+  onToggleColumn,
   dropdownFilters,
   onDropdownFilterChange,
   onDropdownModeChange,
@@ -794,6 +805,16 @@ export function CasesHeader({
         />
 
         <CaseSortSelect value={sortBy} onChange={onSortByChange} />
+
+        {onToggleColumn && visibleColumnIds && (
+          <CaseColumnPicker
+            dropdownDefinitions={dropdownDefinitions}
+            fieldDefinitions={fieldDefinitions}
+            durationDefinitions={durationDefinitions}
+            visibleColumnIds={visibleColumnIds}
+            onToggle={onToggleColumn}
+          />
+        )}
 
         {hasFilters && (
           <button

--- a/frontend/src/components/cases/cases-header.tsx
+++ b/frontend/src/components/cases/cases-header.tsx
@@ -607,13 +607,22 @@ export function CasesHeader({
           />
         </div>
 
-        {(displayCaseCount ?? totalCaseCount) > 0 && (
-          <div className="ml-auto flex items-center gap-2">
+        <div className="ml-auto flex items-center gap-2">
+          {onToggleColumn && visibleColumnIds && (
+            <CaseColumnPicker
+              dropdownDefinitions={dropdownDefinitions}
+              fieldDefinitions={fieldDefinitions}
+              durationDefinitions={durationDefinitions}
+              visibleColumnIds={visibleColumnIds}
+              onToggle={onToggleColumn}
+            />
+          )}
+          {(displayCaseCount ?? totalCaseCount) > 0 && (
             <span className="text-xs text-muted-foreground">
               {displayCaseCount ?? totalCaseCount} cases
             </span>
-          </div>
-        )}
+          )}
+        </div>
       </header>
 
       {/* Row 2: Filter dropdowns */}
@@ -805,16 +814,6 @@ export function CasesHeader({
         />
 
         <CaseSortSelect value={sortBy} onChange={onSortByChange} />
-
-        {onToggleColumn && visibleColumnIds && (
-          <CaseColumnPicker
-            dropdownDefinitions={dropdownDefinitions}
-            fieldDefinitions={fieldDefinitions}
-            durationDefinitions={durationDefinitions}
-            visibleColumnIds={visibleColumnIds}
-            onToggle={onToggleColumn}
-          />
-        )}
 
         {hasFilters && (
           <button

--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/navigation"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import {
   type CaseDropdownDefinitionRead,
+  type CaseDurationDefinitionRead,
+  type CaseFieldReadMinimal,
   type CasePriority,
   type CaseReadMinimal,
   type CaseSearchAggregateRead,
@@ -58,6 +60,10 @@ interface CasesLayoutProps {
   onUpdatedAfterChange: (value: CaseDateFilterValue) => void
   onCreatedAfterChange: (value: CaseDateFilterValue) => void
   dropdownDefinitions?: CaseDropdownDefinitionRead[]
+  fieldDefinitions?: CaseFieldReadMinimal[]
+  durationDefinitions?: CaseDurationDefinitionRead[]
+  visibleColumnIds?: string[]
+  onToggleColumn?: (columnId: string) => void
   onDropdownFilterChange: (ref: string, values: string[]) => void
   onDropdownModeChange: (ref: string, mode: FilterMode) => void
   onDropdownSortDirectionChange: (ref: string, direction: SortDirection) => void
@@ -97,6 +103,10 @@ export function CasesLayout({
   onUpdatedAfterChange,
   onCreatedAfterChange,
   dropdownDefinitions,
+  fieldDefinitions,
+  durationDefinitions,
+  visibleColumnIds,
+  onToggleColumn,
   onDropdownFilterChange,
   onDropdownModeChange,
   onDropdownSortDirectionChange,
@@ -303,6 +313,10 @@ export function CasesLayout({
     members,
     tags,
     dropdownDefinitions,
+    fieldDefinitions,
+    durationDefinitions,
+    visibleColumnIds,
+    onToggleColumn,
     dropdownFilters: filters.dropdownFilters,
     onDropdownFilterChange,
     onDropdownModeChange,
@@ -377,6 +391,7 @@ export function CasesLayout({
             tags={tags}
             members={members}
             dropdownDefinitions={dropdownDefinitions}
+            visibleColumnIds={visibleColumnIds}
             prioritySortDirection={filters.prioritySortDirection}
             severitySortDirection={filters.severitySortDirection}
             assigneeSortDirection={filters.assigneeSortDirection}

--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -277,6 +277,17 @@ export function CasesLayout({
 
     return new Map(fieldDefinitions.map((field) => [field.id, field.type]))
   }, [fieldDefinitions])
+  const durationNamesById = useMemo<
+    ReadonlyMap<CaseDurationDefinitionRead["id"], string> | undefined
+  >(() => {
+    if (!durationDefinitions) {
+      return undefined
+    }
+
+    return new Map(
+      durationDefinitions.map((duration) => [duration.id, duration.name])
+    )
+  }, [durationDefinitions])
 
   const handleDeleteRequest = useCallback((caseData: CaseReadMinimal) => {
     setCaseToDelete(caseData)
@@ -401,6 +412,7 @@ export function CasesLayout({
             members={members}
             dropdownDefinitions={dropdownDefinitions}
             fieldTypesById={fieldTypesById}
+            durationNamesById={durationNamesById}
             visibleColumnIds={visibleColumnIds}
             prioritySortDirection={filters.prioritySortDirection}
             severitySortDirection={filters.severitySortDirection}

--- a/frontend/src/components/cases/cases-layout.tsx
+++ b/frontend/src/components/cases/cases-layout.tsx
@@ -268,6 +268,15 @@ export function CasesLayout({
   useEffect(() => () => resetSelection(), [resetSelection])
 
   const selectedCaseIdsSet = useMemo(() => selectedCaseIds, [selectedCaseIds])
+  const fieldTypesById = useMemo<
+    ReadonlyMap<string, CaseFieldReadMinimal["type"]> | undefined
+  >(() => {
+    if (!fieldDefinitions) {
+      return undefined
+    }
+
+    return new Map(fieldDefinitions.map((field) => [field.id, field.type]))
+  }, [fieldDefinitions])
 
   const handleDeleteRequest = useCallback((caseData: CaseReadMinimal) => {
     setCaseToDelete(caseData)
@@ -391,6 +400,7 @@ export function CasesLayout({
             tags={tags}
             members={members}
             dropdownDefinitions={dropdownDefinitions}
+            fieldTypesById={fieldTypesById}
             visibleColumnIds={visibleColumnIds}
             prioritySortDirection={filters.prioritySortDirection}
             severitySortDirection={filters.severitySortDirection}

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,5 +1,6 @@
 import { cva, type VariantProps } from "class-variance-authority"
 import type * as React from "react"
+import { forwardRef } from "react"
 
 import { cn } from "@/lib/utils"
 
@@ -27,10 +28,17 @@ export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
-function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
-}
+const Badge = forwardRef<HTMLDivElement, BadgeProps>(
+  ({ className, variant, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(badgeVariants({ variant }), className)}
+        {...props}
+      />
+    )
+  }
+)
+Badge.displayName = "Badge"
 
 export { Badge, badgeVariants }

--- a/frontend/src/hooks/use-case-column-visibility.ts
+++ b/frontend/src/hooks/use-case-column-visibility.ts
@@ -22,12 +22,34 @@ function loadPersistedColumns(workspaceId: string): string[] {
     if (!Array.isArray(parsed)) {
       return []
     }
-    return parsed
-      .filter((item): item is string => typeof item === "string")
-      .slice(0, MAX_VISIBLE_COLUMNS)
+    return parsed.filter((item): item is string => typeof item === "string")
   } catch {
     return []
   }
+}
+
+function normalizeVisibleColumnIds(
+  columnIds: string[],
+  knownColumnIds?: Set<string>
+): string[] {
+  const normalized: string[] = []
+  const seen = new Set<string>()
+
+  for (const columnId of columnIds) {
+    if (seen.has(columnId)) {
+      continue
+    }
+    if (knownColumnIds && !knownColumnIds.has(columnId)) {
+      continue
+    }
+    normalized.push(columnId)
+    seen.add(columnId)
+    if (normalized.length >= MAX_VISIBLE_COLUMNS) {
+      break
+    }
+  }
+
+  return normalized
 }
 
 function persistColumns(workspaceId: string, columns: string[]): void {
@@ -51,15 +73,15 @@ export interface UseCaseColumnVisibilityResult {
 
 /**
  * @param knownColumnIds - Set of currently valid column IDs from loaded
- *   definitions. Used to enforce the max-4 cap only on valid IDs so stale
- *   persisted entries don't block new selections.
+ *   definitions. When provided, stale persisted IDs are pruned and the final
+ *   stored selection is normalized to at most four unique visible columns.
  */
 export function useCaseColumnVisibility(
   workspaceId: string,
   knownColumnIds?: Set<string>
 ): UseCaseColumnVisibilityResult {
   const [visibleColumnIds, setVisibleColumnIds] = useState<string[]>(() =>
-    loadPersistedColumns(workspaceId)
+    normalizeVisibleColumnIds(loadPersistedColumns(workspaceId), knownColumnIds)
   )
 
   // Reload from localStorage when workspace changes
@@ -67,9 +89,24 @@ export function useCaseColumnVisibility(
   useEffect(() => {
     if (prevWorkspaceId.current !== workspaceId) {
       prevWorkspaceId.current = workspaceId
-      setVisibleColumnIds(loadPersistedColumns(workspaceId))
+      setVisibleColumnIds(
+        normalizeVisibleColumnIds(
+          loadPersistedColumns(workspaceId),
+          knownColumnIds
+        )
+      )
     }
-  }, [workspaceId])
+  }, [knownColumnIds, workspaceId])
+
+  useEffect(() => {
+    setVisibleColumnIds((prev) => {
+      const normalized = normalizeVisibleColumnIds(prev, knownColumnIds)
+      return prev.length === normalized.length &&
+        prev.every((columnId, index) => columnId === normalized[index])
+        ? prev
+        : normalized
+    })
+  }, [knownColumnIds])
 
   useEffect(() => {
     persistColumns(workspaceId, visibleColumnIds)
@@ -81,18 +118,14 @@ export function useCaseColumnVisibility(
 
   const toggleColumn = useCallback((columnId: string) => {
     setVisibleColumnIds((prev) => {
-      if (prev.includes(columnId)) {
-        return prev.filter((id) => id !== columnId)
+      const normalizedPrev = normalizeVisibleColumnIds(prev, knownRef.current)
+      if (normalizedPrev.includes(columnId)) {
+        return normalizedPrev.filter((id) => id !== columnId)
       }
-      // Count only IDs that map to current definitions toward the cap
-      const known = knownRef.current
-      const validCount = known
-        ? prev.filter((id) => known.has(id)).length
-        : prev.length
-      if (validCount >= MAX_VISIBLE_COLUMNS) {
-        return prev
-      }
-      return [...prev, columnId]
+      return normalizeVisibleColumnIds(
+        [...normalizedPrev, columnId],
+        knownRef.current
+      )
     })
   }, [])
 

--- a/frontend/src/hooks/use-case-column-visibility.ts
+++ b/frontend/src/hooks/use-case-column-visibility.ts
@@ -1,0 +1,79 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+const STORAGE_KEY = "cases-visible-columns:v1"
+const MAX_VISIBLE_COLUMNS = 4
+
+function getStorageKey(workspaceId: string): string {
+  return `${workspaceId}:${STORAGE_KEY}`
+}
+
+function loadPersistedColumns(workspaceId: string): string[] {
+  if (typeof window === "undefined") {
+    return []
+  }
+  try {
+    const stored = window.localStorage.getItem(getStorageKey(workspaceId))
+    if (!stored) {
+      return []
+    }
+    const parsed: unknown = JSON.parse(stored)
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+    return parsed
+      .filter((item): item is string => typeof item === "string")
+      .slice(0, MAX_VISIBLE_COLUMNS)
+  } catch {
+    return []
+  }
+}
+
+function persistColumns(workspaceId: string, columns: string[]): void {
+  if (typeof window === "undefined") {
+    return
+  }
+  try {
+    window.localStorage.setItem(
+      getStorageKey(workspaceId),
+      JSON.stringify(columns)
+    )
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export interface UseCaseColumnVisibilityResult {
+  visibleColumnIds: string[]
+  toggleColumn: (columnId: string) => void
+}
+
+export function useCaseColumnVisibility(
+  workspaceId: string
+): UseCaseColumnVisibilityResult {
+  const [visibleColumnIds, setVisibleColumnIds] = useState<string[]>(() =>
+    loadPersistedColumns(workspaceId)
+  )
+
+  useEffect(() => {
+    persistColumns(workspaceId, visibleColumnIds)
+  }, [workspaceId, visibleColumnIds])
+
+  const toggleColumn = useCallback((columnId: string) => {
+    setVisibleColumnIds((prev) => {
+      if (prev.includes(columnId)) {
+        return prev.filter((id) => id !== columnId)
+      }
+      if (prev.length >= MAX_VISIBLE_COLUMNS) {
+        return prev
+      }
+      return [...prev, columnId]
+    })
+  }, [])
+
+  return {
+    visibleColumnIds,
+    toggleColumn,
+  }
+}

--- a/frontend/src/hooks/use-case-column-visibility.ts
+++ b/frontend/src/hooks/use-case-column-visibility.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 const STORAGE_KEY = "cases-visible-columns:v1"
 const MAX_VISIBLE_COLUMNS = 4
@@ -49,23 +49,47 @@ export interface UseCaseColumnVisibilityResult {
   toggleColumn: (columnId: string) => void
 }
 
+/**
+ * @param knownColumnIds - Set of currently valid column IDs from loaded
+ *   definitions. Used to enforce the max-4 cap only on valid IDs so stale
+ *   persisted entries don't block new selections.
+ */
 export function useCaseColumnVisibility(
-  workspaceId: string
+  workspaceId: string,
+  knownColumnIds?: Set<string>
 ): UseCaseColumnVisibilityResult {
   const [visibleColumnIds, setVisibleColumnIds] = useState<string[]>(() =>
     loadPersistedColumns(workspaceId)
   )
 
+  // Reload from localStorage when workspace changes
+  const prevWorkspaceId = useRef(workspaceId)
+  useEffect(() => {
+    if (prevWorkspaceId.current !== workspaceId) {
+      prevWorkspaceId.current = workspaceId
+      setVisibleColumnIds(loadPersistedColumns(workspaceId))
+    }
+  }, [workspaceId])
+
   useEffect(() => {
     persistColumns(workspaceId, visibleColumnIds)
   }, [workspaceId, visibleColumnIds])
+
+  // Ref so toggleColumn always sees the latest set without re-creating
+  const knownRef = useRef(knownColumnIds)
+  knownRef.current = knownColumnIds
 
   const toggleColumn = useCallback((columnId: string) => {
     setVisibleColumnIds((prev) => {
       if (prev.includes(columnId)) {
         return prev.filter((id) => id !== columnId)
       }
-      if (prev.length >= MAX_VISIBLE_COLUMNS) {
+      // Count only IDs that map to current definitions toward the cap
+      const known = knownRef.current
+      const validCount = known
+        ? prev.filter((id) => known.has(id)).length
+        : prev.length
+      if (validCount >= MAX_VISIBLE_COLUMNS) {
         return prev
       }
       return [...prev, columnId]

--- a/frontend/src/hooks/use-case-column-visibility.ts
+++ b/frontend/src/hooks/use-case-column-visibility.ts
@@ -71,6 +71,11 @@ export interface UseCaseColumnVisibilityResult {
   toggleColumn: (columnId: string) => void
 }
 
+interface VisibleColumnsState {
+  workspaceId: string
+  visibleColumnIds: string[]
+}
+
 /**
  * @param knownColumnIds - Set of currently valid column IDs from loaded
  *   definitions. When provided, stale persisted IDs are pruned and the final
@@ -80,54 +85,92 @@ export function useCaseColumnVisibility(
   workspaceId: string,
   knownColumnIds?: Set<string>
 ): UseCaseColumnVisibilityResult {
-  const [visibleColumnIds, setVisibleColumnIds] = useState<string[]>(() =>
-    normalizeVisibleColumnIds(loadPersistedColumns(workspaceId), knownColumnIds)
+  const loadColumnsForWorkspace = useCallback(
+    (targetWorkspaceId: string) =>
+      normalizeVisibleColumnIds(
+        loadPersistedColumns(targetWorkspaceId),
+        knownColumnIds
+      ),
+    [knownColumnIds]
   )
+  const [state, setState] = useState<VisibleColumnsState>(() => ({
+    workspaceId,
+    visibleColumnIds: loadColumnsForWorkspace(workspaceId),
+  }))
 
-  // Reload from localStorage when workspace changes
-  const prevWorkspaceId = useRef(workspaceId)
+  // Keep the rendered selection scoped to the active workspace so a route-level
+  // workspace switch never exposes or persists the previous workspace's columns.
+  const visibleColumnIds =
+    state.workspaceId === workspaceId
+      ? state.visibleColumnIds
+      : loadColumnsForWorkspace(workspaceId)
+
   useEffect(() => {
-    if (prevWorkspaceId.current !== workspaceId) {
-      prevWorkspaceId.current = workspaceId
-      setVisibleColumnIds(
-        normalizeVisibleColumnIds(
-          loadPersistedColumns(workspaceId),
-          knownColumnIds
-        )
-      )
+    if (state.workspaceId !== workspaceId) {
+      setState({
+        workspaceId,
+        visibleColumnIds: loadColumnsForWorkspace(workspaceId),
+      })
     }
+  }, [loadColumnsForWorkspace, state.workspaceId, workspaceId])
+
+  useEffect(() => {
+    setState((prev) => {
+      if (prev.workspaceId !== workspaceId) {
+        return prev
+      }
+      const normalized = normalizeVisibleColumnIds(
+        prev.visibleColumnIds,
+        knownColumnIds
+      )
+      return prev.visibleColumnIds.length === normalized.length &&
+        prev.visibleColumnIds.every(
+          (columnId, index) => columnId === normalized[index]
+        )
+        ? prev
+        : { workspaceId, visibleColumnIds: normalized }
+    })
   }, [knownColumnIds, workspaceId])
 
   useEffect(() => {
-    setVisibleColumnIds((prev) => {
-      const normalized = normalizeVisibleColumnIds(prev, knownColumnIds)
-      return prev.length === normalized.length &&
-        prev.every((columnId, index) => columnId === normalized[index])
-        ? prev
-        : normalized
-    })
-  }, [knownColumnIds])
-
-  useEffect(() => {
-    persistColumns(workspaceId, visibleColumnIds)
-  }, [workspaceId, visibleColumnIds])
+    if (state.workspaceId !== workspaceId) {
+      return
+    }
+    persistColumns(workspaceId, state.visibleColumnIds)
+  }, [state, workspaceId])
 
   // Ref so toggleColumn always sees the latest set without re-creating
   const knownRef = useRef(knownColumnIds)
   knownRef.current = knownColumnIds
 
-  const toggleColumn = useCallback((columnId: string) => {
-    setVisibleColumnIds((prev) => {
-      const normalizedPrev = normalizeVisibleColumnIds(prev, knownRef.current)
-      if (normalizedPrev.includes(columnId)) {
-        return normalizedPrev.filter((id) => id !== columnId)
-      }
-      return normalizeVisibleColumnIds(
-        [...normalizedPrev, columnId],
-        knownRef.current
-      )
-    })
-  }, [])
+  const toggleColumn = useCallback(
+    (columnId: string) => {
+      setState((prev) => {
+        const baseColumns =
+          prev.workspaceId === workspaceId
+            ? prev.visibleColumnIds
+            : loadColumnsForWorkspace(workspaceId)
+        const normalizedPrev = normalizeVisibleColumnIds(
+          baseColumns,
+          knownRef.current
+        )
+        if (normalizedPrev.includes(columnId)) {
+          return {
+            workspaceId,
+            visibleColumnIds: normalizedPrev.filter((id) => id !== columnId),
+          }
+        }
+        return {
+          workspaceId,
+          visibleColumnIds: normalizeVisibleColumnIds(
+            [...normalizedPrev, columnId],
+            knownRef.current
+          ),
+        }
+      })
+    },
+    [loadColumnsForWorkspace, workspaceId]
+  )
 
   return {
     visibleColumnIds,

--- a/frontend/src/hooks/use-case-column-visibility.ts
+++ b/frontend/src/hooks/use-case-column-visibility.ts
@@ -44,7 +44,7 @@ function normalizeVisibleColumnIds(
     }
     normalized.push(columnId)
     seen.add(columnId)
-    if (knownColumnIds && normalized.length >= MAX_VISIBLE_COLUMNS) {
+    if (normalized.length >= MAX_VISIBLE_COLUMNS) {
       break
     }
   }

--- a/frontend/src/hooks/use-case-column-visibility.ts
+++ b/frontend/src/hooks/use-case-column-visibility.ts
@@ -49,34 +49,16 @@ export interface UseCaseColumnVisibilityResult {
   toggleColumn: (columnId: string) => void
 }
 
-/**
- * Manages which optional columns are visible in the case list.
- *
- * @param validColumnIds - When provided, stale persisted IDs that are not in
- *   this set are pruned automatically. Pass `undefined` while definitions are
- *   still loading to skip pruning.
- */
 export function useCaseColumnVisibility(
-  workspaceId: string,
-  validColumnIds?: Set<string>
+  workspaceId: string
 ): UseCaseColumnVisibilityResult {
   const [visibleColumnIds, setVisibleColumnIds] = useState<string[]>(() =>
     loadPersistedColumns(workspaceId)
   )
 
-  // Persist whenever columns change
   useEffect(() => {
     persistColumns(workspaceId, visibleColumnIds)
   }, [workspaceId, visibleColumnIds])
-
-  // Prune stale column IDs once definitions are available
-  useEffect(() => {
-    if (!validColumnIds) return
-    setVisibleColumnIds((prev) => {
-      const pruned = prev.filter((id) => validColumnIds.has(id))
-      return pruned.length === prev.length ? prev : pruned
-    })
-  }, [validColumnIds])
 
   const toggleColumn = useCallback((columnId: string) => {
     setVisibleColumnIds((prev) => {

--- a/frontend/src/hooks/use-case-column-visibility.ts
+++ b/frontend/src/hooks/use-case-column-visibility.ts
@@ -44,7 +44,7 @@ function normalizeVisibleColumnIds(
     }
     normalized.push(columnId)
     seen.add(columnId)
-    if (normalized.length >= MAX_VISIBLE_COLUMNS) {
+    if (knownColumnIds && normalized.length >= MAX_VISIBLE_COLUMNS) {
       break
     }
   }

--- a/frontend/src/hooks/use-case-column-visibility.ts
+++ b/frontend/src/hooks/use-case-column-visibility.ts
@@ -49,16 +49,34 @@ export interface UseCaseColumnVisibilityResult {
   toggleColumn: (columnId: string) => void
 }
 
+/**
+ * Manages which optional columns are visible in the case list.
+ *
+ * @param validColumnIds - When provided, stale persisted IDs that are not in
+ *   this set are pruned automatically. Pass `undefined` while definitions are
+ *   still loading to skip pruning.
+ */
 export function useCaseColumnVisibility(
-  workspaceId: string
+  workspaceId: string,
+  validColumnIds?: Set<string>
 ): UseCaseColumnVisibilityResult {
   const [visibleColumnIds, setVisibleColumnIds] = useState<string[]>(() =>
     loadPersistedColumns(workspaceId)
   )
 
+  // Persist whenever columns change
   useEffect(() => {
     persistColumns(workspaceId, visibleColumnIds)
   }, [workspaceId, visibleColumnIds])
+
+  // Prune stale column IDs once definitions are available
+  useEffect(() => {
+    if (!validColumnIds) return
+    setVisibleColumnIds((prev) => {
+      const pruned = prev.filter((id) => validColumnIds.has(id))
+      return pruned.length === prev.length ? prev : pruned
+    })
+  }, [validColumnIds])
 
   const toggleColumn = useCallback((columnId: string) => {
     setVisibleColumnIds((prev) => {

--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -105,6 +105,7 @@ export interface UseCasesFilters {
 export interface UseCasesOptions {
   enabled?: boolean
   autoRefresh?: boolean
+  includeFields?: boolean
 }
 
 export interface UseCasesResult {
@@ -572,7 +573,7 @@ function resolveEnumIncludeFilter<T extends string>(
 }
 
 export function useCases(options: UseCasesOptions = {}): UseCasesResult {
-  const { enabled = true, autoRefresh = true } = options
+  const { enabled = true, autoRefresh = true, includeFields = false } = options
   const workspaceId = useWorkspaceId()
   const initialFilterStateRef = useRef<CasesFilterStateSnapshot | null>(null)
   if (initialFilterStateRef.current === null) {
@@ -921,8 +922,9 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
         filtersKey,
         orderBy: serverSortParams.orderBy,
         sort: serverSortParams.sort,
+        includeFields,
       }),
-    [filtersKey, serverSortParams.orderBy, serverSortParams.sort]
+    [filtersKey, serverSortParams.orderBy, serverSortParams.sort, includeFields]
   )
 
   const computeRefetchInterval = useCallback(() => {
@@ -958,6 +960,7 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
         sort: serverSortParams.sort,
         limit: CASES_PAGE_SIZE,
         cursor: (pageParam as string | null) ?? undefined,
+        includeFields: includeFields || undefined,
       }),
     enabled:
       enabled &&

--- a/frontend/src/hooks/use-cases.ts
+++ b/frontend/src/hooks/use-cases.ts
@@ -105,7 +105,8 @@ export interface UseCasesFilters {
 export interface UseCasesOptions {
   enabled?: boolean
   autoRefresh?: boolean
-  includeFields?: boolean
+  fieldIds?: string[]
+  includeDurations?: boolean
 }
 
 export interface UseCasesResult {
@@ -573,8 +574,17 @@ function resolveEnumIncludeFilter<T extends string>(
 }
 
 export function useCases(options: UseCasesOptions = {}): UseCasesResult {
-  const { enabled = true, autoRefresh = true, includeFields = false } = options
+  const {
+    enabled = true,
+    autoRefresh = true,
+    fieldIds = [],
+    includeDurations = false,
+  } = options
   const workspaceId = useWorkspaceId()
+  const normalizedFieldIds = useMemo(
+    () => [...new Set(fieldIds)].sort(),
+    [fieldIds]
+  )
   const initialFilterStateRef = useRef<CasesFilterStateSnapshot | null>(null)
   if (initialFilterStateRef.current === null) {
     initialFilterStateRef.current = loadPersistedCasesFilterState(workspaceId)
@@ -922,9 +932,16 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
         filtersKey,
         orderBy: serverSortParams.orderBy,
         sort: serverSortParams.sort,
-        includeFields,
+        fieldIds: normalizedFieldIds,
+        includeDurations,
       }),
-    [filtersKey, serverSortParams.orderBy, serverSortParams.sort, includeFields]
+    [
+      filtersKey,
+      serverSortParams.orderBy,
+      serverSortParams.sort,
+      normalizedFieldIds,
+      includeDurations,
+    ]
   )
 
   const computeRefetchInterval = useCallback(() => {
@@ -960,7 +977,9 @@ export function useCases(options: UseCasesOptions = {}): UseCasesResult {
         sort: serverSortParams.sort,
         limit: CASES_PAGE_SIZE,
         cursor: (pageParam as string | null) ?? undefined,
-        includeFields: includeFields || undefined,
+        fieldIds:
+          normalizedFieldIds.length > 0 ? normalizedFieldIds : undefined,
+        includeDurations: includeDurations || undefined,
       }),
     enabled:
       enabled &&

--- a/frontend/src/lib/case-field-display.ts
+++ b/frontend/src/lib/case-field-display.ts
@@ -1,0 +1,162 @@
+import type { CaseFieldReadType } from "@/client"
+
+export const MAX_CASE_FIELD_FRACTION_DIGITS = 6
+
+/**
+ * Round numeric case-field values for display without exposing float artifacts.
+ */
+export function formatCaseFieldNumericDisplayValue(
+  value: unknown,
+  maximumFractionDigits = MAX_CASE_FIELD_FRACTION_DIGITS
+): string | null {
+  const preservedValue =
+    typeof value === "string"
+      ? preserveExactNumericDisplay(value, maximumFractionDigits)
+      : null
+  if (preservedValue) {
+    return preservedValue
+  }
+
+  const parsed = parseFiniteCaseFieldNumber(value)
+  if (parsed === null) {
+    return null
+  }
+
+  return new Intl.NumberFormat(undefined, {
+    useGrouping: false,
+    maximumFractionDigits,
+  }).format(parsed)
+}
+
+/**
+ * Normalize editable numeric field values so inputs start from an unrounded raw string.
+ */
+export function getCaseFieldEditorValue(
+  value: unknown,
+  fieldType: CaseFieldReadType
+): unknown {
+  if (fieldType === "NUMERIC") {
+    return getCaseFieldNumericEditorValue(value) ?? value
+  }
+
+  if (fieldType === "INTEGER") {
+    return getCaseFieldIntegerEditorValue(value) ?? value
+  }
+
+  return value
+}
+
+/**
+ * Format a case-field value for badges and read-only labels.
+ */
+export function formatCaseFieldDisplayLabel(
+  value: unknown,
+  fieldType?: CaseFieldReadType
+): string {
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No"
+  }
+
+  if (fieldType === "NUMERIC") {
+    return formatCaseFieldNumericDisplayValue(value) ?? String(value)
+  }
+
+  if (fieldType === "INTEGER") {
+    const parsed = parseFiniteCaseFieldNumber(value)
+    if (parsed !== null && Number.isInteger(parsed)) {
+      return String(parsed)
+    }
+    return String(value)
+  }
+
+  if (typeof value === "number") {
+    return formatCaseFieldNumericDisplayValue(value) ?? String(value)
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const obj = value as Record<string, unknown>
+    return typeof obj.label === "string" ? obj.label : JSON.stringify(value)
+  }
+
+  return String(value)
+}
+
+function parseFiniteCaseFieldNumber(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null
+  }
+
+  if (typeof value !== "string") {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function getCaseFieldNumericEditorValue(value: unknown): string | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : null
+  }
+
+  if (typeof value !== "string") {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return trimmed && Number.isFinite(Number(trimmed)) ? trimmed : null
+}
+
+function getCaseFieldIntegerEditorValue(value: unknown): string | null {
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? String(value) : null
+  }
+
+  if (typeof value !== "string") {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return /^[-+]?\d+$/.test(trimmed) ? trimmed : null
+}
+
+function preserveExactNumericDisplay(
+  value: string,
+  maximumFractionDigits: number
+): string | null {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  const match = trimmed.match(/^([+-]?)(\d*)(?:\.(\d+))?$/)
+  if (!match) {
+    return null
+  }
+
+  const fractionDigits = match[3]?.length ?? 0
+  if (fractionDigits > maximumFractionDigits) {
+    return null
+  }
+
+  if (!Number.isFinite(Number(trimmed))) {
+    return null
+  }
+
+  if (trimmed.startsWith(".")) {
+    return `0${trimmed}`
+  }
+  if (trimmed.startsWith("-.")) {
+    return trimmed.replace("-.", "-0.")
+  }
+  if (trimmed.startsWith("+.")) {
+    return trimmed.replace("+.", "0.")
+  }
+
+  return trimmed.startsWith("+") ? trimmed.slice(1) : trimmed
+}

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -3736,6 +3736,7 @@ export function useCaseDurationDefinitions(
   const {
     data: caseDurationDefinitions,
     isLoading: caseDurationDefinitionsIsLoading,
+    isFetching: caseDurationDefinitionsIsFetching,
     error: caseDurationDefinitionsError,
   } = useQuery<CaseDurationDefinitionRead[], Error>({
     queryKey: ["case-duration-definitions", workspaceId],
@@ -3746,6 +3747,7 @@ export function useCaseDurationDefinitions(
   return {
     caseDurationDefinitions,
     caseDurationDefinitionsIsLoading,
+    caseDurationDefinitionsIsFetching,
     caseDurationDefinitionsError,
   }
 }
@@ -3754,6 +3756,7 @@ export function useCaseFields(workspaceId: string, enabled = true) {
   const {
     data: caseFields,
     isLoading: caseFieldsIsLoading,
+    isFetching: caseFieldsIsFetching,
     error: caseFieldsError,
   } = useQuery<CaseFieldReadMinimal[], TracecatApiError>({
     queryKey: ["case-fields", workspaceId],
@@ -3764,6 +3767,7 @@ export function useCaseFields(workspaceId: string, enabled = true) {
   return {
     caseFields,
     caseFieldsIsLoading,
+    caseFieldsIsFetching,
     caseFieldsError,
   }
 }
@@ -6613,6 +6617,7 @@ export function useCaseDropdownDefinitions(
   const {
     data: dropdownDefinitions,
     isLoading: dropdownDefinitionsIsLoading,
+    isFetching: dropdownDefinitionsIsFetching,
     error: dropdownDefinitionsError,
   } = useQuery<CaseDropdownDefinitionRead[], Error>({
     queryKey: ["case-dropdown-definitions", workspaceId],
@@ -6677,6 +6682,7 @@ export function useCaseDropdownDefinitions(
   return {
     dropdownDefinitions,
     dropdownDefinitionsIsLoading,
+    dropdownDefinitionsIsFetching,
     dropdownDefinitionsError,
     createDropdownDefinition,
     deleteDropdownDefinition,

--- a/frontend/src/lib/sql-value-validation.test.ts
+++ b/frontend/src/lib/sql-value-validation.test.ts
@@ -1,0 +1,37 @@
+import {
+  isValidSqlIntegerInput,
+  isValidSqlNumericInput,
+} from "@/lib/sql-value-validation"
+
+describe("sql value validation", () => {
+  it("accepts backend-compatible integer inputs", () => {
+    expect(isValidSqlIntegerInput("42")).toBe(true)
+    expect(isValidSqlIntegerInput("  -7 ")).toBe(true)
+    expect(isValidSqlIntegerInput("+8")).toBe(true)
+  })
+
+  it("rejects integer inputs the backend would not coerce as INTEGER", () => {
+    expect(isValidSqlIntegerInput("1.5")).toBe(false)
+    expect(isValidSqlIntegerInput("1e3")).toBe(false)
+    expect(isValidSqlIntegerInput("0x10")).toBe(false)
+    expect(isValidSqlIntegerInput("")).toBe(false)
+  })
+
+  it("accepts backend-compatible numeric inputs", () => {
+    expect(isValidSqlNumericInput("42")).toBe(true)
+    expect(isValidSqlNumericInput("1.5")).toBe(true)
+    expect(isValidSqlNumericInput(".5")).toBe(true)
+    expect(isValidSqlNumericInput("1.")).toBe(true)
+    expect(isValidSqlNumericInput("1e3")).toBe(true)
+    expect(isValidSqlNumericInput("+1.2e-3")).toBe(true)
+  })
+
+  it("rejects numeric inputs accepted by JavaScript Number but rejected by the backend", () => {
+    expect(isValidSqlNumericInput("0x10")).toBe(false)
+    expect(isValidSqlNumericInput("0b10")).toBe(false)
+    expect(isValidSqlNumericInput("NaN")).toBe(false)
+    expect(isValidSqlNumericInput("Infinity")).toBe(false)
+    expect(isValidSqlNumericInput(".")).toBe(false)
+    expect(isValidSqlNumericInput("1 / 2")).toBe(false)
+  })
+})

--- a/frontend/src/lib/sql-value-validation.ts
+++ b/frontend/src/lib/sql-value-validation.ts
@@ -1,0 +1,19 @@
+const SQL_INTEGER_INPUT_PATTERN = /^[+-]?\d+$/
+const SQL_NUMERIC_INPUT_PATTERN =
+  /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/
+
+/**
+ * Check whether user input matches the backend's accepted INTEGER syntax.
+ */
+export function isValidSqlIntegerInput(value: string): boolean {
+  const trimmed = value.trim()
+  return trimmed.length > 0 && SQL_INTEGER_INPUT_PATTERN.test(trimmed)
+}
+
+/**
+ * Check whether user input matches the backend's accepted NUMERIC syntax.
+ */
+export function isValidSqlNumericInput(value: string): boolean {
+  const trimmed = value.trim()
+  return trimmed.length > 0 && SQL_NUMERIC_INPUT_PATTERN.test(trimmed)
+}

--- a/frontend/src/lib/time.ts
+++ b/frontend/src/lib/time.ts
@@ -55,7 +55,7 @@ export function durationToISOString(duration: Duration): string {
 
 export function parseISODuration(duration: string): Duration {
   const regex =
-    /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/
+    /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/
   const matches = duration.match(regex)
 
   if (!matches) {
@@ -74,15 +74,32 @@ export function parseISODuration(duration: string): Duration {
     seconds,
   ] = matches
 
-  return {
+  const parsed = {
     years: years ? parseInt(years, 10) : 0,
     months: months ? parseInt(months, 10) : 0,
     weeks: weeks ? parseInt(weeks, 10) : 0,
     days: days ? parseInt(days, 10) : 0,
     hours: hours ? parseInt(hours, 10) : 0,
     minutes: minutes ? parseInt(minutes, 10) : 0,
-    seconds: seconds ? parseInt(seconds, 10) : 0,
+    seconds: seconds ? Math.round(parseFloat(seconds)) : 0,
   }
+
+  if (parsed.seconds >= 60) {
+    parsed.minutes += Math.floor(parsed.seconds / 60)
+    parsed.seconds %= 60
+  }
+
+  if (parsed.minutes >= 60) {
+    parsed.hours += Math.floor(parsed.minutes / 60)
+    parsed.minutes %= 60
+  }
+
+  if (parsed.hours >= 24) {
+    parsed.days += Math.floor(parsed.hours / 24)
+    parsed.hours %= 24
+  }
+
+  return parsed
 }
 
 export function durationToHumanReadable(duration: string): string {

--- a/frontend/tests/case-badge.test.tsx
+++ b/frontend/tests/case-badge.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react"
+import { CaseColumnBadge } from "@/components/cases/case-badge"
+
+describe("CaseColumnBadge", () => {
+  it("forwards DOM attributes and hover handlers", () => {
+    const onPointerMove = jest.fn()
+
+    render(
+      <CaseColumnBadge
+        label="Badge"
+        data-testid="case-column-badge"
+        aria-label="Custom field badge"
+        onPointerMove={onPointerMove}
+      />
+    )
+
+    const badge = screen.getByTestId("case-column-badge")
+    expect(badge).toHaveAttribute("aria-label", "Custom field badge")
+
+    fireEvent.pointerMove(badge)
+    expect(onPointerMove).toHaveBeenCalled()
+  })
+})

--- a/frontend/tests/case-badge.test.tsx
+++ b/frontend/tests/case-badge.test.tsx
@@ -24,4 +24,14 @@ describe("CaseColumnBadge", () => {
     fireEvent.pointerMove(badge)
     expect(onPointerMove).toHaveBeenCalled()
   })
+
+  it("applies flex truncation classes to long labels", () => {
+    render(<CaseColumnBadge label="A very long custom field label" />)
+
+    const label = screen.getByText("A very long custom field label")
+    const badge = label.parentElement
+
+    expect(label).toHaveClass("min-w-0", "flex-1", "truncate")
+    expect(badge).toHaveClass("min-w-0", "max-w-[120px]")
+  })
 })

--- a/frontend/tests/case-field-display.test.ts
+++ b/frontend/tests/case-field-display.test.ts
@@ -1,0 +1,43 @@
+import {
+  formatCaseFieldDisplayLabel,
+  formatCaseFieldNumericDisplayValue,
+  getCaseFieldEditorValue,
+} from "@/lib/case-field-display"
+
+describe("case field display formatting", () => {
+  it("rounds numeric values for display without float artifacts", () => {
+    expect(
+      formatCaseFieldNumericDisplayValue("123.299999999999997157829056")
+    ).toBe("123.3")
+    expect(formatCaseFieldNumericDisplayValue(1.23456)).toBe("1.23456")
+  })
+
+  it("preserves exact short decimal strings", () => {
+    expect(formatCaseFieldNumericDisplayValue("1.30")).toBe("1.30")
+    expect(getCaseFieldEditorValue("1.30", "NUMERIC")).toBe("1.30")
+  })
+
+  it("formats numeric field labels without changing text fields", () => {
+    expect(
+      formatCaseFieldDisplayLabel("123.299999999999997157829056", "NUMERIC")
+    ).toBe("123.3")
+    expect(formatCaseFieldDisplayLabel("00123.4500", "TEXT")).toBe("00123.4500")
+  })
+
+  it("normalizes editor values for numeric fields", () => {
+    expect(
+      getCaseFieldEditorValue("123.299999999999997157829056", "NUMERIC")
+    ).toBe("123.299999999999997157829056")
+    expect(getCaseFieldEditorValue(7, "INTEGER")).toBe("7")
+  })
+
+  it("formats booleans and labeled objects for badges", () => {
+    expect(formatCaseFieldDisplayLabel(true)).toBe("Yes")
+    expect(
+      formatCaseFieldDisplayLabel({
+        label: "Apple",
+        url: "https://example.com",
+      })
+    ).toBe("Apple")
+  })
+})

--- a/frontend/tests/case-item.test.tsx
+++ b/frontend/tests/case-item.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import { CaseItem } from "@/components/cases/case-item"
+
+jest.mock("@/providers/workspace-id", () => ({
+  useWorkspaceId: () => "workspace-1",
+}))
+
+jest.mock("@/components/cases/cases-feed-event", () => ({
+  EventCreatedAt: ({ createdAt }: { createdAt: string }) => (
+    <span>{`created ${createdAt}`}</span>
+  ),
+  EventUpdatedAt: ({ updatedAt }: { updatedAt: string }) => (
+    <span>{`updated ${updatedAt}`}</span>
+  ),
+}))
+
+function renderCaseItem() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CaseItem
+        caseData={{
+          id: "case-1",
+          short_id: "CASE-0001",
+          created_at: "2026-04-13T00:00:00Z",
+          updated_at: "2026-04-13T00:01:30Z",
+          summary: "Database alert",
+          status: "new",
+          priority: "medium",
+          severity: "high",
+          tags: [{ id: "tag-1", ref: "prod", name: "prod", color: null }],
+          dropdown_values: [],
+          durations: [
+            {
+              id: "duration-value-1",
+              definition_id: "duration-1",
+              case_id: "case-1",
+              started_at: "2026-04-13T00:00:00Z",
+              ended_at: "2026-04-13T00:01:30Z",
+              duration: "PT1M30S",
+            },
+          ],
+          field_values: {
+            priority_reason: "Customer impact",
+          },
+        }}
+        isSelected={false}
+        onClick={jest.fn()}
+        visibleColumnIds={["field:priority_reason", "duration:duration-1"]}
+        fieldTypesById={new Map([["priority_reason", "TEXT"]])}
+        durationNamesById={new Map([["duration-1", "Time to resolve"]])}
+      />
+    </QueryClientProvider>
+  )
+}
+
+describe("CaseItem", () => {
+  it("renders durations after tags and before timestamps, with hover labels", async () => {
+    const { container } = renderCaseItem()
+
+    const tag = screen.getByText("prod")
+    const duration = screen.getByText("Time to resolve")
+    const createdAt = screen.getByText("created 2026-04-13T00:00:00Z")
+    const customFieldValue = screen.getByText("Customer impact")
+    const customFieldBadge = customFieldValue.closest("div.inline-flex")
+    const durationBadge = duration.closest("div.inline-flex")
+
+    expect(customFieldBadge).not.toBeNull()
+    expect(durationBadge).not.toBeNull()
+
+    expect(
+      tag.compareDocumentPosition(duration) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    expect(
+      duration.compareDocumentPosition(createdAt) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    expect(container).toHaveTextContent("Time to resolve: 1m30s")
+    expect(screen.getAllByText("Time to resolve")).toHaveLength(1)
+
+    expect(customFieldBadge).toHaveAttribute("title", "priority_reason")
+    expect(durationBadge).toHaveAttribute("title", "Time to resolve")
+  })
+})

--- a/frontend/tests/case-item.test.tsx
+++ b/frontend/tests/case-item.test.tsx
@@ -4,6 +4,7 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
 import { CaseItem } from "@/components/cases/case-item"
 
 jest.mock("@/providers/workspace-id", () => ({
@@ -16,6 +17,15 @@ jest.mock("@/components/cases/cases-feed-event", () => ({
   ),
   EventUpdatedAt: ({ updatedAt }: { updatedAt: string }) => (
     <span>{`updated ${updatedAt}`}</span>
+  ),
+}))
+
+jest.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: ReactNode }) => children,
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => children,
+  TooltipContent: ({ children }: { children: ReactNode }) => (
+    <div role="tooltip">{children}</div>
   ),
 }))
 
@@ -40,7 +50,19 @@ function renderCaseItem() {
           priority: "medium",
           severity: "high",
           tags: [{ id: "tag-1", ref: "prod", name: "prod", color: null }],
-          dropdown_values: [],
+          dropdown_values: [
+            {
+              id: "dropdown-value-1",
+              definition_id: "dropdown-definition-1",
+              definition_ref: "analyst_verdict",
+              definition_name: "Analyst verdict",
+              option_id: "dropdown-option-1",
+              option_label: "Benign",
+              option_ref: "benign",
+              option_icon_name: null,
+              option_color: null,
+            },
+          ],
           durations: [
             {
               id: "duration-value-1",
@@ -48,7 +70,7 @@ function renderCaseItem() {
               case_id: "case-1",
               started_at: "2026-04-13T00:00:00Z",
               ended_at: "2026-04-13T00:01:30Z",
-              duration: "PT1M30S",
+              duration: "P1DT4H4M10.01724S",
             },
           ],
           field_values: {
@@ -57,7 +79,11 @@ function renderCaseItem() {
         }}
         isSelected={false}
         onClick={jest.fn()}
-        visibleColumnIds={["field:priority_reason", "duration:duration-1"]}
+        visibleColumnIds={[
+          "dropdown:analyst_verdict",
+          "field:priority_reason",
+          "duration:duration-1",
+        ]}
         fieldTypesById={new Map([["priority_reason", "TEXT"]])}
         durationNamesById={new Map([["duration-1", "Time to resolve"]])}
       />
@@ -66,11 +92,11 @@ function renderCaseItem() {
 }
 
 describe("CaseItem", () => {
-  it("renders durations after tags and before timestamps, with hover labels", async () => {
+  it("renders durations after tags and before timestamps, with tooltip labels", () => {
     const { container } = renderCaseItem()
 
     const tag = screen.getByText("prod")
-    const duration = screen.getByText("Time to resolve")
+    const [duration] = screen.getAllByText("Time to resolve")
     const createdAt = screen.getByText("created 2026-04-13T00:00:00Z")
     const customFieldValue = screen.getByText("Customer impact")
     const customFieldBadge = customFieldValue.closest("div.inline-flex")
@@ -86,10 +112,14 @@ describe("CaseItem", () => {
       duration.compareDocumentPosition(createdAt) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
-    expect(container).toHaveTextContent("Time to resolve: 1m30s")
-    expect(screen.getAllByText("Time to resolve")).toHaveLength(1)
-
-    expect(customFieldBadge).toHaveAttribute("title", "priority_reason")
-    expect(durationBadge).toHaveAttribute("title", "Time to resolve")
+    expect(container).toHaveTextContent("Time to resolve: 1d")
+    expect(screen.getAllByText("Time to resolve")).toHaveLength(2)
+    expect(
+      screen.getByText("Duration: 1 day, 4 hours, 4 minutes, 10 seconds")
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Started:/)).toBeInTheDocument()
+    expect(screen.getByText(/Ended:/)).toBeInTheDocument()
+    expect(screen.getByText("Analyst verdict")).toBeInTheDocument()
+    expect(screen.getByText("Priority reason")).toBeInTheDocument()
   })
 })

--- a/frontend/tests/cases-page.test.tsx
+++ b/frontend/tests/cases-page.test.tsx
@@ -8,6 +8,7 @@ import CasesPage from "@/app/workspaces/[workspaceId]/cases/page"
 const mockUseCaseColumnVisibility = jest.fn()
 const mockUseCases = jest.fn()
 
+let mockEntitlementsLoaded = true
 let mockCaseAddonsEnabled = true
 let mockDropdownDefinitions:
   | Array<{
@@ -34,6 +35,8 @@ jest.mock("@/hooks/use-entitlements", () => ({
   useEntitlements: () => ({
     hasEntitlement: (entitlement: string) =>
       entitlement === "case_addons" ? mockCaseAddonsEnabled : false,
+    hasEntitlementData: mockEntitlementsLoaded,
+    isLoading: !mockEntitlementsLoaded,
   }),
 }))
 
@@ -74,6 +77,7 @@ jest.mock("@/components/cases/cases-layout", () => ({
 describe("CasesPage", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockEntitlementsLoaded = true
     mockCaseAddonsEnabled = true
     mockDropdownDefinitions = undefined
     mockCaseFields = undefined
@@ -120,7 +124,13 @@ describe("CasesPage", () => {
     })
   })
 
-  it("preserves stored columns until definitions resolve", () => {
+  it("preserves stored columns until entitlement data and definitions resolve", () => {
+    mockEntitlementsLoaded = false
+    mockCaseAddonsEnabled = false
+    mockCaseFields = [{ id: "priority_reason", reserved: false }]
+    mockDropdownDefinitions = [{ ref: "region" }]
+    mockCaseDurationDefinitions = [{ id: "duration-1" }]
+
     const { rerender } = render(<CasesPage />)
 
     expect(mockUseCaseColumnVisibility).toHaveBeenLastCalledWith(
@@ -128,9 +138,8 @@ describe("CasesPage", () => {
       undefined
     )
 
-    mockCaseFields = [{ id: "priority_reason", reserved: false }]
-    mockDropdownDefinitions = [{ ref: "region" }]
-    mockCaseDurationDefinitions = [{ id: "duration-1" }]
+    mockEntitlementsLoaded = true
+    mockCaseAddonsEnabled = true
 
     rerender(<CasesPage />)
 

--- a/frontend/tests/cases-page.test.tsx
+++ b/frontend/tests/cases-page.test.tsx
@@ -15,17 +15,20 @@ let mockDropdownDefinitions:
       ref: string
     }>
   | undefined
+let mockDropdownDefinitionsIsFetching = false
 let mockCaseFields:
   | Array<{
       id: string
       reserved: boolean
     }>
   | undefined
+let mockCaseFieldsIsFetching = false
 let mockCaseDurationDefinitions:
   | Array<{
       id: string
     }>
   | undefined
+let mockCaseDurationDefinitionsIsFetching = false
 
 jest.mock("@/providers/workspace-id", () => ({
   useWorkspaceId: () => "workspace-1",
@@ -58,12 +61,15 @@ jest.mock("@/hooks/use-cases", () => ({
 jest.mock("@/lib/hooks", () => ({
   useCaseDropdownDefinitions: () => ({
     dropdownDefinitions: mockDropdownDefinitions,
+    dropdownDefinitionsIsFetching: mockDropdownDefinitionsIsFetching,
   }),
   useCaseDurationDefinitions: () => ({
     caseDurationDefinitions: mockCaseDurationDefinitions,
+    caseDurationDefinitionsIsFetching: mockCaseDurationDefinitionsIsFetching,
   }),
   useCaseFields: () => ({
     caseFields: mockCaseFields,
+    caseFieldsIsFetching: mockCaseFieldsIsFetching,
   }),
   useCaseTagCatalog: () => ({
     caseTags: [],
@@ -80,8 +86,11 @@ describe("CasesPage", () => {
     mockEntitlementsLoaded = true
     mockCaseAddonsEnabled = true
     mockDropdownDefinitions = undefined
+    mockDropdownDefinitionsIsFetching = false
     mockCaseFields = undefined
+    mockCaseFieldsIsFetching = false
     mockCaseDurationDefinitions = undefined
+    mockCaseDurationDefinitionsIsFetching = false
 
     mockUseCaseColumnVisibility.mockReturnValue({
       visibleColumnIds: [],
@@ -149,6 +158,42 @@ describe("CasesPage", () => {
         "dropdown:region",
         "field:priority_reason",
         "duration:duration-1",
+      ])
+    )
+  })
+
+  it("waits for fresh metadata before pruning cached column selections", () => {
+    mockCaseAddonsEnabled = true
+    mockEntitlementsLoaded = true
+    mockCaseFields = [{ id: "stale_field", reserved: false }]
+    mockCaseFieldsIsFetching = true
+    mockDropdownDefinitions = [{ ref: "stale-region" }]
+    mockDropdownDefinitionsIsFetching = true
+    mockCaseDurationDefinitions = [{ id: "stale-duration" }]
+    mockCaseDurationDefinitionsIsFetching = true
+
+    const { rerender } = render(<CasesPage />)
+
+    expect(mockUseCaseColumnVisibility).toHaveBeenLastCalledWith(
+      "workspace-1",
+      undefined
+    )
+
+    mockCaseFields = [{ id: "fresh_field", reserved: false }]
+    mockCaseFieldsIsFetching = false
+    mockDropdownDefinitions = [{ ref: "fresh-region" }]
+    mockDropdownDefinitionsIsFetching = false
+    mockCaseDurationDefinitions = [{ id: "fresh-duration" }]
+    mockCaseDurationDefinitionsIsFetching = false
+
+    rerender(<CasesPage />)
+
+    expect(mockUseCaseColumnVisibility).toHaveBeenLastCalledWith(
+      "workspace-1",
+      new Set([
+        "dropdown:fresh-region",
+        "field:fresh_field",
+        "duration:fresh-duration",
       ])
     )
   })

--- a/frontend/tests/cases-page.test.tsx
+++ b/frontend/tests/cases-page.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/react"
+import CasesPage from "@/app/workspaces/[workspaceId]/cases/page"
+
+const mockUseCaseColumnVisibility = jest.fn()
+const mockUseCases = jest.fn()
+
+let mockCaseAddonsEnabled = true
+let mockDropdownDefinitions:
+  | Array<{
+      ref: string
+    }>
+  | undefined
+let mockCaseFields:
+  | Array<{
+      id: string
+      reserved: boolean
+    }>
+  | undefined
+let mockCaseDurationDefinitions:
+  | Array<{
+      id: string
+    }>
+  | undefined
+
+jest.mock("@/providers/workspace-id", () => ({
+  useWorkspaceId: () => "workspace-1",
+}))
+
+jest.mock("@/hooks/use-entitlements", () => ({
+  useEntitlements: () => ({
+    hasEntitlement: (entitlement: string) =>
+      entitlement === "case_addons" ? mockCaseAddonsEnabled : false,
+  }),
+}))
+
+jest.mock("@/hooks/use-workspace", () => ({
+  useWorkspaceMembers: () => ({
+    members: [],
+  }),
+}))
+
+jest.mock("@/hooks/use-case-column-visibility", () => ({
+  useCaseColumnVisibility: (...args: unknown[]) =>
+    mockUseCaseColumnVisibility(...args),
+}))
+
+jest.mock("@/hooks/use-cases", () => ({
+  useCases: (...args: unknown[]) => mockUseCases(...args),
+}))
+
+jest.mock("@/lib/hooks", () => ({
+  useCaseDropdownDefinitions: () => ({
+    dropdownDefinitions: mockDropdownDefinitions,
+  }),
+  useCaseDurationDefinitions: () => ({
+    caseDurationDefinitions: mockCaseDurationDefinitions,
+  }),
+  useCaseFields: () => ({
+    caseFields: mockCaseFields,
+  }),
+  useCaseTagCatalog: () => ({
+    caseTags: [],
+  }),
+}))
+
+jest.mock("@/components/cases/cases-layout", () => ({
+  CasesLayout: () => null,
+}))
+
+describe("CasesPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCaseAddonsEnabled = true
+    mockDropdownDefinitions = undefined
+    mockCaseFields = undefined
+    mockCaseDurationDefinitions = undefined
+
+    mockUseCaseColumnVisibility.mockReturnValue({
+      visibleColumnIds: [],
+      toggleColumn: jest.fn(),
+    })
+    mockUseCases.mockReturnValue({
+      cases: [],
+      isLoading: false,
+      error: null,
+      filters: {},
+      refetch: jest.fn(),
+      setSearchQuery: jest.fn(),
+      setSortBy: jest.fn(),
+      setStatusFilter: jest.fn(),
+      setStatusMode: jest.fn(),
+      setPriorityFilter: jest.fn(),
+      setPriorityMode: jest.fn(),
+      setPrioritySortDirection: jest.fn(),
+      setSeverityFilter: jest.fn(),
+      setSeverityMode: jest.fn(),
+      setSeveritySortDirection: jest.fn(),
+      setAssigneeFilter: jest.fn(),
+      setAssigneeMode: jest.fn(),
+      setAssigneeSortDirection: jest.fn(),
+      setTagFilter: jest.fn(),
+      setTagMode: jest.fn(),
+      setTagSortDirection: jest.fn(),
+      setDropdownFilter: jest.fn(),
+      setDropdownMode: jest.fn(),
+      setDropdownSortDirection: jest.fn(),
+      setUpdatedAfter: jest.fn(),
+      setCreatedAfter: jest.fn(),
+      totalFilteredCaseEstimate: 0,
+      stageCounts: undefined,
+      isCountsLoading: false,
+      isCountsFetching: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: jest.fn(),
+    })
+  })
+
+  it("preserves stored columns until definitions resolve", () => {
+    const { rerender } = render(<CasesPage />)
+
+    expect(mockUseCaseColumnVisibility).toHaveBeenLastCalledWith(
+      "workspace-1",
+      undefined
+    )
+
+    mockCaseFields = [{ id: "priority_reason", reserved: false }]
+    mockDropdownDefinitions = [{ ref: "region" }]
+    mockCaseDurationDefinitions = [{ id: "duration-1" }]
+
+    rerender(<CasesPage />)
+
+    expect(mockUseCaseColumnVisibility).toHaveBeenLastCalledWith(
+      "workspace-1",
+      new Set([
+        "dropdown:region",
+        "field:priority_reason",
+        "duration:duration-1",
+      ])
+    )
+  })
+})

--- a/frontend/tests/time.test.ts
+++ b/frontend/tests/time.test.ts
@@ -1,0 +1,19 @@
+import { durationToHumanReadable, parseISODuration } from "@/lib/time"
+
+describe("time helpers", () => {
+  it("parses ISO durations with fractional seconds", () => {
+    expect(parseISODuration("P1DT4H4M10.01724S")).toEqual({
+      years: 0,
+      months: 0,
+      weeks: 0,
+      days: 1,
+      hours: 4,
+      minutes: 4,
+      seconds: 10,
+    })
+  })
+
+  it("renders fractional-second durations without microseconds", () => {
+    expect(durationToHumanReadable("PT1M30.4S")).toBe("1 minute, 30 seconds")
+  })
+})

--- a/frontend/tests/use-case-column-visibility.test.tsx
+++ b/frontend/tests/use-case-column-visibility.test.tsx
@@ -106,27 +106,46 @@ describe("useCaseColumnVisibility", () => {
       "field:gamma",
       "field:delta",
     ])
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem")
 
-    const { result, rerender } = renderHook(
-      ({ workspaceId }: { workspaceId: string }) =>
-        useCaseColumnVisibility(workspaceId, knownColumnIds),
-      {
-        initialProps: { workspaceId: "workspace-1" },
-      }
-    )
+    try {
+      const { result, rerender } = renderHook(
+        ({ workspaceId }: { workspaceId: string }) =>
+          useCaseColumnVisibility(workspaceId, knownColumnIds),
+        {
+          initialProps: { workspaceId: "workspace-1" },
+        }
+      )
 
-    expect(result.current.visibleColumnIds).toEqual([
-      "field:alpha",
-      "field:beta",
-    ])
+      expect(result.current.visibleColumnIds).toEqual([
+        "field:alpha",
+        "field:beta",
+      ])
 
-    rerender({ workspaceId: "workspace-2" })
+      rerender({ workspaceId: "workspace-2" })
 
-    await waitFor(() => {
       expect(result.current.visibleColumnIds).toEqual([
         "field:gamma",
         "field:delta",
       ])
-    })
+      expect(
+        JSON.parse(
+          window.localStorage.getItem(getStorageKey("workspace-2")) ?? "[]"
+        )
+      ).toEqual(["field:gamma", "field:delta"])
+      expect(setItemSpy).not.toHaveBeenCalledWith(
+        getStorageKey("workspace-2"),
+        JSON.stringify(["field:alpha", "field:beta"])
+      )
+
+      await waitFor(() => {
+        expect(result.current.visibleColumnIds).toEqual([
+          "field:gamma",
+          "field:delta",
+        ])
+      })
+    } finally {
+      setItemSpy.mockRestore()
+    }
   })
 })

--- a/frontend/tests/use-case-column-visibility.test.tsx
+++ b/frontend/tests/use-case-column-visibility.test.tsx
@@ -80,67 +80,6 @@ describe("useCaseColumnVisibility", () => {
     ).toEqual(["field:new1", "field:new2", "field:new3", "field:new4"])
   })
 
-  it("does not truncate persisted IDs before known columns load", async () => {
-    window.localStorage.setItem(
-      getStorageKey("workspace-1"),
-      JSON.stringify([
-        "field:stale1",
-        "field:stale2",
-        "field:stale3",
-        "field:stale4",
-        "field:valid1",
-        "field:valid2",
-      ])
-    )
-
-    type KnownColumnProps = {
-      knownColumnIds: Set<string> | undefined
-    }
-
-    const { result, rerender } = renderHook(
-      ({ knownColumnIds }: KnownColumnProps) =>
-        useCaseColumnVisibility("workspace-1", knownColumnIds),
-      {
-        initialProps: { knownColumnIds: undefined } as KnownColumnProps,
-      }
-    )
-
-    expect(result.current.visibleColumnIds).toEqual([
-      "field:stale1",
-      "field:stale2",
-      "field:stale3",
-      "field:stale4",
-      "field:valid1",
-      "field:valid2",
-    ])
-
-    await waitFor(() => {
-      expect(
-        JSON.parse(
-          window.localStorage.getItem(getStorageKey("workspace-1")) ?? "[]"
-        )
-      ).toEqual([
-        "field:stale1",
-        "field:stale2",
-        "field:stale3",
-        "field:stale4",
-        "field:valid1",
-        "field:valid2",
-      ])
-    })
-
-    rerender({
-      knownColumnIds: new Set(["field:valid1", "field:valid2"]),
-    })
-
-    await waitFor(() => {
-      expect(result.current.visibleColumnIds).toEqual([
-        "field:valid1",
-        "field:valid2",
-      ])
-    })
-  })
-
   it("reloads normalized columns when the workspace changes", async () => {
     window.localStorage.setItem(
       getStorageKey("workspace-1"),

--- a/frontend/tests/use-case-column-visibility.test.tsx
+++ b/frontend/tests/use-case-column-visibility.test.tsx
@@ -80,6 +80,67 @@ describe("useCaseColumnVisibility", () => {
     ).toEqual(["field:new1", "field:new2", "field:new3", "field:new4"])
   })
 
+  it("does not truncate persisted IDs before known columns load", async () => {
+    window.localStorage.setItem(
+      getStorageKey("workspace-1"),
+      JSON.stringify([
+        "field:stale1",
+        "field:stale2",
+        "field:stale3",
+        "field:stale4",
+        "field:valid1",
+        "field:valid2",
+      ])
+    )
+
+    type KnownColumnProps = {
+      knownColumnIds: Set<string> | undefined
+    }
+
+    const { result, rerender } = renderHook(
+      ({ knownColumnIds }: KnownColumnProps) =>
+        useCaseColumnVisibility("workspace-1", knownColumnIds),
+      {
+        initialProps: { knownColumnIds: undefined } as KnownColumnProps,
+      }
+    )
+
+    expect(result.current.visibleColumnIds).toEqual([
+      "field:stale1",
+      "field:stale2",
+      "field:stale3",
+      "field:stale4",
+      "field:valid1",
+      "field:valid2",
+    ])
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          window.localStorage.getItem(getStorageKey("workspace-1")) ?? "[]"
+        )
+      ).toEqual([
+        "field:stale1",
+        "field:stale2",
+        "field:stale3",
+        "field:stale4",
+        "field:valid1",
+        "field:valid2",
+      ])
+    })
+
+    rerender({
+      knownColumnIds: new Set(["field:valid1", "field:valid2"]),
+    })
+
+    await waitFor(() => {
+      expect(result.current.visibleColumnIds).toEqual([
+        "field:valid1",
+        "field:valid2",
+      ])
+    })
+  })
+
   it("reloads normalized columns when the workspace changes", async () => {
     window.localStorage.setItem(
       getStorageKey("workspace-1"),

--- a/frontend/tests/use-case-column-visibility.test.tsx
+++ b/frontend/tests/use-case-column-visibility.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { useCaseColumnVisibility } from "@/hooks/use-case-column-visibility"
+
+const STORAGE_KEY = "cases-visible-columns:v1"
+
+function getStorageKey(workspaceId: string): string {
+  return `${workspaceId}:${STORAGE_KEY}`
+}
+
+describe("useCaseColumnVisibility", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it("prunes stale IDs and preserves the max-4 cap after definitions load", async () => {
+    window.localStorage.setItem(
+      getStorageKey("workspace-1"),
+      JSON.stringify([
+        "field:stale1",
+        "field:stale2",
+        "field:stale3",
+        "field:stale4",
+      ])
+    )
+
+    type KnownColumnProps = {
+      knownColumnIds: Set<string> | undefined
+    }
+
+    const { result, rerender } = renderHook(
+      ({ knownColumnIds }: KnownColumnProps) =>
+        useCaseColumnVisibility("workspace-1", knownColumnIds),
+      {
+        initialProps: { knownColumnIds: undefined } as KnownColumnProps,
+      }
+    )
+
+    expect(result.current.visibleColumnIds).toEqual([
+      "field:stale1",
+      "field:stale2",
+      "field:stale3",
+      "field:stale4",
+    ])
+
+    rerender({
+      knownColumnIds: new Set([
+        "field:new1",
+        "field:new2",
+        "field:new3",
+        "field:new4",
+      ]),
+    })
+
+    await waitFor(() => {
+      expect(result.current.visibleColumnIds).toEqual([])
+    })
+
+    act(() => {
+      result.current.toggleColumn("field:new1")
+      result.current.toggleColumn("field:new2")
+      result.current.toggleColumn("field:new3")
+      result.current.toggleColumn("field:new4")
+      result.current.toggleColumn("field:new5")
+    })
+
+    expect(result.current.visibleColumnIds).toEqual([
+      "field:new1",
+      "field:new2",
+      "field:new3",
+      "field:new4",
+    ])
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(getStorageKey("workspace-1")) ?? "[]"
+      )
+    ).toEqual(["field:new1", "field:new2", "field:new3", "field:new4"])
+  })
+
+  it("reloads normalized columns when the workspace changes", async () => {
+    window.localStorage.setItem(
+      getStorageKey("workspace-1"),
+      JSON.stringify([
+        "field:alpha",
+        "field:alpha",
+        "field:stale",
+        "field:beta",
+      ])
+    )
+    window.localStorage.setItem(
+      getStorageKey("workspace-2"),
+      JSON.stringify([
+        "field:gamma",
+        "field:stale",
+        "field:delta",
+        "field:gamma",
+      ])
+    )
+
+    const knownColumnIds = new Set([
+      "field:alpha",
+      "field:beta",
+      "field:gamma",
+      "field:delta",
+    ])
+
+    const { result, rerender } = renderHook(
+      ({ workspaceId }: { workspaceId: string }) =>
+        useCaseColumnVisibility(workspaceId, knownColumnIds),
+      {
+        initialProps: { workspaceId: "workspace-1" },
+      }
+    )
+
+    expect(result.current.visibleColumnIds).toEqual([
+      "field:alpha",
+      "field:beta",
+    ])
+
+    rerender({ workspaceId: "workspace-2" })
+
+    await waitFor(() => {
+      expect(result.current.visibleColumnIds).toEqual([
+        "field:gamma",
+        "field:delta",
+      ])
+    })
+  })
+})

--- a/frontend/tests/use-cases.test.tsx
+++ b/frontend/tests/use-cases.test.tsx
@@ -88,6 +88,16 @@ function HookProbe() {
   )
 }
 
+function RequestedColumnsProbe() {
+  const { cases } = useCases({
+    autoRefresh: false,
+    fieldIds: ["priority_reason"],
+    includeDurations: true,
+  })
+
+  return <span data-testid="rows">{cases.length}</span>
+}
+
 const ALL_STATUSES: CaseStatus[] = [
   "unknown",
   "new",
@@ -294,6 +304,57 @@ describe("useCases", () => {
         workspaceId: "workspace-1",
         searchTerm: "persisted query",
         updatedAfter: expect.stringContaining("T"),
+      })
+    )
+  })
+
+  it("forwards selected field IDs and duration hydration flags", async () => {
+    const firstPage: CasesSearchCasesResponse = {
+      items: [createCase(1)],
+      next_cursor: null,
+      prev_cursor: null,
+      has_more: false,
+      has_previous: false,
+      total_estimate: 1,
+    }
+
+    const aggregate: CasesSearchCaseAggregatesResponse = {
+      total: 1,
+      status_groups: {
+        new: 1,
+        in_progress: 0,
+        on_hold: 0,
+        resolved: 0,
+        other: 0,
+      },
+    }
+
+    mockSearchCases.mockResolvedValue(firstPage)
+    mockSearchCaseAggregates.mockResolvedValue(aggregate)
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <RequestedColumnsProbe />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rows")).toHaveTextContent("1")
+    })
+
+    expect(mockSearchCases).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+        fieldIds: ["priority_reason"],
+        includeDurations: true,
       })
     )
   })

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -954,6 +954,68 @@ async def test_search_cases_success(
 
 
 @pytest.mark.anyio
+async def test_search_cases_hydrates_requested_fields_and_durations(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """Test GET /cases/search forwards duration flag and selected field IDs."""
+    with (
+        patch.object(cases_router, "CasesService") as MockService,
+        patch.object(cases_router, "CaseFieldsService") as MockFieldsService,
+    ):
+        mock_svc = AsyncMock()
+        mock_fields_svc = AsyncMock()
+
+        mock_case_read = CaseReadMinimal(
+            id=mock_case.id,
+            created_at=mock_case.created_at,
+            updated_at=mock_case.updated_at,
+            short_id=mock_case.short_id,
+            summary=mock_case.summary,
+            status=mock_case.status,
+            priority=mock_case.priority,
+            severity=mock_case.severity,
+            assignee=None,
+            tags=[],
+            dropdown_values=[],
+            num_tasks_completed=0,
+            num_tasks_total=0,
+        )
+        mock_svc.search_cases.return_value = CursorPaginatedResponse(
+            items=[mock_case_read],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        mock_fields_svc.batch_get_fields.return_value = {
+            mock_case.id: {"priority_reason": "Customer impact"}
+        }
+        MockService.return_value = mock_svc
+        MockFieldsService.return_value = mock_fields_svc
+
+        response = client.get(
+            "/cases/search",
+            params=[
+                ("workspace_id", str(test_admin_role.workspace_id)),
+                ("field_ids", "priority_reason"),
+                ("include_durations", "true"),
+            ],
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["items"][0]["field_values"] == {
+            "priority_reason": "Customer impact"
+        }
+        assert mock_svc.search_cases.call_args.kwargs["include_durations"] is True
+        mock_fields_svc.batch_get_fields.assert_awaited_once_with(
+            case_ids=[mock_case.id],
+            field_ids=["priority_reason"],
+        )
+
+
+@pytest.mark.anyio
 async def test_search_cases_accepts_frontend_unassigned_sentinel(
     client: TestClient,
     test_admin_role: Role,

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -216,6 +216,47 @@ async def test_list_cases_with_filters(
 
 
 @pytest.mark.anyio
+async def test_list_cases_validates_field_ids_even_when_page_is_empty(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Invalid field hydration requests should not depend on the page containing rows."""
+    with (
+        patch.object(cases_router, "CasesService") as MockService,
+        patch.object(cases_router, "CaseFieldsService") as MockFieldsService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.list_cases.return_value = CursorPaginatedResponse[CaseReadMinimal](
+            items=[],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        mock_fields_svc = AsyncMock()
+        mock_fields_svc.batch_get_fields.side_effect = ValueError(
+            "Field case_id is a reserved field"
+        )
+        MockService.return_value = mock_svc
+        MockFieldsService.return_value = mock_fields_svc
+
+        response = client.get(
+            "/cases",
+            params=[
+                ("workspace_id", str(test_admin_role.workspace_id)),
+                ("field_ids", "case_id"),
+            ],
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Field case_id is a reserved field"
+    mock_fields_svc.batch_get_fields.assert_awaited_once_with(
+        case_ids=[],
+        field_ids=["case_id"],
+    )
+
+
+@pytest.mark.anyio
 async def test_list_case_events_includes_comment_activity(
     client: TestClient,
     test_admin_role: Role,
@@ -1064,6 +1105,47 @@ async def test_search_cases_hydrates_requested_fields_and_durations(
             case_ids=[mock_case.id],
             field_ids=["priority_reason"],
         )
+
+
+@pytest.mark.anyio
+async def test_search_cases_validates_field_ids_even_when_page_is_empty(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Search field validation should remain request-driven when no cases match."""
+    with (
+        patch.object(cases_router, "CasesService") as MockService,
+        patch.object(cases_router, "CaseFieldsService") as MockFieldsService,
+    ):
+        mock_svc = AsyncMock()
+        mock_svc.search_cases.return_value = CursorPaginatedResponse[CaseReadMinimal](
+            items=[],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        mock_fields_svc = AsyncMock()
+        mock_fields_svc.batch_get_fields.side_effect = ValueError(
+            "Field case_id is a reserved field"
+        )
+        MockService.return_value = mock_svc
+        MockFieldsService.return_value = mock_fields_svc
+
+        response = client.get(
+            "/cases/search",
+            params=[
+                ("workspace_id", str(test_admin_role.workspace_id)),
+                ("field_ids", "case_id"),
+            ],
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Field case_id is a reserved field"
+    mock_fields_svc.batch_get_fields.assert_awaited_once_with(
+        case_ids=[],
+        field_ids=["case_id"],
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -290,6 +290,34 @@ async def test_create_case_success(
 
 
 @pytest.mark.anyio
+async def test_create_case_invalid_numeric_fields_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Invalid custom-field numeric input should be surfaced as a client error."""
+    with patch.object(cases_router, "CasesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_case.side_effect = ValueError("Invalid numeric value: 'abc'")
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            "/cases",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={
+                "summary": "Test Case Summary",
+                "description": "Test case description with details",
+                "priority": "medium",
+                "severity": "medium",
+                "status": "new",
+                "fields": {"score": "abc"},
+            },
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Invalid numeric value: 'abc'"
+
+
+@pytest.mark.anyio
 async def test_create_case_with_dropdown_values(
     client: TestClient,
     test_admin_role: Role,
@@ -679,6 +707,29 @@ async def test_update_case_success(
 
         # Verify service was called
         mock_svc.update_case.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_update_case_invalid_integer_fields_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """Invalid custom-field integer input should be surfaced as a client error."""
+    with patch.object(cases_router, "CasesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_case.return_value = mock_case
+        mock_svc.update_case.side_effect = ValueError("Invalid integer value: '1.5'")
+        MockService.return_value = mock_svc
+
+        response = client.patch(
+            f"/cases/{mock_case.id}",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"fields": {"attempts": "1.5"}},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Invalid integer value: '1.5'"
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_internal_cases.py
+++ b/tests/unit/api/test_api_internal_cases.py
@@ -10,9 +10,14 @@ from tracecat.auth.types import Role
 from tracecat.cases import internal_router as internal_cases_router
 from tracecat.cases.enums import CaseEventType, CasePriority, CaseSeverity, CaseStatus
 from tracecat.cases.rows.schemas import CaseTableRowRead
-from tracecat.cases.schemas import CaseCommentRead, CaseCommentThreadRead
+from tracecat.cases.schemas import (
+    CaseCommentRead,
+    CaseCommentThreadRead,
+    CaseReadMinimal,
+)
 from tracecat.db.models import Case, Workspace
 from tracecat.exceptions import EntitlementRequired, TracecatValidationError
+from tracecat.pagination import CursorPaginatedResponse
 
 
 @pytest.fixture
@@ -207,6 +212,92 @@ async def test_internal_update_case_simple_invalid_integer_fields_returns_400(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["detail"] == "Invalid integer value: '1.5'"
+
+
+@pytest.mark.anyio
+async def test_internal_list_cases_validates_field_ids_even_when_page_is_empty(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    with (
+        patch.object(internal_cases_router, "CasesService") as mock_service_cls,
+        patch.object(
+            internal_cases_router, "CaseFieldsService"
+        ) as mock_fields_service_cls,
+    ):
+        mock_service = AsyncMock()
+        mock_service.list_cases.return_value = CursorPaginatedResponse[CaseReadMinimal](
+            items=[],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        mock_fields_service = AsyncMock()
+        mock_fields_service.batch_get_fields.side_effect = ValueError(
+            "Field case_id is a reserved field"
+        )
+        mock_service_cls.return_value = mock_service
+        mock_fields_service_cls.return_value = mock_fields_service
+
+        response = client.get(
+            "/internal/cases",
+            params=[
+                ("workspace_id", str(test_admin_role.workspace_id)),
+                ("field_ids", "case_id"),
+            ],
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Invalid request for case field hydration"
+    mock_fields_service.batch_get_fields.assert_awaited_once_with(
+        case_ids=[],
+        field_ids=["case_id"],
+    )
+
+
+@pytest.mark.anyio
+async def test_internal_search_cases_validates_field_ids_even_when_page_is_empty(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    with (
+        patch.object(internal_cases_router, "CasesService") as mock_service_cls,
+        patch.object(
+            internal_cases_router, "CaseFieldsService"
+        ) as mock_fields_service_cls,
+    ):
+        mock_service = AsyncMock()
+        mock_service.search_cases.return_value = CursorPaginatedResponse[
+            CaseReadMinimal
+        ](
+            items=[],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        mock_fields_service = AsyncMock()
+        mock_fields_service.batch_get_fields.side_effect = ValueError(
+            "Field case_id is a reserved field"
+        )
+        mock_service_cls.return_value = mock_service
+        mock_fields_service_cls.return_value = mock_fields_service
+
+        response = client.get(
+            "/internal/cases/search",
+            params=[
+                ("workspace_id", str(test_admin_role.workspace_id)),
+                ("field_ids", "case_id"),
+            ],
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Invalid request for case field hydration"
+    mock_fields_service.batch_get_fields.assert_awaited_once_with(
+        case_ids=[],
+        field_ids=["case_id"],
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_internal_cases.py
+++ b/tests/unit/api/test_api_internal_cases.py
@@ -157,6 +157,59 @@ async def test_internal_update_case_include_rows_hydrates_rows(
 
 
 @pytest.mark.anyio
+async def test_internal_create_case_simple_invalid_numeric_fields_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    with patch.object(internal_cases_router, "CasesService") as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.create_case.side_effect = ValueError(
+            "Invalid numeric value: 'abc'"
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.post(
+            "/internal/cases/simple",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={
+                "summary": "Internal case summary",
+                "description": "Internal case description",
+                "priority": "medium",
+                "severity": "low",
+                "status": "new",
+                "fields": {"score": "abc"},
+            },
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Invalid numeric value: 'abc'"
+
+
+@pytest.mark.anyio
+async def test_internal_update_case_simple_invalid_integer_fields_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_internal_case: Case,
+) -> None:
+    with patch.object(internal_cases_router, "CasesService") as mock_service_cls:
+        mock_service = AsyncMock()
+        mock_service.get_case.return_value = mock_internal_case
+        mock_service.update_case.side_effect = ValueError(
+            "Invalid integer value: '1.5'"
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.patch(
+            f"/internal/cases/{mock_internal_case.id}/simple",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"fields": {"attempts": "1.5"}},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Invalid integer value: '1.5'"
+
+
+@pytest.mark.anyio
 async def test_internal_list_comment_threads_success(
     client: TestClient,
     test_admin_role: Role,

--- a/tests/unit/api/test_api_internal_tables.py
+++ b/tests/unit/api/test_api_internal_tables.py
@@ -1,0 +1,70 @@
+"""HTTP-level tests for internal tables API endpoints."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.auth.types import Role
+from tracecat.db.models import Table, Workspace
+from tracecat.tables import internal_router as internal_tables_router
+
+
+@pytest.fixture
+def mock_table(test_workspace: Workspace) -> Table:
+    table = Table(
+        id=uuid.UUID("ffffffff-ffff-4fff-ffff-ffffffffffff"),
+        workspace_id=test_workspace.id,
+        name="test_table",
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    table.columns = []
+    return table
+
+
+@pytest.mark.anyio
+async def test_internal_insert_table_row_invalid_numeric_value_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    with patch.object(internal_tables_router, "TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_table_by_name.return_value = mock_table
+        mock_svc.insert_row.side_effect = ValueError("Invalid numeric value: 'abc'")
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            f"/internal/tables/{mock_table.name}/rows",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"data": {"score": "abc"}},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Invalid numeric value: 'abc'"
+
+
+@pytest.mark.anyio
+async def test_internal_update_table_row_invalid_integer_value_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    with patch.object(internal_tables_router, "TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_table_by_name.return_value = mock_table
+        mock_svc.update_row.side_effect = ValueError("Invalid integer value: '1.5'")
+        MockService.return_value = mock_svc
+
+        response = client.patch(
+            f"/internal/tables/{mock_table.name}/rows/{uuid.uuid4()}",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"data": {"attempts": "1.5"}},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Invalid integer value: '1.5'"

--- a/tests/unit/api/test_api_tables.py
+++ b/tests/unit/api/test_api_tables.py
@@ -242,6 +242,29 @@ async def test_insert_table_row_success(
 
 
 @pytest.mark.anyio
+async def test_insert_table_row_invalid_numeric_value_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    """Invalid numeric row input should be surfaced as a client error."""
+    with patch.object(tables_router, "TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_table.return_value = mock_table
+        mock_svc.insert_row.side_effect = ValueError("Invalid numeric value: 'abc'")
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            f"/tables/{mock_table.id}/rows",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"data": {"score": "abc"}},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Invalid numeric value: 'abc'"
+
+
+@pytest.mark.anyio
 async def test_insert_table_rows_batch_success(
     client: TestClient,
     test_admin_role: Role,
@@ -321,3 +344,26 @@ async def test_list_table_rows_success(
         data = response.json()
         assert len(data["items"]) == 2
         assert data["items"][0]["value"] == "test1"
+
+
+@pytest.mark.anyio
+async def test_update_table_row_invalid_integer_value_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    """Invalid integer row input should be surfaced as a client error."""
+    with patch.object(tables_router, "TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_table.return_value = mock_table
+        mock_svc.update_row.side_effect = ValueError("Invalid integer value: '1.5'")
+        MockService.return_value = mock_svc
+
+        response = client.patch(
+            f"/tables/{mock_table.id}/rows/{uuid.uuid4()}",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"data": {"attempts": "1.5"}},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Invalid integer value: '1.5'"

--- a/tests/unit/test_case_fields_service.py
+++ b/tests/unit/test_case_fields_service.py
@@ -1,5 +1,6 @@
 import uuid
 from collections.abc import Iterator
+from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
@@ -462,6 +463,9 @@ class TestCaseFieldsService:
             patch.object(
                 case_fields_service, "ensure_workspace_row"
             ) as mock_ensure_row,
+            patch.object(
+                case_fields_service, "normalize_field_values", return_value=fields_data
+            ) as mock_normalize_fields,
             patch.object(case_fields_service.editor, "update_row") as mock_update_row,
         ):
             mock_ensure_row.return_value = uuid.uuid4()
@@ -475,6 +479,7 @@ class TestCaseFieldsService:
             # Verify the result matches the full mock_result
             assert result == mock_result
             mock_ensure_row.assert_called_once_with(test_case.id)
+            mock_normalize_fields.assert_called_once_with(fields_data)
             mock_update_row.assert_called_once()
 
             # Verify the call arguments
@@ -482,6 +487,66 @@ class TestCaseFieldsService:
             assert "row_id" in call_kwargs
             assert "data" in call_kwargs
             assert call_kwargs["data"] == fields_data
+
+    async def test_upsert_field_values_preserves_numeric_strings(
+        self, case_fields_service: CaseFieldsService, test_case: Case
+    ) -> None:
+        """Numeric strings should be normalized to Decimal before persistence."""
+        fields_data = {"numeric_field": "1.30"}
+        mock_result = {
+            "id": uuid.uuid4(),
+            "case_id": test_case.id,
+            "numeric_field": Decimal("1.30"),
+        }
+
+        with (
+            patch.object(
+                case_fields_service, "ensure_workspace_row"
+            ) as mock_ensure_row,
+            patch.object(
+                case_fields_service,
+                "get_field_schema",
+                return_value={"numeric_field": {"type": "NUMERIC"}},
+            ),
+            patch.object(
+                case_fields_service.editor,
+                "get_columns",
+                return_value=[{"name": "numeric_field", "type": "NUMERIC"}],
+            ),
+            patch.object(case_fields_service.editor, "update_row") as mock_update_row,
+        ):
+            mock_ensure_row.return_value = uuid.uuid4()
+            mock_update_row.return_value = mock_result
+
+            result = await case_fields_service.upsert_field_values(
+                test_case, fields_data
+            )
+
+            assert result == mock_result
+            call_kwargs = mock_update_row.call_args.kwargs
+            assert call_kwargs["data"] == {"numeric_field": Decimal("1.30")}
+
+    async def test_normalize_field_values_reflection_overrides_stale_schema(
+        self, case_fields_service: CaseFieldsService
+    ) -> None:
+        """Physical column types should win when schema metadata is stale."""
+        with (
+            patch.object(
+                case_fields_service,
+                "get_field_schema",
+                return_value={"numeric_field": {"type": "TEXT"}},
+            ),
+            patch.object(
+                case_fields_service.editor,
+                "get_columns",
+                return_value=[{"name": "numeric_field", "type": "NUMERIC"}],
+            ),
+        ):
+            normalized = await case_fields_service.normalize_field_values(
+                {"numeric_field": "1.30"}
+            )
+
+        assert normalized == {"numeric_field": Decimal("1.30")}
 
     async def test_upsert_field_values_empty_fields(
         self, case_fields_service: CaseFieldsService, test_case: Case

--- a/tests/unit/test_case_fields_service.py
+++ b/tests/unit/test_case_fields_service.py
@@ -376,6 +376,54 @@ class TestCaseFieldsService:
 
         assert fields_by_case == {test_case.id: {"custom_field2": 123}}
 
+    async def test_batch_get_fields_uses_reflected_columns_when_schema_missing(
+        self,
+        case_fields_service: CaseFieldsService,
+        test_case: Case,
+    ) -> None:
+        """Reflected columns should keep hydration working when schema metadata is stale."""
+        await case_fields_service.create_field(
+            CaseFieldCreate(name="custom_field1", type=SqlType.TEXT)
+        )
+        await case_fields_service.create_field(
+            CaseFieldCreate(name="custom_field2", type=SqlType.INTEGER)
+        )
+        await case_fields_service.upsert_field_values(
+            test_case,
+            {"custom_field1": "alpha", "custom_field2": 123},
+        )
+
+        reflected_columns = [
+            {
+                "name": "custom_field1",
+                "type": sa.types.String(),
+                "nullable": True,
+                "default": None,
+                "comment": None,
+            },
+            {
+                "name": "custom_field2",
+                "type": sa.types.Integer(),
+                "nullable": True,
+                "default": None,
+                "comment": None,
+            },
+        ]
+
+        with (
+            patch.object(case_fields_service, "get_field_schema", return_value={}),
+            patch.object(
+                case_fields_service.editor,
+                "get_columns",
+                return_value=reflected_columns,
+            ),
+        ):
+            fields_by_case = await case_fields_service.batch_get_fields(
+                [test_case.id], ["custom_field2"]
+            )
+
+        assert fields_by_case == {test_case.id: {"custom_field2": 123}}
+
     async def test_batch_get_fields_rejects_reserved_field_ids(
         self,
         case_fields_service: CaseFieldsService,
@@ -384,6 +432,9 @@ class TestCaseFieldsService:
         """Reserved case-field columns should not be selectable for hydration."""
         with pytest.raises(ValueError, match="reserved field"):
             await case_fields_service.batch_get_fields([test_case.id], ["case_id"])
+
+        with pytest.raises(ValueError, match="reserved field"):
+            await case_fields_service.batch_get_fields([test_case.id], ["CASE_ID"])
 
     async def test_batch_get_fields_rejects_internal_field_ids(
         self,

--- a/tests/unit/test_case_fields_service.py
+++ b/tests/unit/test_case_fields_service.py
@@ -353,6 +353,49 @@ class TestCaseFieldsService:
             assert fields == mock_fields_data
             mock_get_row.assert_called_once_with(row_id)
 
+    async def test_batch_get_fields_selects_only_requested_columns(
+        self,
+        case_fields_service: CaseFieldsService,
+        test_case: Case,
+    ) -> None:
+        """Batch hydration should return only explicitly requested field IDs."""
+        await case_fields_service.create_field(
+            CaseFieldCreate(name="custom_field1", type=SqlType.TEXT)
+        )
+        await case_fields_service.create_field(
+            CaseFieldCreate(name="custom_field2", type=SqlType.INTEGER)
+        )
+        await case_fields_service.upsert_field_values(
+            test_case,
+            {"custom_field1": "alpha", "custom_field2": 123},
+        )
+
+        fields_by_case = await case_fields_service.batch_get_fields(
+            [test_case.id], ["custom_field2"]
+        )
+
+        assert fields_by_case == {test_case.id: {"custom_field2": 123}}
+
+    async def test_batch_get_fields_rejects_reserved_field_ids(
+        self,
+        case_fields_service: CaseFieldsService,
+        test_case: Case,
+    ) -> None:
+        """Reserved case-field columns should not be selectable for hydration."""
+        with pytest.raises(ValueError, match="reserved field"):
+            await case_fields_service.batch_get_fields([test_case.id], ["case_id"])
+
+    async def test_batch_get_fields_rejects_internal_field_ids(
+        self,
+        case_fields_service: CaseFieldsService,
+        test_case: Case,
+    ) -> None:
+        """Internal/system-managed field IDs should be rejected."""
+        with pytest.raises(ValueError, match="reserved for internal use"):
+            await case_fields_service.batch_get_fields(
+                [test_case.id], ["__tc_workspace_id"]
+            )
+
     async def test_upsert_field_values(
         self, case_fields_service: CaseFieldsService, test_case: Case
     ) -> None:

--- a/tests/unit/test_case_fields_service.py
+++ b/tests/unit/test_case_fields_service.py
@@ -437,6 +437,14 @@ class TestCaseFieldsService:
         with pytest.raises(ValueError, match="reserved field"):
             await case_fields_service.batch_get_fields([test_case.id], ["CASE_ID"])
 
+    async def test_batch_get_fields_rejects_reserved_field_ids_with_no_cases(
+        self,
+        case_fields_service: CaseFieldsService,
+    ) -> None:
+        """Requested field IDs should be validated even for empty result pages."""
+        with pytest.raises(ValueError, match="reserved field"):
+            await case_fields_service.batch_get_fields([], ["case_id"])
+
     async def test_batch_get_fields_rejects_internal_field_ids(
         self,
         case_fields_service: CaseFieldsService,
@@ -447,6 +455,14 @@ class TestCaseFieldsService:
             await case_fields_service.batch_get_fields(
                 [test_case.id], ["__tc_workspace_id"]
             )
+
+    async def test_batch_get_fields_rejects_internal_field_ids_with_no_cases(
+        self,
+        case_fields_service: CaseFieldsService,
+    ) -> None:
+        """Internal field IDs should be rejected before empty-case short-circuits."""
+        with pytest.raises(ValueError, match="reserved for internal use"):
+            await case_fields_service.batch_get_fields([], ["__tc_workspace_id"])
 
     async def test_upsert_field_values(
         self, case_fields_service: CaseFieldsService, test_case: Case

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -1,6 +1,7 @@
 import uuid  # noqa: I001
 import asyncio
 from collections.abc import Iterator
+from decimal import Decimal
 from datetime import UTC, datetime
 from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -949,6 +950,9 @@ class TestCasesService:
         with (
             patch.object(cases_service.fields, "get_fields") as mock_get_fields,
             patch.object(
+                cases_service.fields, "normalize_field_values"
+            ) as mock_normalize_fields,
+            patch.object(
                 cases_service.fields, "upsert_field_values"
             ) as mock_upsert_fields,
         ):
@@ -956,6 +960,10 @@ class TestCasesService:
             mock_get_fields.return_value = {
                 "existing_field1": "original value",
                 "existing_field2": 456,
+            }
+            mock_normalize_fields.return_value = {
+                "existing_field1": "updated value",
+                "new_field": "new value",
             }
 
             # Update just the fields
@@ -968,12 +976,48 @@ class TestCasesService:
 
             # Verify get_fields was called
             mock_get_fields.assert_called_once_with(created_case)
+            mock_normalize_fields.assert_called_once_with(
+                {"existing_field1": "updated value", "new_field": "new value"}
+            )
 
             # Verify upsert_field_values was called with the fields (not merged)
             mock_upsert_fields.assert_called_once_with(
                 created_case,
                 {"existing_field1": "updated value", "new_field": "new value"},
             )
+
+    async def test_update_case_skips_no_op_field_event(
+        self, cases_service: CasesService, case_create_params: CaseCreate
+    ) -> None:
+        """No-op field updates should not emit empty field-change events."""
+        created_case = await cases_service.create_case(case_create_params)
+
+        with (
+            patch.object(
+                cases_service.fields,
+                "get_fields",
+                return_value={"numeric_field": Decimal("1.30")},
+            ) as mock_get_fields,
+            patch.object(
+                cases_service.fields,
+                "normalize_field_values",
+                return_value={"numeric_field": Decimal("1.30")},
+            ) as mock_normalize_fields,
+            patch.object(
+                cases_service.fields, "upsert_field_values"
+            ) as mock_upsert_fields,
+            patch.object(cases_service.events, "create_event") as mock_create_event,
+        ):
+            await cases_service.update_case(
+                created_case, CaseUpdate(fields={"numeric_field": "1.30"})
+            )
+
+            mock_get_fields.assert_called_once_with(created_case)
+            mock_normalize_fields.assert_called_once_with({"numeric_field": "1.30"})
+            mock_upsert_fields.assert_called_once_with(
+                created_case, {"numeric_field": Decimal("1.30")}
+            )
+            mock_create_event.assert_not_awaited()
 
     async def test_cascade_delete(
         self,

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -2,12 +2,13 @@ import uuid  # noqa: I001
 import asyncio
 from collections.abc import Iterator
 from datetime import UTC, datetime
-from typing import Literal
+from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import selectinload as sa_selectinload
 
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
@@ -1035,6 +1036,33 @@ class TestCasesService:
         )
 
         assert search_response.model_dump() == list_response.model_dump()
+
+    async def test_search_cases_gates_duration_selectinload(
+        self, cases_service: CasesService
+    ) -> None:
+        """Duration eager loading should be opt-in for cases list/search."""
+        params = CursorPaginationParams(limit=10, cursor=None, reverse=False)
+        loader_calls: list[str] = []
+
+        def tracked_selectinload(attr: Any):
+            if key := getattr(attr, "key", None):
+                loader_calls.append(key)
+            return sa_selectinload(attr)
+
+        with patch(
+            "tracecat.cases.service.selectinload", side_effect=tracked_selectinload
+        ):
+            await cases_service.search_cases(params=params)
+
+        assert "durations" not in loader_calls
+
+        loader_calls.clear()
+        with patch(
+            "tracecat.cases.service.selectinload", side_effect=tracked_selectinload
+        ):
+            await cases_service.search_cases(params=params, include_durations=True)
+
+        assert "durations" in loader_calls
 
     async def test_search_cases_tag_filter_uses_or_logic(
         self, cases_service: CasesService

--- a/tests/unit/test_table_csv_importer.py
+++ b/tests/unit/test_table_csv_importer.py
@@ -1,6 +1,7 @@
 """Unit tests for the CSVImporter class."""
 
 from collections.abc import Mapping
+from decimal import Decimal
 from typing import cast
 from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
@@ -101,8 +102,12 @@ class TestCSVImporter:
 
     def test_convert_value_numeric(self, csv_importer: CSVImporter) -> None:
         """Test convert_value with numeric values."""
-        assert csv_importer.convert_value("123.45", SqlType.NUMERIC) == 123.45
-        assert csv_importer.convert_value("-456.78", SqlType.NUMERIC) == -456.78
+        assert csv_importer.convert_value("123.45", SqlType.NUMERIC) == Decimal(
+            "123.45"
+        )
+        assert csv_importer.convert_value("-456.78", SqlType.NUMERIC) == Decimal(
+            "-456.78"
+        )
         with pytest.raises(
             TypeError, match="Cannot convert value 'abc' to SqlType NUMERIC"
         ):

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -2001,7 +2001,7 @@ class TestTableDataTypes:
             # Test invalid integer
             pytest.param(
                 {"int_col": "not a number"},
-                "('str' object cannot be interpreted as an integer)",
+                "Invalid integer value: 'not a number'",
                 id="invalid_integer",
             ),
             # Test invalid boolean
@@ -2035,7 +2035,9 @@ class TestTableDataTypes:
         """Test that invalid type conversions are handled appropriately."""
         try:
             # Don't start a new transaction, just use the existing one
-            with pytest.raises((DBAPIError, TypeError, StatementError)) as exc_info:
+            with pytest.raises(
+                (DBAPIError, TypeError, ValueError, StatementError)
+            ) as exc_info:
                 row_insert = TableRowInsert(data=invalid_data)
                 await tables_service.insert_row(complex_table, row_insert)
 

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -1909,6 +1909,23 @@ class TestTableDataTypes:
         assert retrieved_timestamptz == expected_timestamp
         assert retrieved_timestamptz.tzinfo == UTC
 
+    async def test_numeric_string_preserves_scale(
+        self, tables_service: TablesService, complex_table: Table
+    ) -> None:
+        """String inputs for NUMERIC columns should round-trip as exact Decimal values."""
+        inserted = await tables_service.insert_row(
+            complex_table, TableRowInsert(data={"numeric_col": "1.30"})
+        )
+
+        assert inserted["numeric_col"] == Decimal("1.30")
+
+        row_id = inserted["id"]
+        updated = await tables_service.update_row(
+            complex_table, row_id, {"numeric_col": "1.230"}
+        )
+
+        assert updated["numeric_col"] == Decimal("1.230")
+
     async def test_timestamptz_normalisation(
         self, tables_service: TablesService, complex_table: Table
     ) -> None:

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -52,6 +52,7 @@ from tracecat.cases.schemas import (
 )
 from tracecat.cases.service import (
     CaseCommentsService,
+    CaseFieldsService,
     CasesService,
     CaseTasksService,
 )
@@ -140,6 +141,7 @@ async def list_cases(
         None, description="Direction to sort (asc or desc)"
     ),
     include_rows: bool = Query(False, description="Include linked table rows"),
+    include_fields: bool = Query(False, description="Include custom field values"),
 ) -> CursorPaginatedResponse[CaseReadMinimal]:
     service = CasesService(session, role)
 
@@ -173,6 +175,15 @@ async def list_cases(
         )
         cases.items = [
             item.model_copy(update={"rows": rows_by_case.get(item.id, [])})
+            for item in cases.items
+        ]
+    if include_fields and cases.items:
+        fields_service = CaseFieldsService(session, role)
+        fields_by_case = await fields_service.batch_get_fields(
+            case_ids=[item.id for item in cases.items]
+        )
+        cases.items = [
+            item.model_copy(update={"field_values": fields_by_case.get(item.id)})
             for item in cases.items
         ]
     return cases
@@ -235,6 +246,7 @@ async def search_cases(
         None, description="Direction to sort (asc or desc)"
     ),
     include_rows: bool = Query(False, description="Include linked table rows"),
+    include_fields: bool = Query(False, description="Include custom field values"),
 ) -> CursorPaginatedResponse[CaseReadMinimal]:
     service = CasesService(session, role)
 
@@ -294,6 +306,15 @@ async def search_cases(
             )
             cases.items = [
                 item.model_copy(update={"rows": rows_by_case.get(item.id, [])})
+                for item in cases.items
+            ]
+        if include_fields and cases.items:
+            fields_service = CaseFieldsService(session, role)
+            fields_by_case = await fields_service.batch_get_fields(
+                case_ids=[item.id for item in cases.items]
+            )
+            cases.items = [
+                item.model_copy(update={"field_values": fields_by_case.get(item.id)})
                 for item in cases.items
             ]
         return cases

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -181,17 +181,20 @@ async def list_cases(
             item.model_copy(update={"rows": rows_by_case.get(item.id, [])})
             for item in cases.items
         ]
-    if field_ids and cases.items:
+    if field_ids:
         try:
             fields_service = CaseFieldsService(session, role)
             fields_by_case = await fields_service.batch_get_fields(
                 case_ids=[item.id for item in cases.items],
                 field_ids=field_ids,
             )
-            cases.items = [
-                item.model_copy(update={"field_values": fields_by_case.get(item.id)})
-                for item in cases.items
-            ]
+            if cases.items:
+                cases.items = [
+                    item.model_copy(
+                        update={"field_values": fields_by_case.get(item.id)}
+                    )
+                    for item in cases.items
+                ]
         except ValueError as e:
             raise HTTPException(
                 status_code=HTTP_400_BAD_REQUEST,
@@ -323,19 +326,20 @@ async def search_cases(
                 item.model_copy(update={"rows": rows_by_case.get(item.id, [])})
                 for item in cases.items
             ]
-        if field_ids and cases.items:
+        if field_ids:
             try:
                 fields_service = CaseFieldsService(session, role)
                 fields_by_case = await fields_service.batch_get_fields(
                     case_ids=[item.id for item in cases.items],
                     field_ids=field_ids,
                 )
-                cases.items = [
-                    item.model_copy(
-                        update={"field_values": fields_by_case.get(item.id)}
-                    )
-                    for item in cases.items
-                ]
+                if cases.items:
+                    cases.items = [
+                        item.model_copy(
+                            update={"field_values": fields_by_case.get(item.id)}
+                        )
+                        for item in cases.items
+                    ]
             except ValueError as e:
                 raise HTTPException(
                     status_code=HTTP_400_BAD_REQUEST,

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -141,7 +141,10 @@ async def list_cases(
         None, description="Direction to sort (asc or desc)"
     ),
     include_rows: bool = Query(False, description="Include linked table rows"),
-    include_fields: bool = Query(False, description="Include custom field values"),
+    field_ids: list[str] | None = Query(
+        None, description="Include only the requested custom field IDs"
+    ),
+    include_durations: bool = Query(False, description="Include case duration values"),
 ) -> CursorPaginatedResponse[CaseReadMinimal]:
     service = CasesService(session, role)
 
@@ -152,6 +155,7 @@ async def list_cases(
             reverse=reverse,
             order_by=order_by,
             sort=sort,
+            include_durations=include_durations,
         )
     except ValueError as e:
         logger.warning(f"Invalid request for list cases: {e}")
@@ -177,15 +181,22 @@ async def list_cases(
             item.model_copy(update={"rows": rows_by_case.get(item.id, [])})
             for item in cases.items
         ]
-    if include_fields and cases.items:
-        fields_service = CaseFieldsService(session, role)
-        fields_by_case = await fields_service.batch_get_fields(
-            case_ids=[item.id for item in cases.items]
-        )
-        cases.items = [
-            item.model_copy(update={"field_values": fields_by_case.get(item.id)})
-            for item in cases.items
-        ]
+    if field_ids and cases.items:
+        try:
+            fields_service = CaseFieldsService(session, role)
+            fields_by_case = await fields_service.batch_get_fields(
+                case_ids=[item.id for item in cases.items],
+                field_ids=field_ids,
+            )
+            cases.items = [
+                item.model_copy(update={"field_values": fields_by_case.get(item.id)})
+                for item in cases.items
+            ]
+        except ValueError as e:
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail="Invalid request for case field hydration",
+            ) from e
     return cases
 
 
@@ -246,7 +257,10 @@ async def search_cases(
         None, description="Direction to sort (asc or desc)"
     ),
     include_rows: bool = Query(False, description="Include linked table rows"),
-    include_fields: bool = Query(False, description="Include custom field values"),
+    field_ids: list[str] | None = Query(
+        None, description="Include only the requested custom field IDs"
+    ),
+    include_durations: bool = Query(False, description="Include case duration values"),
 ) -> CursorPaginatedResponse[CaseReadMinimal]:
     service = CasesService(session, role)
 
@@ -297,6 +311,7 @@ async def search_cases(
             updated_before=updated_before,
             order_by=order_by,
             sort=sort,
+            include_durations=include_durations,
         )
         if include_rows and cases.items:
             rows_service = CaseTableRowsService(session, role)
@@ -308,15 +323,24 @@ async def search_cases(
                 item.model_copy(update={"rows": rows_by_case.get(item.id, [])})
                 for item in cases.items
             ]
-        if include_fields and cases.items:
-            fields_service = CaseFieldsService(session, role)
-            fields_by_case = await fields_service.batch_get_fields(
-                case_ids=[item.id for item in cases.items]
-            )
-            cases.items = [
-                item.model_copy(update={"field_values": fields_by_case.get(item.id)})
-                for item in cases.items
-            ]
+        if field_ids and cases.items:
+            try:
+                fields_service = CaseFieldsService(session, role)
+                fields_by_case = await fields_service.batch_get_fields(
+                    case_ids=[item.id for item in cases.items],
+                    field_ids=field_ids,
+                )
+                cases.items = [
+                    item.model_copy(
+                        update={"field_values": fields_by_case.get(item.id)}
+                    )
+                    for item in cases.items
+                ]
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=HTTP_400_BAD_REQUEST,
+                    detail="Invalid request for case field hydration",
+                ) from e
         return cases
 
     except ValueError as e:

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -190,6 +190,10 @@ async def list_cases(
         None, description="Direction to sort (asc or desc)"
     ),
     include_rows: bool = Query(False, description="Include linked table rows"),
+    field_ids: list[str] | None = Query(
+        None, description="Include only the requested custom field IDs"
+    ),
+    include_durations: bool = Query(False, description="Include case duration values"),
 ) -> CursorPaginatedResponse[CaseReadMinimal]:
     """List cases with default filtering and sorting options."""
     service = CasesService(session, role)
@@ -201,6 +205,7 @@ async def list_cases(
             reverse=reverse,
             order_by=order_by,
             sort=sort,
+            include_durations=include_durations,
         )
     except ValueError as e:
         logger.warning(f"Invalid request for list cases: {e}")
@@ -232,6 +237,29 @@ async def list_cases(
             raise HTTPException(
                 status_code=HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to hydrate linked rows",
+            ) from e
+    if field_ids and cases.items:
+        try:
+            fields_service = CaseFieldsService(session, role)
+            fields_by_case = await fields_service.batch_get_fields(
+                case_ids=[item.id for item in cases.items],
+                field_ids=field_ids,
+            )
+            cases.items = [
+                item.model_copy(update={"field_values": fields_by_case.get(item.id)})
+                for item in cases.items
+            ]
+        except ValueError as e:
+            logger.warning(f"Invalid request for case field hydration: {e}")
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=str(e),
+            ) from e
+        except Exception as e:
+            logger.error(f"Failed to hydrate case fields: {e}")
+            raise HTTPException(
+                status_code=HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to hydrate case fields",
             ) from e
     return cases
 
@@ -298,7 +326,10 @@ async def search_cases(
         None, description="Direction to sort (asc or desc)"
     ),
     include_rows: bool = Query(False, description="Include linked table rows"),
-    include_fields: bool = Query(False, description="Include custom field values"),
+    field_ids: list[str] | None = Query(
+        None, description="Include only the requested custom field IDs"
+    ),
+    include_durations: bool = Query(False, description="Include case duration values"),
 ) -> CursorPaginatedResponse[CaseReadMinimal]:
     """Search cases with cursor-based pagination, filtering, and sorting."""
     service = CasesService(session, role)
@@ -334,6 +365,7 @@ async def search_cases(
             updated_before=updated_before,
             order_by=order_by,
             sort=sort,
+            include_durations=include_durations,
         )
     except ValueError as e:
         logger.warning(f"Invalid request for search cases: {e}")
@@ -366,16 +398,23 @@ async def search_cases(
                 status_code=HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to hydrate linked rows",
             ) from e
-    if include_fields and cases.items:
+    if field_ids and cases.items:
         try:
             fields_service = CaseFieldsService(session, role)
             fields_by_case = await fields_service.batch_get_fields(
-                case_ids=[item.id for item in cases.items]
+                case_ids=[item.id for item in cases.items],
+                field_ids=field_ids,
             )
             cases.items = [
                 item.model_copy(update={"field_values": fields_by_case.get(item.id)})
                 for item in cases.items
             ]
+        except ValueError as e:
+            logger.warning(f"Invalid request for case field hydration: {e}")
+            raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=str(e),
+            ) from e
         except Exception as e:
             logger.error(f"Failed to hydrate case fields: {e}")
             raise HTTPException(

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -238,17 +238,20 @@ async def list_cases(
                 status_code=HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to hydrate linked rows",
             ) from e
-    if field_ids and cases.items:
+    if field_ids:
         try:
             fields_service = CaseFieldsService(session, role)
             fields_by_case = await fields_service.batch_get_fields(
                 case_ids=[item.id for item in cases.items],
                 field_ids=field_ids,
             )
-            cases.items = [
-                item.model_copy(update={"field_values": fields_by_case.get(item.id)})
-                for item in cases.items
-            ]
+            if cases.items:
+                cases.items = [
+                    item.model_copy(
+                        update={"field_values": fields_by_case.get(item.id)}
+                    )
+                    for item in cases.items
+                ]
         except ValueError as e:
             logger.warning(f"Invalid request for case field hydration: {e}")
             raise HTTPException(
@@ -398,17 +401,20 @@ async def search_cases(
                 status_code=HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to hydrate linked rows",
             ) from e
-    if field_ids and cases.items:
+    if field_ids:
         try:
             fields_service = CaseFieldsService(session, role)
             fields_by_case = await fields_service.batch_get_fields(
                 case_ids=[item.id for item in cases.items],
                 field_ids=field_ids,
             )
-            cases.items = [
-                item.model_copy(update={"field_values": fields_by_case.get(item.id)})
-                for item in cases.items
-            ]
+            if cases.items:
+                cases.items = [
+                    item.model_copy(
+                        update={"field_values": fields_by_case.get(item.id)}
+                    )
+                    for item in cases.items
+                ]
         except ValueError as e:
             logger.warning(f"Invalid request for case field hydration: {e}")
             raise HTTPException(

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -298,6 +298,7 @@ async def search_cases(
         None, description="Direction to sort (asc or desc)"
     ),
     include_rows: bool = Query(False, description="Include linked table rows"),
+    include_fields: bool = Query(False, description="Include custom field values"),
 ) -> CursorPaginatedResponse[CaseReadMinimal]:
     """Search cases with cursor-based pagination, filtering, and sorting."""
     service = CasesService(session, role)
@@ -364,6 +365,22 @@ async def search_cases(
             raise HTTPException(
                 status_code=HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to hydrate linked rows",
+            ) from e
+    if include_fields and cases.items:
+        try:
+            fields_service = CaseFieldsService(session, role)
+            fields_by_case = await fields_service.batch_get_fields(
+                case_ids=[item.id for item in cases.items]
+            )
+            cases.items = [
+                item.model_copy(update={"field_values": fields_by_case.get(item.id)})
+                for item in cases.items
+            ]
+        except Exception as e:
+            logger.error(f"Failed to hydrate case fields: {e}")
+            raise HTTPException(
+                status_code=HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to hydrate case fields",
             ) from e
     return cases
 

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -14,6 +14,7 @@ from tracecat.cases.dropdowns.schemas import (
     CaseDropdownValueInput,
     CaseDropdownValueRead,
 )
+from tracecat.cases.durations.schemas import CaseDurationRead
 from tracecat.cases.enums import (
     CaseEventType,
     CaseFieldKind,
@@ -52,6 +53,8 @@ class CaseReadMinimal(Schema):
     tags: list[CaseTagRead] = Field(default_factory=list)
     dropdown_values: list[CaseDropdownValueRead]
     rows: list[CaseTableRowRead] = Field(default_factory=list)
+    durations: list[CaseDurationRead] | None = None
+    field_values: dict[str, Any] | None = None
     num_tasks_completed: int = Field(default=0)
     num_tasks_total: int = Field(default=0)
 

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -121,7 +121,11 @@ from tracecat.pagination import (
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tables.common import normalize_column_options
 from tracecat.tables.enums import SqlType
-from tracecat.tables.service import DYNAMIC_WORKSPACE_TENANT_COLUMN, TablesService
+from tracecat.tables.service import (
+    DYNAMIC_WORKSPACE_TENANT_COLUMN,
+    TablesService,
+    validate_identifier,
+)
 from tracecat.tiers.enums import Entitlement
 
 
@@ -377,9 +381,11 @@ class CasesService(BaseWorkspaceService):
         ]
         | None = None,
         sort: Literal["asc", "desc"] | None = None,
+        include_durations: bool = False,
     ) -> CursorPaginatedResponse[CaseReadMinimal]:
         """Search cases with cursor-based pagination and filtering."""
         paginator = BaseCursorPaginator(self.session)
+        include_case_addons = await self.has_entitlement(Entitlement.CASE_ADDONS)
         filters = self._build_search_filters(
             search_term=search_term,
             short_id=short_id,
@@ -398,7 +404,7 @@ class CasesService(BaseWorkspaceService):
             updated_after=updated_after,
         )
 
-        # Base query - eagerly load tags, assignee, dropdown values, and durations
+        # Base query - eagerly load tags, assignee, and dropdown values.
         stmt = (
             select(Case)
             .options(selectinload(Case.tags))
@@ -413,8 +419,9 @@ class CasesService(BaseWorkspaceService):
                     CaseDropdownValue.option
                 )
             )
-            .options(selectinload(Case.durations))
         )
+        if include_case_addons and include_durations:
+            stmt = stmt.options(selectinload(Case.durations))
 
         for clause in filters:
             stmt = stmt.where(clause)
@@ -600,7 +607,6 @@ class CasesService(BaseWorkspaceService):
 
         # Convert to CaseReadMinimal objects with tags and dropdown values
         case_items = []
-        include_dropdown_values = await self.has_entitlement(Entitlement.CASE_ADDONS)
         for case in cases:
             # Tags are already loaded via selectinload
             tag_reads = [
@@ -610,7 +616,7 @@ class CasesService(BaseWorkspaceService):
 
             dropdown_reads = []
             duration_reads: list[CaseDurationRead] | None = None
-            if include_dropdown_values:
+            if include_case_addons:
                 # Dropdown values are already loaded via selectinload
                 dropdown_reads = [
                     CaseDropdownValueRead(
@@ -626,12 +632,12 @@ class CasesService(BaseWorkspaceService):
                     )
                     for dv in case.dropdown_values
                 ]
+            if include_case_addons and include_durations and case.durations:
                 # Durations are already loaded via selectinload
-                if case.durations:
-                    duration_reads = [
-                        CaseDurationRead.model_validate(d, from_attributes=True)
-                        for d in case.durations
-                    ]
+                duration_reads = [
+                    CaseDurationRead.model_validate(d, from_attributes=True)
+                    for d in case.durations
+                ]
 
             case_items.append(
                 CaseReadMinimal(
@@ -762,12 +768,14 @@ class CasesService(BaseWorkspaceService):
         ]
         | None = None,
         sort: Literal["asc", "desc"] | None = None,
+        include_durations: bool = False,
     ) -> CursorPaginatedResponse[CaseReadMinimal]:
         """List cases with a simplified default search query."""
         return await self.search_cases(
             params=CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse),
             order_by=order_by,
             sort=sort,
+            include_durations=include_durations,
         )
 
     async def get_case(
@@ -1372,36 +1380,44 @@ class CaseFieldsService(CustomFieldsService):
         return await self.editor.get_row(row_id) if row_id else None
 
     async def batch_get_fields(
-        self, case_ids: list[uuid.UUID]
+        self, case_ids: list[uuid.UUID], field_ids: Sequence[str]
     ) -> dict[uuid.UUID, dict[str, Any]]:
         """Batch-load custom field values for multiple cases.
 
-        Uses reflected columns via the editor so that user-defined fields
-        (added at runtime) are included in the result.
+        Only selects requested custom-field columns to keep case list hydration
+        proportional to the visible field badges.
         """
-        if not case_ids:
+        if not case_ids or not field_ids:
             return {}
         await self._ensure_schema_ready()
+
+        available_fields = set(await self.get_field_schema())
+        requested_field_ids: list[str] = []
+        for field_id in dict.fromkeys(field_ids):
+            self._assert_user_field_name_allowed(field_id)
+            if field_id in self._reserved_columns:
+                raise ValueError(f"Field {field_id} is a reserved field")
+            normalized_field_id = validate_identifier(field_id)
+            if normalized_field_id in available_fields:
+                requested_field_ids.append(normalized_field_id)
+
+        if not requested_field_ids:
+            return {}
+
         conn = await self.session.connection()
-        reflected = await self.editor.get_columns()
-        col_clauses = [
-            sa.column(col["name"])
-            for col in reflected
-            if isinstance(col.get("name"), str)
-        ]
         stmt = (
-            sa.select(*col_clauses)
+            sa.select(
+                sa.column("case_id"),
+                *(sa.column(field_id) for field_id in requested_field_ids),
+            )
             .select_from(sa.table(self.sanitized_table_name, schema=self.schema_name))
             .where(sa.column("case_id").in_(case_ids))
         )
         result = await conn.execute(stmt)
         rows = result.mappings().all()
-        reserved = self._reserved_columns
         return {
             row["case_id"]: {
-                k: v
-                for k, v in dict(row).items()
-                if k not in reserved and v is not None
+                k: v for k, v in dict(row).items() if k != "case_id" and v is not None
             }
             for row in rows
         }

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -119,7 +119,11 @@ from tracecat.pagination import (
     CursorPaginationParams,
 )
 from tracecat.service import BaseWorkspaceService, requires_entitlement
-from tracecat.tables.common import normalize_column_options
+from tracecat.tables.common import (
+    coerce_integer_value,
+    coerce_numeric_value,
+    normalize_column_options,
+)
 from tracecat.tables.enums import SqlType
 from tracecat.tables.service import (
     DYNAMIC_WORKSPACE_TENANT_COLUMN,
@@ -1055,22 +1059,24 @@ class CasesService(BaseWorkspaceService):
             if not isinstance(fields, dict):
                 raise ValueError("Fields must be a dict")
 
+            normalized_fields = await self.fields.normalize_field_values(fields)
             # Get existing fields for diff calculation
             existing_fields = await self.fields.get_fields(case) or {}
 
             # Upsert the field values (handles both create and update)
-            await self.fields.upsert_field_values(case, fields)
+            await self.fields.upsert_field_values(case, normalized_fields)
 
             # Calculate diffs for event
             diffs = []
-            for field, value in fields.items():
+            for field, value in normalized_fields.items():
                 old_value = existing_fields.get(field)
                 if old_value != value:
                     diffs.append(FieldDiff(field=field, old=old_value, new=value))
-            await self.events.create_event(
-                case=case,
-                event=FieldsChangedEvent(changes=diffs, wf_exec_id=wf_exec_id),
-            )
+            if diffs:
+                await self.events.create_event(
+                    case=case,
+                    event=FieldsChangedEvent(changes=diffs, wf_exec_id=wf_exec_id),
+                )
 
         if dropdown_values is not None:
             # Update paths keep the same persisted payload shape as create:
@@ -1226,6 +1232,43 @@ class CaseFieldsService(CustomFieldsService):
         result = await self.session.execute(stmt)
         schema = result.scalar_one_or_none()
         return schema or {}
+
+    async def normalize_field_values(self, fields: dict[str, Any]) -> dict[str, Any]:
+        """Normalize case field values to their storage types."""
+        if not fields:
+            return {}
+
+        schema = await self.get_field_schema()
+        reflected_types: dict[str, SqlType] = {}
+        for column in await self.editor.get_columns():
+            column_name = column.get("name")
+            if (
+                isinstance(column_name, str)
+                and column_name not in self._reserved_columns
+            ):
+                reflected_types[column_name] = SqlType(
+                    _normalize_case_field_read_type(column["type"]).value
+                )
+        normalized: dict[str, Any] = {}
+
+        for field_name, value in fields.items():
+            field_type = reflected_types.get(field_name)
+            if isinstance(schema_def := schema.get(field_name), dict):
+                if field_type is None and (raw_type := schema_def.get("type")):
+                    field_type = SqlType(
+                        _normalize_case_field_read_type(raw_type).value
+                    )
+
+            if value is None or field_type is None:
+                normalized[field_name] = value
+            elif field_type is SqlType.INTEGER:
+                normalized[field_name] = coerce_integer_value(value)
+            elif field_type is SqlType.NUMERIC:
+                normalized[field_name] = coerce_numeric_value(value)
+            else:
+                normalized[field_name] = value
+
+        return normalized
 
     async def _update_field_schema(
         self, field_id: str, field_def: dict[str, Any] | None
@@ -1456,11 +1499,14 @@ class CaseFieldsService(CustomFieldsService):
             )
         for field_name in fields:
             self._assert_user_field_name_allowed(field_name)
+        normalized_fields = await self.normalize_field_values(fields)
         row_id = await self.ensure_workspace_row(case.id)
 
         try:
-            if fields:
-                res = await self.editor.update_row(row_id=row_id, data=fields)
+            if normalized_fields:
+                res = await self.editor.update_row(
+                    row_id=row_id, data=normalized_fields
+                )
                 await self.session.flush()
                 return res
             return await self.editor.get_row(row_id=row_id)
@@ -1471,10 +1517,10 @@ class CaseFieldsService(CustomFieldsService):
                 "Case fields row not found after upsert",
                 row_id=row_id,
                 case_id=case.id,
-                fields=fields,
+                fields=normalized_fields,
                 error=str(e),
             )
-            field_names = list(fields.keys()) if fields else []
+            field_names = list(normalized_fields.keys()) if normalized_fields else []
             field_info = (
                 f" Fields attempted: {', '.join(field_names)}." if field_names else ""
             )

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -1374,13 +1374,26 @@ class CaseFieldsService(CustomFieldsService):
     async def batch_get_fields(
         self, case_ids: list[uuid.UUID]
     ) -> dict[uuid.UUID, dict[str, Any]]:
-        """Batch-load custom field values for multiple cases."""
+        """Batch-load custom field values for multiple cases.
+
+        Uses reflected columns via the editor so that user-defined fields
+        (added at runtime) are included in the result.
+        """
         if not case_ids:
             return {}
         await self._ensure_schema_ready()
-        table = self._table_definition()
         conn = await self.session.connection()
-        stmt = sa.select(table).where(table.c.case_id.in_(case_ids))
+        reflected = await self.editor.get_columns()
+        col_clauses = [
+            sa.column(col["name"])
+            for col in reflected
+            if isinstance(col.get("name"), str)
+        ]
+        stmt = (
+            sa.select(*col_clauses)
+            .select_from(sa.table(self.sanitized_table_name, schema=self.schema_name))
+            .where(sa.column("case_id").in_(case_ids))
+        )
         result = await conn.execute(stmt)
         rows = result.mappings().all()
         reserved = self._reserved_columns

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -28,6 +28,7 @@ from tracecat.cases.dropdowns.schemas import (
     CaseDropdownValueRead,
 )
 from tracecat.cases.dropdowns.service import CaseDropdownValuesService
+from tracecat.cases.durations.schemas import CaseDurationRead
 from tracecat.cases.durations.service import CaseDurationService
 from tracecat.cases.enums import (
     CaseEventType,
@@ -397,7 +398,7 @@ class CasesService(BaseWorkspaceService):
             updated_after=updated_after,
         )
 
-        # Base query - eagerly load tags, assignee, and dropdown values
+        # Base query - eagerly load tags, assignee, dropdown values, and durations
         stmt = (
             select(Case)
             .options(selectinload(Case.tags))
@@ -412,6 +413,7 @@ class CasesService(BaseWorkspaceService):
                     CaseDropdownValue.option
                 )
             )
+            .options(selectinload(Case.durations))
         )
 
         for clause in filters:
@@ -607,6 +609,7 @@ class CasesService(BaseWorkspaceService):
             ]
 
             dropdown_reads = []
+            duration_reads: list[CaseDurationRead] | None = None
             if include_dropdown_values:
                 # Dropdown values are already loaded via selectinload
                 dropdown_reads = [
@@ -623,6 +626,12 @@ class CasesService(BaseWorkspaceService):
                     )
                     for dv in case.dropdown_values
                 ]
+                # Durations are already loaded via selectinload
+                if case.durations:
+                    duration_reads = [
+                        CaseDurationRead.model_validate(d, from_attributes=True)
+                        for d in case.durations
+                    ]
 
             case_items.append(
                 CaseReadMinimal(
@@ -641,6 +650,7 @@ class CasesService(BaseWorkspaceService):
                     else None,
                     tags=tag_reads,
                     dropdown_values=dropdown_reads,
+                    durations=duration_reads,
                     num_tasks_completed=task_counts[case.id]["completed"],
                     num_tasks_total=task_counts[case.id]["total"],
                 )
@@ -1360,6 +1370,28 @@ class CaseFieldsService(CustomFieldsService):
             sa.select(table.c.id).where(table.c.case_id == case.id)
         )
         return await self.editor.get_row(row_id) if row_id else None
+
+    async def batch_get_fields(
+        self, case_ids: list[uuid.UUID]
+    ) -> dict[uuid.UUID, dict[str, Any]]:
+        """Batch-load custom field values for multiple cases."""
+        if not case_ids:
+            return {}
+        await self._ensure_schema_ready()
+        table = self._table_definition()
+        conn = await self.session.connection()
+        stmt = sa.select(table).where(table.c.case_id.in_(case_ids))
+        result = await conn.execute(stmt)
+        rows = result.mappings().all()
+        reserved = self._reserved_columns
+        return {
+            row["case_id"]: {
+                k: v
+                for k, v in dict(row).items()
+                if k not in reserved and v is not None
+            }
+            for row in rows
+        }
 
     @require_scope("case:create", "case:update", require_all=False)
     async def upsert_field_values(

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -1391,13 +1391,20 @@ class CaseFieldsService(CustomFieldsService):
             return {}
         await self._ensure_schema_ready()
 
-        available_fields = set(await self.get_field_schema())
+        # Validate requested fields against reflected columns so stale or missing
+        # schema metadata does not hide real columns.
+        available_fields = {
+            column_name
+            for column in await self.editor.get_columns()
+            if isinstance((column_name := column.get("name")), str)
+            and column_name not in self._reserved_columns
+        }
         requested_field_ids: list[str] = []
         for field_id in dict.fromkeys(field_ids):
             self._assert_user_field_name_allowed(field_id)
-            if field_id in self._reserved_columns:
-                raise ValueError(f"Field {field_id} is a reserved field")
             normalized_field_id = validate_identifier(field_id)
+            if normalized_field_id in self._reserved_columns:
+                raise ValueError(f"Field {field_id} is a reserved field")
             if normalized_field_id in available_fields:
                 requested_field_ids.append(normalized_field_id)
 

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -1430,7 +1430,7 @@ class CaseFieldsService(CustomFieldsService):
         Only selects requested custom-field columns to keep case list hydration
         proportional to the visible field badges.
         """
-        if not case_ids or not field_ids:
+        if not field_ids:
             return {}
         await self._ensure_schema_ready()
 
@@ -1451,7 +1451,7 @@ class CaseFieldsService(CustomFieldsService):
             if normalized_field_id in available_fields:
                 requested_field_ids.append(normalized_field_id)
 
-        if not requested_field_ids:
+        if not case_ids or not requested_field_ids:
             return {}
 
         conn = await self.session.connection()

--- a/tracecat/tables/common.py
+++ b/tracecat/tables/common.py
@@ -155,39 +155,18 @@ def coerce_default_value(type: SqlType, default: Any) -> Any:
                     )
         case SqlType.INTEGER:
             try:
-                decimal_value = Decimal(str(default))
-            except (InvalidOperation, TypeError, ValueError) as exc:
+                return coerce_integer_value(default)
+            except ValueError as exc:
                 raise InvalidDefaultValueError(
                     f"Invalid integer default value: {default!r}"
                 ) from exc
-            if not decimal_value.is_finite():
-                raise InvalidDefaultValueError(
-                    f"Invalid integer default value: {default!r}"
-                )
-            if decimal_value != decimal_value.to_integral_value():
-                raise InvalidDefaultValueError(
-                    f"Invalid integer default value: {default!r}"
-                )
-            if (
-                decimal_value < POSTGRES_BIGINT_MIN
-                or decimal_value > POSTGRES_BIGINT_MAX
-            ):
-                raise InvalidDefaultValueError(
-                    f"Invalid integer default value: {default!r}"
-                )
-            return int(decimal_value)
         case SqlType.NUMERIC:
             try:
-                decimal_value = Decimal(str(default))
-            except (InvalidOperation, TypeError, ValueError) as exc:
+                return coerce_numeric_value(default)
+            except ValueError as exc:
                 raise InvalidDefaultValueError(
                     f"Invalid numeric default value: {default!r}"
                 ) from exc
-            if not decimal_value.is_finite():
-                raise InvalidDefaultValueError(
-                    f"Invalid numeric default value: {default!r}"
-                )
-            return decimal_value
         case _:
             raise InvalidDefaultValueError(
                 f"Unsupported SQL type for default value: {type}"

--- a/tracecat/tables/common.py
+++ b/tracecat/tables/common.py
@@ -96,14 +96,14 @@ def coerce_integer_value(value: Any) -> int:
     try:
         decimal_value = Decimal(str(value).strip())
     except (InvalidOperation, TypeError, ValueError, AttributeError) as exc:
-        raise TypeError(f"Invalid integer value: {value!r}") from exc
+        raise ValueError(f"Invalid integer value: {value!r}") from exc
 
     if not decimal_value.is_finite():
-        raise TypeError(f"Invalid integer value: {value!r}")
+        raise ValueError(f"Invalid integer value: {value!r}")
     if decimal_value != decimal_value.to_integral_value():
-        raise TypeError(f"Invalid integer value: {value!r}")
+        raise ValueError(f"Invalid integer value: {value!r}")
     if decimal_value < POSTGRES_BIGINT_MIN or decimal_value > POSTGRES_BIGINT_MAX:
-        raise TypeError(f"Invalid integer value: {value!r}")
+        raise ValueError(f"Invalid integer value: {value!r}")
     return int(decimal_value)
 
 
@@ -112,10 +112,10 @@ def coerce_numeric_value(value: Any) -> Decimal:
     try:
         decimal_value = Decimal(str(value).strip())
     except (InvalidOperation, TypeError, ValueError, AttributeError) as exc:
-        raise TypeError(f"Invalid numeric value: {value!r}") from exc
+        raise ValueError(f"Invalid numeric value: {value!r}") from exc
 
     if not decimal_value.is_finite():
-        raise TypeError(f"Invalid numeric value: {value!r}")
+        raise ValueError(f"Invalid numeric value: {value!r}")
     return decimal_value
 
 

--- a/tracecat/tables/common.py
+++ b/tracecat/tables/common.py
@@ -91,6 +91,34 @@ class InvalidDefaultValueError(ValueError):
     """Raised when a user-provided table default cannot be coerced safely."""
 
 
+def coerce_integer_value(value: Any) -> int:
+    """Coerce a user value to a safe PostgreSQL BIGINT."""
+    try:
+        decimal_value = Decimal(str(value).strip())
+    except (InvalidOperation, TypeError, ValueError, AttributeError) as exc:
+        raise TypeError(f"Invalid integer value: {value!r}") from exc
+
+    if not decimal_value.is_finite():
+        raise TypeError(f"Invalid integer value: {value!r}")
+    if decimal_value != decimal_value.to_integral_value():
+        raise TypeError(f"Invalid integer value: {value!r}")
+    if decimal_value < POSTGRES_BIGINT_MIN or decimal_value > POSTGRES_BIGINT_MAX:
+        raise TypeError(f"Invalid integer value: {value!r}")
+    return int(decimal_value)
+
+
+def coerce_numeric_value(value: Any) -> Decimal:
+    """Coerce a user value to a finite Decimal without float precision loss."""
+    try:
+        decimal_value = Decimal(str(value).strip())
+    except (InvalidOperation, TypeError, ValueError, AttributeError) as exc:
+        raise TypeError(f"Invalid numeric value: {value!r}") from exc
+
+    if not decimal_value.is_finite():
+        raise TypeError(f"Invalid numeric value: {value!r}")
+    return decimal_value
+
+
 def _compile_sql_literal(value: Any, sql_type: sa.types.TypeEngine) -> str:
     expr = sa.literal(value, type_=sql_type)
     compiled = expr.compile(
@@ -275,9 +303,11 @@ def to_sql_clause(value: Any, name: str, sql_type: SqlType) -> sa.BindParameter:
                     )
             return sa.bindparam(key=name, value=bool_value, type_=sa.Boolean)
         case SqlType.INTEGER:
-            return sa.bindparam(key=name, value=value, type_=sa.BigInteger)
+            coerced = None if value is None else coerce_integer_value(value)
+            return sa.bindparam(key=name, value=coerced, type_=sa.BigInteger)
         case SqlType.NUMERIC:
-            return sa.bindparam(key=name, value=value, type_=sa.Numeric)
+            coerced = None if value is None else coerce_numeric_value(value)
+            return sa.bindparam(key=name, value=coerced, type_=sa.Numeric)
         case _:
             raise TypeError(f"Unsupported SQL type for value conversion: {type}")
 
@@ -321,9 +351,9 @@ def convert_value(value: str | None, type: SqlType) -> Any:
     try:
         match type:
             case SqlType.INTEGER:
-                return int(value)
+                return coerce_integer_value(value)
             case SqlType.NUMERIC:
-                return float(value)
+                return coerce_numeric_value(value)
             case SqlType.BOOLEAN:
                 match value.lower():
                     case "true" | "1":

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -44,7 +44,9 @@ from tracecat.pagination import (
 )
 from tracecat.service import BaseWorkspaceService
 from tracecat.tables.common import (
+    coerce_integer_value,
     coerce_multi_select_value,
+    coerce_numeric_value,
     coerce_select_value,
     coerce_to_date,
     coerce_to_utc_datetime,
@@ -261,6 +263,10 @@ class BaseTablesService(BaseWorkspaceService):
 
             if sql_type is SqlType.TIMESTAMPTZ:
                 normalised[column_name] = coerce_to_utc_datetime(value)
+            elif sql_type is SqlType.INTEGER:
+                normalised[column_name] = coerce_integer_value(value)
+            elif sql_type is SqlType.NUMERIC:
+                normalised[column_name] = coerce_numeric_value(value)
             elif sql_type is SqlType.DATE and value is not None:
                 normalised[column_name] = coerce_to_date(value)
             else:


### PR DESCRIPTION
## Summary
- Add column visibility picker (max 4 columns) to cases header, letting users display custom dropdown values, field values, and duration metrics as badges in case rows
- Backend: load durations via `selectinload` (always, like tags/dropdowns), add `include_fields` query param with `batch_get_fields` for efficient multi-case field loading
- Frontend: `CaseColumnBadge` component with max-width truncation, `CaseColumnPicker` popover with grouped checkboxes, localStorage-persisted column visibility per workspace

## Test plan
- [ ] Toggle column picker, verify badges render inline after priority/severity with correct icon/color/truncation
- [ ] Verify max 4 column limit is enforced in the picker
- [ ] Verify default state (no columns selected) matches current UI exactly
- [ ] Test dropdown badges show `option_label` with `option_color`
- [ ] Test field badges with `include_fields` param (select a field column, verify values load)
- [ ] Test duration badges parse ISO 8601 strings correctly
- [ ] Verify column selections persist across page reloads (localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users pick up to four extra columns in the cases list and show them as badges in each row (dropdowns, custom fields, and duration metrics). Case lists now hydrate only the selected fields/durations and preserve exact numeric values end‑to‑end, with stricter validation for invalid inputs.

- **New Features**
  - Header: “Display” picker in the search row; grouped by type, max 4, per‑workspace persistence; default view unchanged.
  - Case rows: inline badges after priority/severity with icons/colors, metadata‑aware truncation, and type‑aware labels (numeric/boolean/object).
  - API/data: add `durations` and `field_values` to `CaseReadMinimal`; list/search accept `field_ids` and `include_durations`; durations eager‑loaded only when requested; `CaseFieldsService.batch_get_fields` uses reflected columns; `useCases` forwards `fieldIds`/`includeDurations`.

- **Bug Fixes**
  - Numeric precision & validation: preserve exact numeric strings (e.g. "1.30") via `Decimal` across tables, CSV import, and case fields; round long float displays without artifacts; strict integer/numeric coercion returns 400; editors validate raw strings for ints/decimals.
  - Hydration & persistence: populate `field_values` from reflected columns when metadata is stale; validate `field_ids` early and reject reserved/invalid IDs even on empty pages; ignore stale persisted column IDs and don’t count them toward the max‑4 cap; reload selections on workspace switch; default column badge uses workflow run palette (`bg-secondary text-secondary-foreground`).
  - Tooltips, durations, and typography: fix column badge tooltips/ARIA; parse ISO durations with fractional seconds and round for display; tighten badge typography for clearer badges.

<sup>Written for commit a8fb9e9e040ba68b8fffaa1179f5ba9e0d4efcad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

