### PR TITLE
feat(agents): type LLM proxy request and inject reasoning_effort

### DIFF
--- a/alembic/versions/0c9a39e54e2f_add_enable_thinking_to_agent_presets.py
+++ b/alembic/versions/0c9a39e54e2f_add_enable_thinking_to_agent_presets.py
@@ -1,0 +1,45 @@
+"""add enable_thinking to agent presets
+
+Revision ID: 0c9a39e54e2f
+Revises: b742858f7d69
+Create Date: 2026-04-16 19:35:51.588612
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0c9a39e54e2f"
+down_revision: str | None = "b742858f7d69"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_preset",
+        sa.Column(
+            "enable_thinking",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.add_column(
+        "agent_preset_version",
+        sa.Column(
+            "enable_thinking",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_preset_version", "enable_thinking")
+    op.drop_column("agent_preset", "enable_thinking")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1254,6 +1254,11 @@ export const $AgentPresetCreate = {
       title: "Retries",
       default: 3,
     },
+    enable_thinking: {
+      type: "boolean",
+      title: "Enable Thinking",
+      default: true,
+    },
     enable_internet_access: {
       type: "boolean",
       title: "Enable Internet Access",
@@ -1403,6 +1408,11 @@ export const $AgentPresetRead = {
       minimum: 0,
       title: "Retries",
       default: 3,
+    },
+    enable_thinking: {
+      type: "boolean",
+      title: "Enable Thinking",
+      default: true,
     },
     enable_internet_access: {
       type: "boolean",
@@ -1712,6 +1722,17 @@ export const $AgentPresetUpdate = {
       ],
       title: "Retries",
     },
+    enable_thinking: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Enable Thinking",
+    },
     enable_internet_access: {
       anyOf: [
         {
@@ -1921,6 +1942,11 @@ export const $AgentPresetVersionRead = {
       title: "Retries",
       default: 3,
     },
+    enable_thinking: {
+      type: "boolean",
+      title: "Enable Thinking",
+      default: true,
+    },
     enable_internet_access: {
       type: "boolean",
       title: "Enable Internet Access",
@@ -2077,6 +2103,11 @@ export const $AgentPresetVersionReadMinimal = {
       minimum: 0,
       title: "Retries",
       default: 3,
+    },
+    enable_thinking: {
+      type: "boolean",
+      title: "Enable Thinking",
+      default: true,
     },
     enable_internet_access: {
       type: "boolean",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -331,6 +331,7 @@ export type AgentPresetCreate = {
   } | null
   mcp_integrations?: Array<string> | null
   retries?: number
+  enable_thinking?: boolean
   enable_internet_access?: boolean
   description?: string | null
   name: string
@@ -353,6 +354,7 @@ export type AgentPresetRead = {
   } | null
   mcp_integrations?: Array<string> | null
   retries?: number
+  enable_thinking?: boolean
   enable_internet_access?: boolean
   id: string
   workspace_id: string
@@ -397,6 +399,7 @@ export type AgentPresetUpdate = {
   } | null
   mcp_integrations?: Array<string> | null
   retries?: number | null
+  enable_thinking?: boolean | null
   enable_internet_access?: boolean | null
 }
 
@@ -433,6 +436,7 @@ export type AgentPresetVersionRead = {
   } | null
   mcp_integrations?: Array<string> | null
   retries?: number
+  enable_thinking?: boolean
   enable_internet_access?: boolean
   id: string
   preset_id: string
@@ -458,6 +462,7 @@ export type AgentPresetVersionReadMinimal = {
   } | null
   mcp_integrations?: Array<string> | null
   retries?: number
+  enable_thinking?: boolean
   enable_internet_access?: boolean
   id: string
   preset_id: string

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -217,6 +217,7 @@ const agentPresetSchema = z
       .number({ invalid_type_error: "Retries must be a number" })
       .int()
       .min(0, "Retries must be 0 or more"),
+    enableThinking: z.boolean().default(true),
     enableInternetAccess: z.boolean().default(false),
   })
   .superRefine((data, ctx) => {
@@ -278,6 +279,7 @@ const DEFAULT_FORM_VALUES: AgentPresetFormValues = {
   mcpIntegrations: [],
   toolApprovals: [],
   retries: DEFAULT_RETRIES,
+  enableThinking: true,
   enableInternetAccess: false,
 }
 
@@ -894,6 +896,7 @@ function getAgentPresetErrorTab(
     errors.namespaces ||
     errors.mcpIntegrations ||
     errors.toolApprovals ||
+    errors.enableThinking ||
     errors.enableInternetAccess
   ) {
     return "configuration"
@@ -1488,6 +1491,7 @@ function AgentPresetConfigurationPanel({
   onRemoveToolApproval: (index: number) => void
 }) {
   const providerValue = form.watch("model_provider")
+  const thinkingEnabled = form.watch("enableThinking")
   const internetAccessEnabled = form.watch("enableInternetAccess")
   const modelOptions = modelOptionsByProvider[providerValue] ?? []
 
@@ -1570,7 +1574,7 @@ function AgentPresetConfigurationPanel({
               )}
             />
           </div>
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_180px]">
             <FormField
               control={form.control}
               name="base_url"
@@ -1606,23 +1610,55 @@ function AgentPresetConfigurationPanel({
               )}
             />
           </div>
-          <div className="flex items-center gap-2">
-            <Switch
-              id="enable-internet-access"
-              checked={internetAccessEnabled}
-              onCheckedChange={(checked) =>
-                form.setValue("enableInternetAccess", checked, {
-                  shouldDirty: true,
-                })
-              }
-              disabled={isSaving}
-            />
-            <label
-              htmlFor="enable-internet-access"
-              className="text-sm font-medium"
-            >
-              Enable internet access
-            </label>
+          <div className="overflow-hidden rounded-lg border">
+            <div className="flex items-start justify-between gap-4 px-4 py-3">
+              <div className="space-y-1">
+                <label
+                  htmlFor="enable-thinking"
+                  className="text-sm font-medium leading-none"
+                >
+                  Thinking
+                </label>
+                <p className="text-xs text-muted-foreground">
+                  Adds higher reasoning effort by default.
+                </p>
+              </div>
+              <Switch
+                id="enable-thinking"
+                checked={thinkingEnabled}
+                onCheckedChange={(checked) =>
+                  form.setValue("enableThinking", checked, {
+                    shouldDirty: true,
+                  })
+                }
+                disabled={isSaving}
+              />
+            </div>
+            <div className="border-t" />
+            <div className="flex items-start justify-between gap-4 px-4 py-3">
+              <div className="space-y-1">
+                <label
+                  htmlFor="enable-internet-access"
+                  className="text-sm font-medium leading-none"
+                >
+                  Internet access
+                </label>
+                <p className="text-xs text-muted-foreground">
+                  Allows the agent to reach the web from the sandbox when tools
+                  need it.
+                </p>
+              </div>
+              <Switch
+                id="enable-internet-access"
+                checked={internetAccessEnabled}
+                onCheckedChange={(checked) =>
+                  form.setValue("enableInternetAccess", checked, {
+                    shouldDirty: true,
+                  })
+                }
+                disabled={isSaving}
+              />
+            </div>
           </div>
         </section>
 
@@ -2207,6 +2243,7 @@ function presetToFormValues(preset: AgentPresetRead): AgentPresetFormValues {
       : [],
     mcpIntegrations: preset.mcp_integrations ?? [],
     retries: preset.retries ?? DEFAULT_RETRIES,
+    enableThinking: preset.enable_thinking ?? true,
     enableInternetAccess: preset.enable_internet_access ?? false,
   }
 }
@@ -2239,6 +2276,7 @@ function formValuesToPayload(values: AgentPresetFormValues): AgentPresetCreate {
       values.mcpIntegrations.length > 0 ? values.mcpIntegrations : null,
     tool_approvals: toToolApprovalMap(values.toolApprovals),
     retries: values.retries,
+    enable_thinking: values.enableThinking,
     enable_internet_access: values.enableInternetAccess,
   }
 }

--- a/frontend/src/components/agents/agents-table.tsx
+++ b/frontend/src/components/agents/agents-table.tsx
@@ -216,6 +216,7 @@ function toDuplicateSourcePreset(
     tool_approvals: preset.tool_approvals ?? null,
     mcp_integrations: preset.mcp_integrations ?? null,
     retries: preset.retries,
+    enable_thinking: preset.enable_thinking,
     enable_internet_access: preset.enable_internet_access,
   }
 }

--- a/frontend/src/lib/agent-presets.ts
+++ b/frontend/src/lib/agent-presets.ts
@@ -46,6 +46,7 @@ export function buildDuplicateAgentPresetPayload(
     tool_approvals: preset.tool_approvals ?? null,
     mcp_integrations: preset.mcp_integrations ?? null,
     retries: preset.retries,
+    enable_thinking: preset.enable_thinking,
     enable_internet_access: preset.enable_internet_access,
   }
 }

--- a/packages/tracecat-ee/tracecat_ee/agent/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/schemas.py
@@ -29,6 +29,7 @@ class AgentActionArgs(BaseModel):
         description="The maximum number of model requests to make per agent run",
     )
     retries: int = 3
+    enable_thinking: bool = True
     base_url: str | None = None
     tool_approvals: dict[str, bool] | None = None
     use_workspace_credentials: bool = Field(

--- a/packages/tracecat-registry/tracecat_registry/core/agent.py
+++ b/packages/tracecat-registry/tracecat_registry/core/agent.py
@@ -245,6 +245,10 @@ async def agent(
     ] = 15,
     max_requests: Annotated[int, Doc("Maximum number of requests for the agent.")] = 45,
     retries: Annotated[int, Doc("Number of retries for the agent.")] = 3,
+    enable_thinking: Annotated[
+        bool,
+        Doc("Whether to enable high thinking for agent runs."),
+    ] = True,
     base_url: Annotated[str | None, Doc("Base URL of the model to use.")] = None,
     # Paid feature
     tool_approvals: Annotated[
@@ -338,6 +342,10 @@ async def action(
     ] = None,
     max_requests: Annotated[int, Doc("Maximum number of requests for the agent.")] = 45,
     retries: Annotated[int, Doc("Number of retries for the agent.")] = 3,
+    enable_thinking: Annotated[
+        bool,
+        Doc("Whether to enable high thinking for agent runs."),
+    ] = True,
     base_url: Annotated[str | None, Doc("Base URL of the model to use.")] = None,
 ) -> dict[str, Any]:
     """Call an LLM with a given prompt and model (no tools)."""

--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -363,6 +363,41 @@ async def test_pre_call_hook_filters_model_settings(
 
 
 @pytest.mark.anyio
+async def test_pre_call_hook_does_not_inject_reasoning_effort_without_model_setting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def mock_get_provider_credentials(**_: object) -> dict[str, str]:
+        return {"OPENAI_API_KEY": "test-openai-key"}
+
+    monkeypatch.setattr(
+        "tracecat.agent.gateway.get_provider_credentials",
+        mock_get_provider_credentials,
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="llm-token",
+        metadata={
+            "workspace_id": "00000000-0000-0000-0000-000000000001",
+            "organization_id": "00000000-0000-0000-0000-000000000002",
+            "model": "gpt-5",
+            "provider": "openai",
+            "model_settings": {},
+            "use_workspace_credentials": True,
+        },
+    )
+
+    handler = TracecatCallbackHandler()
+    result = await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=cast(DualCache, object()),
+        data={},
+        call_type="completion",
+    )
+
+    assert "reasoning_effort" not in result
+
+
+@pytest.mark.anyio
 async def test_pre_call_hook_strips_anthropic_beta_payload_fields_for_non_anthropic_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -46,6 +46,8 @@ async def test_forward_request_streams_litellm_response(
         assert request.method == "POST"
         assert str(request.url) == "http://litellm:4000/v1/messages"
         assert request.headers["Authorization"] == "Bearer llm-token"
+        payload = orjson.loads(request.content)
+        assert "reasoning_effort" not in payload
         return httpx.Response(
             200,
             headers={"Content-Type": "text/event-stream"},
@@ -189,19 +191,19 @@ async def test_forward_request_strips_authorization_for_passthrough_upstream(
 
 
 @pytest.mark.anyio
-async def test_forward_request_strips_anthropic_only_fields_for_passthrough_upstream(
+async def test_forward_request_preserves_anthropic_fields_for_anthropic_upstream(
     tmp_path: Path,
 ) -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
         assert str(request.url) == "https://customer-litellm.example/v1/messages"
         payload = orjson.loads(request.content)
         assert payload["messages"] == [{"role": "user", "content": "hello"}]
-        assert "thinking" not in payload
-        assert "reasoning_effort" not in payload
-        assert "anthropic_beta" not in payload
-        assert "context_management" not in payload
-        assert "output_config" not in payload
-        assert "output_format" not in payload
+        assert payload["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+        assert payload["reasoning_effort"] == "high"
+        assert payload["anthropic_beta"] == ["prompt-caching-2024-07-31"]
+        assert payload["context_management"] == {"strategy": "summarize"}
+        assert payload["output_config"] == {"task_budget": 2048}
+        assert payload["output_format"] == {"type": "json_schema"}
         return httpx.Response(
             200,
             headers={"Content-Type": "application/json"},
@@ -212,6 +214,7 @@ async def test_forward_request_strips_anthropic_only_fields_for_passthrough_upst
         socket_path=tmp_path / "llm.sock",
         upstream_url="https://customer-litellm.example",
         passthrough=True,
+        model_provider="anthropic",
     )
     socket_proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     writer = _FakeWriter()
@@ -230,6 +233,59 @@ async def test_forward_request_strips_anthropic_only_fields_for_passthrough_upst
                         "messages": [{"role": "user", "content": "hello"}],
                         "thinking": {"type": "enabled", "budget_tokens": 1024},
                         "reasoning_effort": "high",
+                        "anthropic_beta": ["prompt-caching-2024-07-31"],
+                        "context_management": {"strategy": "summarize"},
+                        "output_config": {"task_budget": 2048},
+                        "output_format": {"type": "json_schema"},
+                    }
+                ),
+            },
+            cast(asyncio.StreamWriter, writer),
+        )
+    finally:
+        if socket_proxy._client is not None:
+            await socket_proxy._client.aclose()
+
+    response_text = writer.buffer.decode("utf-8")
+    assert response_text.startswith("HTTP/1.1 200 OK")
+
+
+@pytest.mark.anyio
+async def test_forward_request_strips_anthropic_only_fields_for_non_anthropic_upstream(
+    tmp_path: Path,
+) -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        payload = orjson.loads(request.content)
+        assert "anthropic_beta" not in payload
+        assert "context_management" not in payload
+        assert "output_config" not in payload
+        assert "output_format" not in payload
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "application/json"},
+            json={"ok": True},
+        )
+
+    socket_proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        upstream_url="http://litellm:4000",
+        model_provider="openai",
+    )
+    socket_proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    writer = _FakeWriter()
+
+    try:
+        await socket_proxy._forward_request(
+            {
+                "method": "POST",
+                "path": "/v1/chat/completions",
+                "headers": {
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer llm-token",
+                },
+                "body": orjson.dumps(
+                    {
+                        "messages": [{"role": "user", "content": "hello"}],
                         "anthropic_beta": ["prompt-caching-2024-07-31"],
                         "context_management": {"strategy": "summarize"},
                         "output_config": {"task_budget": 2048},

--- a/tests/unit/test_agent_preset_schemas.py
+++ b/tests/unit/test_agent_preset_schemas.py
@@ -30,6 +30,7 @@ def test_agent_preset_create_trims_required_fields() -> None:
         tool_approvals=None,
         mcp_integrations=None,
         retries=3,
+        enable_thinking=True,
     )
 
     assert payload.name == "Triage preset"
@@ -92,6 +93,7 @@ def test_agent_preset_read_schema_accepts_legacy_whitespace_model_fields() -> No
             "tool_approvals": None,
             "mcp_integrations": None,
             "retries": 3,
+            "enable_thinking": True,
             "enable_internet_access": False,
             "current_version_id": None,
             "created_at": "2026-03-09T00:00:00Z",
@@ -101,6 +103,7 @@ def test_agent_preset_read_schema_accepts_legacy_whitespace_model_fields() -> No
 
     assert payload.model_name == "   "
     assert payload.model_provider == "   "
+    assert payload.enable_thinking is True
 
 
 def test_agent_preset_version_read_schema_accepts_legacy_whitespace_model_fields() -> (
@@ -122,6 +125,7 @@ def test_agent_preset_version_read_schema_accepts_legacy_whitespace_model_fields
             "tool_approvals": None,
             "mcp_integrations": None,
             "retries": 3,
+            "enable_thinking": True,
             "enable_internet_access": False,
             "created_at": "2026-03-09T00:00:00Z",
             "updated_at": "2026-03-09T00:00:00Z",
@@ -130,3 +134,4 @@ def test_agent_preset_version_read_schema_accepts_legacy_whitespace_model_fields
 
     assert payload.model_name == "   "
     assert payload.model_provider == "   "
+    assert payload.enable_thinking is True

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -174,6 +174,7 @@ def agent_preset_create_params() -> AgentPresetCreate:
         tool_approvals=None,
         mcp_integrations=None,
         retries=3,
+        enable_thinking=True,
     )
 
 
@@ -196,6 +197,7 @@ class TestAgentPresetService:
         assert (
             created_preset.model_provider == agent_preset_create_params.model_provider
         )
+        assert created_preset.enable_thinking is True
         assert created_preset.workspace_id == agent_preset_service.workspace_id
 
         # Retrieve by ID
@@ -319,6 +321,28 @@ class TestAgentPresetService:
             CursorPaginationParams(limit=10),
         )
         assert [version.version for version in versions.items] == [1]
+
+    async def test_update_preset_enable_thinking_creates_new_version(
+        self,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        created_preset = await agent_preset_service.create_preset(
+            agent_preset_create_params
+        )
+
+        updated_preset = await agent_preset_service.update_preset(
+            created_preset,
+            AgentPresetUpdate(enable_thinking=False),
+        )
+
+        assert updated_preset.enable_thinking is False
+        versions = await agent_preset_service.list_versions(
+            created_preset.id,
+            CursorPaginationParams(limit=10),
+        )
+        assert [version.version for version in versions.items] == [2, 1]
+        assert versions.items[0].enable_thinking is False
 
     async def test_create_preset_creates_initial_version(
         self,
@@ -1009,6 +1033,7 @@ class TestAgentPresetService:
         assert agent_config.namespaces == preset.namespaces
         assert agent_config.tool_approvals == preset.tool_approvals
         assert agent_config.retries == preset.retries
+        assert agent_config.model_settings == {"parallel_tool_calls": False}
 
     async def test_create_preset_with_tool_approvals(
         self,

--- a/tests/unit/test_build_agent_args.py
+++ b/tests/unit/test_build_agent_args.py
@@ -257,6 +257,49 @@ class TestBuildAgentArgsActivity:
 
         mock_get_vars.assert_not_called()
 
+    @pytest.mark.anyio
+    async def test_preserves_enable_thinking_flag(self, role: Role):
+        args = {
+            "user_prompt": "Hello",
+            "model_name": "claude-sonnet-4-5-20250929",
+            "model_provider": "anthropic",
+            "enable_thinking": False,
+        }
+        input = BuildAgentArgsActivityInput(
+            args=args,
+            operand=_make_context(),
+            role=role,
+            task_environment=None,
+            default_environment="default",
+        )
+
+        result = await DSLActivities.build_agent_args_activity(input)
+
+        assert result.enable_thinking is False
+
+    @pytest.mark.anyio
+    async def test_preserves_explicit_reasoning_effort_in_model_settings(
+        self, role: Role
+    ):
+        args = {
+            "user_prompt": "Hello",
+            "model_name": "claude-sonnet-4-5-20250929",
+            "model_provider": "anthropic",
+            "enable_thinking": True,
+            "model_settings": {"reasoning_effort": "medium"},
+        }
+        input = BuildAgentArgsActivityInput(
+            args=args,
+            operand=_make_context(),
+            role=role,
+            task_environment=None,
+            default_environment="default",
+        )
+
+        result = await DSLActivities.build_agent_args_activity(input)
+
+        assert result.model_settings == {"reasoning_effort": "medium"}
+
 
 class TestBuildPresetAgentArgsActivity:
     """Tests for DSLActivities.build_preset_agent_args_activity."""

--- a/tests/unit/test_dsl_converter.py
+++ b/tests/unit/test_dsl_converter.py
@@ -118,6 +118,7 @@ def _build_tracecat_agent_config_payload() -> Payload:
             ],
             model_settings={"parallel_tool_calls": False},
             retries=3,
+            enable_thinking=False,
             enable_internet_access=True,
         )
     )
@@ -161,6 +162,7 @@ def test_converter_decodes_legacy_tracecat_agent_config_as_agent_config_payload(
     assert decoded.tool_approvals == {"tools.datadog.change_signal_state": True}
     assert decoded.model_settings == {"parallel_tool_calls": False}
     assert decoded.retries == 3
+    assert decoded.enable_thinking is False
     assert decoded.enable_internet_access is True
     assert decoded.mcp_servers is not None
     assert len(decoded.mcp_servers) == 1

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -3588,6 +3588,7 @@ async def test_get_agent_preset_returns_full_configuration(
         tool_approvals={"tools.alpha": False},
         mcp_integrations=[str(uuid.uuid4())],
         retries=3,
+        enable_thinking=True,
         enable_internet_access=False,
         current_version_id=None,
         created_at=now,
@@ -4008,6 +4009,7 @@ async def test_create_agent_preset_uses_default_model_and_passes_optional_fields
                 tool_approvals=params.tool_approvals,
                 mcp_integrations=params.mcp_integrations,
                 retries=params.retries,
+                enable_thinking=params.enable_thinking,
                 enable_internet_access=params.enable_internet_access,
                 current_version_id=None,
                 created_at=now,
@@ -4037,6 +4039,7 @@ async def test_create_agent_preset_uses_default_model_and_passes_optional_fields
         tool_approvals={"tools.slack.post_message": False},
         mcp_integration_ids=[str(uuid.uuid4())],
         retries=5,
+        enable_thinking=False,
         enable_internet_access=True,
     )
 
@@ -4045,9 +4048,11 @@ async def test_create_agent_preset_uses_default_model_and_passes_optional_fields
     assert params.model_name == "gpt-4o-mini"
     assert params.model_provider == "openai"
     assert params.mcp_integrations is not None
+    assert params.enable_thinking is False
     assert params.enable_internet_access is True
     assert payload["model_name"] == "gpt-4o-mini"
     assert payload["output_type"]["type"] == "object"
+    assert payload["enable_thinking"] is False
 
 
 @pytest.mark.anyio
@@ -4074,6 +4079,7 @@ async def test_update_agent_preset_updates_existing_preset(
         tool_approvals={"tools.alpha": False},
         mcp_integrations=[str(uuid.uuid4())],
         retries=3,
+        enable_thinking=True,
         enable_internet_access=False,
         current_version_id=None,
         created_at=now,
@@ -4099,6 +4105,7 @@ async def test_update_agent_preset_updates_existing_preset(
                 "actions": params.actions,
                 "mcp_integrations": params.mcp_integrations,
                 "retries": params.retries,
+                "enable_thinking": params.enable_thinking,
                 "enable_internet_access": params.enable_internet_access,
                 "updated_at": datetime.now(UTC),
             }
@@ -4119,6 +4126,7 @@ async def test_update_agent_preset_updates_existing_preset(
         actions=["tools.bravo"],
         mcp_integration_ids=[integration_id],
         retries=5,
+        enable_thinking=False,
         enable_internet_access=True,
     )
 
@@ -4128,11 +4136,13 @@ async def test_update_agent_preset_updates_existing_preset(
     assert params.actions == ["tools.bravo"]
     assert params.mcp_integrations == [integration_id]
     assert params.retries == 5
+    assert params.enable_thinking is False
     assert params.enable_internet_access is True
     assert payload["instructions"] == "Updated prompt"
     assert payload["actions"] == ["tools.bravo"]
     assert payload["mcp_integrations"] == [integration_id]
     assert payload["retries"] == 5
+    assert payload["enable_thinking"] is False
     assert payload["enable_internet_access"] is True
 
 
@@ -4159,6 +4169,7 @@ async def test_update_agent_preset_resolves_explicit_model(
         tool_approvals=None,
         mcp_integrations=None,
         retries=3,
+        enable_thinking=True,
         enable_internet_access=False,
         current_version_id=None,
         created_at=now,
@@ -4325,6 +4336,7 @@ async def test_create_agent_preset_omitted_retry_fields_use_schema_defaults(
                 tool_approvals=params.tool_approvals,
                 mcp_integrations=params.mcp_integrations,
                 retries=params.retries,
+                enable_thinking=params.enable_thinking,
                 enable_internet_access=params.enable_internet_access,
                 current_version_id=None,
                 created_at=now,
@@ -4351,8 +4363,10 @@ async def test_create_agent_preset_omitted_retry_fields_use_schema_defaults(
     payload = _payload(result)
     params = created["params"]
     assert params.retries == 3
+    assert params.enable_thinking is True
     assert params.enable_internet_access is False
     assert payload["retries"] == 3
+    assert payload["enable_thinking"] is True
     assert payload["enable_internet_access"] is False
 
 
@@ -4433,6 +4447,7 @@ async def test_create_agent_preset_allows_custom_model_provider(
                 tool_approvals=params.tool_approvals,
                 mcp_integrations=params.mcp_integrations,
                 retries=params.retries,
+                enable_thinking=params.enable_thinking,
                 enable_internet_access=params.enable_internet_access,
                 current_version_id=None,
                 created_at=now,

--- a/tracecat/agent/common/types.py
+++ b/tracecat/agent/common/types.py
@@ -123,6 +123,8 @@ class SandboxAgentConfig:
     """Expected output type for structured outputs (e.g., "int", "str", or a JSON schema dict)."""
 
     # Sandbox
+    enable_thinking: bool = True
+    """Whether to enable extended thinking for the Claude Code CLI."""
     enable_internet_access: bool = False
     """Whether to enable internet access tools (WebSearch, WebFetch)."""
 
@@ -138,6 +140,7 @@ class SandboxAgentConfig:
             tool_approvals=data.get("tool_approvals"),
             mcp_servers=data.get("mcp_servers"),
             output_type=data.get("output_type"),
+            enable_thinking=data.get("enable_thinking", True),
             enable_internet_access=data.get("enable_internet_access", False),
         )
 
@@ -159,6 +162,7 @@ class SandboxAgentConfig:
             tool_approvals=config.tool_approvals,
             mcp_servers=config.mcp_servers,
             output_type=config.output_type,
+            enable_thinking=getattr(config, "enable_thinking", True),
             enable_internet_access=getattr(config, "enable_internet_access", False),
         )
 
@@ -179,5 +183,6 @@ class SandboxAgentConfig:
             result["mcp_servers"] = self.mcp_servers
         if self.output_type is not None:
             result["output_type"] = self.output_type
+        result["enable_thinking"] = self.enable_thinking
         result["enable_internet_access"] = self.enable_internet_access
         return result

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -173,6 +173,7 @@ class SandboxedAgentExecutor:
             passthrough=self.input.config.passthrough,
             role=self.input.role,
             use_workspace_credentials=self.input.use_workspace_credentials,
+            model_provider=self.input.config.model_provider,
         )
 
     async def run(self) -> AgentExecutorResult:

--- a/tracecat/agent/litellm_config.yaml
+++ b/tracecat/agent/litellm_config.yaml
@@ -45,4 +45,4 @@ litellm_settings:
   callbacks:
     - tracecat.agent.gateway.callback_handler
   drop_params: true
-  use_chat_completions_url_for_anthropic_messages: true
+  reasoning_auto_summary: true

--- a/tracecat/agent/preset/internal_router.py
+++ b/tracecat/agent/preset/internal_router.py
@@ -52,6 +52,8 @@ class PresetCreateRequest(BaseModel):
     base_url: str | None = Field(default=None, max_length=500)
     output_type: OutputType | None = Field(default=None)
     actions: list[str] | None = Field(default=None)
+    enable_thinking: bool = Field(default=True)
+    enable_internet_access: bool = Field(default=False)
 
 
 class PresetUpdateRequest(BaseModel):
@@ -66,6 +68,8 @@ class PresetUpdateRequest(BaseModel):
     base_url: str | None = Field(default=None, max_length=500)
     output_type: OutputType | None = Field(default=None)
     actions: list[str] | None = Field(default=None)
+    enable_thinking: bool | None = Field(default=None)
+    enable_internet_access: bool | None = Field(default=None)
 
 
 @router.get("", response_model=list[AgentPresetReadMinimal])

--- a/tracecat/agent/preset/schemas.py
+++ b/tracecat/agent/preset/schemas.py
@@ -43,6 +43,7 @@ class AgentPresetExecutionConfig(Schema):
     tool_approvals: dict[str, bool] | None = Field(default=None)
     mcp_integrations: list[str] | None = Field(default=None)
     retries: int = Field(default=3, ge=0)
+    enable_thinking: bool = Field(default=True)
     enable_internet_access: bool = Field(default=False)
 
 
@@ -59,6 +60,7 @@ class AgentPresetExecutionConfigWrite(Schema):
     tool_approvals: dict[str, bool] | None = Field(default=None)
     mcp_integrations: list[str] | None = Field(default=None)
     retries: int = Field(default=3, ge=0)
+    enable_thinking: bool = Field(default=True)
     enable_internet_access: bool = Field(default=False)
 
 
@@ -91,6 +93,7 @@ class AgentPresetUpdate(BaseModel):
     tool_approvals: dict[str, bool] | None = Field(default=None)
     mcp_integrations: list[str] | None = Field(default=None)
     retries: int | None = Field(default=None, ge=0)
+    enable_thinking: bool | None = Field(default=None)
     enable_internet_access: bool | None = Field(default=None)
 
 
@@ -134,6 +137,7 @@ class AgentPresetRead(AgentPresetExecutionConfig):
             namespaces=self.namespaces,
             tool_approvals=self.tool_approvals,
             retries=self.retries,
+            enable_thinking=self.enable_thinking,
             enable_internet_access=self.enable_internet_access,
         )
 

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -71,6 +71,7 @@ class AgentPresetService(BaseWorkspaceService):
         "tool_approvals",
         "mcp_integrations",
         "retries",
+        "enable_thinking",
         "enable_internet_access",
     }
 
@@ -114,6 +115,7 @@ class AgentPresetService(BaseWorkspaceService):
             namespaces=params.namespaces,
             tool_approvals=params.tool_approvals,
             mcp_integrations=params.mcp_integrations,
+            enable_thinking=params.enable_thinking,
             enable_internet_access=params.enable_internet_access,
             retries=params.retries,
         )
@@ -133,6 +135,7 @@ class AgentPresetService(BaseWorkspaceService):
             tool_approvals=preset.tool_approvals,
             mcp_integrations=preset.mcp_integrations,
             retries=preset.retries,
+            enable_thinking=preset.enable_thinking,
             enable_internet_access=preset.enable_internet_access,
         )
         self.session.add(version)
@@ -964,6 +967,7 @@ class AgentPresetService(BaseWorkspaceService):
             "base_url",
             "output_type",
             "retries",
+            "enable_thinking",
             "enable_internet_access",
         ):
             old_value = getattr(base_version, field)
@@ -1048,6 +1052,7 @@ class AgentPresetService(BaseWorkspaceService):
             mcp_servers=mcp_servers,
             retries=version.retries,
             model_settings=model_settings,
+            enable_thinking=version.enable_thinking,
             enable_internet_access=version.enable_internet_access,
         )
 
@@ -1083,6 +1088,7 @@ class AgentPresetService(BaseWorkspaceService):
             tool_approvals=preset.tool_approvals,
             mcp_integrations=preset.mcp_integrations,
             retries=preset.retries,
+            enable_thinking=preset.enable_thinking,
             enable_internet_access=preset.enable_internet_access,
         )
         self.session.add(version)
@@ -1105,4 +1111,5 @@ class AgentPresetService(BaseWorkspaceService):
         preset.tool_approvals = version.tool_approvals
         preset.mcp_integrations = version.mcp_integrations
         preset.retries = version.retries
+        preset.enable_thinking = version.enable_thinking
         preset.enable_internet_access = version.enable_internet_access

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -687,6 +687,11 @@ class ClaudeAgentRuntime:
                 include_partial_messages=True,
                 resume=resume_session_id,
                 fork_session=fork_session,  # If True, creates new session from parent's history
+                thinking=(
+                    {"type": "enabled", "budget_tokens": 1024}
+                    if payload.config.enable_thinking
+                    else {"type": "disabled"}
+                ),
                 env={
                     "ANTHROPIC_AUTH_TOKEN": payload.llm_gateway_auth_token,
                     "ANTHROPIC_BASE_URL": get_llm_proxy_url(),

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -97,6 +97,7 @@ class LLMSocketProxy:
         passthrough: bool = False,
         role: Role | None = None,
         use_workspace_credentials: bool = False,
+        model_provider: str | None = None,
     ):
         """Initialize the LLM socket proxy.
 
