### PR TITLE
[codex] cache CI Docker images

### DIFF
--- a/.github/docker-compose.python-tests.yml
+++ b/.github/docker-compose.python-tests.yml
@@ -1,0 +1,10 @@
+x-tracecat-ci-dev-image: &tracecat-ci-dev-image
+  image: tracecat-dev-ci:${TRACECAT__CI_IMAGE_TAG:?Set TRACECAT__CI_IMAGE_TAG}
+  pull_policy: never
+
+services:
+  api:
+    <<: *tracecat-ci-dev-image
+
+  migrations:
+    <<: *tracecat-ci-dev-image

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -94,6 +94,8 @@ jobs:
     environment: internal-registry-ci
     runs-on: blacksmith-8vcpu-ubuntu-2204
     timeout-minutes: 30
+    env:
+      TRACECAT__CI_IMAGE_TAG: integration-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -126,9 +128,19 @@ jobs:
           n
           test@tracecat.com" | bash env.sh
 
-      - name: Build image and start core Docker services
+      - name: Build cached Tracecat image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          target: production
+          tags: tracecat-ci:${{ env.TRACECAT__CI_IMAGE_TAG }}
+          load: true
+          push: false
+          cache-from: type=gha,scope=tracecat-integration-production
+          cache-to: type=gha,scope=tracecat-integration-production,mode=max
+
+      - name: Start core Docker services
         env:
-          TRACECAT__CI_IMAGE_TAG: integration-${{ github.run_id }}-${{ github.run_attempt }}
           TRACECAT__UNSAFE_DISABLE_SM_MASKING: "true"
           TRACECAT__EXECUTOR_BACKEND: "direct"
           TRACECAT__FEATURE_FLAGS: ""
@@ -138,9 +150,8 @@ jobs:
           set -euo pipefail
 
           compose_files=(-f docker-compose.local.yml -f .github/docker-compose.integration.yml)
-          image="tracecat-ci:${TRACECAT__CI_IMAGE_TAG}"
 
-          # Overlap host dependency setup with the Docker image build and service startup.
+          # Overlap host dependency setup with Docker service startup.
           uv sync --locked --group dev &
           uv_sync_pid=$!
           cleanup_uv_sync() {
@@ -150,7 +161,6 @@ jobs:
           }
           trap cleanup_uv_sync EXIT
 
-          docker buildx build --load --target production -t "$image" .
           docker compose "${compose_files[@]}" up --no-build -d temporal api worker executor postgres_db caddy minio redis
 
           # Wait for services with health checks to become healthy
@@ -209,8 +219,6 @@ jobs:
 
       - name: Show Docker logs on failure
         if: failure()
-        env:
-          TRACECAT__CI_IMAGE_TAG: integration-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           echo "=== Docker Service Status ==="
           docker compose -f docker-compose.local.yml -f .github/docker-compose.integration.yml ps
@@ -238,7 +246,5 @@ jobs:
 
       - name: Clean up
         if: always()
-        env:
-          TRACECAT__CI_IMAGE_TAG: integration-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           docker compose -f docker-compose.local.yml -f .github/docker-compose.integration.yml down -v

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -12,6 +12,7 @@ on:
       - pyproject.toml
       - uv.lock
       - Dockerfile
+      - .github/docker-compose.python-tests.yml
       - docker-compose.yml
       - docker-compose.dev.yml
       - docker-compose.local.yml
@@ -27,6 +28,7 @@ on:
       - pyproject.toml
       - uv.lock
       - Dockerfile
+      - .github/docker-compose.python-tests.yml
       - docker-compose.yml
       - docker-compose.dev.yml
       - docker-compose.local.yml
@@ -49,6 +51,10 @@ jobs:
         uses: useblacksmith/setup-uv@f4588471335f14dcb60198856207b916701a9e9f # v4
         with:
           version: "0.9.7"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: Set up Python 3.12
         uses: useblacksmith/setup-python@943b05a7c4ca70c2360391137527a37bee33fb1d # v6
@@ -66,6 +72,8 @@ jobs:
   test-all:
     runs-on: blacksmith-8vcpu-ubuntu-2204
     timeout-minutes: 60
+    env:
+      TRACECAT__CI_IMAGE_TAG: python-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.test_group }}
     strategy:
       matrix:
         test_group:
@@ -81,7 +89,9 @@ jobs:
         with:
           version: "0.9.7"
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: Set up Python 3.12
         uses: useblacksmith/setup-python@943b05a7c4ca70c2360391137527a37bee33fb1d # v6
@@ -103,14 +113,39 @@ jobs:
           n
           test@tracecat.com" | bash env.sh
 
-      - name: Start core Docker services
-        env:
-          COMPOSE_BAKE: "true"
-          TRACECAT__UNSAFE_DISABLE_SM_MASKING: "true"
-        run: docker compose -f docker-compose.dev.yml up -d temporal api postgres_db caddy minio
+      - name: Build cached Tracecat image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          target: development
+          tags: tracecat-dev-ci:${{ env.TRACECAT__CI_IMAGE_TAG }}
+          load: true
+          push: false
+          cache-from: type=gha,scope=tracecat-python-development
+          cache-to: type=gha,scope=tracecat-python-development,mode=max
 
