### PR TITLE
fix(ui): action selector hydration race

### DIFF
--- a/frontend/src/components/builder/canvas/canvas.tsx
+++ b/frontend/src/components/builder/canvas/canvas.tsx
@@ -1,4 +1,6 @@
 import {
+  applyEdgeChanges,
+  applyNodeChanges,
   Background,
   type Connection,
   ConnectionLineType,
@@ -14,13 +16,12 @@ import {
   Panel,
   ReactFlow,
   type ReactFlowInstance,
-  useEdgesState,
-  useNodesState,
   useReactFlow,
   type Viewport,
   type XYPosition,
 } from "@xyflow/react"
 import React, {
+  type SetStateAction,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -60,7 +61,11 @@ import { useGraph, useGraphOperations } from "@/lib/hooks"
 import { pruneGraphObject } from "@/lib/workflow"
 import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
-import { getLayoutedElements, mergeHydratedNodes } from "./graph-layout"
+import {
+  getLayoutedElements,
+  mergeHydratedEdges,
+  mergeHydratedNodes,
+} from "./graph-layout"
 
 const defaultNodeWidth = 172
 const defaultNodeHeight = 36
@@ -96,6 +101,37 @@ const defaultEdgeOptions = {
   },
 }
 
+type CanvasGraphState = {
+  nodes: Node[]
+  edges: Edge[]
+}
+
+function resolveStateAction<T>(value: SetStateAction<T>, current: T): T {
+  return typeof value === "function"
+    ? (value as (current: T) => T)(current)
+    : value
+}
+
+function removeEphemeralGraphElements({
+  nodes,
+  edges,
+}: CanvasGraphState): CanvasGraphState {
+  const ephemeralNodeIds = new Set(
+    nodes.filter((node) => isEphemeral(node)).map((node) => node.id)
+  )
+  if (ephemeralNodeIds.size === 0) {
+    return { nodes, edges }
+  }
+
+  return {
+    nodes: nodes.filter((node) => !isEphemeral(node)),
+    edges: edges.filter(
+      (edge) =>
+        !ephemeralNodeIds.has(edge.source) && !ephemeralNodeIds.has(edge.target)
+    ),
+  }
+}
+
 export function isInvincible(node: Node | Node<NodeData>): boolean {
   return invincibleNodeTypes.includes(node?.type as string)
 }
@@ -114,8 +150,10 @@ export const WorkflowCanvas = React.forwardRef<
   const containerRef = useRef<HTMLDivElement>(null)
   const connectingNodeId = useRef<string | null>(null)
   const connectingHandleId = useRef<string | null>(null)
-  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([])
-  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
+  const [{ nodes, edges }, setCanvasGraph] = useState<CanvasGraphState>({
+    nodes: [],
+    edges: [],
+  })
   const [reactFlowInstance, setReactFlowInstance] =
     useState<ReactFlowInstance | null>(null)
   const { setViewport, getNode, screenToFlowPosition } = useReactFlow()
@@ -139,6 +177,34 @@ export const WorkflowCanvas = React.forwardRef<
   >([])
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const openContextMenuId = useRef<string | null>(null)
+
+  const setNodes = useCallback((value: SetStateAction<Node[]>) => {
+    setCanvasGraph((current) => ({
+      ...current,
+      nodes: resolveStateAction(value, current.nodes),
+    }))
+  }, [])
+
+  const setEdges = useCallback((value: SetStateAction<Edge[]>) => {
+    setCanvasGraph((current) => ({
+      ...current,
+      edges: resolveStateAction(value, current.edges),
+    }))
+  }, [])
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      setNodes((currentNodes) => applyNodeChanges(changes, currentNodes))
+    },
+    [setNodes]
+  )
+
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) => {
+      setEdges((currentEdges) => applyEdgeChanges(changes, currentEdges))
+    },
+    [setEdges]
+  )
 
   /**
    * Convert graph response to React Flow nodes and edges.
@@ -184,6 +250,29 @@ export const WorkflowCanvas = React.forwardRef<
     []
   )
 
+  const hydrateCanvasFromGraph = useCallback(
+    (graphNodes: Node[], graphEdges: Edge[]) => {
+      setCanvasGraph((current) => {
+        const nextNodes = mergeHydratedNodes(current.nodes, graphNodes, {
+          preserveEphemeral: true,
+          isEphemeralNode: isEphemeral,
+        })
+        const nextEdges = mergeHydratedEdges(
+          current.edges,
+          graphEdges,
+          nextNodes,
+          {
+            preserveEphemeral: true,
+            isEphemeralNode: isEphemeral,
+          }
+        )
+
+        return { nodes: nextNodes, edges: nextEdges }
+      })
+    },
+    []
+  )
+
   /**
    * Update canvas state from graph response (used after graph operations).
    */