@@ -104,10 +105,12 @@ class LLMSocketProxy:
             socket_path: Path where the Unix socket will be created.
             upstream_url: Selected upstream base URL. Defaults to the managed gateway.
             on_error: Callback invoked when an error (e.g., auth failure) is detected.
-            passthrough: When True, strip managed auth headers and provider-specific
-                reasoning fields before forwarding directly to the configured upstream.
+            passthrough: When True, strip managed auth headers before forwarding
+                directly to the configured upstream.
             role: Role used to fetch the custom provider API key in passthrough mode.
             use_workspace_credentials: Credential scope for the passthrough key fetch.
+            model_provider: Selected model provider. Used to decide whether to strip
+                Anthropic-only request fields from outbound payloads.
         """
         self.socket_path = socket_path
         self.upstream_url = (
@@ -123,6 +126,7 @@ class LLMSocketProxy:
         self._role = role
         self._use_workspace_credentials = use_workspace_credentials
         self._upstream_api_key: str | None = None
+        self._model_provider = model_provider
 
     async def _resolve_passthrough_api_key(self) -> None:
         """Fetch the custom provider API key for passthrough mode.
@@ -240,12 +244,12 @@ class LLMSocketProxy:
     def _strip_anthropic_only_fields_from_request(
         data: dict[str, Any], headers: dict[str, str]
     ) -> tuple[dict[str, Any], dict[str, str]]:
