### PR TITLE
fix(workflows): coerce empty alias to null on clear

### DIFF
--- a/frontend/src/components/builder/panel/workflow-panel.tsx
+++ b/frontend/src/components/builder/panel/workflow-panel.tsx
@@ -382,7 +382,7 @@ function WorkflowSettingsPanel({
                       placeholder="Unique identifier for this workflow"
                       {...field}
                       value={field.value || ""}
-                      onChange={field.onChange}
+                      onChange={(e) => field.onChange(e.target.value || null)}
                     />
                   </FormControl>
                   <FormMessage />

--- a/tracecat/workflow/management/schemas.py
+++ b/tracecat/workflow/management/schemas.py
@@ -120,6 +120,14 @@ class WorkflowUpdate(BaseModel):
     alias: str | None = None
     error_handler: str | None = None
 
+    @field_validator("alias", "error_handler", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v: Any) -> Any:
+        """Coerce "" to None so clearing the field doesn't collide on unique constraints."""
+        if isinstance(v, str) and v.strip() == "":
+            return None
+        return v
+
 
 class WorkflowCreate(BaseModel):
     title: str | None = Field(


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

Clearing out the `Alias` field would send an empty string, which would violate the duplicate constraint. So the user cannot remove a workflow alias.

Set `""` to `null` on the frontend and handle empty string on the backend.

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

1. Create two workflows
2. Add an alias to one of the workflows
3. Removing the alias should work successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bug where clearing a workflow alias sent an empty string and hit a unique constraint. Now empty or whitespace-only values are coerced to null so users can remove aliases safely. Also normalizes `error_handler`.

- **Bug Fixes**
  - Frontend: alias input sends `null` when cleared.
  - Backend: `WorkflowUpdate` validator maps empty/whitespace strings to `None` for `alias` and `error_handler`, preventing `uq_workflow_alias_workspace_id` collisions.

<sup>Written for commit 84318d20f424e9478f2d933f3ab6ca268b46ba8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

