### PR TITLE
feat(cases): add create_missing_tags option to create_case and update_case actions

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/core/cases.py
@@ -96,6 +96,10 @@ async def create_case(
         list[str] | None,
         Doc("List of tag identifiers (IDs or refs) to add to the case."),
     ] = None,
+    create_missing_tags: Annotated[
+        bool,
+        Doc("If true, create any tags that do not already exist."),
+    ] = False,
 ) -> types.Case:
     params: dict[str, Any] = {}
     if summary is not None:
@@ -116,6 +120,8 @@ async def create_case(
         params["dropdown_values"] = dropdown_values
     if tags is not None:
         params["tags"] = tags
+    if create_missing_tags:
+        params["create_missing_tags"] = create_missing_tags
     return await get_context().cases.create_case_simple(**params)
 
 
@@ -171,6 +177,10 @@ async def update_case(
             "List of tag identifiers (IDs or refs) to set on the case. This will replace all existing tags."
         ),
     ] = None,
+    create_missing_tags: Annotated[
+        bool,
+        Doc("If true, create any tags that do not already exist."),
+    ] = False,
     append: Annotated[
         bool,
         Doc(
@@ -200,6 +210,8 @@ async def update_case(
         client_params["dropdown_values"] = dropdown_values
     if tags is not None:
         client_params["tags"] = tags
+    if create_missing_tags:
+        client_params["create_missing_tags"] = create_missing_tags
     if append and description is not None:
         client_params["append_description"] = True
     return await get_context().cases.update_case_simple(case_id, **client_params)

--- a/packages/tracecat-registry/tracecat_registry/sdk/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/cases.py
@@ -630,6 +630,7 @@ class CasesClient:
         tags: list[str] | None | Unset = UNSET,
         fields: dict[str, Any] | None | Unset = UNSET,
         dropdown_values: list[types.CaseDropdownValueInput] | None | Unset = UNSET,
+        create_missing_tags: bool = False,
     ) -> types.Case:
         """Create a new case and return simple dict format.
 
@@ -669,6 +670,8 @@ class CasesClient:
             # Write payloads use `dropdown_values` because they represent persisted
             # per-case selections (definition/option IDs).
             data["dropdown_values"] = self._serialize_dropdown_values(dropdown_values)
+        if create_missing_tags:
+            data["create_missing_tags"] = create_missing_tags
 
         return await self._client.post("/cases/simple", json=data)
 
@@ -687,6 +690,7 @@ class CasesClient:
         tags: list[str] | None | Unset = UNSET,
         dropdown_values: list[types.CaseDropdownValueInput] | None | Unset = UNSET,
         append_description: bool = False,
+        create_missing_tags: bool = False,
     ) -> types.Case:
         """Update a case and return simple dict format.
 
@@ -734,6 +738,8 @@ class CasesClient:
             data["dropdown_values"] = self._serialize_dropdown_values(dropdown_values)
         if append_description:
             data["append_description"] = append_description
+        if create_missing_tags:
+            data["create_missing_tags"] = create_missing_tags
 
         return await self._client.patch(f"/cases/{case_id}/simple", json=data)
 

--- a/tests/registry/test_cases_characterization.py
+++ b/tests/registry/test_cases_characterization.py
@@ -320,6 +320,27 @@ class TestCreateCase:
         assert result["summary"] == "Case with Tags"
         assert "id" in result
 
+    async def test_create_case_with_tags_create_if_missing(
+        self, db, session: AsyncSession, cases_ctx: Role
+    ):
+        """Create a case with tags using create_missing_tags to auto-create tags."""
+        tag_name = f"auto-create-tag-{uuid.uuid4().hex[:8]}"
+
+        result = await create_case(
+            summary="Case with Auto Tags",
+            description="Test case with auto-created tags.",
+            tags=[tag_name],
+            create_missing_tags=True,
+        )
+
+        assert result["summary"] == "Case with Auto Tags"
+        assert "id" in result
+
+        # Verify the tag was created and attached
+        full_case = await get_case(case_id=str(result["id"]))
+        tag_refs = [t["ref"] for t in full_case["tags"]]
+        assert tag_name in tag_refs
+
 
 # =============================================================================
 # get_case characterization tests
@@ -490,6 +511,30 @@ class TestUpdateCase:
         )
 
         assert "id" in result
+
+    async def test_update_case_tags_create_if_missing(
+        self, db, session: AsyncSession, cases_ctx: Role
+    ):
+        """Update case tags using create_missing_tags to auto-create tags."""
+        created = await create_case(
+            summary="Test Case for Auto Tags",
+            description="Test description",
+        )
+
+        tag_name = f"auto-update-tag-{uuid.uuid4().hex[:8]}"
+
+        result = await update_case(
+            case_id=str(created["id"]),
+            tags=[tag_name],
+            create_missing_tags=True,
+        )
+
+        assert "id" in result
+
+        # Verify the tag was created and attached
+        full_case = await get_case(case_id=str(result["id"]))
+        tag_refs = [t["ref"] for t in full_case["tags"]]
+        assert tag_name in tag_refs
 
 
 # =============================================================================

--- a/tests/registry/test_core_cases.py
+++ b/tests/registry/test_core_cases.py
@@ -184,6 +184,33 @@ class TestCoreCreate:
         )
         assert result == mock_case_dict
 
