### PR TITLE
fix(api): add HTTPException handler for observability

### DIFF
--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -34,6 +34,7 @@ from tracecat.api.common import (
     bootstrap_role,
     custom_generate_unique_id,
     generic_exception_handler,
+    http_exception_handler,
     tracecat_exception_handler,
 )
 from tracecat.auth.credentials import authenticated_user_only
@@ -579,6 +580,7 @@ def create_app(**kwargs) -> FastAPI:
     )
     app.add_exception_handler(EntitlementRequired, entitlement_exception_handler)
     app.add_exception_handler(ScopeDeniedError, scope_denied_exception_handler)
+    app.add_exception_handler(HTTPException, http_exception_handler)
 
     # Middleware
     # Add authorization cache middleware first so it's available for all requests

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -1,4 +1,4 @@
-from fastapi import Request, Response, status
+from fastapi import HTTPException, Request, Response, status
 from fastapi.responses import ORJSONResponse
 from fastapi.routing import APIRoute
 from sqlalchemy import select
@@ -36,6 +36,29 @@ def generic_exception_handler(request: Request, exc: Exception) -> Response:
     return ORJSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         content={"message": "An unexpected error occurred. Please try again later."},
+    )
+
+
+def http_exception_handler(request: Request, exc: Exception) -> Response:
+    """Log HTTP exceptions with tenant context for observability."""
+    if not isinstance(exc, HTTPException):
+        return ORJSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"detail": str(exc)},
+        )
+    role = ctx_role.get()
+    log_method = logger.warning if exc.status_code < 500 else logger.error
+    log_method(
+        "HTTP error",
+        status_code=exc.status_code,
+        detail=exc.detail,
+        path=request.url.path,
+        method=request.method,
+        role=role,
+    )
+    return ORJSONResponse(
+        status_code=exc.status_code,
+        content={"detail": exc.detail},
     )
 
 

--- a/tracecat/api/common.py
+++ b/tracecat/api/common.py
@@ -1,4 +1,5 @@
 from fastapi import HTTPException, Request, Response, status
+from fastapi.exception_handlers import http_exception_handler as default_http_handler
 from fastapi.responses import ORJSONResponse
 from fastapi.routing import APIRoute
 from sqlalchemy import select
@@ -39,27 +40,20 @@ def generic_exception_handler(request: Request, exc: Exception) -> Response:
     )
 
 
-def http_exception_handler(request: Request, exc: Exception) -> Response:
+async def http_exception_handler(request: Request, exc: Exception) -> Response:
     """Log HTTP exceptions with tenant context for observability."""
-    if not isinstance(exc, HTTPException):
-        return ORJSONResponse(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={"detail": str(exc)},
-        )
+    http_exc = exc if isinstance(exc, HTTPException) else HTTPException(500, str(exc))
     role = ctx_role.get()
-    log_method = logger.warning if exc.status_code < 500 else logger.error
+    log_method = logger.warning if http_exc.status_code < 500 else logger.error
     log_method(
         "HTTP error",
-        status_code=exc.status_code,
-        detail=exc.detail,
+        status_code=http_exc.status_code,
+        detail=http_exc.detail,
         path=request.url.path,
         method=request.method,
         role=role,
     )
-    return ORJSONResponse(
-        status_code=exc.status_code,
-        content={"detail": exc.detail},
-    )
+    return await default_http_handler(request, http_exc)
 
 
 def bootstrap_role(organization_id: OrganizationID | None = None) -> Role:


### PR DESCRIPTION
## Summary
- Add custom exception handler for `HTTPException` that logs 4xx/5xx errors with tenant context
- Use `logger.warning` for 4xx, `logger.error` for 5xx
- Include role context (workspace_id, org_id, user_id), path, method, status_code, and detail

## Context
When investigating customer issues (e.g., git sync 400 errors), we could only see HTTP access logs like:
```
GET /api/workflows/sync/branches ... 400 Bad Request
```
The actual error detail (e.g., "Git repository URL not configured") was returned to the client but not logged server-side.

## Test plan
- [ ] Deploy to staging and trigger a 400 error (e.g., call sync/branches without git_repo_url configured)
- [ ] Verify the error detail appears in logs with role context

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a custom FastAPI `HTTPException` handler that logs 4xx as warnings and 5xx as errors with tenant role context and request info, and delegates response formatting to FastAPI’s default handler. Registered globally so API errors are logged with path, method, status, and detail while clients receive the standard JSON response.

<sup>Written for commit 5bb40bb12f4bd11bb17560a2cbb00fc40b134b70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

