### PR TITLE
fix: remote custom registry test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1058,26 +1058,36 @@ def _should_select_fixture_platform_current(
     *,
     current_version: str | None,
     fixture_version: str,
+    executor_backend: str | None = None,
 ) -> bool:
     """Return whether the fixture platform version should be current.
 
-    The fake fixture tarball is safe as the selected version only in the isolated
-    per-test DB. The shared/default DB may be used by live API and executor
-    services, so it must not get a fake current selection when the real builtin
-    registry has not synced yet.
+    The fake fixture tarball is safe as the selected version in the isolated
+    per-test DB and in TestBackend-only runs. The shared/default DB may also be
+    used by live executor services, so real executor paths must not get a fake
+    current selection when the real builtin registry has not synced yet.
     """
+    executor_backend = executor_backend or config.TRACECAT__EXECUTOR_BACKEND
     if sync_db_uri == TEST_DB_CONFIG.test_url_sync:
         return True
-    return current_version == fixture_version
+    if current_version == fixture_version:
+        return True
+    return current_version is None and executor_backend == "test"
 
 
 def _should_wait_for_live_platform_current(
     sync_db_uri: str,
     *,
     current_version: str | None,
+    executor_backend: str | None = None,
 ) -> bool:
     """Return whether a shared DB should wait for API startup registry sync."""
-    return sync_db_uri != TEST_DB_CONFIG.test_url_sync and current_version is None
+    executor_backend = executor_backend or config.TRACECAT__EXECUTOR_BACKEND
+    return (
+        sync_db_uri != TEST_DB_CONFIG.test_url_sync
+        and current_version is None
+        and executor_backend != "test"
+    )
 
 
 def _is_live_platform_current(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ os.environ.setdefault("TRACECAT__WORKFLOW_RETURN_STRATEGY", "context")
 import aioboto3
 import pytest
 import redis
+import tracecat_registry
 import tracecat_registry.integrations.aws_boto3 as boto3_module
 from dotenv import load_dotenv
 from minio import Minio
@@ -979,6 +980,18 @@ def registry_version_with_manifest(default_org: None) -> Iterator[None]:
             ):
                 platform_repo.current_version_id = platform_rv.id
                 session.commit()
+            elif _should_wait_for_live_platform_current(
+                sync_db_uri,
+                current_version=current_platform_version.version
+                if current_platform_version is not None
+                else None,
+            ):
+                _wait_for_live_platform_current(
+                    session,
+                    platform_repo.id,
+                    fixture_version=version,
+                    fixture_tarball_uri=fake_tarball_uri,
+                )
 
             # Create PlatformRegistryIndex entries for each action in the manifest
             # This is required for get_actions_from_index to work in agent tools
@@ -1056,6 +1069,92 @@ def _should_select_fixture_platform_current(
     if sync_db_uri == TEST_DB_CONFIG.test_url_sync:
         return True
     return current_version == fixture_version
+
+
+def _should_wait_for_live_platform_current(
+    sync_db_uri: str,
+    *,
+    current_version: str | None,
+) -> bool:
+    """Return whether a shared DB should wait for API startup registry sync."""
+    return sync_db_uri != TEST_DB_CONFIG.test_url_sync and current_version is None
+
+
+def _is_live_platform_current(
+    *,
+    version: str | None,
+    tarball_uri: str | None,
+    expected_version: str,
+    fixture_version: str,
+    fixture_tarball_uri: str,
+) -> bool:
+    """Return whether the selected platform version is the real synced builtin."""
+    return (
+        version == expected_version
+        and version != fixture_version
+        and tarball_uri is not None
+        and tarball_uri != fixture_tarball_uri
+    )
+
+
+def _wait_for_live_platform_current(
+    session,
+    repository_id: uuid.UUID,
+    *,
+    fixture_version: str,
+    fixture_tarball_uri: str,
+    timeout_seconds: float = 90.0,
+    poll_seconds: float = 0.5,
+) -> None:
+    """Wait for the API startup sync to select the real builtin registry.
+
+    CI starts API and pytest concurrently. The fixture must not promote its fake
+    tarball in the shared DB, but tests should also not race lock resolution
+    while the real platform sync is still packaging the builtin registry.
+    """
+    expected_version = tracecat_registry.__version__
+    deadline = time.monotonic() + timeout_seconds
+
+    while True:
+        current_version = session.scalar(
+            select(PlatformRegistryVersion)
+            .join(
+                PlatformRegistryRepository,
+                PlatformRegistryRepository.current_version_id
+                == PlatformRegistryVersion.id,
+            )
+            .where(PlatformRegistryRepository.id == repository_id)
+        )
+        if _is_live_platform_current(
+            version=current_version.version if current_version is not None else None,
+            tarball_uri=current_version.tarball_uri
+            if current_version is not None
+            else None,
+            expected_version=expected_version,
+            fixture_version=fixture_version,
+            fixture_tarball_uri=fixture_tarball_uri,
+        ):
+            logger.info(
+                "Live platform registry current version is ready",
+                version=current_version.version,
+                tarball_uri=current_version.tarball_uri,
+            )
+            return
+
+        if time.monotonic() >= deadline:
+            logger.warning(
+                "Timed out waiting for live platform registry current version",
+                expected_version=expected_version,
+                current_version=current_version.version
+                if current_version is not None
+                else None,
+                tarball_uri=current_version.tarball_uri
+                if current_version is not None
+                else None,
+            )
+            return
+
+        time.sleep(poll_seconds)
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ os.environ.setdefault("TRACECAT__WORKFLOW_RETURN_STRATEGY", "context")
 import aioboto3
 import pytest
 import redis
-import tracecat_registry
 import tracecat_registry.integrations.aws_boto3 as boto3_module
 from dotenv import load_dotenv
 from minio import Minio
@@ -980,18 +979,6 @@ def registry_version_with_manifest(default_org: None) -> Iterator[None]:
             ):
                 platform_repo.current_version_id = platform_rv.id
                 session.commit()
