### PR TITLE
refactor: Fetch registry SSH keys on executor worker

### DIFF
--- a/tests/unit/test_registry_sync_base_service.py
+++ b/tests/unit/test_registry_sync_base_service.py
@@ -10,13 +10,16 @@ from temporalio.exceptions import ApplicationError
 
 from tracecat import config
 from tracecat.auth.types import Role
-from tracecat.db.models import Organization
+from tracecat.db.models import Organization, RegistryRepository
 from tracecat.registry.actions.schemas import (
     RegistryActionCreate,
     RegistryActionOptions,
     RegistryActionUDFImpl,
 )
-from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
+from tracecat.registry.constants import (
+    DEFAULT_REGISTRY_ORIGIN,
+    REGISTRY_GIT_SSH_KEY_SECRET_NAME,
+)
 from tracecat.registry.repositories.schemas import RegistryRepositoryCreate
 from tracecat.registry.repositories.service import RegistryReposService
 from tracecat.registry.sync.base_service import ArtifactsBuildResult
@@ -211,3 +214,50 @@ async def test_sync_via_temporal_matches_validation_application_error_before_cau
         await sync_service.sync_repository_v2(repo, commit=False)
 
     assert "workflow failed" not in str(exc_info.value).lower()
+
+
+@pytest.mark.anyio
+async def test_sync_via_temporal_git_requires_registry_ssh_key_before_workflow(
+    mock_org_id: uuid.UUID,
+    mocker,
+) -> None:
+    role = Role(
+        type="service",
+        user_id=mock_org_id,
+        organization_id=mock_org_id,
+        workspace_id=uuid.uuid4(),
+        service_id="tracecat-runner",
+    )
+
+    session = mocker.Mock(spec=AsyncSession)
+    repo = RegistryRepository(
+        id=uuid.uuid4(),
+        origin="git+ssh://git@github.com/TracecatHQ/internal-registry.git",
+        organization_id=mock_org_id,
+        current_version_id=None,
+    )
+
+    mock_client = mocker.Mock()
+    mock_client.execute_workflow = mocker.AsyncMock()
+    get_temporal_client = mocker.patch(
+        "tracecat.dsl.client.get_temporal_client",
+        mocker.AsyncMock(return_value=mock_client),
+    )
+    get_org_secret_by_name = mocker.patch(
+        "tracecat.registry.sync.base_service.SecretsService.get_org_secret_by_name",
+        mocker.AsyncMock(side_effect=RuntimeError("missing")),
+    )
+    get_ssh_key = mocker.patch(
+        "tracecat.registry.sync.base_service.SecretsService.get_ssh_key",
+        mocker.AsyncMock(),
+    )
+
+    sync_service = RegistrySyncService(session, role)
+
+    with pytest.raises(RegistrySyncError, match=REGISTRY_GIT_SSH_KEY_SECRET_NAME):
+        await sync_service._sync_via_temporal_workflow(repo, commit=False)
+
+    get_org_secret_by_name.assert_awaited_once_with(REGISTRY_GIT_SSH_KEY_SECRET_NAME)
+    get_ssh_key.assert_not_awaited()
+    get_temporal_client.assert_not_awaited()
+    mock_client.execute_workflow.assert_not_awaited()

--- a/tests/unit/test_registry_sync_base_service.py
+++ b/tests/unit/test_registry_sync_base_service.py
@@ -11,6 +11,7 @@ from temporalio.exceptions import ApplicationError
 from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.db.models import Organization, RegistryRepository