-        """Remove Anthropic-only fields from a JSON request body.
+        """Remove Anthropic-only request fields for non-Anthropic upstreams.
 
-        Strips ``anthropic_beta``, ``context_management``, ``output_config``,
-        and ``output_format`` top-level keys and returns the updated body.
-        The caller is responsible for re-serializing the body and setting
-        ``Content-Length`` accordingly.
+        Strips ``thinking`` and Anthropic-only top-level keys
+        (``anthropic_beta``, ``context_management``, ``output_config``,
+        ``output_format``). The caller is responsible for re-serializing the
+        body and setting ``Content-Length`` accordingly.
         """
         for field in LLMSocketProxy._ANTHROPIC_ONLY_FIELDS:
             data.pop(field, None)
@@ -455,13 +459,10 @@ class LLMSocketProxy:
             if isinstance(parsed, dict):
                 data = parsed
 
-        if data is not None:
-            if self._is_passthrough:
-                data, headers = self._strip_anthropic_only_fields_from_request(
-                    data, headers
-                )
-            # Always attach reasoning_effort to the request body
-            data["reasoning_effort"] = "high"
+        if data is not None and self._model_provider != "anthropic":
+            data, headers = self._strip_anthropic_only_fields_from_request(
+                data, headers
+            )
             body = orjson.dumps(data)
             headers["Content-Length"] = str(len(body))
 

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -13,7 +13,7 @@ import os
 import time
 from collections.abc import AsyncIterable, Callable
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, TypedDict
 from uuid import uuid4
 
 import httpx
@@ -55,6 +55,13 @@ _ERROR_MESSAGES = {
 }
 _proxy_load_tracker = get_load_tracker("llm_socket_proxy")
 _TRACE_REQUEST_ID_HEADER = "x-request-id"
+
+
+class ParsedRequest(TypedDict):
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: bytes
 
 
 def _load_fields() -> dict[str, int]:
@@ -223,8 +230,6 @@ class LLMSocketProxy:
                 self._on_error(message)
 
     _ANTHROPIC_ONLY_FIELDS = (
-        "thinking",
-        "reasoning_effort",
         "anthropic_beta",
         "context_management",
         "output_config",
@@ -233,35 +238,18 @@ class LLMSocketProxy:
 
     @staticmethod
     def _strip_anthropic_only_fields_from_request(
-        body: bytes, headers: dict[str, str]
-    ) -> tuple[bytes, dict[str, str]]:
+        data: dict[str, Any], headers: dict[str, str]
+    ) -> tuple[dict[str, Any], dict[str, str]]:
         """Remove Anthropic-only fields from a JSON request body.
 