-            elif _should_wait_for_live_platform_current(
-                sync_db_uri,
-                current_version=current_platform_version.version
-                if current_platform_version is not None
-                else None,
-            ):
-                _wait_for_live_platform_current(
-                    session,
-                    platform_repo.id,
-                    fixture_version=version,
-                    fixture_tarball_uri=fake_tarball_uri,
-                )
 
             # Create PlatformRegistryIndex entries for each action in the manifest
             # This is required for get_actions_from_index to work in agent tools
@@ -1058,113 +1045,17 @@ def _should_select_fixture_platform_current(
     *,
     current_version: str | None,
     fixture_version: str,
-    executor_backend: str | None = None,
 ) -> bool:
     """Return whether the fixture platform version should be current.
 
-    The fake fixture tarball is safe as the selected version in the isolated
-    per-test DB and in TestBackend-only runs. The shared/default DB may also be
-    used by live executor services, so real executor paths must not get a fake
-    current selection when the real builtin registry has not synced yet.
+    The fake fixture tarball is safe as the selected version when no platform
+    current exists yet. The shared/default DB may also be used by live executor
+    services, so preserve any existing live current selection instead of
+    clobbering it with the fixture version.
     """
-    executor_backend = executor_backend or config.TRACECAT__EXECUTOR_BACKEND
     if sync_db_uri == TEST_DB_CONFIG.test_url_sync:
         return True
-    if current_version == fixture_version:
-        return True
-    return current_version is None and executor_backend == "test"
-
-
-def _should_wait_for_live_platform_current(
-    sync_db_uri: str,
-    *,
-    current_version: str | None,
-    executor_backend: str | None = None,
-) -> bool:
-    """Return whether a shared DB should wait for API startup registry sync."""
-    executor_backend = executor_backend or config.TRACECAT__EXECUTOR_BACKEND
-    return (
-        sync_db_uri != TEST_DB_CONFIG.test_url_sync
-        and current_version is None
-        and executor_backend != "test"
-    )
-
-
-def _is_live_platform_current(
-    *,
-    version: str | None,
-    tarball_uri: str | None,
-    expected_version: str,
-    fixture_version: str,
-    fixture_tarball_uri: str,
-) -> bool:
-    """Return whether the selected platform version is the real synced builtin."""
-    return (
-        version == expected_version
-        and version != fixture_version
-        and tarball_uri is not None
-        and tarball_uri != fixture_tarball_uri
-    )
-
-
-def _wait_for_live_platform_current(
-    session,
-    repository_id: uuid.UUID,
-    *,
-    fixture_version: str,
-    fixture_tarball_uri: str,
-    timeout_seconds: float = 90.0,
-    poll_seconds: float = 0.5,
-) -> None:
-    """Wait for the API startup sync to select the real builtin registry.
-
-    CI starts API and pytest concurrently. The fixture must not promote its fake
-    tarball in the shared DB, but tests should also not race lock resolution
-    while the real platform sync is still packaging the builtin registry.
-    """
-    expected_version = tracecat_registry.__version__
-    deadline = time.monotonic() + timeout_seconds
-
-    while True:
-        current_version = session.scalar(
-            select(PlatformRegistryVersion)
-            .join(
-                PlatformRegistryRepository,
-                PlatformRegistryRepository.current_version_id
-                == PlatformRegistryVersion.id,
-            )
-            .where(PlatformRegistryRepository.id == repository_id)
-        )
-        if _is_live_platform_current(
-            version=current_version.version if current_version is not None else None,
-            tarball_uri=current_version.tarball_uri
-            if current_version is not None
-            else None,
-            expected_version=expected_version,
-            fixture_version=fixture_version,
-            fixture_tarball_uri=fixture_tarball_uri,
-        ):
-            logger.info(
-                "Live platform registry current version is ready",
-                version=current_version.version,
-                tarball_uri=current_version.tarball_uri,
-            )
-            return
-
-        if time.monotonic() >= deadline:
-            logger.warning(
-                "Timed out waiting for live platform registry current version",
-                expected_version=expected_version,
-                current_version=current_version.version
-                if current_version is not None
-                else None,
-                tarball_uri=current_version.tarball_uri
-                if current_version is not None
-                else None,
-            )
-            return
-
-        time.sleep(poll_seconds)
+    return current_version is None or current_version == fixture_version
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -856,13 +856,15 @@ def registry_version_with_manifest(default_org: None) -> Iterator[None]:
                     RegistryVersion.version == version,
                 )
             )
