### PR TITLE
fix(agents): restore max turns on agent harness

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -501,6 +501,7 @@ class DurableAgentWorkflow:
             sdk_session_data=self._sdk_session_data,
             is_fork=is_fork,
             use_workspace_credentials=args.agent_args.use_workspace_credentials,
+            max_requests=self.max_requests,
         )
 
         info = workflow.info()
@@ -591,6 +592,7 @@ class DurableAgentWorkflow:
                     sdk_session_data=self._sdk_session_data,
                     is_approval_continuation=True,
                     use_workspace_credentials=args.agent_args.use_workspace_credentials,
+                    max_requests=self.max_requests,
                 )
                 self._turn += 1
                 continue

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -486,6 +486,40 @@ class TestClaudeAgentRuntimeRun:
         assert captured_options[0].max_buffer_size == CLAUDE_SDK_MAX_BUFFER_SIZE_BYTES
 
     @pytest.mark.anyio
+    @pytest.mark.parametrize("max_requests", [None, 10])
+    async def test_passes_max_requests_as_max_turns(
+        self,
+        mock_socket_writer: MagicMock,
+        mock_claude_sdk_client: MagicMock,
+        sample_init_payload: RuntimeInitPayload,
+        max_requests: int | None,
+    ) -> None:
+        """Test that payload.max_requests is forwarded as max_turns to ClaudeAgentOptions."""
+        captured_options: list[Any] = []
+
+        def _mock_client_ctor(*_args: Any, **kwargs: Any) -> MagicMock:
+            captured_options.append(kwargs["options"])
+            return mock_claude_sdk_client
+
+        payload = replace(sample_init_payload, max_requests=max_requests)
+
+        with (
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKClient",
+                side_effect=_mock_client_ctor,
+            ),
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.create_proxy_mcp_server",
+                AsyncMock(return_value={}),
+            ),
+        ):
+            runtime = ClaudeAgentRuntime(mock_socket_writer)
+            await runtime.run(payload)
+
+        assert captured_options
+        assert captured_options[0].max_turns == max_requests
+
+    @pytest.mark.anyio
     async def test_sets_auto_compact_window_for_custom_model_provider(
         self,
         mock_socket_writer: MagicMock,

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -45,6 +45,7 @@ class RuntimeInitPayload:
     sdk_session_data: str | None = None  # JSONL content for resume
     is_approval_continuation: bool = False  # True when resuming after approval decision
     is_fork: bool = False
+    max_requests: int | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RuntimeInitPayload:
@@ -77,6 +78,7 @@ class RuntimeInitPayload:
             sdk_session_data=data.get("sdk_session_data"),
             is_approval_continuation=data.get("is_approval_continuation", False),
             is_fork=data.get("is_fork", False),
+            max_requests=data.get("max_requests"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -91,6 +93,8 @@ class RuntimeInitPayload:
             "is_approval_continuation": self.is_approval_continuation,
             "is_fork": self.is_fork,
         }
+        if self.max_requests is not None:
+            result["max_requests"] = self.max_requests
         if self.allowed_actions is not None:
             result["allowed_actions"] = {
                 k: v.to_dict() for k, v in self.allowed_actions.items()

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -72,6 +72,8 @@ class AgentExecutorInput(BaseModel):
     # Credential scope used by the LLM proxy in passthrough mode to fetch the
     # customer's upstream API key. Not a secret.
     use_workspace_credentials: bool = False
+    # Maximum number of LLM requests (turns) per execution
+    max_requests: int | None = None
 
 
 class AgentExecutorResult(BaseModel):
@@ -202,6 +204,7 @@ class SandboxedAgentExecutor:
                 sdk_session_data=self.input.sdk_session_data,
                 is_approval_continuation=self.input.is_approval_continuation,
                 is_fork=self.input.is_fork,
+                max_requests=self.input.max_requests,
             )
             handler = LoopbackHandler(input=loopback_input)
 

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -79,6 +79,7 @@ class LoopbackInput:
     sdk_session_data: str | None = None
     is_approval_continuation: bool = False
     is_fork: bool = False  # True when forking from parent session
+    max_requests: int | None = None
 
 
 @dataclass(kw_only=True, slots=True)
@@ -394,6 +395,7 @@ class LoopbackHandler:
             sdk_session_data=self.input.sdk_session_data,
             is_approval_continuation=self.input.is_approval_continuation,
             is_fork=self.input.is_fork,
+            max_requests=self.input.max_requests,
         )
 
         payload_bytes = orjson.dumps(payload.to_dict())

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -687,6 +687,7 @@ class ClaudeAgentRuntime:
                 include_partial_messages=True,
                 resume=resume_session_id,
                 fork_session=fork_session,  # If True, creates new session from parent's history
+                max_turns=payload.max_requests,
                 env={
                     "ANTHROPIC_AUTH_TOKEN": payload.llm_gateway_auth_token,
                     "ANTHROPIC_BASE_URL": get_llm_proxy_url(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores max-turn enforcement in the agent harness end-to-end to prevent unbounded loops and honor the configured workflow limit.

- **Bug Fixes**
  - Propagate `max_requests` from durable workflow to executor and approval continuations.
  - Add `max_requests` to `AgentExecutorInput`, `LoopbackInput`, and `RuntimeInitPayload` (serialize/deserialize); map to Claude runtime `max_turns`.
  - Add unit test ensuring `max_requests` is forwarded as `max_turns` (covers None and explicit limits).

<sup>Written for commit 48e49405d3ee8182311703995bf360ddf77f6726. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

