### PR TITLE
fix(api): make health endpoint async

### DIFF
--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -666,7 +666,7 @@ async def info(session: AsyncDBSessionBypass) -> AppInfo:
 
 
 @app.get("/health", tags=["public"])
-def check_health() -> HealthResponse:
+async def check_health() -> HealthResponse:
     return HealthResponse(status="ok")
 
 


### PR DESCRIPTION
## Summary
- Changes `/health` endpoint from `def` to `async def`
- Per FastAPI docs, simple endpoints returning JSON should use `async def` to run directly on the event loop

## Context
From FastAPI docs:
> "you should still consider defining an endpoint with `async def`, if it doesn't execute any blocking operations inside... but is instead used to return simple JSON data... as FastAPI would likely perform better, when running such a simple endpoint directly in the event loop instead of a separate thread"

With `def`, the health endpoint runs in a threadpool and requires two event loop interactions (schedule + collect). With `async def`, it runs directly on the event loop with one interaction, reducing overhead under load.

## Test plan
- [ ] Verify `/api/health` still returns `{"status": "ok"}`
- [ ] No functional change expected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `/health` endpoint `async def` so it runs on the event loop, removing threadpool overhead and improving probe responsiveness under load.

<sup>Written for commit 6e80a10941c1326df2932d669d7a8fdffe070992. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