+            fake_tarball_uri = "s3://test/test.tar.gz"
+
             if rv is None:
                 rv = RegistryVersion(
                     organization_id=TEST_ORG_ID,
                     repository_id=repo.id,
                     version=version,
                     manifest=manifest,
-                    tarball_uri="s3://test/test.tar.gz",
+                    tarball_uri=fake_tarball_uri,
                 )
                 session.add(rv)
                 try:
@@ -882,7 +884,7 @@ def registry_version_with_manifest(default_org: None) -> Iterator[None]:
                     session.refresh(rv)
             else:
                 rv.manifest = manifest
-                rv.tarball_uri = "s3://test/test.tar.gz"
+                rv.tarball_uri = fake_tarball_uri
                 session.commit()
 
             # Set current_version_id on the repository for lock resolution
@@ -933,7 +935,7 @@ def registry_version_with_manifest(default_org: None) -> Iterator[None]:
                     repository_id=platform_repo.id,
                     version=version,
                     manifest=manifest,
-                    tarball_uri="s3://test/test.tar.gz",
+                    tarball_uri=fake_tarball_uri,
                 )
                 session.add(platform_rv)
                 try:
@@ -952,11 +954,29 @@ def registry_version_with_manifest(default_org: None) -> Iterator[None]:
                     session.refresh(platform_rv)
             else:
                 platform_rv.manifest = manifest
-                platform_rv.tarball_uri = "s3://test/test.tar.gz"
+                platform_rv.tarball_uri = fake_tarball_uri
                 session.commit()
 
-            platform_repo.current_version_id = platform_rv.id
-            session.commit()
+            # Do not replace an already-selected live platform registry version.
+            # Integration tests run against Docker services that sync a real
+            # builtin tarball; clobbering it with this fixture's fake tarball can
+            # make unrelated workflow executions try to download s3://test/test.tar.gz.
+            current_platform_version = (
+                session.scalar(
+                    select(PlatformRegistryVersion).where(
+                        PlatformRegistryVersion.id == platform_repo.current_version_id
+                    )
+                )
+                if platform_repo.current_version_id is not None
+                else None
+            )
+            if (
+                platform_repo.current_version_id is None
+                or current_platform_version is None
+                or current_platform_version.version == version
+            ):
+                platform_repo.current_version_id = platform_rv.id
+                session.commit()
 
             # Create PlatformRegistryIndex entries for each action in the manifest
             # This is required for get_actions_from_index to work in agent tools

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -970,10 +970,12 @@ def registry_version_with_manifest(default_org: None) -> Iterator[None]:
                 if platform_repo.current_version_id is not None
                 else None
             )
