### PR TITLE
fix(workflows): honor input schema optional metadata

### DIFF
--- a/frontend/src/components/builder/panel/workflow-panel.tsx
+++ b/frontend/src/components/builder/panel/workflow-panel.tsx
@@ -74,6 +74,8 @@ const createWorkflowUpdateFormSchema = (workspaceId: string) =>
               type: z.string().min(1, { message: "Type is required" }),
               description: z.string().nullable().optional(),
               default: z.unknown().nullable().optional(),
+              enum: z.array(z.string()).nullable().optional(),
+              optional: z.boolean().nullable().optional(),
             })
             .refine((val): val is ExpectedField_Input => true)
         )
@@ -712,7 +714,8 @@ my_param:
 
 my_list:
   type: list[int]
-  description: This is a list of integers without a default value
+  description: This is an optional list of integers
+  optional: true
 
 my_union:
   type: str | int | None
@@ -730,7 +733,8 @@ function WorkflowInputSchemaTooltip() {
         trigger inputs to the workflow.
       </span>
       <span className="w-full text-muted-foreground">
-        Passing a default value makes the field optional.
+        Use optional: true to allow omitted inputs, or default to provide a
+        fallback value.
       </span>
       <span className="w-full text-muted-foreground">Usage example:</span>
       <div className="rounded-md border bg-muted-foreground/10 p-2">

--- a/tests/unit/test_expectation.py
+++ b/tests/unit/test_expectation.py
@@ -120,6 +120,34 @@ def test_dynamic_model_with_optional_field_omitted():
     assert model_instance_no_optional.optional_with_default == 1
 
 
+def test_expected_field_serialization_omits_unset_metadata():
+    field = ExpectedField(type="str")
+
+    assert field.model_dump() == {"type": "str"}
+
+
+def test_expected_field_serialization_preserves_explicit_default_null():
+    field = ExpectedField(type="str", default=None)
+
+    assert field.model_dump() == {"type": "str", "default": None}
+
+
+def test_dynamic_model_with_optional_field_metadata_omitted():
+    schema = {
+        "cursor": {
+            "type": "str",
+            "description": "Pagination cursor.",
+            "optional": True,
+        },
+    }
+
+    DynamicModel = create_expectation_model(schema)
+
+    model_instance: Any = DynamicModel()
+    assert model_instance.cursor is None
+    assert "cursor" not in DynamicModel.model_json_schema().get("required", [])
+
+
 # Test with invalid data
 def test_dynamic_model_with_invalid_data():
     schema = {
@@ -302,6 +330,49 @@ def test_validate_schema_with_enum(status, priority):
     # Test default priority
     model_instance_default: Any = model(status=status)
     assert model_instance_default.priority == "low"
+
+
+def test_validate_schema_with_enum_metadata():
+    schema: dict[str, Any] = {
+        "object_type": {
+            "type": "str",
+            "description": "Type of object to analyze.",
+            "enum": ["url", "hash", "file"],
+            "default": "url",
+        },
+    }
+
+    model = create_expectation_model(schema)
+
+    model_instance: Any = model(object_type="hash")
+    assert model_instance.object_type == "hash"
+    model_instance_default: Any = model()
+    assert model_instance_default.object_type == "url"
+    assert model.model_json_schema()["properties"]["object_type"]["enum"] == [
+        "url",
+        "hash",
+        "file",
+    ]
+
+    with pytest.raises(ValidationError):
+        model(object_type="domain")
+
+
+def test_validate_schema_with_nullable_enum_metadata():
+    schema: dict[str, Any] = {
+        "status": {
+            "type": "str | None",
+            "enum": ["triggered", "acknowledged", "resolved"],
+            "default": None,
+        },
+    }
+
+    model = create_expectation_model(schema)
+
+    model_instance: Any = model(status=None)
+    assert model_instance.status is None
+    model_instance_default: Any = model()
+    assert model_instance_default.status is None
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_workflow_management_schemas.py
+++ b/tests/unit/test_workflow_management_schemas.py
@@ -23,3 +23,20 @@ def test_build_trigger_inputs_schema_generates_json_schema():
 
     severity_schema = properties["severity"]
     assert severity_schema["enum"] == ["low", "high"]
+
+
+def test_build_trigger_inputs_schema_honors_optional_metadata():
+    expects = {
+        "cursor": {
+            "type": "str",
+            "description": "Pagination cursor.",
+            "optional": True,
+        },
+    }
+
+    schema = build_trigger_inputs_schema(expects)
+
+    assert schema is not None
+    assert "cursor" not in schema.get("required", [])
+    properties = schema.get("properties", {})
+    assert properties["cursor"]["type"] == "string"

--- a/tracecat/expressions/expectations.py
+++ b/tracecat/expressions/expectations.py
@@ -8,7 +8,11 @@ from pydantic_core import to_jsonable_python
 
 from tracecat.expressions.schemas import ExpectedField
 from tracecat.logger import logger
-from tracecat.registry.fields import get_components_for_union_type, type_drop_null
+from tracecat.registry.fields import (
+    get_components_for_union_type,
+    type_drop_null,
+    type_is_nullable,
+)
 
 # Re-export for backwards compatibility
 __all__ = ["ExpectedField", "create_expectation_model"]
@@ -148,6 +152,20 @@ def parse_type(type_string: str, field_name: str) -> Any:
     return TypeTransformer(field_name).transform(tree)
 
 
+def _field_type_from_expected_field(field_info: ExpectedField, field_name: str) -> type:
+    parsed_type = parse_type(field_info.type, field_name)
+    if field_info.enum is None:
+        return parsed_type
+
+    if not field_info.enum:
+        raise ValueError(f"Field {field_name!r} defines an empty enum list")
+
+    literal_type = Literal.__getitem__(tuple(field_info.enum))  # pyright: ignore[reportAttributeAccessIssue]
+    if type_is_nullable(parsed_type):
+        return Union[literal_type, None]  # noqa: UP007  # pyright: ignore[reportReturnType]
+    return literal_type
+
+
 def create_expectation_model(
     schema: Mapping[str, ExpectedField | Mapping[str, Any]],
     model_name: str = "ExpectedSchemaModel",
@@ -159,7 +177,9 @@ def create_expectation_model(
         validated_field_info = ExpectedField.model_validate(field_info)
 
         # Extract metadata
-        field_type: type = parse_type(validated_field_info.type, field_name)
+        field_type: type = _field_type_from_expected_field(
+            validated_field_info, field_name
+        )
         description = validated_field_info.description
 
         if description:
@@ -168,6 +188,8 @@ def create_expectation_model(
         if validated_field_info.has_default():
             # If the field has a default value, use it
             field_info_kwargs["default"] = validated_field_info.default
+        elif validated_field_info.optional:
+            field_info_kwargs["default"] = None
         else:
             # Use ... (ellipsis) to indicate a required field in Pydantic
             field_info_kwargs["default"] = ...

--- a/tracecat/expressions/schemas.py
+++ b/tracecat/expressions/schemas.py
@@ -35,8 +35,18 @@ class ExpectedField(BaseModel):
 
     @model_serializer(mode="plain")
     def _serialize(self) -> dict[str, Any]:
-        """Serialize model, omitting 'default' field when it's UNSET."""
-        data = {k: getattr(self, k) for k in self.model_fields if k != "default"}
+        """Serialize model, omitting unset optional metadata.
+
+        Keep ``default`` special so an explicit ``default: null`` still
+        round-trips distinctly from no default.
+        """
+        data: dict[str, Any] = {"type": self.type}
+        if self.description is not None:
+            data["description"] = self.description
         if self.has_default():
             data["default"] = self.default
+        if self.enum is not None:
+            data["enum"] = self.enum
+        if self.optional is not None:
+            data["optional"] = self.optional
         return data


### PR DESCRIPTION
## Summary
- stop serializing unset input schema metadata as `enum: null` / `optional: null` while preserving explicit `default: null`
- honor `optional: true` and standalone `enum` metadata when building expectation models and trigger input schemas
- preserve `enum` and `optional` through the workflow panel form schema and update the tooltip copy/example

## Testing
- `uv run ruff check tracecat/expressions/schemas.py tracecat/expressions/expectations.py tests/unit/test_expectation.py tests/unit/test_workflow_management_schemas.py`
- `uv run ruff format --check tracecat/expressions/schemas.py tracecat/expressions/expectations.py tests/unit/test_expectation.py tests/unit/test_workflow_management_schemas.py`
- `uv run basedpyright --warnings --threads 4 tracecat/expressions/schemas.py tracecat/expressions/expectations.py tests/unit/test_expectation.py tests/unit/test_workflow_management_schemas.py`
- `pnpm -C frontend exec biome check src/components/builder/panel/workflow-panel.tsx`
- `pnpm -C frontend run typecheck`
- direct `uv run python` validation for serialization, `optional`, `enum`, and trigger input schema behavior


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes input schema metadata handling by omitting unset `enum`/`optional`, preserving explicit `default: null`, and honoring `optional: true` and `enum` across models and trigger schemas. The workflow panel now accepts `enum` and `optional`, and the tooltip clarifies optional vs default.

- **Bug Fixes**
  - Serialization: stop emitting `enum: null` and `optional: null`; keep `default: null` when set.
  - Expectation models: apply `enum` as a Literal (respecting nullable types) and treat `optional: true` as `default=None` (field not required).
  - Trigger input schemas: include `enum` values and exclude optional fields from `required`.
  - UI: extend form schema with `enum` and `optional`; update example and tooltip to explain optional vs default.

<sup>Written for commit b9eb732c9cfa9acb6138e4c9d56274800e446d1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

