### PR TITLE
feat(api): Add unwrap query param to /wait

### DIFF
--- a/docs/automations/triggers/webhooks.mdx
+++ b/docs/automations/triggers/webhooks.mdx
@@ -48,7 +48,76 @@ Default response:
 }
 ```
 
-`echo=true` adds `payload`. `echo=true&empty_echo=true` returns an empty `200` response instead of the default JSON body.
+Query parameters:
+
+- `echo=true`: add the original request body to the response under `payload`.
+- `empty_echo=true`: return an empty `200` with no body. Implies `echo=true`.
+- `vendor=okta`: handle Okta verification challenges. See [Okta verification](#okta-verification).
+
+## Synchronous execution with /wait
+
+Use `POST /webhooks/{workflow_id}/{secret}/wait` to run a workflow and receive its `return` value in the response. The request blocks until the workflow finishes. The workflow must be published. The request body becomes `TRIGGER` exactly as with the default webhook.
+
+This endpoint is designed for workflows-as-APIs: the caller treats the workflow like a synchronous HTTP handler.
+
+### Response schema
+
+The response is an envelope with a `kind` discriminator:
+
+```json
+{
+  "kind": "value",
+  "value": { "status": "ok" }
+}
+```
+
+```json
+{
+  "kind": "download_file",
+  "download_url": "https://...",
+  "expires_in_seconds": 10,
+  "content_type": "application/json",
+  "size_bytes": 262144
+}
+```
+
+### Kinds
+
+- `value`: inline result. The body has `value` set to the workflow's `return` value.
+- `download_file`: externalized result. The body has a presigned `download_url`, plus `expires_in_seconds`, `content_type`, and `size_bytes`.
+- `download_export`: materialized collection result. Same fields as `download_file`; `content_type` is always `application/json`.
+
+Results over `TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES` (default 128 KiB) are stored in object storage and returned as a short-lived presigned URL (default 10-second expiry). This keeps the webhook response small and predictable, so synchronous callers never stream megabytes of workflow state through a single HTTP response.
+
+### Query parameters
+
+- `unwrap=true`: return the workflow's `return` value directly as the response body, with no envelope. Requires the result to fit inline.
+
+If the result was externalized (kind `download_file` or `download_export`), `/wait?unwrap=true` returns `413 Payload Too Large` with the download envelope under `detail`, so the caller can still fetch the data.
+
+Example:
+
+```bash
+curl -X POST "https://<host>/webhooks/<workflow_id>/<secret>/wait?unwrap=true" \
+  -H "Content-Type: application/json" \
+  -d '{"alert_id": "A-001"}'
+# 200 OK
+# {"status": "ok"}
+```
+
+If the workflow returns a result larger than the externalization threshold:
+
+```json
+{
+  "detail": {
+    "kind": "download_file",
+    "download_url": "https://...",
+    "expires_in_seconds": 10,
+    "content_type": "application/json",
+    "size_bytes": 262144
+  }
+}
+```
 
 ## Slack event subscriptions
 

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -21872,6 +21872,17 @@ distinguish multiple files.`,
   description: "A URL to a video.",
 } as const
 