-            if (
-                platform_repo.current_version_id is None
-                or current_platform_version is None
-                or current_platform_version.version == version
+            if _should_select_fixture_platform_current(
+                sync_db_uri,
+                current_version=current_platform_version.version
+                if current_platform_version is not None
+                else None,
+                fixture_version=version,
             ):
                 platform_repo.current_version_id = platform_rv.id
                 session.commit()
@@ -1036,6 +1038,24 @@ def registry_version_with_manifest(default_org: None) -> Iterator[None]:
 
     yield
     # No cleanup needed - the database is dropped at the end of the session
+
+
+def _should_select_fixture_platform_current(
+    sync_db_uri: str,
+    *,
+    current_version: str | None,
+    fixture_version: str,
+) -> bool:
+    """Return whether the fixture platform version should be current.
+
+    The fake fixture tarball is safe as the selected version only in the isolated
+    per-test DB. The shared/default DB may be used by live API and executor
+    services, so it must not get a fake current selection when the real builtin
+    registry has not synced yet.
+    """
+    if sync_db_uri == TEST_DB_CONFIG.test_url_sync:
+        return True
+    return current_version == fixture_version
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/test_install_and_run_custom_remote_registry_flow.py
+++ b/tests/integration/test_install_and_run_custom_remote_registry_flow.py
@@ -32,12 +32,168 @@ from tracecat.dsl.schemas import ActionStatement
 from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
+from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
 from tracecat.secrets.enums import SecretType
 from tracecat.secrets.schemas import SecretCreate
 from tracecat.settings.schemas import GitSettingsUpdate
 
 GIT_SSH_URL = "git+ssh://git@github.com/TracecatHQ/internal-registry.git"
 KNOWN_GOOD_REMOTE_COMMIT_SHA = "e2bfd94c35c93f8052c2b97ff542961596ddd3f8"
+PLACEHOLDER_TARBALL_URI = "s3://test/test.tar.gz"
+
+
+def _assert_response_ok(response: requests.Response, action: str) -> None:
+    assert response.status_code == 200, (
+        f"{action} failed: {response.status_code} - {response.text}"
+    )
+
+
+def _builtin_versions(
+    session: requests.Session,
+    base_url: str,
+    repository_id: str,
+) -> list[dict]:
+    versions_response = session.get(
+        f"{base_url}/admin/registry/versions",
+        params={"repository_id": repository_id},
+    )
+    _assert_response_ok(versions_response, "List builtin platform registry versions")
+    return versions_response.json()
+
+
+def _current_builtin_version(
+    session: requests.Session,
+    base_url: str,
+    repository_id: str,
+    current_version_id: str | None,
+) -> dict | None:
+    if current_version_id is None:
+        return None
+
+    return next(
+        (
+            version
+            for version in _builtin_versions(session, base_url, repository_id)
+            if version["id"] == current_version_id
+        ),
+        None,
+    )
+
+
+def _has_real_tarball(version: dict | None) -> bool:
+    if version is None:
+        return False
+    tarball_uri = version.get("tarball_uri")
+    return bool(tarball_uri and tarball_uri != PLACEHOLDER_TARBALL_URI)
+
+
+def _sync_builtin_platform_registry(
+    session: requests.Session,
+    base_url: str,
+) -> None:
+    """Ensure tracecat_registry resolves to a downloadable platform tarball.
+
+    The remote custom registry sync only updates the org-scoped custom repo.
+    Workflow lock resolution always includes tracecat_registry as a runtime
+    dependency, so this test must ensure the platform builtin repo is not still
+    pointing at the placeholder fixture tarball.
+    """
+    repos_response = session.get(f"{base_url}/admin/registry/repos")
+    _assert_response_ok(repos_response, "List platform registry repositories")
+
+    builtin_repo = next(
+        (
+            repo
+            for repo in repos_response.json()
+            if repo["origin"] == DEFAULT_REGISTRY_ORIGIN
+        ),
+        None,
+    )
+
+    if builtin_repo is None:
+        sync_response = session.post(f"{base_url}/admin/registry/sync")
+        _assert_response_ok(sync_response, "Sync platform registry repositories")
+        sync_data = sync_response.json()
+        builtin_result = next(
+            (
+                result
+                for result in sync_data["repositories"]
+                if result["repository_name"] == DEFAULT_REGISTRY_ORIGIN
+            ),
+            None,
+        )
+        assert builtin_result is not None, "Builtin platform registry was not synced"
+        assert builtin_result["success"] is True, (
+            f"Builtin platform registry sync failed: {builtin_result}"
+        )
+        return
+
+    repository_id = builtin_repo["id"]
+    current_version = _current_builtin_version(
+        session,
+        base_url,
+        repository_id,
+        builtin_repo.get("current_version_id"),
+    )
+    if _has_real_tarball(current_version):
+        assert current_version is not None
+        logger.info(
+            "Builtin platform registry already has a real tarball",
+            version=current_version["version"],
+            tarball_uri=current_version["tarball_uri"],
+        )
+        return
+
+    sync_response = session.post(
+        f"{base_url}/admin/registry/sync/{repository_id}",
+        params={"force": True},
+    )
+    _assert_response_ok(sync_response, "Sync builtin platform registry")
+    sync_data = sync_response.json()
+    builtin_result = sync_data["repositories"][0]
+    assert builtin_result["success"] is True, (
+        f"Builtin platform registry sync failed: {builtin_result}"
+    )
+
+    repos_response = session.get(f"{base_url}/admin/registry/repos")
+    _assert_response_ok(repos_response, "Reload platform registry repositories")
+    builtin_repo = next(
+        repo
+        for repo in repos_response.json()
+        if repo["origin"] == DEFAULT_REGISTRY_ORIGIN
+    )
+    current_version = _current_builtin_version(
+        session,
+        base_url,
+        repository_id,
+        builtin_repo.get("current_version_id"),
+    )
+    if not _has_real_tarball(current_version):
+        versions = _builtin_versions(session, base_url, repository_id)
+        synced_version = builtin_result.get("version")
+        candidate = next(
+            (
+                version
+                for version in versions
+                if _has_real_tarball(version) and version["version"] == synced_version
+            ),
+            None,
+        ) or next(
+            (version for version in versions if _has_real_tarball(version)),
+            None,
+        )
+        assert candidate is not None, (
+            "Builtin platform registry sync did not create a real tarball version"
+        )
+        promote_response = session.post(
+            f"{base_url}/admin/registry/{repository_id}/versions/{candidate['id']}/promote"
+        )
+        _assert_response_ok(promote_response, "Promote builtin platform registry")
+        current_version = candidate
+
+    assert _has_real_tarball(current_version), (
+        "Builtin platform registry still points to the placeholder tarball"
+    )
 
 
 @pytest.mark.anyio
@@ -89,6 +245,9 @@ async def test_remote_custom_registry_repo() -> None:
     org_id = orgs_list[0]["id"]
     session.cookies.set("tracecat-org-id", org_id)
     logger.info("Set organization context", organization_id=org_id)
+
+    logger.info("Ensuring builtin platform registry tarball is synced")
+    _sync_builtin_platform_registry(session, base_url)
 
     # ---------------------------------------------------------------------
     # 2.  Get or create a RegistryRepository pointing to the remote Git repo

--- a/tests/unit/test_registry_fixture_platform_current.py
+++ b/tests/unit/test_registry_fixture_platform_current.py
@@ -19,6 +19,16 @@ def test_fixture_platform_current_is_not_selected_for_empty_default_db() -> None
         "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
         current_version=None,
         fixture_version="test-version",
+        executor_backend="direct",
+    )
+
+
+def test_fixture_platform_current_is_selected_for_test_backend_default_db() -> None:
+    assert _should_select_fixture_platform_current(
+        "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
+        current_version=None,
+        fixture_version="test-version",
+        executor_backend="test",
     )
 
 
