### PR TITLE
fix(engine): always include builtin registry in resolved lock

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -9,6 +9,7 @@ from pydantic import (
     BaseModel,
 )
 from temporalio import activity
+from temporalio.exceptions import ApplicationError
 
 from tracecat.agent.common.types import (
     MCPHttpServerConfig,
@@ -26,6 +27,7 @@ from tracecat.agent.tools import build_agent_tools
 from tracecat.auth.types import Role
 from tracecat.common import all_activities
 from tracecat.contexts import ctx_role
+from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
 from tracecat.logger import logger
 from tracecat.registry.lock.service import RegistryLockService
 from tracecat.registry.lock.types import RegistryLock
@@ -203,10 +205,17 @@ class AgentActivities:
             for name in defs.keys()
             if not name.startswith("mcp__") and not name.startswith("internal.")
         }
-        async with RegistryLockService.with_session() as lock_service:
-            registry_lock = await lock_service.resolve_lock_with_bindings(
-                registry_action_names
-            )
+        try:
+            async with RegistryLockService.with_session() as lock_service:
+                registry_lock = await lock_service.resolve_lock_with_bindings(
+                    registry_action_names
+                )
+        except BuiltinRegistryHasNoSelectionError as e:
+            raise ApplicationError(
+                str(e),
+                e.detail,
+                type=e.__class__.__name__,
+            ) from e
 
         return BuildToolDefsResult(
             tool_definitions=defs,

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -415,21 +415,26 @@ class DurableAgentWorkflow:
 
         # Resolve tool definitions and registry lock from registry
         # Also discovers user MCP tools if configured
-        build_result = await workflow.execute_activity_method(
-            AgentActivities.build_tool_definitions,
-            arg=BuildToolDefsArgs(
-                role=self.role,
-                tool_filters=ToolFilters(
-                    namespaces=cfg.namespaces,
-                    actions=cfg.actions,
+        try:
+            build_result = await workflow.execute_activity_method(
+                AgentActivities.build_tool_definitions,
+                arg=BuildToolDefsArgs(
+                    role=self.role,
+                    tool_filters=ToolFilters(
+                        namespaces=cfg.namespaces,
+                        actions=cfg.actions,
+                    ),
+                    tool_approvals=cfg.tool_approvals,
+                    mcp_servers=cfg.mcp_servers,
+                    internal_tool_context=internal_tool_context,
                 ),
-                tool_approvals=cfg.tool_approvals,
-                mcp_servers=cfg.mcp_servers,
-                internal_tool_context=internal_tool_context,
-            ),
-            start_to_close_timeout=timedelta(seconds=120),
-            retry_policy=RETRY_POLICIES["activity:fail_fast"],
-        )
+                start_to_close_timeout=timedelta(seconds=120),
+                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
+        except ActivityError as e:
+            if isinstance(e.cause, ApplicationError):
+                raise e.cause from e
+            raise
         allowed_actions = build_result.tool_definitions
         self._registry_lock = build_result.registry_lock
         user_mcp_claims = build_result.user_mcp_claims

--- a/tests/unit/api/test_api_workflows.py
+++ b/tests/unit/api/test_api_workflows.py
@@ -271,6 +271,46 @@ async def test_commit_workflow_builtin_registry_not_ready_returns_validation_fai
 
 
 @pytest.mark.anyio
+async def test_create_workflow_import_builtin_registry_not_ready_returns_validation_failure(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Workflow import should return a validation-style failure while builtin sync is pending."""
+    with patch.object(
+        workflow_management_router, "WorkflowsManagementService"
+    ) as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_workflow_from_external_definition.side_effect = (
+            BuiltinRegistryHasNoSelectionError(
+                "Builtin registry sync is still in progress. Please retry shortly.",
+                detail={"origin": "tracecat_registry"},
+            )
+        )
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            "/workflows",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            files={
+                "file": (
+                    "workflow.yaml",
+                    b"definition:\n  title: Imported workflow\n",
+                    "application/yaml",
+                )
+            },
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    payload = response.json()["detail"]
+    assert payload["status"] == "failure"
+    assert payload["message"] == "1 validation error(s)"
+    error = payload["errors"][0]
+    assert error["type"] == "dsl"
+    assert "retry shortly" in error["msg"]
+    assert error["detail"][0]["type"] == "registry.builtin_sync_pending"
+
+
+@pytest.mark.anyio
 async def test_list_workflows_includes_trigger_summary(
     client: TestClient,
     test_admin_role: Role,

--- a/tests/unit/api/test_api_workflows.py
+++ b/tests/unit/api/test_api_workflows.py
@@ -21,6 +21,7 @@ from tracecat.db.models import (
     WorkflowTag,
     Workspace,
 )
+from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
 from tracecat.pagination import CursorPaginatedResponse
 from tracecat.workflow.management import router as workflow_management_router
 from tracecat.workflow.management.types import (
@@ -215,6 +216,58 @@ async def test_list_workflows_with_tag_filter(
         data = response.json()
         assert len(data["items"]) == 1
         assert data["items"][0]["tags"][0]["name"] == "test-tag"
+
+
+@pytest.mark.anyio
+async def test_commit_workflow_builtin_registry_not_ready_returns_validation_failure(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow: Workflow,
+) -> None:
+    """Commit should return a validation-style failure while builtin sync is pending."""
+    mock_dsl = SimpleNamespace(
+        actions=[SimpleNamespace(action="core.transform.reshape")]
+    )
+
+    with (
+        patch.object(
+            workflow_management_router, "WorkflowsManagementService"
+        ) as mock_mgmt_cls,
+        patch.object(
+            workflow_management_router, "RegistryLockService"
+        ) as mock_lock_cls,
+        patch.object(
+            workflow_management_router, "validate_dsl", new=AsyncMock(return_value=[])
+        ),
+    ):
+        mock_mgmt = AsyncMock()
+        mock_mgmt.get_workflow.return_value = mock_workflow
+        mock_mgmt.build_dsl_from_workflow.return_value = mock_dsl
+        mock_mgmt_cls.return_value = mock_mgmt
+
+        mock_lock = AsyncMock()
+        mock_lock.resolve_lock_with_bindings.side_effect = (
+            BuiltinRegistryHasNoSelectionError(
+                "Builtin registry sync is still in progress. Please retry shortly.",
+                detail={"origin": "tracecat_registry"},
+            )
+        )
+        mock_lock_cls.return_value = mock_lock
+
+        response = client.post(
+            f"/workflows/{mock_workflow.id}/commit",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["status"] == "failure"
+    assert payload["message"] == "1 validation error(s)"
+    assert len(payload["errors"]) == 1
+    error = payload["errors"][0]
+    assert error["type"] == "dsl"
+    assert "retry shortly" in error["msg"]
+    assert error["detail"][0]["type"] == "registry.builtin_sync_pending"
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -8,9 +8,13 @@ These tests cover:
 from __future__ import annotations
 
 import uuid
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from temporalio.exceptions import ApplicationError
+from tracecat_ee.agent import activities as agent_activities
+from tracecat_ee.agent.activities import AgentActivities, BuildToolDefsArgs
 
 from tracecat.agent.common.stream_types import HarnessType
 from tracecat.agent.executor.activity import (
@@ -18,6 +22,7 @@ from tracecat.agent.executor.activity import (
     AgentExecutorResult,
     run_agent_activity,
 )
+from tracecat.agent.schemas import ToolFilters
 from tracecat.agent.session.activities import (
     CreateSessionInput,
     CreateSessionResult,
@@ -28,9 +33,11 @@ from tracecat.agent.session.activities import (
     load_session_activity,
 )
 from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.tools import BuildToolsResult
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
 
 
 @pytest.fixture
@@ -83,6 +90,54 @@ class TestSessionActivities:
         assert "create_session_activity" in activity_names
         assert "load_session_activity" in activity_names
         assert "reconcile_tool_results_activity" in activity_names
+
+
+class TestBuildToolDefinitionsActivity:
+    @pytest.mark.anyio
+    async def test_maps_builtin_sync_pending_to_application_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def mock_build_agent_tools(**_kwargs: Any) -> BuildToolsResult:
+            return BuildToolsResult(tools=[], collected_secrets=set())
+
+        class _LockService:
+            async def resolve_lock_with_bindings(self, _actions: set[str]) -> None:
+                raise BuiltinRegistryHasNoSelectionError(
+                    "Builtin registry sync is still in progress. Please retry shortly.",
+                    detail={"origin": "tracecat_registry"},
+                )
+
+        class _AsyncContext:
+            async def __aenter__(self) -> _LockService:
+                return _LockService()
+
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
+                return None
+
+        monkeypatch.setattr(
+            agent_activities, "build_agent_tools", mock_build_agent_tools
+        )
+        monkeypatch.setattr(
+            agent_activities.RegistryLockService,
+            "with_session",
+            lambda: _AsyncContext(),
+        )
+
+        args = BuildToolDefsArgs(
+            role=Role(type="service", service_id="tracecat-api"),
+            tool_filters=ToolFilters(actions=[]),
+        )
+
+        with pytest.raises(ApplicationError) as exc_info:
+            await AgentActivities().build_tool_definitions(args)
+
+        app_error = exc_info.value
+        assert app_error.type == "BuiltinRegistryHasNoSelectionError"
+        assert app_error.non_retryable is False
+        assert app_error.details[0] == {"origin": "tracecat_registry"}
 
 
 class TestCreateSessionActivity:

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -8,6 +8,7 @@ from fastmcp.exceptions import ToolError
 
 from tracecat.agent.mcp import trusted_server
 from tracecat.agent.tokens import MCPTokenClaims, UserMCPServerClaim
+from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
 
 type ExecuteUserMCPTool = Callable[[str, str, dict[str, object], str], Awaitable[str]]
 type ExecuteActionTool = Callable[
@@ -130,3 +131,47 @@ async def test_execute_action_tool_forwards_tool_call_id(
     assert call.args[1] == {"url": "https://example.com"}
     assert call.kwargs["tool_call_id"] == "toolu_123"
     assert result == '{"ok": true}'
+
+
+@pytest.mark.anyio
+async def test_execute_action_tool_surfaces_builtin_registry_sync_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        trusted_server,
+        "verify_mcp_token",
+        lambda _: _build_claims(user_mcp_servers=[]),
+    )
+    monkeypatch.setattr(
+        trusted_server,
+        "execute_action",
+        AsyncMock(return_value={"ok": True}),
+    )
+
+    class _AsyncContext:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def resolve_lock_with_bindings(self, _actions):
+            raise BuiltinRegistryHasNoSelectionError(
+                "Builtin registry sync is still in progress. Please retry shortly.",
+                detail={"origin": "tracecat_registry"},
+            )
+
+    monkeypatch.setattr(
+        trusted_server.RegistryLockService,
+        "with_session",
+        lambda: _AsyncContext(),
+    )
+
+    execute_action_tool = cast(ExecuteActionTool, trusted_server.execute_action_tool)
+    with pytest.raises(ToolError, match="retry shortly"):
+        await execute_action_tool(
+            "core.http_request",
+            {"url": "https://example.com"},
+            "token",
+            None,
+        )

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -24,6 +24,7 @@ from tracecat.agent.common.stream_types import (
     UnifiedStreamEvent,
 )
 from tracecat.agent.stream.events import StreamDelta, StreamEnd
+from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
 from tracecat.expressions.common import ExprType
 from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
 from tracecat.tables.service import TablesService
@@ -783,6 +784,33 @@ async def test_create_workflow_rejects_oversized_inline_definition_yaml(monkeypa
 
 
 @pytest.mark.anyio
+async def test_create_workflow_surfaces_builtin_registry_sync_pending(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    class _WorkflowService:
+        async def create_workflow_from_external_definition(self, *_args, **_kwargs):
+            raise BuiltinRegistryHasNoSelectionError(
+                "Builtin registry sync is still in progress. Please retry shortly.",
+                detail={"origin": "tracecat_registry"},
+            )
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.WorkflowsManagementService,
+        "with_session",
+        lambda role: _AsyncContext(_WorkflowService()),
+    )
+
+    with pytest.raises(ToolError, match="retry shortly"):
+        await _tool(mcp_server.create_workflow)(
+            workspace_id=str(uuid.uuid4()),
+            title="Example",
+            definition_yaml="definition:\n  title: Example\n",
+        )
+
+
+@pytest.mark.anyio
 async def test_update_workflow_rejects_oversized_inline_definition_yaml(monkeypatch):
     async def _resolve(_workspace_id):
         return uuid.uuid4(), SimpleNamespace()
@@ -795,6 +823,67 @@ async def test_update_workflow_rejects_oversized_inline_definition_yaml(monkeypa
             workflow_id=str(uuid.uuid4()),
             definition_yaml="x" * (mcp_server._inline_workflow_yaml_max_bytes() + 1),
         )
+
+
+@pytest.mark.anyio
+async def test_publish_workflow_builtin_registry_not_ready_returns_validation_failure(
+    monkeypatch,
+):
+    workspace_id = uuid.uuid4()
+    workflow_id = uuid.uuid4()
+    role = SimpleNamespace()
+    workflow = SimpleNamespace(id=workflow_id, alias=None, registry_lock=None)
+    dsl = SimpleNamespace(actions=[SimpleNamespace(action="core.transform.reshape")])
+
+    class _WorkflowService:
+        def __init__(self):
+            self.session = object()
+
+        async def get_workflow(self, wf_id):
+            assert wf_id == mcp_server.WorkflowUUID.new(workflow_id)
+            return workflow
+
+        async def build_dsl_from_workflow(self, workflow_obj):
+            assert workflow_obj is workflow
+            return dsl
+
+    class _LockService:
+        def __init__(self, *_args):
+            pass
+
+        async def resolve_lock_with_bindings(self, _action_names):
+            raise BuiltinRegistryHasNoSelectionError(
+                "Builtin registry sync is still in progress. Please retry shortly.",
+                detail={"origin": "tracecat_registry"},
+            )
+
+    async def _resolve(_workspace_id):
+        return workspace_id, role
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.WorkflowsManagementService,
+        "with_session",
+        lambda role: _AsyncContext(_WorkflowService()),
+    )
+    monkeypatch.setattr(
+        mcp_server, "validate_dsl", lambda **_kwargs: asyncio.sleep(0, result=[])
+    )
+    monkeypatch.setattr(mcp_server, "RegistryLockService", _LockService)
+
+    result = await _tool(mcp_server.publish_workflow)(
+        workspace_id=str(workspace_id),
+        workflow_id=str(workflow_id),
+    )
+
+    payload = _payload(result)
+    assert payload["workflow_id"] == str(workflow_id)
+    assert payload["status"] == "failure"
+    assert payload["message"] == "1 validation error(s)"
+    error = payload["errors"][0]
+    assert error["type"] == "dsl"
+    assert "retry shortly" in error["message"]
+    assert error["details"][0]["type"] == "registry.builtin_sync_pending"
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_registry_lock_service.py
+++ b/tests/unit/test_registry_lock_service.py
@@ -23,7 +23,12 @@ from tracecat.db.models import (
     RegistryVersion,
 )
 from tracecat.dsl.enums import PlatformAction
-from tracecat.exceptions import EntitlementRequired, RegistryError
+from tracecat.exceptions import (
+    BuiltinRegistryHasNoSelectionError,
+    EntitlementRequired,
+    RegistryError,
+)
+from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
 from tracecat.registry.lock.service import RegistryLockService
 
 pytestmark = pytest.mark.usefixtures("db")
@@ -116,6 +121,34 @@ def _make_template_manifest(
         "version": "1.0",
         "actions": actions,
     }
+
+
+@pytest.fixture(autouse=True)
+async def seed_builtin_platform_registry(session: AsyncSession) -> None:
+    """Seed the builtin platform registry unless a test explicitly clears it."""
+    platform_repo = await session.scalar(
+        select(PlatformRegistryRepository).where(
+            PlatformRegistryRepository.origin == DEFAULT_REGISTRY_ORIGIN,
+        )
+    )
+    if platform_repo is None:
+        platform_repo = PlatformRegistryRepository(origin=DEFAULT_REGISTRY_ORIGIN)
+        session.add(platform_repo)
+        await session.flush()
+
+    if platform_repo.current_version_id is None:
+        platform_version = PlatformRegistryVersion(
+            repository_id=platform_repo.id,
+            version="seeded-builtin-1",
+            manifest=_make_manifest(["core.transform.reshape"]),
+            tarball_uri="s3://platform/seeded-builtin.tar.gz",
+        )
+        session.add(platform_version)
+        await session.flush()
+        platform_repo.current_version_id = platform_version.id
+        session.add(platform_repo)
+
+    await session.commit()
 
 
 @pytest.mark.anyio
@@ -571,16 +604,72 @@ async def test_resolve_lock_always_includes_builtin_registry(
 
 
 @pytest.mark.anyio
-async def test_resolve_lock_falls_back_to_installed_version_when_platform_not_synced(
+async def test_resolve_lock_overwrites_builtin_origin_with_platform_version(
     svc_role: Role,
     session: AsyncSession,
 ) -> None:
-    """If the platform builtin has never been synced, use installed package version.
+    """Builtin lock origin should always resolve to the platform selected version."""
+    platform_repo = await session.scalar(
+        select(PlatformRegistryRepository).where(
+            PlatformRegistryRepository.origin == "tracecat_registry",
+        )
+    )
+    if platform_repo is None:
+        platform_repo = PlatformRegistryRepository(origin="tracecat_registry")
+        session.add(platform_repo)
+        await session.flush()
 
-    Even when current_version_id is unset for the platform builtin repository,
-    the lock should still include tracecat_registry as a runtime dependency.
-    """
-    from tracecat_registry import __version__ as installed_version
+    platform_version = PlatformRegistryVersion(
+        repository_id=platform_repo.id,
+        version="2.0.0-beta.1",
+        manifest=_make_manifest(["core.transform"]),
+        tarball_uri="s3://platform/builtin-v2.tar.gz",
+    )
+    session.add(platform_version)
+    await session.flush()
+    platform_repo.current_version_id = platform_version.id
+    session.add(platform_repo)
+
+    org_repo = await session.scalar(
+        select(RegistryRepository).where(
+            RegistryRepository.organization_id == svc_role.organization_id,
+            RegistryRepository.origin == "tracecat_registry",
+        )
+    )
+    if org_repo is None:
+        org_repo = RegistryRepository(
+            organization_id=svc_role.organization_id,
+            origin="tracecat_registry",
+        )
+        session.add(org_repo)
+        await session.flush()
+
+    org_version = RegistryVersion(
+        organization_id=svc_role.organization_id,
+        repository_id=org_repo.id,
+        version="org-override-1",
+        manifest=_make_manifest(["tools.custom.same_origin"]),
+        tarball_uri="s3://org/override.tar.gz",
+    )
+    session.add(org_version)
+    await session.flush()
+    org_repo.current_version_id = org_version.id
+    session.add(org_repo)
+    await session.commit()
+
+    service = RegistryLockService(session, role=svc_role)
+    lock = await service.resolve_lock_with_bindings({"tools.custom.same_origin"})
+
+    assert lock.actions["tools.custom.same_origin"] == "tracecat_registry"
+    assert lock.origins["tracecat_registry"] == "2.0.0-beta.1"
+
+
+@pytest.mark.anyio
+async def test_resolve_lock_raises_when_platform_builtin_not_synced(
+    svc_role: Role,
+    session: AsyncSession,
+) -> None:
+    """Unsynced builtin registry should block lock freezing until sync completes."""
 
     # Simulate an unsynced platform by clearing any seeded builtin version.
     seeded_platform_repo = await session.scalar(
@@ -614,12 +703,8 @@ async def test_resolve_lock_falls_back_to_installed_version_when_platform_not_sy
     await session.commit()
 
     service = RegistryLockService(session, role=svc_role)
-    lock = await service.resolve_lock_with_bindings(
-        {"integrations.greetings.say_hello"}
-    )
-
-    assert lock.origins["tracecat_registry"] == installed_version
-    assert "tracecat_registry" not in lock.actions.values()
+    with pytest.raises(BuiltinRegistryHasNoSelectionError, match="retry shortly"):
+        await service.resolve_lock_with_bindings({"integrations.greetings.say_hello"})
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_registry_lock_service.py
+++ b/tests/unit/test_registry_lock_service.py
@@ -497,6 +497,116 @@ async def test_resolve_lock_allows_template_step_with_run_python(
 
 
 @pytest.mark.anyio
+async def test_resolve_lock_always_includes_builtin_registry(
+    svc_role: Role,
+    session: AsyncSession,
+) -> None:
+    """Builtin tracecat_registry must be in the lock as a runtime dependency.
+
+    Custom actions import decorators/secrets/context from tracecat_registry,
+    so the ephemeral nsjail sandbox must always mount the builtin tarball —
+    even when no workflow action directly resolves to it.
+    """
+    # Platform registry with builtin origin
+    platform_repo = PlatformRegistryRepository(origin="tracecat_registry")
+    session.add(platform_repo)
+    await session.flush()
+
+    platform_version = PlatformRegistryVersion(
+        repository_id=platform_repo.id,
+        version="1.0.0-beta.39",
+        manifest=_make_manifest(["core.transform"]),
+        tarball_uri="s3://platform/builtin.tar.gz",
+    )
+    session.add(platform_version)
+    await session.flush()
+    platform_repo.current_version_id = platform_version.id
+    session.add(platform_repo)
+
+    # Org registry with a custom action that the workflow uses
+    org_repo = RegistryRepository(
+        organization_id=svc_role.organization_id,
+        origin="git+ssh://git@github.com/acme/internal.git",
+    )
+    session.add(org_repo)
+    await session.flush()
+
+    org_version = RegistryVersion(
+        organization_id=svc_role.organization_id,
+        repository_id=org_repo.id,
+        version="abc123",
+        manifest=_make_manifest(["integrations.greetings.say_hello"]),
+        tarball_uri="s3://org/custom.tar.gz",
+    )
+    session.add(org_version)
+    await session.flush()
+    org_repo.current_version_id = org_version.id
+    session.add(org_repo)
+    await session.commit()
+
+    # Workflow uses only the custom action — does NOT map to tracecat_registry
+    service = RegistryLockService(session, role=svc_role)
+    lock = await service.resolve_lock_with_bindings(
+        {"integrations.greetings.say_hello"}
+    )
+
+    # Custom origin is present because its action is used
+    assert "git+ssh://git@github.com/acme/internal.git" in lock.origins
+    assert lock.actions["integrations.greetings.say_hello"] == (
+        "git+ssh://git@github.com/acme/internal.git"
+    )
+
+    # Builtin registry is present as a runtime dependency, even though no
+    # workflow action resolves to it.
+    assert "tracecat_registry" in lock.origins
+    assert lock.origins["tracecat_registry"] == "1.0.0-beta.39"
+    # But no action is bound to it
+    assert "tracecat_registry" not in lock.actions.values()
+
+
+@pytest.mark.anyio
+async def test_resolve_lock_falls_back_to_installed_version_when_platform_not_synced(
+    svc_role: Role,
+    session: AsyncSession,
+) -> None:
+    """If the platform builtin has never been synced, fall back to installed version.
+
+    Without a current_version_id on the platform repo, the lock falls back to
+    the installed tracecat_registry package version so workflows can still
+    start (the in-image package remains importable even without a tarball).
+    """
+    from tracecat_registry import __version__ as installed_version
+
+    org_repo = RegistryRepository(
+        organization_id=svc_role.organization_id,
+        origin="git+ssh://git@github.com/acme/internal.git",
+    )
+    session.add(org_repo)
+    await session.flush()
+
+    org_version = RegistryVersion(
+        organization_id=svc_role.organization_id,
+        repository_id=org_repo.id,
+        version="abc123",
+        manifest=_make_manifest(["integrations.greetings.say_hello"]),
+        tarball_uri="s3://org/custom.tar.gz",
+    )
+    session.add(org_version)
+    await session.flush()
+    org_repo.current_version_id = org_version.id
+    session.add(org_repo)
+    await session.commit()
+
+    service = RegistryLockService(session, role=svc_role)
+    lock = await service.resolve_lock_with_bindings(
+        {"integrations.greetings.say_hello"}
+    )
+
+    assert lock.origins["tracecat_registry"] == installed_version
+    assert "tracecat_registry" not in lock.actions.values()
+
+
+@pytest.mark.anyio
 async def test_resolve_lock_rejects_template_step_with_other_platform_action(
     svc_role: Role,
     session: AsyncSession,

--- a/tests/unit/test_registry_lock_service.py
+++ b/tests/unit/test_registry_lock_service.py
@@ -571,17 +571,17 @@ async def test_resolve_lock_always_includes_builtin_registry(
 
 
 @pytest.mark.anyio
-async def test_resolve_lock_skips_builtin_origin_when_platform_not_synced(
+async def test_resolve_lock_falls_back_to_installed_version_when_platform_not_synced(
     svc_role: Role,
     session: AsyncSession,
 ) -> None:
-    """If the platform builtin has never been synced, skip builtin lock origin.
+    """If the platform builtin has never been synced, use installed package version.
 
-    Prefetching lock manifests loads every lock origin from DB before dispatch.
-    In the unsynced bootstrap scenario there is no platform version row for the
-    builtin registry, so adding a fallback version would fail prefetch and block
-    workflow dispatch.
+    Even when current_version_id is unset for the platform builtin repository,
+    the lock should still include tracecat_registry as a runtime dependency.
     """
+    from tracecat_registry import __version__ as installed_version
+
     # Simulate an unsynced platform by clearing any seeded builtin version.
     seeded_platform_repo = await session.scalar(
         select(PlatformRegistryRepository).where(
@@ -618,7 +618,7 @@ async def test_resolve_lock_skips_builtin_origin_when_platform_not_synced(
         {"integrations.greetings.say_hello"}
     )
 
-    assert "tracecat_registry" not in lock.origins
+    assert lock.origins["tracecat_registry"] == installed_version
     assert "tracecat_registry" not in lock.actions.values()
 
 

--- a/tests/unit/test_registry_lock_service.py
+++ b/tests/unit/test_registry_lock_service.py
@@ -565,17 +565,17 @@ async def test_resolve_lock_always_includes_builtin_registry(
 
 
 @pytest.mark.anyio
-async def test_resolve_lock_falls_back_to_installed_version_when_platform_not_synced(
+async def test_resolve_lock_skips_builtin_origin_when_platform_not_synced(
     svc_role: Role,
     session: AsyncSession,
 ) -> None:
-    """If the platform builtin has never been synced, fall back to installed version.
+    """If the platform builtin has never been synced, skip builtin lock origin.
 
-    Without a current_version_id on the platform repo, the lock falls back to
-    the installed tracecat_registry package version so workflows can still
-    start (the in-image package remains importable even without a tarball).
+    Prefetching lock manifests loads every lock origin from DB before dispatch.
+    In the unsynced bootstrap scenario there is no platform version row for the
+    builtin registry, so adding a fallback version would fail prefetch and block
+    workflow dispatch.
     """
-    from tracecat_registry import __version__ as installed_version
 
     org_repo = RegistryRepository(
         organization_id=svc_role.organization_id,
@@ -602,7 +602,7 @@ async def test_resolve_lock_falls_back_to_installed_version_when_platform_not_sy
         {"integrations.greetings.say_hello"}
     )
 
-    assert lock.origins["tracecat_registry"] == installed_version
+    assert "tracecat_registry" not in lock.origins
     assert "tracecat_registry" not in lock.actions.values()
 
 

--- a/tests/unit/test_registry_lock_service.py
+++ b/tests/unit/test_registry_lock_service.py
@@ -507,10 +507,16 @@ async def test_resolve_lock_always_includes_builtin_registry(
     so the ephemeral nsjail sandbox must always mount the builtin tarball —
     even when no workflow action directly resolves to it.
     """
-    # Platform registry with builtin origin
-    platform_repo = PlatformRegistryRepository(origin="tracecat_registry")
-    session.add(platform_repo)
-    await session.flush()
+    # Reuse the seeded builtin platform repo when present; otherwise create one.
+    platform_repo = await session.scalar(
+        select(PlatformRegistryRepository).where(
+            PlatformRegistryRepository.origin == "tracecat_registry",
+        )
+    )
+    if platform_repo is None:
+        platform_repo = PlatformRegistryRepository(origin="tracecat_registry")
+        session.add(platform_repo)
+        await session.flush()
 
     platform_version = PlatformRegistryVersion(
         repository_id=platform_repo.id,
@@ -576,6 +582,16 @@ async def test_resolve_lock_skips_builtin_origin_when_platform_not_synced(
     builtin registry, so adding a fallback version would fail prefetch and block
     workflow dispatch.
     """
+    # Simulate an unsynced platform by clearing any seeded builtin version.
+    seeded_platform_repo = await session.scalar(
+        select(PlatformRegistryRepository).where(
+            PlatformRegistryRepository.origin == "tracecat_registry",
+        )
+    )
+    if seeded_platform_repo is not None:
+        seeded_platform_repo.current_version_id = None
+        session.add(seeded_platform_repo)
+        await session.flush()
 
     org_repo = RegistryRepository(
         organization_id=svc_role.organization_id,

--- a/tests/unit/test_registry_resolver.py
+++ b/tests/unit/test_registry_resolver.py
@@ -228,6 +228,42 @@ class TestPrefetchLock:
         mock_get_manifest_entry.assert_awaited_once()
 
     @pytest.mark.anyio
+    async def test_prefetch_lock_only_fetches_action_bound_origins(self):
+        custom_origin = "git+ssh://git@github.com/acme/custom.git"
+        lock = RegistryLock(
+            origins={
+                "tracecat_registry": "2024.12.10",
+                custom_origin: "v1",
+            },
+            actions={"tools.custom.only_action": custom_origin},
+        )
+        manifest = _make_manifest({})
+        organization_id = uuid.uuid4()
+
+        with (
+            patch.object(
+                registry_resolver,
+                "_has_custom_registry_entitlement",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_has_entitlement,
+            patch.object(
+                registry_resolver,
+                "_get_manifest_entry",
+                new_callable=AsyncMock,
+                return_value=(manifest, {}),
+            ) as mock_get_manifest_entry,
+        ):
+            await registry_resolver.prefetch_lock(lock, organization_id=organization_id)
+
+        mock_has_entitlement.assert_awaited_once()
+        mock_get_manifest_entry.assert_awaited_once_with(
+            custom_origin,
+            "v1",
+            organization_id,
+        )
+
+    @pytest.mark.anyio
     async def test_prefetch_lock_custom_origin_requires_entitlement(self):
         custom_origin = "git+ssh://git@github.com/acme/custom.git"
         lock = RegistryLock(

--- a/tests/unit/test_registry_resolver.py
+++ b/tests/unit/test_registry_resolver.py
@@ -228,7 +228,7 @@ class TestPrefetchLock:
         mock_get_manifest_entry.assert_awaited_once()
 
     @pytest.mark.anyio
-    async def test_prefetch_lock_only_fetches_action_bound_origins(self):
+    async def test_prefetch_lock_fetches_all_lock_origins(self):
         custom_origin = "git+ssh://git@github.com/acme/custom.git"
         lock = RegistryLock(
             origins={
@@ -257,7 +257,13 @@ class TestPrefetchLock:
             await registry_resolver.prefetch_lock(lock, organization_id=organization_id)
 
         mock_has_entitlement.assert_awaited_once()
-        mock_get_manifest_entry.assert_awaited_once_with(
+        assert mock_get_manifest_entry.await_count == 2
+        mock_get_manifest_entry.assert_any_await(
+            "tracecat_registry",
+            "2024.12.10",
+            organization_id,
+        )
+        mock_get_manifest_entry.assert_any_await(
             custom_origin,
             "v1",
             organization_id,

--- a/tests/unit/test_workflow_definitions_activities.py
+++ b/tests/unit/test_workflow_definitions_activities.py
@@ -8,7 +8,7 @@ from temporalio.exceptions import ApplicationError
 
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
-from tracecat.exceptions import EntitlementRequired
+from tracecat.exceptions import BuiltinRegistryHasNoSelectionError, EntitlementRequired
 from tracecat.workflow.management.definitions import resolve_registry_lock_activity
 from tracecat.workflow.management.schemas import ResolveRegistryLockActivityInputs
 
@@ -54,3 +54,37 @@ async def test_resolve_registry_lock_activity_maps_entitlement_error(
     detail = app_error.details[0]
     assert isinstance(detail, dict)
     assert detail["entitlement"] == "custom_registry"
+
+
+@pytest.mark.anyio
+async def test_resolve_registry_lock_activity_maps_builtin_sync_pending_as_retryable(
+    mock_role: Role,
+) -> None:
+    inputs = ResolveRegistryLockActivityInputs(
+        role=mock_role,
+        action_names={"tools.custom.only_action"},
+    )
+    mock_service = AsyncMock()
+    mock_service.resolve_lock_with_bindings.side_effect = (
+        BuiltinRegistryHasNoSelectionError(
+            "Builtin registry sync is still in progress. Please retry shortly.",
+            detail={"origin": "tracecat_registry"},
+        )
+    )
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__.return_value = mock_service
+
+    with patch(
+        "tracecat.workflow.management.definitions.RegistryLockService.with_session",
+        return_value=mock_ctx,
+    ):
+        with pytest.raises(ApplicationError) as exc_info:
+            await resolve_registry_lock_activity(inputs)
+
+    app_error = exc_info.value
+    assert app_error.type == "BuiltinRegistryHasNoSelectionError"
+    assert app_error.non_retryable is False
+    assert len(app_error.details) > 0
+    detail = app_error.details[0]
+    assert isinstance(detail, dict)
+    assert detail["origin"] == "tracecat_registry"

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -34,7 +34,11 @@ from tracecat.agent.tokens import MCPTokenClaims, verify_mcp_token
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.contexts import ctx_role
-from tracecat.exceptions import EntitlementRequired, ExecutionError
+from tracecat.exceptions import (
+    BuiltinRegistryHasNoSelectionError,
+    EntitlementRequired,
+    ExecutionError,
+)
 from tracecat.logger import logger
 from tracecat.registry.lock.service import RegistryLockService
 
@@ -124,6 +128,8 @@ async def execute_action_tool(
         )
         raise ToolError(error_msg) from e
     except EntitlementRequired as e:
+        raise ToolError(str(e)) from e
+    except BuiltinRegistryHasNoSelectionError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
         # Unexpected platform errors - log full details but return generic message

--- a/tracecat/exceptions.py
+++ b/tracecat/exceptions.py
@@ -123,6 +123,10 @@ class RegistryError(TracecatException):
     """Generic exception raised when a registry error occurs."""
 
 
+class BuiltinRegistryHasNoSelectionError(RegistryError):
+    """Raised when the builtin platform registry has no selected version yet."""
+
+
 class RegistryActionError(RegistryError):
     """Exception raised when a registry action error occurs."""
 

--- a/tracecat/executor/registry_resolver.py
+++ b/tracecat/executor/registry_resolver.py
@@ -218,15 +218,24 @@ async def prefetch_lock(lock: RegistryLock, organization_id: OrganizationID) -> 
     """
     await _require_custom_registry_entitlement_if_needed(lock, organization_id)
 
+    prefetch_origins = lock.origins
+    if lock.actions:
+        prefetch_origins = {
+            origin: lock.origins[origin]
+            for origin in set(lock.actions.values())
+            if origin in lock.origins
+        }
+
     tasks = [
         _get_manifest_entry(origin, version, organization_id)
-        for origin, version in lock.origins.items()
+        for origin, version in prefetch_origins.items()
     ]
-    await asyncio.gather(*tasks)
+    if tasks:
+        await asyncio.gather(*tasks)
 
     logger.debug(
         "Prefetched registry lock",
-        num_origins=len(lock.origins),
+        num_origins=len(prefetch_origins),
         num_actions=len(lock.actions),
     )
 

--- a/tracecat/executor/registry_resolver.py
+++ b/tracecat/executor/registry_resolver.py
@@ -218,24 +218,16 @@ async def prefetch_lock(lock: RegistryLock, organization_id: OrganizationID) -> 
     """
     await _require_custom_registry_entitlement_if_needed(lock, organization_id)
 
-    prefetch_origins = lock.origins
-    if lock.actions:
-        prefetch_origins = {
-            origin: lock.origins[origin]
-            for origin in set(lock.actions.values())
-            if origin in lock.origins
-        }
-
     tasks = [
         _get_manifest_entry(origin, version, organization_id)
-        for origin, version in prefetch_origins.items()
+        for origin, version in lock.origins.items()
     ]
     if tasks:
         await asyncio.gather(*tasks)
 
     logger.debug(
         "Prefetched registry lock",
-        num_origins=len(prefetch_origins),
+        num_origins=len(lock.origins),
         num_actions=len(lock.actions),
     )
 

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -82,7 +82,11 @@ from tracecat.dsl.validation import (
     format_input_schema_validation_error,
     normalize_trigger_inputs,
 )
-from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.exceptions import (
+    BuiltinRegistryHasNoSelectionError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
 from tracecat.identifiers.workflow import (
     WorkflowUUID,
     exec_id_to_parts,
@@ -132,7 +136,11 @@ from tracecat.tables.schemas import TableCreate, TableRowInsert, TableUpdate
 from tracecat.tables.service import TablesService
 from tracecat.tags.schemas import TagCreate, TagRead, TagUpdate
 from tracecat.tags.service import TagsService
-from tracecat.validation.schemas import ValidationDetail
+from tracecat.validation.schemas import (
+    ValidationDetail,
+    ValidationResult,
+    ValidationResultType,
+)
 from tracecat.validation.service import validate_dsl
 from tracecat.variables.service import VariablesService
 from tracecat.webhooks import service as webhook_service
@@ -1541,14 +1549,17 @@ async def _create_workflow_from_import_data(
     trigger_position, viewport, action_positions = _extract_layout_positions(
         layout_data
     )
-    async with WorkflowsManagementService.with_session(role=role) as svc:
-        return await svc.create_workflow_from_external_definition(
-            import_data,
-            use_workflow_id=use_workflow_id,
-            trigger_position=trigger_position,
-            viewport=viewport,
-            action_positions=action_positions,
-        )
+    try:
+        async with WorkflowsManagementService.with_session(role=role) as svc:
+            return await svc.create_workflow_from_external_definition(
+                import_data,
+                use_workflow_id=use_workflow_id,
+                trigger_position=trigger_position,
+                viewport=viewport,
+                action_positions=action_positions,
+            )
+    except BuiltinRegistryHasNoSelectionError as exc:
+        raise ToolError(str(exc)) from exc
 
 
 async def _apply_workflow_yaml_update(
@@ -4184,7 +4195,31 @@ async def publish_workflow(
             # Phase 1: Resolve registry lock
             lock_service = RegistryLockService(session, role)
             action_names = {action.action for action in dsl.actions}
-            registry_lock = await lock_service.resolve_lock_with_bindings(action_names)
+            try:
+                registry_lock = await lock_service.resolve_lock_with_bindings(
+                    action_names
+                )
+            except BuiltinRegistryHasNoSelectionError as e:
+                error = ValidationResult.new(
+                    type=ValidationResultType.DSL,
+                    status="error",
+                    msg=str(e),
+                    detail=[
+                        ValidationDetail(
+                            type="registry.builtin_sync_pending",
+                            msg=str(e),
+                            loc=("registry_lock",),
+                        )
+                    ],
+                )
+                return _json(
+                    {
+                        "workflow_id": workflow_id,
+                        "status": "failure",
+                        "message": "1 validation error(s)",
+                        "errors": [_validation_result_payload(error)],
+                    }
+                )
             workflow.registry_lock = registry_lock.model_dump()
 
             # Phase 2: Create workflow definition

--- a/tracecat/registry/lock/service.py
+++ b/tracecat/registry/lock/service.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections import deque
 
 from sqlalchemy import select
-from tracecat_registry import __version__ as TRACECAT_REGISTRY_VERSION
 
 from tracecat.db.models import (
     PlatformRegistryRepository,
@@ -14,7 +13,11 @@ from tracecat.db.models import (
     RegistryVersion,
 )
 from tracecat.dsl.enums import PlatformAction
-from tracecat.exceptions import EntitlementRequired, RegistryError
+from tracecat.exceptions import (
+    BuiltinRegistryHasNoSelectionError,
+    EntitlementRequired,
+    RegistryError,
+)
 from tracecat.registry.actions.schemas import RegistryActionImplValidator
 from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
 from tracecat.registry.lock.types import RegistryLock
@@ -198,22 +201,25 @@ class RegistryLockService(BaseOrgService):
         # treats tracecat_registry as platform-scoped; an org override would miss.
         used_origins = set(actions.values())
         origins = {o: v for o, v in origins.items() if o in used_origins}
-        if DEFAULT_REGISTRY_ORIGIN not in origins:
-            if builtin_version := next(
-                (
-                    str(version)
-                    for origin, version, _ in platform_rows
-                    if origin == DEFAULT_REGISTRY_ORIGIN
-                ),
-                None,
-            ):
-                origins[DEFAULT_REGISTRY_ORIGIN] = builtin_version
-            else:
-                self.logger.warning(
-                    "Platform registry has no selected version; falling back to installed package version",
-                    origin=DEFAULT_REGISTRY_ORIGIN,
-                    fallback_version=TRACECAT_REGISTRY_VERSION,
-                )
+        builtin_version = next(
+            (
+                str(version)
+                for origin, version, _ in platform_rows
+                if origin == DEFAULT_REGISTRY_ORIGIN
+            ),
+            None,
+        )
+        if builtin_version is None:
+            self.logger.info(
+                "Platform registry has no selected version; builtin lock resolution is pending sync",
+                origin=DEFAULT_REGISTRY_ORIGIN,
+            )
+            raise BuiltinRegistryHasNoSelectionError(
+                "Builtin registry sync is still in progress. Please retry shortly.",
+                detail={"origin": DEFAULT_REGISTRY_ORIGIN},
+            )
+
+        origins[DEFAULT_REGISTRY_ORIGIN] = builtin_version
 
         self.logger.debug(
             "Resolved lock with bindings",

--- a/tracecat/registry/lock/service.py
+++ b/tracecat/registry/lock/service.py
@@ -199,15 +199,14 @@ class RegistryLockService(BaseOrgService):
         used_origins = set(actions.values())
         origins = {o: v for o, v in origins.items() if o in used_origins}
         if DEFAULT_REGISTRY_ORIGIN not in origins:
-            builtin_version = next(
+            if builtin_version := next(
                 (
                     str(version)
                     for origin, version, _ in platform_rows
                     if origin == DEFAULT_REGISTRY_ORIGIN
                 ),
                 None,
-            )
-            if builtin_version is not None:
+            ):
                 origins[DEFAULT_REGISTRY_ORIGIN] = builtin_version
             else:
                 self.logger.warning(
@@ -215,7 +214,6 @@ class RegistryLockService(BaseOrgService):
                     origin=DEFAULT_REGISTRY_ORIGIN,
                     fallback_version=TRACECAT_REGISTRY_VERSION,
                 )
-                origins[DEFAULT_REGISTRY_ORIGIN] = TRACECAT_REGISTRY_VERSION
 
         self.logger.debug(
             "Resolved lock with bindings",

--- a/tracecat/registry/lock/service.py
+++ b/tracecat/registry/lock/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import deque
 
 from sqlalchemy import select
+from tracecat_registry import __version__ as TRACECAT_REGISTRY_VERSION
 
 from tracecat.db.models import (
     PlatformRegistryRepository,
@@ -15,6 +16,7 @@ from tracecat.db.models import (
 from tracecat.dsl.enums import PlatformAction
 from tracecat.exceptions import EntitlementRequired, RegistryError
 from tracecat.registry.actions.schemas import RegistryActionImplValidator
+from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.registry.versions.schemas import RegistryVersionManifest
 from tracecat.service import BaseOrgService
@@ -188,13 +190,26 @@ class RegistryLockService(BaseOrgService):
                         if step.action not in actions:
                             queue.append(step.action)
 
-        # Only keep origins that are actually needed for the resolved actions.
+        # Only keep origins needed for resolved actions. Always include the
+        # builtin platform registry — tracecat_registry is a runtime dependency
+        # for every action (decorators, secrets, context, SDK helpers imported
+        # from it), so its tarball must always be mounted in the ephemeral
+        # nsjail sandbox. Use the platform version because artifact lookup
+        # treats tracecat_registry as platform-scoped; an org override would miss.
         used_origins = set(actions.values())
-        origins = {
-            origin: version
-            for origin, version in origins.items()
-            if origin in used_origins
-        }
+        origins = {o: v for o, v in origins.items() if o in used_origins}
+        if DEFAULT_REGISTRY_ORIGIN not in origins:
+            builtin_version = next(
+                (v for o, v, _ in platform_rows if o == DEFAULT_REGISTRY_ORIGIN), None
+            )
+            if builtin_version is None:
+                self.logger.warning(
+                    "Platform registry has no selected version; falling back to installed package version",
+                    origin=DEFAULT_REGISTRY_ORIGIN,
+                    fallback_version=TRACECAT_REGISTRY_VERSION,
+                )
+                builtin_version = TRACECAT_REGISTRY_VERSION
+            origins[DEFAULT_REGISTRY_ORIGIN] = builtin_version
 
         self.logger.debug(
             "Resolved lock with bindings",

--- a/tracecat/registry/lock/service.py
+++ b/tracecat/registry/lock/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import deque
 
 from sqlalchemy import select
+from tracecat_registry import __version__ as TRACECAT_REGISTRY_VERSION
 
 from tracecat.db.models import (
     PlatformRegistryRepository,
@@ -210,9 +211,11 @@ class RegistryLockService(BaseOrgService):
                 origins[DEFAULT_REGISTRY_ORIGIN] = builtin_version
             else:
                 self.logger.warning(
-                    "Platform registry has no selected version; skipping builtin origin in lock",
+                    "Platform registry has no selected version; falling back to installed package version",
                     origin=DEFAULT_REGISTRY_ORIGIN,
+                    fallback_version=TRACECAT_REGISTRY_VERSION,
                 )
+                origins[DEFAULT_REGISTRY_ORIGIN] = TRACECAT_REGISTRY_VERSION
 
         self.logger.debug(
             "Resolved lock with bindings",

--- a/tracecat/registry/lock/service.py
+++ b/tracecat/registry/lock/service.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections import deque
 
 from sqlalchemy import select
-from tracecat_registry import __version__ as TRACECAT_REGISTRY_VERSION
 
 from tracecat.db.models import (
     PlatformRegistryRepository,
@@ -200,16 +199,20 @@ class RegistryLockService(BaseOrgService):
         origins = {o: v for o, v in origins.items() if o in used_origins}
         if DEFAULT_REGISTRY_ORIGIN not in origins:
             builtin_version = next(
-                (v for o, v, _ in platform_rows if o == DEFAULT_REGISTRY_ORIGIN), None
+                (
+                    str(version)
+                    for origin, version, _ in platform_rows
+                    if origin == DEFAULT_REGISTRY_ORIGIN
+                ),
+                None,
             )
-            if builtin_version is None:
+            if builtin_version is not None:
+                origins[DEFAULT_REGISTRY_ORIGIN] = builtin_version
+            else:
                 self.logger.warning(
-                    "Platform registry has no selected version; falling back to installed package version",
+                    "Platform registry has no selected version; skipping builtin origin in lock",
                     origin=DEFAULT_REGISTRY_ORIGIN,
-                    fallback_version=TRACECAT_REGISTRY_VERSION,
                 )
-                builtin_version = TRACECAT_REGISTRY_VERSION
-            origins[DEFAULT_REGISTRY_ORIGIN] = builtin_version
 
         self.logger.debug(
             "Resolved lock with bindings",

--- a/tracecat/workflow/management/definitions.py
+++ b/tracecat/workflow/management/definitions.py
@@ -8,7 +8,7 @@ from temporalio.exceptions import ApplicationError
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import Workflow, WorkflowDefinition
 from tracecat.dsl.common import DSLInput
-from tracecat.exceptions import EntitlementRequired
+from tracecat.exceptions import BuiltinRegistryHasNoSelectionError, EntitlementRequired
 from tracecat.identifiers.workflow import WorkflowID
 from tracecat.logger import logger
 from tracecat.registry.lock.service import RegistryLockService
@@ -143,6 +143,12 @@ async def resolve_registry_lock_activity(
     try:
         async with RegistryLockService.with_session(role=input.role) as service:
             lock = await service.resolve_lock_with_bindings(input.action_names)
+    except BuiltinRegistryHasNoSelectionError as e:
+        raise ApplicationError(
+            str(e),
+            e.detail,
+            type=e.__class__.__name__,
+        ) from e
     except EntitlementRequired as e:
         raise ApplicationError(
             str(e),

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -30,7 +30,11 @@ from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.models import Webhook, WebhookApiKey, Workflow
 from tracecat.dsl.common import DSLInput
 from tracecat.dsl.schemas import DSLConfig
-from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.exceptions import (
+    BuiltinRegistryHasNoSelectionError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
 from tracecat.identifiers.workflow import AnyWorkflowIDPath, WorkflowUUID
 from tracecat.logger import logger
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
@@ -498,7 +502,28 @@ async def commit_workflow(
     # This ensures the lock reflects the actual actions in the workflow, not stale data
     lock_service = RegistryLockService(session, role)
     action_names = {action.action for action in dsl.actions}
-    registry_lock = await lock_service.resolve_lock_with_bindings(action_names)
+    try:
+        registry_lock = await lock_service.resolve_lock_with_bindings(action_names)
+    except BuiltinRegistryHasNoSelectionError as e:
+        return WorkflowCommitResponse(
+            workflow_id=workflow_id.short(),
+            status="failure",
+            message="1 validation error(s)",
+            errors=[
+                ValidationResult.new(
+                    type=ValidationResultType.DSL,
+                    status="error",
+                    msg=str(e),
+                    detail=[
+                        ValidationDetail(
+                            type="registry.builtin_sync_pending",
+                            msg=str(e),
+                            loc=("registry_lock",),
+                        )
+                    ],
+                )
+            ],
+        )
     # Update the workflow with the newly computed lock
     workflow.registry_lock = registry_lock.model_dump()
 

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -273,6 +273,27 @@ async def create_workflow(
             workflow = await service.create_workflow_from_external_definition(
                 external_defn_data, use_workflow_id=use_workflow_id
             )
+        except BuiltinRegistryHasNoSelectionError as e:
+            error = ValidationResult.new(
+                type=ValidationResultType.DSL,
+                status="error",
+                msg=str(e),
+                detail=[
+                    ValidationDetail(
+                        type="registry.builtin_sync_pending",
+                        msg=str(e),
+                        loc=("registry_lock",),
+                    )
+                ],
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "status": "failure",
+                    "message": "1 validation error(s)",
+                    "errors": [error.root.model_dump(mode="json", exclude_none=True)],
+                },
+            ) from e
         except ValidationError as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -505,24 +526,23 @@ async def commit_workflow(
     try:
         registry_lock = await lock_service.resolve_lock_with_bindings(action_names)
     except BuiltinRegistryHasNoSelectionError as e:
+        error = ValidationResult.new(
+            type=ValidationResultType.DSL,
+            status="error",
+            msg=str(e),
+            detail=[
+                ValidationDetail(
+                    type="registry.builtin_sync_pending",
+                    msg=str(e),
+                    loc=("registry_lock",),
+                )
+            ],
+        )
         return WorkflowCommitResponse(
             workflow_id=workflow_id.short(),
             status="failure",
             message="1 validation error(s)",
-            errors=[
-                ValidationResult.new(
-                    type=ValidationResultType.DSL,
-                    status="error",
-                    msg=str(e),
-                    detail=[
-                        ValidationDetail(
-                            type="registry.builtin_sync_pending",
-                            msg=str(e),
-                            loc=("registry_lock",),
-                        )
-                    ],
-                )
-            ],
+            errors=[error],
         )
     # Update the workflow with the newly computed lock
     workflow.registry_lock = registry_lock.model_dump()


### PR DESCRIPTION
## Summary

- Always include the builtin `tracecat_registry` origin in the resolved registry lock so custom actions retain access to decorators, secrets, and SDK helpers imported from it.
- Fall back to the installed `tracecat_registry.__version__` with a warning log when the platform registry has no `current_version_id`, so workflows still start on unsynced bootstraps instead of failing at tarball mount.
- Consolidate the origin filter + builtin re-add into a single pass.
- Rewrite the stale "omits builtin when unsynced" test to assert the fallback version is used.

## Test plan

- [x] `uv run pytest tests/unit/test_registry_lock_service.py -x -q`
- [x] `uv run ruff check` + `ruff format --check`
- [x] `uv run basedpyright --warnings tracecat/registry/lock/service.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always include the builtin `tracecat_registry` in resolved registry locks using the platform-selected version. If it isn’t synced, block lock resolution and surface a clear, retryable error across API endpoints, MCP tools, and the Temporal agent; the executor now prefetches all lock origins.

- **Bug Fixes**
  - Always include `tracecat_registry` with the platform-selected version; if missing, raise `BuiltinRegistryHasNoSelectionError` (no fallback).
  - When builtin sync is pending, return/rethrow validation-style, retryable errors:
    - API commit/import/publish use `registry.builtin_sync_pending`.
    - MCP tools (`create_workflow`, `publish_workflow`, `execute_action_tool`) and the agent (`build_tool_definitions` activity, durable workflow) surface the same message as `ToolError`/Temporal `ApplicationError`.
  - Executor prefetches all lock origins (builtin and custom).

<sup>Written for commit 3cd594b592f41640feca7062a2aee609aa77dd13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