+    async def test_create_case_with_tags_create_if_missing(
+        self, mock_cases_client: AsyncMock, mock_case_dict
+    ):
+        """Test creating a case with tags and create_missing_tags."""
+        mock_cases_client.create_case_simple.return_value = mock_case_dict
+
+        result = await create_case(
+            summary="Test Case",
+            description="Test Description",
+            priority="medium",
+            severity="medium",
+            status="new",
+            tags=["new-tag"],
+            create_missing_tags=True,
+        )
+
+        mock_cases_client.create_case_simple.assert_called_once_with(
+            summary="Test Case",
+            description="Test Description",
+            priority="medium",
+            severity="medium",
+            status="new",
+            tags=["new-tag"],
+            create_missing_tags=True,
+        )
+        assert result == mock_case_dict
+
     async def test_create_case_with_payload(
         self, mock_cases_client: AsyncMock, mock_case_dict
     ):
@@ -269,6 +296,27 @@ class TestCoreUpdate:
             severity="high",
             status="in_progress",
             fields={"field1": "new_value", "field3": "value3"},
+        )
+        assert result == updated_case
+
+    async def test_update_case_with_tags_create_if_missing(
+        self, mock_cases_client: AsyncMock, mock_case_dict
+    ):
+        """Test updating a case with tags and create_missing_tags."""
+        updated_case = {**mock_case_dict, "tags": [{"ref": "new-tag"}]}
+        mock_cases_client.update_case_simple.return_value = updated_case
+
+        case_id = mock_case_dict["id"]
+        result = await update_case(
+            case_id=case_id,
+            tags=["new-tag"],
+            create_missing_tags=True,
+        )
+
+        mock_cases_client.update_case_simple.assert_called_once_with(
+            case_id,
+            tags=["new-tag"],
+            create_missing_tags=True,
         )
         assert result == updated_case
 

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -1160,12 +1160,14 @@ class CaseCreateWithTags(CaseCreate):
     """Extended case create request with tags support for UDFs."""
 
     tags: list[str] | None = None
+    create_missing_tags: bool = False
 
 
 class CaseUpdateWithTags(CaseUpdate):
     """Extended case update request with tags and append support for UDFs."""
 
     tags: list[str] | None = None
+    create_missing_tags: bool = False
     append_description: bool = False
 
 
@@ -1213,7 +1215,9 @@ async def create_case_simple(
         # Add tags if provided
         if params.tags:
             for tag in params.tags:
-                await service.tags.add_case_tag(case.id, tag)
+                await service.tags.add_case_tag(
+                    case.id, tag, create_if_missing=params.create_missing_tags
+                )
             await session.refresh(case)
 
     except NoResultFound as e:
@@ -1285,7 +1289,9 @@ async def update_case_simple(
             for existing_tag in existing_tags:
                 await service.tags.remove_case_tag(case.id, existing_tag.ref)
             for tag in params.tags:
-                await service.tags.add_case_tag(case.id, tag)
+                await service.tags.add_case_tag(
+                    case.id, tag, create_if_missing=params.create_missing_tags
+                )
             await session.refresh(updated_case)
 
     except NoResultFound as e:


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

When tags are provided to `create_case` they are passed through eventually to `service.tags.add_case_tag`, which will raise `NoResultFound` if any of the tags don't exist. Same goes for `update_case`. This PR adds a `create_missing_tags` option to both `create_case` and `update_case` which will also get passed through to `service.tags.add_case_tag` (as `create_if_missing`) to let users use dynamic, potentially nonexistent tags in `create_case` and `update_case`.

@topher-lo the error message is unchanged, but I can still update it if you want. It would require an additional database lookup and potentially make for _very_ long error messages, but it's your call.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a create_missing_tags option to case create/update so missing tags can be auto-created. This prevents NoResultFound and supports dynamic tag workflows.

- **New Features**
  - Added `create_missing_tags` (default false) to `tracecat_registry.core.cases.create_case`/`update_case`, SDK `create_case_simple`/`update_case_simple`, and REST models/payloads in `tracecat/cases/internal_router.py` for `/cases/simple` and `/cases/{id}/simple`.
  - When set, tag operations call `service.tags.add_case_tag(..., create_if_missing=True)`.
  - Added tests covering create/update with auto tag creation.

<sup>Written for commit 11473f3dace77886eb19f8467327a3e57e93dba7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