@@ -27,6 +37,7 @@ def test_fixture_platform_current_is_reselected_when_already_current() -> None:
         "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
         current_version="test-version",
         fixture_version="test-version",
+        executor_backend="direct",
     )
 
 
@@ -35,13 +46,23 @@ def test_fixture_platform_current_preserves_live_default_current() -> None:
         "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
         current_version="1.0.0-beta.40",
         fixture_version="test-version",
+        executor_backend="test",
     )
 
 
-def test_fixture_waits_for_empty_default_db_current() -> None:
+def test_fixture_waits_for_empty_default_db_current_with_real_executor() -> None:
     assert _should_wait_for_live_platform_current(
         "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
         current_version=None,
+        executor_backend="direct",
+    )
+
+
+def test_fixture_does_not_wait_for_test_backend_default_db_current() -> None:
+    assert not _should_wait_for_live_platform_current(
+        "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
+        current_version=None,
+        executor_backend="test",
     )
 
 
@@ -49,6 +70,7 @@ def test_fixture_does_not_wait_for_per_test_db_current() -> None:
     assert not _should_wait_for_live_platform_current(
         TEST_DB_CONFIG.test_url_sync,
         current_version=None,
+        executor_backend="direct",
     )
 
 

--- a/tests/unit/test_registry_fixture_platform_current.py
+++ b/tests/unit/test_registry_fixture_platform_current.py
@@ -1,4 +1,8 @@
-from tests.conftest import _should_select_fixture_platform_current
+from tests.conftest import (
+    _is_live_platform_current,
+    _should_select_fixture_platform_current,
+    _should_wait_for_live_platform_current,
+)
 from tests.database import TEST_DB_CONFIG
 
 
@@ -31,4 +35,38 @@ def test_fixture_platform_current_preserves_live_default_current() -> None:
         "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
         current_version="1.0.0-beta.40",
         fixture_version="test-version",
+    )
+
+
+def test_fixture_waits_for_empty_default_db_current() -> None:
+    assert _should_wait_for_live_platform_current(
+        "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
+        current_version=None,
+    )
+
+
+def test_fixture_does_not_wait_for_per_test_db_current() -> None:
+    assert not _should_wait_for_live_platform_current(
+        TEST_DB_CONFIG.test_url_sync,
+        current_version=None,
+    )
+
+
+def test_live_platform_current_requires_expected_real_tarball() -> None:
+    assert _is_live_platform_current(
+        version="1.0.0-beta.40",
+        tarball_uri="s3://tracecat-registry/platform/tarball.tar.gz",
+        expected_version="1.0.0-beta.40",
+        fixture_version="test-version",
+        fixture_tarball_uri="s3://test/test.tar.gz",
+    )
+
+
+def test_live_platform_current_rejects_fixture_tarball() -> None:
+    assert not _is_live_platform_current(
+        version="test-version",
+        tarball_uri="s3://test/test.tar.gz",
+        expected_version="1.0.0-beta.40",
+        fixture_version="test-version",
+        fixture_tarball_uri="s3://test/test.tar.gz",
     )

--- a/tests/unit/test_registry_fixture_platform_current.py
+++ b/tests/unit/test_registry_fixture_platform_current.py
@@ -1,0 +1,34 @@
+from tests.conftest import _should_select_fixture_platform_current
+from tests.database import TEST_DB_CONFIG
+
+
+def test_fixture_platform_current_is_selected_in_per_test_db() -> None:
+    assert _should_select_fixture_platform_current(
+        TEST_DB_CONFIG.test_url_sync,
+        current_version=None,
+        fixture_version="test-version",
+    )
+
+
+def test_fixture_platform_current_is_not_selected_for_empty_default_db() -> None:
+    assert not _should_select_fixture_platform_current(
+        "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
+        current_version=None,
+        fixture_version="test-version",
+    )
+
+
+def test_fixture_platform_current_is_reselected_when_already_current() -> None:
+    assert _should_select_fixture_platform_current(
+        "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
+        current_version="test-version",
+        fixture_version="test-version",
+    )
+
+
+def test_fixture_platform_current_preserves_live_default_current() -> None:
+    assert not _should_select_fixture_platform_current(
+        "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
+        current_version="1.0.0-beta.40",
+        fixture_version="test-version",
+    )

--- a/tests/unit/test_registry_fixture_platform_current.py
+++ b/tests/unit/test_registry_fixture_platform_current.py
@@ -1,7 +1,5 @@
 from tests.conftest import (
-    _is_live_platform_current,
     _should_select_fixture_platform_current,
-    _should_wait_for_live_platform_current,
 )
 from tests.database import TEST_DB_CONFIG
 
@@ -14,21 +12,11 @@ def test_fixture_platform_current_is_selected_in_per_test_db() -> None:
     )
 
 
-def test_fixture_platform_current_is_not_selected_for_empty_default_db() -> None:
-    assert not _should_select_fixture_platform_current(
-        "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
-        current_version=None,
-        fixture_version="test-version",
-        executor_backend="direct",
-    )
-
-
-def test_fixture_platform_current_is_selected_for_test_backend_default_db() -> None:
+def test_fixture_platform_current_is_selected_for_empty_default_db() -> None:
     assert _should_select_fixture_platform_current(
         "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
         current_version=None,
         fixture_version="test-version",
-        executor_backend="test",
     )
 
 