-        Strips ``thinking``, ``reasoning_effort``, ``anthropic_beta``,
-        ``context_management``, ``output_config``, and ``output_format``
-        top-level keys and returns the updated body with a corrected
-        ``Content-Length`` header.
+        Strips ``anthropic_beta``, ``context_management``, ``output_config``,
+        and ``output_format`` top-level keys and returns the updated body.
+        The caller is responsible for re-serializing the body and setting
+        ``Content-Length`` accordingly.
         """
-        try:
-            data = orjson.loads(body)
-        except orjson.JSONDecodeError:
-            return body, headers
-
-        changed = False
         for field in LLMSocketProxy._ANTHROPIC_ONLY_FIELDS:
-            if field in data:
-                del data[field]
-                changed = True
-
-        if not changed:
-            return body, headers
-
-        new_body = orjson.dumps(data)
-        headers = {
-            key: (str(len(new_body)) if key.lower() == "content-length" else value)
-            for key, value in headers.items()
-        }
-        return new_body, headers
+            data.pop(field, None)
+        return data, headers
 
     @staticmethod
     def _is_client_disconnect_error(exc: Exception) -> bool:
@@ -320,7 +308,7 @@ class LLMSocketProxy:
     async def _parse_http_request(
         self,
         reader: asyncio.StreamReader,
-    ) -> dict | None:
+    ) -> ParsedRequest | None:
         """Parse an HTTP request from the socket.
 
         Returns:
@@ -386,7 +374,7 @@ class LLMSocketProxy:
 
     async def _forward_request(
         self,
-        request: dict,
+        request: ParsedRequest,
         writer: asyncio.StreamWriter,
     ) -> None:
         """Forward an HTTP request to the LLM gateway and stream the response back."""
@@ -437,7 +425,7 @@ class LLMSocketProxy:
         self,
         *,
         writer: asyncio.StreamWriter,
-        request: dict[str, Any],
+        request: ParsedRequest,
         trace_request_id: str,
         request_counter: int,
         started_at: float,
@@ -453,15 +441,29 @@ class LLMSocketProxy:
             self._emit_error("LiteLLM proxy not initialized")
             return
 
-        path = str(request["path"])
-        method = str(request["method"])
-        headers = cast(dict[str, str], request["headers"])
-        body = cast(bytes, request["body"])
+        path = request["path"]
+        method = request["method"]
+        headers = request["headers"]
+        body = request["body"]
 
-        if self._is_passthrough and body:
-            body, headers = self._strip_anthropic_only_fields_from_request(
-                body, headers
-            )
+        data: dict[str, Any] | None = None
+        if body:
+            try:
+                parsed = orjson.loads(body)
+            except orjson.JSONDecodeError:
+                parsed = None
+            if isinstance(parsed, dict):
+                data = parsed
+
+        if data is not None:
+            if self._is_passthrough:
+                data, headers = self._strip_anthropic_only_fields_from_request(
+                    data, headers
+                )
+            # Always attach reasoning_effort to the request body
+            data["reasoning_effort"] = "high"
+            body = orjson.dumps(data)
+            headers["Content-Length"] = str(len(body))
 
         url = f"{self.upstream_url}{path}"
         excluded_headers = {"host", "connection", "transfer-encoding"}