-      - name: Install dependencies
-        run: uv sync --frozen
+      - name: Start core Docker services and install dependencies
+        env:
+          TRACECAT__UNSAFE_DISABLE_SM_MASKING: "true"
+        run: |
+          set -euo pipefail
+
+          compose_files=(-f docker-compose.dev.yml -f .github/docker-compose.python-tests.yml)
+
+          uv sync --frozen &
+          uv_sync_pid=$!
+          cleanup_uv_sync() {
+            if kill -0 "$uv_sync_pid" 2>/dev/null; then
+              kill "$uv_sync_pid" 2>/dev/null || true
+            fi
+          }
+          trap cleanup_uv_sync EXIT
+
+          docker compose "${compose_files[@]}" up --no-build -d temporal api postgres_db caddy minio
+
+          echo "Waiting for Python environment sync..."
+          wait "$uv_sync_pid"
+          trap - EXIT
 
       - name: Run tests
         env:
@@ -120,28 +155,28 @@ jobs:
           TRACECAT__UNSAFE_DISABLE_SM_MASKING: "true"
         run: |
           if [ "${{ matrix.test_group }}" = "ee" ]; then
-            uv run pytest packages/tracecat-ee/tests/ -m "not live_secret" -ra
+            uv run --no-sync pytest packages/tracecat-ee/tests/ -m "not live_secret" -ra
           elif [ "${{ matrix.test_group }}" = "temporal" ]; then
             # Temporal tests run with compression enabled and parallelization
             # Worker-specific task queues in conftest.py enable safe parallel execution
             TRACECAT__CONTEXT_COMPRESSION_ENABLED=true \
             TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB=0 \
-            uv run pytest tests/temporal -m "not live_secret" -n auto -ra -o faulthandler_timeout=300
+            uv run --no-sync pytest tests/temporal -m "not live_secret" -n auto -ra -o faulthandler_timeout=300
           else
-            uv run pytest tests/${{ matrix.test_group }} -m "not live_secret" -n auto -ra -o faulthandler_timeout=300
+            uv run --no-sync pytest tests/${{ matrix.test_group }} -m "not live_secret" -n auto -ra -o faulthandler_timeout=300
           fi
 
       - name: Show Docker logs on failure
         if: failure()
         run: |
           echo "=== Docker Service Status ==="
-          docker compose -f docker-compose.dev.yml ps
+          docker compose -f docker-compose.dev.yml -f .github/docker-compose.python-tests.yml ps
 
           echo "=== Temporal Logs ==="
-          docker compose -f docker-compose.dev.yml logs temporal --tail=200
+          docker compose -f docker-compose.dev.yml -f .github/docker-compose.python-tests.yml logs temporal --tail=200
 
           echo "=== API Logs ==="
-          docker compose -f docker-compose.dev.yml logs api --tail=200
+          docker compose -f docker-compose.dev.yml -f .github/docker-compose.python-tests.yml logs api --tail=200
 
           echo "=== Postgres Logs ==="
-          docker compose -f docker-compose.dev.yml logs postgres_db --tail=200
+          docker compose -f docker-compose.dev.yml -f .github/docker-compose.python-tests.yml logs postgres_db --tail=200


### PR DESCRIPTION
## Summary

Adds GitHub Actions Docker layer caching for CI builds used by integration and Python test workflows.

- Build the integration `production` image with `docker/build-push-action` using `type=gha` cache, `load: true`, and `push: false`.
- Add a CI compose override for Python tests so `api` and `migrations` reuse a prebuilt local `development` image instead of compose rebuilding it.
- Include `uv.lock` in uv cache keys and overlap Python dependency sync with Docker service startup in the Python test matrix.

## Notes

The Docker build steps do not publish to GHCR because `push: false` is set and no registry login is added. The image tags are local runner tags used only by compose.

First runs may spend time populating the cache; warm runs should get the benefit.

## Validation

- `TRACECAT__CI_IMAGE_TAG=test docker compose -f docker-compose.local.yml -f .github/docker-compose.integration.yml config --quiet`
- `TRACECAT__CI_IMAGE_TAG=test docker compose -f docker-compose.dev.yml -f .github/docker-compose.python-tests.yml config --quiet`
- `git diff --check origin/main..HEAD`
- `uv run ruff check .`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache CI Docker layers for integration and Python test workflows to speed up builds. Build and load tagged images locally per run, reuse them in compose, and overlap Python dependency sync with service startup.

- **New Features**
  - Use `docker/build-push-action` with GHA cache for integration `production` and Python `development` images (`load: true`, `push: false`).
  - Add `.github/docker-compose.python-tests.yml` so `api` and `migrations` use the prebuilt `development` image (no compose rebuild).
  - Improve Python setup: include `uv.lock` in `uv` cache keys, overlap `uv sync` with container startup, and run tests with `uv run --no-sync`.

<sup>Written for commit d4d0197f1c81678c133a95bab20e0e7eea47c6bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

