### PR TITLE
fix(ui): Constrain org agent credentials dialog height and enable scrolling 

### DIFF
--- a/frontend/src/components/organization/org-agent-credentials-dialog.tsx
+++ b/frontend/src/components/organization/org-agent-credentials-dialog.tsx
@@ -148,7 +148,7 @@ export function AgentCredentialsDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle className="flex items-center space-x-2">
             <KeyIcon className="size-5" />


### PR DESCRIPTION
### Motivation
- Fix an unscrollable organization agent credentials modal that could exceed the viewport (observed with long provider forms such as Bedrock on Firefox). 

### Description
- Add `max-h-[90vh] overflow-y-auto` to the `DialogContent` in `frontend/src/components/organization/org-agent-credentials-dialog.tsx` so long provider credential forms scroll within the modal instead of overflowing the window. 

### Testing
- Ran `pnpm -C frontend exec biome check src/components/organization/org-agent-credentials-dialog.tsx` which completed with no fixes applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb4aa94088320bc36ba07ecdea23b)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Constrained the organization agent credentials dialog to the viewport and enabled vertical scrolling to stop overflow on long provider forms, fixing the unscrollable modal in Firefox.

- **Bug Fixes**
  - Added `max-h-[90vh] overflow-y-auto` to `DialogContent` in `frontend/src/components/organization/org-agent-credentials-dialog.tsx` so long forms (e.g., Bedrock) scroll within the modal instead of overflowing.

<sup>Written for commit dad2a63fb1145a97f19e67d8c6805b1a8e35c03f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