@@ -192,15 +281,16 @@ export const WorkflowCanvas = React.forwardRef<
       setGraphVersion(graph.version)
       const { nodes: rfNodes, edges: rfEdges } =
         buildNodesAndEdgesFromGraph(graph)
-      setNodes((nodes) => mergeHydratedNodes(nodes, rfNodes))
-      setEdges(rfEdges)
+      hydrateCanvasFromGraph(rfNodes, rfEdges)
       setHydratedWorkflowId(workflowId ?? null)
     },
-    [buildNodesAndEdgesFromGraph, setNodes, setEdges, workflowId]
+    [buildNodesAndEdgesFromGraph, hydrateCanvasFromGraph, workflowId]
   )
 
   useEffect(() => {
     setHydratedWorkflowId(null)
+    setCanvasGraph(removeEphemeralGraphElements)
+    openContextMenuId.current = null
   }, [workflowId])
 
   /**
@@ -215,8 +305,7 @@ export const WorkflowCanvas = React.forwardRef<
       // Build nodes and edges from graph API response
       const { nodes: graphNodes, edges: graphEdges } =
         buildNodesAndEdgesFromGraph(graphData)
-      setNodes((nodes) => mergeHydratedNodes(nodes, graphNodes))
-      setEdges(graphEdges)
+      hydrateCanvasFromGraph(graphNodes, graphEdges)
       setGraphVersion(graphData.version)
 
       // Set viewport from graph if available
@@ -237,8 +326,7 @@ export const WorkflowCanvas = React.forwardRef<
     reactFlowInstance,
     workflowId,
     buildNodesAndEdgesFromGraph,
-    setNodes,
-    setEdges,
+    hydrateCanvasFromGraph,
     setViewport,
   ])
 
@@ -629,7 +717,7 @@ export const WorkflowCanvas = React.forwardRef<
       // apply the changes we kept
       onNodesChange(nextChanges)
     },
-    [nodes, setNodes, pendingDeleteNodes]
+    [getNode, onNodesChange]
   )
 
   /**

--- a/frontend/src/components/builder/canvas/graph-layout.ts
+++ b/frontend/src/components/builder/canvas/graph-layout.ts
@@ -6,6 +6,11 @@ const defaultNodeHeight = 36
 const builderNodeWidth = 256
 const triggerNodeAutoLayoutGap = 64
 
+interface HydratedGraphMergeOptions {
+  preserveEphemeral?: boolean
+  isEphemeralNode?: (node: Node) => boolean
+}
+
 function getDefaultNodeWidth(node: Node): number {
   if (node.type === "trigger" || node.type === "udf") {
     return builderNodeWidth
@@ -92,13 +97,18 @@ export function getLayoutedElements(
   }
 }
 
+/**
+ * Merge backend-hydrated nodes while preserving local node metadata and, when
+ * requested, local-only ephemeral nodes.
+ */
 export function mergeHydratedNodes(
   currentNodes: Node[],
-  hydratedNodes: Node[]
+  hydratedNodes: Node[],
+  options: HydratedGraphMergeOptions = {}
 ): Node[] {
   const currentNodesById = new Map(currentNodes.map((node) => [node.id, node]))
 
-  return hydratedNodes.map((node) => {
+  const mergedNodes = hydratedNodes.map((node) => {
     const currentNode = currentNodesById.get(node.id)
     if (!currentNode) {
       return node
@@ -112,4 +122,52 @@ export function mergeHydratedNodes(
       height: currentNode.height ?? node.height,
     }
   })
+
+  const isEphemeralNode = options.isEphemeralNode
+  if (!options.preserveEphemeral || !isEphemeralNode) {
+    return mergedNodes
+  }
+
+  const hydratedNodeIds = new Set(mergedNodes.map((node) => node.id))
+  const ephemeralNodes = currentNodes.filter(
+    (node) => isEphemeralNode(node) && !hydratedNodeIds.has(node.id)
+  )
+
+  return [...mergedNodes, ...ephemeralNodes]
+}
+
+/**
+ * Merge backend-hydrated edges while preserving local-only edges connected to
+ * preserved ephemeral nodes.
+ */
+export function mergeHydratedEdges(
+  currentEdges: Edge[],
+  hydratedEdges: Edge[],
+  nodes: Node[],
+  options: HydratedGraphMergeOptions = {}
+): Edge[] {
+  const isEphemeralNode = options.isEphemeralNode
+  if (!options.preserveEphemeral || !isEphemeralNode) {
+    return hydratedEdges
+  }
+
+  const nodeIds = new Set(nodes.map((node) => node.id))
+  const ephemeralNodeIds = new Set(
+    nodes.filter((node) => isEphemeralNode(node)).map((node) => node.id)
+  )
+  const hydratedEdgeIds = new Set(hydratedEdges.map((edge) => edge.id))
+
+  const ephemeralEdges = currentEdges.filter((edge) => {
+    if (hydratedEdgeIds.has(edge.id)) {
+      return false
+    }
+    if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target)) {
+      return false
+    }
+    return (
+      ephemeralNodeIds.has(edge.source) || ephemeralNodeIds.has(edge.target)
+    )
+  })
+
+  return [...hydratedEdges, ...ephemeralEdges]
 }

--- a/frontend/src/components/builder/canvas/selector-node.tsx
+++ b/frontend/src/components/builder/canvas/selector-node.tsx
@@ -56,12 +56,34 @@ function isLockedAction(action: RegistryActionReadMinimal): boolean {
   return action.availability?.locked ?? false
 }
 
-function filterActions(actions: RegistryActionReadMinimal[], search: string) {
+type ActionFilterResult = {
+  action: RegistryActionReadMinimal
+  actionResult: Fuzzysort.Result | null
+  titleResult: Fuzzysort.Result | null
+}
+
+function filterActions(
+  actions: RegistryActionReadMinimal[],
+  search: string
+): ActionFilterResult[] {
+  const normalizedSearch = search.trim()
+  if (!normalizedSearch) {
+    return actions.map((action) => ({
+      action,
+      actionResult: null,
+      titleResult: null,
+    }))
+  }
+
   const results = fuzzysort.go<RegistryActionReadMinimal>(search, actions, {
     all: true,
     keys: SEARCH_KEYS as unknown as (keyof RegistryActionReadMinimal)[],
   })
-  return results
+  return results.map((result) => ({
+    action: result.obj,
+    actionResult: result[SEARCH_KEY_INDEX.action] ?? null,
+    titleResult: result[SEARCH_KEY_INDEX.default_title] ?? null,
+  }))
 }
 
 /**
@@ -219,6 +241,16 @@ function ActionCommandSelector({
 }) {
   const { registryActions, registryActionsIsLoading, registryActionsError } =
     useBuilderRegistryActions({ includeLocked: true })
+  const sortedActions = useMemo(() => {
+    if (!registryActions) {
+      return []
+    }
+    return [...registryActions].sort((a, b) => a.action.localeCompare(b.action))
+  }, [registryActions])
+  const filterResults = useMemo(
+    () => filterActions(sortedActions, inputValue),
+    [sortedActions, inputValue]
+  )
 
   if (!registryActions || registryActionsIsLoading) {
     return (
@@ -250,12 +282,11 @@ function ActionCommandSelector({
 
   return (
     <ScrollArea className="h-full overflow-y-auto">
-      {filterActions(registryActions, inputValue).length > 0 && (
+      {filterResults.length > 0 && (
         <ActionCommandGroup
           group="Suggestions"
           nodeId={nodeId}
-          registryActions={registryActions}
-          inputValue={inputValue}
+          filterResults={filterResults}
         />
       )}
     </ScrollArea>
@@ -265,13 +296,11 @@ function ActionCommandSelector({
 function ActionCommandGroup({
   group,
   nodeId,
-  registryActions,
-  inputValue,
+  filterResults,
 }: {
   group: string
   nodeId: string
-  registryActions: RegistryActionReadMinimal[]
-  inputValue: string
+  filterResults: ActionFilterResult[]
 }) {
   const {
     workspaceId,
@@ -306,14 +335,6 @@ function ActionCommandGroup({
     [actionPanelRef, setSelectedNodeId]
   )
 
-  // Move sortedActions and filterResults logic here
-  const sortedActions = useMemo(() => {
-    return [...registryActions].sort((a, b) => a.action.localeCompare(b.action))
-  }, [registryActions])
-
-  const filterResults = useMemo(() => {
-    return filterActions(sortedActions, inputValue)
-  }, [sortedActions, inputValue])
   const [lockedFeatureOpen, setLockedFeatureOpen] = React.useState(false)
 
   const handleSelect = useCallback(
@@ -482,14 +503,10 @@ function ActionCommandGroup({
       />
       <CommandGroup heading={group} className="text-xs">
         {filterResults.map((result) => {
-          const action = result.obj
+          const { action, actionResult, titleResult } = result
           const isLocked = isLockedAction(action)
 
           if (highlight) {
-            // Get fuzzysort results by key name (resilient to SEARCH_KEYS reordering)
-            const actionResult = result[SEARCH_KEY_INDEX.action]
-            const titleResult = result[SEARCH_KEY_INDEX.default_title]
-
             return (
               <CommandItem
                 key={action.action}

--- a/frontend/tests/graph-layout.test.ts
+++ b/frontend/tests/graph-layout.test.ts
@@ -2,6 +2,7 @@ import type { Edge, Node } from "@xyflow/react"
 import {
   getLayoutedElements,
   getNodeLayoutDimensions,
+  mergeHydratedEdges,
   mergeHydratedNodes,
 } from "@/components/builder/canvas/graph-layout"
 
@@ -139,5 +140,66 @@ describe("mergeHydratedNodes", () => {
         position: { x: 50, y: 60 },
       }),
     ])
+  })
+
+  it("preserves local ephemeral nodes when requested", () => {
+    const currentNodes = [
+      createNode("trigger-1", "trigger"),
+      createNode("selector-1", "selector", {
+        position: { x: 100, y: 200 },
+      }),
+    ]
+    const hydratedNodes = [createNode("trigger-1", "trigger")]
+
+    expect(
+      mergeHydratedNodes(currentNodes, hydratedNodes, {
+        preserveEphemeral: true,
+        isEphemeralNode: (node) => node.type === "selector",
+      })
+    ).toEqual([
+      createNode("trigger-1", "trigger"),
+      createNode("selector-1", "selector", {
+        position: { x: 100, y: 200 },
+      }),
+    ])
+  })
+})
+
+describe("mergeHydratedEdges", () => {
+  it("preserves local edges connected to preserved ephemeral nodes", () => {
+    const currentEdges = [
+      createEdge("trigger-1", "selector-1"),
+      createEdge("removed-action", "selector-1"),
+    ]
+    const hydratedEdges = [createEdge("trigger-1", "action-1")]
+    const nodes = [
+      createNode("trigger-1", "trigger"),
+      createNode("action-1", "udf"),
+      createNode("selector-1", "selector"),
+    ]
+
+    expect(
+      mergeHydratedEdges(currentEdges, hydratedEdges, nodes, {
+        preserveEphemeral: true,
+        isEphemeralNode: (node) => node.type === "selector",
+      })
+    ).toEqual([
+      createEdge("trigger-1", "action-1"),
+      createEdge("trigger-1", "selector-1"),
+    ])
+  })
+
+  it("uses the hydrated edge list when ephemeral preservation is disabled", () => {
+    const currentEdges = [createEdge("trigger-1", "selector-1")]
+    const hydratedEdges = [createEdge("trigger-1", "action-1")]
+    const nodes = [
+      createNode("trigger-1", "trigger"),
+      createNode("action-1", "udf"),
+      createNode("selector-1", "selector"),
+    ]
+
+    expect(mergeHydratedEdges(currentEdges, hydratedEdges, nodes)).toEqual(
+      hydratedEdges
+    )
   })
 })


### PR DESCRIPTION
## Summary

- Preserve local-only selector nodes and temporary selector edges when backend graph hydration/refetches run.
- Keep canvas nodes and edges in one state object so hydration uses the latest queued graph state without ref-synced effects.
- Optimize the selector action list by sorting/filtering once and skipping fuzzysort for the initial empty query.

## Root Cause

The action selector is an ephemeral React Flow node that is not persisted in the backend graph. When the first graph hydration/refetch completed after a drag, the canvas replaced local nodes/edges with only the hydrated backend graph, dropping the just-created selector.

## Validation

- `pnpm -C frontend exec biome check --write src/components/builder/canvas/canvas.tsx src/components/builder/canvas/graph-layout.ts tests/graph-layout.test.ts`
- `pnpm -C frontend test -- graph-layout.test.ts`
- `pnpm -C frontend exec biome check --write src/components/builder/canvas/selector-node.tsx`
- `pnpm -C frontend run typecheck`
- `uv run ruff check .`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race that removed the action selector after the first graph hydration by preserving ephemeral nodes/edges and updating canvas state handling. Also speeds up selector filtering for a snappier first keystroke.

- **Bug Fixes**
  - Preserve local-only selector nodes and their temporary edges during backend hydration/refetch by merging hydrated data with ephemeral elements.
  - Reset ephemeral elements when switching workflows to avoid leaking state.
  - Use `applyNodeChanges`/`applyEdgeChanges` from `@xyflow/react` with unified state to avoid stale updates.

- **Refactors**
  - Keep canvas `nodes` and `edges` in a single state object; add `mergeHydratedNodes`/`mergeHydratedEdges` with optional ephemeral preservation.
  - Optimize selector filtering: pre-sort actions, skip `fuzzysort` for empty queries, and compute results once per input.
  - Add tests for node/edge merge behavior with ephemeral nodes.

<sup>Written for commit 8f65f0fbf6790b368a572e221c4822d013828739. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

