### PR TITLE
perf: optimize case duration for burst responsiveness

### DIFF
--- a/alembic/versions/aa5951a3373f_add_case_event_anchor_lookup_index.py
+++ b/alembic/versions/aa5951a3373f_add_case_event_anchor_lookup_index.py
@@ -1,0 +1,30 @@
+"""add case event anchor lookup index
+
+Revision ID: aa5951a3373f
+Revises: 0c6bb8f8e1d1
+Create Date: 2026-04-23 16:12:47.182400
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "aa5951a3373f"
+down_revision: str | None = "0c6bb8f8e1d1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_case_event_anchor_lookup",
+        "case_event",
+        ["workspace_id", "case_id", "type", "created_at", "surrogate_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_case_event_anchor_lookup", table_name="case_event")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5700,19 +5700,10 @@ export const $CaseDurationEventAnchor = {
       $ref: "#/components/schemas/CaseEventType",
       description: "Case event type that should be matched for this anchor.",
     },
-    timestamp_path: {
-      type: "string",
-      title: "Timestamp Path",
+    filters: {
+      $ref: "#/components/schemas/CaseDurationEventFilters",
       description:
-        "Dot-delimited path to the timestamp field on the event. Defaults to the event creation timestamp.",
-      default: "created_at",
-    },
-    field_filters: {
-      additionalProperties: true,
-      type: "object",
-      title: "Field Filters",
-      description:
-        "Optional dot-delimited equality filters that must match on the event payload, e.g. {'data.new': 'resolved'}.",
+        "Optional product-level filters for matching event payload values.",
     },
     selection: {
       $ref: "#/components/schemas/CaseDurationAnchorSelection",
@@ -5721,11 +5712,68 @@ export const $CaseDurationEventAnchor = {
       default: "first",
     },
   },
+  additionalProperties: false,
   type: "object",
   required: ["event_type"],
   title: "CaseDurationEventAnchor",
   description:
     "Selection criteria describing an event boundary for a duration.",
+} as const
+
+export const $CaseDurationEventFilters = {
+  properties: {
+    new_values: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "New Values",
+      description: "New priority, severity, or status values to match.",
+    },
+    tag_refs: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Tag Refs",
+      description: "Case tag refs to match for tag add/remove events.",
+    },
+    field_ids: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Field Ids",
+      description: "Case custom field IDs to match for field change events.",
+    },
+    dropdown_definition_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Dropdown Definition Id",
+      description:
+        "Dropdown definition ID to match for dropdown value change events.",
+    },
+    dropdown_option_ids: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Dropdown Option Ids",
+      description:
+        "Dropdown option IDs to match for dropdown value change events.",
+    },
+  },
+  additionalProperties: false,
+  type: "object",
+  title: "CaseDurationEventFilters",
+  description:
+    "Product-level filters for narrowing case duration event anchors.",
 } as const
 
 export const $CaseDurationRead = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1508,19 +1508,39 @@ export type CaseDurationEventAnchor = {
    */
   event_type: CaseEventType
   /**
-   * Dot-delimited path to the timestamp field on the event. Defaults to the event creation timestamp.
+   * Optional product-level filters for matching event payload values.
    */
-  timestamp_path?: string
-  /**
-   * Optional dot-delimited equality filters that must match on the event payload, e.g. {'data.new': 'resolved'}.
-   */
-  field_filters?: {
-    [key: string]: unknown
-  }
+  filters?: CaseDurationEventFilters
   /**
    * Whether to use the first or last matching event for this anchor. Defaults to the first match.
    */
   selection?: CaseDurationAnchorSelection
+}
+
+/**
+ * Product-level filters for narrowing case duration event anchors.
+ */
+export type CaseDurationEventFilters = {
+  /**
+   * New priority, severity, or status values to match.
+   */
+  new_values?: Array<string>
+  /**
+   * Case tag refs to match for tag add/remove events.
+   */
+  tag_refs?: Array<string>
+  /**
+   * Case custom field IDs to match for field change events.
+   */
+  field_ids?: Array<string>
+  /**
+   * Dropdown definition ID to match for dropdown value change events.
+   */
+  dropdown_definition_id?: string | null
+  /**
+   * Dropdown option IDs to match for dropdown value change events.
+   */
+  dropdown_option_ids?: Array<string>
 }
 
 /**

--- a/frontend/src/components/cases/add-case-duration-dialog.tsx
+++ b/frontend/src/components/cases/add-case-duration-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import {
-  buildFieldFilters,
+  buildDurationFilters,
   CaseDurationDialog,
   type CaseDurationFormValues,
 } from "@/components/cases/case-duration-dialog"
@@ -28,12 +28,12 @@ export function AddCaseDurationDialog({
         throw new Error("Workspace ID is required")
       }
 
-      const startFieldFilters = buildFieldFilters(
+      const startFilters = buildDurationFilters(
         values.start.eventType,
         values.start.filterValues,
         values.start
       )
-      const endFieldFilters = buildFieldFilters(
+      const endFilters = buildDurationFilters(
         values.end.eventType,
         values.end.filterValues,
         values.end
@@ -45,14 +45,12 @@ export function AddCaseDurationDialog({
         start_anchor: {
           event_type: values.start.eventType,
           selection: values.start.selection,
-          timestamp_path: "created_at",
-          ...(startFieldFilters ? { field_filters: startFieldFilters } : {}),
+          ...(startFilters ? { filters: startFilters } : {}),
         },
         end_anchor: {
           event_type: values.end.eventType,
           selection: values.end.selection,
-          timestamp_path: "created_at",
-          ...(endFieldFilters ? { field_filters: endFieldFilters } : {}),
+          ...(endFilters ? { filters: endFilters } : {}),
         },
       }
 

--- a/frontend/src/components/cases/case-duration-dialog.tsx
+++ b/frontend/src/components/cases/case-duration-dialog.tsx
@@ -5,6 +5,7 @@ import { FlagTriangleRight, Tag, Timer } from "lucide-react"
 import { type ReactNode, useEffect, useMemo } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
+import type { CaseDurationEventFilters } from "@/client"
 import {
   PRIORITIES,
   SEVERITIES,
@@ -317,43 +318,37 @@ export const normalizeFilterValues = (value: unknown): string[] => {
   return []
 }
 
-export const getFilterFieldKey = (
-  eventType: CaseDurationFormValues["start"]["eventType"]
-): string | null => {
-  if (isCaseEventFilterType(eventType)) {
-    return "data.new"
-  }
-  if (isCaseTagEventType(eventType)) {
-    return "data.tag_ref"
-  }
-  if (isCaseFieldEventType(eventType)) {
-    return "data.changes.field"
-  }
-  return null
-}
-
-export const buildFieldFilters = (
+export const buildDurationFilters = (
   eventType: CaseDurationFormValues["start"]["eventType"],
   filterValues: CaseDurationFormValues["start"]["filterValues"],
   anchor?: CaseDurationFormValues["start"]
-): Record<string, unknown> | null => {
+): CaseDurationEventFilters | null => {
   if (isCaseDropdownEventType(eventType) && anchor) {
     const { dropdownDefinitionId, dropdownOptionIds } = anchor
     if (!dropdownDefinitionId || !dropdownOptionIds?.length) {
       return null
     }
     return {
-      "data.definition_id": dropdownDefinitionId,
-      "data.new_option_id": dropdownOptionIds,
+      dropdown_definition_id: dropdownDefinitionId,
+      dropdown_option_ids: dropdownOptionIds,
     }
   }
 
-  const fieldKey = getFilterFieldKey(eventType)
-  if (!fieldKey || !filterValues || filterValues.length === 0) {
+  if (!filterValues || filterValues.length === 0) {
     return null
   }
 
-  return { [fieldKey]: filterValues }
+  if (isCaseEventFilterType(eventType)) {
+    return { new_values: filterValues }
+  }
+  if (isCaseTagEventType(eventType)) {
+    return { tag_refs: filterValues }
+  }
+  if (isCaseFieldEventType(eventType)) {
+    return { field_ids: filterValues }
+  }
+
+  return null
 }
 
 export function CaseDurationDialog({

--- a/frontend/src/components/cases/case-durations-table.tsx
+++ b/frontend/src/components/cases/case-durations-table.tsx
@@ -8,14 +8,13 @@ import type {
   CaseDurationDefinitionRead,
   CaseDurationDefinitionUpdate,
 } from "@/client"
-import {
-  getFilterFieldKey,
-  normalizeFilterValues,
-} from "@/components/cases/case-duration-dialog"
+import { normalizeFilterValues } from "@/components/cases/case-duration-dialog"
 import {
   CASE_EVENT_FILTER_OPTIONS,
   getCaseEventOption,
+  isCaseDropdownEventType,
   isCaseEventFilterType,
+  isCaseFieldEventType,
   isCaseTagEventType,
 } from "@/components/cases/case-duration-options"
 import { UpdateCaseDurationDialog } from "@/components/cases/update-case-duration-dialog"
@@ -74,6 +73,24 @@ const defaultToolbarProps: DataTableToolbarProps<CaseDurationDefinitionRead> = {
     placeholder: "Filter durations...",
     column: "name",
   },
+}
+
+function getAnchorFilterValues(
+  anchor: CaseDurationDefinitionRead["start_anchor"]
+): unknown {
+  if (isCaseEventFilterType(anchor.event_type)) {
+    return anchor.filters?.new_values
+  }
+  if (isCaseTagEventType(anchor.event_type)) {
+    return anchor.filters?.tag_refs
+  }
+  if (isCaseFieldEventType(anchor.event_type)) {
+    return anchor.filters?.field_ids
+  }
+  if (isCaseDropdownEventType(anchor.event_type)) {
+    return anchor.filters?.dropdown_option_ids
+  }
+  return undefined
 }
 
 export function CaseDurationsTable({
@@ -137,9 +154,8 @@ export function CaseDurationsTable({
     const selection = anchor.selection ?? "first"
     const valueLabels: string[] = []
 
-    const filterFieldKey = getFilterFieldKey(anchor.event_type)
-    if (filterFieldKey) {
-      const rawFilterValue = anchor.field_filters?.[filterFieldKey]
+    const rawFilterValue = getAnchorFilterValues(anchor)
+    if (rawFilterValue) {
       const values = normalizeFilterValues(rawFilterValue)
 
       for (const value of values) {
@@ -155,6 +171,12 @@ export function CaseDurationsTable({
           valueLabels.push(value)
         }
       }
+    }
+    if (
+      isCaseDropdownEventType(anchor.event_type) &&
+      anchor.filters?.dropdown_definition_id
+    ) {
+      valueLabels.unshift(anchor.filters.dropdown_definition_id)
     }
 
     return (

--- a/frontend/src/components/cases/update-case-duration-dialog.tsx
+++ b/frontend/src/components/cases/update-case-duration-dialog.tsx
@@ -6,14 +6,18 @@ import type {
   CaseDurationDefinitionUpdate,
 } from "@/client"
 import {
-  buildFieldFilters,
+  buildDurationFilters,
   CaseDurationDialog,
   type CaseDurationFormValues,
   createEmptyCaseDurationFormValues,
-  getFilterFieldKey,
   normalizeFilterValues,
 } from "@/components/cases/case-duration-dialog"
-import { isCaseDropdownEventType } from "@/components/cases/case-duration-options"
+import {
+  isCaseDropdownEventType,
+  isCaseEventFilterType,
+  isCaseFieldEventType,
+  isCaseTagEventType,
+} from "@/components/cases/case-duration-options"
 
 interface UpdateCaseDurationDialogProps {
   open: boolean
@@ -30,10 +34,8 @@ function extractAnchorFormValues(
   anchor: CaseDurationDefinitionRead["start_anchor"]
 ): CaseDurationFormValues["start"] {
   if (isCaseDropdownEventType(anchor.event_type)) {
-    const defId = anchor.field_filters?.["data.definition_id"]
-    const optionIds = normalizeFilterValues(
-      anchor.field_filters?.["data.new_option_id"]
-    )
+    const defId = anchor.filters?.dropdown_definition_id
+    const optionIds = normalizeFilterValues(anchor.filters?.dropdown_option_ids)
     return {
       selection: anchor.selection ?? "first",
       eventType: anchor.event_type,
@@ -43,10 +45,7 @@ function extractAnchorFormValues(
     }
   }
 
-  const fieldKey = getFilterFieldKey(anchor.event_type)
-  const filterValues = normalizeFilterValues(
-    fieldKey ? anchor.field_filters?.[fieldKey] : undefined
-  )
+  const filterValues = normalizeFilterValues(getAnchorFilterValues(anchor))
   return {
     selection: anchor.selection ?? "first",
     eventType: anchor.event_type,
@@ -54,6 +53,21 @@ function extractAnchorFormValues(
     dropdownDefinitionId: undefined,
     dropdownOptionIds: [],
   }
+}
+
+function getAnchorFilterValues(
+  anchor: CaseDurationDefinitionRead["start_anchor"]
+): unknown {
+  if (isCaseEventFilterType(anchor.event_type)) {
+    return anchor.filters?.new_values
+  }
+  if (isCaseTagEventType(anchor.event_type)) {
+    return anchor.filters?.tag_refs
+  }
+  if (isCaseFieldEventType(anchor.event_type)) {
+    return anchor.filters?.field_ids
+  }
+  return undefined
 }
 
 const getInitialValues = (
@@ -89,12 +103,12 @@ export function UpdateCaseDurationDialog({
         return
       }
 
-      const startFieldFilters = buildFieldFilters(
+      const startFilters = buildDurationFilters(
         values.start.eventType,
         values.start.filterValues,
         values.start
       )
-      const endFieldFilters = buildFieldFilters(
+      const endFilters = buildDurationFilters(
         values.end.eventType,
         values.end.filterValues,
         values.end
@@ -106,14 +120,12 @@ export function UpdateCaseDurationDialog({
         start_anchor: {
           event_type: values.start.eventType,
           selection: values.start.selection,
-          timestamp_path: "created_at",
-          ...(startFieldFilters ? { field_filters: startFieldFilters } : {}),
+          ...(startFilters ? { filters: startFilters } : {}),
         },
         end_anchor: {
           event_type: values.end.eventType,
           selection: values.end.selection,
-          timestamp_path: "created_at",
-          ...(endFieldFilters ? { field_filters: endFieldFilters } : {}),
+          ...(endFilters ? { filters: endFilters } : {}),
         },
       }
 

--- a/tests/integration/test_case_duration_benchmarks.py
+++ b/tests/integration/test_case_duration_benchmarks.py
@@ -1,0 +1,420 @@
+"""Opt-in benchmarks for case duration recomputation under burst updates.
+
+Run with:
+
+    TRACECAT_RUN_CASE_DURATION_BENCHMARKS=1 \
+    uv run pytest tests/integration/test_case_duration_benchmarks.py -s
+
+Tune the synthetic load with:
+
+    TRACECAT_CASE_DURATION_BENCHMARK_CASES
+    TRACECAT_CASE_DURATION_BENCHMARK_DEFINITIONS
+    TRACECAT_CASE_DURATION_BENCHMARK_HISTORY_EVENTS
+    TRACECAT_CASE_DURATION_BENCHMARK_UPDATES_PER_CASE
+    TRACECAT_CASE_DURATION_BENCHMARK_HEALTH_INTERVAL_MS
+    TRACECAT_CASE_DURATION_BENCHMARK_HEALTH_TIMEOUT_MS
+    TRACECAT_CASE_DURATION_BENCHMARK_OUTPUT
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import statistics
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from tests.database import TEST_DB_CONFIG
+from tracecat import config
+from tracecat.api.app import app
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import ADMIN_SCOPES
+from tracecat.cases.durations.schemas import (
+    CaseDurationAnchorSelection,
+    CaseDurationDefinitionCreate,
+    CaseDurationEventAnchor,
+)
+from tracecat.cases.durations.service import (
+    CaseDurationDefinitionService,
+    CaseDurationService,
+)
+from tracecat.cases.enums import CaseEventType, CasePriority, CaseSeverity, CaseStatus
+from tracecat.cases.schemas import CaseCreate, CaseUpdate
+from tracecat.cases.service import CasesService
+from tracecat.db.models import CaseEvent, Organization, Workspace
+
+RUN_BENCHMARKS = os.environ.get("TRACECAT_RUN_CASE_DURATION_BENCHMARKS") == "1"
+BENCHMARK_OUTPUT_PATH = os.environ.get("TRACECAT_CASE_DURATION_BENCHMARK_OUTPUT")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.usefixtures("db"),
+    pytest.mark.skipif(
+        not RUN_BENCHMARKS,
+        reason="Set TRACECAT_RUN_CASE_DURATION_BENCHMARKS=1 to run benchmarks",
+    ),
+]
+
+
+@dataclass(frozen=True)
+class CaseDurationBurstBenchmarkConfig:
+    """Config for the synthetic duration benchmark."""
+
+    case_count: int = int(
+        os.environ.get("TRACECAT_CASE_DURATION_BENCHMARK_CASES") or 20
+    )
+    definition_count: int = int(
+        os.environ.get("TRACECAT_CASE_DURATION_BENCHMARK_DEFINITIONS") or 80
+    )
+    history_events_per_case: int = int(
+        os.environ.get("TRACECAT_CASE_DURATION_BENCHMARK_HISTORY_EVENTS") or 600
+    )
+    updates_per_case: int = int(
+        os.environ.get("TRACECAT_CASE_DURATION_BENCHMARK_UPDATES_PER_CASE") or 1
+    )
+    health_interval_s: float = (
+        int(os.environ.get("TRACECAT_CASE_DURATION_BENCHMARK_HEALTH_INTERVAL_MS") or 50)
+        / 1000
+    )
+    health_timeout_s: float = (
+        int(
+            os.environ.get("TRACECAT_CASE_DURATION_BENCHMARK_HEALTH_TIMEOUT_MS") or 1000
+        )
+        / 1000
+    )
+
+
+def _percentile(values: list[float], percentile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = max(0, min(len(ordered) - 1, int(len(ordered) * percentile) - 1))
+    return ordered[index]
+
+
+def _latency_stats(values: list[float]) -> dict[str, float | int | None]:
+    if not values:
+        return {
+            "samples": 0,
+            "p50_ms": None,
+            "p95_ms": None,
+            "max_ms": None,
+        }
+    return {
+        "samples": len(values),
+        "p50_ms": round(statistics.median(values) * 1000, 1),
+        "p95_ms": round((_percentile(values, 0.95) or 0) * 1000, 1),
+        "max_ms": round(max(values) * 1000, 1),
+    }
+
+
+def _write_summary_to_file(summary: dict[str, object]) -> None:
+    if not BENCHMARK_OUTPUT_PATH:
+        return
+    output_path = os.path.abspath(BENCHMARK_OUTPUT_PATH)
+    if parent := os.path.dirname(output_path):
+        os.makedirs(parent, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2, sort_keys=True)
+
+
+async def _seed_cases_definitions_and_history(
+    *,
+    async_engine,
+    role: Role,
+    cfg: CaseDurationBurstBenchmarkConfig,
+) -> list[uuid.UUID]:
+    case_ids: list[uuid.UUID] = []
+    async with AsyncSession(async_engine, expire_on_commit=False) as session:
+        cases_service = CasesService(session=session, role=role)
+        for index in range(cfg.case_count):
+            case = await cases_service.create_case(
+                CaseCreate(
+                    summary=f"Duration benchmark case {index}",
+                    description="Synthetic benchmark case",
+                    status=CaseStatus.NEW,
+                    priority=CasePriority.MEDIUM,
+                    severity=CaseSeverity.MEDIUM,
+                )
+            )
+            case_ids.append(case.id)
+
+        definition_service = CaseDurationDefinitionService(session=session, role=role)
+        for index in range(cfg.definition_count):
+            await definition_service.create_definition(
+                CaseDurationDefinitionCreate(
+                    name=f"Benchmark Duration {index}",
+                    description="Synthetic duration benchmark definition",
+                    start_anchor=CaseDurationEventAnchor(
+                        event_type=CaseEventType.CASE_CREATED,
+                    ),
+                    end_anchor=CaseDurationEventAnchor(
+                        event_type=CaseEventType.STATUS_CHANGED,
+                        field_filters={
+                            "data.new": [
+                                CaseStatus.IN_PROGRESS,
+                                CaseStatus.RESOLVED,
+                                CaseStatus.CLOSED,
+                            ]
+                        },
+                        selection=CaseDurationAnchorSelection.LAST,
+                    ),
+                )
+            )
+
+        base_time = datetime.now(UTC) - timedelta(hours=1)
+        for case_index, case_id in enumerate(case_ids):
+            current_status = CaseStatus.NEW
+            for event_index in range(cfg.history_events_per_case):
+                new_status = (
+                    CaseStatus.IN_PROGRESS
+                    if event_index % 3 == 0
+                    else CaseStatus.RESOLVED
+                    if event_index % 3 == 1
+                    else CaseStatus.CLOSED
+                )
+                session.add(
+                    CaseEvent(
+                        workspace_id=role.workspace_id,
+                        case_id=case_id,
+                        type=CaseEventType.STATUS_CHANGED,
+                        data={
+                            "old": current_status.value,
+                            "new": new_status.value,
+                        },
+                        user_id=role.user_id,
+                        created_at=base_time
+                        + timedelta(
+                            milliseconds=(
+                                case_index * cfg.history_events_per_case + event_index
+                            )
+                        ),
+                    )
+                )
+                current_status = new_status
+        await session.commit()
+
+    return case_ids
+
+
+async def _seed_benchmark_role(async_engine) -> Role:
+    organization_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    async with AsyncSession(async_engine, expire_on_commit=False) as session:
+        session.add(
+            Organization(
+                id=organization_id,
+                name="Case Duration Benchmark Org",
+                slug=f"case-duration-benchmark-{organization_id.hex[:8]}",
+                is_active=True,
+            )
+        )
+        session.add(
+            Workspace(
+                id=workspace_id,
+                organization_id=organization_id,
+                name="Case Duration Benchmark Workspace",
+                last_case_number=0,
+            )
+        )
+        await session.commit()
+
+    return Role(
+        type="user",
+        workspace_id=workspace_id,
+        organization_id=organization_id,
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+        scopes=ADMIN_SCOPES,
+    )
+
+
+async def _run_case_update_burst(
+    *,
+    async_engine,
+    role: Role,
+    case_ids: list[uuid.UUID],
+    updates_per_case: int,
+) -> tuple[list[float], int]:
+    async def update_one_case(
+        case_id: uuid.UUID, worker_index: int
+    ) -> tuple[list[float], int]:
+        latencies: list[float] = []
+        errors = 0
+        async with AsyncSession(async_engine, expire_on_commit=False) as session:
+            service = CasesService(session=session, role=role)
+            for update_index in range(updates_per_case):
+                case = await service.get_case(case_id, for_update=True)
+                if case is None:
+                    raise AssertionError(f"Case {case_id} not found during benchmark")
+                started = time.perf_counter()
+                try:
+                    await service.update_case(
+                        case,
+                        CaseUpdate(
+                            summary=(
+                                "duration-burst-"
+                                f"{worker_index}-{update_index}-{uuid.uuid4().hex[:8]}"
+                            )
+                        ),
+                    )
+                except Exception:
+                    errors += 1
+                    await session.rollback()
+                else:
+                    latencies.append(time.perf_counter() - started)
+        return latencies, errors
+
+    worker_results = await asyncio.gather(
+        *[
+            update_one_case(case_id, worker_index)
+            for worker_index, case_id in enumerate(case_ids)
+        ]
+    )
+    return (
+        [latency for values, _ in worker_results for latency in values],
+        sum(errors for _, errors in worker_results),
+    )
+
+
+@pytest.mark.anyio
+async def test_case_duration_update_burst_health_latency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Measure health latency during a burst of case updates with duration sync."""
+
+    cfg = CaseDurationBurstBenchmarkConfig()
+    monkeypatch.setattr(config, "TRACECAT__CASE_TRIGGERS_ENABLED", False)
+
+    async_engine = create_async_engine(
+        TEST_DB_CONFIG.test_url,
+        poolclass=NullPool,
+    )
+
+    phase = {"name": "baseline"}
+    stop_probe = asyncio.Event()
+    health_latencies: dict[str, list[float]] = {
+        "baseline": [],
+        "burst": [],
+        "cooldown": [],
+    }
+    loop_lags: dict[str, list[float]] = {
+        "baseline": [],
+        "burst": [],
+        "cooldown": [],
+    }
+    health_errors: dict[str, int] = {"baseline": 0, "burst": 0, "cooldown": 0}
+
+    async def probe_health() -> None:
+        next_tick = time.perf_counter() + cfg.health_interval_s
+        transport = httpx.ASGITransport(app=app)
+        async with (
+            transport,
+            httpx.AsyncClient(
+                transport=transport, base_url="http://benchmark"
+            ) as client,
+        ):
+            while not stop_probe.is_set():
+                await asyncio.sleep(max(0, next_tick - time.perf_counter()))
+                scheduled = next_tick
+                current_phase = phase["name"]
+                started = time.perf_counter()
+                try:
+                    response = await asyncio.wait_for(
+                        client.get("/health"),
+                        timeout=cfg.health_timeout_s,
+                    )
+                    response.raise_for_status()
+                    health_latencies[current_phase].append(
+                        time.perf_counter() - started
+                    )
+                except Exception:
+                    health_errors[current_phase] += 1
+                loop_lags[current_phase].append(time.perf_counter() - scheduled)
+                next_tick += cfg.health_interval_s
+
+    try:
+        with (
+            patch.object(
+                CaseDurationDefinitionService,
+                "has_entitlement",
+                new=AsyncMock(return_value=True),
+            ),
+            patch.object(
+                CaseDurationService,
+                "has_entitlement",
+                new=AsyncMock(return_value=True),
+            ),
+            patch.object(
+                CasesService,
+                "has_entitlement",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
+            role = await _seed_benchmark_role(async_engine)
+            case_ids = await _seed_cases_definitions_and_history(
+                async_engine=async_engine,
+                role=role,
+                cfg=cfg,
+            )
+
+            probe_task = asyncio.create_task(probe_health())
+            await asyncio.sleep(0.25)
+
+            phase["name"] = "burst"
+            burst_started = time.perf_counter()
+            update_latencies, update_errors = await _run_case_update_burst(
+                async_engine=async_engine,
+                role=role,
+                case_ids=case_ids,
+                updates_per_case=cfg.updates_per_case,
+            )
+            burst_elapsed = time.perf_counter() - burst_started
+
+            phase["name"] = "cooldown"
+            await asyncio.sleep(0.25)
+            stop_probe.set()
+            await probe_task
+
+        summary: dict[str, object] = {
+            "config": {
+                "cases": cfg.case_count,
+                "definitions": cfg.definition_count,
+                "history_events_per_case": cfg.history_events_per_case,
+                "updates_per_case": cfg.updates_per_case,
+                "health_interval_ms": round(cfg.health_interval_s * 1000),
+                "health_timeout_ms": round(cfg.health_timeout_s * 1000),
+            },
+            "burst_elapsed_s": round(burst_elapsed, 3),
+            "update_latencies": _latency_stats(update_latencies),
+            "update_errors": update_errors,
+            "health_baseline": _latency_stats(health_latencies["baseline"]),
+            "health_burst": _latency_stats(health_latencies["burst"]),
+            "health_cooldown": _latency_stats(health_latencies["cooldown"]),
+            "loop_lag_baseline": _latency_stats(loop_lags["baseline"]),
+            "loop_lag_burst": _latency_stats(loop_lags["burst"]),
+            "loop_lag_cooldown": _latency_stats(loop_lags["cooldown"]),
+            "health_errors": health_errors,
+        }
+        _write_summary_to_file(summary)
+
+        print("\nCase duration burst benchmark:")
+        print(summary)
+
+        attempted_updates = cfg.case_count * cfg.updates_per_case
+        assert len(update_latencies) + update_errors == attempted_updates
+        assert update_latencies
+        assert health_latencies["baseline"]
+        assert health_latencies["burst"] or health_errors["burst"] > 0
+    finally:
+        await async_engine.dispose()

--- a/tests/integration/test_case_duration_benchmarks.py
+++ b/tests/integration/test_case_duration_benchmarks.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import os
 import statistics
 import time
@@ -98,7 +99,7 @@ def _percentile(values: list[float], percentile: float) -> float | None:
     if not values:
         return None
     ordered = sorted(values)
-    index = max(0, min(len(ordered) - 1, int(len(ordered) * percentile) - 1))
+    index = max(0, min(len(ordered) - 1, math.ceil(len(ordered) * percentile) - 1))
     return ordered[index]
 
 
@@ -116,6 +117,14 @@ def _latency_stats(values: list[float]) -> dict[str, float | int | None]:
         "p95_ms": round((_percentile(values, 0.95) or 0) * 1000, 1),
         "max_ms": round(max(values) * 1000, 1),
     }
+
+
+def test_percentile_uses_ceil_rank_for_tail_latency() -> None:
+    assert _percentile([1.0, 2.0, 3.0, 4.0, 5.0], 0.95) == 5.0
+
+
+def test_latency_stats_reports_small_sample_p95_tail() -> None:
+    assert _latency_stats([0.001, 0.002, 0.003, 0.004, 0.005])["p95_ms"] == 5.0
 
 
 def _write_summary_to_file(summary: dict[str, object]) -> None:

--- a/tests/integration/test_case_duration_benchmarks.py
+++ b/tests/integration/test_case_duration_benchmarks.py
@@ -43,6 +43,7 @@ from tracecat.cases.durations.schemas import (
     CaseDurationAnchorSelection,
     CaseDurationDefinitionCreate,
     CaseDurationEventAnchor,
+    CaseDurationEventFilters,
 )
 from tracecat.cases.durations.service import (
     CaseDurationDefinitionService,
@@ -169,13 +170,13 @@ async def _seed_cases_definitions_and_history(
                     ),
                     end_anchor=CaseDurationEventAnchor(
                         event_type=CaseEventType.STATUS_CHANGED,
-                        field_filters={
-                            "data.new": [
-                                CaseStatus.IN_PROGRESS,
-                                CaseStatus.RESOLVED,
-                                CaseStatus.CLOSED,
+                        filters=CaseDurationEventFilters(
+                            new_values=[
+                                CaseStatus.IN_PROGRESS.value,
+                                CaseStatus.RESOLVED.value,
+                                CaseStatus.CLOSED.value,
                             ]
-                        },
+                        ),
                         selection=CaseDurationAnchorSelection.LAST,
                     ),
                 )

--- a/tests/unit/test_case_duration_service.py
+++ b/tests/unit/test_case_duration_service.py
@@ -345,6 +345,46 @@ async def test_duration_filters_preserve_json_value_types(
 
 
 @pytest.mark.anyio
+async def test_duration_filters_preserve_python_bool_number_overlap(
+    session: AsyncSession, svc_role
+) -> None:
+    cases_service = CasesService(session=session, role=svc_role)
+    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    await definition_service.create_definition(
+        CaseDurationDefinitionCreate(
+            name="Time to truthy flag update",
+            start_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.CASE_CREATED,
+            ),
+            end_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.FIELDS_CHANGED,
+                field_filters={"data.flag": 1},
+            ),
+        )
+    )
+
+    case = await cases_service.create_case(make_case_create())
+    event = CaseEvent(
+        workspace_id=case.workspace_id,
+        case_id=case.id,
+        type=CaseEventType.FIELDS_CHANGED,
+        data={"flag": True},
+        created_at=datetime.now(UTC) + timedelta(seconds=1),
+    )
+    session.add(event)
+    await session.flush()
+
+    assert not duration_service._filters_are_sql_compatible({"data.flag": 1})
+
+    values = await duration_service.compute_duration(case)
+    assert len(values) == 1
+    assert values[0].end_event_id == event.id
+    assert values[0].duration is not None
+
+
+@pytest.mark.anyio
 async def test_duration_filters_match_closed_under_status_changed(
     session: AsyncSession, svc_role
 ) -> None:

--- a/tests/unit/test_case_duration_service.py
+++ b/tests/unit/test_case_duration_service.py
@@ -256,6 +256,48 @@ async def test_duration_filters_match_json_array_payload_overlap(
 
 
 @pytest.mark.anyio
+async def test_duration_filters_match_nested_json_array_paths(
+    session: AsyncSession, svc_role
+) -> None:
+    cases_service = CasesService(session=session, role=svc_role)
+    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    await definition_service.create_definition(
+        CaseDurationDefinitionCreate(
+            name="Time to item update",
+            start_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.CASE_CREATED,
+            ),
+            end_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.FIELDS_CHANGED,
+                field_filters={"data.items.name": ["foo"]},
+            ),
+        )
+    )
+
+    case = await cases_service.create_case(make_case_create())
+    event = CaseEvent(
+        workspace_id=case.workspace_id,
+        case_id=case.id,
+        type=CaseEventType.FIELDS_CHANGED,
+        data={"items": [{"name": "foo"}, {"name": "bar"}]},
+        created_at=datetime.now(UTC) + timedelta(seconds=1),
+    )
+    session.add(event)
+    await session.flush()
+
+    assert not duration_service._filters_are_sql_compatible(
+        {"data.items.name": ["foo"]}
+    )
+
+    values = await duration_service.compute_duration(case)
+    assert len(values) == 1
+    assert values[0].end_event_id == event.id
+    assert values[0].duration is not None
+
+
+@pytest.mark.anyio
 async def test_duration_filters_preserve_json_value_types(
     session: AsyncSession, svc_role
 ) -> None:

--- a/tests/unit/test_case_duration_service.py
+++ b/tests/unit/test_case_duration_service.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,6 +14,7 @@ from tracecat.cases.durations import (
     CaseDurationDefinitionCreate,
     CaseDurationDefinitionUpdate,
     CaseDurationEventAnchor,
+    CaseDurationEventFilters,
 )
 from tracecat.cases.durations.service import (
     CaseDurationDefinitionService,
@@ -23,6 +25,7 @@ from tracecat.cases.schemas import CaseCreate, CaseUpdate
 from tracecat.cases.service import CasesService
 from tracecat.cases.tags.service import CaseTagsService
 from tracecat.db.models import CaseDuration, CaseEvent
+from tracecat.db.models import CaseDurationDefinition as CaseDurationDefinitionDB
 from tracecat.tags.schemas import TagCreate
 
 pytestmark = pytest.mark.usefixtures("db")
@@ -87,7 +90,9 @@ async def test_compute_case_durations_from_events(
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.STATUS_CHANGED,
-                field_filters={"data.new": CaseStatus.RESOLVED},
+                filters=CaseDurationEventFilters(
+                    new_values=[CaseStatus.RESOLVED.value]
+                ),
             ),
         )
     )
@@ -150,7 +155,6 @@ async def test_duration_filters_match_event_payload(
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.CASE_CLOSED,
-                field_filters={"data.new": CaseStatus.CLOSED},
             ),
         )
     )
@@ -192,7 +196,9 @@ async def test_duration_filters_support_multiple_values(
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.STATUS_CHANGED,
-                field_filters={"data.new": [CaseStatus.RESOLVED, CaseStatus.CLOSED]},
+                filters=CaseDurationEventFilters(
+                    new_values=[CaseStatus.RESOLVED.value, CaseStatus.CLOSED.value]
+                ),
             ),
         )
     )
@@ -218,7 +224,7 @@ async def test_duration_filters_support_multiple_values(
 
 
 @pytest.mark.anyio
-async def test_duration_filters_match_json_array_payload_overlap(
+async def test_duration_filters_match_custom_field_changes(
     session: AsyncSession, svc_role
 ) -> None:
     cases_service = CasesService(session=session, role=svc_role)
@@ -227,160 +233,43 @@ async def test_duration_filters_match_json_array_payload_overlap(
 
     await definition_service.create_definition(
         CaseDurationDefinitionCreate(
-            name="Time to urgent update",
+            name="Time to severity score update",
             start_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.CASE_CREATED,
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.FIELDS_CHANGED,
-                field_filters={"data.tags": ["urgent"]},
+                filters=CaseDurationEventFilters(field_ids=["severity_score"]),
             ),
         )
     )
 
     case = await cases_service.create_case(make_case_create())
-    event = CaseEvent(
+    unrelated_event = CaseEvent(
         workspace_id=case.workspace_id,
         case_id=case.id,
         type=CaseEventType.FIELDS_CHANGED,
-        data={"tags": ["urgent", "vip"]},
+        data={"changes": [{"field": "team", "old": "alpha", "new": "beta"}]},
         created_at=datetime.now(UTC) + timedelta(seconds=1),
     )
-    session.add(event)
+    matching_event = CaseEvent(
+        workspace_id=case.workspace_id,
+        case_id=case.id,
+        type=CaseEventType.FIELDS_CHANGED,
+        data={
+            "changes": [
+                {"field": "severity_score", "old": 3, "new": 8},
+                {"field": "team", "old": "alpha", "new": "beta"},
+            ]
+        },
+        created_at=datetime.now(UTC) + timedelta(seconds=2),
+    )
+    session.add_all([unrelated_event, matching_event])
     await session.flush()
 
     values = await duration_service.compute_duration(case)
     assert len(values) == 1
-    assert values[0].end_event_id == event.id
-    assert values[0].duration is not None
-
-
-@pytest.mark.anyio
-async def test_duration_filters_match_nested_json_array_paths(
-    session: AsyncSession, svc_role
-) -> None:
-    cases_service = CasesService(session=session, role=svc_role)
-    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
-    duration_service = CaseDurationService(session=session, role=svc_role)
-
-    await definition_service.create_definition(
-        CaseDurationDefinitionCreate(
-            name="Time to item update",
-            start_anchor=CaseDurationEventAnchor(
-                event_type=CaseEventType.CASE_CREATED,
-            ),
-            end_anchor=CaseDurationEventAnchor(
-                event_type=CaseEventType.FIELDS_CHANGED,
-                field_filters={"data.items.name": ["foo"]},
-            ),
-        )
-    )
-
-    case = await cases_service.create_case(make_case_create())
-    event = CaseEvent(
-        workspace_id=case.workspace_id,
-        case_id=case.id,
-        type=CaseEventType.FIELDS_CHANGED,
-        data={"items": [{"name": "foo"}, {"name": "bar"}]},
-        created_at=datetime.now(UTC) + timedelta(seconds=1),
-    )
-    session.add(event)
-    await session.flush()
-
-    assert not duration_service._filters_are_sql_compatible(
-        {"data.items.name": ["foo"]}
-    )
-
-    values = await duration_service.compute_duration(case)
-    assert len(values) == 1
-    assert values[0].end_event_id == event.id
-    assert values[0].duration is not None
-
-
-@pytest.mark.anyio
-async def test_duration_filters_preserve_json_value_types(
-    session: AsyncSession, svc_role
-) -> None:
-    cases_service = CasesService(session=session, role=svc_role)
-    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
-    duration_service = CaseDurationService(session=session, role=svc_role)
-
-    await definition_service.create_definition(
-        CaseDurationDefinitionCreate(
-            name="Time to counted update",
-            start_anchor=CaseDurationEventAnchor(
-                event_type=CaseEventType.CASE_CREATED,
-            ),
-            end_anchor=CaseDurationEventAnchor(
-                event_type=CaseEventType.FIELDS_CHANGED,
-                field_filters={"data.count": 1},
-            ),
-        )
-    )
-
-    case = await cases_service.create_case(make_case_create())
-    first_event_time = datetime.now(UTC) + timedelta(seconds=1)
-    string_count_event = CaseEvent(
-        workspace_id=case.workspace_id,
-        case_id=case.id,
-        type=CaseEventType.FIELDS_CHANGED,
-        data={"count": "1"},
-        created_at=first_event_time,
-    )
-    numeric_count_event = CaseEvent(
-        workspace_id=case.workspace_id,
-        case_id=case.id,
-        type=CaseEventType.FIELDS_CHANGED,
-        data={"count": 1},
-        created_at=first_event_time + timedelta(seconds=1),
-    )
-    session.add_all([string_count_event, numeric_count_event])
-    await session.flush()
-
-    values = await duration_service.compute_duration(case)
-    assert len(values) == 1
-    assert values[0].end_event_id == numeric_count_event.id
-    assert values[0].end_event_id != string_count_event.id
-    assert values[0].duration is not None
-
-
-@pytest.mark.anyio
-async def test_duration_filters_preserve_python_bool_number_overlap(
-    session: AsyncSession, svc_role
-) -> None:
-    cases_service = CasesService(session=session, role=svc_role)
-    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
-    duration_service = CaseDurationService(session=session, role=svc_role)
-
-    await definition_service.create_definition(
-        CaseDurationDefinitionCreate(
-            name="Time to truthy flag update",
-            start_anchor=CaseDurationEventAnchor(
-                event_type=CaseEventType.CASE_CREATED,
-            ),
-            end_anchor=CaseDurationEventAnchor(
-                event_type=CaseEventType.FIELDS_CHANGED,
-                field_filters={"data.flag": 1},
-            ),
-        )
-    )
-
-    case = await cases_service.create_case(make_case_create())
-    event = CaseEvent(
-        workspace_id=case.workspace_id,
-        case_id=case.id,
-        type=CaseEventType.FIELDS_CHANGED,
-        data={"flag": True},
-        created_at=datetime.now(UTC) + timedelta(seconds=1),
-    )
-    session.add(event)
-    await session.flush()
-
-    assert not duration_service._filters_are_sql_compatible({"data.flag": 1})
-
-    values = await duration_service.compute_duration(case)
-    assert len(values) == 1
-    assert values[0].end_event_id == event.id
+    assert values[0].end_event_id == matching_event.id
     assert values[0].duration is not None
 
 
@@ -400,7 +289,7 @@ async def test_duration_filters_match_closed_under_status_changed(
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.STATUS_CHANGED,
-                field_filters={"data.new": CaseStatus.CLOSED},
+                filters=CaseDurationEventFilters(new_values=[CaseStatus.CLOSED.value]),
             ),
         )
     )
@@ -437,7 +326,9 @@ async def test_duration_filters_match_reopened_under_status_changed(
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.STATUS_CHANGED,
-                field_filters={"data.new": CaseStatus.IN_PROGRESS},
+                filters=CaseDurationEventFilters(
+                    new_values=[CaseStatus.IN_PROGRESS.value]
+                ),
             ),
         )
     )
@@ -477,11 +368,11 @@ async def test_duration_supports_tag_events(session: AsyncSession, svc_role) -> 
             name="Tag window",
             start_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.TAG_ADDED,
-                field_filters={"data.tag_ref": [tag.ref]},
+                filters=CaseDurationEventFilters(tag_refs=[tag.ref]),
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.TAG_REMOVED,
-                field_filters={"data.tag_ref": [tag.ref]},
+                filters=CaseDurationEventFilters(tag_refs=[tag.ref]),
             ),
         )
     )
@@ -531,7 +422,9 @@ async def test_duration_definition_update_accepts_nested_anchor_models(
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.STATUS_CHANGED,
-                field_filters={"data.new": CaseStatus.RESOLVED},
+                filters=CaseDurationEventFilters(
+                    new_values=[CaseStatus.RESOLVED.value]
+                ),
             ),
         )
     )
@@ -540,12 +433,12 @@ async def test_duration_definition_update_accepts_nested_anchor_models(
         start_anchor=CaseDurationEventAnchor(
             event_type=CaseEventType.STATUS_CHANGED,
             selection=CaseDurationAnchorSelection.LAST,
-            field_filters={"data.new": CaseStatus.IN_PROGRESS},
+            filters=CaseDurationEventFilters(new_values=[CaseStatus.IN_PROGRESS.value]),
         ),
         end_anchor=CaseDurationEventAnchor(
             event_type=CaseEventType.STATUS_CHANGED,
             selection=CaseDurationAnchorSelection.FIRST,
-            field_filters={"data.new": CaseStatus.RESOLVED},
+            filters=CaseDurationEventFilters(new_values=[CaseStatus.RESOLVED.value]),
         ),
     )
 
@@ -553,14 +446,20 @@ async def test_duration_definition_update_accepts_nested_anchor_models(
 
     assert updated.start_anchor.event_type == CaseEventType.STATUS_CHANGED
     assert updated.start_anchor.selection == CaseDurationAnchorSelection.LAST
-    assert updated.start_anchor.field_filters == {"data.new": CaseStatus.IN_PROGRESS}
+    assert updated.start_anchor.filters == CaseDurationEventFilters(
+        new_values=[CaseStatus.IN_PROGRESS.value]
+    )
     assert updated.end_anchor.selection == CaseDurationAnchorSelection.FIRST
-    assert updated.end_anchor.field_filters == {"data.new": CaseStatus.RESOLVED}
+    assert updated.end_anchor.filters == CaseDurationEventFilters(
+        new_values=[CaseStatus.RESOLVED.value]
+    )
 
     persisted = await definition_service.get_definition(definition.id)
     assert persisted.start_anchor.event_type == CaseEventType.STATUS_CHANGED
     assert persisted.start_anchor.selection == CaseDurationAnchorSelection.LAST
-    assert persisted.start_anchor.field_filters == {"data.new": CaseStatus.IN_PROGRESS}
+    assert persisted.start_anchor.filters == CaseDurationEventFilters(
+        new_values=[CaseStatus.IN_PROGRESS.value]
+    )
 
 
 @pytest.mark.anyio
@@ -579,7 +478,9 @@ async def test_duration_anchor_selection_first_vs_last(
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.STATUS_CHANGED,
-                field_filters={"data.new": CaseStatus.RESOLVED},
+                filters=CaseDurationEventFilters(
+                    new_values=[CaseStatus.RESOLVED.value]
+                ),
                 selection=CaseDurationAnchorSelection.FIRST,
             ),
         )
@@ -592,7 +493,9 @@ async def test_duration_anchor_selection_first_vs_last(
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.STATUS_CHANGED,
-                field_filters={"data.new": CaseStatus.RESOLVED},
+                filters=CaseDurationEventFilters(
+                    new_values=[CaseStatus.RESOLVED.value]
+                ),
                 selection=CaseDurationAnchorSelection.LAST,
             ),
         )
@@ -704,7 +607,9 @@ async def test_compute_time_series_returns_metrics(
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.STATUS_CHANGED,
-                field_filters={"data.new": CaseStatus.RESOLVED},
+                filters=CaseDurationEventFilters(
+                    new_values=[CaseStatus.RESOLVED.value]
+                ),
             ),
         )
     )
@@ -805,7 +710,9 @@ async def test_compute_time_series_excludes_incomplete_durations(
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.STATUS_CHANGED,
-                field_filters={"data.new": CaseStatus.RESOLVED},
+                filters=CaseDurationEventFilters(
+                    new_values=[CaseStatus.RESOLVED.value]
+                ),
             ),
         )
     )
@@ -842,7 +749,9 @@ async def test_compute_durations_batch_multiple_cases(
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.STATUS_CHANGED,
-                field_filters={"data.new": CaseStatus.RESOLVED},
+                filters=CaseDurationEventFilters(
+                    new_values=[CaseStatus.RESOLVED.value]
+                ),
             ),
         )
     )
@@ -919,7 +828,9 @@ async def test_compute_time_series_multiple_cases_with_mixed_completion(
             ),
             end_anchor=CaseDurationEventAnchor(
                 event_type=CaseEventType.STATUS_CHANGED,
-                field_filters={"data.new": CaseStatus.RESOLVED},
+                filters=CaseDurationEventFilters(
+                    new_values=[CaseStatus.RESOLVED.value]
+                ),
             ),
         )
     )
@@ -980,18 +891,86 @@ async def test_compute_durations_empty_cases_list(
     assert durations == {}
 
 
-# --- _resolve_field array traversal tests ---
+def test_duration_anchor_rejects_legacy_dot_path_filters() -> None:
+    with pytest.raises(ValidationError):
+        CaseDurationEventAnchor.model_validate(
+            {
+                "event_type": CaseEventType.FIELDS_CHANGED,
+                "field_filters": {"data.changes.field": ["severity_score"]},
+            }
+        )
+
+
+def test_duration_anchor_rejects_custom_timestamp_paths() -> None:
+    with pytest.raises(ValidationError):
+        CaseDurationEventAnchor.model_validate(
+            {
+                "event_type": CaseEventType.CASE_CREATED,
+                "timestamp_path": "data.created_at",
+            }
+        )
 
 
 @pytest.mark.anyio
-async def test_resolve_field_traverses_array_of_dicts(
+async def test_duration_storage_maps_known_legacy_ui_filters(
     session: AsyncSession, svc_role
 ) -> None:
-    """_resolve_field should collect values from each item in a list."""
-    from tracecat.db.models import CaseEvent
+    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
 
+    filters, unsupported = definition_service._filters_from_storage(
+        CaseEventType.FIELDS_CHANGED,
+        {"data.changes.field": ["severity_score"]},
+    )
+
+    assert not unsupported
+    assert filters == CaseDurationEventFilters(field_ids=["severity_score"])
+
+
+@pytest.mark.anyio
+async def test_duration_storage_marks_arbitrary_legacy_filters_unsupported(
+    session: AsyncSession, svc_role
+) -> None:
+    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
+
+    filters, unsupported = definition_service._filters_from_storage(
+        CaseEventType.FIELDS_CHANGED,
+        {"data.items.name": ["foo"]},
+    )
+
+    assert unsupported
+    assert filters == CaseDurationEventFilters()
+
+
+@pytest.mark.anyio
+async def test_duration_storage_marks_invalid_legacy_anchor_unsupported(
+    session: AsyncSession, svc_role
+) -> None:
+    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
+    assert svc_role.workspace_id is not None
+    entity = CaseDurationDefinitionDB(
+        workspace_id=svc_role.workspace_id,
+        name="Legacy status duration",
+        start_event_type=CaseEventType.STATUS_CHANGED,
+        start_timestamp_path="created_at",
+        start_field_filters={},
+        start_selection=CaseDurationAnchorSelection.FIRST,
+        end_event_type=CaseEventType.CASE_CLOSED,
+        end_timestamp_path="created_at",
+        end_field_filters={},
+        end_selection=CaseDurationAnchorSelection.FIRST,
+    )
+
+    anchor = definition_service._anchor_from_entity(entity, "start")
+
+    assert anchor._has_unsupported_filters
+    assert anchor.filters == CaseDurationEventFilters()
+
+
+@pytest.mark.anyio
+async def test_matches_custom_field_change_filters(
+    session: AsyncSession, svc_role
+) -> None:
     duration_service = CaseDurationService(session=session, role=svc_role)
-
     event = CaseEvent(
         workspace_id=uuid.uuid4(),
         case_id=uuid.uuid4(),
@@ -1003,63 +982,14 @@ async def test_resolve_field_traverses_array_of_dicts(
             ]
         },
     )
-
-    result = duration_service._resolve_field(event, "data.changes.field")
-    assert result == ["severity_score", "team"]
-
-
-@pytest.mark.anyio
-async def test_resolve_field_array_returns_none_when_no_items_have_key(
-    session: AsyncSession, svc_role
-) -> None:
-    """_resolve_field should return None if no array items have the target key."""
-    from tracecat.db.models import CaseEvent
-
-    duration_service = CaseDurationService(session=session, role=svc_role)
-
-    event = CaseEvent(
-        workspace_id=uuid.uuid4(),
-        case_id=uuid.uuid4(),
-        type=CaseEventType.FIELDS_CHANGED,
-        data={"changes": [{"other": "value"}, {"other": "value2"}]},
+    anchor = CaseDurationEventAnchor(
+        event_type=CaseEventType.FIELDS_CHANGED,
+        filters=CaseDurationEventFilters(field_ids=["severity_score"]),
+    )
+    nonmatching_anchor = CaseDurationEventAnchor(
+        event_type=CaseEventType.FIELDS_CHANGED,
+        filters=CaseDurationEventFilters(field_ids=["nonexistent_field"]),
     )
 
-    result = duration_service._resolve_field(event, "data.changes.field")
-    assert result is None
-
-
-@pytest.mark.anyio
-async def test_matches_filters_with_array_resolved_values(
-    session: AsyncSession, svc_role
-) -> None:
-    """_matches_filters should work when _resolve_field returns a list from array traversal."""
-    from tracecat.db.models import CaseEvent
-
-    duration_service = CaseDurationService(session=session, role=svc_role)
-
-    event = CaseEvent(
-        workspace_id=uuid.uuid4(),
-        case_id=uuid.uuid4(),
-        type=CaseEventType.FIELDS_CHANGED,
-        data={
-            "changes": [
-                {"field": "severity_score", "old": 3, "new": 8},
-                {"field": "team", "old": "alpha", "new": "beta"},
-            ]
-        },
-    )
-
-    # Should match when filter value is in the resolved list
-    assert duration_service._matches_filters(
-        event, {"data.changes.field": ["severity_score"]}
-    )
-
-    # Should match when multiple filter values overlap
-    assert duration_service._matches_filters(
-        event, {"data.changes.field": ["severity_score", "unrelated"]}
-    )
-
-    # Should NOT match when filter value is not in the resolved list
-    assert not duration_service._matches_filters(
-        event, {"data.changes.field": ["nonexistent_field"]}
-    )
+    assert duration_service._matches_anchor_filters(event, anchor)
+    assert not duration_service._matches_anchor_filters(event, nonmatching_anchor)

--- a/tests/unit/test_case_duration_service.py
+++ b/tests/unit/test_case_duration_service.py
@@ -812,6 +812,110 @@ async def test_compute_durations_batch_multiple_cases(
 
 
 @pytest.mark.anyio
+async def test_compute_durations_batch_applies_start_bound_per_case(
+    session: AsyncSession, svc_role
+) -> None:
+    cases_service = CasesService(session=session, role=svc_role)
+    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    await definition_service.create_definition(
+        CaseDurationDefinitionCreate(
+            name="Time from progress to resolve",
+            start_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.STATUS_CHANGED,
+                filters=CaseDurationEventFilters(
+                    new_values=[CaseStatus.IN_PROGRESS.value]
+                ),
+            ),
+            end_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.STATUS_CHANGED,
+                filters=CaseDurationEventFilters(
+                    new_values=[CaseStatus.RESOLVED.value]
+                ),
+            ),
+        )
+    )
+
+    case1 = await cases_service.create_case(make_case_create(summary="Case 1"))
+    case2 = await cases_service.create_case(make_case_create(summary="Case 2"))
+    case3 = await cases_service.create_case(make_case_create(summary="Case 3"))
+    base_time = datetime.now(UTC)
+
+    case1_early_resolved = CaseEvent(
+        workspace_id=case1.workspace_id,
+        case_id=case1.id,
+        type=CaseEventType.STATUS_CHANGED,
+        data={"old": CaseStatus.NEW.value, "new": CaseStatus.RESOLVED.value},
+        created_at=base_time + timedelta(seconds=1),
+    )
+    case1_start = CaseEvent(
+        workspace_id=case1.workspace_id,
+        case_id=case1.id,
+        type=CaseEventType.STATUS_CHANGED,
+        data={"old": CaseStatus.NEW.value, "new": CaseStatus.IN_PROGRESS.value},
+        created_at=base_time + timedelta(seconds=2),
+    )
+    case1_end = CaseEvent(
+        workspace_id=case1.workspace_id,
+        case_id=case1.id,
+        type=CaseEventType.STATUS_CHANGED,
+        data={"old": CaseStatus.IN_PROGRESS.value, "new": CaseStatus.RESOLVED.value},
+        created_at=base_time + timedelta(seconds=3),
+    )
+    case2_start = CaseEvent(
+        workspace_id=case2.workspace_id,
+        case_id=case2.id,
+        type=CaseEventType.STATUS_CHANGED,
+        data={"old": CaseStatus.NEW.value, "new": CaseStatus.IN_PROGRESS.value},
+        created_at=base_time + timedelta(seconds=4),
+    )
+    case2_end = CaseEvent(
+        workspace_id=case2.workspace_id,
+        case_id=case2.id,
+        type=CaseEventType.STATUS_CHANGED,
+        data={"old": CaseStatus.IN_PROGRESS.value, "new": CaseStatus.RESOLVED.value},
+        created_at=base_time + timedelta(seconds=5),
+    )
+    case3_end_without_start = CaseEvent(
+        workspace_id=case3.workspace_id,
+        case_id=case3.id,
+        type=CaseEventType.STATUS_CHANGED,
+        data={"old": CaseStatus.NEW.value, "new": CaseStatus.RESOLVED.value},
+        created_at=base_time + timedelta(seconds=6),
+    )
+    session.add_all(
+        [
+            case1_early_resolved,
+            case1_start,
+            case1_end,
+            case2_start,
+            case2_end,
+            case3_end_without_start,
+        ]
+    )
+    await session.flush()
+
+    durations_by_case = await duration_service.compute_durations([case1, case2, case3])
+
+    case1_duration = durations_by_case[case1.id][0]
+    assert case1_duration.start_event_id == case1_start.id
+    assert case1_duration.end_event_id == case1_end.id
+    assert case1_duration.end_event_id != case1_early_resolved.id
+    assert case1_duration.duration is not None
+
+    case2_duration = durations_by_case[case2.id][0]
+    assert case2_duration.start_event_id == case2_start.id
+    assert case2_duration.end_event_id == case2_end.id
+    assert case2_duration.duration is not None
+
+    case3_duration = durations_by_case[case3.id][0]
+    assert case3_duration.start_event_id is None
+    assert case3_duration.end_event_id == case3_end_without_start.id
+    assert case3_duration.duration is None
+
+
+@pytest.mark.anyio
 async def test_compute_time_series_multiple_cases_with_mixed_completion(
     session: AsyncSession, svc_role
 ) -> None:
@@ -964,32 +1068,3 @@ async def test_duration_storage_marks_invalid_legacy_anchor_unsupported(
 
     assert anchor._has_unsupported_filters
     assert anchor.filters == CaseDurationEventFilters()
-
-
-@pytest.mark.anyio
-async def test_matches_custom_field_change_filters(
-    session: AsyncSession, svc_role
-) -> None:
-    duration_service = CaseDurationService(session=session, role=svc_role)
-    event = CaseEvent(
-        workspace_id=uuid.uuid4(),
-        case_id=uuid.uuid4(),
-        type=CaseEventType.FIELDS_CHANGED,
-        data={
-            "changes": [
-                {"field": "severity_score", "old": 3, "new": 8},
-                {"field": "team", "old": "alpha", "new": "beta"},
-            ]
-        },
-    )
-    anchor = CaseDurationEventAnchor(
-        event_type=CaseEventType.FIELDS_CHANGED,
-        filters=CaseDurationEventFilters(field_ids=["severity_score"]),
-    )
-    nonmatching_anchor = CaseDurationEventAnchor(
-        event_type=CaseEventType.FIELDS_CHANGED,
-        filters=CaseDurationEventFilters(field_ids=["nonexistent_field"]),
-    )
-
-    assert duration_service._matches_anchor_filters(event, anchor)
-    assert not duration_service._matches_anchor_filters(event, nonmatching_anchor)

--- a/tests/unit/test_case_duration_service.py
+++ b/tests/unit/test_case_duration_service.py
@@ -22,7 +22,7 @@ from tracecat.cases.enums import CaseEventType, CasePriority, CaseSeverity, Case
 from tracecat.cases.schemas import CaseCreate, CaseUpdate
 from tracecat.cases.service import CasesService
 from tracecat.cases.tags.service import CaseTagsService
-from tracecat.db.models import CaseDuration
+from tracecat.db.models import CaseDuration, CaseEvent
 from tracecat.tags.schemas import TagCreate
 
 pytestmark = pytest.mark.usefixtures("db")
@@ -215,6 +215,91 @@ async def test_duration_filters_support_multiple_values(
     updated_value = values[0]
     assert updated_value.end_event_id is not None
     assert updated_value.duration is not None
+
+
+@pytest.mark.anyio
+async def test_duration_filters_match_json_array_payload_overlap(
+    session: AsyncSession, svc_role
+) -> None:
+    cases_service = CasesService(session=session, role=svc_role)
+    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    await definition_service.create_definition(
+        CaseDurationDefinitionCreate(
+            name="Time to urgent update",
+            start_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.CASE_CREATED,
+            ),
+            end_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.FIELDS_CHANGED,
+                field_filters={"data.tags": ["urgent"]},
+            ),
+        )
+    )
+
+    case = await cases_service.create_case(make_case_create())
+    event = CaseEvent(
+        workspace_id=case.workspace_id,
+        case_id=case.id,
+        type=CaseEventType.FIELDS_CHANGED,
+        data={"tags": ["urgent", "vip"]},
+        created_at=datetime.now(UTC) + timedelta(seconds=1),
+    )
+    session.add(event)
+    await session.flush()
+
+    values = await duration_service.compute_duration(case)
+    assert len(values) == 1
+    assert values[0].end_event_id == event.id
+    assert values[0].duration is not None
+
+
+@pytest.mark.anyio
+async def test_duration_filters_preserve_json_value_types(
+    session: AsyncSession, svc_role
+) -> None:
+    cases_service = CasesService(session=session, role=svc_role)
+    definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    await definition_service.create_definition(
+        CaseDurationDefinitionCreate(
+            name="Time to counted update",
+            start_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.CASE_CREATED,
+            ),
+            end_anchor=CaseDurationEventAnchor(
+                event_type=CaseEventType.FIELDS_CHANGED,
+                field_filters={"data.count": 1},
+            ),
+        )
+    )
+
+    case = await cases_service.create_case(make_case_create())
+    first_event_time = datetime.now(UTC) + timedelta(seconds=1)
+    string_count_event = CaseEvent(
+        workspace_id=case.workspace_id,
+        case_id=case.id,
+        type=CaseEventType.FIELDS_CHANGED,
+        data={"count": "1"},
+        created_at=first_event_time,
+    )
+    numeric_count_event = CaseEvent(
+        workspace_id=case.workspace_id,
+        case_id=case.id,
+        type=CaseEventType.FIELDS_CHANGED,
+        data={"count": 1},
+        created_at=first_event_time + timedelta(seconds=1),
+    )
+    session.add_all([string_count_event, numeric_count_event])
+    await session.flush()
+
+    values = await duration_service.compute_duration(case)
+    assert len(values) == 1
+    assert values[0].end_event_id == numeric_count_event.id
+    assert values[0].end_event_id != string_count_event.id
+    assert values[0].duration is not None
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -5,7 +5,12 @@ from unittest.mock import patch
 
 import pytest
 
-from tracecat.concurrency import GatheringTaskGroup, apartial, cooperative
+from tracecat.concurrency import (
+    GatheringTaskGroup,
+    apartial,
+    cooperative,
+    cooperative_every,
+)
 
 
 @pytest.mark.anyio
@@ -268,6 +273,88 @@ async def test_cooperative_return_type():
     coop_gen = cooperative(items)
 
     assert isinstance(coop_gen, AsyncGenerator)
+
+
+@pytest.mark.anyio
+async def test_cooperative_every_basic():
+    """Test cooperative_every() with a basic list."""
+    items = [1, 2, 3, 4, 5]
+
+    result = []
+    async for item in cooperative_every(items, every=2):
+        result.append(item)
+
+    assert result == items
+
+
+@pytest.mark.anyio
+async def test_cooperative_every_sleep_frequency():
+    """Test that cooperative_every() sleeps once per checkpoint."""
+    items = [1, 2, 3, 4, 5]
+
+    with patch("asyncio.sleep") as mock_sleep:
+        mock_sleep.return_value = None
+
+        result = []
+        async for item in cooperative_every(items, every=2):
+            result.append(item)
+
+        assert result == items
+        assert mock_sleep.call_count == 2
+        for call in mock_sleep.call_args_list:
+            assert call[0] == (0,)
+
+
+@pytest.mark.anyio
+async def test_cooperative_every_custom_delay():
+    """Test cooperative_every() with a custom delay."""
+    items = [1, 2, 3, 4]
+    delay = 0.01
+
+    with patch("asyncio.sleep") as mock_sleep:
+        mock_sleep.return_value = None
+
+        result = []
+        async for item in cooperative_every(items, every=2, delay=delay):
+            result.append(item)
+
+        assert result == items
+        assert mock_sleep.call_count == 2
+        for call in mock_sleep.call_args_list:
+            assert call[0] == (delay,)
+
+
+@pytest.mark.anyio
+async def test_cooperative_every_allows_event_loop_cooperation():
+    """Test that cooperative_every() allows other tasks to run."""
+    items = list(range(10))
+    other_task_executed = False
+
+    async def other_task():
+        nonlocal other_task_executed
+        await asyncio.sleep(0.001)
+        other_task_executed = True
+
+    task = asyncio.create_task(other_task())
+
+    result = []
+    async for item in cooperative_every(items, every=3, delay=0.001):
+        result.append(item)
+        if len(result) == 6:
+            await asyncio.sleep(0.002)
+
+    await task
+
+    assert result == items
+    assert other_task_executed
+
+
+@pytest.mark.anyio
+async def test_cooperative_every_invalid_frequency():
+    """Test cooperative_every() validates the checkpoint frequency."""
+    with pytest.raises(ValueError, match="'every' must be greater than 0"):
+        async for _ in cooperative_every([1, 2, 3], every=0):
+            pass
 
 
 # Integration tests

--- a/tracecat/cases/durations/__init__.py
+++ b/tracecat/cases/durations/__init__.py
@@ -8,6 +8,7 @@ from .schemas import (
     CaseDurationDefinitionRead,
     CaseDurationDefinitionUpdate,
     CaseDurationEventAnchor,
+    CaseDurationEventFilters,
     CaseDurationRead,
     CaseDurationUpdate,
 )
@@ -21,6 +22,7 @@ __all__ = [
     "CaseDurationDefinitionService",  # pyright: ignore[reportUnsupportedDunderAll]
     "CaseDurationDefinitionUpdate",
     "CaseDurationEventAnchor",
+    "CaseDurationEventFilters",
     "CaseDurationRead",
     "CaseDurationService",  # pyright: ignore[reportUnsupportedDunderAll]
     "CaseDurationUpdate",

--- a/tracecat/cases/durations/schemas.py
+++ b/tracecat/cases/durations/schemas.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 from tracecat.cases.dropdowns.schemas import CaseDropdownValueRead
 from tracecat.cases.enums import CaseEventType
@@ -21,25 +21,51 @@ class CaseDurationAnchorSelection(StrEnum):
     LAST = "last"
 
 
+class CaseDurationEventFilters(BaseModel):
+    """Product-level filters for narrowing case duration event anchors."""
+
+    new_values: list[str] = Field(
+        default_factory=list,
+        description="New priority, severity, or status values to match.",
+    )
+    tag_refs: list[str] = Field(
+        default_factory=list,
+        description="Case tag refs to match for tag add/remove events.",
+    )
+    field_ids: list[str] = Field(
+        default_factory=list,
+        description="Case custom field IDs to match for field change events.",
+    )
+    dropdown_definition_id: str | None = Field(
+        default=None,
+        description="Dropdown definition ID to match for dropdown value change events.",
+    )
+    dropdown_option_ids: list[str] = Field(
+        default_factory=list,
+        description="Dropdown option IDs to match for dropdown value change events.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    def is_empty(self) -> bool:
+        return (
+            not self.new_values
+            and not self.tag_refs
+            and not self.field_ids
+            and self.dropdown_definition_id is None
+            and not self.dropdown_option_ids
+        )
+
+
 class CaseDurationEventAnchor(BaseModel):
     """Selection criteria describing an event boundary for a duration."""
 
     event_type: CaseEventType = Field(
         ..., description="Case event type that should be matched for this anchor."
     )
-    timestamp_path: str = Field(
-        default="created_at",
-        description=(
-            "Dot-delimited path to the timestamp field on the event. "
-            "Defaults to the event creation timestamp."
-        ),
-    )
-    field_filters: dict[str, Any] = Field(
-        default_factory=dict,
-        description=(
-            "Optional dot-delimited equality filters that must match on the event "
-            "payload, e.g. {'data.new': 'resolved'}."
-        ),
+    filters: CaseDurationEventFilters = Field(
+        default_factory=CaseDurationEventFilters,
+        description="Optional product-level filters for matching event payload values.",
     )
     selection: CaseDurationAnchorSelection = Field(
         default=CaseDurationAnchorSelection.FIRST,
@@ -48,6 +74,86 @@ class CaseDurationEventAnchor(BaseModel):
             "Defaults to the first match."
         ),
     )
+
+    model_config = ConfigDict(extra="forbid")
+
+    _has_unsupported_filters: bool = PrivateAttr(default=False)
+
+    @model_validator(mode="after")
+    def validate_filters_for_event_type(self) -> CaseDurationEventAnchor:
+        filters = self.filters
+        if filters.is_empty():
+            if self.event_type in _FILTER_REQUIRED_EVENT_TYPES:
+                raise ValueError(f"{self.event_type.value} requires filters")
+            return self
+
+        allowed_fields = _allowed_filter_fields_for_event_type(self.event_type)
+        active_fields = _active_filter_fields(filters)
+        unsupported = active_fields - allowed_fields
+        if unsupported:
+            fields = ", ".join(sorted(unsupported))
+            raise ValueError(
+                f"Unsupported filters for {self.event_type.value}: {fields}"
+            )
+
+        if self.event_type in _CATEGORY_FILTER_EVENT_TYPES and not filters.new_values:
+            raise ValueError(f"{self.event_type.value} requires new_values filters")
+        if self.event_type in _TAG_FILTER_EVENT_TYPES and not filters.tag_refs:
+            raise ValueError(f"{self.event_type.value} requires tag_refs filters")
+        if self.event_type is CaseEventType.FIELDS_CHANGED and not filters.field_ids:
+            raise ValueError("fields_changed requires field_ids filters")
+        if self.event_type is CaseEventType.DROPDOWN_VALUE_CHANGED and (
+            not filters.dropdown_definition_id or not filters.dropdown_option_ids
+        ):
+            raise ValueError(
+                "dropdown_value_changed requires dropdown_definition_id and "
+                "dropdown_option_ids filters"
+            )
+        return self
+
+
+_CATEGORY_FILTER_EVENT_TYPES = frozenset(
+    {
+        CaseEventType.PRIORITY_CHANGED,
+        CaseEventType.SEVERITY_CHANGED,
+        CaseEventType.STATUS_CHANGED,
+    }
+)
+_TAG_FILTER_EVENT_TYPES = frozenset(
+    {CaseEventType.TAG_ADDED, CaseEventType.TAG_REMOVED}
+)
+_FILTER_REQUIRED_EVENT_TYPES = (
+    _CATEGORY_FILTER_EVENT_TYPES
+    | _TAG_FILTER_EVENT_TYPES
+    | {CaseEventType.FIELDS_CHANGED, CaseEventType.DROPDOWN_VALUE_CHANGED}
+)
+
+
+def _active_filter_fields(filters: CaseDurationEventFilters) -> set[str]:
+    fields: set[str] = set()
+    if filters.new_values:
+        fields.add("new_values")
+    if filters.tag_refs:
+        fields.add("tag_refs")
+    if filters.field_ids:
+        fields.add("field_ids")
+    if filters.dropdown_definition_id is not None:
+        fields.add("dropdown_definition_id")
+    if filters.dropdown_option_ids:
+        fields.add("dropdown_option_ids")
+    return fields
+
+
+def _allowed_filter_fields_for_event_type(event_type: CaseEventType) -> set[str]:
+    if event_type in _CATEGORY_FILTER_EVENT_TYPES:
+        return {"new_values"}
+    if event_type in _TAG_FILTER_EVENT_TYPES:
+        return {"tag_refs"}
+    if event_type is CaseEventType.FIELDS_CHANGED:
+        return {"field_ids"}
+    if event_type is CaseEventType.DROPDOWN_VALUE_CHANGED:
+        return {"dropdown_definition_id", "dropdown_option_ids"}
+    return set()
 
 
 class CaseDurationDefinitionBase(BaseModel):

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -806,9 +806,16 @@ class CaseDurationService(BaseWorkspaceService):
                     isinstance(item, list | tuple | set | dict) for item in normalized
                 ):
                     return False
+                if any(self._has_bool_number_overlap(item) for item in normalized):
+                    return False
             elif isinstance(normalized, dict):
                 return False
+            elif self._has_bool_number_overlap(normalized):
+                return False
         return True
+
+    def _has_bool_number_overlap(self, value: Any) -> bool:
+        return isinstance(value, bool | int | float)
 
     def _build_sql_filter_conditions(
         self, filters: dict[str, Any]

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -25,6 +25,7 @@ from tracecat.cases.durations.schemas import (
     CaseDurationDefinitionRead,
     CaseDurationDefinitionUpdate,
     CaseDurationEventAnchor,
+    CaseDurationEventFilters,
     CaseDurationMetric,
     CaseDurationRead,
     CaseDurationUpdate,
@@ -38,7 +39,6 @@ from tracecat.exceptions import (
     TracecatValidationError,
 )
 from tracecat.service import BaseWorkspaceService, requires_entitlement
-from tracecat.tables.common import coerce_to_utc_datetime
 from tracecat.tiers.enums import Entitlement
 
 
@@ -182,23 +182,42 @@ class CaseDurationDefinitionService(BaseWorkspaceService):
     def _anchor_from_entity(
         self, entity: CaseDurationDefinitionDB, prefix: Literal["start", "end"]
     ) -> CaseDurationEventAnchor:
-        return CaseDurationEventAnchor(
-            event_type=getattr(entity, f"{prefix}_event_type"),
-            timestamp_path=getattr(entity, f"{prefix}_timestamp_path"),
-            field_filters=dict(getattr(entity, f"{prefix}_field_filters") or {}),
-            selection=getattr(entity, f"{prefix}_selection"),
+        raw_filters = dict(getattr(entity, f"{prefix}_field_filters") or {})
+        event_type = getattr(entity, f"{prefix}_event_type")
+        selection = getattr(entity, f"{prefix}_selection")
+        filters, has_unsupported_filters = self._filters_from_storage(
+            event_type, raw_filters
         )
+        if has_unsupported_filters:
+            anchor = CaseDurationEventAnchor.model_construct(
+                event_type=event_type,
+                filters=filters,
+                selection=selection,
+            )
+        else:
+            try:
+                anchor = CaseDurationEventAnchor(
+                    event_type=event_type,
+                    filters=filters,
+                    selection=selection,
+                )
+            except ValueError:
+                has_unsupported_filters = True
+                anchor = CaseDurationEventAnchor.model_construct(
+                    event_type=event_type,
+                    filters=filters,
+                    selection=selection,
+                )
+        anchor._has_unsupported_filters = has_unsupported_filters
+        return anchor
 
     def _anchor_attributes(
         self, anchor: CaseDurationEventAnchor, prefix: Literal["start", "end"]
     ) -> dict[str, Any]:
-        filters = {
-            key: self._json_compatible(value)
-            for key, value in anchor.field_filters.items()
-        }
+        filters = self._filters_to_storage(anchor.filters)
         return {
             f"{prefix}_event_type": anchor.event_type,
-            f"{prefix}_timestamp_path": anchor.timestamp_path,
+            f"{prefix}_timestamp_path": "created_at",
             f"{prefix}_field_filters": filters,
             f"{prefix}_selection": anchor.selection,
         }
@@ -220,6 +239,106 @@ class CaseDurationDefinitionService(BaseWorkspaceService):
         if isinstance(value, list | tuple | set):
             return [self._json_compatible(item) for item in value]
         return value
+
+    def _filters_to_storage(self, filters: CaseDurationEventFilters) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        if filters.new_values:
+            payload["new_values"] = self._json_compatible(filters.new_values)
+        if filters.tag_refs:
+            payload["tag_refs"] = self._json_compatible(filters.tag_refs)
+        if filters.field_ids:
+            payload["field_ids"] = self._json_compatible(filters.field_ids)
+        if filters.dropdown_definition_id is not None:
+            payload["dropdown_definition_id"] = self._json_compatible(
+                filters.dropdown_definition_id
+            )
+        if filters.dropdown_option_ids:
+            payload["dropdown_option_ids"] = self._json_compatible(
+                filters.dropdown_option_ids
+            )
+        return payload
+
+    def _filters_from_storage(
+        self, event_type: CaseEventType, raw_filters: dict[str, Any]
+    ) -> tuple[CaseDurationEventFilters, bool]:
+        if not raw_filters:
+            return CaseDurationEventFilters(), False
+
+        if self._storage_filters_are_typed(raw_filters):
+            return CaseDurationEventFilters.model_validate(raw_filters), False
+
+        filters = self._known_legacy_filters_to_typed(event_type, raw_filters)
+        if filters is not None:
+            return filters, False
+        return CaseDurationEventFilters(), True
+
+    def _storage_filters_are_typed(self, raw_filters: dict[str, Any]) -> bool:
+        typed_keys = {
+            "new_values",
+            "tag_refs",
+            "field_ids",
+            "dropdown_definition_id",
+            "dropdown_option_ids",
+        }
+        return all(key in typed_keys for key in raw_filters)
+
+    def _known_legacy_filters_to_typed(
+        self, event_type: CaseEventType, raw_filters: dict[str, Any]
+    ) -> CaseDurationEventFilters | None:
+        if event_type in {
+            CaseEventType.PRIORITY_CHANGED,
+            CaseEventType.SEVERITY_CHANGED,
+            CaseEventType.STATUS_CHANGED,
+        }:
+            if set(raw_filters) == {"data.new"}:
+                values = self._normalize_string_filter_values(raw_filters["data.new"])
+                return CaseDurationEventFilters(new_values=values) if values else None
+            return None
+
+        if event_type in {CaseEventType.TAG_ADDED, CaseEventType.TAG_REMOVED}:
+            if set(raw_filters) == {"data.tag_ref"}:
+                values = self._normalize_string_filter_values(
+                    raw_filters["data.tag_ref"]
+                )
+                return CaseDurationEventFilters(tag_refs=values) if values else None
+            return None
+
+        if event_type is CaseEventType.FIELDS_CHANGED:
+            if set(raw_filters) == {"data.changes.field"}:
+                values = self._normalize_string_filter_values(
+                    raw_filters["data.changes.field"]
+                )
+                return CaseDurationEventFilters(field_ids=values) if values else None
+            return None
+
+        if event_type is CaseEventType.DROPDOWN_VALUE_CHANGED:
+            if set(raw_filters) == {"data.definition_id", "data.new_option_id"}:
+                definition_id = raw_filters["data.definition_id"]
+                if not isinstance(definition_id, str):
+                    return None
+                option_ids = self._normalize_string_filter_values(
+                    raw_filters["data.new_option_id"]
+                )
+                if not option_ids:
+                    return None
+                return CaseDurationEventFilters(
+                    dropdown_definition_id=definition_id,
+                    dropdown_option_ids=option_ids,
+                )
+        return None
+
+    def _normalize_string_filter_values(self, value: Any) -> list[str]:
+        if isinstance(value, Enum):
+            return [str(value.value)]
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, list | tuple | set):
+            return [
+                str(item.value) if isinstance(item, Enum) else item
+                for item in value
+                if isinstance(item, str | Enum)
+            ]
+        return []
 
 
 class CaseDurationService(BaseWorkspaceService):
@@ -341,13 +460,7 @@ class CaseDurationService(BaseWorkspaceService):
         if not definitions:
             return []
 
-        if computations := await self._compute_durations_from_db(case_obj, definitions):
-            return computations
-
-        events = await self._list_case_events(case_obj)
-        return await asyncio.to_thread(
-            self._compute_durations_from_events, events, definitions
-        )
+        return await self._compute_durations_from_db(case_obj, definitions)
 
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def compute_durations(
@@ -534,7 +647,7 @@ class CaseDurationService(BaseWorkspaceService):
         self,
         case: Case,
         definitions: Sequence[CaseDurationDefinitionRead],
-    ) -> list[CaseDurationComputation] | None:
+    ) -> list[CaseDurationComputation]:
         start_match_cache: dict[tuple[Any, ...], tuple[CaseEvent, datetime] | None] = {}
         end_match_cache: dict[
             tuple[tuple[Any, ...], datetime | None], tuple[CaseEvent, datetime] | None
@@ -545,8 +658,6 @@ class CaseDurationService(BaseWorkspaceService):
         # cache-hit-heavy definition sets from monopolizing the event loop.
         async for definition in cooperative_every(definitions, every=64):
             start_anchor_key = self._sql_anchor_cache_key(definition.start_anchor)
-            if start_anchor_key is None:
-                return None
             if start_anchor_key not in start_match_cache:
                 start_match_cache[
                     start_anchor_key
@@ -558,8 +669,6 @@ class CaseDurationService(BaseWorkspaceService):
 
             earliest_after = start_match[1] if start_match else None
             end_anchor_base_key = self._sql_anchor_cache_key(definition.end_anchor)
-            if end_anchor_base_key is None:
-                return None
             end_anchor_key = (end_anchor_base_key, earliest_after)
             if end_anchor_key not in end_match_cache:
                 end_match_cache[end_anchor_key] = await self._find_matching_event_db(
@@ -688,18 +797,6 @@ class CaseDurationService(BaseWorkspaceService):
             raise TracecatNotFoundError(f"Case {case} not found in this workspace")
         return resolved
 
-    async def _list_case_events(self, case: Case) -> list[CaseEvent]:
-        stmt = (
-            select(CaseEvent)
-            .where(
-                CaseEvent.case_id == case.id,
-                CaseEvent.workspace_id == self.workspace_id,
-            )
-            .order_by(CaseEvent.created_at.asc())
-        )
-        result = await self.session.execute(stmt)
-        return list(result.scalars().all())
-
     def _find_matching_event(
         self,
         events: Sequence[CaseEvent],
@@ -722,7 +819,7 @@ class CaseDurationService(BaseWorkspaceService):
                     continue
             elif event.type != anchor.event_type:
                 continue
-            if not self._matches_filters(event, anchor.field_filters):
+            if not self._matches_anchor_filters(event, anchor):
                 continue
             timestamp = self._extract_timestamp(event, anchor)
             if timestamp is None:
@@ -768,10 +865,7 @@ class CaseDurationService(BaseWorkspaceService):
         if earliest_after is not None:
             conditions.append(CaseEvent.created_at >= earliest_after)
 
-        filter_conditions = self._build_sql_filter_conditions(anchor.field_filters)
-        if filter_conditions is None:
-            return None
-        conditions.extend(filter_conditions)
+        conditions.extend(self._build_sql_filter_conditions(anchor))
 
         order_by = (
             (CaseEvent.created_at.desc(), CaseEvent.surrogate_id.desc())
@@ -784,64 +878,40 @@ class CaseDurationService(BaseWorkspaceService):
             return None
         return event, event.created_at
 
-    def _sql_anchor_cache_key(
-        self, anchor: CaseDurationEventAnchor
-    ) -> tuple[Any, ...] | None:
-        if anchor.timestamp_path != "created_at":
-            return None
-        if not self._filters_are_sql_compatible(anchor.field_filters):
-            return None
+    def _sql_anchor_cache_key(self, anchor: CaseDurationEventAnchor) -> tuple[Any, ...]:
         return self._anchor_cache_key(anchor)
 
-    def _filters_are_sql_compatible(self, filters: dict[str, Any]) -> bool:
-        for path, expected in filters.items():
-            parts = path.split(".")
-            # Deeper paths may traverse arrays in _resolve_field; keep them on
-            # the Python path until the SQL builder can mirror that behavior.
-            if len(parts) != 2 or parts[0] != "data" or not parts[1]:
-                return False
-            normalized = self._normalize_filter_value(expected)
-            if isinstance(normalized, list):
-                if any(
-                    isinstance(item, list | tuple | set | dict) for item in normalized
-                ):
-                    return False
-                if any(self._has_bool_number_overlap(item) for item in normalized):
-                    return False
-            elif isinstance(normalized, dict):
-                return False
-            elif self._has_bool_number_overlap(normalized):
-                return False
-        return True
-
-    def _has_bool_number_overlap(self, value: Any) -> bool:
-        return isinstance(value, bool | int | float)
-
     def _build_sql_filter_conditions(
-        self, filters: dict[str, Any]
-    ) -> list[ColumnElement[bool]] | None:
-        if not self._filters_are_sql_compatible(filters):
-            return None
-
+        self, anchor: CaseDurationEventAnchor
+    ) -> list[ColumnElement[bool]]:
+        filters = anchor.filters
         conditions: list[ColumnElement[bool]] = []
-        for path, expected in filters.items():
-            parts = path.split(".")
-            if len(parts) != 2 or parts[0] != "data" or not parts[1]:
-                return None
-
-            value_expr: Any = CaseEvent.data
-            for part in parts[1:]:
-                value_expr = value_expr[part]
-
-            normalized = self._normalize_filter_value(expected)
-            if isinstance(normalized, list):
-                conditions.append(self._build_jsonb_list_filter(value_expr, normalized))
-            elif normalized is None:
-                conditions.append(
-                    or_(value_expr.is_(None), value_expr == self._jsonb_bindparam(None))
+        if anchor._has_unsupported_filters:
+            conditions.append(false())
+            return conditions
+        if filters.new_values:
+            conditions.append(
+                self._build_jsonb_list_filter(CaseEvent.data["new"], filters.new_values)
+            )
+        if filters.tag_refs:
+            conditions.append(
+                self._build_jsonb_list_filter(
+                    CaseEvent.data["tag_ref"], filters.tag_refs
                 )
-            else:
-                conditions.append(value_expr == self._jsonb_bindparam(normalized))
+            )
+        if filters.field_ids:
+            conditions.append(self._build_jsonb_change_field_filter(filters.field_ids))
+        if filters.dropdown_definition_id is not None:
+            conditions.append(
+                CaseEvent.data["definition_id"]
+                == self._jsonb_bindparam(filters.dropdown_definition_id)
+            )
+        if filters.dropdown_option_ids:
+            conditions.append(
+                self._build_jsonb_list_filter(
+                    CaseEvent.data["new_option_id"], filters.dropdown_option_ids
+                )
+            )
         return conditions
 
     def _build_jsonb_list_filter(
@@ -873,97 +943,106 @@ class CaseDurationService(BaseWorkspaceService):
         )
         return or_(scalar_matches, array_matches)
 
+    def _build_jsonb_change_field_filter(
+        self, field_ids: list[str]
+    ) -> ColumnElement[bool]:
+        if not field_ids:
+            return false()
+
+        changes_value = sql_case(
+            (
+                func.jsonb_typeof(CaseEvent.data["changes"]) == "array",
+                CaseEvent.data["changes"],
+            ),
+            else_=literal([], type_=JSONB),
+        )
+        elem = (
+            func.jsonb_array_elements(changes_value)
+            .table_valued(column("value", JSONB))
+            .alias("change_elem")
+        )
+        return (
+            select(literal(True))
+            .select_from(elem)
+            .where(
+                elem.c.value["field"].in_(
+                    [self._jsonb_bindparam(field_id) for field_id in field_ids]
+                )
+            )
+            .correlate(CaseEvent)
+            .exists()
+        )
+
     def _jsonb_bindparam(self, value: Any) -> ColumnElement[Any]:
         return bindparam(None, value, type_=JSONB)
 
     def _anchor_cache_key(self, anchor: CaseDurationEventAnchor) -> tuple[Any, ...]:
-        filter_items = tuple(
-            sorted(
-                (
-                    path,
-                    self._freeze_filter_value(expected),
-                )
-                for path, expected in anchor.field_filters.items()
-            )
+        filter_items = self._freeze_filter_value(
+            anchor.filters.model_dump(exclude_defaults=True)
         )
         return (
             anchor.event_type,
-            anchor.timestamp_path,
             anchor.selection,
             filter_items,
+            anchor._has_unsupported_filters,
         )
 
     def _freeze_filter_value(self, value: Any) -> Any:
-        normalized = self._normalize_filter_value(value)
-        if isinstance(normalized, list):
-            return tuple(self._freeze_filter_value(item) for item in normalized)
-        if isinstance(normalized, dict):
-            return tuple(
-                sorted(
-                    (key, self._freeze_filter_value(item))
-                    for key, item in normalized.items()
-                )
-            )
-        return normalized
-
-    def _matches_filters(self, event: CaseEvent, filters: dict[str, Any]) -> bool:
-        for path, expected in filters.items():
-            actual = self._resolve_field(event, path)
-            actual_normalized = self._normalize_filter_value(actual)
-            expected_normalized = self._normalize_filter_value(expected)
-            if isinstance(expected_normalized, list):
-                if actual_normalized is None:
-                    return False
-                if isinstance(actual_normalized, list):
-                    if not any(
-                        item in expected_normalized for item in actual_normalized
-                    ):
-                        return False
-                elif actual_normalized not in expected_normalized:
-                    return False
-            elif actual_normalized != expected_normalized:
-                return False
-        return True
-
-    def _normalize_filter_value(self, value: Any) -> Any:
         if isinstance(value, Enum):
             return value.value
         if isinstance(value, list | tuple | set):
-            return [self._normalize_filter_value(item) for item in value]
+            return tuple(self._freeze_filter_value(item) for item in value)
+        if isinstance(value, dict):
+            return tuple(
+                sorted(
+                    (key, self._freeze_filter_value(item))
+                    for key, item in value.items()
+                )
+            )
         return value
+
+    def _matches_anchor_filters(
+        self, event: CaseEvent, anchor: CaseDurationEventAnchor
+    ) -> bool:
+        if anchor._has_unsupported_filters:
+            return False
+
+        filters = anchor.filters
+        data = event.data or {}
+        if filters.new_values and data.get("new") not in filters.new_values:
+            return False
+        if filters.tag_refs and data.get("tag_ref") not in filters.tag_refs:
+            return False
+        if filters.field_ids and not self._event_changed_any_field(
+            event, filters.field_ids
+        ):
+            return False
+        if (
+            filters.dropdown_definition_id is not None
+            and data.get("definition_id") != filters.dropdown_definition_id
+        ):
+            return False
+        if (
+            filters.dropdown_option_ids
+            and data.get("new_option_id") not in filters.dropdown_option_ids
+        ):
+            return False
+        return True
+
+    def _event_changed_any_field(self, event: CaseEvent, field_ids: list[str]) -> bool:
+        changes = (event.data or {}).get("changes")
+        if not isinstance(changes, list):
+            return False
+        return any(
+            isinstance(change, dict) and change.get("field") in field_ids
+            for change in changes
+        )
 
     def _extract_timestamp(
         self, event: CaseEvent, anchor: CaseDurationEventAnchor
     ) -> datetime | None:
-        value = self._resolve_field(event, anchor.timestamp_path)
-        try:
-            return coerce_to_utc_datetime(value)
-        except (TypeError, ValueError, OverflowError):
-            return None
-
-    def _resolve_field(self, event: CaseEvent, path: str) -> Any:
-        value: Any = event
-        for part in path.split("."):
-            if isinstance(value, list):
-                # Traverse into each list item and collect the resolved values
-                collected = []
-                for item in value:
-                    if isinstance(item, dict):
-                        resolved = item.get(part)
-                    else:
-                        resolved = getattr(item, part, None)
-                    if resolved is not None:
-                        collected.append(resolved)
-                if not collected:
-                    return None
-                value = collected
-            elif isinstance(value, dict):
-                value = value.get(part)
-            else:
-                value = getattr(value, part, None)
-            if value is None:
-                return None
-        return value
+        del anchor
+        return event.created_at
 
     def _to_read_model(self, entity: CaseDuration) -> CaseDurationRead:
         return CaseDurationRead(

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import Sequence
 from datetime import datetime
@@ -337,7 +338,9 @@ class CaseDurationService(BaseWorkspaceService):
             return []
 
         events = await self._list_case_events(case_obj)
-        return self._compute_durations_from_events(events, definitions)
+        return await asyncio.to_thread(
+            self._compute_durations_from_events, events, definitions
+        )
 
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def compute_durations(
@@ -381,11 +384,11 @@ class CaseDurationService(BaseWorkspaceService):
         for event in all_events:
             events_by_case[event.case_id].append(event)
 
-        # Compute durations for each case
-        return {
-            case_id: self._compute_durations_from_events(events, definitions)
-            for case_id, events in events_by_case.items()
-        }
+        return await asyncio.to_thread(
+            self._compute_durations_by_case,
+            events_by_case,
+            definitions,
+        )
 
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def compute_time_series(
@@ -463,13 +466,30 @@ class CaseDurationService(BaseWorkspaceService):
     ) -> list[CaseDurationComputation]:
         """Pure computation of durations from events and definitions."""
         results: list[CaseDurationComputation] = []
+        start_match_cache: dict[tuple[Any, ...], tuple[CaseEvent, datetime] | None] = {}
+        end_match_cache: dict[
+            tuple[tuple[Any, ...], datetime | None], tuple[CaseEvent, datetime] | None
+        ] = {}
         for definition in definitions:
-            start_match = self._find_matching_event(events, definition.start_anchor)
-            end_match = self._find_matching_event(
-                events,
-                definition.end_anchor,
-                earliest_after=start_match[1] if start_match else None,
+            start_anchor_key = self._anchor_cache_key(definition.start_anchor)
+            if start_anchor_key not in start_match_cache:
+                start_match_cache[start_anchor_key] = self._find_matching_event(
+                    events, definition.start_anchor
+                )
+            start_match = start_match_cache[start_anchor_key]
+
+            earliest_after = start_match[1] if start_match else None
+            end_anchor_key = (
+                self._anchor_cache_key(definition.end_anchor),
+                earliest_after,
             )
+            if end_anchor_key not in end_match_cache:
+                end_match_cache[end_anchor_key] = self._find_matching_event(
+                    events,
+                    definition.end_anchor,
+                    earliest_after=earliest_after,
+                )
+            end_match = end_match_cache[end_anchor_key]
 
             started_at = start_match[1] if start_match else None
             ended_at = end_match[1] if end_match else None
@@ -492,6 +512,16 @@ class CaseDurationService(BaseWorkspaceService):
             )
 
         return results
+
+    def _compute_durations_by_case(
+        self,
+        events_by_case: dict[uuid.UUID, list[CaseEvent]],
+        definitions: Sequence[CaseDurationDefinitionRead],
+    ) -> dict[uuid.UUID, list[CaseDurationComputation]]:
+        return {
+            case_id: self._compute_durations_from_events(events, definitions)
+            for case_id, events in events_by_case.items()
+        }
 
     async def sync_case_durations(
         self, case: Case | uuid.UUID
@@ -609,7 +639,7 @@ class CaseDurationService(BaseWorkspaceService):
         *,
         earliest_after: datetime | None = None,
     ) -> tuple[CaseEvent, datetime] | None:
-        candidates: list[tuple[CaseEvent, datetime]] = []
+        best_match: tuple[CaseEvent, datetime] | None = None
         for event in events:
             # A transition to `closed` is emitted as `case_closed` (and reopening
             # as `case_reopened`), so exact matching on `status_changed` would
@@ -631,14 +661,46 @@ class CaseDurationService(BaseWorkspaceService):
                 continue
             if earliest_after and timestamp < earliest_after:
                 continue
-            candidates.append((event, timestamp))
+            if best_match is None:
+                best_match = (event, timestamp)
+                continue
+            if anchor.selection is CaseDurationAnchorSelection.LAST:
+                if timestamp >= best_match[1]:
+                    best_match = (event, timestamp)
+            elif timestamp < best_match[1]:
+                best_match = (event, timestamp)
 
-        if not candidates:
-            return None
-        candidates.sort(key=lambda item: item[1])
-        if anchor.selection is CaseDurationAnchorSelection.LAST:
-            return candidates[-1]
-        return candidates[0]
+        return best_match
+
+    def _anchor_cache_key(self, anchor: CaseDurationEventAnchor) -> tuple[Any, ...]:
+        filter_items = tuple(
+            sorted(
+                (
+                    path,
+                    self._freeze_filter_value(expected),
+                )
+                for path, expected in anchor.field_filters.items()
+            )
+        )
+        return (
+            anchor.event_type,
+            anchor.timestamp_path,
+            anchor.selection,
+            filter_items,
+        )
+
+    def _freeze_filter_value(self, value: Any) -> Any:
+        normalized = self._normalize_filter_value(value)
+        if isinstance(normalized, list):
+            return tuple(self._freeze_filter_value(item) for item in normalized)
+        if isinstance(normalized, dict):
+            return tuple(
+                sorted(
+                    (key, self._freeze_filter_value(item))
+                    for key, item in normalized.items()
+                )
+            )
+        return normalized
 
     def _matches_filters(self, event: CaseEvent, filters: dict[str, Any]) -> bool:
         for path, expected in filters.items():

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 from slugify import slugify
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
 
 from tracecat.auth.types import Role
 from tracecat.cases.durations.schemas import (
@@ -27,6 +28,7 @@ from tracecat.cases.durations.schemas import (
     CaseDurationUpdate,
 )
 from tracecat.cases.enums import CaseEventType
+from tracecat.concurrency import cooperative_every
 from tracecat.db.models import Case, CaseDuration, CaseEvent
 from tracecat.db.models import CaseDurationDefinition as CaseDurationDefinitionDB
 from tracecat.exceptions import (
@@ -337,6 +339,9 @@ class CaseDurationService(BaseWorkspaceService):
         if not definitions:
             return []
 
+        if computations := await self._compute_durations_from_db(case_obj, definitions):
+            return computations
+
         events = await self._list_case_events(case_obj)
         return await asyncio.to_thread(
             self._compute_durations_from_events, events, definitions
@@ -523,6 +528,67 @@ class CaseDurationService(BaseWorkspaceService):
             for case_id, events in events_by_case.items()
         }
 
+    async def _compute_durations_from_db(
+        self,
+        case: Case,
+        definitions: Sequence[CaseDurationDefinitionRead],
+    ) -> list[CaseDurationComputation] | None:
+        start_match_cache: dict[tuple[Any, ...], tuple[CaseEvent, datetime] | None] = {}
+        end_match_cache: dict[
+            tuple[tuple[Any, ...], datetime | None], tuple[CaseEvent, datetime] | None
+        ] = {}
+        results: list[CaseDurationComputation] = []
+
+        # Most iterations await on DB I/O, but periodic checkpoints keep
+        # cache-hit-heavy definition sets from monopolizing the event loop.
+        async for definition in cooperative_every(definitions, every=64):
+            start_anchor_key = self._sql_anchor_cache_key(definition.start_anchor)
+            if start_anchor_key is None:
+                return None
+            if start_anchor_key not in start_match_cache:
+                start_match_cache[
+                    start_anchor_key
+                ] = await self._find_matching_event_db(
+                    case.id,
+                    definition.start_anchor,
+                )
+            start_match = start_match_cache[start_anchor_key]
+
+            earliest_after = start_match[1] if start_match else None
+            end_anchor_base_key = self._sql_anchor_cache_key(definition.end_anchor)
+            if end_anchor_base_key is None:
+                return None
+            end_anchor_key = (end_anchor_base_key, earliest_after)
+            if end_anchor_key not in end_match_cache:
+                end_match_cache[end_anchor_key] = await self._find_matching_event_db(
+                    case.id,
+                    definition.end_anchor,
+                    earliest_after=earliest_after,
+                )
+            end_match = end_match_cache[end_anchor_key]
+
+            started_at = start_match[1] if start_match else None
+            ended_at = end_match[1] if end_match else None
+            if started_at and ended_at and ended_at < started_at:
+                end_match = None
+                ended_at = None
+            duration = ended_at - started_at if started_at and ended_at else None
+
+            results.append(
+                CaseDurationComputation(
+                    duration_id=definition.id,
+                    name=definition.name,
+                    description=definition.description,
+                    start_event_id=start_match[0].id if start_match else None,
+                    end_event_id=end_match[0].id if end_match else None,
+                    started_at=started_at,
+                    ended_at=ended_at,
+                    duration=duration,
+                )
+            )
+
+        return results
+
     async def sync_case_durations(
         self, case: Case | uuid.UUID
     ) -> list[CaseDurationComputation]:
@@ -671,6 +737,100 @@ class CaseDurationService(BaseWorkspaceService):
                 best_match = (event, timestamp)
 
         return best_match
+
+    async def _find_matching_event_db(
+        self,
+        case_id: uuid.UUID,
+        anchor: CaseDurationEventAnchor,
+        *,
+        earliest_after: datetime | None = None,
+    ) -> tuple[CaseEvent, datetime] | None:
+        conditions: list[ColumnElement[bool]] = [
+            CaseEvent.workspace_id == self.workspace_id,
+            CaseEvent.case_id == case_id,
+        ]
+
+        if anchor.event_type is CaseEventType.STATUS_CHANGED:
+            conditions.append(
+                CaseEvent.type.in_(
+                    (
+                        CaseEventType.STATUS_CHANGED,
+                        CaseEventType.CASE_CLOSED,
+                        CaseEventType.CASE_REOPENED,
+                    )
+                )
+            )
+        else:
+            conditions.append(CaseEvent.type == anchor.event_type)
+
+        if earliest_after is not None:
+            conditions.append(CaseEvent.created_at >= earliest_after)
+
+        filter_conditions = self._build_sql_filter_conditions(anchor.field_filters)
+        if filter_conditions is None:
+            return None
+        conditions.extend(filter_conditions)
+
+        order_by = (
+            (CaseEvent.created_at.desc(), CaseEvent.surrogate_id.desc())
+            if anchor.selection is CaseDurationAnchorSelection.LAST
+            else (CaseEvent.created_at.asc(), CaseEvent.surrogate_id.asc())
+        )
+        stmt = select(CaseEvent).where(*conditions).order_by(*order_by).limit(1)
+        result = await self.session.execute(stmt)
+        if (event := result.scalars().first()) is None:
+            return None
+        return event, event.created_at
+
+    def _sql_anchor_cache_key(
+        self, anchor: CaseDurationEventAnchor
+    ) -> tuple[Any, ...] | None:
+        if anchor.timestamp_path != "created_at":
+            return None
+        if not self._filters_are_sql_compatible(anchor.field_filters):
+            return None
+        return self._anchor_cache_key(anchor)
+
+    def _filters_are_sql_compatible(self, filters: dict[str, Any]) -> bool:
+        for path, expected in filters.items():
+            if not path.startswith("data."):
+                return False
+            normalized = self._normalize_filter_value(expected)
+            if isinstance(normalized, list):
+                if any(
+                    isinstance(item, list | tuple | set | dict) for item in normalized
+                ):
+                    return False
+            elif isinstance(normalized, dict):
+                return False
+        return True
+
+    def _build_sql_filter_conditions(
+        self, filters: dict[str, Any]
+    ) -> list[ColumnElement[bool]] | None:
+        if not self._filters_are_sql_compatible(filters):
+            return None
+
+        conditions: list[ColumnElement[bool]] = []
+        for path, expected in filters.items():
+            parts = path.split(".")
+            if not parts or parts[0] != "data" or len(parts) < 2:
+                return None
+
+            value_expr = CaseEvent.data
+            for part in parts[1:]:
+                value_expr = value_expr[part]
+
+            normalized = self._normalize_filter_value(expected)
+            if isinstance(normalized, list):
+                conditions.append(
+                    value_expr.astext.in_([str(item) for item in normalized])
+                )
+            elif normalized is None:
+                conditions.append(value_expr.is_(None))
+            else:
+                conditions.append(value_expr.astext == str(normalized))
+        return conditions
 
     def _anchor_cache_key(self, anchor: CaseDurationEventAnchor) -> tuple[Any, ...]:
         filter_items = tuple(

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import uuid
 from collections.abc import Sequence
 from datetime import datetime
@@ -10,9 +9,21 @@ from enum import Enum
 from typing import Any, Literal
 
 from slugify import slugify
-from sqlalchemy import bindparam, column, false, func, literal, or_, select
+from sqlalchemy import (
+    DateTime,
+    bindparam,
+    cast,
+    column,
+    false,
+    func,
+    literal,
+    or_,
+    select,
+)
 from sqlalchemy import case as sql_case
+from sqlalchemy import values as sql_values
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -40,6 +51,8 @@ from tracecat.exceptions import (
 )
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tiers.enums import Entitlement
+
+type _DurationEventMatch = tuple[uuid.UUID, datetime]
 
 
 class CaseDurationDefinitionService(BaseWorkspaceService):
@@ -468,8 +481,8 @@ class CaseDurationService(BaseWorkspaceService):
     ) -> dict[uuid.UUID, list[CaseDurationComputation]]:
         """Compute durations for multiple cases efficiently.
 
-        Fetches definitions once and all events in a single query,
-        then computes durations for each case.
+        Fetches definitions once, then batches each unique anchor lookup across all
+        cases so PostgreSQL handles event filtering and first/last selection.
 
         Args:
             cases: Sequence of Case objects (must belong to workspace).
@@ -484,29 +497,9 @@ class CaseDurationService(BaseWorkspaceService):
         if not definitions:
             return {case.id: [] for case in cases}
 
-        # Fetch all events for all cases in one query
-        case_ids = [case.id for case in cases]
-        stmt = (
-            select(CaseEvent)
-            .where(
-                CaseEvent.workspace_id == self.workspace_id,
-                CaseEvent.case_id.in_(case_ids),
-            )
-            .order_by(CaseEvent.case_id.asc(), CaseEvent.created_at.asc())
-        )
-        result = await self.session.execute(stmt)
-        all_events = list(result.scalars().all())
-
-        # Group events by case_id
-        events_by_case: dict[uuid.UUID, list[CaseEvent]] = {
-            case_id: [] for case_id in case_ids
-        }
-        for event in all_events:
-            events_by_case[event.case_id].append(event)
-
-        return await asyncio.to_thread(
-            self._compute_durations_by_case,
-            events_by_case,
+        case_ids = list(dict.fromkeys(case.id for case in cases))
+        return await self._compute_durations_from_db_for_cases(
+            case_ids,
             definitions,
         )
 
@@ -579,80 +572,35 @@ class CaseDurationService(BaseWorkspaceService):
                 )
         return metrics
 
-    def _compute_durations_from_events(
-        self,
-        events: Sequence[CaseEvent],
-        definitions: Sequence[CaseDurationDefinitionRead],
-    ) -> list[CaseDurationComputation]:
-        """Pure computation of durations from events and definitions."""
-        results: list[CaseDurationComputation] = []
-        start_match_cache: dict[tuple[Any, ...], tuple[CaseEvent, datetime] | None] = {}
-        end_match_cache: dict[
-            tuple[tuple[Any, ...], datetime | None], tuple[CaseEvent, datetime] | None
-        ] = {}
-        for definition in definitions:
-            start_anchor_key = self._anchor_cache_key(definition.start_anchor)
-            if start_anchor_key not in start_match_cache:
-                start_match_cache[start_anchor_key] = self._find_matching_event(
-                    events, definition.start_anchor
-                )
-            start_match = start_match_cache[start_anchor_key]
-
-            earliest_after = start_match[1] if start_match else None
-            end_anchor_key = (
-                self._anchor_cache_key(definition.end_anchor),
-                earliest_after,
-            )
-            if end_anchor_key not in end_match_cache:
-                end_match_cache[end_anchor_key] = self._find_matching_event(
-                    events,
-                    definition.end_anchor,
-                    earliest_after=earliest_after,
-                )
-            end_match = end_match_cache[end_anchor_key]
-
-            started_at = start_match[1] if start_match else None
-            ended_at = end_match[1] if end_match else None
-            if started_at and ended_at and ended_at < started_at:
-                end_match = None
-                ended_at = None
-            duration = ended_at - started_at if started_at and ended_at else None
-
-            results.append(
-                CaseDurationComputation(
-                    duration_id=definition.id,
-                    name=definition.name,
-                    description=definition.description,
-                    start_event_id=start_match[0].id if start_match else None,
-                    end_event_id=end_match[0].id if end_match else None,
-                    started_at=started_at,
-                    ended_at=ended_at,
-                    duration=duration,
-                )
-            )
-
-        return results
-
-    def _compute_durations_by_case(
-        self,
-        events_by_case: dict[uuid.UUID, list[CaseEvent]],
-        definitions: Sequence[CaseDurationDefinitionRead],
-    ) -> dict[uuid.UUID, list[CaseDurationComputation]]:
-        return {
-            case_id: self._compute_durations_from_events(events, definitions)
-            for case_id, events in events_by_case.items()
-        }
-
     async def _compute_durations_from_db(
         self,
         case: Case,
         definitions: Sequence[CaseDurationDefinitionRead],
     ) -> list[CaseDurationComputation]:
-        start_match_cache: dict[tuple[Any, ...], tuple[CaseEvent, datetime] | None] = {}
-        end_match_cache: dict[
-            tuple[tuple[Any, ...], datetime | None], tuple[CaseEvent, datetime] | None
+        durations_by_case = await self._compute_durations_from_db_for_cases(
+            [case.id],
+            definitions,
+        )
+        return durations_by_case.get(case.id, [])
+
+    async def _compute_durations_from_db_for_cases(
+        self,
+        case_ids: Sequence[uuid.UUID],
+        definitions: Sequence[CaseDurationDefinitionRead],
+    ) -> dict[uuid.UUID, list[CaseDurationComputation]]:
+        results_by_case: dict[uuid.UUID, list[CaseDurationComputation]] = {
+            case_id: [] for case_id in case_ids
+        }
+        if not case_ids:
+            return results_by_case
+
+        start_match_cache: dict[
+            tuple[Any, ...], dict[uuid.UUID, _DurationEventMatch]
         ] = {}
-        results: list[CaseDurationComputation] = []
+        end_match_cache: dict[
+            tuple[tuple[Any, ...], tuple[Any, ...]],
+            dict[uuid.UUID, _DurationEventMatch],
+        ] = {}
 
         # Most iterations await on DB I/O, but periodic checkpoints keep
         # cache-hit-heavy definition sets from monopolizing the event loop.
@@ -661,44 +609,144 @@ class CaseDurationService(BaseWorkspaceService):
             if start_anchor_key not in start_match_cache:
                 start_match_cache[
                     start_anchor_key
-                ] = await self._find_matching_event_db(
-                    case.id,
+                ] = await self._find_matching_events_db(
+                    case_ids,
                     definition.start_anchor,
                 )
-            start_match = start_match_cache[start_anchor_key]
+            start_matches = start_match_cache[start_anchor_key]
 
-            earliest_after = start_match[1] if start_match else None
-            end_anchor_base_key = self._sql_anchor_cache_key(definition.end_anchor)
-            end_anchor_key = (end_anchor_base_key, earliest_after)
-            if end_anchor_key not in end_match_cache:
-                end_match_cache[end_anchor_key] = await self._find_matching_event_db(
-                    case.id,
-                    definition.end_anchor,
-                    earliest_after=earliest_after,
+            earliest_after_by_case: dict[uuid.UUID, datetime | None] = {}
+            for case_id in case_ids:
+                start_match = start_matches.get(case_id)
+                earliest_after_by_case[case_id] = (
+                    start_match[1] if start_match else None
                 )
-            end_match = end_match_cache[end_anchor_key]
 
-            started_at = start_match[1] if start_match else None
-            ended_at = end_match[1] if end_match else None
-            if started_at and ended_at and ended_at < started_at:
-                end_match = None
-                ended_at = None
-            duration = ended_at - started_at if started_at and ended_at else None
+            end_anchor_key = (
+                self._sql_anchor_cache_key(definition.end_anchor),
+                start_anchor_key,
+            )
+            if end_anchor_key not in end_match_cache:
+                end_match_cache[end_anchor_key] = await self._find_matching_events_db(
+                    case_ids,
+                    definition.end_anchor,
+                    earliest_after_by_case=earliest_after_by_case,
+                )
+            end_matches = end_match_cache[end_anchor_key]
 
-            results.append(
-                CaseDurationComputation(
-                    duration_id=definition.id,
-                    name=definition.name,
-                    description=definition.description,
-                    start_event_id=start_match[0].id if start_match else None,
-                    end_event_id=end_match[0].id if end_match else None,
-                    started_at=started_at,
-                    ended_at=ended_at,
-                    duration=duration,
+            for case_id in case_ids:
+                start_match = start_matches.get(case_id)
+                end_match = end_matches.get(case_id)
+
+                started_at = start_match[1] if start_match else None
+                ended_at = end_match[1] if end_match else None
+                if started_at and ended_at and ended_at < started_at:
+                    end_match = None
+                    ended_at = None
+                duration = ended_at - started_at if started_at and ended_at else None
+
+                results_by_case[case_id].append(
+                    CaseDurationComputation(
+                        duration_id=definition.id,
+                        name=definition.name,
+                        description=definition.description,
+                        start_event_id=start_match[0] if start_match else None,
+                        end_event_id=end_match[0] if end_match else None,
+                        started_at=started_at,
+                        ended_at=ended_at,
+                        duration=duration,
+                    )
+                )
+
+        return results_by_case
+
+    async def _find_matching_events_db(
+        self,
+        case_ids: Sequence[uuid.UUID],
+        anchor: CaseDurationEventAnchor,
+        *,
+        earliest_after_by_case: dict[uuid.UUID, datetime | None] | None = None,
+    ) -> dict[uuid.UUID, _DurationEventMatch]:
+        if not case_ids:
+            return {}
+
+        conditions: list[ColumnElement[bool]] = [
+            CaseEvent.workspace_id == self.workspace_id,
+        ]
+
+        anchor_bounds = None
+        if earliest_after_by_case is None:
+            conditions.append(CaseEvent.case_id.in_(case_ids))
+        else:
+            anchor_bounds = self._anchor_bounds_table(
+                case_ids,
+                earliest_after_by_case,
+            )
+            conditions.append(
+                or_(
+                    anchor_bounds.c.earliest_after.is_(None),
+                    CaseEvent.created_at
+                    >= cast(anchor_bounds.c.earliest_after, DateTime(timezone=True)),
                 )
             )
 
-        return results
+        if anchor.event_type is CaseEventType.STATUS_CHANGED:
+            conditions.append(
+                CaseEvent.type.in_(
+                    (
+                        CaseEventType.STATUS_CHANGED,
+                        CaseEventType.CASE_CLOSED,
+                        CaseEventType.CASE_REOPENED,
+                    )
+                )
+            )
+        else:
+            conditions.append(CaseEvent.type == anchor.event_type)
+
+        conditions.extend(self._build_sql_filter_conditions(anchor))
+
+        stmt = select(CaseEvent)
+        if anchor_bounds is not None:
+            stmt = stmt.join(
+                anchor_bounds, CaseEvent.case_id == anchor_bounds.c.case_id
+            )
+
+        stmt = (
+            stmt.where(*conditions)
+            .distinct(CaseEvent.case_id)
+            .order_by(CaseEvent.case_id.asc(), *self._sql_anchor_order_by(anchor))
+        )
+        result = await self.session.execute(stmt)
+        return {
+            event.case_id: (event.id, event.created_at)
+            for event in result.scalars().all()
+        }
+
+    def _anchor_bounds_table(
+        self,
+        case_ids: Sequence[uuid.UUID],
+        earliest_after_by_case: dict[uuid.UUID, datetime | None],
+    ) -> Any:
+        return (
+            sql_values(
+                column("case_id", PG_UUID(as_uuid=True)),
+                column("earliest_after", DateTime(timezone=True)),
+                name="duration_anchor_bounds",
+            )
+            .data(
+                [(case_id, earliest_after_by_case.get(case_id)) for case_id in case_ids]
+            )
+            .alias("duration_anchor_bounds")
+        )
+
+    def _sql_anchor_order_by(
+        self, anchor: CaseDurationEventAnchor
+    ) -> tuple[ColumnElement[Any], ColumnElement[Any]]:
+        return (
+            (CaseEvent.created_at.desc(), CaseEvent.surrogate_id.desc())
+            if anchor.selection is CaseDurationAnchorSelection.LAST
+            else (CaseEvent.created_at.asc(), CaseEvent.surrogate_id.asc())
+        )
 
     async def sync_case_durations(
         self, case: Case | uuid.UUID
@@ -796,87 +844,6 @@ class CaseDurationService(BaseWorkspaceService):
         if resolved is None:
             raise TracecatNotFoundError(f"Case {case} not found in this workspace")
         return resolved
-
-    def _find_matching_event(
-        self,
-        events: Sequence[CaseEvent],
-        anchor: CaseDurationEventAnchor,
-        *,
-        earliest_after: datetime | None = None,
-    ) -> tuple[CaseEvent, datetime] | None:
-        best_match: tuple[CaseEvent, datetime] | None = None
-        for event in events:
-            # A transition to `closed` is emitted as `case_closed` (and reopening
-            # as `case_reopened`), so exact matching on `status_changed` would
-            # otherwise miss those transitions. Expand the match here so duration
-            # definitions filtered on `status_changed` still see close/reopen.
-            if anchor.event_type is CaseEventType.STATUS_CHANGED:
-                if event.type not in (
-                    CaseEventType.STATUS_CHANGED,
-                    CaseEventType.CASE_CLOSED,
-                    CaseEventType.CASE_REOPENED,
-                ):
-                    continue
-            elif event.type != anchor.event_type:
-                continue
-            if not self._matches_anchor_filters(event, anchor):
-                continue
-            timestamp = self._extract_timestamp(event, anchor)
-            if timestamp is None:
-                continue
-            if earliest_after and timestamp < earliest_after:
-                continue
-            if best_match is None:
-                best_match = (event, timestamp)
-                continue
-            if anchor.selection is CaseDurationAnchorSelection.LAST:
-                if timestamp >= best_match[1]:
-                    best_match = (event, timestamp)
-            elif timestamp < best_match[1]:
-                best_match = (event, timestamp)
-
-        return best_match
-
-    async def _find_matching_event_db(
-        self,
-        case_id: uuid.UUID,
-        anchor: CaseDurationEventAnchor,
-        *,
-        earliest_after: datetime | None = None,
-    ) -> tuple[CaseEvent, datetime] | None:
-        conditions: list[ColumnElement[bool]] = [
-            CaseEvent.workspace_id == self.workspace_id,
-            CaseEvent.case_id == case_id,
-        ]
-
-        if anchor.event_type is CaseEventType.STATUS_CHANGED:
-            conditions.append(
-                CaseEvent.type.in_(
-                    (
-                        CaseEventType.STATUS_CHANGED,
-                        CaseEventType.CASE_CLOSED,
-                        CaseEventType.CASE_REOPENED,
-                    )
-                )
-            )
-        else:
-            conditions.append(CaseEvent.type == anchor.event_type)
-
-        if earliest_after is not None:
-            conditions.append(CaseEvent.created_at >= earliest_after)
-
-        conditions.extend(self._build_sql_filter_conditions(anchor))
-
-        order_by = (
-            (CaseEvent.created_at.desc(), CaseEvent.surrogate_id.desc())
-            if anchor.selection is CaseDurationAnchorSelection.LAST
-            else (CaseEvent.created_at.asc(), CaseEvent.surrogate_id.asc())
-        )
-        stmt = select(CaseEvent).where(*conditions).order_by(*order_by).limit(1)
-        result = await self.session.execute(stmt)
-        if (event := result.scalars().first()) is None:
-            return None
-        return event, event.created_at
 
     def _sql_anchor_cache_key(self, anchor: CaseDurationEventAnchor) -> tuple[Any, ...]:
         return self._anchor_cache_key(anchor)
@@ -1000,49 +967,6 @@ class CaseDurationService(BaseWorkspaceService):
                 )
             )
         return value
-
-    def _matches_anchor_filters(
-        self, event: CaseEvent, anchor: CaseDurationEventAnchor
-    ) -> bool:
-        if anchor._has_unsupported_filters:
-            return False
-
-        filters = anchor.filters
-        data = event.data or {}
-        if filters.new_values and data.get("new") not in filters.new_values:
-            return False
-        if filters.tag_refs and data.get("tag_ref") not in filters.tag_refs:
-            return False
-        if filters.field_ids and not self._event_changed_any_field(
-            event, filters.field_ids
-        ):
-            return False
-        if (
-            filters.dropdown_definition_id is not None
-            and data.get("definition_id") != filters.dropdown_definition_id
-        ):
-            return False
-        if (
-            filters.dropdown_option_ids
-            and data.get("new_option_id") not in filters.dropdown_option_ids
-        ):
-            return False
-        return True
-
-    def _event_changed_any_field(self, event: CaseEvent, field_ids: list[str]) -> bool:
-        changes = (event.data or {}).get("changes")
-        if not isinstance(changes, list):
-            return False
-        return any(
-            isinstance(change, dict) and change.get("field") in field_ids
-            for change in changes
-        )
-
-    def _extract_timestamp(
-        self, event: CaseEvent, anchor: CaseDurationEventAnchor
-    ) -> datetime | None:
-        del anchor
-        return event.created_at
 
     def _to_read_model(self, entity: CaseDuration) -> CaseDurationRead:
         return CaseDurationRead(

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -795,7 +795,10 @@ class CaseDurationService(BaseWorkspaceService):
 
     def _filters_are_sql_compatible(self, filters: dict[str, Any]) -> bool:
         for path, expected in filters.items():
-            if not path.startswith("data."):
+            parts = path.split(".")
+            # Deeper paths may traverse arrays in _resolve_field; keep them on
+            # the Python path until the SQL builder can mirror that behavior.
+            if len(parts) != 2 or parts[0] != "data" or not parts[1]:
                 return False
             normalized = self._normalize_filter_value(expected)
             if isinstance(normalized, list):
@@ -816,7 +819,7 @@ class CaseDurationService(BaseWorkspaceService):
         conditions: list[ColumnElement[bool]] = []
         for path, expected in filters.items():
             parts = path.split(".")
-            if not parts or parts[0] != "data" or len(parts) < 2:
+            if len(parts) != 2 or parts[0] != "data" or not parts[1]:
                 return None
 
             value_expr: Any = CaseEvent.data

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -10,7 +10,9 @@ from enum import Enum
 from typing import Any, Literal
 
 from slugify import slugify
-from sqlalchemy import select
+from sqlalchemy import bindparam, column, false, func, literal, or_, select
+from sqlalchemy import case as sql_case
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -817,20 +819,52 @@ class CaseDurationService(BaseWorkspaceService):
             if not parts or parts[0] != "data" or len(parts) < 2:
                 return None
 
-            value_expr = CaseEvent.data
+            value_expr: Any = CaseEvent.data
             for part in parts[1:]:
                 value_expr = value_expr[part]
 
             normalized = self._normalize_filter_value(expected)
             if isinstance(normalized, list):
-                conditions.append(
-                    value_expr.astext.in_([str(item) for item in normalized])
-                )
+                conditions.append(self._build_jsonb_list_filter(value_expr, normalized))
             elif normalized is None:
-                conditions.append(value_expr.is_(None))
+                conditions.append(
+                    or_(value_expr.is_(None), value_expr == self._jsonb_bindparam(None))
+                )
             else:
-                conditions.append(value_expr.astext == str(normalized))
+                conditions.append(value_expr == self._jsonb_bindparam(normalized))
         return conditions
+
+    def _build_jsonb_list_filter(
+        self, value_expr: ColumnElement[Any], expected: list[Any]
+    ) -> ColumnElement[bool]:
+        if not expected:
+            return false()
+
+        scalar_expected = [
+            self._jsonb_bindparam(item) for item in expected if item is not None
+        ]
+        scalar_matches = value_expr.in_(scalar_expected) if scalar_expected else false()
+
+        array_value = sql_case(
+            (func.jsonb_typeof(value_expr) == "array", value_expr),
+            else_=literal([], type_=JSONB),
+        )
+        elem = (
+            func.jsonb_array_elements(array_value)
+            .table_valued(column("value", JSONB))
+            .alias("filter_elem")
+        )
+        array_matches = (
+            select(literal(True))
+            .select_from(elem)
+            .where(elem.c.value.in_([self._jsonb_bindparam(item) for item in expected]))
+            .correlate(CaseEvent)
+            .exists()
+        )
+        return or_(scalar_matches, array_matches)
+
+    def _jsonb_bindparam(self, value: Any) -> ColumnElement[Any]:
+        return bindparam(None, value, type_=JSONB)
 
     def _anchor_cache_key(self, anchor: CaseDurationEventAnchor) -> tuple[Any, ...]:
         filter_items = tuple(

--- a/tracecat/concurrency.py
+++ b/tracecat/concurrency.py
@@ -74,6 +74,27 @@ async def cooperative[T](
         it: The iterable to yield items from.
         duration: The duration to sleep between yielding items.
     """
-    for item in it:
+    async for item in cooperative_every(it, every=1, delay=delay):
         yield item
-        await asyncio.sleep(delay)
+
+
+async def cooperative_every[T](
+    it: Iterable[T], *, every: int, delay: float = 0
+) -> AsyncGenerator[T, None]:
+    """Yield items from an iterable and checkpoint every N items.
+
+    This is useful when iterating over large collections where per-item
+    checkpoints are unnecessary but the loop should still yield periodically.
+
+    Args:
+        it: The iterable to yield items from.
+        every: Yield control back to the event loop after this many items.
+        delay: The duration to sleep at each checkpoint.
+    """
+    if every <= 0:
+        raise ValueError("'every' must be greater than 0")
+
+    for index, item in enumerate(it, start=1):
+        yield item
+        if index % every == 0:
+            await asyncio.sleep(delay)

--- a/tracecat/concurrency.py
+++ b/tracecat/concurrency.py
@@ -74,8 +74,9 @@ async def cooperative[T](
         it: The iterable to yield items from.
         duration: The duration to sleep between yielding items.
     """
-    async for item in cooperative_every(it, every=1, delay=delay):
+    for item in it:
         yield item
+        await asyncio.sleep(delay)
 
 
 async def cooperative_every[T](

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -2340,6 +2340,16 @@ class CaseEvent(WorkspaceModel):
     """
 
     __tablename__ = "case_event"
+    __table_args__ = (
+        Index(
+            "ix_case_event_anchor_lookup",
+            "workspace_id",
+            "case_id",
+            "type",
+            "created_at",
+            "surrogate_id",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID,


### PR DESCRIPTION
## Summary
- add an opt-in case duration burst benchmark that measures API update latency, `/health` latency, and event loop lag under synthetic duration-sync load
- add a SQL-friendly fast path for case duration anchor lookups, with fallback to the existing Python path when definitions are not DB-compatible
- add `cooperative_every()` and use it in the DB fast path so cache-hit-heavy definition loops still checkpoint periodically

## Benchmark Results
Baseline artifact: `artifacts/case-duration-benchmark-baseline.json`
- update latency p50: 2619.2ms
- `/health` burst p95: 192.5ms
- `/health` burst max: 801.9ms
- burst health errors: 1

Current 5-run batch median:
- update latency p50: 653.6ms
- `/health` burst p95: 100.9ms
- `/health` burst max: 207.0ms
- burst health errors: 0 across all 5 runs

## Testing
- `uv run ruff check tracecat/concurrency.py tracecat/cases/durations/service.py tests/unit/test_concurrency.py tests/integration/test_case_duration_benchmarks.py`
- `uv run basedpyright tracecat/concurrency.py tracecat/cases/durations/service.py tests/unit/test_concurrency.py tests/integration/test_case_duration_benchmarks.py`
- `uv run pytest tests/unit/test_concurrency.py -k "cooperative_every or cooperative_return_type"`
- `TRACECAT_RUN_CASE_DURATION_BENCHMARKS=1 uv run pytest tests/integration/test_case_duration_benchmarks.py -k update_burst -x`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in case-duration burst benchmark and a SQL-first, batched fast path for anchor lookups to cut recompute latency and keep `/health` responsive under load. Introduces typed, product-level filters for duration anchors with validation, UI updates, and legacy filter compatibility. Median update latency drops ~4x (2.6s → 0.65s); `/health` burst p95 ~2x (193ms → 101ms) with zero errors across 5 runs.

- **New Features**
  - SQL-first anchor matching now batches lookups across cases; per-anchor results are cached; bounds passed per case to select first/last in SQL.
  - Typed `CaseDurationEventFilters` on anchors (`new_values`, `tag_refs`, `field_ids`, `dropdown_definition_id`, `dropdown_option_ids`) with strict validation; legacy dot-path filters auto-mapped when possible.
  - Opt-in integration benchmark for duration-sync bursts (update latency, `/health` latency, event-loop lag) with JSON summary and ceil-rank p95.
  - New `cooperative_every()` helper (and restored `cooperative()`), plus `ix_case_event_anchor_lookup` index and Alembic migration.

- **Refactors**
  - DB filter builder preserves JSONB semantics (scalar/array overlaps), expands `status_changed` to include `case_closed`/`case_reopened`, and falls back if filters are not DB-compatible.
  - Replaced per-case in-memory scans with SQL queries ordered by `(created_at, surrogate_id)` and `distinct(case_id)` for first/last selection.
  - Frontend updated to typed filters: dialogs/builders/rendering now read/write `filters` instead of `timestamp_path`/`field_filters`; generated client/types updated.

<sup>Written for commit ee988be52b10b08b5de827e30d949d5f03998ea1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

