### PR TITLE
ci: disable IPv6 on Blacksmith runners before BuildKit

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Disable IPv6 (Blacksmith VMs lack IPv6 routing)
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -115,6 +120,11 @@ jobs:
           pattern: digests-*
           merge-multiple: true
 
+      - name: Disable IPv6 (Blacksmith VMs lack IPv6 routing)
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -175,6 +185,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Disable IPv6 (Blacksmith VMs lack IPv6 routing)
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -256,6 +271,11 @@ jobs:
           path: /tmp/digests
           pattern: ui-digests-*
           merge-multiple: true
+
+      - name: Disable IPv6 (Blacksmith VMs lack IPv6 routing)
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -107,6 +107,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Disable IPv6 (Blacksmith VMs lack IPv6 routing)
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 

--- a/.github/workflows/test-pnpm-build.yml
+++ b/.github/workflows/test-pnpm-build.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Disable IPv6 (Blacksmith VMs lack IPv6 routing)
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -88,6 +88,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Disable IPv6 (Blacksmith VMs lack IPv6 routing)
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 


### PR DESCRIPTION
## Summary

Workaround for BuildKit failing to pull images on Blacksmith runners:

```
failed to do request: Head "https://registry-1.docker.io/v2/library/node/manifests/22.13.1-slim":
dial tcp [2600:1f18:2148:bc01:...]:443: connect: network is unreachable
```

Blacksmith VMs return IPv6 addresses in DNS but don't route IPv6 traffic. BuildKit (Go binary, own resolver) picks IPv6 first and fails. Docker Compose's pull path previously cached IPv4 resolutions, which is why `postgres` / `temporal_postgres_db` pulls succeeded while BuildKit builds for `node`, `python`, `debian` failed in the same step.

This PR adds a kernel-level IPv6 disable via `sysctl` immediately before `docker/setup-buildx-action` in every BuildKit-using job:

- `test-python.yml` (test-all)
- `run-integration-tests.yml` (test-integration)
- `test-pnpm-build.yml` (push-ui-to-ghcr-test)
- `build-push-images.yml` (build-and-push-api, merge-api, build-and-push-ui, merge-ui)

### Why sysctl and not `/etc/gai.conf`

`gai.conf` only affects glibc's `getaddrinfo`. BuildKit is a Go binary, and when it runs under the `docker-container` driver it runs inside its own container — neither path reliably honors host `gai.conf`. Disabling IPv6 at the kernel level is the workaround documented in [actions/runner#2739](https://github.com/actions/runner/issues/2739) for this exact failure mode.

### Scope

Only affects CI runners. No production or local-dev impact.

## Test plan

- [ ] CI on this PR exercises `test-python.yml`, `run-integration-tests.yml`, and `test-pnpm-build.yml` — they should all get past the "Start core Docker services" / buildx steps without the IPv6 unreachable error
- [ ] `build-push-images.yml` only runs on staging/preview/tags/nightly — will be validated on next publish


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable IPv6 on Blacksmith CI runners before BuildKit to stop image pull failures over IPv6. BuildKit now resolves Docker registries over IPv4 and proceeds reliably.

- **Bug Fixes**
  - Run `sysctl` to disable IPv6 before `docker/setup-buildx-action` in `test-python.yml`, `run-integration-tests.yml`, `test-pnpm-build.yml`, and `build-push-images.yml`.
  - Reason: Blacksmith VMs return IPv6 in DNS but don’t route it; BuildKit prefers IPv6 and fails. CI-only change.

<sup>Written for commit bb94c3dfc77c5a0f3efc7b92ad28263ca5af1307. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

