### PR TITLE
feat(mcp): sync_custom_registry tool with org-scoped service refactor

### DIFF
--- a/docs/snippets/mcp-tools.mdx
+++ b/docs/snippets/mcp-tools.mdx
@@ -59,6 +59,11 @@
 
   Common namespaces: `core`, `tools`, `ai`.
     </ResponseField>
+    <ResponseField name="workflows_sync_custom_registry" type="tool">
+  Sync the organization's custom action registry from its remote git repository.
+
+  Pulls the latest code from the custom registry repo registered in the caller's organization, builds a versioned tarball, and makes the synced actions available to agents and workflows. Use this after pushing changes to the custom integrations repo, or to roll forward/back to a specific commit. Existing published workflows must be republished to pick up newly synced action versions.
+    </ResponseField>
     <ResponseField name="workflows_get_action_context" type="tool">
   Get full schema and configuration context for a single action.
 

--- a/tests/unit/api/test_api_registry_repositories_entitlements.py
+++ b/tests/unit/api/test_api_registry_repositories_entitlements.py
@@ -32,24 +32,13 @@ async def test_sync_custom_repository_requires_entitlement(
     client: TestClient, test_admin_role: Role, mock_role_acl_dependency: AsyncMock
 ) -> None:
     repository_id = uuid4()
-    repository = SimpleNamespace(
-        id=repository_id,
-        origin="git+ssh://git@github.com/acme/custom-registry.git",
-        current_version_id=None,
-    )
 
-    with (
-        patch.object(repos_router_module, "RegistryReposService") as MockReposService,
-        patch.object(
-            repos_router_module,
-            "check_entitlement",
-            new_callable=AsyncMock,
-        ) as mock_check_entitlement,
-    ):
+    with patch.object(repos_router_module, "RegistryReposService") as MockReposService:
         mock_repos_service = AsyncMock()
-        mock_repos_service.get_repository_by_id.return_value = repository
+        mock_repos_service.sync_repository.side_effect = EntitlementRequired(
+            "custom_registry"
+        )
         MockReposService.return_value = mock_repos_service
