### PR TITLE
infra: Support isolated Fargate stacks

### DIFF
--- a/deployments/fargate/main.tf
+++ b/deployments/fargate/main.tf
@@ -12,16 +12,22 @@ locals {
 module "network" {
   source = "./modules/network"
 
-  aws_region     = var.aws_region
-  domain_name    = var.domain_name
-  hosted_zone_id = var.hosted_zone_id
+  aws_region           = var.aws_region
+  name_prefix          = var.name_prefix
+  vpc_cidr             = var.vpc_cidr
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+  domain_name          = var.domain_name
+  hosted_zone_id       = var.hosted_zone_id
 }
 
 module "ecs" {
   source = "./modules/ecs"
 
   # AWS provider
-  aws_region = var.aws_region
+  aws_region      = var.aws_region
+  name_prefix     = var.name_prefix
+  iam_name_prefix = var.iam_name_prefix
 
   # Network configuration from network module
   vpc_id                  = module.network.vpc_id
@@ -128,6 +134,7 @@ module "ecs" {
   # Compute / memory
   api_cpu                                  = var.api_cpu
   api_memory                               = var.api_memory
+  api_desired_count                        = var.api_desired_count
   worker_cpu                               = var.worker_cpu
   worker_memory                            = var.worker_memory
   worker_desired_count                     = var.worker_desired_count

--- a/deployments/fargate/main.tf
+++ b/deployments/fargate/main.tf
@@ -25,9 +25,13 @@ module "ecs" {
   source = "./modules/ecs"
 
   # AWS provider
-  aws_region      = var.aws_region
-  name_prefix     = var.name_prefix
-  iam_name_prefix = var.iam_name_prefix
+  aws_region                       = var.aws_region
+  name_prefix                      = var.name_prefix
+  iam_name_prefix                  = var.iam_name_prefix
+  core_db_identifier               = var.core_db_identifier
+  temporal_db_identifier           = var.temporal_db_identifier
+  temporal_db_parameter_group_name = var.temporal_db_parameter_group_name
+  redis_default_user_id            = var.redis_default_user_id
 
   # Network configuration from network module
   vpc_id                  = module.network.vpc_id

--- a/deployments/fargate/modules/ecs/alb.tf
+++ b/deployments/fargate/modules/ecs/alb.tf
@@ -3,20 +3,20 @@
 # behaviour for Service Connect SSE traffic must be handled in the downstream
 # proxies (Caddy and the managed Envoy sidecars).
 resource "aws_alb" "this" {
-  name               = "tracecat-alb"
+  name               = "${var.name_prefix}-alb"
   internal           = var.is_internal
   load_balancer_type = "application"
   subnets            = var.public_subnet_ids
   security_groups    = [aws_security_group.alb.id]
 
   tags = {
-    Name = "tracecat-alb"
+    Name = "${var.name_prefix}-alb"
   }
 }
 
 # Target Group for Caddy
 resource "aws_alb_target_group" "caddy" {
-  name        = "tracecat-caddy-tg"
+  name        = "${var.name_prefix}-caddy-tg"
   port        = 80
   protocol    = "HTTP"
   vpc_id      = var.vpc_id
@@ -68,7 +68,7 @@ resource "aws_alb_listener" "http" {
 resource "aws_wafv2_web_acl" "this" {
   count = var.enable_waf ? 1 : 0
 
-  name        = "tracecat-waf-acl"
+  name        = "${var.name_prefix}-waf-acl"
   description = "Default WAF configuration for Tracecat ALB"
   scope       = "REGIONAL"
 
@@ -524,7 +524,7 @@ resource "aws_wafv2_web_acl" "this" {
 
   visibility_config {
     cloudwatch_metrics_enabled = true
-    metric_name                = "tracecat-waf-metric"
+    metric_name                = "${var.name_prefix}-waf-metric"
     sampled_requests_enabled   = true
   }
 }
@@ -533,7 +533,7 @@ resource "aws_wafv2_web_acl" "this" {
 resource "aws_wafv2_regex_pattern_set" "attachments_endpoint" {
   count = var.enable_waf ? 1 : 0
 
-  name        = "attachments-endpoint-pattern"
+  name        = "${var.name_prefix}-attachments-endpoint-pattern"
   description = "Pattern to match attachments API endpoint"
   scope       = "REGIONAL"
 
@@ -545,7 +545,7 @@ resource "aws_wafv2_regex_pattern_set" "attachments_endpoint" {
 resource "aws_wafv2_regex_pattern_set" "mcp_oauth_endpoints" {
   count = var.enable_waf ? 1 : 0
 
-  name        = "mcp-oauth-endpoints-pattern"
+  name        = "${var.name_prefix}-mcp-oauth-endpoints-pattern"
   description = "Matches MCP OAuth endpoints that carry loopback redirect URIs"
   scope       = "REGIONAL"
 
@@ -559,7 +559,7 @@ resource "aws_wafv2_regex_pattern_set" "mcp_oauth_endpoints" {
 resource "aws_wafv2_regex_pattern_set" "mcp_public_endpoints" {
   count = var.enable_waf ? 1 : 0
 
-  name        = "mcp-public-endpoint-pattern"
+  name        = "${var.name_prefix}-mcp-public-endpoint-pattern"
   description = "Matches MCP discovery, transport, and OAuth endpoints"
   scope       = "REGIONAL"
 

--- a/deployments/fargate/modules/ecs/cloudwatch.tf
+++ b/deployments/fargate/modules/ecs/cloudwatch.tf
@@ -1,4 +1,4 @@
 resource "aws_cloudwatch_log_group" "tracecat_log_group" {
-  name              = "/ecs/tracecat"
+  name              = "/ecs/${var.name_prefix}"
   retention_in_days = 30
 }

--- a/deployments/fargate/modules/ecs/ecs-agent-executor.tf
+++ b/deployments/fargate/modules/ecs/ecs-agent-executor.tf
@@ -1,6 +1,6 @@
 # ECS Task Definition for Agent executor service
 resource "aws_ecs_task_definition" "agent_executor_task_definition" {
-  family                   = "TracecatAgentExecutorTaskDefinition"
+  family                   = "${var.iam_name_prefix}AgentExecutorTaskDefinition"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.agent_executor_cpu

--- a/deployments/fargate/modules/ecs/ecs-agent-worker.tf
+++ b/deployments/fargate/modules/ecs/ecs-agent-worker.tf
@@ -1,6 +1,6 @@
 # ECS Task Definition for Agent worker service
 resource "aws_ecs_task_definition" "agent_worker_task_definition" {
-  family                   = "TracecatAgentWorkerTaskDefinition"
+  family                   = "${var.iam_name_prefix}AgentWorkerTaskDefinition"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.agent_worker_cpu

--- a/deployments/fargate/modules/ecs/ecs-api.tf
+++ b/deployments/fargate/modules/ecs/ecs-api.tf
@@ -1,6 +1,6 @@
 # ECS Task Definition for API Service
 resource "aws_ecs_task_definition" "api_task_definition" {
-  family                   = "TracecatApiTaskDefinition"
+  family                   = "${var.iam_name_prefix}ApiTaskDefinition"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.api_cpu

--- a/deployments/fargate/modules/ecs/ecs-caddy.tf
+++ b/deployments/fargate/modules/ecs/ecs-caddy.tf
@@ -1,6 +1,6 @@
 # ECS Task Definition for Caddy service
 resource "aws_ecs_task_definition" "caddy_task_definition" {
-  family                   = "TracecatCaddyTaskDefinition"
+  family                   = "${var.iam_name_prefix}CaddyTaskDefinition"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.caddy_cpu

--- a/deployments/fargate/modules/ecs/ecs-executor.tf
+++ b/deployments/fargate/modules/ecs/ecs-executor.tf
@@ -1,6 +1,6 @@
 # ECS Task Definition for Executor service
 resource "aws_ecs_task_definition" "executor_task_definition" {
-  family                   = "TracecatExecutorTaskDefinition"
+  family                   = "${var.iam_name_prefix}ExecutorTaskDefinition"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.executor_cpu

--- a/deployments/fargate/modules/ecs/ecs-litellm.tf
+++ b/deployments/fargate/modules/ecs/ecs-litellm.tf
@@ -1,6 +1,6 @@
 # ECS Task Definition for LiteLLM Service
 resource "aws_ecs_task_definition" "litellm_task_definition" {
-  family                   = "TracecatLitellmTaskDefinition"
+  family                   = "${var.iam_name_prefix}LitellmTaskDefinition"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.litellm_cpu

--- a/deployments/fargate/modules/ecs/ecs-mcp.tf
+++ b/deployments/fargate/modules/ecs/ecs-mcp.tf
@@ -1,7 +1,7 @@
 # ECS Task Definition for MCP Service
 resource "aws_ecs_task_definition" "mcp_task_definition" {
   count                    = var.enable_mcp ? 1 : 0
-  family                   = "TracecatMcpTaskDefinition"
+  family                   = "${var.iam_name_prefix}McpTaskDefinition"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.mcp_cpu

--- a/deployments/fargate/modules/ecs/ecs-temporal-ui.tf
+++ b/deployments/fargate/modules/ecs/ecs-temporal-ui.tf
@@ -2,7 +2,7 @@
 resource "aws_ecs_task_definition" "temporal_ui_task_definition" {
   count = var.disable_temporal_ui ? 0 : 1
 
-  family                   = "TemporalUiTaskDefinition"
+  family                   = "${var.iam_name_prefix}TemporalUiTaskDefinition"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = "256"

--- a/deployments/fargate/modules/ecs/ecs-temporal.tf
+++ b/deployments/fargate/modules/ecs/ecs-temporal.tf
@@ -1,7 +1,7 @@
 # ECS Task Definition for Temporal Service
 resource "aws_ecs_task_definition" "temporal_task_definition" {
   count                    = var.disable_temporal_autosetup ? 0 : 1
-  family                   = "temporal"
+  family                   = "${var.name_prefix}-temporal"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.temporal_cpu

--- a/deployments/fargate/modules/ecs/ecs-ui.tf
+++ b/deployments/fargate/modules/ecs/ecs-ui.tf
@@ -1,6 +1,6 @@
 # ECS Task Definition for UI Service
 resource "aws_ecs_task_definition" "ui_task_definition" {
-  family                   = "TracecatUiTaskDefinition"
+  family                   = "${var.iam_name_prefix}UiTaskDefinition"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.ui_cpu

--- a/deployments/fargate/modules/ecs/ecs-worker.tf
+++ b/deployments/fargate/modules/ecs/ecs-worker.tf
@@ -1,6 +1,6 @@
 # ECS Task Definition for Worker service
 resource "aws_ecs_task_definition" "worker_task_definition" {
-  family                   = "TracecatWorkerTaskDefinition"
+  family                   = "${var.iam_name_prefix}WorkerTaskDefinition"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.worker_cpu

--- a/deployments/fargate/modules/ecs/ecs.tf
+++ b/deployments/fargate/modules/ecs/ecs.tf
@@ -1,6 +1,6 @@
 # CloudMap Namespace for Service Connect
 resource "aws_service_discovery_http_namespace" "namespace" {
-  name        = "tracecat.local"
+  name        = "${var.name_prefix}.local"
   description = "Private DNS namespace for ECS services"
 }
 
@@ -11,7 +11,7 @@ resource "time_sleep" "wait_for_namespace" {
 }
 
 resource "aws_ecs_cluster" "tracecat_cluster" {
-  name = "tracecat-cluster"
+  name = "${var.name_prefix}-cluster"
 
   depends_on = [time_sleep.wait_for_namespace]
 

--- a/deployments/fargate/modules/ecs/iam.tf
+++ b/deployments/fargate/modules/ecs/iam.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "assume_role" {
 
 # ECS Poll policy
 resource "aws_iam_policy" "ecs_poll" {
-  name        = "TracecatECSPollPolicy"
+  name        = "${var.iam_name_prefix}ECSPollPolicy"
   description = "Policy for ECS Poll action"
 
   policy = jsonencode({
@@ -50,7 +50,7 @@ resource "aws_iam_policy" "ecs_poll" {
 
 # Redis IAM access policy
 resource "aws_iam_policy" "redis_iam_access" {
-  name        = "TracecatRedisIAMAccessPolicy"
+  name        = "${var.iam_name_prefix}RedisIAMAccessPolicy"
   description = "Policy for ElastiCache Redis metadata access (no IAM auth)"
 
   policy = jsonencode({
@@ -69,7 +69,7 @@ resource "aws_iam_policy" "redis_iam_access" {
 
 # S3 access policy for Tracecat blob storage buckets
 resource "aws_iam_policy" "s3_blob_access" {
-  name        = "TracecatS3BlobStoragePolicy"
+  name        = "${var.iam_name_prefix}S3BlobStoragePolicy"
   description = "Policy for S3 blob storage access (attachments, registry, skills, workflow)"
 
   policy = jsonencode({
@@ -126,7 +126,7 @@ resource "aws_iam_policy" "s3_blob_access" {
 
 # Secrets access policy
 resource "aws_iam_policy" "secrets_access" {
-  name        = "TracecatSecretsAccessPolicy"
+  name        = "${var.iam_name_prefix}SecretsAccessPolicy"
   description = "Policy for accessing Tracecat secrets"
 
   policy = jsonencode({
@@ -161,7 +161,7 @@ resource "aws_iam_policy" "secrets_access" {
 # service (internal OIDC client-secret derivation).  It must NOT be
 # accessible from worker or executor services to limit blast radius.
 resource "aws_iam_policy" "api_only_secrets_access" {
-  name        = "TracecatAPIOnlySecretsAccessPolicy"
+  name        = "${var.iam_name_prefix}APIOnlySecretsAccessPolicy"
   description = "Policy for accessing API-only secrets (USER_AUTH_SECRET)"
 
   policy = jsonencode({
@@ -178,7 +178,7 @@ resource "aws_iam_policy" "api_only_secrets_access" {
 
 resource "aws_iam_policy" "temporal_payload_encryption_keyring_access" {
   count       = var.temporal_payload_encryption_keyring_arn != null ? 1 : 0
-  name        = "TracecatTemporalPayloadEncryptionKeyringAccessPolicy"
+  name        = "${var.iam_name_prefix}TemporalPayloadEncryptionKeyringAccessPolicy"
   description = "Policy for accessing the Temporal payload encryption keyring"
 
   policy = jsonencode({
@@ -194,7 +194,7 @@ resource "aws_iam_policy" "temporal_payload_encryption_keyring_access" {
 }
 
 resource "aws_iam_policy" "ui_secrets_access" {
-  name        = "TracecatUISecretsAccessPolicy"
+  name        = "${var.iam_name_prefix}UISecretsAccessPolicy"
   description = "Policy for accessing Tracecat UI secrets"
 
   policy = jsonencode({
@@ -213,7 +213,7 @@ resource "aws_iam_policy" "ui_secrets_access" {
 
 resource "aws_iam_policy" "temporal_secrets_access" {
   count       = var.disable_temporal_autosetup ? 0 : 1
-  name        = "TracecatTemporalSecretsAccessPolicy"
+  name        = "${var.iam_name_prefix}TemporalSecretsAccessPolicy"
   description = "Policy for accessing Temporal secrets"
 
   policy = jsonencode({
@@ -234,7 +234,7 @@ resource "aws_iam_policy" "temporal_secrets_access" {
 
 # API execution role
 resource "aws_iam_role" "api_execution" {
-  name               = "TracecatAPIExecutionRole"
+  name               = "${var.iam_name_prefix}APIExecutionRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -255,7 +255,7 @@ resource "aws_iam_role_policy_attachment" "api_execution_api_only_secrets" {
 
 # Worker execution role
 resource "aws_iam_role" "worker_execution" {
-  name               = "TracecatWorkerExecutionRole"
+  name               = "${var.iam_name_prefix}WorkerExecutionRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -271,12 +271,12 @@ resource "aws_iam_role_policy_attachment" "worker_execution_secrets" {
 
 # API and Worker task role
 resource "aws_iam_role" "api_worker_task" {
-  name               = "TracecatAPIWorkerTaskRole"
+  name               = "${var.iam_name_prefix}APIWorkerTaskRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role_policy" "api_worker_task_db_access" {
-  name = "TracecatAPIWorkerDBAccessPolicy"
+  name = "${var.iam_name_prefix}APIWorkerDBAccessPolicy"
   role = aws_iam_role.api_worker_task.id
 
   policy = jsonencode({
@@ -316,12 +316,12 @@ resource "aws_iam_role_policy_attachment" "api_worker_task_temporal_payload_encr
 }
 
 resource "aws_iam_role" "executor_task" {
-  name               = "TracecatExecutorTaskRole"
+  name               = "${var.iam_name_prefix}ExecutorTaskRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role_policy" "executor_task_db_access" {
-  name = "TracecatExecutorDBAccessPolicy"
+  name = "${var.iam_name_prefix}ExecutorDBAccessPolicy"
   role = aws_iam_role.executor_task.id
 
   policy = jsonencode({
@@ -343,7 +343,7 @@ resource "aws_iam_role_policy" "executor_task_db_access" {
 }
 
 resource "aws_iam_role_policy" "executor_task_assume_role" {
-  name = "TracecatExecutorAssumeRolePolicy"
+  name = "${var.iam_name_prefix}ExecutorAssumeRolePolicy"
   role = aws_iam_role.executor_task.id
 
   policy = jsonencode({
@@ -380,7 +380,7 @@ resource "aws_iam_role_policy_attachment" "executor_task_temporal_payload_encryp
 
 # UI execution role
 resource "aws_iam_role" "ui_execution" {
-  name               = "TracecatUIExecutionRole"
+  name               = "${var.iam_name_prefix}UIExecutionRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -398,7 +398,7 @@ resource "aws_iam_role_policy_attachment" "ui_execution_secrets" {
 # Temporal execution role
 resource "aws_iam_role" "temporal_execution" {
   count              = var.disable_temporal_autosetup ? 0 : 1
-  name               = "TracecatTemporalExecutionRole"
+  name               = "${var.iam_name_prefix}TemporalExecutionRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -417,13 +417,13 @@ resource "aws_iam_role_policy_attachment" "temporal_execution_secrets" {
 # Temporal task role
 resource "aws_iam_role" "temporal_task" {
   count              = var.disable_temporal_autosetup ? 0 : 1
-  name               = "TracecatTemporalTaskRole"
+  name               = "${var.iam_name_prefix}TemporalTaskRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role_policy" "temporal_task_db_access" {
   count = var.disable_temporal_autosetup ? 0 : 1
-  name  = "TracecatTemporalDBAccessPolicy"
+  name  = "${var.iam_name_prefix}TemporalDBAccessPolicy"
   role  = aws_iam_role.temporal_task[0].id
 
   policy = jsonencode({
@@ -445,7 +445,7 @@ resource "aws_iam_role_policy" "temporal_task_db_access" {
 # MCP execution role
 resource "aws_iam_role" "mcp_execution" {
   count              = var.enable_mcp ? 1 : 0
-  name               = "TracecatMCPExecutionRole"
+  name               = "${var.iam_name_prefix}MCPExecutionRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -476,13 +476,13 @@ resource "aws_iam_role_policy_attachment" "mcp_execution_cloudwatch_logs" {
 # MCP task role
 resource "aws_iam_role" "mcp_task" {
   count              = var.enable_mcp ? 1 : 0
-  name               = "TracecatMCPTaskRole"
+  name               = "${var.iam_name_prefix}MCPTaskRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role_policy" "mcp_task_db_access" {
   count = var.enable_mcp ? 1 : 0
-  name  = "TracecatMCPDBAccessPolicy"
+  name  = "${var.iam_name_prefix}MCPDBAccessPolicy"
   role  = aws_iam_role.mcp_task[0].id
 
   policy = jsonencode({
@@ -511,7 +511,7 @@ resource "aws_iam_role_policy_attachment" "mcp_task_temporal_payload_encryption_
 
 # LiteLLM execution role
 resource "aws_iam_role" "litellm_execution" {
-  name               = "TracecatLitellmExecutionRole"
+  name               = "${var.iam_name_prefix}LitellmExecutionRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -532,12 +532,12 @@ resource "aws_iam_role_policy_attachment" "litellm_execution_cloudwatch_logs" {
 
 # LiteLLM task role
 resource "aws_iam_role" "litellm_task" {
-  name               = "TracecatLitellmTaskRole"
+  name               = "${var.iam_name_prefix}LitellmTaskRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role_policy" "litellm_task_db_access" {
-  name = "TracecatLitellmDBAccessPolicy"
+  name = "${var.iam_name_prefix}LitellmDBAccessPolicy"
   role = aws_iam_role.litellm_task.id
 
   policy = jsonencode({
@@ -559,7 +559,7 @@ resource "aws_iam_role_policy" "litellm_task_db_access" {
 }
 
 resource "aws_iam_role_policy" "litellm_task_assume_role" {
-  name = "TracecatLitellmAssumeRolePolicy"
+  name = "${var.iam_name_prefix}LitellmAssumeRolePolicy"
   role = aws_iam_role.litellm_task.id
 
   policy = jsonencode({
@@ -580,7 +580,7 @@ resource "aws_iam_role_policy" "litellm_task_assume_role" {
 
 # Caddy execution role
 resource "aws_iam_role" "caddy_execution" {
-  name               = "TracecatCaddyExecutionRole"
+  name               = "${var.iam_name_prefix}CaddyExecutionRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -591,7 +591,7 @@ resource "aws_iam_role_policy_attachment" "caddy_execution_ecs_poll" {
 
 # Add CloudWatch Logs policy
 resource "aws_iam_policy" "cloudwatch_logs" {
-  name        = "TracecatCloudWatchLogsPolicy"
+  name        = "${var.iam_name_prefix}CloudWatchLogsPolicy"
   description = "Policy for writing to CloudWatch Logs"
 
   policy = jsonencode({
@@ -640,7 +640,7 @@ resource "aws_iam_role_policy_attachment" "caddy_execution_cloudwatch_logs" {
 # (Optional) Temporal UI execution role
 resource "aws_iam_policy" "temporal_ui_secrets_access" {
   count       = var.disable_temporal_ui ? 0 : 1
-  name        = "TracecatTemporalUISecretsAccessPolicy"
+  name        = "${var.iam_name_prefix}TemporalUISecretsAccessPolicy"
   description = "Policy for accessing Temporal UI secrets"
 
   policy = jsonencode({
@@ -660,7 +660,7 @@ resource "aws_iam_policy" "temporal_ui_secrets_access" {
 
 resource "aws_iam_role" "temporal_ui_execution" {
   count              = var.disable_temporal_ui ? 0 : 1
-  name               = "TracecatTemporalUIExecutionRole"
+  name               = "${var.iam_name_prefix}TemporalUIExecutionRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -685,6 +685,6 @@ resource "aws_iam_role_policy_attachment" "temporal_ui_execution_secrets" {
 # Temporal UI task role (minimal permissions)
 resource "aws_iam_role" "temporal_ui_task" {
   count              = var.disable_temporal_ui ? 0 : 1
-  name               = "TracecatTemporalUITaskRole"
+  name               = "${var.iam_name_prefix}TemporalUITaskRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }

--- a/deployments/fargate/modules/ecs/rds.tf
+++ b/deployments/fargate/modules/ecs/rds.tf
@@ -14,7 +14,7 @@ resource "random_string" "temporal_snapshot_suffix" {
 # Check if snapshots exist for core database
 data "aws_db_snapshot" "core_snapshots" {
   count                  = var.restore_from_snapshot && var.core_db_snapshot_name == null ? 1 : 0
-  db_instance_identifier = "core-database"
+  db_instance_identifier = "${var.name_prefix}-core-database"
   most_recent            = true
   include_shared         = false
   include_public         = false
@@ -30,7 +30,7 @@ data "aws_db_snapshot" "core_snapshots" {
 # Check if snapshots exist for temporal database
 data "aws_db_snapshot" "temporal_snapshots" {
   count                  = var.disable_temporal_autosetup ? 0 : (var.restore_from_snapshot && var.temporal_db_snapshot_name == null ? 1 : 0)
-  db_instance_identifier = "temporal-database"
+  db_instance_identifier = "${var.name_prefix}-temporal-database"
   most_recent            = true
   include_shared         = false
   include_public         = false
@@ -44,7 +44,7 @@ data "aws_db_snapshot" "temporal_snapshots" {
 }
 
 resource "aws_db_subnet_group" "tracecat_db_subnet" {
-  name       = "tracecat-db-subnet"
+  name       = "${var.name_prefix}-db-subnet"
   subnet_ids = var.private_subnet_ids
 }
 
@@ -63,7 +63,7 @@ resource "time_sleep" "wait_for_rds_dependencies" {
 resource "aws_db_parameter_group" "temporal_database_compatibility" {
   count = var.disable_temporal_autosetup || var.temporal_db_force_ssl ? 0 : 1
 
-  name        = "temporal-db-compatibility"
+  name        = "${var.name_prefix}-temporal-db-compatibility"
   family      = "postgres${split(".", var.db_engine_version)[0]}"
   description = "Temporal PostgreSQL parameter group for Fargate auto-setup compatibility"
 
@@ -75,7 +75,7 @@ resource "aws_db_parameter_group" "temporal_database_compatibility" {
 }
 
 resource "aws_db_instance" "core_database" {
-  identifier                  = "core-database"
+  identifier                  = "${var.name_prefix}-core-database"
   engine                      = "postgres"
   engine_version              = var.db_engine_version
   instance_class              = var.tracecat_db_instance_class
@@ -88,7 +88,7 @@ resource "aws_db_instance" "core_database" {
   db_subnet_group_name        = aws_db_subnet_group.tracecat_db_subnet.name
   vpc_security_group_ids      = [aws_security_group.core_db.id]
   skip_final_snapshot         = var.rds_skip_final_snapshot
-  final_snapshot_identifier   = "final-core-db-${local.snapshot_timestamp}-${random_string.core_snapshot_suffix.result}"
+  final_snapshot_identifier   = "final-${var.name_prefix}-core-db-${local.snapshot_timestamp}-${random_string.core_snapshot_suffix.result}"
   snapshot_identifier = var.restore_from_snapshot ? (
     var.core_db_snapshot_name != null ?
     var.core_db_snapshot_name :
@@ -113,7 +113,7 @@ resource "aws_db_instance" "core_database" {
 
 resource "aws_db_instance" "temporal_database" {
   count                       = var.disable_temporal_autosetup ? 0 : 1
-  identifier                  = "temporal-database"
+  identifier                  = "${var.name_prefix}-temporal-database"
   engine                      = "postgres"
   engine_version              = var.db_engine_version
   instance_class              = var.temporal_db_instance_class
@@ -129,7 +129,7 @@ resource "aws_db_instance" "temporal_database" {
     "default.postgres${split(".", var.db_engine_version)[0]}"
   ) : aws_db_parameter_group.temporal_database_compatibility[0].name
   skip_final_snapshot       = var.rds_skip_final_snapshot
-  final_snapshot_identifier = "final-temporal-db-${local.snapshot_timestamp}-${random_string.temporal_snapshot_suffix[0].result}"
+  final_snapshot_identifier = "final-${var.name_prefix}-temporal-db-${local.snapshot_timestamp}-${random_string.temporal_snapshot_suffix[0].result}"
   snapshot_identifier = var.restore_from_snapshot ? (
     var.temporal_db_snapshot_name != null ?
     var.temporal_db_snapshot_name :

--- a/deployments/fargate/modules/ecs/rds.tf
+++ b/deployments/fargate/modules/ecs/rds.tf
@@ -14,7 +14,7 @@ resource "random_string" "temporal_snapshot_suffix" {
 # Check if snapshots exist for core database
 data "aws_db_snapshot" "core_snapshots" {
   count                  = var.restore_from_snapshot && var.core_db_snapshot_name == null ? 1 : 0
-  db_instance_identifier = "${var.name_prefix}-core-database"
+  db_instance_identifier = var.core_db_identifier
   most_recent            = true
   include_shared         = false
   include_public         = false
@@ -30,7 +30,7 @@ data "aws_db_snapshot" "core_snapshots" {
 # Check if snapshots exist for temporal database
 data "aws_db_snapshot" "temporal_snapshots" {
   count                  = var.disable_temporal_autosetup ? 0 : (var.restore_from_snapshot && var.temporal_db_snapshot_name == null ? 1 : 0)
-  db_instance_identifier = "${var.name_prefix}-temporal-database"
+  db_instance_identifier = var.temporal_db_identifier
   most_recent            = true
   include_shared         = false
   include_public         = false
@@ -63,7 +63,7 @@ resource "time_sleep" "wait_for_rds_dependencies" {
 resource "aws_db_parameter_group" "temporal_database_compatibility" {
   count = var.disable_temporal_autosetup || var.temporal_db_force_ssl ? 0 : 1
 
-  name        = "${var.name_prefix}-temporal-db-compatibility"
+  name        = var.temporal_db_parameter_group_name
   family      = "postgres${split(".", var.db_engine_version)[0]}"
   description = "Temporal PostgreSQL parameter group for Fargate auto-setup compatibility"
 
@@ -75,7 +75,7 @@ resource "aws_db_parameter_group" "temporal_database_compatibility" {
 }
 
 resource "aws_db_instance" "core_database" {
-  identifier                  = "${var.name_prefix}-core-database"
+  identifier                  = var.core_db_identifier
   engine                      = "postgres"
   engine_version              = var.db_engine_version
   instance_class              = var.tracecat_db_instance_class
@@ -113,7 +113,7 @@ resource "aws_db_instance" "core_database" {
 
 resource "aws_db_instance" "temporal_database" {
   count                       = var.disable_temporal_autosetup ? 0 : 1
-  identifier                  = "${var.name_prefix}-temporal-database"
+  identifier                  = var.temporal_db_identifier
   engine                      = "postgres"
   engine_version              = var.db_engine_version
   instance_class              = var.temporal_db_instance_class

--- a/deployments/fargate/modules/ecs/redis.tf
+++ b/deployments/fargate/modules/ecs/redis.tf
@@ -11,7 +11,7 @@ resource "random_password" "redis_app_user_password" {
 
 # Default user (required by AWS ElastiCache)
 resource "aws_elasticache_user" "default" {
-  user_id       = "${var.name_prefix}-default"
+  user_id       = var.redis_default_user_id
   user_name     = "default" # Must be named "default"
   engine        = "redis"
   access_string = "off ~* -@all" # Disabled user with no access

--- a/deployments/fargate/modules/ecs/redis.tf
+++ b/deployments/fargate/modules/ecs/redis.tf
@@ -1,6 +1,6 @@
 # subnet group (or use an existing one from your network module)
 resource "aws_elasticache_subnet_group" "redis" {
-  name       = "tracecat-redis-subnet"
+  name       = "${var.name_prefix}-redis-subnet"
   subnet_ids = var.private_subnet_ids
 }
 
@@ -11,7 +11,7 @@ resource "random_password" "redis_app_user_password" {
 
 # Default user (required by AWS ElastiCache)
 resource "aws_elasticache_user" "default" {
-  user_id       = "default-user-tracecat"
+  user_id       = "${var.name_prefix}-default"
   user_name     = "default" # Must be named "default"
   engine        = "redis"
   access_string = "off ~* -@all" # Disabled user with no access
@@ -27,8 +27,8 @@ resource "aws_elasticache_user" "default" {
 
 # Application user
 resource "aws_elasticache_user" "app_user" {
-  user_id       = "tracecat-app"
-  user_name     = "tracecat-app" # App connections will use this username
+  user_id       = "${var.name_prefix}-app"
+  user_name     = "${var.name_prefix}-app" # App connections will use this username
   engine        = "redis"
   access_string = "on ~* +@all" # Full access; refine later if needed
 
@@ -40,7 +40,7 @@ resource "aws_elasticache_user" "app_user" {
 }
 
 resource "aws_elasticache_user_group" "redis" {
-  user_group_id = "tracecat-users"
+  user_group_id = "${var.name_prefix}-users"
   engine        = "redis"
   user_ids = [
     aws_elasticache_user.default.user_id,
@@ -54,7 +54,7 @@ resource "aws_elasticache_user_group" "redis" {
 
 # The replication group (single-node, TLS & KMS encryption are ON by default in Redis 7)
 resource "aws_elasticache_replication_group" "redis" {
-  replication_group_id = "tracecat-redis"
+  replication_group_id = "${var.name_prefix}-redis"
   description          = "Tracecat Redis - password-protected app user"
   engine               = "redis"
   engine_version       = "7.1"
@@ -73,7 +73,7 @@ resource "aws_elasticache_replication_group" "redis" {
 
 # Store the complete Redis URL in Secrets Manager so ECS tasks can inject it.
 resource "aws_secretsmanager_secret" "redis_url" {
-  name_prefix = "tracecat-redis-url-"
+  name_prefix = "${var.name_prefix}-redis-url-"
   description = "Tracecat Redis connection URL"
 }
 

--- a/deployments/fargate/modules/ecs/s3.tf
+++ b/deployments/fargate/modules/ecs/s3.tf
@@ -16,7 +16,7 @@ resource "random_id" "workflow_bucket_suffix" {
 
 # S3 bucket for Tracecat case attachments
 resource "aws_s3_bucket" "attachments" {
-  bucket = "tracecat-attachments-${var.tracecat_app_env}-${random_id.attachments_bucket_suffix.hex}"
+  bucket = "${var.name_prefix}-attachments-${var.tracecat_app_env}-${random_id.attachments_bucket_suffix.hex}"
 
   tags = {
     Name        = "Tracecat attachments storage"
@@ -148,7 +148,7 @@ resource "aws_s3_bucket_cors_configuration" "attachments" {
 
 # S3 bucket for Tracecat registry tarballs
 resource "aws_s3_bucket" "registry" {
-  bucket = "tracecat-registry-${var.tracecat_app_env}-${random_id.registry_bucket_suffix.hex}"
+  bucket = "${var.name_prefix}-registry-${var.tracecat_app_env}-${random_id.registry_bucket_suffix.hex}"
 
   tags = {
     Name        = "Tracecat registry storage"
@@ -278,7 +278,7 @@ resource "aws_s3_bucket_cors_configuration" "skills" {
 
 # S3 bucket for Tracecat workspace skills
 resource "aws_s3_bucket" "skills" {
-  bucket = "tracecat-skills-${var.tracecat_app_env}-${random_id.skills_bucket_suffix.hex}"
+  bucket = "${var.name_prefix}-skills-${var.tracecat_app_env}-${random_id.skills_bucket_suffix.hex}"
 
   tags = {
     Name        = "Tracecat skills storage"
@@ -362,7 +362,7 @@ resource "aws_s3_bucket_policy" "skills" {
 
 # S3 bucket for externalized workflow artifacts
 resource "aws_s3_bucket" "workflow" {
-  bucket = "tracecat-workflow-${var.tracecat_app_env}-${random_id.workflow_bucket_suffix.hex}"
+  bucket = "${var.name_prefix}-workflow-${var.tracecat_app_env}-${random_id.workflow_bucket_suffix.hex}"
 
   tags = {
     Name        = "Tracecat workflow storage"

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -5,6 +5,18 @@ variable "aws_region" {
   description = "AWS region (secrets and hosted zone must be in the same region)"
 }
 
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for same-account/regional AWS resource names."
+  default     = "tracecat"
+}
+
+variable "iam_name_prefix" {
+  type        = string
+  description = "Prefix for IAM role and policy names."
+  default     = "Tracecat"
+}
+
 ### Networking
 
 variable "is_internal" {
@@ -239,7 +251,7 @@ variable "db_max_overflow" {
 variable "db_pool_size" {
   type        = string
   description = "The size of the database connection pool"
-  default     = "30"
+  default     = "10"
 }
 
 variable "db_pool_timeout" {
@@ -251,13 +263,13 @@ variable "db_pool_timeout" {
 variable "db_pool_recycle" {
   type        = string
   description = "The time in seconds after which pool connections are recycled"
-  default     = "1800"
+  default     = "300"
 }
 
 variable "db_max_overflow_executor" {
   type        = string
   description = "The maximum number of connections to allow in the DB pool"
-  default     = "30"
+  default     = "60"
 }
 
 variable "db_pool_size_executor" {

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -9,12 +9,41 @@ variable "name_prefix" {
   type        = string
   description = "Prefix for same-account/regional AWS resource names."
   default     = "tracecat"
+
+  validation {
+    condition     = length(var.name_prefix) <= 23 && can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", var.name_prefix))
+    error_message = "name_prefix must be 23 characters or fewer, contain only lowercase letters, numbers, and hyphens, and start and end with a letter or number."
+  }
 }
 
 variable "iam_name_prefix" {
   type        = string
   description = "Prefix for IAM role and policy names."
   default     = "Tracecat"
+}
+
+variable "core_db_identifier" {
+  type        = string
+  description = "RDS DB instance identifier for the core Tracecat database."
+  default     = "core-database"
+}
+
+variable "temporal_db_identifier" {
+  type        = string
+  description = "RDS DB instance identifier for the Temporal database."
+  default     = "temporal-database"
+}
+
+variable "temporal_db_parameter_group_name" {
+  type        = string
+  description = "RDS parameter group name for Temporal database compatibility settings."
+  default     = "temporal-db-compatibility"
+}
+
+variable "redis_default_user_id" {
+  type        = string
+  description = "ElastiCache Redis default ACL user ID."
+  default     = "default-user-tracecat"
 }
 
 ### Networking

--- a/deployments/fargate/modules/network/network.tf
+++ b/deployments/fargate/modules/network/network.tf
@@ -1,16 +1,16 @@
 # network.tf
 
 locals {
-  az_count = 2
+  az_count = length(var.public_subnet_cidrs)
 }
 
 resource "aws_vpc" "tracecat" {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = var.vpc_cidr
   enable_dns_hostnames = true
   enable_dns_support   = true
 
   tags = {
-    Name = "tracecat-vpc"
+    Name = "${var.name_prefix}-vpc"
   }
 }
 
@@ -19,12 +19,12 @@ data "aws_availability_zones" "available" {}
 resource "aws_subnet" "public" {
   count                   = local.az_count
   vpc_id                  = aws_vpc.tracecat.id
-  cidr_block              = "10.0.${count.index + 1}.0/24"
+  cidr_block              = var.public_subnet_cidrs[count.index]
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   map_public_ip_on_launch = true
 
   tags = {
-    Name = "tracecat-public-subnet-${count.index + 1}"
+    Name = "${var.name_prefix}-public-subnet-${count.index + 1}"
   }
 }
 
@@ -53,11 +53,11 @@ resource "aws_nat_gateway" "gw" {
 resource "aws_subnet" "private" {
   count             = local.az_count
   vpc_id            = aws_vpc.tracecat.id
-  cidr_block        = "10.0.${count.index + 10}.0/24"
+  cidr_block        = var.private_subnet_cidrs[count.index]
   availability_zone = data.aws_availability_zones.available.names[count.index]
 
   tags = {
-    Name = "tracecat-private-subnet-${count.index + 1}"
+    Name = "${var.name_prefix}-private-subnet-${count.index + 1}"
   }
 }
 
@@ -86,7 +86,7 @@ resource "aws_route_table" "public_rt" {
   }
 
   tags = {
-    Name = "tracecat-public-rt"
+    Name = "${var.name_prefix}-public-rt"
   }
 }
 

--- a/deployments/fargate/modules/network/network.tf
+++ b/deployments/fargate/modules/network/network.tf
@@ -9,6 +9,13 @@ resource "aws_vpc" "tracecat" {
   enable_dns_hostnames = true
   enable_dns_support   = true
 
+  lifecycle {
+    precondition {
+      condition     = length(var.public_subnet_cidrs) > 0 && length(var.private_subnet_cidrs) > 0 && length(var.public_subnet_cidrs) == length(var.private_subnet_cidrs)
+      error_message = "public_subnet_cidrs and private_subnet_cidrs must be non-empty and have the same number of entries."
+    }
+  }
+
   tags = {
     Name = "${var.name_prefix}-vpc"
   }

--- a/deployments/fargate/modules/network/network.tf
+++ b/deployments/fargate/modules/network/network.tf
@@ -11,8 +11,8 @@ resource "aws_vpc" "tracecat" {
 
   lifecycle {
     precondition {
-      condition     = length(var.public_subnet_cidrs) > 0 && length(var.private_subnet_cidrs) > 0 && length(var.public_subnet_cidrs) == length(var.private_subnet_cidrs)
-      error_message = "public_subnet_cidrs and private_subnet_cidrs must be non-empty and have the same number of entries."
+      condition     = length(var.public_subnet_cidrs) >= 2 && length(var.private_subnet_cidrs) >= 2 && length(var.public_subnet_cidrs) == length(var.private_subnet_cidrs)
+      error_message = "public_subnet_cidrs and private_subnet_cidrs must each have at least two entries and the same number of entries."
     }
   }
 

--- a/deployments/fargate/modules/network/variables.tf
+++ b/deployments/fargate/modules/network/variables.tf
@@ -5,6 +5,30 @@ variable "aws_region" {
   description = "AWS region (secrets and hosted zone must be in the same region)"
 }
 
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for network resource names"
+  default     = "tracecat"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the Tracecat VPC"
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "CIDR blocks for public subnets"
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "CIDR blocks for private subnets"
+  default     = ["10.0.10.0/24", "10.0.11.0/24"]
+}
+
 ## DNS
 
 variable "domain_name" {

--- a/deployments/fargate/modules/network/variables.tf
+++ b/deployments/fargate/modules/network/variables.tf
@@ -9,6 +9,11 @@ variable "name_prefix" {
   type        = string
   description = "Prefix for network resource names"
   default     = "tracecat"
+
+  validation {
+    condition     = length(var.name_prefix) <= 23 && can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", var.name_prefix))
+    error_message = "name_prefix must be 23 characters or fewer, contain only lowercase letters, numbers, and hyphens, and start and end with a letter or number."
+  }
 }
 
 variable "vpc_cidr" {

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -5,6 +5,38 @@ variable "aws_region" {
   description = "AWS region (secrets and hosted zone must be in the same region)"
 }
 
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for same-account/regional AWS resource names."
+  default     = "tracecat"
+}
+
+variable "iam_name_prefix" {
+  type        = string
+  description = "Prefix for IAM role and policy names."
+  default     = "Tracecat"
+}
+
+### Networking
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the Tracecat VPC"
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "CIDR blocks for public subnets"
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "CIDR blocks for private subnets"
+  default     = ["10.0.10.0/24", "10.0.11.0/24"]
+}
+
 ### DNS
 
 variable "domain_name" {
@@ -187,7 +219,7 @@ variable "db_max_overflow" {
 variable "db_pool_size" {
   type        = string
   description = "The size of the database connection pool"
-  default     = "30"
+  default     = "10"
 }
 
 variable "db_pool_timeout" {
@@ -199,13 +231,13 @@ variable "db_pool_timeout" {
 variable "db_pool_recycle" {
   type        = string
   description = "The time in seconds after which pool connections are recycled"
-  default     = "1800"
+  default     = "300"
 }
 
 variable "db_max_overflow_executor" {
   type        = string
   description = "The maximum number of connections to allow in the DB pool"
-  default     = "30"
+  default     = "60"
 }
 
 variable "db_pool_size_executor" {

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -9,12 +9,41 @@ variable "name_prefix" {
   type        = string
   description = "Prefix for same-account/regional AWS resource names."
   default     = "tracecat"
+
+  validation {
+    condition     = length(var.name_prefix) <= 23 && can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", var.name_prefix))
+    error_message = "name_prefix must be 23 characters or fewer, contain only lowercase letters, numbers, and hyphens, and start and end with a letter or number."
+  }
 }
 
 variable "iam_name_prefix" {
   type        = string
   description = "Prefix for IAM role and policy names."
   default     = "Tracecat"
+}
+
+variable "core_db_identifier" {
+  type        = string
+  description = "RDS DB instance identifier for the core Tracecat database."
+  default     = "core-database"
+}
+
+variable "temporal_db_identifier" {
+  type        = string
+  description = "RDS DB instance identifier for the Temporal database."
+  default     = "temporal-database"
+}
+
+variable "temporal_db_parameter_group_name" {
+  type        = string
+  description = "RDS parameter group name for Temporal database compatibility settings."
+  default     = "temporal-db-compatibility"
+}
+
+variable "redis_default_user_id" {
+  type        = string
+  description = "ElastiCache Redis default ACL user ID."
+  default     = "default-user-tracecat"
 }
 
 ### Networking


### PR DESCRIPTION
## Summary

- Allow same-account Fargate deployments to use custom resource name prefixes and VPC CIDRs.
- Tune default Fargate DB pool settings for a larger single-tenant baseline.
- Pass the root API desired count into the ECS module.

## Validation

- `terraform fmt -check -recursive deployments/fargate`
- `terraform -chdir=deployments/fargate validate`

## Notes

- This only changes Terraform defaults and naming inputs.
- No production resources were applied from this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables isolated, same-account Fargate stacks with prefixed names and configurable, multi-AZ networking. Adds RDS/Redis identifier inputs, exposes `api_desired_count`, and tightens DB pool defaults.

- **New Features**
  - Prefix and naming fixes across ALB/WAF (incl. metrics/pattern sets), CloudWatch logs, CloudMap, ECS cluster/task families, IAM, RDS, Redis, and S3 using `name_prefix` and `iam_name_prefix` with format/length validation.
  - Configurable network: `vpc_cidr`, `public_subnet_cidrs`, `private_subnet_cidrs`; lists must be the same length and have at least two entries (multi-AZ enforced).
  - New identifiers for persistence: `core_db_identifier`, `temporal_db_identifier`, `temporal_db_parameter_group_name`, `redis_default_user_id`.
  - API scaling input `api_desired_count`; DB defaults tuned for single-tenant: `db_pool_size=10`, `db_pool_recycle=300s`, `db_max_overflow_executor=60`.

- **Migration**
  - For multiple stacks in one account/region, set `name_prefix` and `iam_name_prefix`. Changing prefixes will rename resources (ALB, ECS cluster/task defs, RDS, Redis, S3, CloudWatch, CloudMap).
  - To isolate networking, set `vpc_cidr`, `public_subnet_cidrs`, and `private_subnet_cidrs` with equal counts and at least two subnets each (multi-AZ).
  - If restoring or keeping existing DB/Redis, set `core_db_identifier`, `temporal_db_identifier`, `temporal_db_parameter_group_name`, and `redis_default_user_id` to match current resources.

<sup>Written for commit 561774951cba6dee567018044b59e3fd6455cfe8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