+from tracecat.exceptions import TracecatNotFoundError
 from tracecat.registry.actions.schemas import (
     RegistryActionCreate,
     RegistryActionOptions,
@@ -245,7 +246,7 @@ async def test_sync_via_temporal_git_requires_registry_ssh_key_before_workflow(
     )
     get_org_secret_by_name = mocker.patch(
         "tracecat.registry.sync.base_service.SecretsService.get_org_secret_by_name",
-        mocker.AsyncMock(side_effect=RuntimeError("missing")),
+        mocker.AsyncMock(side_effect=TracecatNotFoundError("missing")),
     )
     get_ssh_key = mocker.patch(
         "tracecat.registry.sync.base_service.SecretsService.get_ssh_key",
@@ -261,3 +262,42 @@ async def test_sync_via_temporal_git_requires_registry_ssh_key_before_workflow(
     get_ssh_key.assert_not_awaited()
     get_temporal_client.assert_not_awaited()
     mock_client.execute_workflow.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_sync_via_temporal_git_preserves_unexpected_secret_check_error(
+    mock_org_id: uuid.UUID,
+    mocker,
+) -> None:
+    role = Role(
+        type="service",
+        user_id=mock_org_id,
+        organization_id=mock_org_id,
+        workspace_id=uuid.uuid4(),
+        service_id="tracecat-runner",
+    )
+
+    session = mocker.Mock(spec=AsyncSession)
+    repo = RegistryRepository(
+        id=uuid.uuid4(),
+        origin="git+ssh://git@github.com/TracecatHQ/internal-registry.git",
+        organization_id=mock_org_id,
+        current_version_id=None,
+    )
+
+    get_temporal_client = mocker.patch(
+        "tracecat.dsl.client.get_temporal_client",
+        mocker.AsyncMock(),
+    )
+    get_org_secret_by_name = mocker.patch(
+        "tracecat.registry.sync.base_service.SecretsService.get_org_secret_by_name",
+        mocker.AsyncMock(side_effect=RuntimeError("database unavailable")),
+    )
+
+    sync_service = RegistrySyncService(session, role)
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await sync_service._sync_via_temporal_workflow(repo, commit=False)
+
+    get_org_secret_by_name.assert_awaited_once_with(REGISTRY_GIT_SSH_KEY_SECRET_NAME)
+    get_temporal_client.assert_not_awaited()

--- a/tests/unit/test_registry_sync_runner.py
+++ b/tests/unit/test_registry_sync_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from tracecat.registry.actions.enums import TemplateActionValidationErrorType
 from tracecat.registry.actions.schemas import RegistryActionValidationErrorInfo
@@ -14,19 +15,35 @@ from tracecat.registry.sync.schemas import RegistrySyncRequest
 from tracecat.registry.sync.tarball import TarballVenvBuildResult
 
 
+def test_registry_sync_request_rejects_ssh_key() -> None:
+    """SSH keys must never be serializable into Temporal request payloads."""
+    payload = {
+        "repository_id": str(uuid4()),
+        "origin": "git+ssh://git@github.com/TracecatHQ/internal-registry.git",
+        "origin_type": "git",
+        "git_url": "git+ssh://git@github.com/TracecatHQ/internal-registry.git",
+        "organization_id": str(uuid4()),
+        "ssh_key": "fake-ssh-key",
+    }
+
+    with pytest.raises(ValidationError, match="ssh_key"):
+        RegistrySyncRequest.model_validate(payload)
+
+
 @pytest.mark.anyio
 async def test_runner_passes_resolved_commit_sha_to_discovery(
     tmp_path,
     mocker,
 ) -> None:
     runner = RegistrySyncRunner()
+    organization_id = uuid4()
     request = RegistrySyncRequest(
         repository_id=uuid4(),
         origin="git+ssh://git@github.com/TracecatHQ/internal-registry.git",
         origin_type="git",
         git_url="git+ssh://git@github.com/TracecatHQ/internal-registry.git",
         commit_sha="requested-sha",
-        ssh_key="fake-ssh-key",
+        organization_id=organization_id,
         validate_actions=True,
     )
 
@@ -37,6 +54,11 @@ async def test_runner_passes_resolved_commit_sha_to_discovery(
         runner,
         "_clone_repository",
         mocker.AsyncMock(return_value=(tmp_path, "resolved-sha")),
+    )
+    fetch_registry_ssh_key = mocker.patch.object(
+        runner,
+        "_fetch_registry_ssh_key",
+        mocker.AsyncMock(return_value="fake-ssh-key"),
     )
     mocker.patch.object(
         runner,
@@ -63,14 +85,20 @@ async def test_runner_passes_resolved_commit_sha_to_discovery(
 
     result = await runner.run(request)
 
-    clone_repository.assert_awaited_once()
+    fetch_registry_ssh_key.assert_awaited_once_with(organization_id)
+    clone_repository.assert_awaited_once_with(
+        git_url=request.git_url,
+        commit_sha="requested-sha",
+        ssh_key="fake-ssh-key",
+        work_dir=mocker.ANY,
+    )
     discover_actions.assert_awaited_once_with(
         repository_id=request.repository_id,
         origin=request.origin,
         commit_sha="resolved-sha",
         validate=True,
         git_repo_package_name=None,
-        organization_id=None,
+        organization_id=organization_id,
     )
     upload_tarball.assert_awaited_once()
     assert result.commit_sha == "resolved-sha"

--- a/tests/unit/test_registry_sync_runner.py
+++ b/tests/unit/test_registry_sync_runner.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from uuid import uuid4
 
 import pytest
+from pydantic import SecretStr
 
+from tracecat.auth.types import Role
 from tracecat.registry.actions.enums import TemplateActionValidationErrorType
 from tracecat.registry.actions.schemas import RegistryActionValidationErrorInfo
 from tracecat.registry.sync.runner import (
@@ -102,6 +105,30 @@ async def test_runner_passes_resolved_commit_sha_to_discovery(
     )
     upload_tarball.assert_awaited_once()
     assert result.commit_sha == "resolved-sha"
+
+
+@pytest.mark.anyio
+async def test_fetch_registry_ssh_key_uses_role_scoped_service_session(mocker) -> None:
+    runner = RegistrySyncRunner()
+    organization_id = uuid4()
+    secrets_service = mocker.Mock()
+    secrets_service.get_ssh_key = mocker.AsyncMock(return_value=SecretStr("fake-key\n"))
+
+    @asynccontextmanager
+    async def fake_with_session(*, role: Role):
+        assert role.organization_id == organization_id
+        yield secrets_service
+
+    with_session = mocker.patch(
+        "tracecat.registry.sync.runner.SecretsService.with_session",
+        side_effect=fake_with_session,
+    )
+
+    ssh_key = await runner._fetch_registry_ssh_key(organization_id)
+
+    assert ssh_key == "fake-key\n"
+    with_session.assert_called_once()
+    secrets_service.get_ssh_key.assert_awaited_once_with(target="registry")
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_registry_sync_runner.py
+++ b/tests/unit/test_registry_sync_runner.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from uuid import uuid4
 
 import pytest
-from pydantic import ValidationError
 
 from tracecat.registry.actions.enums import TemplateActionValidationErrorType
 from tracecat.registry.actions.schemas import RegistryActionValidationErrorInfo
@@ -15,8 +14,8 @@ from tracecat.registry.sync.schemas import RegistrySyncRequest
 from tracecat.registry.sync.tarball import TarballVenvBuildResult
 
 
-def test_registry_sync_request_rejects_ssh_key() -> None:
-    """SSH keys must never be serializable into Temporal request payloads."""
+def test_registry_sync_request_ignores_legacy_ssh_key() -> None:
+    """Legacy SSH keys are accepted for rollout compatibility but not serialized."""
     payload = {
         "repository_id": str(uuid4()),
         "origin": "git+ssh://git@github.com/TracecatHQ/internal-registry.git",
@@ -26,8 +25,9 @@ def test_registry_sync_request_rejects_ssh_key() -> None:
         "ssh_key": "fake-ssh-key",
     }
 
-    with pytest.raises(ValidationError, match="ssh_key"):
-        RegistrySyncRequest.model_validate(payload)
+    request = RegistrySyncRequest.model_validate(payload)
+
+    assert "ssh_key" not in request.model_dump()
 
 
 @pytest.mark.anyio

--- a/tracecat/registry/sync/base_service.py
+++ b/tracecat/registry/sync/base_service.py
@@ -582,26 +582,12 @@ class BaseRegistrySyncService[
 
         origin_type = self._get_origin_type(origin)
 
-        ssh_key: str | None = None
         if origin_type == "git":
-            # Git origins require SSH key for authentication
-            if not isinstance(self.role, Role):
+            # Git origins require org context so the worker can fetch the SSH key.
+            if not isinstance(self.role, Role) or self.role.organization_id is None:
                 raise self._sync_error_cls()(
                     "Git repository sync requires organization context (Role with organization_id)"
                 )
-
-            from tracecat.secrets.service import SecretsService
-
-            secrets_service = SecretsService(self.session, role=self.role)
-            try:
-                secret = await secrets_service.get_ssh_key(target="registry")
-                ssh_key = secret.get_secret_value()
-            except Exception as exc:
-                # SSH key is required for git repos - fail fast with clear error
-                raise self._sync_error_cls()(
-                    f"Failed to retrieve SSH key for git operations: {exc}. "
-                    "Ensure a 'github-ssh-key' secret exists in your organization."
-                ) from exc
 
         request = RegistrySyncRequest(
             repository_id=repo_id,
@@ -610,7 +596,6 @@ class BaseRegistrySyncService[
             git_url=origin if origin_type == "git" else None,
             commit_sha=target_commit_sha,
             git_repo_package_name=git_repo_package_name,
-            ssh_key=ssh_key,
             validate_actions=True,
             storage_namespace=self._get_storage_namespace(),
             organization_id=self.role.organization_id

--- a/tracecat/registry/sync/base_service.py
+++ b/tracecat/registry/sync/base_service.py
@@ -26,6 +26,7 @@ from tracecat.registry.actions.schemas import (
 from tracecat.registry.constants import (
     DEFAULT_LOCAL_REGISTRY_ORIGIN,
     DEFAULT_REGISTRY_ORIGIN,
+    REGISTRY_GIT_SSH_KEY_SECRET_NAME,
 )
 from tracecat.registry.sync.schemas import RegistrySyncRequest
 from tracecat.registry.sync.subprocess import fetch_actions_from_subprocess
@@ -42,6 +43,7 @@ from tracecat.registry.versions.schemas import (
     RegistryVersionCreate,
     RegistryVersionManifest,
 )
+from tracecat.secrets.service import SecretsService
 from tracecat.service import BaseService
 from tracecat.storage import blob
 
@@ -584,10 +586,24 @@ class BaseRegistrySyncService[
 
         if origin_type == "git":
             # Git origins require org context so the worker can fetch the SSH key.
-            if not isinstance(self.role, Role) or self.role.organization_id is None:
+            role = self.role
+            if not isinstance(role, Role) or role.organization_id is None:
                 raise self._sync_error_cls()(
                     "Git repository sync requires organization context (Role with organization_id)"
                 )
+
+            # Validate that the key exists before scheduling the workflow.
+            # The worker fetches the value again and the key is not serialized.
+            secrets_service = SecretsService(self.session, role=role)
+            try:
+                await secrets_service.get_org_secret_by_name(
+                    REGISTRY_GIT_SSH_KEY_SECRET_NAME
+                )
+            except Exception as exc:
+                raise self._sync_error_cls()(
+                    "Git repository sync requires a "
+                    f"'{REGISTRY_GIT_SSH_KEY_SECRET_NAME}' organization secret."
+                ) from exc
 
         request = RegistrySyncRequest(
             repository_id=repo_id,

--- a/tracecat/registry/sync/base_service.py
+++ b/tracecat/registry/sync/base_service.py
@@ -19,6 +19,7 @@ from temporalio.exceptions import ApplicationError
 from tracecat import config
 from tracecat.auth.types import PlatformRole, Role
 from tracecat.contexts import ctx_role
+from tracecat.exceptions import TracecatNotFoundError
 from tracecat.registry.actions.schemas import (
     RegistryActionCreate,
     RegistryActionValidationErrorInfo,
@@ -599,7 +600,7 @@ class BaseRegistrySyncService[
                 await secrets_service.get_org_secret_by_name(
                     REGISTRY_GIT_SSH_KEY_SECRET_NAME
                 )
-            except Exception as exc:
+            except TracecatNotFoundError as exc:
                 raise self._sync_error_cls()(
                     "Git repository sync requires a "
                     f"'{REGISTRY_GIT_SSH_KEY_SECRET_NAME}' organization secret."

--- a/tracecat/registry/sync/runner.py
+++ b/tracecat/registry/sync/runner.py
@@ -28,7 +28,6 @@ import aiofiles
 from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
-from tracecat.db.engine import get_async_session_context_manager
 from tracecat.logger import logger
 from tracecat.registry.actions.schemas import RegistryActionCreate
 from tracecat.registry.sync.platform_service import PLATFORM_REGISTRY_TARBALL_NAMESPACE
@@ -260,8 +259,7 @@ class RegistrySyncRunner:
             scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-service"],
         )
 
-        async with get_async_session_context_manager() as session:
-            secrets_service = SecretsService(session, role=role)
+        async with SecretsService.with_session(role=role) as secrets_service:
             try:
                 secret = await secrets_service.get_ssh_key(target="registry")
             except Exception as exc:

--- a/tracecat/registry/sync/runner.py
+++ b/tracecat/registry/sync/runner.py
@@ -26,6 +26,9 @@ from uuid import UUID
 import aiofiles
 
 from tracecat import config
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.db.engine import get_async_session_context_manager
 from tracecat.logger import logger
 from tracecat.registry.actions.schemas import RegistryActionCreate
 from tracecat.registry.sync.platform_service import PLATFORM_REGISTRY_TARBALL_NAMESPACE
@@ -39,6 +42,7 @@ from tracecat.registry.sync.tarball import (
     get_tarball_venv_s3_key,
     upload_tarball_venv,
 )
+from tracecat.secrets.service import SecretsService
 from tracecat.storage import blob
 
 if TYPE_CHECKING:
@@ -156,10 +160,11 @@ class RegistrySyncRunner:
                     raise RegistrySyncRunnerError(
                         "git_url is required for git origin type"
                     )
+                ssh_key = await self._fetch_registry_ssh_key(request.organization_id)
                 package_path, commit_sha = await self._clone_repository(
                     git_url=request.git_url,
                     commit_sha=request.commit_sha,
-                    ssh_key=request.ssh_key,
+                    ssh_key=ssh_key,
                     work_dir=work_dir,
                 )
             else:
@@ -240,6 +245,31 @@ class RegistrySyncRunner:
             return get_builtin_registry_source_path()
         except TarballBuildError as e:
             raise RegistrySyncRunnerError(str(e)) from e
+
+    async def _fetch_registry_ssh_key(self, organization_id: UUID | None) -> str:
+        """Fetch the org-scoped registry SSH key on the ExecutorWorker."""
+        if organization_id is None:
+            raise GitCloneError(
+                "Git repository sync requires organization_id to fetch the SSH key"
+            )
+
+        role = Role(
+            type="service",
+            service_id="tracecat-service",
+            organization_id=organization_id,
+            scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-service"],
+        )
+
+        async with get_async_session_context_manager() as session:
+            secrets_service = SecretsService(session, role=role)
+            try:
+                secret = await secrets_service.get_ssh_key(target="registry")
+            except Exception as exc:
+                raise GitCloneError(
+                    f"Failed to retrieve SSH key for git operations: {exc}. "
+                    "Ensure a 'github-ssh-key' secret exists in your organization."
+                ) from exc
+        return secret.get_secret_value()
 
     async def _clone_repository(
         self,

--- a/tracecat/registry/sync/schemas.py
+++ b/tracecat/registry/sync/schemas.py
@@ -61,7 +61,7 @@ class RegistrySyncRequest(BaseModel):
     Git SSH keys are fetched by the ExecutorWorker and never enter Temporal args.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     repository_id: UUID = Field(..., description="Database repository ID")
     origin: str = Field(..., description="Repository origin URL or name")

--- a/tracecat/registry/sync/schemas.py
+++ b/tracecat/registry/sync/schemas.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field, TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
 from tracecat.registry.actions.schemas import (
     RegistryActionCreate,
@@ -58,8 +58,10 @@ class RegistrySyncRequest(BaseModel):
     """Request for sandboxed registry sync via Temporal workflow.
 
     This is passed from the API service to the ExecutorWorker via Temporal.
-    The SSH key is used for git clone only and never enters the nsjail sandbox.
+    Git SSH keys are fetched by the ExecutorWorker and never enter Temporal args.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     repository_id: UUID = Field(..., description="Database repository ID")
     origin: str = Field(..., description="Repository origin URL or name")
@@ -75,10 +77,6 @@ class RegistrySyncRequest(BaseModel):
     git_repo_package_name: str | None = Field(
         default=None,
         description="Optional Python package name override for git repositories",
-    )
-    ssh_key: str | None = Field(
-        default=None,
-        description="SSH private key for git clone (never enters nsjail sandbox)",
     )
     validate_actions: bool = Field(
         default=False, description="Whether to validate template actions"


### PR DESCRIPTION
## Summary

- Stop serializing registry SSH private keys into `RegistrySyncRequest` Temporal payloads.
- Fetch the org-scoped registry SSH key on the ExecutorWorker immediately before git clone.
- Forbid unexpected fields on the Temporal sync request and add regression coverage that rejects `ssh_key` in request payloads.

## Why

Sandboxed registry sync runs the git clone inside the executor worker, but the previous implementation resolved the private key in the API service and carried it through the workflow/activity request. This change keeps Temporal workflow and activity payloads limited to non-secret lookup context, so the key only exists in the worker process at clone time.

## Validation

- `uv run ruff check tracecat/registry/sync/schemas.py tracecat/registry/sync/base_service.py tracecat/registry/sync/runner.py tests/unit/test_registry_sync_runner.py`
- `uv run ruff format --check tracecat/registry/sync/schemas.py tracecat/registry/sync/base_service.py tracecat/registry/sync/runner.py tests/unit/test_registry_sync_runner.py`
- `uv run basedpyright tracecat/registry/sync/schemas.py tracecat/registry/sync/base_service.py tracecat/registry/sync/runner.py tests/unit/test_registry_sync_runner.py`
- Commit hooks passed, including Ruff, secret scan, and Python type check.

Focused pytest was not completed after the worktree move because the repo test session fixtures require local services; the earlier run was interrupted before completion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch org-scoped registry SSH keys on the executor worker right before git clone, and ignore any legacy `ssh_key` in Temporal payloads. Adds role-scoped secret access and clearer preflight failures to reduce secret exposure and improve reliability.

- **Refactors**
  - Remove `ssh_key` from `RegistrySyncRequest`; accept legacy payloads with `extra="ignore"`.
  - Worker fetches the org SSH key via SecretsService using `organization_id`; API only preflights that the secret exists before scheduling.
  - Runner resolves the key with `_fetch_registry_ssh_key(...)`, passes it to `_clone_repository(...)`, and forwards `organization_id` to discovery.

- **Bug Fixes**
  - Bind a role-scoped service session when fetching the SSH key on the worker.
  - Preflight now preserves unexpected secret lookup errors; missing key raises a clear error naming the required org secret.

<sup>Written for commit 81611884a3e9ce31d310142eb3931c6a7c9f0b12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

