### PR TITLE
feat(agents): budget caps for token use

### DIFF
--- a/alembic/versions/a2dff003aa79_add_agent_run_cost_event_ledger.py
+++ b/alembic/versions/a2dff003aa79_add_agent_run_cost_event_ledger.py
@@ -1,0 +1,82 @@
+"""add agent_run_cost event ledger
+
+Revision ID: a2dff003aa79
+Revises: 548aa7691799
+Create Date: 2026-04-23 11:23:50.439524
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from tracecat.db.tenant_rls import (
+    disable_org_optional_workspace_table_rls,
+    enable_org_optional_workspace_table_rls,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "a2dff003aa79"
+down_revision: str | None = "548aa7691799"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_run_cost",
+        sa.Column("organization_id", sa.UUID(), nullable=False),
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("workspace_id", sa.UUID(), nullable=False),
+        sa.Column("session_id", sa.UUID(), nullable=True),
+        sa.Column("cost_usd", sa.Numeric(precision=14, scale=5), nullable=False),
+        sa.Column("surrogate_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organization.id"],
+            name=op.f("fk_agent_run_cost_organization_id_organization"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_agent_run_cost_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name=op.f("pk_agent_run_cost")),
+    )
+    op.create_index(op.f("ix_agent_run_cost_id"), "agent_run_cost", ["id"], unique=True)
+    op.create_index(
+        "ix_agent_run_cost_org_created_at",
+        "agent_run_cost",
+        ["organization_id", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_agent_run_cost_org_ws_created_at",
+        "agent_run_cost",
+        ["organization_id", "workspace_id", "created_at"],
+        unique=False,
+    )
+    op.execute(enable_org_optional_workspace_table_rls("agent_run_cost"))
+
+
+def downgrade() -> None:
+    op.execute(disable_org_optional_workspace_table_rls("agent_run_cost"))
+    op.drop_index("ix_agent_run_cost_org_ws_created_at", table_name="agent_run_cost")
+    op.drop_index("ix_agent_run_cost_org_created_at", table_name="agent_run_cost")
+    op.drop_index(op.f("ix_agent_run_cost_id"), table_name="agent_run_cost")
+    op.drop_table("agent_run_cost")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1198,6 +1198,28 @@ export const $AdminUserRead = {
   description: "Admin view of a user.",
 } as const
 
+export const $AgentBudgetUpdate = {
+  properties: {
+    monthly_budget_cents: {
+      anyOf: [
+        {
+          type: "integer",
+          minimum: 1,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Monthly Budget Cents",
+      description:
+        "Monthly agent spend cap in US cents (1000 = $10.00). Pass null to remove the cap.",
+    },
+  },
+  type: "object",
+  title: "AgentBudgetUpdate",
+  description: "Set or clear an org's monthly agent budget (cents).",
+} as const
+
 export const $AgentChannelTokenCreate = {
   properties: {
     agent_preset_id: {
@@ -14247,6 +14269,41 @@ export const $OrgUpdate = {
   type: "object",
   title: "OrgUpdate",
   description: "Update organization request.",
+} as const
+
+export const $OrgUsageSnapshot = {
+  properties: {
+    month_utc: {
+      type: "string",
+      title: "Month Utc",
+    },
+    total_cents: {
+      type: "integer",
+      title: "Total Cents",
+    },
+    limit_cents: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Limit Cents",
+    },
+    by_workspace_cents: {
+      additionalProperties: {
+        type: "integer",
+      },
+      type: "object",
+      title: "By Workspace Cents",
+    },
+  },
+  type: "object",
+  required: ["month_utc", "total_cents", "limit_cents", "by_workspace_cents"],
+  title: "OrgUsageSnapshot",
+  description: "Point-in-time read of an org's monthly agent spend.",
 } as const
 
 export const $OrganizationSecretRead = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -365,6 +365,8 @@ import type {
   OrganizationGetInvitationByTokenResponse,
   OrganizationGetInvitationTokenData,
   OrganizationGetInvitationTokenResponse,
+  OrganizationGetOrgAgentUsageData,
+  OrganizationGetOrgAgentUsageResponse,
   OrganizationGetOrganizationEntitlementsResponse,
   OrganizationGetOrganizationResponse,
   OrganizationListInvitationsData,
@@ -385,6 +387,8 @@ import type {
   OrganizationSecretsListOrgSecretsResponse,
   OrganizationSecretsUpdateOrgSecretByIdData,
   OrganizationSecretsUpdateOrgSecretByIdResponse,
+  OrganizationSetOrgAgentBudgetData,
+  OrganizationSetOrgAgentBudgetResponse,
   OrganizationUpdateOrgMemberData,
   OrganizationUpdateOrgMemberResponse,
   ProvidersCreateCustomProviderData,
@@ -4125,6 +4129,51 @@ export const organizationGetInvitationByToken = (
     path: {
       token: data.token,
     },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Org Agent Usage
+ * Read the caller's organization agent spend for a UTC month.
+ * @param data The data for the request.
+ * @param data.month UTC month in YYYY-MM format. Defaults to the current UTC month.
+ * @returns OrgUsageSnapshot Successful Response
+ * @throws ApiError
+ */
+export const organizationGetOrgAgentUsage = (
+  data: OrganizationGetOrgAgentUsageData = {}
+): CancelablePromise<OrganizationGetOrgAgentUsageResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/organization/agent-usage",
+    query: {
+      month: data.month,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Set Org Agent Budget
+ * Set or clear the caller's organization monthly agent budget.
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns OrgUsageSnapshot Successful Response
+ * @throws ApiError
+ */
+export const organizationSetOrgAgentBudget = (
+  data: OrganizationSetOrgAgentBudgetData
+): CancelablePromise<OrganizationSetOrgAgentBudgetResponse> => {
+  return __request(OpenAPI, {
+    method: "PUT",
+    url: "/organization/agent-usage/limit",
+    body: data.requestBody,
+    mediaType: "application/json",
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -312,6 +312,16 @@ export type AdminUserRead = {
 }
 
 /**
+ * Set or clear an org's monthly agent budget (cents).
+ */
+export type AgentBudgetUpdate = {
+  /**
+   * Monthly agent spend cap in US cents (1000 = $10.00). Pass null to remove the cap.
+   */
+  monthly_budget_cents?: number | null
+}
+
+/**
  * Request schema for creating an external channel token.
  */
 export type AgentChannelTokenCreate = {
@@ -4415,6 +4425,18 @@ export type OrgUpdate = {
   name?: string | null
   slug?: string | null
   is_active?: boolean | null
+}
+
+/**
+ * Point-in-time read of an org's monthly agent spend.
+ */
+export type OrgUsageSnapshot = {
+  month_utc: string
+  total_cents: number
+  limit_cents: number | null
+  by_workspace_cents: {
+    [key: string]: number
+  }
 }
 
 /**
@@ -9165,6 +9187,21 @@ export type OrganizationGetInvitationByTokenData = {
 
 export type OrganizationGetInvitationByTokenResponse = OrgInvitationReadMinimal
 
+export type OrganizationGetOrgAgentUsageData = {
+  /**
+   * UTC month in YYYY-MM format. Defaults to the current UTC month.
+   */
+  month?: string | null
+}
+
+export type OrganizationGetOrgAgentUsageResponse = OrgUsageSnapshot
+
+export type OrganizationSetOrgAgentBudgetData = {
+  requestBody: AgentBudgetUpdate
+}
+
+export type OrganizationSetOrgAgentBudgetResponse = OrgUsageSnapshot
+
 export type ServiceAccountsListOrganizationServiceAccountsData = {
   cursor?: string | null
   limit?: number
@@ -13091,6 +13128,36 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: OrgInvitationReadMinimal
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/organization/agent-usage": {
+    get: {
+      req: OrganizationGetOrgAgentUsageData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: OrgUsageSnapshot
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/organization/agent-usage/limit": {
+    put: {
+      req: OrganizationSetOrgAgentBudgetData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: OrgUsageSnapshot
         /**
          * Validation Error
          */

--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -435,10 +435,13 @@ function AgentUsageSection() {
   const limitCents = usage.limit_cents ?? null
   const byWorkspaceCents = usage.by_workspace_cents ?? {}
 
+  // Intentionally uncapped: an org can record spend past its cap between the
+  // last check and the SDK terminating a run, and we want that visible (e.g.
+  // "$0.09 of $0.06 (150%)") rather than flattened to 100%.
   const percentUsed =
     limitCents == null || limitCents === 0
       ? null
-      : Math.min(100, Math.round((totalCents / limitCents) * 100))
+      : Math.round((totalCents / limitCents) * 100)
 
   const workspaceRows = Object.entries(byWorkspaceCents).sort(
     ([, a], [, b]) => b - a

--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -4,15 +4,22 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import {
   BotIcon,
   CheckCircleIcon,
+  ChevronDownIcon,
   SettingsIcon,
   Trash2Icon,
 } from "lucide-react"
 import { useState } from "react"
-import { useForm, useFormContext } from "react-hook-form"
+import { useForm } from "react-hook-form"
 import { z } from "zod"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
 import { AgentCredentialsDialog } from "@/components/organization/org-agent-credentials-dialog"
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -33,6 +40,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
 import {
   Select,
   SelectContent,
@@ -40,12 +48,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { toast } from "@/components/ui/use-toast"
+import { useEntitlements } from "@/hooks/use-entitlements"
 import {
   useAgentDefaultModel,
   useAgentModels,
   useDeleteProviderCredentials,
   useModelProvidersStatus,
+  useOrgAgentUsage,
   useProviderCredentialConfigs,
+  useWorkspaceManager,
 } from "@/lib/hooks"
 
 const agentFormSchema = z.object({
@@ -55,22 +67,52 @@ const agentFormSchema = z.object({
 type AgentFormValues = z.infer<typeof agentFormSchema>
 
 /**
- * Subcomponent that handles the default model selection field
- * Uses useFormContext to access the form and depends on models and defaultModel data
+ * Default-model form. A dropdown and a Save button — mirrors the shape of
+ * every other settings form on the site.
  */
-function DefaultModelSelector({ isUpdating }: { isUpdating: boolean }) {
-  const form = useFormContext<AgentFormValues>()
+function DefaultModelForm() {
   const { models, modelsLoading, modelsError } = useAgentModels()
+  const {
+    defaultModel,
+    defaultModelLoading,
+    defaultModelError,
+    updateDefaultModel,
+    isUpdating,
+  } = useAgentDefaultModel()
 
-  if (modelsLoading) {
+  const form = useForm<AgentFormValues>({
+    resolver: zodResolver(agentFormSchema),
+    values: { default_model: defaultModel || "" },
+  })
+
+  async function onSubmit(data: AgentFormValues) {
+    if (!data.default_model || data.default_model === defaultModel) return
+    try {
+      await updateDefaultModel(data.default_model)
+      toast({
+        title: "Default model updated",
+        description: `Agent operations will now use ${data.default_model}.`,
+      })
+    } catch (err) {
+      console.error("Failed to update default model", err)
+      toast({
+        title: "Failed to update default model",
+        description: "Please try again.",
+        variant: "destructive",
+      })
+    }
+  }
+
+  if (modelsLoading || defaultModelLoading) {
     return <CenteredSpinner />
   }
 
-  if (modelsError) {
+  if (modelsError || defaultModelError) {
+    const err = modelsError || defaultModelError
     return (
       <AlertNotification
         level="error"
-        message={`Error loading models: ${modelsError instanceof Error ? modelsError.message : "Unknown error"}`}
+        message={`Error loading agent configuration: ${err instanceof Error ? err.message : "Unknown error"}`}
       />
     )
   }
@@ -85,46 +127,49 @@ function DefaultModelSelector({ isUpdating }: { isUpdating: boolean }) {
   }
 
   return (
-    <>
-      <FormField
-        control={form.control}
-        name="default_model"
-        render={({ field }) => (
-          <FormItem className="flex flex-col">
-            <FormLabel>Default AI model</FormLabel>
-            <FormControl>
-              <Select onValueChange={field.onChange} value={field.value}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select a model" />
-                </SelectTrigger>
-                <SelectContent>
-                  {Object.entries(models).map(([modelName, model]) => (
-                    <SelectItem key={modelName} value={modelName}>
-                      <div className="flex items-center space-x-2">
-                        <BotIcon className="size-4" />
-                        <span>{model.name}</span>
-                        <span className="text-xs text-muted-foreground">
-                          ({model.provider})
-                        </span>
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </FormControl>
-            <FormDescription>
-              Select the default AI model for agent operations in your
-              organization.
-            </FormDescription>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-
-      <Button type="submit" disabled={isUpdating}>
-        {isUpdating ? "Updating..." : "Update agent settings"}
-      </Button>
-    </>
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <FormField
+          control={form.control}
+          name="default_model"
+          render={({ field }) => (
+            <FormItem className="flex flex-col">
+              <FormLabel>Default AI model</FormLabel>
+              <div className="flex items-center gap-2">
+                <FormControl>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a model" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.entries(models).map(([modelName, model]) => (
+                        <SelectItem key={modelName} value={modelName}>
+                          <div className="flex items-center space-x-2">
+                            <BotIcon className="size-4" />
+                            <span>{model.name}</span>
+                            <span className="text-xs text-muted-foreground">
+                              ({model.provider})
+                            </span>
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <Button type="submit" disabled={isUpdating}>
+                  {isUpdating ? "Saving..." : "Save"}
+                </Button>
+              </div>
+              <FormDescription>
+                Select the default AI model for agent operations in your
+                organization.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </form>
+    </Form>
   )
 }
 
@@ -287,57 +332,242 @@ function ProviderCredentialsSection() {
   )
 }
 
-/**
- * Main form component that coordinates the subcomponents and handles form submission
- */
-export function OrgSettingsAgentForm() {
-  const {
-    defaultModel,
-    defaultModelLoading,
-    defaultModelError,
-    updateDefaultModel,
-    isUpdating,
-  } = useAgentDefaultModel()
+const DOLLAR_FORMATTER = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+})
 
-  const form = useForm<AgentFormValues>({
-    resolver: zodResolver(agentFormSchema),
+/**
+ * Format a cent amount as a localized USD string ("1234" → "$12.34").
+ */
+function formatCents(cents: number | null | undefined): string {
+  if (cents == null || !Number.isFinite(cents)) return "$0.00"
+  return DOLLAR_FORMATTER.format(cents / 100)
+}
+
+const budgetFormSchema = z.object({
+  // Blank string clears the cap; otherwise must be a non-negative dollar
+  // value (up to 2 decimal places). The backend stores integer cents so we
+  // reject anything finer-grained than a cent.
+  monthly_budget_dollars: z
+    .string()
+    .trim()
+    .refine(
+      (value) => {
+        if (value === "") return true
+        const parsed = Number(value)
+        return Number.isFinite(parsed) && parsed > 0
+      },
+      {
+        message: "Enter a positive dollar amount, or leave blank to remove.",
+      }
+    ),
+})
+
+type BudgetFormValues = z.infer<typeof budgetFormSchema>
+
+/**
+ * Agent spend section: shows the current UTC-month total, an optional
+ * per-workspace breakdown, and a form to set or clear the monthly dollar
+ * budget cap.
+ */
+function AgentUsageSection() {
+  const { usage, usageLoading, usageError, updateUsageLimit, isUpdatingLimit } =
+    useOrgAgentUsage()
+  const { workspaces } = useWorkspaceManager()
+  const workspaceNameById = new Map(
+    (workspaces ?? []).map((ws) => [ws.id, ws.name])
+  )
+
+  const initialBudgetDollars =
+    usage?.limit_cents != null ? (usage.limit_cents / 100).toFixed(2) : ""
+
+  const form = useForm<BudgetFormValues>({
+    resolver: zodResolver(budgetFormSchema),
     values: {
-      default_model: defaultModel || "",
+      monthly_budget_dollars: initialBudgetDollars,
     },
   })
 
-  const onSubmit = async (data: AgentFormValues) => {
-    if (!data.default_model) return
-
+  async function onSubmit(data: BudgetFormValues) {
+    const raw = data.monthly_budget_dollars.trim()
+    const nextCents =
+      raw === "" ? null : Math.round(Number.parseFloat(raw) * 100)
     try {
-      await updateDefaultModel(data.default_model)
-    } catch (err) {
-      console.error("Failed to update default model:", err)
+      await updateUsageLimit({ monthly_budget_cents: nextCents })
+      toast({
+        title: nextCents === null ? "Budget cleared" : "Budget updated",
+        description:
+          nextCents === null
+            ? "Agent runs in this organization are now uncapped."
+            : `Monthly budget set to ${formatCents(nextCents)}.`,
+      })
+    } catch (error) {
+      console.error("Failed to update budget", error)
+      toast({
+        title: "Failed to update budget",
+        description: "Please try again.",
+        variant: "destructive",
+      })
     }
   }
 
-  // Handle loading state for the initial form data
-  if (defaultModelLoading) {
+  if (usageLoading) {
     return <CenteredSpinner />
   }
 
-  // Handle error state for the initial form data
-  if (defaultModelError) {
+  if (usageError) {
     return (
       <AlertNotification
         level="error"
-        message={`Error loading agent configuration: ${defaultModelError instanceof Error ? defaultModelError.message : "Unknown error"}`}
+        message={`Error loading agent usage: ${usageError instanceof Error ? usageError.message : "Unknown error"}`}
       />
     )
   }
 
+  if (!usage) {
+    return (
+      <AlertNotification level="error" message="Failed to load agent usage" />
+    )
+  }
+
+  const totalCents = usage.total_cents ?? 0
+  const limitCents = usage.limit_cents ?? null
+  const byWorkspaceCents = usage.by_workspace_cents ?? {}
+
+  const percentUsed =
+    limitCents == null || limitCents === 0
+      ? null
+      : Math.min(100, Math.round((totalCents / limitCents) * 100))
+
+  const workspaceRows = Object.entries(byWorkspaceCents).sort(
+    ([, a], [, b]) => b - a
+  )
+
+  const spentLine =
+    limitCents == null
+      ? `Spent ${formatCents(totalCents)} this month`
+      : `Spent ${formatCents(totalCents)} of ${formatCents(limitCents)} this month${
+          percentUsed != null ? ` (${percentUsed}%)` : ""
+        }`
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <FormItem>
+          <FormLabel>Spend this month (UTC)</FormLabel>
+          <FormControl>
+            <Input value={spentLine} disabled />
+          </FormControl>
+          <FormDescription>
+            Dollar cost of agent runs in this organization. Counters reset at
+            the start of each UTC month.
+          </FormDescription>
+        </FormItem>
+
+        <FormField
+          control={form.control}
+          name="monthly_budget_dollars"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Monthly budget (USD)</FormLabel>
+              <div className="flex items-center gap-2">
+                <FormControl>
+                  <Input
+                    type="number"
+                    min={0}
+                    step={0.01}
+                    inputMode="decimal"
+                    placeholder="Leave blank for unlimited"
+                    {...field}
+                  />
+                </FormControl>
+                <Button type="submit" disabled={isUpdatingLimit}>
+                  {isUpdatingLimit ? "Saving..." : "Save"}
+                </Button>
+              </div>
+              <FormDescription>
+                New agent runs are blocked once the organization's spend for the
+                current UTC month reaches this budget.
+              </FormDescription>
+              <FormMessage />
+
+              {workspaceRows.length > 0 ? (
+                <Accordion type="single" collapsible>
+                  <AccordionItem value="by-workspace" className="border-b-0">
+                    <AccordionTrigger
+                      className={
+                        "justify-start gap-2 py-2 text-sm text-muted-foreground " +
+                        "hover:no-underline [&>svg:last-child]:hidden " +
+                        "[&[data-state=open]_[data-chevron]]:rotate-180"
+                      }
+                    >
+                      <ChevronDownIcon
+                        data-chevron
+                        className="size-4 shrink-0 transition-transform duration-200"
+                      />
+                      <span>Spend by workspace</span>
+                    </AccordionTrigger>
+                    <AccordionContent className="pb-2 pt-2">
+                      <ul className="space-y-1 text-sm">
+                        {workspaceRows.map(([workspaceId, cents]) => {
+                          const name = workspaceNameById.get(workspaceId)
+                          const label =
+                            name ??
+                            (workspaceId === "unknown"
+                              ? "Unknown workspace"
+                              : "Deleted workspace")
+                          return (
+                            <li
+                              key={workspaceId}
+                              className="flex items-center justify-between text-muted-foreground"
+                            >
+                              <span>{label}</span>
+                              <span className="tabular-nums">
+                                {formatCents(cents)}
+                              </span>
+                            </li>
+                          )
+                        })}
+                      </ul>
+                    </AccordionContent>
+                  </AccordionItem>
+                </Accordion>
+              ) : null}
+            </FormItem>
+          )}
+        />
+      </form>
+    </Form>
+  )
+}
+
+/**
+ * Conditionally mounts the agent usage section only when the organization has
+ * the agent_addons entitlement. Keeps the section's queries from firing for
+ * orgs that don't have access.
+ */
+function AgentUsageGate() {
+  const { hasEntitlement, isLoading } = useEntitlements()
+  if (isLoading) return null
+  if (!hasEntitlement("agent_addons")) return null
+  return (
+    <>
+      <AgentUsageSection />
+      <div className="h-px w-full bg-border" />
+    </>
+  )
+}
+
+/**
+ * Main form component that coordinates the subcomponents.
+ */
+export function OrgSettingsAgentForm() {
   return (
     <div className="space-y-8">
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-          <DefaultModelSelector isUpdating={isUpdating} />
-        </form>
-      </Form>
+      <AgentUsageGate />
+
+      <DefaultModelForm />
 
       <ProviderCredentialsSection />
     </div>

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -12,6 +12,7 @@ import {
   type ActionRead,
   type ActionsDeleteActionData,
   type ActionUpdate,
+  type AgentBudgetUpdate,
   type AgentGetProviderCredentialConfigResponse,
   type AgentGetProvidersStatusResponse,
   type AgentGetWorkspaceProvidersStatusResponse,
@@ -152,9 +153,11 @@ import {
   type OrganizationUpdateOrgMemberData,
   type OrgInvitationCreate,
   type OrgMemberRead,
+  type OrgUsageSnapshot,
   organizationCreateInvitation,
   organizationDeleteOrgMember,
   organizationDeleteSession,
+  organizationGetOrgAgentUsage,
   organizationListOrgMembers,
   organizationListSessions,
   organizationRevokeInvitation,
@@ -162,6 +165,7 @@ import {
   organizationSecretsDeleteOrgSecretById,
   organizationSecretsListOrgSecrets,
   organizationSecretsUpdateOrgSecretById,
+  organizationSetOrgAgentBudget,
   organizationUpdateOrgMember,
   type ProviderCredentialConfig,
   type ProviderRead,
@@ -5184,6 +5188,47 @@ export function useAgentDefaultModel() {
     updateDefaultModel,
     isUpdating,
     updateError,
+  }
+}
+
+/**
+ * Read the caller's organization agent spend for a UTC month (defaults to
+ * current) and expose a mutation to set or clear the monthly budget cap.
+ *
+ * Values are in integer cents on the wire; the caller is responsible for
+ * display formatting (USD).
+ */
+export function useOrgAgentUsage(month?: string) {
+  const queryClient = useQueryClient()
+
+  const {
+    data: usage,
+    isLoading: usageLoading,
+    error: usageError,
+  } = useQuery<OrgUsageSnapshot>({
+    queryKey: ["org-agent-usage", month ?? "current"],
+    queryFn: async () => await organizationGetOrgAgentUsage({ month }),
+  })
+
+  const {
+    mutateAsync: updateUsageLimit,
+    isPending: isUpdatingLimit,
+    error: updateLimitError,
+  } = useMutation({
+    mutationFn: async (params: AgentBudgetUpdate) =>
+      await organizationSetOrgAgentBudget({ requestBody: params }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["org-agent-usage"] })
+    },
+  })
+
+  return {
+    usage,
+    usageLoading,
+    usageError,
+    updateUsageLimit,
+    isUpdatingLimit,
+    updateLimitError,
   }
 }
 

--- a/tests/unit/test_agent_mcp_proxy_server.py
+++ b/tests/unit/test_agent_mcp_proxy_server.py
@@ -11,8 +11,8 @@ from claude_agent_sdk.types import (
     PreToolUseHookSpecificOutput,
     SyncHookJSONOutput,
 )
-from mcp import types as mt
 
+from mcp import types as mt
 from tracecat.agent.common.types import MCPToolDefinition
 from tracecat.agent.mcp import proxy_server
 from tracecat.agent.runtime.claude_code.runtime import ClaudeAgentRuntime

--- a/tests/unit/test_agent_mcp_proxy_server.py
+++ b/tests/unit/test_agent_mcp_proxy_server.py
@@ -11,8 +11,8 @@ from claude_agent_sdk.types import (
     PreToolUseHookSpecificOutput,
     SyncHookJSONOutput,
 )
-
 from mcp import types as mt
+
 from tracecat.agent.common.types import MCPToolDefinition
 from tracecat.agent.mcp import proxy_server
 from tracecat.agent.runtime.claude_code.runtime import ClaudeAgentRuntime

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -41,6 +41,7 @@ from tracecat.agent.mcp.proxy_server import (
 from tracecat.agent.runtime.claude_code.runtime import (
     CLAUDE_SDK_MAX_BUFFER_SIZE_BYTES,
     ClaudeAgentRuntime,
+    _merge_usage,
     get_litellm_route_model,
 )
 from tracecat.agent.types import AgentConfig
@@ -1201,3 +1202,94 @@ class TestClaudeAgentRuntimeInternalSessionLines:
         }
 
         assert runtime._is_internal_session_line(line_data) is True
+
+
+# -----------------------------------------------------------------------------
+# _merge_usage — folds SDK model_usage camelCase into usage snake_case
+# -----------------------------------------------------------------------------
+
+
+class TestMergeUsage:
+    def test_anthropic_native_preserves_usage_and_adds_cost(self) -> None:
+        """Native Anthropic populates both; merge only adds cost_usd."""
+        usage = {
+            "input_tokens": 10,
+            "output_tokens": 125,
+            "cache_creation_input_tokens": 9321,
+            "cache_read_input_tokens": 0,
+        }
+        model_usage = {
+            "anthropic/claude-haiku-4-5-20251001": {
+                "inputTokens": 10,
+                "outputTokens": 125,
+                "cacheCreationInputTokens": 9321,
+                "cacheReadInputTokens": 0,
+                "costUSD": 0.012286249999999999,
+            }
+        }
+        merged = _merge_usage(usage, model_usage)
+        assert merged is not None
+        assert merged["input_tokens"] == 10
+        assert merged["output_tokens"] == 125
+        assert merged["cache_creation_input_tokens"] == 9321
+        assert merged["total_cost_usd"] == pytest.approx(0.012286249999999999)
+
+    def test_litellm_route_fills_zeroed_usage_from_model_usage(self) -> None:
+        """The 'ant' route zeros usage; merge must rehydrate from model_usage."""
+        usage = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        }
+        model_usage = {
+            "ant": {
+                "inputTokens": 8968,
+                "outputTokens": 24,
+                "cacheReadInputTokens": 0,
+                "cacheCreationInputTokens": 0,
+                "costUSD": 0.027264,
+            }
+        }
+        merged = _merge_usage(usage, model_usage)
+        assert merged is not None
+        assert merged["input_tokens"] == 8968
+        assert merged["output_tokens"] == 24
+        assert merged["total_cost_usd"] == pytest.approx(0.027264)
+
+    def test_multi_model_sums_across_entries(self) -> None:
+        usage = {}
+        model_usage = {
+            "openai/gpt-5.2": {
+                "inputTokens": 100,
+                "outputTokens": 10,
+                "costUSD": 0.02,
+            },
+            "anthropic/claude-haiku": {
+                "inputTokens": 50,
+                "outputTokens": 5,
+                "costUSD": 0.05,
+            },
+        }
+        merged = _merge_usage(usage, model_usage)
+        assert merged is not None
+        assert merged["input_tokens"] == 150
+        assert merged["output_tokens"] == 15
+        assert merged["total_cost_usd"] == pytest.approx(0.07)
+
+    def test_no_model_usage_returns_usage_as_is(self) -> None:
+        usage = {"input_tokens": 3, "output_tokens": 1}
+        assert _merge_usage(usage, None) == usage
+
+    def test_both_missing_returns_none(self) -> None:
+        assert _merge_usage(None, None) is None
+        assert _merge_usage({}, {}) is None
+
+    def test_native_nonzero_not_overwritten_by_model_usage(self) -> None:
+        """Preserve SDK-native values when they disagree with model_usage."""
+        usage = {"input_tokens": 99}
+        model_usage = {"r": {"inputTokens": 500, "costUSD": 0.01}}
+        merged = _merge_usage(usage, model_usage)
+        assert merged is not None
+        assert merged["input_tokens"] == 99  # native wins
+        assert merged["total_cost_usd"] == pytest.approx(0.01)

--- a/tests/unit/test_agent_usage.py
+++ b/tests/unit/test_agent_usage.py
@@ -1,0 +1,417 @@
+"""Tests for tracecat/agent/usage.py (monthly budget cap + cost counters)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from tracecat.agent import usage as usage_module
+
+
+class _FakePipeline:
+    def __init__(self, client: _FakeRedisClient) -> None:
+        self._client = client
+        self._ops: list[tuple[str, tuple[Any, ...]]] = []
+
+    def incrby(self, key: str, amount: int) -> _FakePipeline:
+        self._ops.append(("incrby", (key, amount)))
+        return self
+
+    def hincrby(self, key: str, field: str, amount: int) -> _FakePipeline:
+        self._ops.append(("hincrby", (key, field, amount)))
+        return self
+
+    def expire(self, key: str, seconds: int) -> _FakePipeline:
+        self._ops.append(("expire", (key, seconds)))
+        return self
+
+    async def execute(self) -> list[Any]:
+        results: list[Any] = []
+        for name, args in self._ops:
+            method = getattr(self._client, f"_{name}")
+            results.append(method(*args))
+        self._ops.clear()
+        return results
+
+
+class _FakeRedisClient:
+    def __init__(self) -> None:
+        self.ints: dict[str, int] = {}
+        self.hashes: dict[str, dict[str, int]] = {}
+        self.expires: dict[str, int] = {}
+
+    async def get(self, key: str) -> str | None:
+        value = self.ints.get(key)
+        return None if value is None else str(value)
+
+    async def hgetall(self, key: str) -> dict[str, str]:
+        return {k: str(v) for k, v in self.hashes.get(key, {}).items()}
+
+    def pipeline(self, transaction: bool = False) -> _FakePipeline:
+        del transaction
+        return _FakePipeline(self)
+
+    def _incrby(self, key: str, amount: int) -> int:
+        self.ints[key] = self.ints.get(key, 0) + amount
+        return self.ints[key]
+
+    def _hincrby(self, key: str, field: str, amount: int) -> int:
+        bucket = self.hashes.setdefault(key, {})
+        bucket[field] = bucket.get(field, 0) + amount
+        return bucket[field]
+
+    def _expire(self, key: str, seconds: int) -> bool:
+        self.expires[key] = seconds
+        return True
+
+
+class _FakeRedisWrapper:
+    def __init__(self, client: _FakeRedisClient) -> None:
+        self._client = client
+
+    async def _get_client(self) -> _FakeRedisClient:
+        return self._client
+
+
+@pytest.fixture
+def fake_redis(monkeypatch: pytest.MonkeyPatch) -> _FakeRedisClient:
+    client = _FakeRedisClient()
+    wrapper = _FakeRedisWrapper(client)
+
+    async def _get_redis_client() -> _FakeRedisWrapper:
+        return wrapper
+
+    monkeypatch.setattr(usage_module, "get_redis_client", _get_redis_client)
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _reset_cap_cache() -> None:  # pyright: ignore[reportUnusedFunction]
+    usage_module.invalidate_cap_cache()
+
+
+@pytest.fixture
+def fake_db(
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[tuple[str, str], tuple[int, dict[str, int]]]:
+    """In-memory stand-in for the durable Postgres usage row.
+
+    Mirrors ``agents.usage.{YYYY-MM}`` keyed by (org_id, month).
+    """
+    storage: dict[tuple[str, str], tuple[int, dict[str, int]]] = {}
+
+    async def _increment(
+        *,
+        org_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        cost_cents: int,
+        month: str,
+    ) -> None:
+        key = (str(org_id), month)
+        total, by_ws = storage.get(key, (0, {}))
+        total += cost_cents
+        ws_field = str(workspace_id)
+        by_ws = {**by_ws, ws_field: by_ws.get(ws_field, 0) + cost_cents}
+        storage[key] = (total, by_ws)
+
+    async def _read(org_id: uuid.UUID, month: str) -> tuple[int, dict[str, int]] | None:
+        return storage.get((str(org_id), month))
+
+    monkeypatch.setattr(usage_module, "_increment_usage_in_db", _increment)
+    monkeypatch.setattr(usage_module, "_read_usage_from_db", _read)
+    return storage
+
+
+@pytest.fixture
+def fixed_month(monkeypatch: pytest.MonkeyPatch) -> str:
+    month = "2026-04"
+
+    def _current_month_utc() -> str:
+        return month
+
+    monkeypatch.setattr(usage_module, "_current_month_utc", _current_month_utc)
+    return month
+
+
+def _patch_budget(monkeypatch: pytest.MonkeyPatch, cents: int | None) -> None:
+    async def _loader(_org_id: uuid.UUID) -> int | None:
+        return cents
+
+    monkeypatch.setattr(usage_module, "_load_monthly_budget_cents", _loader)
+
+
+# -----------------------------------------------------------------------------
+# cents_from_usage (reads the merged usage dict produced by the runtime)
+# -----------------------------------------------------------------------------
+
+
+def test_cents_from_usage_rounds_cost_usd_to_cents() -> None:
+    # Real shape: runtime folds SDK model_usage costUSD into usage.total_cost_usd.
+    usage = {
+        "input_tokens": 10,
+        "output_tokens": 125,
+        "cache_creation_input_tokens": 9321,
+        "cache_read_input_tokens": 0,
+        "total_cost_usd": 0.012286249999999999,
+    }
+    assert usage_module.cents_from_usage(usage) == 1
+
+
+def test_cents_from_usage_handles_multi_model_sum() -> None:
+    # Post-merge the runtime has already summed across models.
+    usage = {"total_cost_usd": 0.070004}
+    assert usage_module.cents_from_usage(usage) == 7
+
+
+def test_cents_from_usage_empty_or_missing() -> None:
+    assert usage_module.cents_from_usage(None) == 0
+    assert usage_module.cents_from_usage({}) == 0
+    assert usage_module.cents_from_usage({"total_cost_usd": None}) == 0
+    # Tokens without cost → still 0 (guardrail is dollar-based)
+    assert usage_module.cents_from_usage({"input_tokens": 1000}) == 0
+
+
+def test_cents_from_usage_rejects_negative() -> None:
+    assert usage_module.cents_from_usage({"total_cost_usd": -1.5}) == 0
+
+
+# -----------------------------------------------------------------------------
+# record_agent_cost
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_record_agent_cost_increments_total_and_workspace_hash(
+    fake_redis: _FakeRedisClient,
+    fake_db: dict[tuple[str, str], tuple[int, dict[str, int]]],
+    fixed_month: str,
+) -> None:
+    org_id = uuid.uuid4()
+    ws_a = uuid.uuid4()
+    ws_b = uuid.uuid4()
+
+    await usage_module.record_agent_cost(
+        org_id=org_id, workspace_id=ws_a, cost_cents=50
+    )
+    await usage_module.record_agent_cost(
+        org_id=org_id, workspace_id=ws_b, cost_cents=125
+    )
+    await usage_module.record_agent_cost(
+        org_id=org_id, workspace_id=ws_a, cost_cents=25
+    )
+
+    total_key = f"usage:cost_cents:org:{org_id}:{fixed_month}"
+    by_ws_key = f"usage:cost_cents:org:{org_id}:{fixed_month}:by_ws"
+
+    # Redis mirror
+    assert fake_redis.ints[total_key] == 200
+    assert fake_redis.hashes[by_ws_key][str(ws_a)] == 75
+    assert fake_redis.hashes[by_ws_key][str(ws_b)] == 125
+    assert fake_redis.expires[total_key] == 90 * 24 * 60 * 60
+
+    # Postgres source of truth
+    durable_total, durable_by_ws = fake_db[(str(org_id), fixed_month)]
+    assert durable_total == 200
+    assert durable_by_ws[str(ws_a)] == 75
+    assert durable_by_ws[str(ws_b)] == 125
+
+
+@pytest.mark.anyio
+async def test_record_agent_cost_zero_noops(
+    fake_redis: _FakeRedisClient,
+    fake_db: dict[tuple[str, str], tuple[int, dict[str, int]]],
+    fixed_month: str,
+) -> None:
+    await usage_module.record_agent_cost(
+        org_id=uuid.uuid4(), workspace_id=uuid.uuid4(), cost_cents=0
+    )
+    assert fake_redis.ints == {}
+    assert fake_redis.hashes == {}
+    assert fake_db == {}
+
+
+# -----------------------------------------------------------------------------
+# check_monthly_budget
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_check_monthly_budget_allows_below_limit(
+    fake_redis: _FakeRedisClient,
+    fixed_month: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    _patch_budget(monkeypatch, 1000)  # $10.00
+    fake_redis.ints[f"usage:cost_cents:org:{org_id}:{fixed_month}"] = 900
+    await usage_module.check_monthly_budget(org_id)
+
+
+@pytest.mark.anyio
+async def test_check_monthly_budget_raises_at_limit(
+    fake_redis: _FakeRedisClient,
+    fixed_month: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    _patch_budget(monkeypatch, 1000)
+    fake_redis.ints[f"usage:cost_cents:org:{org_id}:{fixed_month}"] = 1000
+    with pytest.raises(usage_module.BudgetExceededError) as excinfo:
+        await usage_module.check_monthly_budget(org_id)
+    assert excinfo.value.limit_cents == 1000
+    assert excinfo.value.used_cents == 1000
+
+
+@pytest.mark.anyio
+async def test_check_monthly_budget_no_limit_is_unlimited(
+    fake_redis: _FakeRedisClient,
+    fixed_month: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    _patch_budget(monkeypatch, None)
+    fake_redis.ints[f"usage:cost_cents:org:{org_id}:{fixed_month}"] = 10**9
+    await usage_module.check_monthly_budget(org_id)
+
+
+@pytest.mark.anyio
+async def test_check_monthly_budget_falls_back_to_postgres(
+    fake_redis: _FakeRedisClient,
+    fake_db: dict[tuple[str, str], tuple[int, dict[str, int]]],
+    fixed_month: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Redis is empty (e.g. evicted) but Postgres has the real total."""
+    org_id = uuid.uuid4()
+    _patch_budget(monkeypatch, 500)
+    # Redis returns nothing — no keys seeded.
+    # Postgres has the durable counter with 600 cents already spent.
+    fake_db[(str(org_id), fixed_month)] = (600, {str(uuid.uuid4()): 600})
+
+    del fake_redis  # unused: redis is empty by design
+    with pytest.raises(usage_module.BudgetExceededError) as excinfo:
+        await usage_module.check_monthly_budget(org_id)
+    assert excinfo.value.used_cents == 600
+    assert excinfo.value.limit_cents == 500
+
+
+# -----------------------------------------------------------------------------
+# get_usage_snapshot
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_usage_snapshot_returns_total_and_breakdown(
+    fake_redis: _FakeRedisClient,
+    fixed_month: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    ws_a = uuid.uuid4()
+    _patch_budget(monkeypatch, 500)
+    fake_redis.ints[f"usage:cost_cents:org:{org_id}:{fixed_month}"] = 250
+    fake_redis.hashes[f"usage:cost_cents:org:{org_id}:{fixed_month}:by_ws"] = {
+        str(ws_a): 250,
+    }
+
+    snapshot = await usage_module.get_usage_snapshot(org_id)
+    assert snapshot.month_utc == fixed_month
+    assert snapshot.total_cents == 250
+    assert snapshot.limit_cents == 500
+    assert snapshot.by_workspace_cents == {str(ws_a): 250}
+
+
+@pytest.mark.anyio
+async def test_get_usage_snapshot_empty_is_zero(
+    fake_redis: _FakeRedisClient,
+    fake_db: dict[tuple[str, str], tuple[int, dict[str, int]]],
+    fixed_month: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del fake_redis, fake_db
+    _patch_budget(monkeypatch, None)
+    snapshot = await usage_module.get_usage_snapshot(uuid.uuid4())
+    assert snapshot.month_utc == fixed_month
+    assert snapshot.total_cents == 0
+    assert snapshot.by_workspace_cents == {}
+
+
+@pytest.mark.anyio
+async def test_get_usage_snapshot_falls_back_to_postgres(
+    fake_redis: _FakeRedisClient,
+    fake_db: dict[tuple[str, str], tuple[int, dict[str, int]]],
+    fixed_month: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Redis empty → snapshot rebuilds from Postgres."""
+    org_id = uuid.uuid4()
+    ws_a = uuid.uuid4()
+    _patch_budget(monkeypatch, 1000)
+    fake_db[(str(org_id), fixed_month)] = (750, {str(ws_a): 750})
+    del fake_redis  # empty by design
+
+    snapshot = await usage_module.get_usage_snapshot(org_id)
+    assert snapshot.total_cents == 750
+    assert snapshot.by_workspace_cents == {str(ws_a): 750}
+    assert snapshot.limit_cents == 1000
+
+
+# -----------------------------------------------------------------------------
+# UTC month rollover
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_current_month_rolls_over_at_utc_boundary(
+    fake_redis: _FakeRedisClient,
+    fake_db: dict[tuple[str, str], tuple[int, dict[str, int]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del fake_db
+    org_id = uuid.uuid4()
+    ws = uuid.uuid4()
+
+    monkeypatch.setattr(usage_module, "_current_month_utc", lambda: "2026-03")
+    await usage_module.record_agent_cost(org_id=org_id, workspace_id=ws, cost_cents=10)
+
+    monkeypatch.setattr(usage_module, "_current_month_utc", lambda: "2026-04")
+    await usage_module.record_agent_cost(org_id=org_id, workspace_id=ws, cost_cents=20)
+
+    assert fake_redis.ints[f"usage:cost_cents:org:{org_id}:2026-03"] == 10
+    assert fake_redis.ints[f"usage:cost_cents:org:{org_id}:2026-04"] == 20
+
+
+@pytest.mark.anyio
+async def test_current_month_utc_uses_utc_not_local() -> None:
+    value = usage_module._current_month_utc()
+    now = datetime.now(UTC)
+    assert value == now.strftime("%Y-%m")
+
+
+# -----------------------------------------------------------------------------
+# Cap cache invalidation
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_cap_cache_invalidation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    values = iter([100, 500])
+
+    async def _loader(_org: uuid.UUID) -> int | None:
+        return next(values)
+
+    monkeypatch.setattr(usage_module, "_load_monthly_budget_cents", _loader)
+    first = await usage_module.get_monthly_budget_cents(org_id)
+    cached = await usage_module.get_monthly_budget_cents(org_id)
+    assert first == 100
+    assert cached == 100
+
+    usage_module.invalidate_cap_cache(org_id)
+    refreshed = await usage_module.get_monthly_budget_cents(org_id)
+    assert refreshed == 500

--- a/tests/unit/test_agent_usage.py
+++ b/tests/unit/test_agent_usage.py
@@ -4,104 +4,24 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
-from typing import Any
 
 import pytest
 
 from tracecat.agent import usage as usage_module
+from tracecat.agent.usage import UsageRow
 
-
-class _FakePipeline:
-    def __init__(self, client: _FakeRedisClient) -> None:
-        self._client = client
-        self._ops: list[tuple[str, tuple[Any, ...]]] = []
-
-    def incrby(self, key: str, amount: int) -> _FakePipeline:
-        self._ops.append(("incrby", (key, amount)))
-        return self
-
-    def hincrby(self, key: str, field: str, amount: int) -> _FakePipeline:
-        self._ops.append(("hincrby", (key, field, amount)))
-        return self
-
-    def expire(self, key: str, seconds: int) -> _FakePipeline:
-        self._ops.append(("expire", (key, seconds)))
-        return self
-
-    async def execute(self) -> list[Any]:
-        results: list[Any] = []
-        for name, args in self._ops:
-            method = getattr(self._client, f"_{name}")
-            results.append(method(*args))
-        self._ops.clear()
-        return results
-
-
-class _FakeRedisClient:
-    def __init__(self) -> None:
-        self.ints: dict[str, int] = {}
-        self.hashes: dict[str, dict[str, int]] = {}
-        self.expires: dict[str, int] = {}
-
-    async def get(self, key: str) -> str | None:
-        value = self.ints.get(key)
-        return None if value is None else str(value)
-
-    async def hgetall(self, key: str) -> dict[str, str]:
-        return {k: str(v) for k, v in self.hashes.get(key, {}).items()}
-
-    def pipeline(self, transaction: bool = False) -> _FakePipeline:
-        del transaction
-        return _FakePipeline(self)
-
-    def _incrby(self, key: str, amount: int) -> int:
-        self.ints[key] = self.ints.get(key, 0) + amount
-        return self.ints[key]
-
-    def _hincrby(self, key: str, field: str, amount: int) -> int:
-        bucket = self.hashes.setdefault(key, {})
-        bucket[field] = bucket.get(field, 0) + amount
-        return bucket[field]
-
-    def _expire(self, key: str, seconds: int) -> bool:
-        self.expires[key] = seconds
-        return True
-
-
-class _FakeRedisWrapper:
-    def __init__(self, client: _FakeRedisClient) -> None:
-        self._client = client
-
-    async def _get_client(self) -> _FakeRedisClient:
-        return self._client
-
-
-@pytest.fixture
-def fake_redis(monkeypatch: pytest.MonkeyPatch) -> _FakeRedisClient:
-    client = _FakeRedisClient()
-    wrapper = _FakeRedisWrapper(client)
-
-    async def _get_redis_client() -> _FakeRedisWrapper:
-        return wrapper
-
-    monkeypatch.setattr(usage_module, "get_redis_client", _get_redis_client)
-    return client
-
-
-@pytest.fixture(autouse=True)
-def _reset_cap_cache() -> None:  # pyright: ignore[reportUnusedFunction]
-    usage_module.invalidate_cap_cache()
+FakeDb = dict[tuple[str, str], UsageRow]
 
 
 @pytest.fixture
 def fake_db(
     monkeypatch: pytest.MonkeyPatch,
-) -> dict[tuple[str, str], tuple[int, dict[str, int]]]:
+) -> FakeDb:
     """In-memory stand-in for the durable Postgres usage row.
 
     Mirrors ``agents.usage.{YYYY-MM}`` keyed by (org_id, month).
     """
-    storage: dict[tuple[str, str], tuple[int, dict[str, int]]] = {}
+    storage: FakeDb = {}
 
     async def _increment(
         *,
@@ -111,13 +31,18 @@ def fake_db(
         month: str,
     ) -> None:
         key = (str(org_id), month)
-        total, by_ws = storage.get(key, (0, {}))
-        total += cost_cents
+        current = storage.get(key, UsageRow(total_cents=0, by_workspace_cents={}))
         ws_field = str(workspace_id)
-        by_ws = {**by_ws, ws_field: by_ws.get(ws_field, 0) + cost_cents}
-        storage[key] = (total, by_ws)
+        merged_by_ws = {
+            **current.by_workspace_cents,
+            ws_field: current.by_workspace_cents.get(ws_field, 0) + cost_cents,
+        }
+        storage[key] = UsageRow(
+            total_cents=current.total_cents + cost_cents,
+            by_workspace_cents=merged_by_ws,
+        )
 
-    async def _read(org_id: uuid.UUID, month: str) -> tuple[int, dict[str, int]] | None:
+    async def _read(org_id: uuid.UUID, month: str) -> UsageRow | None:
         return storage.get((str(org_id), month))
 
     monkeypatch.setattr(usage_module, "_increment_usage_in_db", _increment)
@@ -185,8 +110,7 @@ def test_cents_from_usage_rejects_negative() -> None:
 
 @pytest.mark.anyio
 async def test_record_agent_cost_increments_total_and_workspace_hash(
-    fake_redis: _FakeRedisClient,
-    fake_db: dict[tuple[str, str], tuple[int, dict[str, int]]],
+    fake_db: FakeDb,
     fixed_month: str,
 ) -> None:
     org_id = uuid.uuid4()
@@ -203,33 +127,21 @@ async def test_record_agent_cost_increments_total_and_workspace_hash(
         org_id=org_id, workspace_id=ws_a, cost_cents=25
     )
 
-    total_key = f"usage:cost_cents:org:{org_id}:{fixed_month}"
-    by_ws_key = f"usage:cost_cents:org:{org_id}:{fixed_month}:by_ws"
-
-    # Redis mirror
-    assert fake_redis.ints[total_key] == 200
-    assert fake_redis.hashes[by_ws_key][str(ws_a)] == 75
-    assert fake_redis.hashes[by_ws_key][str(ws_b)] == 125
-    assert fake_redis.expires[total_key] == 90 * 24 * 60 * 60
-
-    # Postgres source of truth
-    durable_total, durable_by_ws = fake_db[(str(org_id), fixed_month)]
-    assert durable_total == 200
-    assert durable_by_ws[str(ws_a)] == 75
-    assert durable_by_ws[str(ws_b)] == 125
+    durable = fake_db[(str(org_id), fixed_month)]
+    assert durable.total_cents == 200
+    assert durable.by_workspace_cents[str(ws_a)] == 75
+    assert durable.by_workspace_cents[str(ws_b)] == 125
 
 
 @pytest.mark.anyio
 async def test_record_agent_cost_zero_noops(
-    fake_redis: _FakeRedisClient,
-    fake_db: dict[tuple[str, str], tuple[int, dict[str, int]]],
+    fake_db: FakeDb,
     fixed_month: str,
 ) -> None:
+    del fixed_month
     await usage_module.record_agent_cost(
         org_id=uuid.uuid4(), workspace_id=uuid.uuid4(), cost_cents=0
     )
-    assert fake_redis.ints == {}
-    assert fake_redis.hashes == {}
     assert fake_db == {}
 
 
@@ -240,25 +152,29 @@ async def test_record_agent_cost_zero_noops(
 
 @pytest.mark.anyio
 async def test_check_monthly_budget_allows_below_limit(
-    fake_redis: _FakeRedisClient,
+    fake_db: FakeDb,
     fixed_month: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     org_id = uuid.uuid4()
     _patch_budget(monkeypatch, 1000)  # $10.00
-    fake_redis.ints[f"usage:cost_cents:org:{org_id}:{fixed_month}"] = 900
+    fake_db[(str(org_id), fixed_month)] = UsageRow(
+        total_cents=900, by_workspace_cents={str(uuid.uuid4()): 900}
+    )
     await usage_module.check_monthly_budget(org_id)
 
 
 @pytest.mark.anyio
 async def test_check_monthly_budget_raises_at_limit(
-    fake_redis: _FakeRedisClient,
+    fake_db: FakeDb,
     fixed_month: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     org_id = uuid.uuid4()
     _patch_budget(monkeypatch, 1000)
-    fake_redis.ints[f"usage:cost_cents:org:{org_id}:{fixed_month}"] = 1000
+    fake_db[(str(org_id), fixed_month)] = UsageRow(
+        total_cents=1000, by_workspace_cents={str(uuid.uuid4()): 1000}
+    )
     with pytest.raises(usage_module.BudgetExceededError) as excinfo:
         await usage_module.check_monthly_budget(org_id)
     assert excinfo.value.limit_cents == 1000
@@ -267,35 +183,16 @@ async def test_check_monthly_budget_raises_at_limit(
 
 @pytest.mark.anyio
 async def test_check_monthly_budget_no_limit_is_unlimited(
-    fake_redis: _FakeRedisClient,
+    fake_db: FakeDb,
     fixed_month: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     org_id = uuid.uuid4()
     _patch_budget(monkeypatch, None)
-    fake_redis.ints[f"usage:cost_cents:org:{org_id}:{fixed_month}"] = 10**9
+    fake_db[(str(org_id), fixed_month)] = UsageRow(
+        total_cents=10**9, by_workspace_cents={str(uuid.uuid4()): 10**9}
+    )
     await usage_module.check_monthly_budget(org_id)
-
-
-@pytest.mark.anyio
-async def test_check_monthly_budget_falls_back_to_postgres(
-    fake_redis: _FakeRedisClient,
-    fake_db: dict[tuple[str, str], tuple[int, dict[str, int]]],
-    fixed_month: str,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Redis is empty (e.g. evicted) but Postgres has the real total."""
-    org_id = uuid.uuid4()
-    _patch_budget(monkeypatch, 500)
-    # Redis returns nothing — no keys seeded.
-    # Postgres has the durable counter with 600 cents already spent.
-    fake_db[(str(org_id), fixed_month)] = (600, {str(uuid.uuid4()): 600})
-
-    del fake_redis  # unused: redis is empty by design
-    with pytest.raises(usage_module.BudgetExceededError) as excinfo:
-        await usage_module.check_monthly_budget(org_id)
-    assert excinfo.value.used_cents == 600
-    assert excinfo.value.limit_cents == 500
 
 
 # -----------------------------------------------------------------------------
@@ -305,17 +202,16 @@ async def test_check_monthly_budget_falls_back_to_postgres(
 
 @pytest.mark.anyio
 async def test_get_usage_snapshot_returns_total_and_breakdown(
-    fake_redis: _FakeRedisClient,
+    fake_db: FakeDb,
     fixed_month: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     org_id = uuid.uuid4()
     ws_a = uuid.uuid4()
     _patch_budget(monkeypatch, 500)
-    fake_redis.ints[f"usage:cost_cents:org:{org_id}:{fixed_month}"] = 250
-    fake_redis.hashes[f"usage:cost_cents:org:{org_id}:{fixed_month}:by_ws"] = {
-        str(ws_a): 250,
-    }
+    fake_db[(str(org_id), fixed_month)] = UsageRow(
+        total_cents=250, by_workspace_cents={str(ws_a): 250}
+    )
 
     snapshot = await usage_module.get_usage_snapshot(org_id)
     assert snapshot.month_utc == fixed_month
@@ -326,37 +222,16 @@ async def test_get_usage_snapshot_returns_total_and_breakdown(
 
 @pytest.mark.anyio
 async def test_get_usage_snapshot_empty_is_zero(
-    fake_redis: _FakeRedisClient,
-    fake_db: dict[tuple[str, str], tuple[int, dict[str, int]]],
+    fake_db: FakeDb,
     fixed_month: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    del fake_redis, fake_db
+    del fake_db
     _patch_budget(monkeypatch, None)
     snapshot = await usage_module.get_usage_snapshot(uuid.uuid4())
     assert snapshot.month_utc == fixed_month
     assert snapshot.total_cents == 0
     assert snapshot.by_workspace_cents == {}
-
-
-@pytest.mark.anyio
-async def test_get_usage_snapshot_falls_back_to_postgres(
-    fake_redis: _FakeRedisClient,
-    fake_db: dict[tuple[str, str], tuple[int, dict[str, int]]],
-    fixed_month: str,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Redis empty → snapshot rebuilds from Postgres."""
-    org_id = uuid.uuid4()
-    ws_a = uuid.uuid4()
-    _patch_budget(monkeypatch, 1000)
-    fake_db[(str(org_id), fixed_month)] = (750, {str(ws_a): 750})
-    del fake_redis  # empty by design
-
-    snapshot = await usage_module.get_usage_snapshot(org_id)
-    assert snapshot.total_cents == 750
-    assert snapshot.by_workspace_cents == {str(ws_a): 750}
-    assert snapshot.limit_cents == 1000
 
 
 # -----------------------------------------------------------------------------
@@ -366,11 +241,9 @@ async def test_get_usage_snapshot_falls_back_to_postgres(
 
 @pytest.mark.anyio
 async def test_current_month_rolls_over_at_utc_boundary(
-    fake_redis: _FakeRedisClient,
-    fake_db: dict[tuple[str, str], tuple[int, dict[str, int]]],
+    fake_db: FakeDb,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    del fake_db
     org_id = uuid.uuid4()
     ws = uuid.uuid4()
 
@@ -380,8 +253,8 @@ async def test_current_month_rolls_over_at_utc_boundary(
     monkeypatch.setattr(usage_module, "_current_month_utc", lambda: "2026-04")
     await usage_module.record_agent_cost(org_id=org_id, workspace_id=ws, cost_cents=20)
 
-    assert fake_redis.ints[f"usage:cost_cents:org:{org_id}:2026-03"] == 10
-    assert fake_redis.ints[f"usage:cost_cents:org:{org_id}:2026-04"] == 20
+    assert fake_db[(str(org_id), "2026-03")].total_cents == 10
+    assert fake_db[(str(org_id), "2026-04")].total_cents == 20
 
 
 @pytest.mark.anyio
@@ -389,29 +262,3 @@ async def test_current_month_utc_uses_utc_not_local() -> None:
     value = usage_module._current_month_utc()
     now = datetime.now(UTC)
     assert value == now.strftime("%Y-%m")
-
-
-# -----------------------------------------------------------------------------
-# Cap cache invalidation
-# -----------------------------------------------------------------------------
-
-
-@pytest.mark.anyio
-async def test_cap_cache_invalidation(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    org_id = uuid.uuid4()
-    values = iter([100, 500])
-
-    async def _loader(_org: uuid.UUID) -> int | None:
-        return next(values)
-
-    monkeypatch.setattr(usage_module, "_load_monthly_budget_cents", _loader)
-    first = await usage_module.get_monthly_budget_cents(org_id)
-    cached = await usage_module.get_monthly_budget_cents(org_id)
-    assert first == 100
-    assert cached == 100
-
-    usage_module.invalidate_cap_cache(org_id)
-    refreshed = await usage_module.get_monthly_budget_cents(org_id)
-    assert refreshed == 500

--- a/tests/unit/test_agent_usage.py
+++ b/tests/unit/test_agent_usage.py
@@ -1,64 +1,79 @@
-"""Tests for tracecat/agent/usage.py (monthly budget cap + cost counters)."""
+"""Tests for tracecat/agent/usage.py (monthly budget cap + per-run cost ledger)."""
 
 from __future__ import annotations
 
 import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent import usage as usage_module
-from tracecat.agent.usage import UsageRow
-
-FakeDb = dict[tuple[str, str], UsageRow]
-
-
-@pytest.fixture
-def fake_db(
-    monkeypatch: pytest.MonkeyPatch,
-) -> FakeDb:
-    """In-memory stand-in for the durable Postgres usage row.
-
-    Mirrors ``agents.usage.{YYYY-MM}`` keyed by (org_id, month).
-    """
-    storage: FakeDb = {}
-
-    async def _increment(
-        *,
-        org_id: uuid.UUID,
-        workspace_id: uuid.UUID,
-        cost_cents: int,
-        month: str,
-    ) -> None:
-        key = (str(org_id), month)
-        current = storage.get(key, UsageRow(total_cents=0, by_workspace_cents={}))
-        ws_field = str(workspace_id)
-        merged_by_ws = {
-            **current.by_workspace_cents,
-            ws_field: current.by_workspace_cents.get(ws_field, 0) + cost_cents,
-        }
-        storage[key] = UsageRow(
-            total_cents=current.total_cents + cost_cents,
-            by_workspace_cents=merged_by_ws,
-        )
-
-    async def _read(org_id: uuid.UUID, month: str) -> UsageRow | None:
-        return storage.get((str(org_id), month))
-
-    monkeypatch.setattr(usage_module, "_increment_usage_in_db", _increment)
-    monkeypatch.setattr(usage_module, "_read_usage_from_db", _read)
-    return storage
+from tracecat.db.models import Organization, Workspace
 
 
 @pytest.fixture
 def fixed_month(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Freeze ``_current_month_utc`` for deterministic month_utc values."""
     month = "2026-04"
-
-    def _current_month_utc() -> str:
-        return month
-
-    monkeypatch.setattr(usage_module, "_current_month_utc", _current_month_utc)
+    monkeypatch.setattr(usage_module, "_current_month_utc", lambda: month)
     return month
+
+
+@pytest.fixture
+async def session_ctx(
+    monkeypatch: pytest.MonkeyPatch, session: AsyncSession
+) -> AsyncSession:
+    """Route ``usage``'s DB accesses through the test's savepoint-scoped session.
+
+    The module opens its own sessions via ``get_async_session_bypass_rls_context_manager``;
+    we replace that with a context manager that yields the test session so all
+    reads and writes land in the same transactional scope (rolled back on teardown).
+    """
+
+    @asynccontextmanager
+    async def _fake_session_manager() -> AsyncIterator[AsyncSession]:
+        yield session
+
+    monkeypatch.setattr(
+        usage_module,
+        "get_async_session_bypass_rls_context_manager",
+        _fake_session_manager,
+    )
+    return session
+
+
+@pytest.fixture
+async def org_and_workspace(
+    session_ctx: AsyncSession,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    """Create an ``Organization`` + ``Workspace`` visible to the test transaction.
+
+    Both are required for the ``agent_run_cost`` FK constraints; flushing (not
+    committing) makes them visible within the test's SAVEPOINT and they roll
+    back at teardown with everything else.
+    """
+    org = Organization(
+        id=uuid.uuid4(),
+        name="usage test org",
+        slug=f"usage-test-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session_ctx.add(org)
+    await session_ctx.flush()
+
+    ws = Workspace(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        name="usage test ws",
+        settings={},
+    )
+    session_ctx.add(ws)
+    await session_ctx.flush()
+
+    return org.id, ws.id
 
 
 def _patch_budget(monkeypatch: pytest.MonkeyPatch, cents: int | None) -> None:
@@ -104,95 +119,99 @@ def test_cents_from_usage_rejects_negative() -> None:
 
 
 # -----------------------------------------------------------------------------
-# record_agent_cost
+# record_agent_cost + ledger queries
 # -----------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
-async def test_record_agent_cost_increments_total_and_workspace_hash(
-    fake_db: FakeDb,
+async def test_record_agent_cost_appends_and_aggregates(
+    org_and_workspace: tuple[uuid.UUID, uuid.UUID],
     fixed_month: str,
 ) -> None:
-    org_id = uuid.uuid4()
-    ws_a = uuid.uuid4()
-    ws_b = uuid.uuid4()
+    """Three runs → three rows; SUM aggregates totals and GROUP BY splits by ws."""
+    org_id, ws_a = org_and_workspace
 
     await usage_module.record_agent_cost(
         org_id=org_id, workspace_id=ws_a, cost_cents=50
     )
     await usage_module.record_agent_cost(
-        org_id=org_id, workspace_id=ws_b, cost_cents=125
+        org_id=org_id, workspace_id=ws_a, cost_cents=125
     )
     await usage_module.record_agent_cost(
         org_id=org_id, workspace_id=ws_a, cost_cents=25
     )
 
-    durable = fake_db[(str(org_id), fixed_month)]
-    assert durable.total_cents == 200
-    assert durable.by_workspace_cents[str(ws_a)] == 75
-    assert durable.by_workspace_cents[str(ws_b)] == 125
+    total = await usage_module._sum_month_cents(org_id, fixed_month)
+    assert total == 200
+
+    snapshot_total, by_ws = await usage_module._workspace_totals(org_id, fixed_month)
+    assert snapshot_total == 200
+    assert by_ws == {str(ws_a): 200}
 
 
 @pytest.mark.anyio
-async def test_record_agent_cost_zero_noops(
-    fake_db: FakeDb,
+async def test_record_agent_cost_zero_is_noop(
+    org_and_workspace: tuple[uuid.UUID, uuid.UUID],
     fixed_month: str,
+) -> None:
+    org_id, ws_a = org_and_workspace
+    await usage_module.record_agent_cost(org_id=org_id, workspace_id=ws_a, cost_cents=0)
+    assert await usage_module._sum_month_cents(org_id, fixed_month) == 0
+
+
+# -----------------------------------------------------------------------------
+# resolve_run_budget
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_resolve_run_budget_returns_remaining_dollars(
+    org_and_workspace: tuple[uuid.UUID, uuid.UUID],
+    fixed_month: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     del fixed_month
+    org_id, ws_a = org_and_workspace
+    _patch_budget(monkeypatch, 1000)  # $10.00 cap
     await usage_module.record_agent_cost(
-        org_id=uuid.uuid4(), workspace_id=uuid.uuid4(), cost_cents=0
+        org_id=org_id, workspace_id=ws_a, cost_cents=900
     )
-    assert fake_db == {}
-
-
-# -----------------------------------------------------------------------------
-# check_monthly_budget
-# -----------------------------------------------------------------------------
+    # $10 cap, $9 spent → $1 headroom for this run.
+    assert await usage_module.resolve_run_budget(org_id) == pytest.approx(1.0)
 
 
 @pytest.mark.anyio
-async def test_check_monthly_budget_allows_below_limit(
-    fake_db: FakeDb,
+async def test_resolve_run_budget_raises_at_limit(
+    org_and_workspace: tuple[uuid.UUID, uuid.UUID],
     fixed_month: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    org_id = uuid.uuid4()
-    _patch_budget(monkeypatch, 1000)  # $10.00
-    fake_db[(str(org_id), fixed_month)] = UsageRow(
-        total_cents=900, by_workspace_cents={str(uuid.uuid4()): 900}
-    )
-    await usage_module.check_monthly_budget(org_id)
-
-
-@pytest.mark.anyio
-async def test_check_monthly_budget_raises_at_limit(
-    fake_db: FakeDb,
-    fixed_month: str,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    org_id = uuid.uuid4()
+    del fixed_month
+    org_id, ws_a = org_and_workspace
     _patch_budget(monkeypatch, 1000)
-    fake_db[(str(org_id), fixed_month)] = UsageRow(
-        total_cents=1000, by_workspace_cents={str(uuid.uuid4()): 1000}
+    await usage_module.record_agent_cost(
+        org_id=org_id, workspace_id=ws_a, cost_cents=1000
     )
     with pytest.raises(usage_module.BudgetExceededError) as excinfo:
-        await usage_module.check_monthly_budget(org_id)
+        await usage_module.resolve_run_budget(org_id)
     assert excinfo.value.limit_cents == 1000
     assert excinfo.value.used_cents == 1000
 
 
 @pytest.mark.anyio
-async def test_check_monthly_budget_no_limit_is_unlimited(
-    fake_db: FakeDb,
+async def test_resolve_run_budget_no_cap_returns_none(
+    org_and_workspace: tuple[uuid.UUID, uuid.UUID],
     fixed_month: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    org_id = uuid.uuid4()
+    del fixed_month
+    org_id, ws_a = org_and_workspace
     _patch_budget(monkeypatch, None)
-    fake_db[(str(org_id), fixed_month)] = UsageRow(
-        total_cents=10**9, by_workspace_cents={str(uuid.uuid4()): 10**9}
+    # Any amount of spend — uncapped org always gets None.
+    await usage_module.record_agent_cost(
+        org_id=org_id, workspace_id=ws_a, cost_cents=10_000
     )
-    await usage_module.check_monthly_budget(org_id)
+    assert await usage_module.resolve_run_budget(org_id) is None
 
 
 # -----------------------------------------------------------------------------
@@ -202,63 +221,76 @@ async def test_check_monthly_budget_no_limit_is_unlimited(
 
 @pytest.mark.anyio
 async def test_get_usage_snapshot_returns_total_and_breakdown(
-    fake_db: FakeDb,
+    org_and_workspace: tuple[uuid.UUID, uuid.UUID],
+    session_ctx: AsyncSession,
     fixed_month: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    org_id = uuid.uuid4()
-    ws_a = uuid.uuid4()
+    org_id, ws_a = org_and_workspace
+
+    # Second workspace under the same org to prove the GROUP BY splits correctly.
+    ws_b = uuid.uuid4()
+    session_ctx.add(
+        Workspace(id=ws_b, organization_id=org_id, name="ws-b", settings={})
+    )
+    await session_ctx.flush()
+
     _patch_budget(monkeypatch, 500)
-    fake_db[(str(org_id), fixed_month)] = UsageRow(
-        total_cents=250, by_workspace_cents={str(ws_a): 250}
+    await usage_module.record_agent_cost(
+        org_id=org_id, workspace_id=ws_a, cost_cents=100
+    )
+    await usage_module.record_agent_cost(
+        org_id=org_id, workspace_id=ws_b, cost_cents=150
     )
 
     snapshot = await usage_module.get_usage_snapshot(org_id)
     assert snapshot.month_utc == fixed_month
     assert snapshot.total_cents == 250
     assert snapshot.limit_cents == 500
-    assert snapshot.by_workspace_cents == {str(ws_a): 250}
+    assert snapshot.by_workspace_cents == {str(ws_a): 100, str(ws_b): 150}
 
 
 @pytest.mark.anyio
 async def test_get_usage_snapshot_empty_is_zero(
-    fake_db: FakeDb,
+    org_and_workspace: tuple[uuid.UUID, uuid.UUID],
     fixed_month: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    del fake_db
+    org_id, _ = org_and_workspace
     _patch_budget(monkeypatch, None)
-    snapshot = await usage_module.get_usage_snapshot(uuid.uuid4())
+    snapshot = await usage_module.get_usage_snapshot(org_id)
     assert snapshot.month_utc == fixed_month
     assert snapshot.total_cents == 0
     assert snapshot.by_workspace_cents == {}
 
 
 # -----------------------------------------------------------------------------
-# UTC month rollover
+# UTC month rollover — nothing to "reset", the filter just changes
 # -----------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
-async def test_current_month_rolls_over_at_utc_boundary(
-    fake_db: FakeDb,
+async def test_month_filter_rolls_over_at_utc_boundary(
+    org_and_workspace: tuple[uuid.UUID, uuid.UUID],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    org_id = uuid.uuid4()
-    ws = uuid.uuid4()
+    org_id, ws_a = org_and_workspace
 
     monkeypatch.setattr(usage_module, "_current_month_utc", lambda: "2026-03")
-    await usage_module.record_agent_cost(org_id=org_id, workspace_id=ws, cost_cents=10)
+    await usage_module.record_agent_cost(
+        org_id=org_id, workspace_id=ws_a, cost_cents=10
+    )
 
     monkeypatch.setattr(usage_module, "_current_month_utc", lambda: "2026-04")
-    await usage_module.record_agent_cost(org_id=org_id, workspace_id=ws, cost_cents=20)
+    await usage_module.record_agent_cost(
+        org_id=org_id, workspace_id=ws_a, cost_cents=20
+    )
 
-    assert fake_db[(str(org_id), "2026-03")].total_cents == 10
-    assert fake_db[(str(org_id), "2026-04")].total_cents == 20
+    assert await usage_module._sum_month_cents(org_id, "2026-03") == 10
+    assert await usage_module._sum_month_cents(org_id, "2026-04") == 20
 
 
-@pytest.mark.anyio
-async def test_current_month_utc_uses_utc_not_local() -> None:
+def test_current_month_utc_uses_utc_not_local() -> None:
     value = usage_module._current_month_utc()
     now = datetime.now(UTC)
     assert value == now.strftime("%Y-%m")

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -139,7 +139,11 @@ class RuntimeEventEnvelope:
     sdk_session_id: str | None = None  # For type="session_update" or "session_line"
     sdk_session_data: str | None = None  # For type="session_update"
     error: str | None = None  # For type="error"
-    # For type="result" - final usage data from Claude SDK ResultMessage
+    # For type="result" - final usage data from Claude SDK ResultMessage.
+    # ``result_usage`` is the runtime-merged projection: it folds the SDK's
+    # per-model ``model_usage`` (camelCase, per-route) into the native
+    # ``usage`` (snake_case) so downstream reads one shape. Carries an extra
+    # ``cost_usd`` field summed from ``costUSD`` per model.
     result_usage: dict[str, Any] | None = None
     result_num_turns: int | None = None
     result_duration_ms: int | None = None

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -46,6 +46,12 @@ class RuntimeInitPayload:
     is_approval_continuation: bool = False  # True when resuming after approval decision
     is_fork: bool = False
 
+    # Per-run dollar cap, forwarded to the SDK as ``max_budget_usd``. Derived
+    # from the org's remaining monthly budget at the moment the run starts;
+    # ``None`` means the org is uncapped and the SDK should run without a
+    # ceiling.
+    max_budget_usd: float | None = None
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RuntimeInitPayload:
         """Construct from dict (orjson parsed)."""
@@ -77,6 +83,7 @@ class RuntimeInitPayload:
             sdk_session_data=data.get("sdk_session_data"),
             is_approval_continuation=data.get("is_approval_continuation", False),
             is_fork=data.get("is_fork", False),
+            max_budget_usd=data.get("max_budget_usd"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -99,6 +106,8 @@ class RuntimeInitPayload:
             result["sdk_session_id"] = self.sdk_session_id
         if self.sdk_session_data is not None:
             result["sdk_session_data"] = self.sdk_session_data
+        if self.max_budget_usd is not None:
+            result["max_budget_usd"] = self.max_budget_usd
         return result
 
 

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -38,6 +38,12 @@ from tracecat.agent.runtime_services import get_claude_runtime_broker
 from tracecat.agent.sandbox.llm_proxy import LLM_SOCKET_NAME, LLMSocketProxy
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.types import AgentConfig
+from tracecat.agent.usage import (
+    BudgetExceededError,
+    cents_from_usage,
+    check_monthly_budget,
+    record_agent_cost,
+)
 from tracecat.auth.types import Role
 from tracecat.chat.schemas import ChatMessage
 from tracecat.logger import logger
@@ -214,6 +220,7 @@ class SandboxedAgentExecutor:
         """
         result = AgentExecutorResult(success=False)
         self._log_benchmark_phase("activity_start")
+        org_id = self.input.role.organization_id
 
         try:
             # Create job directory with sockets
@@ -232,6 +239,31 @@ class SandboxedAgentExecutor:
                 workspace_id=self.input.workspace_id,
             )
             handler = LoopbackHandler(input=loopback_input)
+
+            # Pre-run monthly budget check. Happens after the handler is
+            # constructed so we can push a terminal error through the same
+            # Redis stream the UI is listening on — otherwise the UI would
+            # hang waiting for events that never arrive.
+            if org_id is not None:
+                try:
+                    await check_monthly_budget(org_id)
+                except BudgetExceededError as exc:
+                    logger.info(
+                        "Blocked agent run: monthly budget cap reached",
+                        org_id=str(org_id),
+                        used_cents=exc.used_cents,
+                        limit_cents=exc.limit_cents,
+                        session_id=self.input.session_id,
+                    )
+                    try:
+                        await handler.emit_terminal_error(str(exc))
+                    except Exception:
+                        logger.exception(
+                            "Failed to emit budget-exceeded stream error",
+                            session_id=self.input.session_id,
+                        )
+                    result.error = str(exc)
+                    return result
 
             llm_socket_path = socket_dir / LLM_SOCKET_NAME
             self._llm_proxy = self._create_llm_socket_proxy(llm_socket_path)
@@ -252,6 +284,19 @@ class SandboxedAgentExecutor:
             result.error = f"Unexpected error: {e}"
         finally:
             await self._cleanup()
+
+        # Record actual cost for this run (best-effort). The runtime folds
+        # the SDK's per-model costUSD into the merged ``usage`` dict; we
+        # just round to integer cents.
+        if org_id is not None and result.result_usage:
+            cost_cents = cents_from_usage(result.result_usage)
+            if cost_cents > 0:
+                await record_agent_cost(
+                    org_id=org_id,
+                    workspace_id=self.input.workspace_id,
+                    cost_cents=cost_cents,
+                    session_id=str(self.input.session_id),
+                )
 
         return result
 

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -40,9 +40,9 @@ from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.types import AgentConfig
 from tracecat.agent.usage import (
     BudgetExceededError,
-    cents_from_usage,
-    check_monthly_budget,
     record_agent_cost,
+    resolve_run_budget,
+    usd_from_usage,
 )
 from tracecat.auth.types import Role
 from tracecat.chat.schemas import ChatMessage
@@ -197,8 +197,15 @@ class SandboxedAgentExecutor:
             model_provider=self.input.config.model_provider,
         )
 
-    def _build_runtime_init_payload(self) -> RuntimeInitPayload:
-        """Build the runtime init payload for this execution."""
+    def _build_runtime_init_payload(
+        self, *, max_budget_usd: float | None = None
+    ) -> RuntimeInitPayload:
+        """Build the runtime init payload for this execution.
+
+        Pure assembly — no I/O. ``max_budget_usd`` is resolved by the caller
+        (see ``run``) so this helper stays trivially testable and callers
+        control when the budget DB read happens.
+        """
         return RuntimeInitPayload(
             session_id=self.input.session_id,
             mcp_auth_token=self.input.mcp_auth_token,
@@ -210,6 +217,7 @@ class SandboxedAgentExecutor:
             sdk_session_data=self.input.sdk_session_data,
             is_approval_continuation=self.input.is_approval_continuation,
             is_fork=self.input.is_fork,
+            max_budget_usd=max_budget_usd,
         )
 
     async def run(self) -> AgentExecutorResult:
@@ -222,48 +230,36 @@ class SandboxedAgentExecutor:
         self._log_benchmark_phase("activity_start")
         org_id = self.input.role.organization_id
 
+        handler: LoopbackHandler | None = None
         try:
             # Create job directory with sockets
             self._job_dir = await self._create_job_directory()
             socket_dir = self._job_dir / "sockets"
-            init_payload = self._build_runtime_init_payload()
-            self._log_benchmark_phase(
-                "job_dir_ready",
-                job_dir=str(self._job_dir),
-                socket_dir=str(socket_dir),
-            )
 
-            # Create loopback handler
+            # Build the loopback handler first so budget-exceeded errors raised
+            # by ``resolve_run_budget`` can reach the UI stream.
             loopback_input = LoopbackInput(
                 session_id=self.input.session_id,
                 workspace_id=self.input.workspace_id,
             )
             handler = LoopbackHandler(input=loopback_input)
 
-            # Pre-run monthly budget check. Happens after the handler is
-            # constructed so we can push a terminal error through the same
-            # Redis stream the UI is listening on — otherwise the UI would
-            # hang waiting for events that never arrive.
-            if org_id is not None:
-                try:
-                    await check_monthly_budget(org_id)
-                except BudgetExceededError as exc:
-                    logger.info(
-                        "Blocked agent run: monthly budget cap reached",
-                        org_id=str(org_id),
-                        used_cents=exc.used_cents,
-                        limit_cents=exc.limit_cents,
-                        session_id=self.input.session_id,
-                    )
-                    try:
-                        await handler.emit_terminal_error(str(exc))
-                    except Exception:
-                        logger.exception(
-                            "Failed to emit budget-exceeded stream error",
-                            session_id=self.input.session_id,
-                        )
-                    result.error = str(exc)
-                    return result
+            # Resolve the org's remaining monthly headroom and forward it as
+            # ``max_budget_usd`` for the SDK/CLI to enforce per-run. Resolving
+            # here (rather than inside ``_build_runtime_init_payload``) keeps
+            # the payload builder pure and the DB read on the activity's
+            # own async path where ``BudgetExceededError`` is caught below.
+            max_budget_usd = (
+                await resolve_run_budget(org_id) if org_id is not None else None
+            )
+            init_payload = self._build_runtime_init_payload(
+                max_budget_usd=max_budget_usd
+            )
+            self._log_benchmark_phase(
+                "job_dir_ready",
+                job_dir=str(self._job_dir),
+                socket_dir=str(socket_dir),
+            )
 
             llm_socket_path = socket_dir / LLM_SOCKET_NAME
             self._llm_proxy = self._create_llm_socket_proxy(llm_socket_path)
@@ -276,6 +272,23 @@ class SandboxedAgentExecutor:
                 llm_socket_path=llm_socket_path,
             )
 
+        except BudgetExceededError as exc:
+            logger.info(
+                "Blocked agent run: monthly budget cap reached",
+                org_id=str(org_id),
+                used_cents=exc.used_cents,
+                limit_cents=exc.limit_cents,
+                session_id=self.input.session_id,
+            )
+            if handler is not None:
+                try:
+                    await handler.emit_terminal_error(str(exc))
+                except Exception:
+                    logger.exception(
+                        "Failed to emit budget-exceeded stream error",
+                        session_id=self.input.session_id,
+                    )
+            result.error = str(exc)
         except AgentSandboxExecutionError as e:
             logger.error("Agent sandbox execution failed", error=str(e))
             result.error = str(e)
@@ -287,15 +300,15 @@ class SandboxedAgentExecutor:
 
         # Record actual cost for this run (best-effort). The runtime folds
         # the SDK's per-model costUSD into the merged ``usage`` dict; we
-        # just round to integer cents.
+        # persist it exactly (Decimal) so sub-cent spend survives aggregation.
         if org_id is not None and result.result_usage:
-            cost_cents = cents_from_usage(result.result_usage)
-            if cost_cents > 0:
+            cost_usd = usd_from_usage(result.result_usage)
+            if cost_usd is not None:
                 await record_agent_cost(
                     org_id=org_id,
                     workspace_id=self.input.workspace_id,
-                    cost_cents=cost_cents,
-                    session_id=str(self.input.session_id),
+                    cost_usd=cost_usd,
+                    session_id=self.input.session_id,
                 )
 
         return result

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -132,6 +132,55 @@ def get_litellm_route_model(
     return model_name
 
 
+_MODEL_USAGE_KEY_MAP: dict[str, str] = {
+    "inputTokens": "input_tokens",
+    "outputTokens": "output_tokens",
+    "cacheCreationInputTokens": "cache_creation_input_tokens",
+    "cacheReadInputTokens": "cache_read_input_tokens",
+}
+
+
+def _merge_usage(
+    usage: dict[str, Any] | None,
+    model_usage: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Merge the SDK ResultMessage's two usage projections into one dict.
+
+    Some LiteLLM-routed providers zero out ``usage`` and only populate
+    ``model_usage``; Anthropic-native populates both. This helper folds
+    ``model_usage`` (camelCase, per-model) into a single ``usage`` dict
+    (snake_case, summed across models) so downstream consumers always read
+    one shape. Adds a ``total_cost_usd`` field summed from ``costUSD``,
+    matching the SDK ResultMessage's outer attribute name.
+    """
+    merged: dict[str, Any] = dict(usage) if isinstance(usage, dict) else {}
+    if not isinstance(model_usage, dict) or not model_usage:
+        return merged or None
+
+    sums: dict[str, int] = dict.fromkeys(_MODEL_USAGE_KEY_MAP.values(), 0)
+    total_cost_usd_sum = 0.0
+    for entry in model_usage.values():
+        if not isinstance(entry, dict):
+            continue
+        for camel, snake in _MODEL_USAGE_KEY_MAP.items():
+            value = entry.get(camel)
+            if isinstance(value, int):
+                sums[snake] += value
+        cost = entry.get("costUSD")
+        if isinstance(cost, (int, float)):
+            total_cost_usd_sum += float(cost)
+
+    for snake, summed in sums.items():
+        # Only fill in zero/missing fields — preserve native values when set.
+        if not merged.get(snake):
+            merged[snake] = summed
+
+    if total_cost_usd_sum > 0:
+        merged["total_cost_usd"] = total_cost_usd_sum
+
+    return merged or None
+
+
 def _configure_claude_sdk_process_env() -> None:
     """Prime process-level SDK env before ClaudeSDKClient.connect().
 
@@ -952,12 +1001,15 @@ class ClaudeAgentRuntime:
                         elif isinstance(message, ResultMessage):
                             # Final result - emit any remaining lines
                             await self._emit_new_session_lines()
+                            merged_usage = _merge_usage(
+                                message.usage, message.model_usage
+                            )
                             await self._event_writer.send_log(
                                 "info",
                                 "Agent turn completed",
                                 num_turns=message.num_turns,
                                 duration_ms=message.duration_ms,
-                                usage=message.usage,
+                                usage=merged_usage,
                             )
                             log_benchmark_phase(
                                 "runtime_result_received",
@@ -970,7 +1022,7 @@ class ClaudeAgentRuntime:
                                 else message.result
                             )
                             await self._event_writer.send_result(
-                                usage=message.usage,
+                                usage=merged_usage,
                                 num_turns=message.num_turns,
                                 duration_ms=message.duration_ms,
                                 output=result_output,

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -866,6 +866,7 @@ class ClaudeAgentRuntime:
                 include_partial_messages=True,
                 resume=resume_session_id,
                 fork_session=fork_session,  # If True, creates new session from parent's history
+                max_budget_usd=payload.max_budget_usd,
                 thinking=(
                     {"type": "enabled", "budget_tokens": 1024}
                     if payload.config.enable_thinking

--- a/tracecat/agent/usage.py
+++ b/tracecat/agent/usage.py
@@ -9,14 +9,10 @@ Two ``OrganizationSetting`` keys, JSON-encoded:
 - ``agents.usage.{YYYY-MM}`` — one row per UTC calendar month, shaped as
   ``{"total_cents": int, "by_workspace_cents": {workspace_id: cents}}``.
 
-Redis mirrors the month row for the hot path (cap check on every run):
-
-- ``usage:cost_cents:org:{org_id}:{YYYY-MM}`` — scalar INT
-- ``usage:cost_cents:org:{org_id}:{YYYY-MM}:by_ws`` — HASH of ws_id → cents
-
-Both Redis keys expire after 90 days. Postgres is the durable source of
-truth; Redis can be evicted / lost and we rebuild from the settings row on
-the next read.
+Postgres is the single source of truth for both the cap (read on every agent
+launch) and the monthly counter (read for the admin usage-snapshot endpoint).
+Agent launches are not high-QPS, so a small indexed SELECT per launch is fine
+and lets us avoid the correctness hazards of a best-effort mirror cache.
 
 Source of cost
 --------------
@@ -28,30 +24,32 @@ on the way in so no floats hit storage.
 
 from __future__ import annotations
 
-import time
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import Any, NamedTuple
 
 import orjson
 from pydantic import BaseModel
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import SQLAlchemyError
 
-from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import OrganizationSetting
 from tracecat.identifiers import OrganizationID, WorkspaceID
 from tracecat.logger import logger
-from tracecat.redis.client import get_redis_client
 from tracecat.settings.service import SettingsService
 
 MONTHLY_BUDGET_CENTS_KEY = "agents.monthly_budget_cents"
 """OrganizationSetting key storing the per-org monthly budget in cents."""
 
-_USAGE_KEY_TTL_SECONDS = 90 * 24 * 60 * 60
-"""Keep roughly the last three UTC months of Redis counters hot."""
+
+class UsageRow(NamedTuple):
+    """Decoded ``agents.usage.{YYYY-MM}`` row."""
+
+    total_cents: int
+    by_workspace_cents: dict[str, int]
 
 
 def _usage_setting_key(month: str) -> str:
@@ -98,23 +96,9 @@ def _current_month_utc() -> str:
     return datetime.now(UTC).strftime("%Y-%m")
 
 
-def _total_key(org_id: OrganizationID, month: str) -> str:
-    return f"usage:cost_cents:org:{org_id}:{month}"
-
-
-def _by_ws_key(org_id: OrganizationID, month: str) -> str:
-    return f"usage:cost_cents:org:{org_id}:{month}:by_ws"
-
-
 # -----------------------------------------------------------------------------
-# Cap lookup (in-process TTL cache to avoid a DB hit on every run)
+# Cap lookup
 # -----------------------------------------------------------------------------
-
-_cap_cache: dict[OrganizationID, tuple[float, int | None]] = {}
-
-
-def _cap_cache_ttl() -> int:
-    return max(0, config.TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS)
 
 
 async def _load_monthly_budget_cents(org_id: OrganizationID) -> int | None:
@@ -157,44 +141,19 @@ async def _load_monthly_budget_cents(org_id: OrganizationID) -> int | None:
     return limit if limit > 0 else None
 
 
-async def get_monthly_budget_cents(org_id: OrganizationID) -> int | None:
-    """Return the effective monthly budget (cents) for the org, cached in-process.
-
-    Cache TTL reuses ``TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS``.
-    """
-    ttl = _cap_cache_ttl()
-    now = time.monotonic()
-    cached = _cap_cache.get(org_id)
-    if cached is not None and ttl > 0 and cached[0] > now:
-        return cached[1]
-
-    limit = await _load_monthly_budget_cents(org_id)
-    if ttl > 0:
-        _cap_cache[org_id] = (now + ttl, limit)
-    return limit
-
-
-def invalidate_cap_cache(org_id: OrganizationID | None = None) -> None:
-    """Drop cached budget(s). Called after a budget PUT."""
-    if org_id is None:
-        _cap_cache.clear()
-    else:
-        _cap_cache.pop(org_id, None)
-
-
 # -----------------------------------------------------------------------------
-# Postgres persistence (durable counter; survives Redis eviction/restarts)
+# Postgres persistence (durable counter)
 # -----------------------------------------------------------------------------
 
 
-def _decode_usage_row(raw: bytes | None) -> tuple[int, dict[str, int]]:
-    """Decode the ``agents.usage.{YYYY-MM}`` blob into (total, by_ws)."""
+def _decode_usage_row(raw: bytes | None) -> UsageRow:
+    """Decode the stored JSON blob into a ``UsageRow``."""
     if raw is None:
-        return 0, {}
+        return UsageRow(total_cents=0, by_workspace_cents={})
     try:
         data = orjson.loads(raw)
     except Exception:
-        return 0, {}
+        return UsageRow(total_cents=0, by_workspace_cents={})
     total = data.get("total_cents") if isinstance(data, dict) else None
     by_ws_raw = data.get("by_workspace_cents") if isinstance(data, dict) else None
     total_int = int(total) if isinstance(total, (int, float)) else 0
@@ -205,12 +164,15 @@ def _decode_usage_row(raw: bytes | None) -> tuple[int, dict[str, int]]:
                 by_ws[str(k)] = int(v)
             except (TypeError, ValueError):
                 continue
-    return total_int, by_ws
+    return UsageRow(total_cents=total_int, by_workspace_cents=by_ws)
 
 
-def _encode_usage_row(total: int, by_ws: dict[str, int]) -> bytes:
+def _encode_usage_row(row: UsageRow) -> bytes:
     return orjson.dumps(
-        {"total_cents": total, "by_workspace_cents": by_ws},
+        {
+            "total_cents": row.total_cents,
+            "by_workspace_cents": row.by_workspace_cents,
+        },
         option=orjson.OPT_SORT_KEYS,
     )
 
@@ -224,16 +186,38 @@ async def _increment_usage_in_db(
 ) -> None:
     """Increment the durable ``agents.usage.{month}`` counter for this org.
 
-    Uses ``SELECT ... FOR UPDATE`` to serialize concurrent writers on the
-    same org+month row. Creates the row on first write of the month.
+    First write of the month is an atomic ``INSERT ... ON CONFLICT DO NOTHING``
+    so two racing first-writers don't both try to INSERT and lose one to a
+    unique-constraint violation. Subsequent writes lock the existing row with
+    ``SELECT ... FOR UPDATE`` and apply the JSON-in-Python merge.
     """
     if cost_cents <= 0:
         return
     ws_field = str(workspace_id)
     key = _usage_setting_key(month)
+    initial = UsageRow(
+        total_cents=cost_cents, by_workspace_cents={ws_field: cost_cents}
+    )
 
     async with get_async_session_bypass_rls_context_manager() as session:
-        stmt = (
+        insert_stmt = (
+            pg_insert(OrganizationSetting)
+            .values(
+                organization_id=org_id,
+                key=key,
+                value_type="json",
+                value=_encode_usage_row(initial),
+                is_encrypted=False,
+            )
+            .on_conflict_do_nothing(index_elements=["organization_id", "key"])
+            .returning(OrganizationSetting.id)
+        )
+        inserted = (await session.execute(insert_stmt)).scalar_one_or_none()
+        if inserted is not None:
+            await session.commit()
+            return
+
+        sel = (
             select(OrganizationSetting)
             .where(
                 OrganizationSetting.organization_id == org_id,
@@ -241,31 +225,20 @@ async def _increment_usage_in_db(
             )
             .with_for_update()
         )
-        result = await session.execute(stmt)
-        row = result.scalar_one_or_none()
-
-        if row is None:
-            row = OrganizationSetting(
-                organization_id=org_id,
-                key=key,
-                value_type="json",
-                value=_encode_usage_row(cost_cents, {ws_field: cost_cents}),
-                is_encrypted=False,
-            )
-            session.add(row)
-        else:
-            total, by_ws = _decode_usage_row(row.value)
-            total += cost_cents
-            by_ws[ws_field] = by_ws.get(ws_field, 0) + cost_cents
-            row.value = _encode_usage_row(total, by_ws)
-            row.is_encrypted = False
-
+        db_row = (await session.execute(sel)).scalar_one()
+        current = _decode_usage_row(db_row.value)
+        merged_by_ws = dict(current.by_workspace_cents)
+        merged_by_ws[ws_field] = merged_by_ws.get(ws_field, 0) + cost_cents
+        updated = UsageRow(
+            total_cents=current.total_cents + cost_cents,
+            by_workspace_cents=merged_by_ws,
+        )
+        db_row.value = _encode_usage_row(updated)
+        db_row.is_encrypted = False
         await session.commit()
 
 
-async def _read_usage_from_db(
-    org_id: OrganizationID, month: str
-) -> tuple[int, dict[str, int]] | None:
+async def _read_usage_from_db(org_id: OrganizationID, month: str) -> UsageRow | None:
     """Read the durable counter. Returns ``None`` if the row doesn't exist."""
     key = _usage_setting_key(month)
     async with get_async_session_bypass_rls_context_manager() as session:
@@ -286,44 +259,22 @@ async def _read_usage_from_db(
 
 
 async def check_monthly_budget(org_id: OrganizationID) -> None:
-    """Raise ``BudgetExceededError`` if the current month's spend is at cap.
-
-    Reads Redis first (fast path); falls back to the durable Postgres row if
-    Redis is empty or unreachable. No headroom math — we block *new* runs
-    once the counter reaches the limit.
-    """
-    limit = await get_monthly_budget_cents(org_id)
+    """Raise ``BudgetExceededError`` if the current month's spend is at cap."""
+    limit = await _load_monthly_budget_cents(org_id)
     if limit is None:
         return
 
     month = _current_month_utc()
-    used: int | None = None
     try:
-        redis = await get_redis_client()
-        client = await redis._get_client()
-        raw = await client.get(_total_key(org_id, month))
-        if raw is not None:
-            try:
-                used = int(raw)
-            except (TypeError, ValueError):
-                used = None
+        durable = await _read_usage_from_db(org_id, month)
     except Exception:
         logger.warning(
-            "Redis budget check failed; falling back to Postgres",
+            "Budget check DB read failed; allowing run",
             org_id=str(org_id),
         )
+        return
 
-    if used is None:
-        try:
-            durable = await _read_usage_from_db(org_id, month)
-            used = durable[0] if durable is not None else 0
-        except Exception:
-            logger.warning(
-                "Postgres budget fallback failed; allowing run",
-                org_id=str(org_id),
-            )
-            return
-
+    used = durable.total_cents if durable is not None else 0
     if used >= limit:
         raise BudgetExceededError(org_id=org_id, used_cents=used, limit_cents=limit)
 
@@ -350,11 +301,11 @@ async def record_agent_cost(
     cost_cents: int,
     session_id: str | None = None,
 ) -> None:
-    """Persist this run's cost to Postgres (durable) and Redis (hot path).
+    """Persist this run's cost to the durable Postgres counter.
 
-    Postgres is the source of truth; Redis is mirrored for the cap-check
-    fast path. Failures on either side are logged and swallowed — a
-    metering blip must never fail a live agent run.
+    Failures are logged and swallowed — a metering blip must never fail a
+    live agent run. The next successful write will include this run's cost
+    only if the DB write itself succeeded here; a failed DB write is lost.
     """
     if cost_cents <= 0:
         return
@@ -388,26 +339,6 @@ async def record_agent_cost(
             session_id=session_id,
         )
 
-    total_key = _total_key(org_id, month)
-    by_ws_key = _by_ws_key(org_id, month)
-    try:
-        redis = await get_redis_client()
-        client = await redis._get_client()
-        pipe = client.pipeline(transaction=False)
-        pipe.incrby(total_key, cost_cents)
-        pipe.hincrby(by_ws_key, ws_field, cost_cents)
-        pipe.expire(total_key, _USAGE_KEY_TTL_SECONDS)
-        pipe.expire(by_ws_key, _USAGE_KEY_TTL_SECONDS)
-        await pipe.execute()
-    except Exception:
-        logger.warning(
-            "Failed to mirror agent cost to Redis",
-            org_id=str(org_id),
-            workspace_id=ws_field,
-            cost_cents=cost_cents,
-            session_id=session_id,
-        )
-
     logger.info(
         "Recorded agent cost",
         org_id=str(org_id),
@@ -423,56 +354,23 @@ async def get_usage_snapshot(
     *,
     month: str | None = None,
 ) -> OrgUsageSnapshot:
-    """Read total + per-workspace breakdown for a UTC month.
-
-    Postgres is the source of truth. Redis is used only to avoid a DB read
-    on the happy path — if Redis is empty or has a lower total than the
-    durable row (e.g. was evicted), we trust Postgres.
-    """
+    """Read total + per-workspace breakdown for a UTC month from Postgres."""
     target_month = month or _current_month_utc()
-    total = 0
-    by_workspace: dict[str, int] = {}
 
+    row: UsageRow | None = None
     try:
-        redis = await get_redis_client()
-        client = await redis._get_client()
-        raw_total = await client.get(_total_key(org_id, target_month))
-        if raw_total is not None:
-            try:
-                total = int(raw_total)
-            except (TypeError, ValueError):
-                total = 0
-        raw_hash_any = cast(Any, client.hgetall(_by_ws_key(org_id, target_month)))
-        raw_hash = await raw_hash_any
-        if isinstance(raw_hash, dict):
-            for field, value in raw_hash.items():
-                try:
-                    by_workspace[str(field)] = int(value)
-                except (TypeError, ValueError):
-                    continue
+        row = await _read_usage_from_db(org_id, target_month)
     except Exception:
         logger.warning(
-            "Failed to read Redis usage snapshot; falling back to Postgres",
+            "Failed to read Postgres usage snapshot",
             org_id=str(org_id),
             month=target_month,
         )
 
-    if total == 0 and not by_workspace:
-        try:
-            durable = await _read_usage_from_db(org_id, target_month)
-            if durable is not None:
-                total, by_workspace = durable
-        except Exception:
-            logger.warning(
-                "Failed to read Postgres usage snapshot",
-                org_id=str(org_id),
-                month=target_month,
-            )
-
-    limit = await get_monthly_budget_cents(org_id)
+    limit = await _load_monthly_budget_cents(org_id)
     return OrgUsageSnapshot(
         month_utc=target_month,
-        total_cents=total,
+        total_cents=row.total_cents if row is not None else 0,
         limit_cents=limit,
-        by_workspace_cents=by_workspace,
+        by_workspace_cents=row.by_workspace_cents if row is not None else {},
     )

--- a/tracecat/agent/usage.py
+++ b/tracecat/agent/usage.py
@@ -3,57 +3,46 @@
 Storage layout
 --------------
 
-Two ``OrganizationSetting`` keys, JSON-encoded:
-
-- ``agents.monthly_budget_cents`` — int, the per-org cap (absent = unlimited).
-- ``agents.usage.{YYYY-MM}`` — one row per UTC calendar month, shaped as
-  ``{"total_cents": int, "by_workspace_cents": {workspace_id: cents}}``.
-
-Postgres is the single source of truth for both the cap (read on every agent
-launch) and the monthly counter (read for the admin usage-snapshot endpoint).
-Agent launches are not high-QPS, so a small indexed SELECT per launch is fine
-and lets us avoid the correctness hazards of a best-effort mirror cache.
+- ``OrganizationSetting`` key ``agents.monthly_budget_cents`` holds the per-org
+  cap in integer cents (absent = unlimited).
+- ``agent_run_cost`` holds one row per completed run: ``(organization_id,
+  workspace_id, session_id, cost_usd, created_at)``. Cost is stored as exact
+  Numeric USD (5-decimal, i.e. millicent precision) so many cheap runs can
+  accumulate without sub-cent losses from per-run rounding. Enforcement
+  aggregates via ``SUM(cost_usd)`` and rounds once to integer cents at the
+  API boundary. Monthly "reset" is just the date filter rolling over — no
+  stored state becomes stale.
 
 Source of cost
 --------------
 
 Claude Agent SDK's ``ResultMessage.model_usage`` map: ``{route: {"costUSD":
-float, ...}}``. We sum ``costUSD`` across entries and round to integer cents
-on the way in so no floats hit storage.
+float, ...}}``. The runtime folds this into a single ``total_cost_usd`` field
+on the merged ``usage`` dict; we store it as-is (as ``Decimal``) and only
+round to cents when reading aggregates.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any, NamedTuple
+from decimal import ROUND_HALF_EVEN, Decimal
+from typing import Any
+from uuid import UUID
 
-import orjson
 from pydantic import BaseModel
-from sqlalchemy import select
-from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy import func, select
 from sqlalchemy.exc import SQLAlchemyError
 
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
-from tracecat.db.models import OrganizationSetting
+from tracecat.db.models import AgentRunCost
 from tracecat.identifiers import OrganizationID, WorkspaceID
 from tracecat.logger import logger
 from tracecat.settings.service import SettingsService
 
 MONTHLY_BUDGET_CENTS_KEY = "agents.monthly_budget_cents"
 """OrganizationSetting key storing the per-org monthly budget in cents."""
-
-
-class UsageRow(NamedTuple):
-    """Decoded ``agents.usage.{YYYY-MM}`` row."""
-
-    total_cents: int
-    by_workspace_cents: dict[str, int]
-
-
-def _usage_setting_key(month: str) -> str:
-    return f"agents.usage.{month}"
 
 
 class BudgetExceededError(Exception):
@@ -94,6 +83,49 @@ class OrgUsageSnapshot(BaseModel):
 
 def _current_month_utc() -> str:
     return datetime.now(UTC).strftime("%Y-%m")
+
+
+def _now_utc() -> datetime:
+    """Module seam for 'now' that honors a pinned ``_current_month_utc``.
+
+    For real runs this is just ``datetime.now(UTC)``. In tests, monkey-patching
+    ``_current_month_utc`` also shifts this clock into the corresponding month
+    so rows land in the bucket the test is exercising — the same patch controls
+    both filter and storage.
+    """
+    now = datetime.now(UTC)
+    pinned = _current_month_utc()
+    if pinned == now.strftime("%Y-%m"):
+        return now
+    year, mm = int(pinned[:4]), int(pinned[5:7])
+    return now.replace(year=year, month=mm, day=1)
+
+
+def _usd_to_cents(usd: Decimal) -> int:
+    """Round USD to integer cents using banker's rounding.
+
+    Rounding happens exactly once, on an aggregate — not per run — so no
+    sub-cent spend is silently dropped or over-attributed.
+    """
+    cents = (usd * 100).quantize(Decimal("1"), rounding=ROUND_HALF_EVEN)
+    return max(0, int(cents))
+
+
+def _month_bounds_utc(month: str | None = None) -> tuple[datetime, datetime, str]:
+    """Return ``(start, end, label)`` for the given (or current) UTC month.
+
+    ``start`` is inclusive, ``end`` is exclusive — suitable for indexed range
+    scans on ``created_at``. ``label`` is the ``YYYY-MM`` string used in API
+    responses.
+    """
+    label = month or _current_month_utc()
+    year, mm = int(label[:4]), int(label[5:7])
+    start = datetime(year, mm, 1, tzinfo=UTC)
+    if mm == 12:
+        end = datetime(year + 1, 1, 1, tzinfo=UTC)
+    else:
+        end = datetime(year, mm + 1, 1, tzinfo=UTC)
+    return start, end, label
 
 
 # -----------------------------------------------------------------------------
@@ -142,115 +174,52 @@ async def _load_monthly_budget_cents(org_id: OrganizationID) -> int | None:
 
 
 # -----------------------------------------------------------------------------
-# Postgres persistence (durable counter)
+# Ledger queries
 # -----------------------------------------------------------------------------
 
 
-def _decode_usage_row(raw: bytes | None) -> UsageRow:
-    """Decode the stored JSON blob into a ``UsageRow``."""
-    if raw is None:
-        return UsageRow(total_cents=0, by_workspace_cents={})
-    try:
-        data = orjson.loads(raw)
-    except Exception:
-        return UsageRow(total_cents=0, by_workspace_cents={})
-    total = data.get("total_cents") if isinstance(data, dict) else None
-    by_ws_raw = data.get("by_workspace_cents") if isinstance(data, dict) else None
-    total_int = int(total) if isinstance(total, (int, float)) else 0
-    by_ws: dict[str, int] = {}
-    if isinstance(by_ws_raw, dict):
-        for k, v in by_ws_raw.items():
-            try:
-                by_ws[str(k)] = int(v)
-            except (TypeError, ValueError):
-                continue
-    return UsageRow(total_cents=total_int, by_workspace_cents=by_ws)
+async def _sum_month_cents(org_id: OrganizationID, month: str) -> int:
+    """Sum ``cost_usd`` for an org's runs in the given UTC month, as cents.
 
-
-def _encode_usage_row(row: UsageRow) -> bytes:
-    return orjson.dumps(
-        {
-            "total_cents": row.total_cents,
-            "by_workspace_cents": row.by_workspace_cents,
-        },
-        option=orjson.OPT_SORT_KEYS,
-    )
-
-
-async def _increment_usage_in_db(
-    *,
-    org_id: OrganizationID,
-    workspace_id: WorkspaceID,
-    cost_cents: int,
-    month: str,
-) -> None:
-    """Increment the durable ``agents.usage.{month}`` counter for this org.
-
-    First write of the month is an atomic ``INSERT ... ON CONFLICT DO NOTHING``
-    so two racing first-writers don't both try to INSERT and lose one to a
-    unique-constraint violation. Subsequent writes lock the existing row with
-    ``SELECT ... FOR UPDATE`` and apply the JSON-in-Python merge.
+    Rounds once on the aggregate so sub-cent per-run spend is preserved in
+    storage and only lost (to the nearest cent) at the enforcement boundary.
     """
-    if cost_cents <= 0:
-        return
-    ws_field = str(workspace_id)
-    key = _usage_setting_key(month)
-    initial = UsageRow(
-        total_cents=cost_cents, by_workspace_cents={ws_field: cost_cents}
-    )
-
+    start, end, _ = _month_bounds_utc(month)
     async with get_async_session_bypass_rls_context_manager() as session:
-        insert_stmt = (
-            pg_insert(OrganizationSetting)
-            .values(
-                organization_id=org_id,
-                key=key,
-                value_type="json",
-                value=_encode_usage_row(initial),
-                is_encrypted=False,
-            )
-            .on_conflict_do_nothing(index_elements=["organization_id", "key"])
-            .returning(OrganizationSetting.id)
+        stmt = select(func.coalesce(func.sum(AgentRunCost.cost_usd), 0)).where(
+            AgentRunCost.organization_id == org_id,
+            AgentRunCost.created_at >= start,
+            AgentRunCost.created_at < end,
         )
-        inserted = (await session.execute(insert_stmt)).scalar_one_or_none()
-        if inserted is not None:
-            await session.commit()
-            return
+        total_usd = Decimal((await session.execute(stmt)).scalar_one())
+        return _usd_to_cents(total_usd)
 
-        sel = (
-            select(OrganizationSetting)
+
+async def _workspace_totals(
+    org_id: OrganizationID, month: str
+) -> tuple[int, dict[str, int]]:
+    """Return ``(total_cents, by_workspace_cents)`` for an org in a UTC month."""
+    start, end, _ = _month_bounds_utc(month)
+    async with get_async_session_bypass_rls_context_manager() as session:
+        stmt = (
+            select(
+                AgentRunCost.workspace_id,
+                func.sum(AgentRunCost.cost_usd),
+            )
             .where(
-                OrganizationSetting.organization_id == org_id,
-                OrganizationSetting.key == key,
+                AgentRunCost.organization_id == org_id,
+                AgentRunCost.created_at >= start,
+                AgentRunCost.created_at < end,
             )
-            .with_for_update()
+            .group_by(AgentRunCost.workspace_id)
         )
-        db_row = (await session.execute(sel)).scalar_one()
-        current = _decode_usage_row(db_row.value)
-        merged_by_ws = dict(current.by_workspace_cents)
-        merged_by_ws[ws_field] = merged_by_ws.get(ws_field, 0) + cost_cents
-        updated = UsageRow(
-            total_cents=current.total_cents + cost_cents,
-            by_workspace_cents=merged_by_ws,
-        )
-        db_row.value = _encode_usage_row(updated)
-        db_row.is_encrypted = False
-        await session.commit()
-
-
-async def _read_usage_from_db(org_id: OrganizationID, month: str) -> UsageRow | None:
-    """Read the durable counter. Returns ``None`` if the row doesn't exist."""
-    key = _usage_setting_key(month)
-    async with get_async_session_bypass_rls_context_manager() as session:
-        stmt = select(OrganizationSetting).where(
-            OrganizationSetting.organization_id == org_id,
-            OrganizationSetting.key == key,
-        )
-        result = await session.execute(stmt)
-        row = result.scalar_one_or_none()
-    if row is None:
-        return None
-    return _decode_usage_row(row.value)
+        by_ws: dict[str, int] = {}
+        total = 0
+        for ws_id, total_usd in (await session.execute(stmt)).all():
+            cents_int = _usd_to_cents(Decimal(total_usd or 0))
+            by_ws[str(ws_id)] = cents_int
+            total += cents_int
+        return total, by_ws
 
 
 # -----------------------------------------------------------------------------
@@ -258,93 +227,127 @@ async def _read_usage_from_db(org_id: OrganizationID, month: str) -> UsageRow | 
 # -----------------------------------------------------------------------------
 
 
-async def check_monthly_budget(org_id: OrganizationID) -> None:
-    """Raise ``BudgetExceededError`` if the current month's spend is at cap."""
-    limit = await _load_monthly_budget_cents(org_id)
-    if limit is None:
-        return
+async def resolve_run_budget(org_id: OrganizationID) -> float | None:
+    """Return the per-run dollar cap to pass as SDK ``max_budget_usd``.
+
+    - ``None`` → org is uncapped; the SDK should run without a ceiling.
+    - ``float`` → remaining headroom in dollars; the SDK must not exceed it.
+
+    Raises ``BudgetExceededError`` when the org has already reached its cap.
+    One ``SUM`` query answers both the gate and the single-run cap.
+    """
+    limit_cents = await _load_monthly_budget_cents(org_id)
+    if limit_cents is None:
+        return None
 
     month = _current_month_utc()
     try:
-        durable = await _read_usage_from_db(org_id, month)
+        used_cents = await _sum_month_cents(org_id, month)
     except Exception:
         logger.warning(
             "Budget check DB read failed; allowing run",
             org_id=str(org_id),
         )
-        return
+        return None
 
-    used = durable.total_cents if durable is not None else 0
-    if used >= limit:
-        raise BudgetExceededError(org_id=org_id, used_cents=used, limit_cents=limit)
+    if used_cents >= limit_cents:
+        raise BudgetExceededError(
+            org_id=org_id, used_cents=used_cents, limit_cents=limit_cents
+        )
+    return (limit_cents - used_cents) / 100
+
+
+def usd_from_usage(usage: dict[str, Any] | None) -> Decimal | None:
+    """Extract exact cost in USD from the runtime-merged ``usage`` dict.
+
+    The Claude Code runtime folds the SDK's per-model ``costUSD`` values into
+    a single ``total_cost_usd`` field on the merged ``usage`` dict. We return
+    it as a ``Decimal`` so the storage layer can keep sub-cent precision —
+    rounding to cents happens once on aggregates, not per run.
+    """
+    if not isinstance(usage, dict):
+        return None
+    cost = usage.get("total_cost_usd")
+    if not isinstance(cost, (int, float)):
+        return None
+    # str() round-trips through the shortest float repr, which is as close to
+    # the SDK's intended value as we can get without reading their source.
+    usd = Decimal(str(cost))
+    return usd if usd > 0 else None
 
 
 def cents_from_usage(usage: dict[str, Any] | None) -> int:
-    """Extract cost in integer cents from a merged ``usage`` dict.
-
-    The Claude Code runtime folds the SDK's per-model ``costUSD`` values into
-    a single ``total_cost_usd`` field on the merged ``usage`` dict before it
-    reaches us, so we just round and scale.
-    """
-    if not isinstance(usage, dict):
-        return 0
-    cost = usage.get("total_cost_usd")
-    if not isinstance(cost, (int, float)):
-        return 0
-    return max(0, round(float(cost) * 100))
+    """Convenience wrapper returning integer cents for display/logging."""
+    usd = usd_from_usage(usage)
+    return 0 if usd is None else _usd_to_cents(usd)
 
 
 async def record_agent_cost(
     *,
     org_id: OrganizationID,
     workspace_id: WorkspaceID,
-    cost_cents: int,
-    session_id: str | None = None,
+    cost_cents: int | None = None,
+    cost_usd: Decimal | None = None,
+    session_id: UUID | None = None,
 ) -> None:
-    """Persist this run's cost to the durable Postgres counter.
+    """Append this run's cost to the durable ledger.
+
+    Pass ``cost_usd`` to preserve sub-cent precision (the runtime path); the
+    ``cost_cents`` input is converted exactly and retained for callers that
+    only know integer cents.
 
     Failures are logged and swallowed — a metering blip must never fail a
-    live agent run. The next successful write will include this run's cost
-    only if the DB write itself succeeded here; a failed DB write is lost.
+    live agent run. A failed insert is simply lost from the counter; no
+    shared row to merge against and no race to recover from.
     """
-    if cost_cents <= 0:
+    if (cost_usd is None) == (cost_cents is None):
+        raise ValueError("Pass exactly one of cost_usd or cost_cents")
+    exact_usd = cost_usd if cost_usd is not None else Decimal(cost_cents or 0) / 100
+    if exact_usd <= 0:
         return
 
-    month = _current_month_utc()
     ws_field = str(workspace_id)
 
     db_ok = False
     try:
-        await _increment_usage_in_db(
-            org_id=org_id,
-            workspace_id=workspace_id,
-            cost_cents=cost_cents,
-            month=month,
-        )
+        async with get_async_session_bypass_rls_context_manager() as session:
+            session.add(
+                AgentRunCost(
+                    organization_id=org_id,
+                    workspace_id=workspace_id,
+                    session_id=session_id,
+                    cost_usd=exact_usd,
+                    # Stamped client-side so callers that pin ``_now_utc``
+                    # (tests, and any replay/backfill path) control month
+                    # placement deterministically.
+                    created_at=_now_utc(),
+                )
+            )
+            await session.commit()
         db_ok = True
     except SQLAlchemyError:
         logger.warning(
             "Failed to persist agent cost to Postgres",
             org_id=str(org_id),
             workspace_id=ws_field,
-            cost_cents=cost_cents,
-            session_id=session_id,
+            cost_usd=str(exact_usd),
+            session_id=str(session_id) if session_id else None,
         )
     except Exception:
         logger.exception(
             "Unexpected error persisting agent cost to Postgres",
             org_id=str(org_id),
             workspace_id=ws_field,
-            cost_cents=cost_cents,
-            session_id=session_id,
+            cost_usd=str(exact_usd),
+            session_id=str(session_id) if session_id else None,
         )
 
     logger.info(
         "Recorded agent cost",
         org_id=str(org_id),
         workspace_id=ws_field,
-        cost_cents=cost_cents,
-        session_id=session_id,
+        cost_usd=str(exact_usd),
+        session_id=str(session_id) if session_id else None,
         durable=db_ok,
     )
 
@@ -354,15 +357,16 @@ async def get_usage_snapshot(
     *,
     month: str | None = None,
 ) -> OrgUsageSnapshot:
-    """Read total + per-workspace breakdown for a UTC month from Postgres."""
+    """Read total + per-workspace breakdown for a UTC month from the ledger."""
     target_month = month or _current_month_utc()
 
-    row: UsageRow | None = None
+    total = 0
+    by_workspace: dict[str, int] = {}
     try:
-        row = await _read_usage_from_db(org_id, target_month)
+        total, by_workspace = await _workspace_totals(org_id, target_month)
     except Exception:
         logger.warning(
-            "Failed to read Postgres usage snapshot",
+            "Failed to read usage snapshot",
             org_id=str(org_id),
             month=target_month,
         )
@@ -370,7 +374,7 @@ async def get_usage_snapshot(
     limit = await _load_monthly_budget_cents(org_id)
     return OrgUsageSnapshot(
         month_utc=target_month,
-        total_cents=row.total_cents if row is not None else 0,
+        total_cents=total,
         limit_cents=limit,
-        by_workspace_cents=row.by_workspace_cents if row is not None else {},
+        by_workspace_cents=by_workspace,
     )

--- a/tracecat/agent/usage.py
+++ b/tracecat/agent/usage.py
@@ -1,0 +1,478 @@
+"""Per-organization agent cost accounting and monthly budget caps.
+
+Storage layout
+--------------
+
+Two ``OrganizationSetting`` keys, JSON-encoded:
+
+- ``agents.monthly_budget_cents`` — int, the per-org cap (absent = unlimited).
+- ``agents.usage.{YYYY-MM}`` — one row per UTC calendar month, shaped as
+  ``{"total_cents": int, "by_workspace_cents": {workspace_id: cents}}``.
+
+Redis mirrors the month row for the hot path (cap check on every run):
+
+- ``usage:cost_cents:org:{org_id}:{YYYY-MM}`` — scalar INT
+- ``usage:cost_cents:org:{org_id}:{YYYY-MM}:by_ws`` — HASH of ws_id → cents
+
+Both Redis keys expire after 90 days. Postgres is the durable source of
+truth; Redis can be evicted / lost and we rebuild from the settings row on
+the next read.
+
+Source of cost
+--------------
+
+Claude Agent SDK's ``ResultMessage.model_usage`` map: ``{route: {"costUSD":
+float, ...}}``. We sum ``costUSD`` across entries and round to integer cents
+on the way in so no floats hit storage.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import Any, cast
+
+import orjson
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+
+from tracecat import config
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.db.engine import get_async_session_bypass_rls_context_manager
+from tracecat.db.models import OrganizationSetting
+from tracecat.identifiers import OrganizationID, WorkspaceID
+from tracecat.logger import logger
+from tracecat.redis.client import get_redis_client
+from tracecat.settings.service import SettingsService
+
+MONTHLY_BUDGET_CENTS_KEY = "agents.monthly_budget_cents"
+"""OrganizationSetting key storing the per-org monthly budget in cents."""
+
+_USAGE_KEY_TTL_SECONDS = 90 * 24 * 60 * 60
+"""Keep roughly the last three UTC months of Redis counters hot."""
+
+
+def _usage_setting_key(month: str) -> str:
+    return f"agents.usage.{month}"
+
+
+class BudgetExceededError(Exception):
+    """Raised when the org's current-month spend has reached the cap.
+
+    ``org_id`` is retained as a structured attribute for logging and metrics,
+    but intentionally omitted from the message string — that message is
+    surfaced to end users via the UI stream, and the raw UUID is not useful
+    or relevant to them.
+    """
+
+    def __init__(
+        self,
+        *,
+        org_id: OrganizationID,
+        used_cents: int,
+        limit_cents: int,
+    ) -> None:
+        self.org_id = org_id
+        self.used_cents = used_cents
+        self.limit_cents = limit_cents
+        super().__init__(
+            f"Monthly agent budget reached "
+            f"(${used_cents / 100:.2f} of ${limit_cents / 100:.2f} used). "
+            "Contact an org admin to raise the cap in "
+            "Organization → Agent settings."
+        )
+
+
+class OrgUsageSnapshot(BaseModel):
+    """Point-in-time read of an org's monthly agent spend."""
+
+    month_utc: str
+    total_cents: int
+    limit_cents: int | None
+    by_workspace_cents: dict[str, int]
+
+
+def _current_month_utc() -> str:
+    return datetime.now(UTC).strftime("%Y-%m")
+
+
+def _total_key(org_id: OrganizationID, month: str) -> str:
+    return f"usage:cost_cents:org:{org_id}:{month}"
+
+
+def _by_ws_key(org_id: OrganizationID, month: str) -> str:
+    return f"usage:cost_cents:org:{org_id}:{month}:by_ws"
+
+
+# -----------------------------------------------------------------------------
+# Cap lookup (in-process TTL cache to avoid a DB hit on every run)
+# -----------------------------------------------------------------------------
+
+_cap_cache: dict[OrganizationID, tuple[float, int | None]] = {}
+
+
+def _cap_cache_ttl() -> int:
+    return max(0, config.TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS)
+
+
+async def _load_monthly_budget_cents(org_id: OrganizationID) -> int | None:
+    """Read the cap directly from ``OrganizationSetting``.
+
+    Returns None for unlimited (no row, or an unparseable value).
+    """
+    role = Role(
+        type="service",
+        user_id=None,
+        service_id="tracecat-agent-executor",
+        organization_id=org_id,
+        workspace_id=None,
+        scopes=SERVICE_PRINCIPAL_SCOPES["tracecat-agent-executor"],
+    )
+    try:
+        async with SettingsService.with_session(role=role) as service:
+            setting = await service.get_org_setting(MONTHLY_BUDGET_CENTS_KEY)
+            if setting is None:
+                return None
+            raw = service.get_value(setting)
+    except Exception:
+        logger.warning(
+            "Failed to read monthly budget; treating as unlimited",
+            org_id=str(org_id),
+        )
+        return None
+
+    if raw is None:
+        return None
+    try:
+        limit = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid monthly_budget_cents value; treating as unlimited",
+            org_id=str(org_id),
+            raw=raw,
+        )
+        return None
+    return limit if limit > 0 else None
+
+
+async def get_monthly_budget_cents(org_id: OrganizationID) -> int | None:
+    """Return the effective monthly budget (cents) for the org, cached in-process.
+
+    Cache TTL reuses ``TRACECAT__TIER_LIMITS_CACHE_TTL_SECONDS``.
+    """
+    ttl = _cap_cache_ttl()
+    now = time.monotonic()
+    cached = _cap_cache.get(org_id)
+    if cached is not None and ttl > 0 and cached[0] > now:
+        return cached[1]
+
+    limit = await _load_monthly_budget_cents(org_id)
+    if ttl > 0:
+        _cap_cache[org_id] = (now + ttl, limit)
+    return limit
+
+
+def invalidate_cap_cache(org_id: OrganizationID | None = None) -> None:
+    """Drop cached budget(s). Called after a budget PUT."""
+    if org_id is None:
+        _cap_cache.clear()
+    else:
+        _cap_cache.pop(org_id, None)
+
+
+# -----------------------------------------------------------------------------
+# Postgres persistence (durable counter; survives Redis eviction/restarts)
+# -----------------------------------------------------------------------------
+
+
+def _decode_usage_row(raw: bytes | None) -> tuple[int, dict[str, int]]:
+    """Decode the ``agents.usage.{YYYY-MM}`` blob into (total, by_ws)."""
+    if raw is None:
+        return 0, {}
+    try:
+        data = orjson.loads(raw)
+    except Exception:
+        return 0, {}
+    total = data.get("total_cents") if isinstance(data, dict) else None
+    by_ws_raw = data.get("by_workspace_cents") if isinstance(data, dict) else None
+    total_int = int(total) if isinstance(total, (int, float)) else 0
+    by_ws: dict[str, int] = {}
+    if isinstance(by_ws_raw, dict):
+        for k, v in by_ws_raw.items():
+            try:
+                by_ws[str(k)] = int(v)
+            except (TypeError, ValueError):
+                continue
+    return total_int, by_ws
+
+
+def _encode_usage_row(total: int, by_ws: dict[str, int]) -> bytes:
+    return orjson.dumps(
+        {"total_cents": total, "by_workspace_cents": by_ws},
+        option=orjson.OPT_SORT_KEYS,
+    )
+
+
+async def _increment_usage_in_db(
+    *,
+    org_id: OrganizationID,
+    workspace_id: WorkspaceID,
+    cost_cents: int,
+    month: str,
+) -> None:
+    """Increment the durable ``agents.usage.{month}`` counter for this org.
+
+    Uses ``SELECT ... FOR UPDATE`` to serialize concurrent writers on the
+    same org+month row. Creates the row on first write of the month.
+    """
+    if cost_cents <= 0:
+        return
+    ws_field = str(workspace_id)
+    key = _usage_setting_key(month)
+
+    async with get_async_session_bypass_rls_context_manager() as session:
+        stmt = (
+            select(OrganizationSetting)
+            .where(
+                OrganizationSetting.organization_id == org_id,
+                OrganizationSetting.key == key,
+            )
+            .with_for_update()
+        )
+        result = await session.execute(stmt)
+        row = result.scalar_one_or_none()
+
+        if row is None:
+            row = OrganizationSetting(
+                organization_id=org_id,
+                key=key,
+                value_type="json",
+                value=_encode_usage_row(cost_cents, {ws_field: cost_cents}),
+                is_encrypted=False,
+            )
+            session.add(row)
+        else:
+            total, by_ws = _decode_usage_row(row.value)
+            total += cost_cents
+            by_ws[ws_field] = by_ws.get(ws_field, 0) + cost_cents
+            row.value = _encode_usage_row(total, by_ws)
+            row.is_encrypted = False
+
+        await session.commit()
+
+
+async def _read_usage_from_db(
+    org_id: OrganizationID, month: str
+) -> tuple[int, dict[str, int]] | None:
+    """Read the durable counter. Returns ``None`` if the row doesn't exist."""
+    key = _usage_setting_key(month)
+    async with get_async_session_bypass_rls_context_manager() as session:
+        stmt = select(OrganizationSetting).where(
+            OrganizationSetting.organization_id == org_id,
+            OrganizationSetting.key == key,
+        )
+        result = await session.execute(stmt)
+        row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    return _decode_usage_row(row.value)
+
+
+# -----------------------------------------------------------------------------
+# Cap enforcement + recording
+# -----------------------------------------------------------------------------
+
+
+async def check_monthly_budget(org_id: OrganizationID) -> None:
+    """Raise ``BudgetExceededError`` if the current month's spend is at cap.
+
+    Reads Redis first (fast path); falls back to the durable Postgres row if
+    Redis is empty or unreachable. No headroom math — we block *new* runs
+    once the counter reaches the limit.
+    """
+    limit = await get_monthly_budget_cents(org_id)
+    if limit is None:
+        return
+
+    month = _current_month_utc()
+    used: int | None = None
+    try:
+        redis = await get_redis_client()
+        client = await redis._get_client()
+        raw = await client.get(_total_key(org_id, month))
+        if raw is not None:
+            try:
+                used = int(raw)
+            except (TypeError, ValueError):
+                used = None
+    except Exception:
+        logger.warning(
+            "Redis budget check failed; falling back to Postgres",
+            org_id=str(org_id),
+        )
+
+    if used is None:
+        try:
+            durable = await _read_usage_from_db(org_id, month)
+            used = durable[0] if durable is not None else 0
+        except Exception:
+            logger.warning(
+                "Postgres budget fallback failed; allowing run",
+                org_id=str(org_id),
+            )
+            return
+
+    if used >= limit:
+        raise BudgetExceededError(org_id=org_id, used_cents=used, limit_cents=limit)
+
+
+def cents_from_usage(usage: dict[str, Any] | None) -> int:
+    """Extract cost in integer cents from a merged ``usage`` dict.
+
+    The Claude Code runtime folds the SDK's per-model ``costUSD`` values into
+    a single ``total_cost_usd`` field on the merged ``usage`` dict before it
+    reaches us, so we just round and scale.
+    """
+    if not isinstance(usage, dict):
+        return 0
+    cost = usage.get("total_cost_usd")
+    if not isinstance(cost, (int, float)):
+        return 0
+    return max(0, round(float(cost) * 100))
+
+
+async def record_agent_cost(
+    *,
+    org_id: OrganizationID,
+    workspace_id: WorkspaceID,
+    cost_cents: int,
+    session_id: str | None = None,
+) -> None:
+    """Persist this run's cost to Postgres (durable) and Redis (hot path).
+
+    Postgres is the source of truth; Redis is mirrored for the cap-check
+    fast path. Failures on either side are logged and swallowed — a
+    metering blip must never fail a live agent run.
+    """
+    if cost_cents <= 0:
+        return
+
+    month = _current_month_utc()
+    ws_field = str(workspace_id)
+
+    db_ok = False
+    try:
+        await _increment_usage_in_db(
+            org_id=org_id,
+            workspace_id=workspace_id,
+            cost_cents=cost_cents,
+            month=month,
+        )
+        db_ok = True
+    except SQLAlchemyError:
+        logger.warning(
+            "Failed to persist agent cost to Postgres",
+            org_id=str(org_id),
+            workspace_id=ws_field,
+            cost_cents=cost_cents,
+            session_id=session_id,
+        )
+    except Exception:
+        logger.exception(
+            "Unexpected error persisting agent cost to Postgres",
+            org_id=str(org_id),
+            workspace_id=ws_field,
+            cost_cents=cost_cents,
+            session_id=session_id,
+        )
+
+    total_key = _total_key(org_id, month)
+    by_ws_key = _by_ws_key(org_id, month)
+    try:
+        redis = await get_redis_client()
+        client = await redis._get_client()
+        pipe = client.pipeline(transaction=False)
+        pipe.incrby(total_key, cost_cents)
+        pipe.hincrby(by_ws_key, ws_field, cost_cents)
+        pipe.expire(total_key, _USAGE_KEY_TTL_SECONDS)
+        pipe.expire(by_ws_key, _USAGE_KEY_TTL_SECONDS)
+        await pipe.execute()
+    except Exception:
+        logger.warning(
+            "Failed to mirror agent cost to Redis",
+            org_id=str(org_id),
+            workspace_id=ws_field,
+            cost_cents=cost_cents,
+            session_id=session_id,
+        )
+
+    logger.info(
+        "Recorded agent cost",
+        org_id=str(org_id),
+        workspace_id=ws_field,
+        cost_cents=cost_cents,
+        session_id=session_id,
+        durable=db_ok,
+    )
+
+
+async def get_usage_snapshot(
+    org_id: OrganizationID,
+    *,
+    month: str | None = None,
+) -> OrgUsageSnapshot:
+    """Read total + per-workspace breakdown for a UTC month.
+
+    Postgres is the source of truth. Redis is used only to avoid a DB read
+    on the happy path — if Redis is empty or has a lower total than the
+    durable row (e.g. was evicted), we trust Postgres.
+    """
+    target_month = month or _current_month_utc()
+    total = 0
+    by_workspace: dict[str, int] = {}
+
+    try:
+        redis = await get_redis_client()
+        client = await redis._get_client()
+        raw_total = await client.get(_total_key(org_id, target_month))
+        if raw_total is not None:
+            try:
+                total = int(raw_total)
+            except (TypeError, ValueError):
+                total = 0
+        raw_hash_any = cast(Any, client.hgetall(_by_ws_key(org_id, target_month)))
+        raw_hash = await raw_hash_any
+        if isinstance(raw_hash, dict):
+            for field, value in raw_hash.items():
+                try:
+                    by_workspace[str(field)] = int(value)
+                except (TypeError, ValueError):
+                    continue
+    except Exception:
+        logger.warning(
+            "Failed to read Redis usage snapshot; falling back to Postgres",
+            org_id=str(org_id),
+            month=target_month,
+        )
+
+    if total == 0 and not by_workspace:
+        try:
+            durable = await _read_usage_from_db(org_id, target_month)
+            if durable is not None:
+                total, by_workspace = durable
+        except Exception:
+            logger.warning(
+                "Failed to read Postgres usage snapshot",
+                org_id=str(org_id),
+                month=target_month,
+            )
+
+    limit = await get_monthly_budget_cents(org_id)
+    return OrgUsageSnapshot(
+        month_utc=target_month,
+        total_cents=total,
+        limit_cents=limit,
+        by_workspace_cents=by_workspace,
+    )

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import uuid
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from typing import Any, Literal
 
 from fastapi_users.db import (
@@ -29,6 +30,7 @@ from sqlalchemy import (
     Interval,
     LargeBinary,
     MetaData,
+    Numeric,
     PrimaryKeyConstraint,
     String,
     Text,
@@ -1685,6 +1687,60 @@ class OrganizationSetting(OrganizationModel):
         default=False,
         server_default=text("false"),
         doc="Whether the setting is encrypted",
+    )
+
+
+class AgentRunCost(OrganizationModel):
+    """Per-run agent cost ledger.
+
+    One row per completed agent run. Enforcement aggregates via SUM over
+    (organization_id, created_at) range scans; admin attribution groups by
+    workspace_id. Monthly "reset" is just the date filter rolling over — no
+    stored state becomes stale.
+    """
+
+    __tablename__ = "agent_run_cost"
+    __table_args__ = (
+        Index(
+            "ix_agent_run_cost_org_created_at",
+            "organization_id",
+            "created_at",
+        ),
+        Index(
+            "ix_agent_run_cost_org_ws_created_at",
+            "organization_id",
+            "workspace_id",
+            "created_at",
+        ),
+    )
+
+    organization_id: Mapped[OrganizationID] = mapped_column(
+        UUID,
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("workspace.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    session_id: Mapped[uuid.UUID | None] = mapped_column(UUID, nullable=True)
+    cost_usd: Mapped[Decimal] = mapped_column(
+        Numeric(14, 5),
+        nullable=False,
+        doc=(
+            "Run cost in USD with millicent precision (5 decimals). Storing "
+            "exact amounts avoids losing sub-cent spend to per-run rounding; "
+            "cents are derived at the API boundary by aggregating then "
+            "rounding once. Non-negative."
+        ),
     )
 
 

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -85,6 +85,7 @@ POST_RLS_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES = (
     "watchtower_agent_session",
     "watchtower_agent_tool_call",
     "service_account",
+    "agent_run_cost",
 )
 
 SPECIAL_TENANT_POLICY_TABLES = frozenset(

--- a/tracecat/organization/router.py
+++ b/tracecat/organization/router.py
@@ -2,10 +2,18 @@ from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID
 
+import orjson
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
 from sqlalchemy import and_, func, select
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
+from tracecat.agent.usage import (
+    MONTHLY_BUDGET_CENTS_KEY,
+    OrgUsageSnapshot,
+    get_usage_snapshot,
+    invalidate_cap_cache,
+)
 from tracecat.auth.credentials import AuthenticatedUserOnly, OptionalUserDep
 from tracecat.auth.dependencies import OrgActorRole, OrgUserRole
 from tracecat.auth.schemas import SessionRead, UserUpdate
@@ -17,6 +25,7 @@ from tracecat.db.models import (
     OrganizationDomain,
     OrganizationInvitation,
     OrganizationMembership,
+    OrganizationSetting,
     User,
     UserRoleAssignment,
 )
@@ -24,6 +33,7 @@ from tracecat.db.models import (
     Role as DBRole,
 )
 from tracecat.exceptions import (
+    EntitlementRequired,
     TracecatAuthorizationError,
     TracecatNotFoundError,
     TracecatValidationError,
@@ -43,6 +53,8 @@ from tracecat.organization.schemas import (
     OrgRead,
 )
 from tracecat.organization.service import OrgService, accept_invitation_for_user
+from tracecat.tiers.access import is_org_entitled
+from tracecat.tiers.enums import Entitlement
 from tracecat.tiers.schemas import EffectiveEntitlements
 from tracecat.tiers.service import TierService
 
@@ -716,3 +728,96 @@ async def get_invitation_by_token(
         )
     except TracecatNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+# Agent token usage endpoints (org-scoped; caller's own org via role context)
+
+
+class AgentBudgetUpdate(BaseModel):
+    """Set or clear an org's monthly agent budget (cents)."""
+
+    monthly_budget_cents: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Monthly agent spend cap in US cents (1000 = $10.00). "
+            "Pass null to remove the cap."
+        ),
+    )
+
+
+def _require_org_context(role: OrgUserRole) -> UUID:
+    if role.organization_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No organization context",
+        )
+    return role.organization_id
+
+
+async def _require_agent_addons_entitlement(
+    session: AsyncDBSession, org_id: UUID
+) -> None:
+    if not await is_org_entitled(session, org_id, Entitlement.AGENT_ADDONS):
+        raise EntitlementRequired(Entitlement.AGENT_ADDONS.value)
+
+
+@router.get("/agent-usage", response_model=OrgUsageSnapshot)
+@require_scope("org:settings:read")
+async def get_org_agent_usage(
+    *,
+    role: OrgUserRole,
+    session: AsyncDBSession,
+    month: str | None = Query(
+        default=None,
+        description=("UTC month in YYYY-MM format. Defaults to the current UTC month."),
+        pattern=r"^\d{4}-\d{2}$",
+    ),
+) -> OrgUsageSnapshot:
+    """Read the caller's organization agent spend for a UTC month."""
+    org_id = _require_org_context(role)
+    await _require_agent_addons_entitlement(session, org_id)
+    return await get_usage_snapshot(org_id, month=month)
+
+
+@router.put("/agent-usage/limit", response_model=OrgUsageSnapshot)
+@require_scope("org:settings:update")
+async def set_org_agent_budget(
+    *,
+    role: OrgUserRole,
+    session: AsyncDBSession,
+    params: AgentBudgetUpdate,
+) -> OrgUsageSnapshot:
+    """Set or clear the caller's organization monthly agent budget."""
+    org_id = _require_org_context(role)
+    await _require_agent_addons_entitlement(session, org_id)
+
+    stmt = select(OrganizationSetting).where(
+        OrganizationSetting.organization_id == org_id,
+        OrganizationSetting.key == MONTHLY_BUDGET_CENTS_KEY,
+    )
+    result = await session.execute(stmt)
+    setting = result.scalar_one_or_none()
+
+    if params.monthly_budget_cents is None:
+        if setting is not None:
+            await session.delete(setting)
+            await session.commit()
+    else:
+        encoded = orjson.dumps(params.monthly_budget_cents)
+        if setting is None:
+            setting = OrganizationSetting(
+                organization_id=org_id,
+                key=MONTHLY_BUDGET_CENTS_KEY,
+                value_type="json",
+                value=encoded,
+                is_encrypted=False,
+            )
+            session.add(setting)
+        else:
+            setting.value = encoded
+            setting.is_encrypted = False
+        await session.commit()
+
+    invalidate_cap_cache(org_id)
+    return await get_usage_snapshot(org_id)

--- a/tracecat/organization/router.py
+++ b/tracecat/organization/router.py
@@ -5,14 +5,14 @@ from uuid import UUID
 import orjson
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, delete, func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
 from tracecat.agent.usage import (
     MONTHLY_BUDGET_CENTS_KEY,
     OrgUsageSnapshot,
     get_usage_snapshot,
-    invalidate_cap_cache,
 )
 from tracecat.auth.credentials import AuthenticatedUserOnly, OptionalUserDep
 from tracecat.auth.dependencies import OrgActorRole, OrgUserRole
@@ -792,32 +792,33 @@ async def set_org_agent_budget(
     org_id = _require_org_context(role)
     await _require_agent_addons_entitlement(session, org_id)
 
-    stmt = select(OrganizationSetting).where(
-        OrganizationSetting.organization_id == org_id,
-        OrganizationSetting.key == MONTHLY_BUDGET_CENTS_KEY,
-    )
-    result = await session.execute(stmt)
-    setting = result.scalar_one_or_none()
-
     if params.monthly_budget_cents is None:
-        if setting is not None:
-            await session.delete(setting)
-            await session.commit()
+        # DELETE is idempotent; no pre-SELECT, no race.
+        await session.execute(
+            delete(OrganizationSetting).where(
+                OrganizationSetting.organization_id == org_id,
+                OrganizationSetting.key == MONTHLY_BUDGET_CENTS_KEY,
+            )
+        )
     else:
         encoded = orjson.dumps(params.monthly_budget_cents)
-        if setting is None:
-            setting = OrganizationSetting(
-                organization_id=org_id,
-                key=MONTHLY_BUDGET_CENTS_KEY,
-                value_type="json",
-                value=encoded,
-                is_encrypted=False,
-            )
-            session.add(setting)
-        else:
-            setting.value = encoded
-            setting.is_encrypted = False
-        await session.commit()
+        # Atomic set-or-replace; avoids IntegrityError on concurrent first PUTs.
+        upsert = pg_insert(OrganizationSetting).values(
+            organization_id=org_id,
+            key=MONTHLY_BUDGET_CENTS_KEY,
+            value_type="json",
+            value=encoded,
+            is_encrypted=False,
+        )
+        upsert = upsert.on_conflict_do_update(
+            index_elements=["organization_id", "key"],
+            set_={
+                "value": upsert.excluded.value,
+                "value_type": upsert.excluded.value_type,
+                "is_encrypted": upsert.excluded.is_encrypted,
+            },
+        )
+        await session.execute(upsert)
+    await session.commit()
 
-    invalidate_cap_cache(org_id)
     return await get_usage_snapshot(org_id)

--- a/tracecat/organization/router.py
+++ b/tracecat/organization/router.py
@@ -771,7 +771,7 @@ async def get_org_agent_usage(
     month: str | None = Query(
         default=None,
         description=("UTC month in YYYY-MM format. Defaults to the current UTC month."),
-        pattern=r"^\d{4}-\d{2}$",
+        pattern=r"^\d{4}-(0[1-9]|1[0-2])$",
     ),
 ) -> OrgUsageSnapshot:
     """Read the caller's organization agent spend for a UTC month."""


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add org-level monthly agent budgets with enforcement and a settings UI. Per-run headroom is enforced via `max_budget_usd`; actual run costs are recorded and used to cap or block runs within the current UTC month.

- **New Features**
  - Enforcement: Executor computes remaining monthly headroom and forwards it as `max_budget_usd`; blocks runs at/over cap with a terminal stream error. After each run, records actual cost (exact USD, 5‑decimal) to Postgres (best effort).
  - Runtime: Merges SDK `model_usage` into snake_case `usage` with `total_cost_usd`, forwards `max_budget_usd` to Claude options, and emits merged `result_usage`.
  - Storage: New `agent_run_cost` ledger (RLS) storing exact USD per run with org/month/workspace indexes; monthly snapshots return total and per‑workspace cents (rounded once on aggregate).
  - API: `GET /organization/agent-usage` (optional `month=YYYY-MM`) and `PUT /organization/agent-usage/limit` to set/clear the monthly budget; both require org scopes and the `agent_addons` entitlement.
  - Frontend: Agent Settings shows current UTC‑month spend (and percent of cap) with an expandable per‑workspace breakdown, plus a field to set or clear a monthly USD budget. Adds `useOrgAgentUsage` hook and entitlement gating.
  - Tests: Unit coverage for usage merging, ledger math, cap checks, and monthly snapshots.

<sup>Written for commit dfb062bc42a9e71c1ab00d3d1435d92a7d1b8f6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