-        mock_check_entitlement.side_effect = EntitlementRequired("custom_registry")
 
         response = client.post(f"/registry/repos/{repository_id}/sync")
 

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -1279,3 +1279,127 @@ async def test_mcp_pre_role_lookups_use_bypass_session_manager(
                 await fn(*args)
 
         assert call_count == 1
+
+
+def _patch_resolve_org_role_deps(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    identity_org_ids: frozenset[uuid.UUID] = frozenset(),
+    membership_org_ids: list[uuid.UUID],
+    user_id: uuid.UUID | None = None,
+    is_superuser: bool = False,
+) -> None:
+    """Wire token identity, user lookup, and the membership query."""
+
+    user_id = user_id or uuid.uuid4()
+
+    class _Result:
+        def __init__(self, values: list[uuid.UUID]) -> None:
+            self._values = values
+
+        def all(self) -> list[tuple[uuid.UUID]]:
+            return [(v,) for v in self._values]
+
+    class _Session:
+        async def execute(self, _stmt):
+            return _Result(membership_org_ids)
+
+    class _AsyncContext:
+        def __init__(self, session: _Session) -> None:
+            self._session = session
+
+        async def __aenter__(self) -> _Session:
+            return self._session
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    identity = SimpleNamespace(
+        client_id="tracecat-client",
+        email="user@example.com",
+        organization_ids=identity_org_ids,
+        workspace_ids=frozenset(),
+    )
+
+    async def _resolve_user_by_email(_email: str) -> SimpleNamespace:
+        return SimpleNamespace(id=user_id, is_superuser=is_superuser)
+
+    async def _compute_effective_scopes(_role) -> frozenset[str]:
+        return frozenset({"org:registry:update"})
+
+    monkeypatch.setattr(mcp_auth, "get_token_identity", lambda: identity)
+    monkeypatch.setattr(mcp_auth, "resolve_user_by_email", _resolve_user_by_email)
+    monkeypatch.setattr(mcp_auth, "compute_effective_scopes", _compute_effective_scopes)
+    monkeypatch.setattr(
+        mcp_auth,
+        "get_async_session_bypass_rls_context_manager",
+        lambda: _AsyncContext(_Session()),
+    )
+    monkeypatch.setattr(mcp_auth.config, "TRACECAT__EE_MULTI_TENANT", False)
+
+
+@pytest.mark.anyio
+async def test_resolve_org_role_intersects_token_scoping_with_memberships(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scoped token + multi-org user should resolve cleanly to the scoped org."""
+    scoped_org = uuid.uuid4()
+    other_org = uuid.uuid4()
+    _patch_resolve_org_role_deps(
+        monkeypatch,
+        identity_org_ids=frozenset({scoped_org}),
+        membership_org_ids=[scoped_org, other_org],
+    )
+
+    role = await mcp_auth.resolve_org_role_for_request()
+
+    assert role.organization_id == scoped_org
+    assert role.workspace_id is None
+
+
+@pytest.mark.anyio
+async def test_resolve_org_role_unscoped_token_with_single_membership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unscoped token + single-org user resolves without scoping."""
+    org = uuid.uuid4()
+    _patch_resolve_org_role_deps(
+        monkeypatch,
+        identity_org_ids=frozenset(),
+        membership_org_ids=[org],
+    )
+
+    role = await mcp_auth.resolve_org_role_for_request()
+
+    assert role.organization_id == org
+
+
+@pytest.mark.anyio
+async def test_resolve_org_role_unscoped_token_with_multi_org_user_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unscoped token + multi-org user must surface a clear error."""
+    _patch_resolve_org_role_deps(
+        monkeypatch,
+        identity_org_ids=frozenset(),
+        membership_org_ids=[uuid.uuid4(), uuid.uuid4()],
+    )
+
+    with pytest.raises(ValueError, match="single-org token"):
+        await mcp_auth.resolve_org_role_for_request()
+
+
+@pytest.mark.anyio
+async def test_resolve_org_role_token_scoped_to_unowned_org_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Token scoped to an org the user has no membership in must error."""
+    foreign_org = uuid.uuid4()
+    _patch_resolve_org_role_deps(
+        monkeypatch,
+        identity_org_ids=frozenset({foreign_org}),
+        membership_org_ids=[uuid.uuid4()],
+    )
+
+    with pytest.raises(ValueError, match="matching the token's org scope"):
+        await mcp_auth.resolve_org_role_for_request()

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -1403,3 +1403,30 @@ async def test_resolve_org_role_token_scoped_to_unowned_org_errors(
 
     with pytest.raises(ValueError, match="matching the token's org scope"):
         await mcp_auth.resolve_org_role_for_request()
+
+
+@pytest.mark.anyio
+async def test_resolve_org_role_single_tenant_superuser_uses_default_org(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Single-tenant superusers without memberships fall back to default org."""
+    default_org = uuid.uuid4()
+    _patch_resolve_org_role_deps(
+        monkeypatch,
+        identity_org_ids=frozenset(),
+        membership_org_ids=[],  # superuser with no memberships
+        is_superuser=True,
+    )
+
+    async def _get_default_organization_id(_session) -> uuid.UUID:
+        return default_org
+
+    monkeypatch.setattr(
+        "tracecat.organization.management.get_default_organization_id",
+        _get_default_organization_id,
+    )
+
+    role = await mcp_auth.resolve_org_role_for_request()
+
+    assert role.organization_id == default_org
+    assert role.is_platform_superuser is True

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -1422,8 +1422,7 @@ async def test_resolve_org_role_single_tenant_superuser_uses_default_org(
         return default_org
 
     monkeypatch.setattr(
-        "tracecat.organization.management.get_default_organization_id",
-        _get_default_organization_id,
+        mcp_auth, "get_default_organization_id", _get_default_organization_id
     )
 
     role = await mcp_auth.resolve_org_role_for_request()

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import inspect
 import json
 import sys
 import uuid
@@ -4709,6 +4710,281 @@ async def test_list_workspaces_returns_multi_org_workspaces(monkeypatch):
 def test_tool_namespace_mapping_includes_get_agent_preset() -> None:
     assert mcp_server._TOOL_NAMESPACE_BY_NAME["get_agent_preset"] == "agents"
     assert mcp_server._TOOL_NAMESPACE_BY_NAME["update_agent_preset"] == "agents"
+
+
+def test_tool_namespace_mapping_includes_sync_custom_registry() -> None:
+    assert mcp_server._TOOL_NAMESPACE_BY_NAME["sync_custom_registry"] == "workflows"
+
+
+_UNSET = object()
+
+
+def _registry_role(
+    *,
+    organization_id: Any = _UNSET,
+    workspace_id: Any = _UNSET,
+    scopes: frozenset[str] | None = frozenset({"org:registry:update"}),
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        organization_id=(
+            uuid.uuid4() if organization_id is _UNSET else organization_id
+        ),
+        workspace_id=uuid.uuid4() if workspace_id is _UNSET else workspace_id,
+        scopes=scopes,
+    )
+
+
+class _FakeRegistrySession:
+    def expire(self, _obj: object) -> None:
+        return None
+
+    async def flush(self) -> None:
+        return None
+
+
+class _FakeRegistryActionsService:
+    def __init__(self, *, fail_origins: set[str] | None = None) -> None:
+        self.fail_origins = fail_origins or set()
+        self.synced_origins: list[str] = []
+
+    async def sync_actions_from_repository(
+        self,
+        repo,
+        *,
+        target_commit_sha=None,
+        git_repo_package_name=None,
+        ssh_env=None,
+    ):
+        _ = git_repo_package_name, ssh_env
+        self.synced_origins.append(repo.origin)
+        if repo.origin in self.fail_origins:
+            from tracecat.exceptions import RegistryError
+
+            raise RegistryError("sync failed")
+        return target_commit_sha or "a" * 40, "2026.04.24"
+
+    async def list_actions_from_index_by_repository(self, _repository_id):
+        return [SimpleNamespace(), SimpleNamespace()]
+
+
+class _FakeRegistryReposService:
+    def __init__(
+        self,
+        repositories: list[SimpleNamespace],
+        actions_service: _FakeRegistryActionsService,
+    ) -> None:
+        self.repositories = repositories
+        self.actions_service = actions_service
+        self.calls: list[str] = []
+
+    async def list_repositories(self):
+        self.calls.append("list_repositories")
+        return self.repositories
+
+    async def get_repository_by_id(self, repository_id):
+        self.calls.append("get_repository_by_id")
+        from sqlalchemy.exc import NoResultFound
+
+        for repo in self.repositories:
+            if repo.id == repository_id:
+                return repo
+        raise NoResultFound()
+
+    async def get_repository(self, origin):
+        self.calls.append("get_repository")
+        return next((repo for repo in self.repositories if repo.origin == origin), None)
+
+    async def update_repository(self, repository, params):
+        self.calls.append("update_repository")
+        repository.last_synced_at = params.last_synced_at
+        repository.commit_sha = params.commit_sha
+        return repository
+
+    async def sync_repository(self, repository, sync_params=None):
+        self.calls.append("sync_repository")
+        commit_sha, version = await self.actions_service.sync_actions_from_repository(
+            repository,
+            target_commit_sha=sync_params.target_commit_sha if sync_params else None,
+        )
+        actions = await self.actions_service.list_actions_from_index_by_repository(
+            repository.id
+        )
+        return SimpleNamespace(
+            success=True,
+            repository_id=repository.id,
+            origin=repository.origin,
+            version=version,
+            commit_sha=commit_sha,
+            actions_count=len(actions),
+            forced=sync_params.force if sync_params else False,
+        )
+
+
+def _registry_repo(origin: str, *, current_version_id=None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        origin=origin,
+        current_version_id=current_version_id,
+        last_synced_at=None,
+        commit_sha=None,
+    )
+
+
+def _patch_registry_sync_services(
+    monkeypatch,
+    *,
+    repositories: list[SimpleNamespace],
+    actions_service: _FakeRegistryActionsService | None = None,
+):
+    actions_service = actions_service or _FakeRegistryActionsService()
+    repos_service = _FakeRegistryReposService(repositories, actions_service)
+
+    monkeypatch.setattr(
+        mcp_server,
+        "get_async_session_context_manager",
+        lambda: _AsyncContext(_FakeRegistrySession()),
+    )
+    monkeypatch.setattr(
+        mcp_server,
+        "RegistryReposService",
+        lambda _session, _role: repos_service,
+    )
+    monkeypatch.setattr(
+        mcp_server,
+        "RegistryActionsService",
+        lambda _session, _role: actions_service,
+    )
+    return repos_service, actions_service
+
+
+def _patch_org_role(monkeypatch, role: SimpleNamespace) -> None:
+    async def _resolve_org() -> SimpleNamespace:
+        return role
+
+    monkeypatch.setattr(mcp_server, "_resolve_org_role", _resolve_org)
+
+
+@pytest.mark.anyio
+async def test_sync_custom_registry_requires_registry_read_scope(monkeypatch):
+    """Caller hits list_repositories first; missing org:registry:read fails fast."""
+    _patch_org_role(monkeypatch, _registry_role(scopes=frozenset({"workflow:read"})))
+
+    with pytest.raises(ToolError, match="org:registry:read"):
+        await _tool(mcp_server.sync_custom_registry)()
+
+
+@pytest.mark.anyio
+async def test_sync_custom_registry_requires_organization_context(monkeypatch):
+    _patch_org_role(monkeypatch, _registry_role(organization_id=None))
+
+    with pytest.raises(ToolError, match="organization context"):
+        await _tool(mcp_server.sync_custom_registry)()
+
+
+def test_sync_custom_registry_public_signature_drops_repo_selectors() -> None:
+    signature = inspect.signature(_tool(mcp_server.sync_custom_registry))
+    assert "repository_id" not in signature.parameters
+    assert "origin" not in signature.parameters
+    assert "workspace_id" not in signature.parameters
+
+
+@pytest.mark.anyio
+async def test_sync_custom_registry_uses_org_scoped_repos_service(monkeypatch):
+    repo = _registry_repo("custom_actions")
+    _patch_org_role(monkeypatch, _registry_role())
+    repos_service, actions_service = _patch_registry_sync_services(
+        monkeypatch, repositories=[repo]
+    )
+
+    result = await _tool(mcp_server.sync_custom_registry)()
+    payload = _payload(result)
+
+    assert payload["success"] is True
+    assert repos_service.calls[0] == "list_repositories"
+    assert "sync_repository" in repos_service.calls
+    assert actions_service.synced_origins == [repo.origin]
+
+
+@pytest.mark.anyio
+async def test_sync_custom_registry_all_excludes_platform_registry(monkeypatch):
+    platform_repo = _registry_repo(mcp_server.DEFAULT_REGISTRY_ORIGIN)
+    custom_repo = _registry_repo("custom_actions")
+
+    _patch_org_role(monkeypatch, _registry_role())
+    repos_service, actions_service = _patch_registry_sync_services(
+        monkeypatch, repositories=[platform_repo, custom_repo]
+    )
+
+    result = await _tool(mcp_server.sync_custom_registry)()
+    payload = _payload(result)
+
+    assert payload["success"] is True
+    assert repos_service.calls[0] == "list_repositories"
+    assert actions_service.synced_origins == [custom_repo.origin]
+    assert [item["origin"] for item in payload["results"]] == [custom_repo.origin]
+
+
+@pytest.mark.anyio
+async def test_sync_custom_registry_excludes_local_registry(monkeypatch):
+    platform_repo = _registry_repo(mcp_server.DEFAULT_REGISTRY_ORIGIN)
+    local_repo = _registry_repo(mcp_server.DEFAULT_LOCAL_REGISTRY_ORIGIN)
+    custom_repo = _registry_repo("custom_actions")
+
+    _patch_org_role(monkeypatch, _registry_role())
+    _, actions_service = _patch_registry_sync_services(
+        monkeypatch, repositories=[platform_repo, local_repo, custom_repo]
+    )
+
+    result = await _tool(mcp_server.sync_custom_registry)()
+    payload = _payload(result)
+
+    assert payload["success"] is True
+    assert actions_service.synced_origins == [custom_repo.origin]
+    assert [item["origin"] for item in payload["results"]] == [custom_repo.origin]
+
+
+@pytest.mark.anyio
+async def test_sync_custom_registry_rejects_no_custom_registry(monkeypatch):
+    platform_repo = _registry_repo(mcp_server.DEFAULT_REGISTRY_ORIGIN)
+
+    _patch_org_role(monkeypatch, _registry_role())
+    _patch_registry_sync_services(monkeypatch, repositories=[platform_repo])
+
+    with pytest.raises(ToolError, match="No custom registry repository found"):
+        await _tool(mcp_server.sync_custom_registry)()
+
+
+@pytest.mark.anyio
+async def test_sync_custom_registry_rejects_multiple_custom_registries(monkeypatch):
+    first_repo = _registry_repo("custom_one")
+    second_repo = _registry_repo("custom_two")
+
+    _patch_org_role(monkeypatch, _registry_role())
+    _patch_registry_sync_services(monkeypatch, repositories=[first_repo, second_repo])
+
+    with pytest.raises(ToolError, match="Expected exactly one custom registry"):
+        await _tool(mcp_server.sync_custom_registry)()
+
+
+@pytest.mark.anyio
+async def test_sync_custom_registry_reports_per_repo_failure(monkeypatch):
+    bad_repo = _registry_repo("custom_bad")
+
+    _patch_org_role(monkeypatch, _registry_role())
+    _patch_registry_sync_services(
+        monkeypatch,
+        repositories=[bad_repo],
+        actions_service=_FakeRegistryActionsService(fail_origins={bad_repo.origin}),
+    )
+
+    result = await _tool(mcp_server.sync_custom_registry)()
+    payload = _payload(result)
+
+    assert payload["success"] is False
+    assert len(payload["results"]) == 1
+    assert payload["results"][0]["origin"] == bad_repo.origin
+    assert payload["results"][0]["success"] is False
+    assert payload["results"][0]["error"] == "sync failed"
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -10,6 +10,7 @@ from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime, timedelta
 from types import ModuleType, SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import yaml
@@ -4716,158 +4717,84 @@ def test_tool_namespace_mapping_includes_sync_custom_registry() -> None:
     assert mcp_server._TOOL_NAMESPACE_BY_NAME["sync_custom_registry"] == "workflows"
 
 
-_UNSET = object()
-
-
 def _registry_role(
-    *,
-    organization_id: Any = _UNSET,
-    workspace_id: Any = _UNSET,
-    scopes: frozenset[str] | None = frozenset({"org:registry:update"}),
+    *, scopes: frozenset[str] = frozenset({"org:registry:update"})
 ) -> SimpleNamespace:
+    return SimpleNamespace(organization_id=uuid.uuid4(), scopes=scopes)
+
+
+def _registry_repo(origin: str) -> SimpleNamespace:
+    return SimpleNamespace(id=uuid.uuid4(), origin=origin)
+
+
+def _sync_response(repo: SimpleNamespace, *, forced: bool = False) -> SimpleNamespace:
     return SimpleNamespace(
-        organization_id=(
-            uuid.uuid4() if organization_id is _UNSET else organization_id
-        ),
-        workspace_id=uuid.uuid4() if workspace_id is _UNSET else workspace_id,
-        scopes=scopes,
+        success=True,
+        repository_id=repo.id,
+        origin=repo.origin,
+        version="2026.04.25",
+        commit_sha="a" * 40,
+        actions_count=2,
+        forced=forced,
     )
 
 
-class _FakeRegistrySession:
-    def expire(self, _obj: object) -> None:
-        return None
-
-    async def flush(self) -> None:
-        return None
-
-
-class _FakeRegistryActionsService:
-    def __init__(self, *, fail_origins: set[str] | None = None) -> None:
-        self.fail_origins = fail_origins or set()
-        self.synced_origins: list[str] = []
-
-    async def sync_actions_from_repository(
-        self,
-        repo,
-        *,
-        target_commit_sha=None,
-        git_repo_package_name=None,
-        ssh_env=None,
-    ):
-        _ = git_repo_package_name, ssh_env
-        self.synced_origins.append(repo.origin)
-        if repo.origin in self.fail_origins:
-            from tracecat.exceptions import RegistryError
-
-            raise RegistryError("sync failed")
-        return target_commit_sha or "a" * 40, "2026.04.24"
-
-    async def list_actions_from_index_by_repository(self, _repository_id):
-        return [SimpleNamespace(), SimpleNamespace()]
-
-
-class _FakeRegistryReposService:
-    def __init__(
-        self,
-        repositories: list[SimpleNamespace],
-        actions_service: _FakeRegistryActionsService,
-    ) -> None:
-        self.repositories = repositories
-        self.actions_service = actions_service
-        self.calls: list[str] = []
-
-    async def list_repositories(self):
-        self.calls.append("list_repositories")
-        return self.repositories
-
-    async def get_repository_by_id(self, repository_id):
-        self.calls.append("get_repository_by_id")
-        from sqlalchemy.exc import NoResultFound
-
-        for repo in self.repositories:
-            if repo.id == repository_id:
-                return repo
-        raise NoResultFound()
-
-    async def get_repository(self, origin):
-        self.calls.append("get_repository")
-        return next((repo for repo in self.repositories if repo.origin == origin), None)
-
-    async def update_repository(self, repository, params):
-        self.calls.append("update_repository")
-        repository.last_synced_at = params.last_synced_at
-        repository.commit_sha = params.commit_sha
-        return repository
-
-    async def sync_repository(self, repository, sync_params=None):
-        self.calls.append("sync_repository")
-        commit_sha, version = await self.actions_service.sync_actions_from_repository(
-            repository,
-            target_commit_sha=sync_params.target_commit_sha if sync_params else None,
-        )
-        actions = await self.actions_service.list_actions_from_index_by_repository(
-            repository.id
-        )
-        return SimpleNamespace(
-            success=True,
-            repository_id=repository.id,
-            origin=repository.origin,
-            version=version,
-            commit_sha=commit_sha,
-            actions_count=len(actions),
-            forced=sync_params.force if sync_params else False,
-        )
-
-
-def _registry_repo(origin: str, *, current_version_id=None) -> SimpleNamespace:
-    return SimpleNamespace(
-        id=uuid.uuid4(),
-        origin=origin,
-        current_version_id=current_version_id,
-        last_synced_at=None,
-        commit_sha=None,
-    )
-
-
-def _patch_registry_sync_services(
+def _patch_sync_custom_registry(
     monkeypatch,
     *,
-    repositories: list[SimpleNamespace],
-    actions_service: _FakeRegistryActionsService | None = None,
-):
-    actions_service = actions_service or _FakeRegistryActionsService()
-    repos_service = _FakeRegistryReposService(repositories, actions_service)
+    role: SimpleNamespace,
+    repositories: list[SimpleNamespace] | None = None,
+    sync_response: SimpleNamespace | None = None,
+    sync_error: Exception | None = None,
+) -> AsyncMock:
+    """Wire role + a mock RegistryReposService into mcp_server."""
 
-    monkeypatch.setattr(
-        mcp_server,
-        "get_async_session_context_manager",
-        lambda: _AsyncContext(_FakeRegistrySession()),
-    )
-    monkeypatch.setattr(
-        mcp_server,
-        "RegistryReposService",
-        lambda _session, _role: repos_service,
-    )
-    monkeypatch.setattr(
-        mcp_server,
-        "RegistryActionsService",
-        lambda _session, _role: actions_service,
-    )
-    return repos_service, actions_service
-
-
-def _patch_org_role(monkeypatch, role: SimpleNamespace) -> None:
     async def _resolve_org() -> SimpleNamespace:
         return role
 
     monkeypatch.setattr(mcp_server, "_resolve_org_role", _resolve_org)
 
+    repos_service = AsyncMock()
+    repos_service.list_repositories.return_value = repositories or []
+    if sync_error is not None:
+        repos_service.sync_repository.side_effect = sync_error
+    elif sync_response is not None:
+        repos_service.sync_repository.return_value = sync_response
+
+    monkeypatch.setattr(
+        mcp_server, "RegistryReposService", lambda *_, **__: repos_service
+    )
+    monkeypatch.setattr(
+        mcp_server,
+        "get_async_session_context_manager",
+        lambda: _AsyncContext(MagicMock()),
+    )
+    return repos_service
+
 
 @pytest.mark.anyio
-async def test_sync_custom_registry_requires_registry_read_scope(monkeypatch):
-    """Caller hits list_repositories first; missing org:registry:read fails fast."""
-    _patch_org_role(monkeypatch, _registry_role(scopes=frozenset({"workflow:read"})))
+async def test_sync_custom_registry_surfaces_scope_denied(monkeypatch):
+    """A ScopeDeniedError from the service is surfaced as a ToolError."""
+    from tracecat.exceptions import ScopeDeniedError
+
+    repos_service = AsyncMock()
+    repos_service.list_repositories.side_effect = ScopeDeniedError(
+        required_scopes=["org:registry:read"],
+        missing_scopes=["org:registry:read"],
+    )
+
+    async def _resolve_org() -> SimpleNamespace:
+        return _registry_role()
+
+    monkeypatch.setattr(mcp_server, "_resolve_org_role", _resolve_org)
+    monkeypatch.setattr(
+        mcp_server, "RegistryReposService", lambda *_, **__: repos_service
+    )
+    monkeypatch.setattr(
+        mcp_server,
+        "get_async_session_context_manager",
+        lambda: _AsyncContext(MagicMock()),
+    )
 
     with pytest.raises(ToolError, match="org:registry:read"):
         await _tool(mcp_server.sync_custom_registry)()
@@ -4875,7 +4802,10 @@ async def test_sync_custom_registry_requires_registry_read_scope(monkeypatch):
 
 @pytest.mark.anyio
 async def test_sync_custom_registry_requires_organization_context(monkeypatch):
-    _patch_org_role(monkeypatch, _registry_role(organization_id=None))
+    role = SimpleNamespace(
+        organization_id=None, scopes=frozenset({"org:registry:update"})
+    )
+    _patch_sync_custom_registry(monkeypatch, role=role)
 
     with pytest.raises(ToolError, match="organization context"):
         await _tool(mcp_server.sync_custom_registry)()
@@ -4891,36 +4821,38 @@ def test_sync_custom_registry_public_signature_drops_repo_selectors() -> None:
 @pytest.mark.anyio
 async def test_sync_custom_registry_uses_org_scoped_repos_service(monkeypatch):
     repo = _registry_repo("custom_actions")
-    _patch_org_role(monkeypatch, _registry_role())
-    repos_service, actions_service = _patch_registry_sync_services(
-        monkeypatch, repositories=[repo]
+    repos_service = _patch_sync_custom_registry(
+        monkeypatch,
+        role=_registry_role(),
+        repositories=[repo],
+        sync_response=_sync_response(repo),
     )
 
     result = await _tool(mcp_server.sync_custom_registry)()
     payload = _payload(result)
 
     assert payload["success"] is True
-    assert repos_service.calls[0] == "list_repositories"
-    assert "sync_repository" in repos_service.calls
-    assert actions_service.synced_origins == [repo.origin]
+    repos_service.list_repositories.assert_awaited_once()
+    repos_service.sync_repository.assert_awaited_once()
+    assert repos_service.sync_repository.await_args.args[0] is repo
 
 
 @pytest.mark.anyio
 async def test_sync_custom_registry_all_excludes_platform_registry(monkeypatch):
     platform_repo = _registry_repo(mcp_server.DEFAULT_REGISTRY_ORIGIN)
     custom_repo = _registry_repo("custom_actions")
-
-    _patch_org_role(monkeypatch, _registry_role())
-    repos_service, actions_service = _patch_registry_sync_services(
-        monkeypatch, repositories=[platform_repo, custom_repo]
+    repos_service = _patch_sync_custom_registry(
+        monkeypatch,
+        role=_registry_role(),
+        repositories=[platform_repo, custom_repo],
+        sync_response=_sync_response(custom_repo),
     )
 
     result = await _tool(mcp_server.sync_custom_registry)()
     payload = _payload(result)
 
     assert payload["success"] is True
-    assert repos_service.calls[0] == "list_repositories"
-    assert actions_service.synced_origins == [custom_repo.origin]
+    assert repos_service.sync_repository.await_args.args[0] is custom_repo
     assert [item["origin"] for item in payload["results"]] == [custom_repo.origin]
 
 
@@ -4929,26 +4861,27 @@ async def test_sync_custom_registry_excludes_local_registry(monkeypatch):
     platform_repo = _registry_repo(mcp_server.DEFAULT_REGISTRY_ORIGIN)
     local_repo = _registry_repo(mcp_server.DEFAULT_LOCAL_REGISTRY_ORIGIN)
     custom_repo = _registry_repo("custom_actions")
-
-    _patch_org_role(monkeypatch, _registry_role())
-    _, actions_service = _patch_registry_sync_services(
-        monkeypatch, repositories=[platform_repo, local_repo, custom_repo]
+    repos_service = _patch_sync_custom_registry(
+        monkeypatch,
+        role=_registry_role(),
+        repositories=[platform_repo, local_repo, custom_repo],
+        sync_response=_sync_response(custom_repo),
     )
 
     result = await _tool(mcp_server.sync_custom_registry)()
     payload = _payload(result)
 
     assert payload["success"] is True
-    assert actions_service.synced_origins == [custom_repo.origin]
+    assert repos_service.sync_repository.await_args.args[0] is custom_repo
     assert [item["origin"] for item in payload["results"]] == [custom_repo.origin]
 
 
 @pytest.mark.anyio
 async def test_sync_custom_registry_rejects_no_custom_registry(monkeypatch):
     platform_repo = _registry_repo(mcp_server.DEFAULT_REGISTRY_ORIGIN)
-
-    _patch_org_role(monkeypatch, _registry_role())
-    _patch_registry_sync_services(monkeypatch, repositories=[platform_repo])
+    _patch_sync_custom_registry(
+        monkeypatch, role=_registry_role(), repositories=[platform_repo]
+    )
 
     with pytest.raises(ToolError, match="No custom registry repository found"):
         await _tool(mcp_server.sync_custom_registry)()
@@ -4956,11 +4889,8 @@ async def test_sync_custom_registry_rejects_no_custom_registry(monkeypatch):
 
 @pytest.mark.anyio
 async def test_sync_custom_registry_rejects_multiple_custom_registries(monkeypatch):
-    first_repo = _registry_repo("custom_one")
-    second_repo = _registry_repo("custom_two")
-
-    _patch_org_role(monkeypatch, _registry_role())
-    _patch_registry_sync_services(monkeypatch, repositories=[first_repo, second_repo])
+    repos = [_registry_repo("custom_one"), _registry_repo("custom_two")]
+    _patch_sync_custom_registry(monkeypatch, role=_registry_role(), repositories=repos)
 
     with pytest.raises(ToolError, match="Expected exactly one custom registry"):
         await _tool(mcp_server.sync_custom_registry)()
@@ -4968,13 +4898,14 @@ async def test_sync_custom_registry_rejects_multiple_custom_registries(monkeypat
 
 @pytest.mark.anyio
 async def test_sync_custom_registry_reports_per_repo_failure(monkeypatch):
-    bad_repo = _registry_repo("custom_bad")
+    from tracecat.exceptions import RegistryError
 
-    _patch_org_role(monkeypatch, _registry_role())
-    _patch_registry_sync_services(
+    bad_repo = _registry_repo("custom_bad")
+    _patch_sync_custom_registry(
         monkeypatch,
+        role=_registry_role(),
         repositories=[bad_repo],
-        actions_service=_FakeRegistryActionsService(fail_origins={bad_repo.origin}),
+        sync_error=RegistryError("sync failed"),
     )
 
     result = await _tool(mcp_server.sync_custom_registry)()

--- a/tests/unit/test_registry_repositories_service.py
+++ b/tests/unit/test_registry_repositories_service.py
@@ -9,6 +9,8 @@ import pytest
 
 from tracecat.auth.types import Role
 from tracecat.db.models import RegistryRepository
+from tracecat.exceptions import ScopeDeniedError
+from tracecat.registry.repositories.schemas import RegistryRepositorySync
 from tracecat.registry.repositories.service import RegistryReposService
 
 
@@ -21,6 +23,30 @@ def role() -> Role:
         organization_id=uuid.uuid4(),
         user_id=uuid.uuid4(),
         scopes=frozenset({"org:registry:delete"}),
+    )
+
+
+@pytest.fixture
+def role_with_read_only_scope() -> Role:
+    return Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset({"org:registry:read"}),
+    )
+
+
+@pytest.fixture
+def role_without_registry_scopes() -> Role:
+    return Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset({"workflow:read"}),
     )
 
 
@@ -65,3 +91,27 @@ async def test_delete_repository_without_promoted_version_skips_flush(
         call.delete(repository),
         call.commit(),
     ]
+
+
+@pytest.mark.anyio
+async def test_sync_repository_requires_registry_update_scope(
+    role_with_read_only_scope: Role,
+) -> None:
+    """sync_repository must reject roles missing org:registry:update."""
+    service = RegistryReposService(AsyncMock(), role=role_with_read_only_scope)
+    repository = RegistryRepository(
+        organization_id=role_with_read_only_scope.organization_id,
+        origin="custom_actions",
+    )
+    with pytest.raises(ScopeDeniedError):
+        await service.sync_repository(repository, RegistryRepositorySync(force=False))
+
+
+@pytest.mark.anyio
+async def test_list_repositories_requires_registry_read_scope(
+    role_without_registry_scopes: Role,
+) -> None:
+    """list_repositories must reject roles missing org:registry:read."""
+    service = RegistryReposService(AsyncMock(), role=role_without_registry_scopes)
+    with pytest.raises(ScopeDeniedError):
+        await service.list_repositories()

--- a/tests/unit/test_registry_repositories_service.py
+++ b/tests/unit/test_registry_repositories_service.py
@@ -9,7 +9,7 @@ import pytest
 
 from tracecat.auth.types import Role
 from tracecat.db.models import RegistryRepository
-from tracecat.exceptions import ScopeDeniedError
+from tracecat.exceptions import RegistryNotFound, ScopeDeniedError
 from tracecat.registry.repositories.schemas import RegistryRepositorySync
 from tracecat.registry.repositories.service import RegistryReposService
 
@@ -115,3 +115,26 @@ async def test_list_repositories_requires_registry_read_scope(
     service = RegistryReposService(AsyncMock(), role=role_without_registry_scopes)
     with pytest.raises(ScopeDeniedError):
         await service.list_repositories()
+
+
+@pytest.mark.anyio
+async def test_sync_repository_rejects_cross_org_repository() -> None:
+    """Cross-org repository must surface RegistryNotFound (probing-resistant)."""
+    role_with_update = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset({"org:registry:update"}),
+    )
+    service = RegistryReposService(AsyncMock(), role=role_with_update)
+    foreign_repository = RegistryRepository(
+        organization_id=uuid.uuid4(),  # different org
+        origin="custom_actions",
+    )
+
+    with pytest.raises(RegistryNotFound):
+        await service.sync_repository(
+            foreign_repository, RegistryRepositorySync(force=False)
+        )

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -1309,6 +1309,49 @@ async def resolve_role_for_request(workspace_id: WorkspaceID) -> Role:
     return await resolve_role(email, workspace_id)
 
 
+async def resolve_org_role_for_request() -> Role:
+    """Resolve a role with organization context from the current MCP token.
+
+    Mirrors the HTTP API's ``_resolve_org_for_regular_user`` pattern: looks up
+    the caller's organization memberships directly and rejects ambiguous
+    multi-org cases. Used by org-scoped tools (e.g. registry sync) that should
+    not require a workspace selector.
+    """
+    email = get_email_from_token()
+    user = await resolve_user_by_email(email)
+    _raise_if_multi_tenant_superuser(user)
+
+    async with get_async_session_bypass_rls_context_manager() as session:
+        result = await session.execute(
+            select(OrganizationMembership.organization_id).where(
+                OrganizationMembership.user_id == user.id
+            )
+        )
+        org_ids = {row[0] for row in result.all()}
+
+    if not org_ids:
+        raise ValueError(f"User {email} has no organization memberships")
+    if len(org_ids) > 1:
+        raise ValueError(
+            "Multiple organizations found for caller. "
+            "Org-scoped tools require a single-org token."
+        )
+
+    organization_id = next(iter(org_ids))
+    role = Role(
+        type="user",
+        user_id=user.id,
+        workspace_id=None,
+        organization_id=organization_id,
+        service_id="tracecat-mcp",
+        is_platform_superuser=user.is_superuser,
+    )
+    scopes = await compute_effective_scopes(role)
+    role = role.model_copy(update={"scopes": scopes})
+    ctx_role.set(role)
+    return role
+
+
 async def list_workspaces_for_request() -> list[dict[str, str]]:
     """List workspaces accessible to the current MCP caller."""
     identity = get_token_identity()

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -69,6 +69,7 @@ from tracecat.mcp.oidc.features import (
     OFFLINE_ACCESS_SCOPE,
     get_supported_scopes,
 )
+from tracecat.organization.management import get_default_organization_id
 
 
 class MCPTokenIdentity(BaseModel):
@@ -1322,8 +1323,6 @@ async def resolve_org_role_for_request() -> Role:
     the default organization (matching ``_resolve_org_for_superuser``) so
     they can use org-scoped tools without an explicit OrganizationMembership.
     """
-    from tracecat.organization.management import get_default_organization_id
-
     identity = get_token_identity()
     if identity.email is None:
         raise ValueError("Token does not contain an email claim")

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -1318,8 +1318,12 @@ async def resolve_org_role_for_request() -> Role:
     an ``organization_id`` claim or ``org:<uuid>`` scope, that scoping is
     intersected with the user's memberships before the ambiguity check, so a
     single-org-scoped token resolves cleanly even when the user belongs to
-    multiple orgs overall.
+    multiple orgs overall. Single-tenant platform superusers fall back to
+    the default organization (matching ``_resolve_org_for_superuser``) so
+    they can use org-scoped tools without an explicit OrganizationMembership.
     """
+    from tracecat.organization.management import get_default_organization_id
+
     identity = get_token_identity()
     if identity.email is None:
         raise ValueError("Token does not contain an email claim")
@@ -1328,12 +1332,15 @@ async def resolve_org_role_for_request() -> Role:
     _raise_if_multi_tenant_superuser(user)
 
     async with get_async_session_bypass_rls_context_manager() as session:
-        result = await session.execute(
-            select(OrganizationMembership.organization_id).where(
-                OrganizationMembership.user_id == user.id
+        if user.is_superuser and not config.TRACECAT__EE_MULTI_TENANT:
+            org_ids = {await get_default_organization_id(session)}
+        else:
+            result = await session.execute(
+                select(OrganizationMembership.organization_id).where(
+                    OrganizationMembership.user_id == user.id
+                )
             )
-        )
-        org_ids = {row[0] for row in result.all()}
+            org_ids = {row[0] for row in result.all()}
 
     if identity.organization_ids:
         org_ids &= identity.organization_ids

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -1312,13 +1312,19 @@ async def resolve_role_for_request(workspace_id: WorkspaceID) -> Role:
 async def resolve_org_role_for_request() -> Role:
     """Resolve a role with organization context from the current MCP token.
 
-    Mirrors the HTTP API's ``_resolve_org_for_regular_user`` pattern: looks up
-    the caller's organization memberships directly and rejects ambiguous
-    multi-org cases. Used by org-scoped tools (e.g. registry sync) that should
-    not require a workspace selector.
+    Mirrors the HTTP API's ``_resolve_org_for_regular_user`` and the MCP
+    ``list_user_workspaces`` patterns: looks up the caller's organization
+    memberships and rejects ambiguous multi-org cases. When the token carries
+    an ``organization_id`` claim or ``org:<uuid>`` scope, that scoping is
+    intersected with the user's memberships before the ambiguity check, so a
+    single-org-scoped token resolves cleanly even when the user belongs to
+    multiple orgs overall.
     """
-    email = get_email_from_token()
-    user = await resolve_user_by_email(email)
+    identity = get_token_identity()
+    if identity.email is None:
+        raise ValueError("Token does not contain an email claim")
+
+    user = await resolve_user_by_email(identity.email)
     _raise_if_multi_tenant_superuser(user)
 
     async with get_async_session_bypass_rls_context_manager() as session:
@@ -1329,12 +1335,21 @@ async def resolve_org_role_for_request() -> Role:
         )
         org_ids = {row[0] for row in result.all()}
 
+    if identity.organization_ids:
+        org_ids &= identity.organization_ids
+
     if not org_ids:
-        raise ValueError(f"User {email} has no organization memberships")
+        if identity.organization_ids:
+            raise ValueError(
+                f"User {identity.email} has no organization memberships "
+                "matching the token's org scope"
+            )
+        raise ValueError(f"User {identity.email} has no organization memberships")
     if len(org_ids) > 1:
         raise ValueError(
-            "Multiple organizations found for caller. "
-            "Org-scoped tools require a single-org token."
+            "Multiple organizations resolved for caller; org-scoped tools "
+            "require a single-org token (set organization_id claim or "
+            "org:<uuid> scope)."
         )
 
     organization_id = next(iter(org_ids))

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -128,6 +128,10 @@ from tracecat.dsl.validation import (
 )
 from tracecat.exceptions import (
     BuiltinRegistryHasNoSelectionError,
+    RegistryActionValidationError,
+    RegistryError,
+    ScopeDeniedError,
+    TracecatCredentialsNotFoundError,
     TracecatNotFoundError,
     TracecatValidationError,
 )
@@ -145,6 +149,7 @@ from tracecat.mcp.auth import (
     create_mcp_auth,
     get_token_identity,
     list_workspaces_for_request,
+    resolve_org_role_for_request,
     resolve_role_for_request,
 )
 from tracecat.mcp.config import (
@@ -172,8 +177,14 @@ from tracecat.registry.actions.service import (
 from tracecat.registry.actions.service import (
     validate_action_template as validate_template_action_impl,
 )
+from tracecat.registry.constants import (
+    DEFAULT_LOCAL_REGISTRY_ORIGIN,
+    DEFAULT_REGISTRY_ORIGIN,
+)
 from tracecat.registry.lock.service import RegistryLockService
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.registry.repositories.schemas import RegistryRepositorySync
+from tracecat.registry.repositories.service import RegistryReposService
 from tracecat.registry.repository import Repository
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
 from tracecat.secrets.service import SecretsService
@@ -321,6 +332,19 @@ async def _resolve_workspace_role(workspace_id: uuid.UUID) -> tuple[uuid.UUID, R
     except ValueError as exc:
         raise ToolError(str(exc)) from exc
     return workspace_id, role
+
+
+async def _resolve_org_role() -> Role:
+    """Resolve a role with organization context for the caller's token.
+
+    Mirrors the HTTP API: queries the caller's OrganizationMembership rows
+    directly. Errors with a clear message on the multi-org case (matching
+    `_resolve_org_for_regular_user` in tracecat/auth/credentials.py).
+    """
+    try:
+        return await resolve_org_role_for_request()
+    except ValueError as exc:
+        raise ToolError(str(exc)) from exc
 
 
 def _role_workspace_id(role: Role) -> uuid.UUID:
@@ -961,6 +985,28 @@ class TemplateValidationResponse(BaseModel):
     valid: bool
     action_name: str | None = None
     errors: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class CustomRegistrySyncResult(BaseModel):
+    """Per-repository custom registry sync result."""
+
+    success: bool
+    synced_at: datetime
+    repository_id: uuid.UUID
+    origin: str
+    version: str | None = None
+    commit_sha: str | None = None
+    actions_count: int | None = None
+    forced: bool = False
+    error: str | None = None
+
+
+class CustomRegistrySyncResponse(BaseModel):
+    """Aggregate custom registry sync response."""
+
+    success: bool
+    synced_at: datetime
+    results: list[CustomRegistrySyncResult] = Field(default_factory=list)
 
 
 class ActionCatalogAction(BaseModel):
@@ -3586,6 +3632,7 @@ _TOOL_NAMESPACE_BY_NAME: dict[str, str] = {
     "validate_workflow": "workflows",
     "prepare_template_file_upload": "workflows",
     "validate_template_action": "workflows",
+    "sync_custom_registry": "workflows",
     "publish_workflow": "workflows",
     "run_draft_workflow": "workflows",
     "run_published_workflow": "workflows",
@@ -4604,6 +4651,116 @@ async def list_actions(
     except Exception as e:
         logger.error("Failed to list actions", error=str(e))
         raise ToolError(f"Failed to list actions: {e}") from None
+
+
+@mcp.tool()
+async def sync_custom_registry(
+    target_commit_sha: str | None = None,
+    force: bool = False,
+) -> CustomRegistrySyncResponse:
+    """Sync the organization's custom action registry from its remote git repository.
+
+    Pulls the latest code from the custom registry repo registered in the
+    caller's organization, builds a versioned tarball, and makes the synced
+    actions available to agents and workflows. Use this after pushing changes
+    to the custom integrations repo, or to roll forward/back to a specific
+    commit. Existing published workflows must be republished to
+    pick up newly synced action versions.
+
+    Args:
+        target_commit_sha: 40-character commit SHA to sync to. Defaults to
+            the remote's HEAD when omitted.
+        force: Delete the repository's current registry version before
+            syncing, so the same commit can be re-synced from scratch.
+
+    Returns JSON with `success`, `synced_at`, and a `results` array containing
+    the per-repository `repository_id`, `origin`, `version`, `commit_sha`,
+    `actions_count`, `forced`, and `error` (if the sync failed).
+    """
+    try:
+        role = await _resolve_org_role()
+        _role_organization_id(role)
+        synced_at = datetime.now(UTC)
+
+        async with get_async_session_context_manager() as session:
+            repos_service = RegistryReposService(session, role)
+            # Tracecat's data model allows at most one custom registry per
+            # org today: either a remote git repo (`git+ssh://...`) or, in
+            # local-dev deployments, a `local` repo. The MCP tool targets the
+            # remote one. Both built-in origins (platform default, local) are
+            # excluded so a deployment running both still resolves to a
+            # single custom repo. Revisit if multiple custom repos per org
+            # are ever supported.
+            repositories = [
+                repo
+                for repo in await repos_service.list_repositories()
+                if repo.origin
+                not in (DEFAULT_REGISTRY_ORIGIN, DEFAULT_LOCAL_REGISTRY_ORIGIN)
+            ]
+            if not repositories:
+                raise ToolError("No custom registry repository found")
+            if len(repositories) > 1:
+                raise ToolError("Expected exactly one custom registry repository")
+
+            repo = repositories[0]
+            try:
+                response = await repos_service.sync_repository(
+                    repo,
+                    RegistryRepositorySync(
+                        target_commit_sha=target_commit_sha,
+                        force=force,
+                    ),
+                )
+            except ScopeDeniedError:
+                raise
+            except (
+                RegistryActionValidationError,
+                RegistryError,
+                TracecatCredentialsNotFoundError,
+                TracecatValidationError,
+                ValueError,
+            ) as exc:
+                return CustomRegistrySyncResponse(
+                    success=False,
+                    synced_at=synced_at,
+                    results=[
+                        CustomRegistrySyncResult(
+                            success=False,
+                            synced_at=synced_at,
+                            repository_id=repo.id,
+                            origin=repo.origin,
+                            forced=force,
+                            error=str(exc),
+                        )
+                    ],
+                )
+
+            return CustomRegistrySyncResponse(
+                success=response.success,
+                synced_at=synced_at,
+                results=[
+                    CustomRegistrySyncResult(
+                        success=response.success,
+                        synced_at=synced_at,
+                        repository_id=response.repository_id,
+                        origin=response.origin,
+                        version=response.version,
+                        commit_sha=response.commit_sha,
+                        actions_count=response.actions_count,
+                        forced=force,
+                    )
+                ],
+            )
+    except ToolError:
+        raise
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to sync custom registry", error=str(e))
+        raise ToolError(f"Failed to sync custom registry: {e}") from None
 
 
 @mcp.tool()

--- a/tracecat/registry/repositories/router.py
+++ b/tracecat/registry/repositories/router.py
@@ -126,7 +126,7 @@ async def sync_registry_repository(
         logger.error("Unexpected error while syncing repository", exc=e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Unexpected error while syncing repository: {e}",
+            detail="Unexpected error while syncing repository",
         ) from e
 
 

--- a/tracecat/registry/repositories/router.py
+++ b/tracecat/registry/repositories/router.py
@@ -17,6 +17,7 @@ from tracecat.exceptions import (
     EntitlementRequired,
     RegistryActionValidationError,
     RegistryError,
+    RegistryNotFound,
     TracecatCredentialsNotFoundError,
     TracecatValidationError,
 )
@@ -98,6 +99,13 @@ async def sync_registry_repository(
 
     try:
         return await repos_service.sync_repository(repo, sync_params)
+    except RegistryNotFound as e:
+        # Service-level defense-in-depth (cross-org repository) collapses
+        # into the same 404 response as a missing repository.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Registry repository not found",
+        ) from e
     except RegistryActionValidationError as e:
         logger.warning("Validation errors while syncing repository", exc=e)
         raise HTTPException(

--- a/tracecat/registry/repositories/router.py
+++ b/tracecat/registry/repositories/router.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
 
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import select
@@ -15,6 +14,7 @@ from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.models import RegistryRepository
 from tracecat.exceptions import (
+    EntitlementRequired,
     RegistryActionValidationError,
     RegistryError,
     TracecatCredentialsNotFoundError,
@@ -96,118 +96,8 @@ async def sync_registry_repository(
             detail="Registry repository not found",
         ) from e
 
-    # Check entitlement for custom registry (non-default repositories)
-    if repo.origin != DEFAULT_REGISTRY_ORIGIN:
-        await check_entitlement(session, role, Entitlement.CUSTOM_REGISTRY)
-
-    actions_service = RegistryActionsService(session, role)
-    last_synced_at = datetime.now(UTC)
-    target_commit_sha = sync_params.target_commit_sha if sync_params else None
-    force = sync_params.force if sync_params else False
-
-    # For git+ssh repos, we need SSH context for tarball building
-    is_git_ssh = repo.origin.startswith("git+ssh://")
-    git_repo_package_name: str | None = None
-    if is_git_ssh:
-        git_repo_package_name = await get_setting("git_repo_package_name", role=role)
-
-    # If force=True, delete the current version before syncing
-    if force and repo.current_version_id is not None:
-        versions_service = RegistryVersionsService(session, role)
-        current_version = await versions_service.get_version(repo.current_version_id)
-        if current_version:
-            logger.info(
-                "Force sync: deleting current version",
-                repository_id=str(repository_id),
-                version_id=str(current_version.id),
-                version=current_version.version,
-            )
-            await versions_service.delete_version(current_version, commit=False)
-            await session.flush()
-
-    version: str | None = None
-    commit_sha: str | None = None
-    actions_count: int | None = None
-
     try:
-        if is_git_ssh:
-            # Get SSH context for git operations
-            allowed_domains_setting = await get_setting(
-                "git_allowed_domains", role=role
-            )
-            allowed_domains = allowed_domains_setting or {"github.com"}
-            git_url = parse_git_url(repo.origin, allowed_domains=allowed_domains)
-
-            async with ssh_context(
-                role=role, git_url=git_url, session=session
-            ) as ssh_env:
-                # Sync with SSH env for tarball building
-                (
-                    commit_sha,
-                    version,
-                ) = await actions_service.sync_actions_from_repository(
-                    repo,
-                    target_commit_sha=target_commit_sha,
-                    git_repo_package_name=git_repo_package_name,
-                    ssh_env=ssh_env,
-                )
-        else:
-            # Sync without SSH (built-in registry)
-            (
-                commit_sha,
-                version,
-            ) = await actions_service.sync_actions_from_repository(
-                repo,
-                target_commit_sha=target_commit_sha,
-                git_repo_package_name=git_repo_package_name,
-            )
-        logger.info(
-            "Synced repository",
-            origin=repo.origin,
-            commit_sha=commit_sha,
-            version=version,
-            target_commit_sha=target_commit_sha,
-            last_synced_at=last_synced_at,
-            force=force,
-        )
-
-        session.expire(repo)
-        # Update the registry repository table
-        await repos_service.update_repository(
-            repo,
-            RegistryRepositoryUpdate(
-                last_synced_at=last_synced_at, commit_sha=commit_sha
-            ),
-        )
-        logger.info("Updated repository", origin=repo.origin)
-
-        # Get action count from registry index (v2 sync populates index, not RegistryAction)
-        index_actions = await actions_service.list_actions_from_index_by_repository(
-            repo.id
-        )
-        actions_count = len(index_actions)
-
-        return RegistrySyncResponse(
-            success=True,
-            repository_id=repo.id,
-            origin=repo.origin,
-            version=version,
-            commit_sha=commit_sha,
-            actions_count=actions_count,
-            forced=force,
-        )
-
-    except RegistryError as e:
-        logger.warning("Cannot sync repository", exc=e)
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
-        ) from e
-    except TracecatCredentialsNotFoundError as e:
-        logger.warning("Credentials not found", exc=e)
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e),
-        ) from e
+        return await repos_service.sync_repository(repo, sync_params)
     except RegistryActionValidationError as e:
         logger.warning("Validation errors while syncing repository", exc=e)
         raise HTTPException(
@@ -219,11 +109,24 @@ async def sync_registry_repository(
                 errors=e.detail,
             ).model_dump(),
         ) from e
+    except RegistryError as e:
+        logger.warning("Cannot sync repository", exc=e)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from e
+    except TracecatCredentialsNotFoundError as e:
+        logger.warning("Credentials not found", exc=e)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except (EntitlementRequired, HTTPException):
+        raise
     except Exception as e:
         logger.error("Unexpected error while syncing repository", exc=e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Unexpected error while syncing repository {repo.origin!r}: {e}",
+            detail=f"Unexpected error while syncing repository: {e}",
         ) from e
 
 

--- a/tracecat/registry/repositories/service.py
+++ b/tracecat/registry/repositories/service.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import selectinload
 
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import RegistryRepository, RegistryVersion
-from tracecat.exceptions import RegistryError
+from tracecat.exceptions import RegistryError, RegistryNotFound
 from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
 from tracecat.registry.repositories.schemas import (
     RegistryRepositoryCreate,
@@ -100,9 +100,13 @@ class RegistryReposService(BaseOrgService):
         the org-scoped lookup has happened.
 
         Raises:
+            RegistryNotFound: if the repository does not belong to the
+                caller's organization. Surfaced as the same 404 the route
+                returns for missing IDs so this defense-in-depth check
+                cannot be used to probe for cross-org repository IDs.
             EntitlementRequired: for non-default origins without the entitlement.
-            RegistryError, RegistryActionValidationError,
-            TracecatCredentialsNotFoundError: surfaced from the underlying sync.
+            RegistryActionValidationError, TracecatCredentialsNotFoundError:
+                surfaced from the underlying sync.
         """
         # parse_git_url and RegistryActionsService are imported lazily
         # because tracecat.git.utils and tracecat.registry.repository both
@@ -110,6 +114,13 @@ class RegistryReposService(BaseOrgService):
         # module scope.
         from tracecat.git.utils import parse_git_url
         from tracecat.registry.actions.service import RegistryActionsService
+
+        # Defense-in-depth: real callers already org-scope via
+        # get_repository_by_id / list_repositories, but this method accepts a
+        # RegistryRepository instance directly. Treat a wrong-org repository
+        # the same as "not found" so this check cannot enable probing.
+        if repository.organization_id != self.organization_id:
+            raise RegistryNotFound("Registry repository not found")
 
         if repository.origin != DEFAULT_REGISTRY_ORIGIN:
             await check_entitlement(

--- a/tracecat/registry/repositories/service.py
+++ b/tracecat/registry/repositories/service.py
@@ -2,15 +2,20 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Sequence
+from datetime import UTC, datetime
 
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
+from tracecat.authz.controls import require_scope
 from tracecat.db.models import RegistryRepository, RegistryVersion
 from tracecat.exceptions import RegistryError
+from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
 from tracecat.registry.repositories.schemas import (
     RegistryRepositoryCreate,
+    RegistryRepositorySync,
     RegistryRepositoryUpdate,
+    RegistrySyncResponse,
 )
 from tracecat.registry.versions.service import RegistryVersionsService
 from tracecat.service import BaseOrgService
@@ -21,8 +26,9 @@ class RegistryReposService(BaseOrgService):
 
     service_name = "registry_repositories"
 
+    @require_scope("org:registry:read")
     async def list_repositories(self) -> Sequence[RegistryRepository]:
-        """Get all registry repositories."""
+        """Get all registry repositories for the caller's organization."""
         statement = select(RegistryRepository).where(
             RegistryRepository.organization_id == self.organization_id
         )
@@ -77,6 +83,119 @@ class RegistryReposService(BaseOrgService):
         await self.session.commit()
         await self.session.refresh(repository, ["actions"])
         return repository
+
+    @require_scope("org:registry:update")
+    async def sync_repository(
+        self,
+        repository: RegistryRepository,
+        sync_params: RegistryRepositorySync | None = None,
+    ) -> RegistrySyncResponse:
+        """Sync an org-scoped registry repository.
+
+        The caller must have already obtained ``repository`` through this
+        service (e.g. ``get_repository_by_id`` or ``list_repositories``) so
+        the org-scoped lookup has happened.
+
+        Raises:
+            EntitlementRequired: for non-default origins without the entitlement.
+            RegistryError, RegistryActionValidationError,
+            TracecatCredentialsNotFoundError: surfaced from the underlying sync.
+        """
+        from tracecat.git.utils import parse_git_url
+        from tracecat.registry.actions.service import RegistryActionsService
+        from tracecat.settings.service import get_setting
+        from tracecat.ssh import ssh_context
+        from tracecat.tiers.entitlements import Entitlement, check_entitlement
+
+        if repository.origin != DEFAULT_REGISTRY_ORIGIN:
+            await check_entitlement(
+                self.session, self.role, Entitlement.CUSTOM_REGISTRY
+            )
+
+        actions_service = RegistryActionsService(self.session, self.role)
+        last_synced_at = datetime.now(UTC)
+        target_commit_sha = sync_params.target_commit_sha if sync_params else None
+        force = sync_params.force if sync_params else False
+
+        is_git_ssh = repository.origin.startswith("git+ssh://")
+        git_repo_package_name: str | None = None
+        if is_git_ssh:
+            git_repo_package_name = await get_setting(
+                "git_repo_package_name", role=self.role
+            )
+
+        if force and repository.current_version_id is not None:
+            versions_service = RegistryVersionsService(self.session, self.role)
+            current_version = await versions_service.get_version(
+                repository.current_version_id
+            )
+            if current_version:
+                self.logger.info(
+                    "Force sync: deleting current version",
+                    repository_id=str(repository.id),
+                    version_id=str(current_version.id),
+                    version=current_version.version,
+                )
+                await versions_service.delete_version(current_version, commit=False)
+                await self.session.flush()
+
+        if is_git_ssh:
+            allowed_domains_setting = await get_setting(
+                "git_allowed_domains", role=self.role
+            )
+            allowed_domains = allowed_domains_setting or {"github.com"}
+            git_url = parse_git_url(repository.origin, allowed_domains=allowed_domains)
+
+            async with ssh_context(
+                role=self.role, git_url=git_url, session=self.session
+            ) as ssh_env:
+                (
+                    commit_sha,
+                    version,
+                ) = await actions_service.sync_actions_from_repository(
+                    repository,
+                    target_commit_sha=target_commit_sha,
+                    git_repo_package_name=git_repo_package_name,
+                    ssh_env=ssh_env,
+                )
+        else:
+            commit_sha, version = await actions_service.sync_actions_from_repository(
+                repository,
+                target_commit_sha=target_commit_sha,
+                git_repo_package_name=git_repo_package_name,
+            )
+
+        self.logger.info(
+            "Synced repository",
+            repository_id=str(repository.id),
+            commit_sha=commit_sha,
+            version=version,
+            target_commit_sha=target_commit_sha,
+            last_synced_at=last_synced_at,
+            force=force,
+        )
+
+        self.session.expire(repository)
+        await self.update_repository(
+            repository,
+            RegistryRepositoryUpdate(
+                last_synced_at=last_synced_at, commit_sha=commit_sha
+            ),
+        )
+        self.logger.info("Updated repository", repository_id=str(repository.id))
+
+        index_actions = await actions_service.list_actions_from_index_by_repository(
+            repository.id
+        )
+        return RegistrySyncResponse(
+            success=True,
+            repository_id=repository.id,
+            origin=repository.origin,
+            version=version,
+            commit_sha=commit_sha,
+            actions_count=len(index_actions),
+            forced=force,
+        )
 
     async def delete_repository(self, repository: RegistryRepository) -> None:
         """Delete a registry repository."""

--- a/tracecat/registry/repositories/service.py
+++ b/tracecat/registry/repositories/service.py
@@ -19,6 +19,9 @@ from tracecat.registry.repositories.schemas import (
 )
 from tracecat.registry.versions.service import RegistryVersionsService
 from tracecat.service import BaseOrgService
+from tracecat.settings.service import get_setting
+from tracecat.ssh import ssh_context
+from tracecat.tiers.entitlements import Entitlement, check_entitlement
 
 
 class RegistryReposService(BaseOrgService):
@@ -101,11 +104,12 @@ class RegistryReposService(BaseOrgService):
             RegistryError, RegistryActionValidationError,
             TracecatCredentialsNotFoundError: surfaced from the underlying sync.
         """
+        # parse_git_url and RegistryActionsService are imported lazily
+        # because tracecat.git.utils and tracecat.registry.repository both
+        # import RegistryReposService back, which would cycle if pulled to
+        # module scope.
         from tracecat.git.utils import parse_git_url
         from tracecat.registry.actions.service import RegistryActionsService
-        from tracecat.settings.service import get_setting
-        from tracecat.ssh import ssh_context
-        from tracecat.tiers.entitlements import Entitlement, check_entitlement
 
         if repository.origin != DEFAULT_REGISTRY_ORIGIN:
             await check_entitlement(


### PR DESCRIPTION
## Summary

- Adds the `workflows_sync_custom_registry` MCP tool so org admins can sync their custom action registry from any MCP client without picking a workspace.
- Consolidates the sync pipeline onto `RegistryReposService.sync_repository`, gated by `@require_scope("org:registry:update")`, so the existing HTTP route and the new MCP tool share one source of truth instead of duplicating entitlement / SSH / force-version-delete / action-sync logic.
- Mirrors the API layer's multi-org guard in MCP via a new `resolve_org_role_for_request` helper that queries `OrganizationMembership` directly (same pattern as `_resolve_org_for_regular_user`).

## Why

[#2565](https://github.com/TracecatHQ/tracecat/pull/2565) added the same MCP tool but left the existing `POST /registry/repos/{id}/sync` route owning the full sync pipeline inline, with the service method re-implementing it next door. This PR keeps the new MCP capability while turning the route into a thin caller of the service so the two paths can't drift.

## Behavior changes

- `RegistryReposService.sync_repository(repository, sync_params)` now takes a `RegistryRepository` (not `repository_id`) so callers reuse the org-scoped lookup they already did. The route fetches once at the top for 404 handling and reuses the same instance for the 422 validation-error body.
- `RegistryReposService.list_repositories` is gated on `org:registry:read` — it had no other callers, and read scope matches the operation's intent.
- `sync_custom_registry` filters out both `DEFAULT_REGISTRY_ORIGIN` and `DEFAULT_LOCAL_REGISTRY_ORIGIN` so a deployment running both built-ins still resolves to a single custom repo. The "exactly one custom registry" check stays as a defensive guard documented inline.
- The MCP tool no longer takes `workspace_id`; the org is resolved from the auth token. Multi-org tokens get a clear error matching the HTTP API's behavior.
- `sync_repository` and the new `Updated repository` log line key off `repository_id` rather than `origin` to remove a theoretical credential-leak path.

## Test plan

- [x] `uv run pytest tests/unit/test_registry_repositories_service.py tests/unit/test_registry_repositories_router.py tests/unit/api/test_api_registry_repositories_entitlements.py tests/unit/test_route_scope_guards.py tests/unit/test_mcp_server.py` (256 passed)
- [x] `uv run ruff check` and `uv run ruff format --check` on changed files
- [x] `uv run basedpyright --warnings tracecat/registry/repositories tracecat/mcp/server.py tracecat/mcp/auth.py` (0 errors, 0 warnings)
- [ ] Manual: hit `POST /registry/repos/{id}/sync` against a registered git+ssh repo via `just cluster up -d` and confirm response shape is unchanged.
- [ ] Manual: invoke `workflows_sync_custom_registry` from an MCP client against an org with one custom registry; confirm success and per-repo result fields.
- [ ] Manual: invoke against an org with no custom registry → expect `No custom registry repository found` ToolError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `workflows_sync_custom_registry` MCP tool to sync an org’s custom action registry without a workspace, and consolidates the sync flow into `RegistryReposService.sync_repository` with org-scoped scopes and entitlements. Honors token org scoping (with single-tenant superuser default‑org fallback), adds a cross‑org 404, and returns generic 500s.

- **New Features**
  - `workflows_sync_custom_registry`: sync to HEAD or `target_commit_sha`, optional `force`, and clear ToolErrors for missing scope or org context; filters out `DEFAULT_REGISTRY_ORIGIN` and `DEFAULT_LOCAL_REGISTRY_ORIGIN` and reports per‑repo results (`version`, `commit_sha`, `actions_count`, errors).
  - `resolve_org_role_for_request`: intersects token org scope with memberships; clear errors for multi‑org tokens and unowned scopes; single‑tenant superusers fall back to the default org.

- **Refactors**
  - Moved the full sync pipeline into `RegistryReposService.sync_repository`, gated by `@require_scope("org:registry:update")`, with entitlement checks for non‑default repos; route now delegates and returns a generic 500 detail.
  - `RegistryReposService.list_repositories` now requires `org:registry:read`; `sync_repository` rejects cross‑org repositories with `RegistryNotFound` (mapped to 404); logs use `repository_id` instead of origin.

<sup>Written for commit dfa7e14f9e9ed9c16416fa69f4380f9db427476a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

