### PR TITLE
feat(agents): cap on stop hook retries

### DIFF
--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -707,6 +707,83 @@ class TestClaudeAgentRuntimePreToolUseHook:
         runtime.client.interrupt.assert_awaited()
 
 
+class TestClaudeAgentRuntimeStopHook:
+    """Tests for ClaudeAgentRuntime._stop_hook().
+
+    The Stop hook guards against structured-output death loops: the CLI re-invokes
+    the model when its final message fails a stop-hook check (e.g. schema
+    validation). Without a cap the loop can run indefinitely.
+    """
+
+    @staticmethod
+    def _make_stop_input(*, stop_hook_active: bool) -> dict[str, Any]:
+        return {
+            "session_id": "test-session-id",
+            "transcript_path": "/tmp/test-transcript.jsonl",
+            "cwd": "/tmp",
+            "hook_event_name": "Stop",
+            "stop_hook_active": stop_hook_active,
+        }
+
+    @pytest.mark.anyio
+    async def test_natural_stop_passes_through(
+        self,
+        mock_socket_writer: MagicMock,
+    ) -> None:
+        """A natural stop (stop_hook_active=False) must not count against the cap."""
+        runtime = ClaudeAgentRuntime(mock_socket_writer)
+
+        result = await runtime._stop_hook(
+            input_data=cast(Any, self._make_stop_input(stop_hook_active=False)),
+            tool_use_id=None,
+            context=make_hook_context(),
+        )
+
+        assert result == {}
+        assert runtime._stop_hook_retries == 0
+
+    @pytest.mark.anyio
+    async def test_allows_retries_up_to_cap(
+        self,
+        mock_socket_writer: MagicMock,
+    ) -> None:
+        """The first MAX_STOP_HOOK_RETRIES active retries pass through unchanged."""
+        from tracecat.agent.runtime.claude_code.runtime import MAX_STOP_HOOK_RETRIES
+
+        runtime = ClaudeAgentRuntime(mock_socket_writer)
+
+        for _ in range(MAX_STOP_HOOK_RETRIES):
+            result = await runtime._stop_hook(
+                input_data=cast(Any, self._make_stop_input(stop_hook_active=True)),
+                tool_use_id=None,
+                context=make_hook_context(),
+            )
+            assert result == {}
+
+        assert runtime._stop_hook_retries == MAX_STOP_HOOK_RETRIES
+
+    @pytest.mark.anyio
+    async def test_terminates_turn_when_cap_exceeded(
+        self,
+        mock_socket_writer: MagicMock,
+    ) -> None:
+        """Once retries exceed the cap, the hook must stop the turn cleanly."""
+        from tracecat.agent.runtime.claude_code.runtime import MAX_STOP_HOOK_RETRIES
+
+        runtime = ClaudeAgentRuntime(mock_socket_writer)
+        runtime._stop_hook_retries = MAX_STOP_HOOK_RETRIES
+
+        result = await runtime._stop_hook(
+            input_data=cast(Any, self._make_stop_input(stop_hook_active=True)),
+            tool_use_id=None,
+            context=make_hook_context(),
+        )
+
+        assert result.get("continue_") is False
+        assert "retry cap" in (result.get("stopReason") or "").lower()
+        mock_socket_writer.send_log.assert_awaited()
+
+
 class TestClaudeAgentRuntimeInternalSessionLines:
     """Tests for ClaudeAgentRuntime internal session line filtering."""
 

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -17,6 +17,7 @@ import pytest
 from claude_agent_sdk.types import (
     HookContext,
     PreToolUseHookInput,
+    StopHookInput,
     SyncHookJSONOutput,
 )
 
@@ -716,7 +717,7 @@ class TestClaudeAgentRuntimeStopHook:
     """
 
     @staticmethod
-    def _make_stop_input(*, stop_hook_active: bool) -> dict[str, Any]:
+    def _make_stop_input(*, stop_hook_active: bool) -> StopHookInput:
         return {
             "session_id": "test-session-id",
             "transcript_path": "/tmp/test-transcript.jsonl",
@@ -734,7 +735,7 @@ class TestClaudeAgentRuntimeStopHook:
         runtime = ClaudeAgentRuntime(mock_socket_writer)
 
         result = await runtime._stop_hook(
-            input_data=cast(Any, self._make_stop_input(stop_hook_active=False)),
+            input_data=self._make_stop_input(stop_hook_active=False),
             tool_use_id=None,
             context=make_hook_context(),
         )
@@ -754,7 +755,7 @@ class TestClaudeAgentRuntimeStopHook:
 
         for _ in range(MAX_STOP_HOOK_RETRIES):
             result = await runtime._stop_hook(
-                input_data=cast(Any, self._make_stop_input(stop_hook_active=True)),
+                input_data=self._make_stop_input(stop_hook_active=True),
                 tool_use_id=None,
                 context=make_hook_context(),
             )
@@ -774,7 +775,7 @@ class TestClaudeAgentRuntimeStopHook:
         runtime._stop_hook_retries = MAX_STOP_HOOK_RETRIES
 
         result = await runtime._stop_hook(
-            input_data=cast(Any, self._make_stop_input(stop_hook_active=True)),
+            input_data=self._make_stop_input(stop_hook_active=True),
             tool_use_id=None,
             context=make_hook_context(),
         )

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -30,6 +30,7 @@ from claude_agent_sdk.types import (
     HookInput,
     PreToolUseHookSpecificOutput,
     ResultMessage,
+    StopHookInput,
     StreamEvent,
     SyncHookJSONOutput,
     SystemMessage,
@@ -160,6 +161,11 @@ LEGACY_REGISTRY_MCP_DOT_PREFIX = "mcp.tracecat_registry."
 CLAUDE_SDK_MAX_BUFFER_SIZE_BYTES = 5 * 1024 * 1024
 CUSTOM_MODEL_PROVIDER_AUTO_COMPACT_WINDOW = "128000"
 
+# Cap on how many times the CLI may re-invoke the model to satisfy a Stop hook
+# (e.g. structured-output schema validation). Without a cap the CLI can death-loop
+# when the model keeps emitting output that fails validation.
+MAX_STOP_HOOK_RETRIES = 3
+
 
 class ClaudeAgentRuntime:
     """Stateless, sandboxed Claude SDK runtime.