--- a/tracecat/agent/schemas.py
+++ b/tracecat/agent/schemas.py
@@ -257,6 +257,7 @@ class AgentConfigSchema(BaseModel):
     model_settings: dict[str, Any] | None = None
     mcp_servers: list[MCPServerConfigSchema] | None = None
     retries: int = Field(default=20)
+    enable_thinking: bool = Field(default=True)
 
 
 class RankableItemSchema(TypedDict):

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -1378,6 +1378,7 @@ class AgentSessionService(BaseWorkspaceService):
                             model_name=preset_config.model_name,
                             model_provider=preset_config.model_provider,
                             actions=[],  # No tools for forked sessions
+                            enable_thinking=preset_config.enable_thinking,
                         )
                 else:
                     # No preset - use workspace model with fork context

--- a/tracecat/agent/types.py
+++ b/tracecat/agent/types.py
@@ -131,6 +131,7 @@ class AgentConfig:
     deps_type: type[Any] | None = None
     custom_tools: CustomToolList | None = None
     # Sandbox
+    enable_thinking: bool = True
     enable_internet_access: bool = False
 
 

--- a/tracecat/agent/workflow_config.py
+++ b/tracecat/agent/workflow_config.py
@@ -98,6 +98,7 @@ def agent_config_to_payload(config: AgentConfig) -> AgentConfigPayload:
             else None
         ),
         retries=config.retries,
