### PR TITLE
chore(dev): Add dev cluster seed bootstrap

### DIFF
--- a/packages/tracecat-admin/tests/test_admin_commands.py
+++ b/packages/tracecat-admin/tests/test_admin_commands.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 import respx
@@ -231,3 +233,128 @@ class TestDemoteUser:
 
         assert result.exit_code == 1
         assert "not a superuser" in result.stdout
+
+
+class TestCreateDevUser:
+    """Tests for create-dev-user command."""
+
+    def test_create_dev_user_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test successful dev user creation."""
+        captured: dict[str, Any] = {}
+
+        async def fake_create_dev_user(**kwargs: Any) -> SimpleNamespace:
+            captured.update(kwargs)
+            return SimpleNamespace(
+                email=kwargs["email"],
+                superuser_email=kwargs["superuser_email"],
+                superuser_created=True,
+                organization_id=str(uuid.uuid4()),
+                workspace_id=str(uuid.uuid4()),
+                default_tier_id=str(uuid.uuid4()),
+                default_tier_entitlements={
+                    "custom_registry": True,
+                    "case_addons": True,
+                },
+                org_role=kwargs["org_role"],
+                workspace_role=kwargs["workspace_role"],
+                created=True,
+            )
+
+        monkeypatch.setattr(
+            "tracecat_admin.services.bootstrap.create_dev_user",
+            fake_create_dev_user,
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "admin",
+                "create-dev-user",
+                "--email",
+                "dev@example.com",
+                "--password",
+                "password1234",
+                "--superuser-email",
+                "test@tracecat.com",
+                "--superuser-password",
+                "password1234",
+                "--default-tier-entitlements",
+                "custom_registry,case_addons",
+                "--org-role",
+                "organization-admin",
+                "--workspace-role",
+                "workspace-editor",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert (
+            "[dev-seed] Created platform superuser 'test@tracecat.com'" in result.stdout
+        )
+        assert "[dev-seed] Created dev user 'dev@example.com'" in result.stdout
+        assert (
+            "[dev-seed] Default tier entitlements: custom_registry, case_addons"
+            in result.stdout
+        )
+        assert captured == {
+            "email": "dev@example.com",
+            "password": "password1234",
+            "superuser_email": "test@tracecat.com",
+            "superuser_password": "password1234",
+            "default_tier_entitlements": "custom_registry,case_addons",
+            "org_role": "organization-admin",
+            "workspace_role": "workspace-editor",
+        }
+
+    def test_create_dev_user_rejects_short_password(self) -> None:
+        """Test password length validation."""
+        result = runner.invoke(
+            app,
+            [
+                "admin",
+                "create-dev-user",
+                "--email",
+                "dev@example.com",
+                "--password",
+                "short",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Password must be at least 12 characters" in result.stdout
+
+    def test_create_dev_user_rejects_short_superuser_password(self) -> None:
+        """Test superuser password length validation."""
+        result = runner.invoke(
+            app,
+            [
+                "admin",
+                "create-dev-user",
+                "--email",
+                "dev@example.com",
+                "--password",
+                "password1234",
+                "--superuser-password",
+                "short",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Superuser password must be at least 12 characters" in result.stdout
+
+    def test_default_tier_entitlement_selection(self) -> None:
+        """Test default tier entitlement selector modes."""
+        from tracecat_admin.services.bootstrap import (
+            ALL_ENTITLEMENTS,
+            resolve_default_tier_entitlements,
+        )
+
+        assert all(resolve_default_tier_entitlements("all").values())
+        assert not any(resolve_default_tier_entitlements("none").values())
+
+        selected = resolve_default_tier_entitlements("custom_registry,case-addons")
+        assert selected["custom_registry"] is True
+        assert selected["case_addons"] is True
+        assert {name for name in ALL_ENTITLEMENTS if not selected[name]} == set(
+            ALL_ENTITLEMENTS
+        ) - {"custom_registry", "case_addons"}

--- a/packages/tracecat-admin/tests/test_admin_commands.py
+++ b/packages/tracecat-admin/tests/test_admin_commands.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import respx
 from httpx import Response
+from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat_admin.cli import app
 from typer.testing import CliRunner
 
@@ -358,3 +359,37 @@ class TestCreateDevUser:
         assert {name for name in ALL_ENTITLEMENTS if not selected[name]} == set(
             ALL_ENTITLEMENTS
         ) - {"custom_registry", "case_addons"}
+
+    @pytest.mark.anyio
+    async def test_role_assignment_lookup_is_organization_scoped(self) -> None:
+        """Ensure role assignment upserts never match across organizations."""
+        from tracecat_admin.services.bootstrap import _ensure_role_assignment
+
+        class FakeResult:
+            def scalar_one_or_none(self) -> SimpleNamespace:
+                return SimpleNamespace()
+
+        class FakeSession:
+            statement: Any | None = None
+
+            async def execute(self, statement: Any) -> FakeResult:
+                self.statement = statement
+                return FakeResult()
+
+            def add(self, value: Any) -> None:
+                raise AssertionError("No insert expected")
+
+        session = FakeSession()
+
+        await _ensure_role_assignment(
+            session=cast(AsyncSession, session),
+            user_id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+            workspace_id=None,
+            role_id=uuid.uuid4(),
+        )
+
+        assert session.statement is not None
+        assert "user_role_assignment.organization_id =" in str(
+            session.statement.compile()
+        )

--- a/packages/tracecat-admin/tests/test_cli.py
+++ b/packages/tracecat-admin/tests/test_cli.py
@@ -38,6 +38,7 @@ class TestAdminCommands:
         assert "promote-user" in result.stdout
         assert "demote-user" in result.stdout
         assert "create-superuser" in result.stdout
+        assert "create-dev-user" in result.stdout
 
     def test_list_users_requires_service_key(self) -> None:
         """Test list-users requires service key."""

--- a/packages/tracecat-admin/tracecat_admin/commands/admin.py
+++ b/packages/tracecat-admin/tracecat_admin/commands/admin.py
@@ -8,9 +8,11 @@ from functools import wraps
 from typing import Annotated, Any
 
 import typer
+from rich.text import Text
 
 from tracecat_admin.client import AdminClient, AdminClientError
 from tracecat_admin.output import (
+    console,
     print_error,
     print_success,
     print_user_detail,
@@ -28,6 +30,13 @@ def async_command[F: Callable[..., Any]](func: F) -> F:
         return asyncio.run(func(*args, **kwargs))
 
     return wrapper  # type: ignore[return-value]
+
+
+def print_dev_seed(message: str) -> None:
+    """Print a colorized dev seed message with a literal prefix."""
+    text = Text("[dev-seed] ", style="green")
+    text.append(message, style="green")
+    console.print(text)
 
 
 @app.command("list-users")
@@ -200,6 +209,127 @@ def create_superuser(
             print_success(f"Created and promoted user '{email}' to superuser")
         else:
             print_success(f"Promoted existing user '{email}' to superuser")
+    except Exception as e:
+        print_error(str(e))
+        raise typer.Exit(1) from None
+
+
+@app.command("create-dev-user")
+def create_dev_user(
+    email: Annotated[
+        str,
+        typer.Option(
+            "--email",
+            "-e",
+            help="Dev user email address",
+            envvar="TRACECAT__DEV_USER_EMAIL",
+        ),
+    ] = "dev@tracecat.com",
+    password: Annotated[
+        str,
+        typer.Option(
+            "--password",
+            "-p",
+            help="Dev user password",
+            envvar="TRACECAT__DEV_USER_PASSWORD",
+        ),
+    ] = "password1234",
+    superuser_email: Annotated[
+        str,
+        typer.Option(
+            "--superuser-email",
+            help="Dev platform superuser email address",
+            envvar="TRACECAT__DEV_SUPERUSER_EMAIL",
+        ),
+    ] = "test@tracecat.com",
+    superuser_password: Annotated[
+        str,
+        typer.Option(
+            "--superuser-password",
+            help="Dev platform superuser password",
+            envvar="TRACECAT__DEV_SUPERUSER_PASSWORD",
+        ),
+    ] = "password1234",
+    default_tier_entitlements: Annotated[
+        str,
+        typer.Option(
+            "--default-tier-entitlements",
+            help="Default tier entitlements: all, none, or comma-separated names",
+            envvar="TRACECAT__DEV_DEFAULT_TIER_ENTITLEMENTS",
+        ),
+    ] = "all",
+    org_role: Annotated[
+        str,
+        typer.Option(
+            "--org-role",
+            help="Organization role slug to assign",
+            envvar="TRACECAT__DEV_ORG_ROLE",
+        ),
+    ] = "organization-owner",
+    workspace_role: Annotated[
+        str,
+        typer.Option(
+            "--workspace-role",
+            help="Workspace role slug to assign",
+            envvar="TRACECAT__DEV_WORKSPACE_ROLE",
+        ),
+    ] = "workspace-admin",
+) -> None:
+    """Create local development superuser and tenant accounts.
+
+    This command operates directly on the database and is intended for dev
+    cluster seeding only. It creates or updates a platform superuser, creates
+    or updates a tenant user, adds org and workspace memberships, and assigns
+    RBAC roles.
+    """
+    try:
+        from tracecat_admin.services.bootstrap import (
+            create_dev_user as bootstrap_create_dev_user,
+        )
+    except ImportError:
+        print_error(
+            "Bootstrap dependencies not installed. "
+            "Install with: pip install tracecat-admin[bootstrap]"
+        )
+        raise typer.Exit(1) from None
+
+    if len(password) < 12:
+        print_error("Password must be at least 12 characters")
+        raise typer.Exit(1)
+    if len(superuser_password) < 12:
+        print_error("Superuser password must be at least 12 characters")
+        raise typer.Exit(1)
+
+    try:
+        result = asyncio.run(
+            bootstrap_create_dev_user(
+                email=email,
+                password=password,
+                superuser_email=superuser_email,
+                superuser_password=superuser_password,
+                default_tier_entitlements=default_tier_entitlements,
+                org_role=org_role,
+                workspace_role=workspace_role,
+            )
+        )
+        verb = "Created" if result.created else "Updated"
+        superuser_verb = "Created" if result.superuser_created else "Updated"
+        print_dev_seed(
+            f"{superuser_verb} platform superuser '{result.superuser_email}'"
+        )
+        print_dev_seed(
+            f"{verb} dev user '{result.email}' ({result.org_role}, {result.workspace_role})"
+        )
+        enabled_entitlements = [
+            name
+            for name, enabled in result.default_tier_entitlements.items()
+            if enabled
+        ]
+        enabled_display = ", ".join(enabled_entitlements) or "none"
+        print_dev_seed(f"Organization: {result.organization_id}")
+        print_dev_seed(f"Workspace: {result.workspace_id}")
+        print_dev_seed(f"Default tier: {result.default_tier_id}")
+        print_dev_seed(f"Default tier entitlements: {enabled_display}")
     except Exception as e:
         print_error(str(e))
         raise typer.Exit(1) from None

--- a/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
+++ b/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
@@ -384,6 +384,7 @@ async def _ensure_role_assignment(
 ) -> None:
     statement = select(UserRoleAssignment).where(
         UserRoleAssignment.user_id == user_id,
+        UserRoleAssignment.organization_id == organization_id,
     )
     if workspace_id is None:
         statement = statement.where(UserRoleAssignment.workspace_id.is_(None))

--- a/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
+++ b/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
@@ -9,6 +9,11 @@ Requires: tracecat package to be installed (tracecat-admin[bootstrap]).
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.schemas import UserCreate, UserRole, UserUpdate
 from tracecat.auth.users import (
@@ -17,7 +22,26 @@ from tracecat.auth.users import (
     get_user_manager_context,
     lookup_user_by_email,
 )
-from tracecat.db.engine import get_async_session_context_manager
+from tracecat.db.engine import (
+    get_async_session_bypass_rls_context_manager,
+    get_async_session_context_manager,
+)
+from tracecat.db.models import (
+    Membership,
+    OrganizationMembership,
+    OrganizationTier,
+    Tier,
+    User,
+    UserRoleAssignment,
+    Workspace,
+)
+from tracecat.db.models import Role as DBRole
+from tracecat.organization.management import ensure_default_organization
+from tracecat.tiers import defaults as tier_defaults
+from tracecat.tiers.enums import Entitlement
+from tracecat.tiers.types import EntitlementsDict
+
+ALL_ENTITLEMENTS = tuple(entitlement.value for entitlement in Entitlement)
 
 
 @dataclass
@@ -27,6 +51,47 @@ class CreateSuperuserResult:
     email: str
     user_id: str
     created: bool  # True if user was created, False if promoted existing
+
+
+@dataclass
+class CreateDevUserResult:
+    """Result of create_dev_user operation."""
+
+    email: str
+    user_id: str
+    superuser_email: str
+    superuser_user_id: str
+    superuser_created: bool
+    organization_id: str
+    workspace_id: str
+    default_tier_id: str
+    default_tier_entitlements: dict[str, bool]
+    org_role: str
+    workspace_role: str
+    created: bool
+
+
+def resolve_default_tier_entitlements(value: str | None) -> dict[str, bool]:
+    """Resolve dev default-tier entitlement selection into a full bool mapping."""
+    normalized = (value or "all").strip().lower().replace("-", "_")
+    if normalized in {"", "all"}:
+        return dict.fromkeys(ALL_ENTITLEMENTS, True)
+    if normalized in {"none", "false", "off", "disabled"}:
+        return dict.fromkeys(ALL_ENTITLEMENTS, False)
+
+    requested = {
+        item.strip().lower().replace("-", "_")
+        for item in normalized.split(",")
+        if item.strip()
+    }
+    unknown = requested - set(ALL_ENTITLEMENTS)
+    if unknown:
+        valid = ", ".join(ALL_ENTITLEMENTS)
+        invalid = ", ".join(sorted(unknown))
+        raise ValueError(
+            f"Unknown entitlements: {invalid}. Valid entitlements: {valid}"
+        )
+    return {entitlement: entitlement in requested for entitlement in ALL_ENTITLEMENTS}
 
 
 async def create_superuser(
@@ -98,3 +163,344 @@ async def create_superuser(
                 user_id=str(user.id),
                 created=False,
             )
+
+
+async def _get_role_by_slug(
+    *,
+    session: AsyncSession,
+    organization_id: UUID,
+    slug: str,
+) -> DBRole:
+    result = await session.execute(
+        select(DBRole).where(
+            DBRole.organization_id == organization_id,
+            DBRole.slug == slug,
+        )
+    )
+    role = result.scalar_one_or_none()
+    if role is None:
+        raise ValueError(
+            f"Role '{slug}' was not found for organization '{organization_id}'"
+        )
+    return role
+
+
+async def _get_default_workspace(
+    *, session: AsyncSession, organization_id: UUID
+) -> Workspace:
+    result = await session.execute(
+        select(Workspace)
+        .where(Workspace.organization_id == organization_id)
+        .order_by(Workspace.created_at.asc())
+        .limit(1)
+    )
+    workspace = result.scalar_one_or_none()
+    if workspace is None:
+        raise ValueError(f"No workspace found for organization '{organization_id}'")
+    return workspace
+
+
+async def _ensure_default_tier(
+    *,
+    session: AsyncSession,
+    entitlements: dict[str, bool],
+) -> Tier:
+    result = await session.execute(
+        select(Tier)
+        .where(Tier.is_default.is_(True))
+        .order_by(Tier.is_active.desc(), Tier.created_at.asc())
+    )
+    default_tiers = list(result.scalars().all())
+    if default_tiers:
+        tier = default_tiers[0]
+    else:
+        tier = Tier(
+            display_name=tier_defaults.DEFAULT_TIER_DISPLAY_NAME,
+            max_concurrent_workflows=None,
+            max_action_executions_per_workflow=None,
+            max_concurrent_actions=None,
+            api_rate_limit=None,
+            api_burst_capacity=None,
+            entitlements=cast(EntitlementsDict, entitlements),
+            is_default=True,
+            sort_order=0,
+            is_active=True,
+        )
+        session.add(tier)
+        await session.flush()
+
+    tier.display_name = tier_defaults.DEFAULT_TIER_DISPLAY_NAME
+    tier.entitlements = cast(EntitlementsDict, entitlements)
+    tier.is_default = True
+    tier.is_active = True
+
+    for extra_tier in default_tiers[1:]:
+        extra_tier.is_default = False
+
+    return tier
+
+
+async def _ensure_org_tier(
+    *,
+    session: AsyncSession,
+    organization_id: UUID,
+    tier_id: UUID,
+) -> None:
+    result = await session.execute(
+        select(OrganizationTier).where(
+            OrganizationTier.organization_id == organization_id
+        )
+    )
+    org_tier = result.scalar_one_or_none()
+    if org_tier is None:
+        session.add(
+            OrganizationTier(
+                organization_id=organization_id,
+                tier_id=tier_id,
+            )
+        )
+        return
+
+    org_tier.tier_id = tier_id
+    org_tier.entitlement_overrides = None
+
+
+async def _hash_password(*, session: AsyncSession, password: str) -> str:
+    async with get_user_db_context(session) as user_db:
+        async with get_user_manager_context(user_db) as user_manager:
+            return user_manager.password_helper.hash(password)
+
+
+async def _ensure_platform_superuser(
+    *,
+    session: AsyncSession,
+    email: str,
+    password: str,
+) -> tuple[User, bool]:
+    hashed_password = await _hash_password(session=session, password=password)
+    existing = await lookup_user_by_email(session=session, email=email)
+    if existing is not None:
+        existing.hashed_password = hashed_password
+        existing.is_active = True
+        existing.is_verified = True
+        existing.is_superuser = True
+        existing.role = UserRole.ADMIN
+        return existing, False
+
+    user = User(
+        email=email,
+        hashed_password=hashed_password,
+        role=UserRole.ADMIN,
+        is_active=True,
+        is_superuser=True,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.flush()
+    return user, True
+
+
+async def _get_or_create_local_user(
+    *,
+    session: AsyncSession,
+    email: str,
+    password: str,
+) -> tuple[User, bool]:
+    hashed_password = await _hash_password(session=session, password=password)
+    existing = await lookup_user_by_email(session=session, email=email)
+    if existing is not None:
+        if existing.is_superuser:
+            raise ValueError(
+                f"User '{email}' already exists as a superuser; choose a non-superuser dev email"
+            )
+        existing.hashed_password = hashed_password
+        existing.is_active = True
+        existing.is_verified = True
+        existing.role = UserRole.BASIC
+        return existing, False
+
+    user = User(
+        email=email,
+        hashed_password=hashed_password,
+        role=UserRole.BASIC,
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.flush()
+    return user, True
+
+
+async def _ensure_org_membership(
+    *,
+    session: AsyncSession,
+    user_id: UUID,
+    organization_id: UUID,
+) -> None:
+    result = await session.execute(
+        select(OrganizationMembership).where(
+            OrganizationMembership.user_id == user_id,
+            OrganizationMembership.organization_id == organization_id,
+        )
+    )
+    if result.scalar_one_or_none() is None:
+        session.add(
+            OrganizationMembership(
+                user_id=user_id,
+                organization_id=organization_id,
+            )
+        )
+
+
+async def _ensure_workspace_membership(
+    *,
+    session: AsyncSession,
+    user_id: UUID,
+    workspace_id: UUID,
+) -> None:
+    result = await session.execute(
+        select(Membership).where(
+            Membership.user_id == user_id,
+            Membership.workspace_id == workspace_id,
+        )
+    )
+    if result.scalar_one_or_none() is None:
+        session.add(
+            Membership(
+                user_id=user_id,
+                workspace_id=workspace_id,
+            )
+        )
+
+
+async def _ensure_role_assignment(
+    *,
+    session: AsyncSession,
+    user_id: UUID,
+    organization_id: UUID,
+    workspace_id: UUID | None,
+    role_id: UUID,
+) -> None:
+    statement = select(UserRoleAssignment).where(
+        UserRoleAssignment.user_id == user_id,
+    )
+    if workspace_id is None:
+        statement = statement.where(UserRoleAssignment.workspace_id.is_(None))
+    else:
+        statement = statement.where(UserRoleAssignment.workspace_id == workspace_id)
+
+    result = await session.execute(statement)
+    assignment = result.scalar_one_or_none()
+    if assignment is None:
+        session.add(
+            UserRoleAssignment(
+                organization_id=organization_id,
+                user_id=user_id,
+                workspace_id=workspace_id,
+                role_id=role_id,
+            )
+        )
+        return
+
+    assignment.organization_id = organization_id
+    assignment.role_id = role_id
+
+
+async def create_dev_user(
+    *,
+    email: str,
+    password: str,
+    superuser_email: str = "test@tracecat.com",
+    superuser_password: str = "password1234",
+    default_tier_entitlements: str = "all",
+    org_role: str = "organization-owner",
+    workspace_role: str = "workspace-admin",
+) -> CreateDevUserResult:
+    """Create local development SU and tenant user accounts.
+
+    This bypasses public first-user registration on purpose. It is intended for
+    dev clusters where platform superusers cannot enter tenant context.
+    """
+    if email.lower() == superuser_email.lower():
+        raise ValueError("Dev user email must be different from superuser email")
+
+    organization_id = await ensure_default_organization()
+    entitlements = resolve_default_tier_entitlements(default_tier_entitlements)
+
+    async with get_async_session_bypass_rls_context_manager() as session:
+        default_tier = await _ensure_default_tier(
+            session=session,
+            entitlements=entitlements,
+        )
+        await _ensure_org_tier(
+            session=session,
+            organization_id=organization_id,
+            tier_id=default_tier.id,
+        )
+        superuser, superuser_created = await _ensure_platform_superuser(
+            session=session,
+            email=superuser_email,
+            password=superuser_password,
+        )
+        user, created = await _get_or_create_local_user(
+            session=session,
+            email=email,
+            password=password,
+        )
+        workspace = await _get_default_workspace(
+            session=session,
+            organization_id=organization_id,
+        )
+        org_role_obj = await _get_role_by_slug(
+            session=session,
+            organization_id=organization_id,
+            slug=org_role,
+        )
+        workspace_role_obj = await _get_role_by_slug(
+            session=session,
+            organization_id=organization_id,
+            slug=workspace_role,
+        )
+
+        await _ensure_org_membership(
+            session=session,
+            user_id=user.id,
+            organization_id=organization_id,
+        )
+        await _ensure_workspace_membership(
+            session=session,
+            user_id=user.id,
+            workspace_id=workspace.id,
+        )
+        await _ensure_role_assignment(
+            session=session,
+            user_id=user.id,
+            organization_id=organization_id,
+            workspace_id=None,
+            role_id=org_role_obj.id,
+        )
+        await _ensure_role_assignment(
+            session=session,
+            user_id=user.id,
+            organization_id=organization_id,
+            workspace_id=workspace.id,
+            role_id=workspace_role_obj.id,
+        )
+
+        await session.commit()
+
+        return CreateDevUserResult(
+            email=user.email,
+            user_id=str(user.id),
+            superuser_email=superuser.email,
+            superuser_user_id=str(superuser.id),
+            superuser_created=superuser_created,
+            organization_id=str(organization_id),
+            workspace_id=str(workspace.id),
+            default_tier_id=str(default_tier.id),
+            default_tier_entitlements=entitlements,
+            org_role=org_role,
+            workspace_role=workspace_role,
+            created=created,
+        )

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -70,7 +70,7 @@ get_running_clusters() {
 
     docker compose ls --format json 2>/dev/null | jq -r '.[].Name' 2>/dev/null | while read -r project; do
         if [[ "$project" == ${prefix}* ]]; then
-            local num="${project#$prefix}"
+            local num="${project#"$prefix"}"
             if [[ "$num" =~ ^[0-9]+$ ]]; then
                 echo "$num"
             fi
@@ -223,7 +223,10 @@ Commands:
   up [args]     Start the cluster (e.g., up -d)
                 Reuses existing cluster for this worktree if one is running.
                 Use --new/-n to force a new cluster instead.
-                Use --seed to auto-register test@tracecat.com:password1234
+                Seeds test@tracecat.com superuser, dev@tracecat.com tenant
+                user, and all default tier entitlements by default for the dev
+                profile. Use --no-seed to skip.
+                Use --default-tier-entitlements all|none|a,b to override.
   down          Stop the cluster (keeps volumes)
   rm            Remove the cluster (down + remove volumes)
   restart [svc] Restart the cluster or specific service
@@ -244,9 +247,11 @@ Nuke options:
   nuke volumes          List and select volumes to remove
 
 Examples:
-  ./cluster up -d                Start cluster (reuses existing, or starts new)
+  ./cluster up -d                Start cluster and create dev users
   ./cluster up -d --new          Force a new cluster on next available number
-  ./cluster up -d --seed         Start cluster and register test user
+  ./cluster up -d --no-seed      Start cluster without creating dev tenant user
+  ./cluster up -d --default-tier-entitlements none
+  ./cluster up -d --default-tier-entitlements custom_registry,case_addons
   ./cluster down                 Stop cluster (keeps volumes)
   ./cluster rm                   Remove cluster and volumes
   ./cluster restart api          Restart the api service
@@ -366,11 +371,8 @@ list_clusters() {
         # Match any tracecat cluster: tracecat-{worktree}-{num}
         if [[ "$project" =~ ^tracecat-(.+)-([0-9]+)$ ]]; then
             found=true
-            local worktree="${BASH_REMATCH[1]}"
             local cluster_num="${BASH_REMATCH[2]}"
             calculate_ports "$cluster_num"
-            local status
-            status=$(docker compose -p "$project" ps --format json 2>/dev/null | jq -r 'if type == "array" then .[0].State else .State end' 2>/dev/null || echo "unknown")
             local marker=""
             [[ "$project" == "${current_worktree_prefix}${cluster_num}" ]] && marker=" (this worktree)"
             echo "  ${project}: http://localhost:${PUBLIC_APP_PORT}${marker}"
@@ -623,7 +625,7 @@ if [[ "$COMMAND" == "nuke" ]]; then
         fi
 
         echo "Volumes to remove:"
-        echo "$VOLUMES" | sed 's/^/  /'
+        printf '  %s\n' "${VOLUMES//$'\n'/$'\n'  }"
 
         if [[ "$DRY_RUN" == "true" ]]; then
             echo ""
@@ -732,33 +734,64 @@ if [[ "$COMMAND" == "up" ]]; then
     (cd "$REPO_ROOT" && pnpm -C frontend install > /dev/null 2>&1)
 fi
 
-# Check for --seed flag in up command
+# Check for seed flags in up command. Dev profile seeds by default.
 SEED_USER=false
+if [[ "$COMMAND" == "up" && "$PROFILE" == "dev" ]]; then
+    SEED_USER=true
+fi
+DETACHED_UP=false
+DEFAULT_TIER_ENTITLEMENTS="${TRACECAT__DEV_DEFAULT_TIER_ENTITLEMENTS:-all}"
 UP_ARGS=()
 if [[ "$COMMAND" == "up" ]]; then
-    for arg in "$@"; do
-        if [[ "$arg" == "--seed" ]]; then
-            SEED_USER=true
-        else
-            UP_ARGS+=("$arg")
-        fi
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -d|--detach)
+                DETACHED_UP=true
+                UP_ARGS+=("$1")
+                shift
+                ;;
+            --seed)
+                SEED_USER=true
+                shift
+                ;;
+            --no-seed)
+                SEED_USER=false
+                shift
+                ;;
+            --default-tier-entitlements)
+                if [[ $# -lt 2 ]]; then
+                    echo "Error: --default-tier-entitlements requires a value" >&2
+                    exit 1
+                fi
+                DEFAULT_TIER_ENTITLEMENTS="$2"
+                shift 2
+                ;;
+            --default-tier-entitlements=*)
+                DEFAULT_TIER_ENTITLEMENTS="${1#*=}"
+                shift
+                ;;
+            *)
+                UP_ARGS+=("$1")
+                shift
+                ;;
+        esac
     done
     set -- ${UP_ARGS[@]+"${UP_ARGS[@]}"}
 fi
 
-# Function to seed test user after cluster starts
-seed_test_user() {
+# Function to seed a tenant dev user after cluster starts
+seed_dev_user() {
     local api_url="http://localhost:${PUBLIC_APP_PORT}/api"
     local max_attempts=60
     local attempt=1
 
-    echo "Waiting for API to be ready..."
+    echo "[dev-seed] Waiting for API to be ready..."
     while [[ $attempt -le $max_attempts ]]; do
         # Use /ready endpoint which checks full startup completion (not /health which returns immediately)
         local status_code
         status_code=$(curl -s -o /dev/null -w "%{http_code}" "${api_url}/ready" 2>/dev/null || echo "000")
         if [[ "$status_code" == "200" ]]; then
-            echo "API is ready"
+            echo "[dev-seed] API is ready"
             break
         fi
         sleep 2
@@ -766,39 +799,44 @@ seed_test_user() {
     done
 
     if [[ $attempt -gt $max_attempts ]]; then
-        echo "Warning: API did not become ready in time, skipping user registration"
+        echo "[dev-seed] Warning: API did not become ready in time, skipping dev seed"
         return 1
     fi
 
-    echo "Registering test user (test@tracecat.com)..."
-    local response
-    response=$(curl -s -w "\n%{http_code}" -X POST "${api_url}/auth/register" \
-        -H "Content-Type: application/json" \
-        -d '{"email": "test@tracecat.com", "password": "password1234"}')
+    local seed_email="${TRACECAT__DEV_USER_EMAIL:-dev@tracecat.com}"
+    local seed_password="${TRACECAT__DEV_USER_PASSWORD:-password1234}"
+    local seed_superuser_email="${TRACECAT__DEV_SUPERUSER_EMAIL:-test@tracecat.com}"
+    local seed_superuser_password="${TRACECAT__DEV_SUPERUSER_PASSWORD:-password1234}"
+    local seed_org_role="${TRACECAT__DEV_ORG_ROLE:-organization-owner}"
+    local seed_workspace_role="${TRACECAT__DEV_WORKSPACE_ROLE:-workspace-admin}"
+    local seed_default_tier_entitlements="${DEFAULT_TIER_ENTITLEMENTS}"
+    local seed_db_uri="postgresql+psycopg://postgres:postgres@localhost:${PG_PORT}/postgres"
 
-    local http_code
-    http_code=$(echo "$response" | tail -n1)
-    local body
-    body=$(echo "$response" | sed '$d')
-
-    case "$http_code" in
-        201)
-            echo "Successfully registered test user"
-            ;;
-        400|409)
-            echo "Test user already exists"
-            ;;
-        *)
-            echo "Warning: Registration returned status $http_code: $body"
-            ;;
-    esac
+    echo "[dev-seed] Seeding dev superuser (${seed_superuser_email}), tenant user (${seed_email}), and default tier (${seed_default_tier_entitlements})..."
+    (
+        cd "$REPO_ROOT"
+        TRACECAT__DB_URI="$seed_db_uri" \
+            uv run tracecat admin create-dev-user \
+            --email "$seed_email" \
+            --password "$seed_password" \
+            --superuser-email "$seed_superuser_email" \
+            --superuser-password "$seed_superuser_password" \
+            --default-tier-entitlements "$seed_default_tier_entitlements" \
+            --org-role "$seed_org_role" \
+            --workspace-role "$seed_workspace_role"
+    )
 }
 
 # Run docker compose with the configured environment
 if [[ "$SEED_USER" == "true" && "$COMMAND" == "up" ]]; then
-    # Run in background mode for seeding, then seed
-    docker compose -f "$COMPOSE_FILE" -p "tracecat-${WORKTREE_ID}-${CLUSTER_NUM}" "$COMMAND" "$@"
-    seed_test_user
+    if [[ "$DETACHED_UP" == "true" ]]; then
+        docker compose -f "$COMPOSE_FILE" -p "tracecat-${WORKTREE_ID}-${CLUSTER_NUM}" "$COMMAND" "$@"
+        seed_dev_user
+    else
+        # Keep compose attached while a background seeder waits for API readiness.
+        seed_dev_user &
+        exec docker compose -f "$COMPOSE_FILE" -p "tracecat-${WORKTREE_ID}-${CLUSTER_NUM}" "$COMMAND" "$@"
+    fi
 else
     exec docker compose -f "$COMPOSE_FILE" -p "tracecat-${WORKTREE_ID}-${CLUSTER_NUM}" "$COMMAND" "$@"
 fi


### PR DESCRIPTION
## Summary

- Seed local dev clusters with a platform superuser (`test@tracecat.com`) and a tenant dev user (`dev@tracecat.com`).
- Make dev-profile `just cluster up` seed by default, while `--no-seed` skips it and attached mode keeps compose logs attached immediately via a background seeder.
- Add default-tier entitlement seeding with `--default-tier-entitlements all|none|a,b`, defaulting to all known entitlement enum values.
- Prefix and colorize bootstrap output with `[dev-seed]` so it is distinguishable from app/container logs.

## Why

Platform superusers can no longer enter tenant context, so local dev clusters need a first-class way to create both a platform SU and a normal tenant user without manually doing the tenant invite flow.

## Validation

- `shellcheck -x scripts/cluster`
- `bash -n scripts/cluster`
- `uv run ruff check .`
- `uv run basedpyright packages/tracecat-admin/tracecat_admin/services/bootstrap.py packages/tracecat-admin/tracecat_admin/commands/admin.py packages/tracecat-admin/tests/test_admin_commands.py packages/tracecat-admin/tests/test_cli.py`
- `uv run pytest packages/tracecat-admin/tests/test_admin_commands.py::TestCreateDevUser packages/tracecat-admin/tests/test_cli.py::TestAdminCommands::test_admin_help`

Pre-commit hooks also passed during commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dev cluster seeding flow that creates a platform superuser and a tenant dev user by default, plus a `tracecat admin create-dev-user` command to bootstrap local environments fast. Also scopes role assignment upserts to the organization to avoid cross-org matches during seeding.

- **New Features**
  - `scripts/cluster up` (dev profile) now auto-seeds: superuser `test@tracecat.com` and tenant `dev@tracecat.com`. Use `--no-seed` to skip. Supports `--default-tier-entitlements all|none|a,b` (default: `all`). Attached mode keeps logs; a background seeder waits for API readiness. Output is prefixed with `[dev-seed]`.
  - New `tracecat admin create-dev-user` CLI command with options for user creds, superuser creds, entitlements, and role slugs. Enforces 12+ char passwords and prints colorized seed logs.
  - New `tracecat_admin.services.bootstrap.create_dev_user` flow: bypasses RLS to ensure default organization, default tier + entitlements, org/workspace memberships, and role assignments. Supports `organization-owner` and `workspace-admin` (configurable).

- **Bug Fixes**
  - Role assignment lookup/upsert is now organization-scoped in `_ensure_role_assignment` to prevent cross-organization matches. Test coverage added.

<sup>Written for commit cd8013951539634db88b6882f76f152db35766ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