+export const $WaitResultOutput = {
+  anyOf: [
+    {
+      $ref: "#/components/schemas/WebhookStoredObjectInlineResponse",
+    },
+    {
+      $ref: "#/components/schemas/WebhookStoredObjectDownloadResponse",
+    },
+  ],
+} as const
+
 export const $WaitStrategy = {
   type: "string",
   enum: ["wait", "detach"],
@@ -22689,6 +22700,57 @@ export const $WebhookRead = {
 export const $WebhookStatus = {
   type: "string",
   enum: ["online", "offline"],
+} as const
+
+export const $WebhookStoredObjectDownloadResponse = {
+  properties: {
+    kind: {
+      type: "string",
+      enum: ["download_file", "download_export"],
+      title: "Kind",
+    },
+    download_url: {
+      type: "string",
+      title: "Download Url",
+    },
+    expires_in_seconds: {
+      type: "integer",
+      title: "Expires In Seconds",
+    },
+    content_type: {
+      type: "string",
+      title: "Content Type",
+    },
+    size_bytes: {
+      type: "integer",
+      title: "Size Bytes",
+    },
+  },
+  type: "object",
+  required: [
+    "kind",
+    "download_url",
+    "expires_in_seconds",
+    "content_type",
+    "size_bytes",
+  ],
+  title: "WebhookStoredObjectDownloadResponse",
+} as const
+
+export const $WebhookStoredObjectInlineResponse = {
+  properties: {
+    kind: {
+      type: "string",
+      const: "value",
+      title: "Kind",
+    },
+    value: {
+      title: "Value",
+    },
+  },
+  type: "object",
+  required: ["kind", "value"],
+  title: "WebhookStoredObjectInlineResponse",
 } as const
 
 export const $WebhookUpdate = {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -21894,34 +21894,6 @@ export const $WaitResultUnwrapOverflowResponse = {
   title: "WaitResultUnwrapOverflowResponse",
 } as const
 
-export const $WaitResultUnwrappedOutput = {
-  anyOf: [
-    {
-      additionalProperties: true,
-      type: "object",
-    },
-    {
-      items: {},
-      type: "array",
-    },
-    {
-      type: "string",
-    },
-    {
-      type: "integer",
-    },
-    {
-      type: "number",
-    },
-    {
-      type: "boolean",
-    },
-    {
-      type: "null",
-    },
-  ],
-} as const
-
 export const $WaitStrategy = {
   type: "string",
   enum: ["wait", "detach"],

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -21872,17 +21872,6 @@ distinguish multiple files.`,
   description: "A URL to a video.",
 } as const
 
-export const $WaitResultOutput = {
-  anyOf: [
-    {
-      $ref: "#/components/schemas/WebhookStoredObjectInlineResponse",
-    },
-    {
-      $ref: "#/components/schemas/WebhookStoredObjectDownloadResponse",
-    },
-  ],
-} as const
-
 export const $WaitStrategy = {
   type: "string",
   enum: ["wait", "detach"],
@@ -22700,57 +22689,6 @@ export const $WebhookRead = {
 export const $WebhookStatus = {
   type: "string",
   enum: ["online", "offline"],
-} as const
-
-export const $WebhookStoredObjectDownloadResponse = {
-  properties: {
-    kind: {
-      type: "string",
-      enum: ["download_file", "download_export"],
-      title: "Kind",
-    },
-    download_url: {
-      type: "string",
-      title: "Download Url",
-    },
-    expires_in_seconds: {
-      type: "integer",
-      title: "Expires In Seconds",
-    },
-    content_type: {
-      type: "string",
-      title: "Content Type",
-    },
-    size_bytes: {
-      type: "integer",
-      title: "Size Bytes",
-    },
-  },
-  type: "object",
-  required: [
-    "kind",
-    "download_url",
-    "expires_in_seconds",
-    "content_type",
-    "size_bytes",
-  ],
-  title: "WebhookStoredObjectDownloadResponse",
-} as const
-
-export const $WebhookStoredObjectInlineResponse = {
-  properties: {
-    kind: {
-      type: "string",
-      const: "value",
-      title: "Kind",
-    },
-    value: {
-      title: "Value",
-    },
-  },
-  type: "object",
-  required: ["kind", "value"],
-  title: "WebhookStoredObjectInlineResponse",
 } as const
 
 export const $WebhookUpdate = {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -21883,6 +21883,45 @@ export const $WaitResultOutput = {
   ],
 } as const
 
+export const $WaitResultUnwrapOverflowResponse = {
+  properties: {
+    detail: {
+      $ref: "#/components/schemas/WebhookStoredObjectDownloadResponse",
+    },
+  },
+  type: "object",
+  required: ["detail"],
+  title: "WaitResultUnwrapOverflowResponse",
+} as const
+
+export const $WaitResultUnwrappedOutput = {
+  anyOf: [
+    {
+      additionalProperties: true,
+      type: "object",
+    },
+    {
+      items: {},
+      type: "array",
+    },
+    {
+      type: "string",
+    },
+    {
+      type: "integer",
+    },
+    {
+      type: "number",
+    },
+    {
+      type: "boolean",
+    },
+    {
+      type: "null",
+    },
+  ],
+} as const
+
 export const $WaitStrategy = {
   type: "string",
   enum: ["wait", "detach"],

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -815,8 +815,9 @@ export const publicIncomingWebhookGet = (
  * @param data The data for the request.
  * @param data.secret
  * @param data.workflowId
+ * @param data.unwrap Return the workflow result directly as the response body, without the `{kind, value}` envelope. Requires the result to fit inline. If the result was externalized, returns 413 with the download envelope in `detail`.
  * @param data.contentType
- * @returns WaitResultOutput Successful Response
+ * @returns unknown Successful Response
  * @throws ApiError
  */
 export const publicIncomingWebhookWait = (
@@ -831,6 +832,9 @@ export const publicIncomingWebhookWait = (
     },
     headers: {
       "content-type": data.contentType,
+    },
+    query: {
+      unwrap: data.unwrap,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -817,7 +817,7 @@ export const publicIncomingWebhookGet = (
  * @param data.workflowId
  * @param data.unwrap Return the workflow result directly as the response body, without the `{kind, value}` envelope. Requires the result to fit inline. If the result was externalized, returns 413 with the download envelope in `detail`.
  * @param data.contentType
- * @returns unknown Successful Response
+ * @returns WaitResultOutput Successful Response
  * @throws ApiError
  */
 export const publicIncomingWebhookWait = (

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -817,7 +817,7 @@ export const publicIncomingWebhookGet = (
  * @param data.workflowId
  * @param data.unwrap Return the workflow result directly as the response body, without the `{kind, value}` envelope. Requires the result to fit inline. If the result was externalized, returns 413 with the download envelope in `detail`.
  * @param data.contentType
- * @returns WaitResultOutput Successful Response
+ * @returns unknown Successful Response
  * @throws ApiError
  */
 export const publicIncomingWebhookWait = (
@@ -837,6 +837,7 @@ export const publicIncomingWebhookWait = (
       unwrap: data.unwrap,
     },
     errors: {
+      413: "Unwrapped workflow result exceeded inline response limits. Use `detail.download_url` to fetch the externalized result.",
       422: "Validation Error",
     },
   })

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6758,6 +6758,20 @@ export type WaitResultOutput =
   | WebhookStoredObjectInlineResponse
   | WebhookStoredObjectDownloadResponse
 
+export type WaitResultUnwrapOverflowResponse = {
+  detail: WebhookStoredObjectDownloadResponse
+}
+
+export type WaitResultUnwrappedOutput =
+  | {
+      [key: string]: unknown
+    }
+  | Array<unknown>
+  | string
+  | number
+  | boolean
+  | null
+
 export type WaitStrategy = "wait" | "detach"
 
 /**
@@ -7990,7 +8004,9 @@ export type PublicIncomingWebhookWaitData = {
   workflowId: string
 }
 
-export type PublicIncomingWebhookWaitResponse = WaitResultOutput
+export type PublicIncomingWebhookWaitResponse =
+  | WaitResultOutput
+  | WaitResultUnwrappedOutput
 
 export type PublicIncomingWebhookDraftData = {
   contentType?: string | null
@@ -10964,7 +10980,11 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: WaitResultOutput
+        200: WaitResultOutput | WaitResultUnwrappedOutput
+        /**
+         * Unwrapped workflow result exceeded inline response limits. Use `detail.download_url` to fetch the externalized result.
+         */
+        413: WaitResultUnwrapOverflowResponse
         /**
          * Validation Error
          */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6754,10 +6754,6 @@ export type VideoUrl = {
   readonly identifier: string
 }
 
-export type WaitResultOutput =
-  | WebhookStoredObjectInlineResponse
-  | WebhookStoredObjectDownloadResponse
-
 export type WaitStrategy = "wait" | "detach"
 
 /**
@@ -6948,21 +6944,6 @@ export type WebhookRead = {
 }
 
 export type WebhookStatus = "online" | "offline"
-
-export type WebhookStoredObjectDownloadResponse = {
-  kind: "download_file" | "download_export"
-  download_url: string
-  expires_in_seconds: number
-  content_type: string
-  size_bytes: number
-}
-
-export type kind = "download_file" | "download_export"
-
-export type WebhookStoredObjectInlineResponse = {
-  kind: "value"
-  value: unknown
-}
 
 export type WebhookUpdate = {
   status?: WebhookStatus | null
@@ -7983,10 +7964,14 @@ export type PublicIncomingWebhookGetResponse = unknown
 export type PublicIncomingWebhookWaitData = {
   contentType?: string | null
   secret: string
+  /**
+   * Return the workflow result directly as the response body, without the `{kind, value}` envelope. Requires the result to fit inline. If the result was externalized, returns 413 with the download envelope in `detail`.
+   */
+  unwrap?: boolean
   workflowId: string
 }
 
-export type PublicIncomingWebhookWaitResponse = WaitResultOutput
+export type PublicIncomingWebhookWaitResponse = unknown
 
 export type PublicIncomingWebhookDraftData = {
   contentType?: string | null
@@ -10960,7 +10945,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: WaitResultOutput
+        200: unknown
         /**
          * Validation Error
          */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6762,16 +6762,6 @@ export type WaitResultUnwrapOverflowResponse = {
   detail: WebhookStoredObjectDownloadResponse
 }
 
-export type WaitResultUnwrappedOutput =
-  | {
-      [key: string]: unknown
-    }
-  | Array<unknown>
-  | string
-  | number
-  | boolean
-  | null
-
 export type WaitStrategy = "wait" | "detach"
 
 /**
@@ -8004,9 +7994,7 @@ export type PublicIncomingWebhookWaitData = {
   workflowId: string
 }
 
-export type PublicIncomingWebhookWaitResponse =
-  | WaitResultOutput
-  | WaitResultUnwrappedOutput
+export type PublicIncomingWebhookWaitResponse = WaitResultOutput
 
 export type PublicIncomingWebhookDraftData = {
   contentType?: string | null
@@ -10980,7 +10968,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: WaitResultOutput | WaitResultUnwrappedOutput
+        200: WaitResultOutput
         /**
          * Unwrapped workflow result exceeded inline response limits. Use `detail.download_url` to fetch the externalized result.
          */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -6754,6 +6754,10 @@ export type VideoUrl = {
   readonly identifier: string
 }
 
+export type WaitResultOutput =
+  | WebhookStoredObjectInlineResponse
+  | WebhookStoredObjectDownloadResponse
+
 export type WaitStrategy = "wait" | "detach"
 
 /**
@@ -6944,6 +6948,21 @@ export type WebhookRead = {
 }
 
 export type WebhookStatus = "online" | "offline"
+
+export type WebhookStoredObjectDownloadResponse = {
+  kind: "download_file" | "download_export"
+  download_url: string
+  expires_in_seconds: number
+  content_type: string
+  size_bytes: number
+}
+
+export type kind = "download_file" | "download_export"
+
+export type WebhookStoredObjectInlineResponse = {
+  kind: "value"
+  value: unknown
+}
 
 export type WebhookUpdate = {
   status?: WebhookStatus | null
@@ -7971,7 +7990,7 @@ export type PublicIncomingWebhookWaitData = {
   workflowId: string
 }
 
-export type PublicIncomingWebhookWaitResponse = unknown
+export type PublicIncomingWebhookWaitResponse = WaitResultOutput
 
 export type PublicIncomingWebhookDraftData = {
   contentType?: string | null
@@ -10945,7 +10964,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: unknown
+        200: WaitResultOutput
         /**
          * Validation Error
          */

--- a/tests/unit/test_webhook_execution_path.py
+++ b/tests/unit/test_webhook_execution_path.py
@@ -11,6 +11,7 @@ WorkflowExecutionsService and the webhook router.
 from __future__ import annotations
 
 import datetime
+import json
 import uuid
 from hashlib import sha256
 from types import SimpleNamespace
@@ -18,7 +19,8 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import Request
+from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse
 from temporalio.client import Client
 from temporalio.common import TypedSearchAttributes, WorkflowIDReusePolicy
 
@@ -655,8 +657,8 @@ class TestWebhookRouterExecutionPath:
                 payload=payload,
             )
 
-        assert response["kind"] == "value"
         response_obj = cast(dict[str, Any], response)
+        assert response_obj["kind"] == "value"
         assert response_obj["value"] == {"_": "result-ref"}
         mock_service.create_workflow_execution.assert_awaited_once()
         call_kwargs = mock_service.create_workflow_execution.call_args.kwargs
@@ -703,8 +705,8 @@ class TestWebhookRouterExecutionPath:
                 payload=payload,
             )
 
-        assert response["kind"] == "download_file"
         response_obj = cast(dict[str, Any], response)
+        assert response_obj["kind"] == "download_file"
         assert response_obj["download_url"] == "https://example.com/presigned/external"
 
     @pytest.mark.anyio
@@ -762,8 +764,8 @@ class TestWebhookRouterExecutionPath:
                 payload=payload,
             )
 
-        assert response["kind"] == "download_export"
         response_obj = cast(dict[str, Any], response)
+        assert response_obj["kind"] == "download_export"
         assert (
             response_obj["download_url"] == "https://example.com/presigned/collection"
         )
@@ -822,7 +824,8 @@ class TestWebhookRouterExecutionPath:
                 payload=payload,
             )
 
-        assert response["kind"] == "download_export"
+        response_obj = cast(dict[str, Any], response)
+        assert response_obj["kind"] == "download_export"
         get_page_mock.assert_awaited_once_with(collection_result, offset=1, limit=1)
 
         await_args = upload_file_mock.await_args
@@ -903,13 +906,150 @@ class TestWebhookRouterExecutionPath:
                 payload=payload,
             )
 
-        assert response["kind"] == "download_export"
         response_obj = cast(dict[str, Any], response)
+        assert response_obj["kind"] == "download_export"
         assert (
             response_obj["download_url"] == "https://example.com/presigned/collection"
         )
         cached_download_mock.assert_awaited_once()
         upload_file_mock.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_wait_webhook_unwrap_returns_raw_value_for_inline_object(self):
+        """unwrap=True returns the workflow result directly for inline objects."""
+        workflow_id = WorkflowUUID.new_uuid4()
+        payload = {"event": "test"}
+        inline_result = InlineObject(type="inline", data={"_": "result-ref"})
+        mock_service = AsyncMock()
+        mock_service.create_workflow_execution = AsyncMock(
+            return_value={
+                "wf_id": workflow_id,
+                "result": inline_result,
+            }
+        )
+
+        with patch(
+            "tracecat.webhooks.router.WorkflowExecutionsService.connect",
+            AsyncMock(return_value=mock_service),
+        ):
+            response = await incoming_webhook_wait(
+                workflow_id=workflow_id,
+                defn=_definition(),
+                payload=payload,
+                unwrap=True,
+            )
+
+        assert isinstance(response, JSONResponse)
+        assert isinstance(response.body, bytes)
+        body = json.loads(response.body)
+        assert body == {"_": "result-ref"}
+
+    @pytest.mark.anyio
+    async def test_wait_webhook_unwrap_returns_413_for_external_object(self):
+        """unwrap=True raises 413 with the download envelope for externalized results."""
+        workflow_id = WorkflowUUID.new_uuid4()
+        payload = {"event": "test"}
+        external_result = ExternalObject(
+            type="external",
+            ref=ObjectRef(
+                backend="s3",
+                bucket="tracecat-workflow",
+                key="wf/test/return.json",
+                size_bytes=42,
+                sha256="abc123",
+                content_type="application/json",
+                encoding="json",
+            ),
+        )
+        mock_service = AsyncMock()
+        mock_service.create_workflow_execution = AsyncMock(
+            return_value={
+                "wf_id": workflow_id,
+                "result": external_result,
+            }
+        )
+
+        with (
+            patch(
+                "tracecat.webhooks.router.WorkflowExecutionsService.connect",
+                AsyncMock(return_value=mock_service),
+            ),
+            patch(
+                "tracecat.webhooks.router.blob.generate_presigned_download_url",
+                AsyncMock(return_value="https://example.com/presigned/external"),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await incoming_webhook_wait(
+                    workflow_id=workflow_id,
+                    defn=_definition(),
+                    payload=payload,
+                    unwrap=True,
+                )
+
+        assert exc_info.value.status_code == 413
+        detail = cast(dict[str, Any], exc_info.value.detail)
+        assert detail["kind"] == "download_file"
+        assert detail["download_url"] == "https://example.com/presigned/external"
+
+    @pytest.mark.anyio
+    async def test_wait_webhook_unwrap_returns_413_for_collection_object(self):
+        """unwrap=True raises 413 with the download envelope for collection results."""
+        workflow_id = WorkflowUUID.new_uuid4()
+        payload = {"event": "test"}
+        collection_result = CollectionObject(
+            type="collection",
+            manifest_ref=ObjectRef(
+                backend="s3",
+                bucket="tracecat-workflow",
+                key="wf/test/return/manifest.json",
+                size_bytes=128,
+                sha256="manifest-sha",
+                content_type="application/json",
+                encoding="json",
+            ),
+            count=3,
+            chunk_size=2,
+            element_kind="value",
+        )
+        mock_service = AsyncMock()
+        mock_service.create_workflow_execution = AsyncMock(
+            return_value={
+                "wf_id": workflow_id,
+                "result": collection_result,
+            }
+        )
+
+        with (
+            patch(
+                "tracecat.webhooks.router.WorkflowExecutionsService.connect",
+                AsyncMock(return_value=mock_service),
+            ),
+            patch(
+                "tracecat.webhooks.router.get_collection_page",
+                AsyncMock(return_value=[{"id": 1}, {"id": 2}, {"id": 3}]),
+            ),
+            patch(
+                "tracecat.webhooks.router.blob.upload_file",
+                AsyncMock(),
+            ),
+            patch(
+                "tracecat.webhooks.router.blob.generate_presigned_download_url",
+                AsyncMock(return_value="https://example.com/presigned/collection"),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await incoming_webhook_wait(
+                    workflow_id=workflow_id,
+                    defn=_definition(),
+                    payload=payload,
+                    unwrap=True,
+                )
+
+        assert exc_info.value.status_code == 413
+        detail = cast(dict[str, Any], exc_info.value.detail)
+        assert detail["kind"] == "download_export"
+        assert detail["download_url"] == "https://example.com/presigned/collection"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_webhook_execution_path.py
+++ b/tests/unit/test_webhook_execution_path.py
@@ -19,7 +19,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from temporalio.client import Client
 from temporalio.common import TypedSearchAttributes, WorkflowIDReusePolicy
@@ -37,6 +37,7 @@ from tracecat.storage.object import (
 )
 from tracecat.storage.utils import deserialize_object
 from tracecat.webhooks.router import _incoming_webhook, incoming_webhook_wait
+from tracecat.webhooks.router import router as webhook_router
 from tracecat.workflow.executions.enums import (
     ExecutionType,
     TemporalSearchAttr,
@@ -1050,6 +1051,22 @@ class TestWebhookRouterExecutionPath:
         detail = cast(dict[str, Any], exc_info.value.detail)
         assert detail["kind"] == "download_export"
         assert detail["download_url"] == "https://example.com/presigned/collection"
+
+    def test_wait_webhook_openapi_keeps_default_200_schema_enveloped(self):
+        """The default /wait 200 schema should stay discriminated for generated clients."""
+        app = FastAPI()
+        app.include_router(webhook_router)
+
+        responses = app.openapi()["paths"]["/webhooks/{workflow_id}/{secret}/wait"][
+            "post"
+        ]["responses"]
+        success_schema = responses["200"]["content"]["application/json"]["schema"]
+        overflow_schema = responses["413"]["content"]["application/json"]["schema"]
+
+        assert success_schema == {"$ref": "#/components/schemas/WaitResultOutput"}
+        assert overflow_schema == {
+            "$ref": "#/components/schemas/WaitResultUnwrapOverflowResponse"
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -12,6 +12,8 @@ from fastapi import (
     Response,
     status,
 )
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
 from temporalio.service import RPCError
 
 from tracecat import config
@@ -383,12 +385,23 @@ async def _incoming_webhook(
     return response
 
 
-@router.post("/wait")
+@router.post("/wait", response_model=None)
 async def incoming_webhook_wait(
     workflow_id: AnyWorkflowIDPath,
     defn: ValidWorkflowDefinitionDep,
     payload: PayloadDep,
-) -> WaitResultOutput:
+    unwrap: Annotated[
+        bool,
+        Query(
+            description=(
+                "Return the workflow result directly as the response body, without the "
+                "`{kind, value}` envelope. Requires the result to fit inline. If the "
+                "result was externalized, returns 413 with the download envelope in "
+                "`detail`."
+            ),
+        ),
+    ] = False,
+) -> WaitResultOutput | Response:
     """Webhook endpoint to trigger a workflow.
 
     This is an external facing endpoint is used to trigger a workflow by sending a webhook request.
@@ -410,7 +423,16 @@ async def incoming_webhook_wait(
         else None,
     )
 
-    return await _normalize_wait_result(response["result"])
+    result = response["result"]
+    if unwrap:
+        if isinstance(result, InlineObject):
+            return JSONResponse(content=jsonable_encoder(result.data))
+        envelope = await _normalize_wait_result(result)
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=envelope,
+        )
+    return await _normalize_wait_result(result)
 
 
 @router.post("/draft", response_model=None)

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -396,7 +396,7 @@ async def _incoming_webhook(
 
 @router.post(
     "/wait",
-    response_model=WaitResultOutput | WaitResultUnwrappedOutput,
+    response_model=WaitResultOutput,
     responses={
         status.HTTP_413_REQUEST_ENTITY_TOO_LARGE: {
             "model": WaitResultUnwrapOverflowResponse,

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -385,7 +385,7 @@ async def _incoming_webhook(
     return response
 
 
-@router.post("/wait", response_model=None)
+@router.post("/wait", response_model=WaitResultOutput)
 async def incoming_webhook_wait(
     workflow_id: AnyWorkflowIDPath,
     defn: ValidWorkflowDefinitionDep,

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -87,6 +87,15 @@ type WaitResultOutput = (
 )
 
 
+type WaitResultUnwrappedOutput = (
+    dict[str, Any] | list[Any] | str | int | float | bool | None
+)
+
+
+class WaitResultUnwrapOverflowResponse(TypedDict):
+    detail: WebhookStoredObjectDownloadResponse
+
+
 type WebhookResponse = (
     WorkflowExecutionCreateResponse | OktaVerificationResponse | Response
 )
@@ -385,7 +394,19 @@ async def _incoming_webhook(
     return response
 
 
-@router.post("/wait", response_model=WaitResultOutput)
+@router.post(
+    "/wait",
+    response_model=WaitResultOutput | WaitResultUnwrappedOutput,
+    responses={
+        status.HTTP_413_REQUEST_ENTITY_TOO_LARGE: {
+            "model": WaitResultUnwrapOverflowResponse,
+            "description": (
+                "Unwrapped workflow result exceeded inline response limits. "
+                "Use `detail.download_url` to fetch the externalized result."
+            ),
+        }
+    },
+)
 async def incoming_webhook_wait(
     workflow_id: AnyWorkflowIDPath,
     defn: ValidWorkflowDefinitionDep,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `unwrap` to `POST /webhooks/{workflow_id}/{secret}/wait` so workflows-as-APIs can return the raw result when it fits inline; externalized results return `413` with a download envelope in `detail`. OpenAPI keeps `200` typed as the envelope (`WaitResultOutput`), with `413` as a typed overflow response.

- **New Features**
  - `POST /wait?unwrap=true`: returns the workflow’s `return` value directly; inline only.
  - For externalized results with `unwrap=true`: respond `413 Payload Too Large` and include the `download_*` envelope in `detail`.
  - OpenAPI/SDK: `200` is `WaitResultOutput`; `413` is `WaitResultUnwrapOverflowResponse`. `publicIncomingWebhookWait` supports `unwrap`.
  - Docs expanded for `/wait`, envelope kinds, externalization, and query params (incl. `vendor=okta`). Tests cover unwrap for inline, external file, collection, and OpenAPI invariants.

- **Migration**
  - Generated client `publicIncomingWebhookWait` accepts `unwrap`; `200` stays `WaitResultOutput`, and `413` is `WaitResultUnwrapOverflowResponse`.
  - If you need the envelope, omit `unwrap` and handle `{ kind: "value" | "download_file" | "download_export", ... }`.
  - With `unwrap=true`, expect:
    - Inline results: raw JSON body.
    - Externalized results: HTTP `413` with the download envelope under `detail`.

<sup>Written for commit 6a69958dec694b4c228db6799d33c7f10d0bef29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