+        enable_thinking=config.enable_thinking,
         enable_internet_access=config.enable_internet_access,
     )
 
@@ -121,5 +122,6 @@ def agent_config_from_payload(payload: AgentConfigPayload) -> AgentConfig:
             else None
         ),
         retries=payload.retries,
+        enable_thinking=payload.enable_thinking,
         enable_internet_access=payload.enable_internet_access,
     )

--- a/tracecat/agent/workflow_schemas.py
+++ b/tracecat/agent/workflow_schemas.py
@@ -98,4 +98,5 @@ class AgentConfigPayload(BaseModel):
     model_settings: dict[str, Any] | None = Field(default=None)
     mcp_servers: list[MCPServerConfigPayload] | None = Field(default=None)
     retries: int
+    enable_thinking: bool = Field(default=True)
     enable_internet_access: bool = Field(default=False)

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3063,6 +3063,13 @@ class AgentPreset(WorkspaceModel):
     retries: Mapped[int] = mapped_column(
         Integer, default=3, nullable=False, doc="Maximum retry attempts per run"
     )
+    enable_thinking: Mapped[bool] = mapped_column(
+        Boolean,
+        default=True,
+        server_default=text("true"),
+        nullable=False,
+        doc="Whether to enable high thinking for agent runs",
+    )
     enable_internet_access: Mapped[bool] = mapped_column(
         Boolean,
         default=False,
@@ -3160,6 +3167,13 @@ class AgentPresetVersion(WorkspaceModel):
     )
     retries: Mapped[int] = mapped_column(
         Integer, default=3, nullable=False, doc="Maximum retry attempts per run"
+    )
+    enable_thinking: Mapped[bool] = mapped_column(
+        Boolean,
+        default=True,
+        server_default=text("true"),
+        nullable=False,
+        doc="Whether to enable high thinking for agent runs",
     )
     enable_internet_access: Mapped[bool] = mapped_column(
         Boolean,

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -947,6 +947,7 @@ class DSLWorkflow:
                                 output_type=action_args.output_type,
                                 model_settings=action_args.model_settings,
                                 retries=action_args.retries,
+                                enable_thinking=action_args.enable_thinking,
                                 base_url=action_args.base_url,
                                 actions=action_args.actions,
                                 tool_approvals=action_args.tool_approvals,
@@ -1009,6 +1010,7 @@ class DSLWorkflow:
                                 output_type=action_args.output_type,
                                 model_settings=action_args.model_settings,
                                 retries=action_args.retries,
+                                enable_thinking=action_args.enable_thinking,
                                 base_url=action_args.base_url,
                                 # AI action has no tools
                                 actions=None,

--- a/tracecat/mcp/README.md
+++ b/tracecat/mcp/README.md
@@ -128,8 +128,8 @@ Case field and table `type` values are:
 
 - `list_integrations(workspace_id)`
 - `get_agent_preset_authoring_context(workspace_id)`
-- `create_agent_preset(workspace_id, name, slug=None, description=None, instructions=None, model_name=None, model_provider=None, base_url=None, output_type=None, actions=None, namespaces=None, tool_approvals=None, mcp_integration_ids=None, retries=None, enable_internet_access=None)`
-- `update_agent_preset(workspace_id, preset_slug, name=None, slug=None, description=None, instructions=None, model_name=None, model_provider=None, base_url=None, output_type=None, actions=None, namespaces=None, tool_approvals=None, mcp_integration_ids=None, retries=None, enable_internet_access=None)`
+- `create_agent_preset(workspace_id, name, slug=None, description=None, instructions=None, model_name=None, model_provider=None, base_url=None, output_type=None, actions=None, namespaces=None, tool_approvals=None, mcp_integration_ids=None, retries=None, enable_thinking=None, enable_internet_access=None)`
+- `update_agent_preset(workspace_id, preset_slug, name=None, slug=None, description=None, instructions=None, model_name=None, model_provider=None, base_url=None, output_type=None, actions=None, namespaces=None, tool_approvals=None, mcp_integration_ids=None, retries=None, enable_thinking=None, enable_internet_access=None)`
 - `list_agent_presets(workspace_id, limit=20, cursor=None)`
 - `get_agent_preset(workspace_id, preset_slug)`
 - `run_agent_preset(workspace_id, preset_slug, prompt, preset_version=None, timeout_seconds=120)`

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -5984,6 +5984,7 @@ async def create_agent_preset(
     tool_approvals: dict[str, bool] | None = None,
     mcp_integration_ids: list[str] | None = None,
     retries: int | None = None,
+    enable_thinking: bool | None = None,
     enable_internet_access: bool | None = None,
 ) -> str:
     """Create an agent preset in the selected workspace."""
@@ -6014,6 +6015,7 @@ async def create_agent_preset(
             "tool_approvals": tool_approvals,
             "mcp_integrations": mcp_integration_ids,
             "retries": retries,
+            "enable_thinking": enable_thinking,
             "enable_internet_access": enable_internet_access,
         }
         create_data.update(
@@ -6055,6 +6057,7 @@ async def update_agent_preset(
     tool_approvals: dict[str, bool] | None = None,
     mcp_integration_ids: list[str] | None = None,
     retries: int | None = None,
+    enable_thinking: bool | None = None,
     enable_internet_access: bool | None = None,
 ) -> str:
     """Update an existing agent preset in the selected workspace."""
@@ -6074,6 +6077,7 @@ async def update_agent_preset(
             "tool_approvals": tool_approvals,
             "mcp_integrations": mcp_integration_ids,
             "retries": retries,
+            "enable_thinking": enable_thinking,
             "enable_internet_access": enable_internet_access,
         }
         update_data.update(


### PR DESCRIPTION
## Summary
- Add `ParsedRequest` TypedDict to properly type parsed HTTP requests flowing through the LLM socket proxy
- Parse the JSON body once upfront and always attach `reasoning_effort=high` before forwarding to the upstream gateway
- Simplify `_strip_anthropic_only_fields_from_request` to operate on the already-parsed dict instead of raw bytes

## Test plan
- [ ] Verify agent LLM requests include `reasoning_effort=high` in the forwarded body
- [ ] Verify passthrough mode still strips Anthropic-only fields correctly
- [ ] Verify non-JSON bodies are forwarded without modification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed the LLM socket proxy and added a preset toggle for model “thinking”. The proxy preserves inbound `thinking`/`reasoning_effort` and only strips Anthropic-only fields when the upstream provider is not Anthropic.

- **New Features**
  - Added `enable_thinking` to agent presets across DB, API/MCP, and UI; default true, versioned, and propagated into `AgentConfig`, workflows, sandbox, and the Claude Code runtime (which sets `thinking: {type: "disabled"}` when off).

- **Refactors**
  - Introduced `ParsedRequest`; parse JSON once, update `Content-Length`, and strip Anthropic-only fields at the dict level.
  - Added `model_provider` awareness to the socket proxy: preserve inbound `thinking`/`reasoning_effort`, and only strip `anthropic_beta`, `context_management`, `output_config`, `output_format` for non-Anthropic upstreams.

<sup>Written for commit 0cd64f6a8f30e99cc1bd7e0011cfcb126544731b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

