### PR TITLE
feat(ui): chat input refocus after model responses

### DIFF
--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -22,6 +22,7 @@ import {
 import { motion } from "motion/react"
 import {
   type ChangeEvent,
+  type FocusEvent,
   type KeyboardEvent,
   memo,
   useCallback,
@@ -249,6 +250,8 @@ export function ChatSessionPane({
 }: ChatSessionPaneProps) {
   const queryClient = useQueryClient()
   const promptInputContainerRef = useRef<HTMLDivElement>(null)
+  const promptTextareaFocusedRef = useRef(false)
+  const shouldRestoreInputFocusRef = useRef(false)
   const processedMessageRef = useRef<
     | {
         messageId: string
@@ -339,21 +342,63 @@ export function ChatSessionPane({
   }, [status, messages])
 
   const isInputDisabled = isReadonly || inputDisabled || !canSubmit
+  const isInputDisabledRef = useRef(isInputDisabled)
+  isInputDisabledRef.current = isInputDisabled
   const wasInputDisabledRef = useRef(isInputDisabled)
 
   useEffect(() => {
     const wasInputDisabled = wasInputDisabledRef.current
     wasInputDisabledRef.current = isInputDisabled
 
+    if (!wasInputDisabled && isInputDisabled) {
+      shouldRestoreInputFocusRef.current = promptTextareaFocusedRef.current
+      return
+    }
+
     if (!wasInputDisabled || isInputDisabled) {
       return
     }
+
+    if (!shouldRestoreInputFocusRef.current) {
+      return
+    }
+    shouldRestoreInputFocusRef.current = false
 
     const textarea =
       promptInputContainerRef.current?.querySelector<HTMLTextAreaElement>(
         'textarea[name="message"]'
       )
     textarea?.focus()
+  }, [isInputDisabled])
+
+  useEffect(() => {
+    if (!isInputDisabled) {
+      return
+    }
+
+    function cancelPendingFocusRestore(event: Event) {
+      const target = event.target
+      if (!(target instanceof Node)) {
+        return
+      }
+      if (promptInputContainerRef.current?.contains(target)) {
+        return
+      }
+      shouldRestoreInputFocusRef.current = false
+      promptTextareaFocusedRef.current = false
+    }
+
+    document.addEventListener("pointerdown", cancelPendingFocusRestore, true)
+    document.addEventListener("focusin", cancelPendingFocusRestore, true)
+
+    return () => {
+      document.removeEventListener(
+        "pointerdown",
+        cancelPendingFocusRestore,
+        true
+      )
+      document.removeEventListener("focusin", cancelPendingFocusRestore, true)
+    }
   }, [isInputDisabled])
 
   const handleSubmitApprovals = useCallback(
@@ -680,6 +725,30 @@ export function ChatSessionPane({
     [filteredToolSuggestions, handleSelectMentionTool, toolMention]
   )
 
+  const handleInputFocus = useCallback(() => {
+    promptTextareaFocusedRef.current = true
+  }, [])
+
+  const handleInputBlur = useCallback(
+    (event: FocusEvent<HTMLTextAreaElement>) => {
+      setToolMention(undefined)
+
+      const nextFocusedElement = event.relatedTarget
+      if (
+        nextFocusedElement instanceof Node &&
+        promptInputContainerRef.current?.contains(nextFocusedElement)
+      ) {
+        return
+      }
+
+      if (!isInputDisabledRef.current) {
+        promptTextareaFocusedRef.current = false
+        shouldRestoreInputFocusRef.current = false
+      }
+    },
+    []
+  )
+
   const selectedToolBadges = useMemo(
     () =>
       selectedTools.map((toolName) => {
@@ -972,7 +1041,8 @@ export function ChatSessionPane({
             <PromptInputTextarea
               onChange={handleInputChange}
               onKeyDown={handleInputKeyDown}
-              onBlur={() => setToolMention(undefined)}
+              onFocus={handleInputFocus}
+              onBlur={handleInputBlur}
               placeholder={
                 isReadonly
                   ? "This is a legacy session (read-only)"

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -252,6 +252,8 @@ export function ChatSessionPane({
   const promptInputContainerRef = useRef<HTMLDivElement>(null)
   const promptTextareaFocusedRef = useRef(false)
   const shouldRestoreInputFocusRef = useRef(false)
+  const promptPointerDownInsideRef = useRef(false)
+  const promptPointerDownResetTimerRef = useRef<number>()
   const processedMessageRef = useRef<
     | {
         messageId: string
@@ -729,6 +731,17 @@ export function ChatSessionPane({
     promptTextareaFocusedRef.current = true
   }, [])
 
+  const handlePromptPointerDownCapture = useCallback(() => {
+    promptPointerDownInsideRef.current = true
+    if (promptPointerDownResetTimerRef.current !== undefined) {
+      window.clearTimeout(promptPointerDownResetTimerRef.current)
+    }
+    promptPointerDownResetTimerRef.current = window.setTimeout(() => {
+      promptPointerDownInsideRef.current = false
+      promptPointerDownResetTimerRef.current = undefined
+    }, 0)
+  }, [])
+
   const handleInputBlur = useCallback(
     (event: FocusEvent<HTMLTextAreaElement>) => {
       setToolMention(undefined)
@@ -741,6 +754,10 @@ export function ChatSessionPane({
         return
       }
 
+      if (nextFocusedElement === null && promptPointerDownInsideRef.current) {
+        return
+      }
+
       if (!isInputDisabledRef.current) {
         promptTextareaFocusedRef.current = false
         shouldRestoreInputFocusRef.current = false
@@ -748,6 +765,14 @@ export function ChatSessionPane({
     },
     []
   )
+
+  useEffect(() => {
+    return () => {
+      if (promptPointerDownResetTimerRef.current !== undefined) {
+        window.clearTimeout(promptPointerDownResetTimerRef.current)
+      }
+    }
+  }, [])
 
   const selectedToolBadges = useMemo(
     () =>
@@ -947,7 +972,11 @@ export function ChatSessionPane({
           <ConversationScrollButton />
         </Conversation>
       </div>
-      <div className="relative px-3 pb-3" ref={promptInputContainerRef}>
+      <div
+        className="relative px-3 pb-3"
+        onPointerDownCapture={handlePromptPointerDownCapture}
+        ref={promptInputContainerRef}
+      >
         {mentionEnabled && toolMention && (
           <div className="absolute inset-x-3 bottom-full z-30 mb-2">
             <div className="overflow-hidden rounded-md border bg-popover shadow-md">

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -248,6 +248,7 @@ export function ChatSessionPane({
   presetSelector,
 }: ChatSessionPaneProps) {
   const queryClient = useQueryClient()
+  const promptInputContainerRef = useRef<HTMLDivElement>(null)
   const processedMessageRef = useRef<
     | {
         messageId: string
@@ -336,6 +337,24 @@ export function ChatSessionPane({
     }
     return false
   }, [status, messages])
+
+  const isInputDisabled = isReadonly || inputDisabled || !canSubmit
+  const wasInputDisabledRef = useRef(isInputDisabled)
+
+  useEffect(() => {
+    const wasInputDisabled = wasInputDisabledRef.current
+    wasInputDisabledRef.current = isInputDisabled
+
+    if (!wasInputDisabled || isInputDisabled) {
+      return
+    }
+
+    const textarea =
+      promptInputContainerRef.current?.querySelector<HTMLTextAreaElement>(
+        'textarea[name="message"]'
+      )
+    textarea?.focus()
+  }, [isInputDisabled])
 
   const handleSubmitApprovals = useCallback(
     async (decisionPayload: ApprovalDecision[]) => {
@@ -859,7 +878,7 @@ export function ChatSessionPane({
           <ConversationScrollButton />
         </Conversation>
       </div>
-      <div className="relative px-3 pb-3">
+      <div className="relative px-3 pb-3" ref={promptInputContainerRef}>
         {mentionEnabled && toolMention && (
           <div className="absolute inset-x-3 bottom-full z-30 mb-2">
             <div className="overflow-hidden rounded-md border bg-popover shadow-md">
@@ -963,7 +982,7 @@ export function ChatSessionPane({
               }
               value={input}
               autoFocus={autoFocusInput && !isReadonly && !inputDisabled}
-              disabled={isReadonly || inputDisabled || !canSubmit}
+              disabled={isInputDisabled}
             />
           </PromptInputBody>
           <PromptInputFooter>
@@ -976,9 +995,7 @@ export function ChatSessionPane({
               )}
             </PromptInputTools>
             <PromptInputSubmit
-              disabled={
-                isReadonly || inputDisabled || !canSubmit || !input.trim()
-              }
+              disabled={isInputDisabled || !input.trim()}
               status={status}
               className="text-muted-foreground/80"
             />

--- a/frontend/tests/chat-session-pane.test.tsx
+++ b/frontend/tests/chat-session-pane.test.tsx
@@ -138,6 +138,18 @@ describe("ChatSessionPane", () => {
     jest.clearAllMocks()
   })
 
+  function mockUseVercelChatStatus(status: "ready" | "submitted") {
+    mockUseVercelChat.mockReturnValue({
+      sendMessage: jest.fn(),
+      regenerate: jest.fn(),
+      messages: [],
+      status,
+      lastError: null,
+      clearError: jest.fn(),
+      // biome-ignore lint/suspicious/noExplicitAny: mock return type needs flexibility for testing
+    } as any)
+  }
+
   it("logs and recovers when sendMessage throws", async () => {
     const sendMessage = jest.fn(() => {
       throw new Error("network down")
@@ -211,6 +223,125 @@ describe("ChatSessionPane", () => {
     )
 
     expect(screen.getByTestId("dots-loader")).toBeInTheDocument()
+  })
+
+  it("does not refocus after response if the textarea was not focused before disabling", async () => {
+    mockUseVercelChatStatus("ready")
+
+    const renderSubject = () => (
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <ChatSessionPane
+            chat={createChatFixture()}
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+          />
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+
+    const { rerender } = render(renderSubject())
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    const focusSpy = jest.spyOn(textarea, "focus")
+
+    mockUseVercelChatStatus("submitted")
+    rerender(renderSubject())
+    expect(textarea).toBeDisabled()
+
+    mockUseVercelChatStatus("ready")
+    rerender(renderSubject())
+
+    await waitFor(() => {
+      expect(textarea).toBeEnabled()
+      expect(focusSpy).not.toHaveBeenCalled()
+    })
+    expect(textarea).not.toHaveFocus()
+  })
+
+  it("does not refocus after response if focus moves outside while waiting", async () => {
+    mockUseVercelChatStatus("ready")
+
+    const renderSubject = () => (
+      <>
+        <button type="button">Outside target</button>
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>
+            <ChatSessionPane
+              chat={createChatFixture()}
+              workspaceId="workspace-1"
+              entityType="case"
+              entityId="case-1"
+              modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+            />
+          </TooltipProvider>
+        </QueryClientProvider>
+      </>
+    )
+
+    const { rerender } = render(renderSubject())
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    textarea.focus()
+    fireEvent.focus(textarea)
+    expect(textarea).toHaveFocus()
+    const focusSpy = jest.spyOn(textarea, "focus")
+
+    mockUseVercelChatStatus("submitted")
+    rerender(renderSubject())
+    expect(textarea).toBeDisabled()
+
+    const outsideTarget = screen.getByRole("button", { name: "Outside target" })
+    fireEvent.pointerDown(outsideTarget)
+    outsideTarget.focus()
+    expect(outsideTarget).toHaveFocus()
+
+    mockUseVercelChatStatus("ready")
+    rerender(renderSubject())
+
+    await waitFor(() => {
+      expect(textarea).toBeEnabled()
+      expect(focusSpy).not.toHaveBeenCalled()
+    })
+    expect(outsideTarget).toHaveFocus()
+  })
+
+  it("refocuses after response if the textarea had focus before disabling", async () => {
+    mockUseVercelChatStatus("ready")
+
+    const renderSubject = () => (
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <ChatSessionPane
+            chat={createChatFixture()}
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+          />
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+
+    const { rerender } = render(renderSubject())
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    textarea.focus()
+    fireEvent.focus(textarea)
+    expect(textarea).toHaveFocus()
+    const focusSpy = jest.spyOn(textarea, "focus")
+
+    mockUseVercelChatStatus("submitted")
+    rerender(renderSubject())
+    expect(textarea).toBeDisabled()
+
+    mockUseVercelChatStatus("ready")
+    rerender(renderSubject())
+
+    await waitFor(() => {
+      expect(textarea).toBeEnabled()
+      expect(focusSpy).toHaveBeenCalledTimes(1)
+    })
+    expect(textarea).toHaveFocus()
   })
 
   it("submits approval decisions with continue payload", async () => {

--- a/frontend/tests/chat-session-pane.test.tsx
+++ b/frontend/tests/chat-session-pane.test.tsx
@@ -344,6 +344,49 @@ describe("ChatSessionPane", () => {
     expect(textarea).toHaveFocus()
   })
 
+  it("preserves refocus when submit button blur omits related target", async () => {
+    mockUseVercelChatStatus("ready")
+
+    const renderSubject = () => (
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <ChatSessionPane
+            chat={createChatFixture()}
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+          />
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+
+    const { rerender } = render(renderSubject())
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    textarea.focus()
+    fireEvent.focus(textarea)
+    fireEvent.change(textarea, { target: { value: "Hello" } })
+    const focusSpy = jest.spyOn(textarea, "focus")
+
+    const submitButton = screen.getByRole("button", { name: "Submit" })
+    expect(submitButton).toBeEnabled()
+    fireEvent.pointerDown(submitButton)
+    fireEvent.blur(textarea, { relatedTarget: null })
+
+    mockUseVercelChatStatus("submitted")
+    rerender(renderSubject())
+    expect(textarea).toBeDisabled()
+
+    mockUseVercelChatStatus("ready")
+    rerender(renderSubject())
+
+    await waitFor(() => {
+      expect(textarea).toBeEnabled()
+      expect(focusSpy).toHaveBeenCalledTimes(1)
+    })
+    expect(textarea).toHaveFocus()
+  })
+
   it("submits approval decisions with continue payload", async () => {
     const sendMessage = jest.fn().mockResolvedValue(undefined)
     const clearError = jest.fn()


### PR DESCRIPTION
### Motivation
- The chat composer was disabled while the model was responding but did not restore focus to the message textarea when it became enabled again, forcing users to click the input before sending follow-ups.
- Improve UX by automatically restoring focus after a disabled->enabled transition and keep disabled-state logic consistent across input and submit controls.

### Description
- Added a scoped `promptInputContainerRef` to the prompt area and attached it to the prompt container element.
- Introduced `isInputDisabled` and `wasInputDisabledRef` and a `useEffect` that detects the disabled->enabled transition and focuses the scoped textarea via `querySelector` when the composer becomes enabled.
- Replaced scattered disabled checks with `isInputDisabled` on the `PromptInputTextarea` and the `PromptInputSubmit` so the textarea and submit button remain in sync.
- Modified `frontend/src/components/chat/chat-session-pane.tsx` to implement the changes.

### Testing
- Ran `pnpm -C frontend exec biome check src/components/chat/chat-session-pane.tsx` which initially reported formatting differences and failed.
- Ran `pnpm -C frontend exec biome check --write src/components/chat/chat-session-pane.tsx` which applied formatter fixes successfully.
- Re-ran `pnpm -C frontend exec biome check src/components/chat/chat-session-pane.tsx` which completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee5c42ebc08320b8953e7935ae8c6f)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores focus to the chat input after the model finishes responding, so users can immediately type follow-ups. Also unifies the composer’s disabled state across the textarea and submit button.

- **Bug Fixes**
  - Added a scoped `promptInputContainerRef` and an effect to focus the textarea on a disabled→enabled transition.
  - Introduced `isInputDisabled` to keep the textarea and submit button in sync.

<sup>Written for commit c5f8a03f24c850ab5f1cc1c190d74e613a78fd26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

