### PR TITLE
fix(agents): custom model provider routing

### DIFF
--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -204,7 +204,7 @@ def test_get_litellm_url_requires_bridge_port(
             "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
         ),
         ("azure_openai", "my-deployment", False, "azure/my-deployment"),
-        ("custom-model-provider", "custom", False, "openai/custom"),
+        ("custom-model-provider", "custom", False, "custom"),
         ("custom-model-provider", "customer-alias", True, "customer-alias"),
         ("openai", "openai/gpt-5", False, "openai/gpt-5"),
     ],

--- a/tracecat/agent/gateway.py
+++ b/tracecat/agent/gateway.py
@@ -523,7 +523,7 @@ def _inject_provider_credentials(
             if base_url := creds.get("CUSTOM_MODEL_PROVIDER_BASE_URL"):
                 data["api_base"] = base_url
             if model_name := creds.get("CUSTOM_MODEL_PROVIDER_MODEL_NAME"):
-                data["model"] = f"openai/{model_name}"
+                data["model"] = model_name
 
         case "azure_openai":
             base = creds.get("AZURE_API_BASE")

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -77,7 +77,6 @@ _LITELLM_ROUTE_PREFIXES: dict[str, str] = {
     "bedrock": "bedrock",
     "azure_openai": "azure",
     "azure_ai": "azure_ai",
-    "custom-model-provider": "openai",
 }
 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes custom model provider routing with a passthrough mode and always proxies LLM traffic through the local bridge. Drops the "openai/" prefix for custom providers in both runtime routing and credential injection for correct upstream routing.

- **Refactors**
  - Replaced `litellm` with `custom-model-provider` + `passthrough` on `AgentConfig` and `SandboxAgentConfig` (propagated through workflow schemas/payloads).
  - Added `resolve_custom_model_provider_config_activity` to load `base_url`, optional `model_name`, and `passthrough` from workspace credentials; applied in the durable workflow and management service.
  - Updated `LLMSocketProxy`: renamed `litellm_url` to `upstream_url`, added `passthrough` that strips `Authorization` and Anthropic-only fields before forwarding; proxy now always starts.
  - Removed `openai/` prefix for `custom-model-provider` (runtime no longer maps to "openai"; gateway injects the raw `model` name).
  - Secrets API now returns aggregated registry definitions (sorted) and adds `litellm` with optional `LITELLM_BASE_URL`; frontend copy updated to reflect “aggregated” definitions.

- **Migration**
  - Replace any `litellm` provider usage with `custom-model-provider`.
  - Configure workspace credentials: `CUSTOM_MODEL_PROVIDER_BASE_URL` (required), optional `CUSTOM_MODEL_PROVIDER_MODEL_NAME`, and `CUSTOM_MODEL_PROVIDER_PASSTHROUGH=true` to forward directly to your upstream.
  - No app config changes needed for the bridge; the LLM socket proxy and bridge start automatically.

<sup>Written for commit a4388c97d6681d7d0ba49df4ab8782816b051a03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