@@ -194,6 +200,8 @@ class ClaudeAgentRuntime:
         # Working directory for session file path resolution
         # Must match the cwd passed to ClaudeAgentOptions for session resume
         self._cwd: Path = Path.cwd()
+        # Tracks Stop hook retries within this run to break structured-output loops
+        self._stop_hook_retries: int = 0
 
     @staticmethod
     def _is_manual_compaction_prompt(prompt: str) -> bool:
@@ -553,6 +561,40 @@ class ClaudeAgentRuntime:
             "hookSpecificOutput": hook_output,
         }
 
+    async def _stop_hook(
+        self,
+        input_data: HookInput,
+        tool_use_id: str | None,  # noqa: ARG002
+        context: HookContext,  # noqa: ARG002
+    ) -> SyncHookJSONOutput:
+        """Stop hook: cap structured-output retry loops.
+
+        The CLI runs this on every natural stop. When ``stop_hook_active`` is True
+        the CLI is already inside a retry loop (e.g. structured-output schema
+        validation failed and it wants the model to try again). We let the first
+        ``MAX_STOP_HOOK_RETRIES`` retries through, then terminate the turn so a
+        broken schema or stuck model can't death-loop.
+        """
+        stop_input = cast(StopHookInput, input_data)
+        if not stop_input.get("stop_hook_active"):
+            return {}
+
+        self._stop_hook_retries += 1
+        if self._stop_hook_retries <= MAX_STOP_HOOK_RETRIES:
+            return {}
+
+        reason = (
+            f"Stop hook retry cap reached ({MAX_STOP_HOOK_RETRIES}); ending turn "
+            "to prevent a structured-output death loop."
+        )
+        await self._socket_writer.send_log(
+            "warning",
+            "Stop hook retry cap reached, terminating turn",
+            retries=self._stop_hook_retries,
+            cap=MAX_STOP_HOOK_RETRIES,
+        )
+        return {"continue_": False, "stopReason": reason}
+
     def _build_system_prompt(
         self, instructions: str | None, output_type: str | dict[str, Any] | None = None
     ) -> str:
@@ -722,6 +764,7 @@ class ClaudeAgentRuntime:
                 sandbox=sandbox_settings,
                 hooks={
                     "PreToolUse": [HookMatcher(hooks=[self._pre_tool_use_hook])],
+                    "Stop": [HookMatcher(hooks=[self._stop_hook])],
                 },
                 # Stable per-session working directory (deterministic across turns)
                 cwd=self._cwd,

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -30,7 +30,6 @@ from claude_agent_sdk.types import (
     HookInput,
     PreToolUseHookSpecificOutput,
     ResultMessage,
-    StopHookInput,
     StreamEvent,
     SyncHookJSONOutput,
     SystemMessage,
@@ -564,8 +563,8 @@ class ClaudeAgentRuntime:
     async def _stop_hook(
         self,
         input_data: HookInput,
-        tool_use_id: str | None,  # noqa: ARG002
-        context: HookContext,  # noqa: ARG002
+        tool_use_id: str | None,
+        context: HookContext,
     ) -> SyncHookJSONOutput:
         """Stop hook: cap structured-output retry loops.
 
@@ -575,8 +574,11 @@ class ClaudeAgentRuntime:
         ``MAX_STOP_HOOK_RETRIES`` retries through, then terminate the turn so a
         broken schema or stuck model can't death-loop.
         """
-        stop_input = cast(StopHookInput, input_data)
-        if not stop_input.get("stop_hook_active"):
+        if input_data["hook_event_name"] != "Stop":
+            raise ValueError(
+                f"Expected Stop hook event, got {input_data['hook_event_name']!r}"
+            )
+        if not input_data.get("stop_hook_active"):
             return {}
 
         self._stop_hook_retries += 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a retry cap to the Claude agent Stop hook to prevent structured-output death loops. Allows up to 3 active retries; on the next retry, the runtime stops the turn and logs a warning.

- **New Features**
  - Implemented `_stop_hook` with `MAX_STOP_HOOK_RETRIES=3`; natural stops don’t count. Exceeding the cap stops the turn and logs a warning.
  - Registered the `Stop` hook, typed input as `StopHookInput` from `claude_agent_sdk`, and added tests for natural pass-through, cap-bound retries, and cap-exceeded termination.

<sup>Written for commit 240906b7b2d868d65f9f1950c91a40fd8651f699. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