@@ -37,7 +25,6 @@ def test_fixture_platform_current_is_reselected_when_already_current() -> None:
         "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
         current_version="test-version",
         fixture_version="test-version",
-        executor_backend="direct",
     )
 
 
@@ -46,49 +33,4 @@ def test_fixture_platform_current_preserves_live_default_current() -> None:
         "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
         current_version="1.0.0-beta.40",
         fixture_version="test-version",
-        executor_backend="test",
-    )
-
-
-def test_fixture_waits_for_empty_default_db_current_with_real_executor() -> None:
-    assert _should_wait_for_live_platform_current(
-        "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
-        current_version=None,
-        executor_backend="direct",
-    )
-
-
-def test_fixture_does_not_wait_for_test_backend_default_db_current() -> None:
-    assert not _should_wait_for_live_platform_current(
-        "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
-        current_version=None,
-        executor_backend="test",
-    )
-
-
-def test_fixture_does_not_wait_for_per_test_db_current() -> None:
-    assert not _should_wait_for_live_platform_current(
-        TEST_DB_CONFIG.test_url_sync,
-        current_version=None,
-        executor_backend="direct",
-    )
-
-
-def test_live_platform_current_requires_expected_real_tarball() -> None:
-    assert _is_live_platform_current(
-        version="1.0.0-beta.40",
-        tarball_uri="s3://tracecat-registry/platform/tarball.tar.gz",
-        expected_version="1.0.0-beta.40",
-        fixture_version="test-version",
-        fixture_tarball_uri="s3://test/test.tar.gz",
-    )
-
-
-def test_live_platform_current_rejects_fixture_tarball() -> None:
-    assert not _is_live_platform_current(
-        version="test-version",
-        tarball_uri="s3://test/test.tar.gz",
-        expected_version="1.0.0-beta.40",
-        fixture_version="test-version",
-        fixture_tarball_uri="s3://test/test.tar.gz",
     )

--- a/tests/unit/test_registry_lock_resolution.py
+++ b/tests/unit/test_registry_lock_resolution.py
@@ -11,8 +11,11 @@ These tests verify the fix for the regression where:
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.types import Role
@@ -60,15 +63,41 @@ async def _setup_platform_registry(
     session: AsyncSession, action_names: list[str], origin: str = "test_registry"
 ) -> PlatformRegistryVersion:
     """Set up a platform registry with the given actions."""
-    repo = PlatformRegistryRepository(origin=origin)
-    session.add(repo)
-    await session.flush()
+    effective_origin = (
+        origin if origin == DEFAULT_REGISTRY_ORIGIN else f"{origin}_{uuid.uuid4().hex}"
+    )
+
+    await session.execute(
+        insert(PlatformRegistryRepository)
+        .values(origin=effective_origin)
+        .on_conflict_do_nothing(index_elements=["origin"])
+    )
+    repo = await session.scalar(
+        select(PlatformRegistryRepository).where(
+            PlatformRegistryRepository.origin == effective_origin
+        )
+    )
+    if repo is None:
+        raise RuntimeError("Failed to create platform registry repository")
+
+    if (
+        effective_origin == DEFAULT_REGISTRY_ORIGIN
+        and not action_names
+        and repo.current_version_id is not None
+    ):
+        existing_version = await session.scalar(
+            select(PlatformRegistryVersion).where(
+                PlatformRegistryVersion.id == repo.current_version_id
+            )
+        )
+        if existing_version is not None:
+            return existing_version
 
     version = PlatformRegistryVersion(
         repository_id=repo.id,
-        version="1.0.0",
+        version=f"1.0.0-{uuid.uuid4().hex}",
         manifest=_make_manifest(action_names),
-        tarball_uri=f"s3://{origin}/v1.tar.gz",
+        tarball_uri=f"s3://{effective_origin}/v1.tar.gz",
     )
     session.add(version)
     await session.flush()

--- a/tests/unit/test_registry_lock_resolution.py
+++ b/tests/unit/test_registry_lock_resolution.py
@@ -25,6 +25,7 @@ from tracecat.db.models import (
     Tier,
 )
 from tracecat.dsl.common import DSLInput
+from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
 from tracecat.registry.lock.service import RegistryLockService
@@ -158,6 +159,25 @@ def _create_dsl_with_action(action_name: str, title: str = "Test Workflow") -> D
 
 class TestDraftWorkflowRegistryLock:
     """Tests for draft workflow registry_lock behavior."""
