### PR TITLE
fix: Throttle massive scatter gather regression test

### DIFF
--- a/tests/temporal/test_large_collection_regressions.py
+++ b/tests/temporal/test_large_collection_regressions.py
@@ -52,6 +52,7 @@ type WorkerFactory = Callable[[Client], Worker]
 ITEM_COUNT = 25
 MASSIVE_ITEM_COUNT = 50
 ITEM_SIZE_BYTES = 2 * 1024 * 1024
+MASSIVE_SCATTER_GATHER_MAX_PENDING_TASKS = 8
 
 
 async def _create_and_commit_workflow(
@@ -414,6 +415,15 @@ async def test_scatter_gather_massive_payload_50x2mb_e2e(
     without hanging and with refs-only collection chunk layout.
     """
     _configure_storage_credentials(monkeypatch)
+    monkeypatch.setenv(
+        "TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS",
+        str(MASSIVE_SCATTER_GATHER_MAX_PENDING_TASKS),
+    )
+    monkeypatch.setattr(
+        config,
+        "TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS",
+        MASSIVE_SCATTER_GATHER_MAX_PENDING_TASKS,
+    )
     sentinel = f"__massive-scatter-gather-sentinel-{uuid.uuid4().hex}__"
     items = _build_large_items(
         item_count=MASSIVE_ITEM_COUNT,


### PR DESCRIPTION
## Summary

Adds a test-local scheduler concurrency cap for `test_scatter_gather_massive_payload_50x2mb_e2e`.

## Why

The massive scatter/gather regression test drives a ~100MB logical payload through 50 branches. Without a local cap, the test can pressure Temporal and object storage enough to produce partial gather results under load.

## Impact

Only this regression test is throttled. Production defaults and the other large collection regression tests are unchanged.

## Validation

- `uv run ruff check tests/temporal/test_large_collection_regressions.py`
- `uv run ruff format --check tests/temporal/test_large_collection_regressions.py`
- `uv run basedpyright tests/temporal/test_large_collection_regressions.py`
- `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/temporal/test_large_collection_regressions.py::test_scatter_gather_massive_payload_50x2mb_e2e -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the DSL scheduler concurrency to 8 within `test_scatter_gather_massive_payload_50x2mb_e2e` to stabilize the 50×2MB scatter/gather run under load. This is test-only; production defaults and other large-collection tests are unchanged.

- **Bug Fixes**
  - Forces `TRACECAT__DSL_SCHEDULER_MAX_PENDING_TASKS` to `8` via env and `config` monkeypatch in this test to avoid load-induced partial gather results.

<sup>Written for commit b815acb0b2301fd8da7f0a6ffbe2a02e4beeac0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

