### PR TITLE
fix(ui): show warning when GitHub App not configured for git sync

### DIFF
--- a/frontend/src/components/settings/workspace-sync-settings.tsx
+++ b/frontend/src/components/settings/workspace-sync-settings.tsx
@@ -1,11 +1,13 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
-import { GitPullRequestIcon } from "lucide-react"
+import { AlertTriangleIcon, GitPullRequestIcon } from "lucide-react"
+import Link from "next/link"
 import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 import type { WorkspaceRead } from "@/client"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import {
   Form,
@@ -18,7 +20,10 @@ import {
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { validateGitSshUrl } from "@/lib/git"
-import { useWorkspaceSettings } from "@/lib/hooks"
+import {
+  useGitHubAppCredentialsStatus,
+  useWorkspaceSettings,
+} from "@/lib/hooks"
 import { WorkflowPullDialog } from "../organization/workflow-pull-dialog"
 
 export const syncSettingsSchema = z.object({
@@ -40,6 +45,10 @@ export function WorkspaceSyncSettings({
 }: WorkspaceSyncSettingsProps) {
   const [pullDialogOpen, setPullDialogOpen] = useState(false)
   const { updateWorkspace, isUpdating } = useWorkspaceSettings(workspace.id)
+  const { credentialsStatus } = useGitHubAppCredentialsStatus()
+
+  const isGitHubAppConfigured =
+    credentialsStatus?.exists && !credentialsStatus?.is_corrupted
 
   const form = useForm<SyncSettingsForm>({
     resolver: zodResolver(syncSettingsSchema),
@@ -102,17 +111,41 @@ export function WorkspaceSyncSettings({
                 workspace
               </p>
             </div>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => setPullDialogOpen(true)}
-              className="flex items-center space-x-2"
-            >
-              <GitPullRequestIcon className="size-4" />
-              <span>Pull workflows</span>
-            </Button>
+            {isGitHubAppConfigured && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setPullDialogOpen(true)}
+                className="flex items-center space-x-2"
+              >
+                <GitPullRequestIcon className="size-4" />
+                <span>Pull workflows</span>
+              </Button>
+            )}
           </div>
+
+          {!isGitHubAppConfigured && credentialsStatus && (
+            <Alert variant="warning" className="mb-4">
+              <AlertTriangleIcon className="size-4" />
+              <AlertTitle>
+                {credentialsStatus.is_corrupted
+                  ? "GitHub App credentials are invalid"
+                  : "GitHub App not configured"}
+              </AlertTitle>
+              <AlertDescription>
+                {credentialsStatus.is_corrupted
+                  ? "The stored credentials could not be validated."
+                  : "A GitHub App is required to pull workflows from your repository."}{" "}
+                <Link
+                  href="/organization/vcs"
+                  className="font-medium underline underline-offset-4"
+                >
+                  Configure in organization settings
+                </Link>
+              </AlertDescription>
+            </Alert>
+          )}
 
           <div className="text-xs text-muted-foreground">
             <p>• Select a commit SHA to pull specific workflow versions</p>


### PR DESCRIPTION
## Summary
- Check GitHub App credentials status when workspace settings page loads
- Show inline warning with link to org settings when credentials are missing or corrupted
- Hide "Pull workflows" button when GitHub App is not properly configured

Previously, the button was always clickable but would fail to load commits if the GitHub App wasn't set up correctly.

## Test plan
- [ ] Navigate to workspace settings with a `git_repo_url` configured
- [ ] Without GitHub App credentials: verify warning "GitHub App not configured" appears with link to `/organization/vcs`
- [ ] With corrupted credentials: verify warning "GitHub App credentials are invalid" appears
- [ ] With valid credentials: verify "Pull workflows" button appears and works normally
- [ ] Click the org settings link and verify navigation works


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the "Pull workflows" action behind a GitHub App credentials check on the workspace settings page and show a clear warning with a link to configure when not set up. Prevents users from clicking a non-functional button.

- **Bug Fixes**
  - Hide "Pull workflows" unless valid GitHub App credentials exist.
  - Show an inline warning when credentials are missing or invalid, with a link to `/organization/vcs`.

<sup>Written for commit 537529c49be08737b807fe636f4d4f8bcddd4411. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