+
+    @pytest.mark.anyio
+    async def test_missing_builtin_current_raises_retryable_sync_pending(
+        self,
+        svc_role: Role,
+        session: AsyncSession,
+    ) -> None:
+        repo = await session.scalar(
+            select(PlatformRegistryRepository).where(
+                PlatformRegistryRepository.origin == DEFAULT_REGISTRY_ORIGIN
+            )
+        )
+        assert repo is not None
+        repo.current_version_id = None
+        await session.commit()
+
+        lock_service = RegistryLockService(session, role=svc_role)
+        with pytest.raises(BuiltinRegistryHasNoSelectionError):
+            await lock_service.resolve_lock_with_bindings({"core.transform.reshape"})
 
     @pytest.mark.anyio
     async def test_draft_workflow_returns_none_registry_lock(

--- a/tests/unit/test_registry_platform_startup.py
+++ b/tests/unit/test_registry_platform_startup.py
@@ -246,6 +246,37 @@ async def test_startup_sync_does_not_promote_existing_non_current_version(
 
 
 @pytest.mark.anyio
+async def test_startup_sync_promotes_existing_target_when_no_current_version(
+    session: AsyncSession,
+) -> None:
+    """Test startup sync repairs an existing target version with no current pointer."""
+    from tracecat.registry.sync.jobs import _sync_as_leader
+
+    repo = await _get_or_create_platform_repo(session)
+    repo.current_version_id = None
+    session.add(repo)
+    await session.flush()
+
+    version = PlatformRegistryVersion(
+        repository_id=repo.id,
+        version="1.0.0",
+        manifest=_make_manifest(["test.action"]),
+        tarball_uri="s3://test/v1.tar.gz",
+    )
+    session.add(version)
+    await session.commit()
+
+    with patch(
+        "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
+    ) as mock_sync_service:
+        await _sync_as_leader(session, "1.0.0")
+        mock_sync_service.assert_not_called()
+
+    await session.refresh(repo)
+    assert repo.current_version_id == version.id
+
+
+@pytest.mark.anyio
 async def test_startup_sync_refuses_downgrade(
     session: AsyncSession,
 ) -> None:

--- a/tracecat/registry/lock/service.py
+++ b/tracecat/registry/lock/service.py
@@ -136,6 +136,24 @@ class RegistryLockService(BaseOrgService):
                     RegistryVersionManifest.model_validate(manifest_dict)
                 )
 
+        builtin_version = next(
+            (
+                str(version)
+                for origin, version, _ in platform_rows
+                if origin == DEFAULT_REGISTRY_ORIGIN
+            ),
+            None,
+        )
+        if builtin_version is None:
+            self.logger.info(
+                "Platform registry has no selected version; builtin lock resolution is pending sync",
+                origin=DEFAULT_REGISTRY_ORIGIN,
+            )
+            raise BuiltinRegistryHasNoSelectionError(
+                "Builtin registry sync is still in progress. Please retry shortly.",
+                detail={"origin": DEFAULT_REGISTRY_ORIGIN},
+            )
+
         # 3. Build action -> origin mapping using BFS to include template step actions
         actions: dict[str, str] = {}
         queue: deque[str] = deque(sorted(action_names))
@@ -201,24 +219,6 @@ class RegistryLockService(BaseOrgService):
         # treats tracecat_registry as platform-scoped; an org override would miss.
         used_origins = set(actions.values())
         origins = {o: v for o, v in origins.items() if o in used_origins}
-        builtin_version = next(
-            (
-                str(version)
-                for origin, version, _ in platform_rows
-                if origin == DEFAULT_REGISTRY_ORIGIN
-            ),
-            None,
-        )
-        if builtin_version is None:
-            self.logger.info(
-                "Platform registry has no selected version; builtin lock resolution is pending sync",
-                origin=DEFAULT_REGISTRY_ORIGIN,
-            )
-            raise BuiltinRegistryHasNoSelectionError(
-                "Builtin registry sync is still in progress. Please retry shortly.",
-                detail={"origin": DEFAULT_REGISTRY_ORIGIN},
-            )
-
         origins[DEFAULT_REGISTRY_ORIGIN] = builtin_version
 
         self.logger.debug(

--- a/tracecat/registry/lock/service.py
+++ b/tracecat/registry/lock/service.py
@@ -63,7 +63,7 @@ class RegistryLockService(BaseOrgService):
             RegistryError: If an action is not found in any registry or is ambiguous
             RegistryError: If a repository has no current_version_id set
         """
-        # 1. Query platform registries via current_version_id
+        # Query platform registries via current_version_id.
         platform_statement = (
             select(
                 PlatformRegistryRepository.origin,
@@ -82,7 +82,25 @@ class RegistryLockService(BaseOrgService):
         platform_result = await self.session.execute(platform_statement)
         platform_rows = platform_result.tuples().all()
 
-        # 2. Query org registries via current_version_id
+        builtin_version = next(
+            (
+                str(version)
+                for origin, version, _ in platform_rows
+                if origin == DEFAULT_REGISTRY_ORIGIN
+            ),
+            None,
+        )
+        if builtin_version is None:
+            self.logger.info(
+                "Platform registry has no selected version; builtin lock resolution is pending sync",
+                origin=DEFAULT_REGISTRY_ORIGIN,
+            )
+            raise BuiltinRegistryHasNoSelectionError(
+                "Builtin registry sync is still in progress. Please retry shortly.",
+                detail={"origin": DEFAULT_REGISTRY_ORIGIN},
+            )
+
+        # Query org registries via current_version_id.
         org_statement = (
             select(
                 RegistryRepository.origin,
@@ -111,14 +129,14 @@ class RegistryLockService(BaseOrgService):
                 org_registry_count=len(org_rows),
             )
 
-        # 3. Combine: platform first, then org (org overrides for same origin).
+        # Combine: platform first, then org (org overrides for same origin).
         # When custom registry entitlement is disabled, only platform registries
         # are considered for lock resolution.
         rows = list(platform_rows)
         if custom_registry_enabled:
             rows.extend(org_rows)
 
-        # 2. Build origins dict and parse manifests
+        # Build origins dict and parse manifests.
         origins: dict[str, str] = {}
         origin_manifests: dict[str, RegistryVersionManifest] = {}
         excluded_custom_origin_manifests: dict[str, RegistryVersionManifest] = {}
@@ -136,25 +154,7 @@ class RegistryLockService(BaseOrgService):
                     RegistryVersionManifest.model_validate(manifest_dict)
                 )
 
-        builtin_version = next(
-            (
-                str(version)
-                for origin, version, _ in platform_rows
-                if origin == DEFAULT_REGISTRY_ORIGIN
-            ),
-            None,
-        )
-        if builtin_version is None:
-            self.logger.info(
-                "Platform registry has no selected version; builtin lock resolution is pending sync",
-                origin=DEFAULT_REGISTRY_ORIGIN,
-            )
-            raise BuiltinRegistryHasNoSelectionError(
-                "Builtin registry sync is still in progress. Please retry shortly.",
-                detail={"origin": DEFAULT_REGISTRY_ORIGIN},
-            )
-
-        # 3. Build action -> origin mapping using BFS to include template step actions
+        # Build action -> origin mapping using BFS to include template step actions.
         actions: dict[str, str] = {}
         queue: deque[str] = deque(sorted(action_names))
 

--- a/tracecat/registry/sync/jobs.py
+++ b/tracecat/registry/sync/jobs.py
@@ -103,6 +103,20 @@ async def _sync_as_leader(session: AsyncSession, target_version: str) -> None:
             )
             return
 
+        # If there is no current selection, repair the pointer to the target
+        # version. This is idempotent startup behavior, not an auto-upgrade over
+        # an intentional rollback.
+        if repo.current_version_id is None:
+            repo.current_version_id = existing_version.id
+            session.add(repo)
+            await session.commit()
+            logger.info(
+                "Promoted existing platform registry target version with no current selection",
+                target_version=target_version,
+                version_id=str(existing_version.id),
+            )
+            return
+
         # Version exists but is not current - don't auto-promote
         # There may be a deliberate reason it's not current (e.g., manual rollback)
         logger.info(


### PR DESCRIPTION
## Summary
- Ensures the remote custom registry integration test syncs the builtin platform registry before workflow execution.
- Detects and replaces/promotes away from the placeholder builtin tarball URI (`s3://test/test.tar.gz`).
- Makes registry lock setup idempotent for platform registry rows used by xdist/unit tests.
- Preserves an already-selected live platform registry version in `registry_version_with_manifest`, so temporal/integration tests do not clobber the API-synced builtin tarball with the fake fixture version.

## Root Cause
Commit `5d1d745c1` made resolved workflow locks always include `tracecat_registry` as a runtime dependency. The remote custom registry test synced only the custom repo, so executor setup could try to download the builtin fixture placeholder tarball and fail with a 404.

The additional CI failures came from tests assuming platform registry setup was isolated/idempotent. Platform registry rows are global by origin, so parallel setup could collide on `tracecat_registry`, and the shared manifest fixture could overwrite a live platform registry current version with `test-version` and the fake tarball.

## Validation
- `uv run pytest tests/unit/test_registry_lock_resolution.py -n 4`
- `uv run pytest --collect-only -q tests/temporal/test_large_collection_regressions.py tests/integration/test_install_and_run_custom_remote_registry_flow.py`
- `uv run ruff check tests/conftest.py tests/unit/test_registry_lock_resolution.py tests/integration/test_install_and_run_custom_remote_registry_flow.py`
- `uv run ruff format --check tests/conftest.py tests/unit/test_registry_lock_resolution.py tests/integration/test_install_and_run_custom_remote_registry_flow.py`
- `uv run basedpyright tests/conftest.py tests/unit/test_registry_lock_resolution.py tests/integration/test_install_and_run_custom_remote_registry_flow.py`

CI is green for Ruff, Pyright, unit, registry, temporal, integration, custom registry install, CodeQL, Semgrep, and Terraform Cloud.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the remote custom registry integration test by syncing the builtin platform registry and ensuring a real tarball is selected, so `tracecat_registry` resolves to a downloadable tarball and executor setup avoids 404s. Also makes registry setup idempotent, repairs missing current selections at startup, and applies a safe fixture fallback in shared DBs.

- **Bug Fixes**
  - Syncs the builtin platform registry (`DEFAULT_REGISTRY_ORIGIN`) before the workflow; creates it if missing, forces sync when needed, and promotes a version with a real tarball when the placeholder is current.
  - Safe fixture fallback: in per-test DBs, select the fixture platform version; in the default/shared DB, select it only if no current exists or it already matches the fixture; otherwise, wait for API/startup to select the live builtin version.
  - Makes platform setup idempotent: upserts repositories by origin (unique non-default origins), generates unique versions/tarballs, and reuses an existing current for the default repo; startup sync repairs a missing current pointer when the target version already exists.
  - Adds an early lock-resolution check and raises `BuiltinRegistryHasNoSelectionError` when the builtin has no selected version, so tests and workflows retry while sync is pending.

<sup>Written for commit dfe91a61cd7f24f7b23958dd542f7919afdfdef7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

