### PR TITLE
feat: add pasta networking and lock down /proc in nsjail

### DIFF
--- a/tests/unit/test_agent_sandbox_config.py
+++ b/tests/unit/test_agent_sandbox_config.py
@@ -83,3 +83,17 @@ def test_build_agent_nsjail_config_uses_reduced_broker_shim_mounts() -> None:
         'exec_bin { path: "/usr/local/bin/python3" arg: "/work/shim_entrypoint.py" }'
         in config_text
     )
+
+
+def test_build_agent_nsjail_config_mounts_fresh_procfs() -> None:
+    config_text = build_agent_nsjail_config(
+        rootfs=Path("/var/lib/tracecat/sandbox-rootfs"),
+        job_dir=Path("/tmp/agent-job"),
+        socket_dir=Path("/tmp/agent-job/sockets"),
+        config=AgentSandboxConfig(),
+        site_packages_dir=Path("/app/.venv/lib/python3.12/site-packages"),
+        llm_socket_path=Path("/tmp/agent-job/sockets/llm.sock"),
+    )
+
+    assert 'src: "/proc"' not in config_text
+    assert 'mount { dst: "/proc" fstype: "proc" rw: false }' in config_text

--- a/tests/unit/test_agent_sandbox_litellm.py
+++ b/tests/unit/test_agent_sandbox_litellm.py
@@ -661,6 +661,7 @@ def _run_nsjail_harness_in_docker_or_skip(
                 "      - SYS_ADMIN",
                 "    security_opt:",
                 "      - seccomp:unconfined",
+                "      - systempaths=unconfined",
                 *device_lines,
                 "    volumes:",
                 f"      - {json.dumps(tests_mount)}",

--- a/tests/unit/test_agent_sandbox_litellm.py
+++ b/tests/unit/test_agent_sandbox_litellm.py
@@ -514,6 +514,7 @@ async def _run_full_claude_harness_runtime_case(
     disable_nsjail_mode: bool,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    enable_internet_access: bool = False,
 ) -> None:
     _FakeLLMSocketProxy.instances.clear()
     broker = ClaudeRuntimeBroker()
@@ -577,7 +578,9 @@ async def _run_full_claude_harness_runtime_case(
 
     try:
         result = await run_agent_activity(
-            _make_passthrough_executor_input(enable_internet_access=False),
+            _make_passthrough_executor_input(
+                enable_internet_access=enable_internet_access
+            ),
         )
     finally:
         await broker.stop()
@@ -604,6 +607,7 @@ def _run_nsjail_harness_in_docker_or_skip(
     *,
     cli_flag: str = "--run-nsjail-harness-smoke",
     failure_label: str = "Dockerized nsjail harness fallback failed.",
+    requires_tun: bool = False,
 ) -> None:
     if os.environ.get("TRACECAT__AGENT_NSJAIL_DOCKER_FALLBACK_CHILD") == "1":
         pytest.skip("nsjail unavailable inside Docker fallback child")
@@ -619,9 +623,30 @@ def _run_nsjail_harness_in_docker_or_skip(
     )
     if docker_info.returncode != 0:
         pytest.skip("Docker daemon unavailable for nsjail fallback")
+    if requires_tun and not Path("/dev/net/tun").exists():
+        pytest.skip("Dockerized nsjail pasta smoke requires host /dev/net/tun")
 
     repo_root = Path(__file__).resolve().parents[2]
+    compose_env = os.environ.copy()
+    compose_env.setdefault(
+        "TRACECAT__LOCAL_REPOSITORY_PATH",
+        str(repo_root / "packages"),
+    )
+    compose_env.setdefault("TRACECAT__LOCAL_REPOSITORY_ENABLED", "false")
+    compose_env.setdefault("PUBLIC_APP_PORT", "80")
+    compose_env.setdefault("BASE_DOMAIN", ":80")
+    compose_env.setdefault("ADDRESS", "0.0.0.0")
+    compose_env.setdefault("LOG_LEVEL", "INFO")
+    compose_env.setdefault("TRACECAT__APP_ENV", "development")
     tests_mount = f"{repo_root / 'tests'}:/app/tests:ro"
+    device_lines = (
+        [
+            "    devices:",
+            "      - /dev/net/tun:/dev/net/tun",
+        ]
+        if requires_tun
+        else []
+    )
     override_path = Path(
         tempfile.mkstemp(prefix="tracecat-agent-nsjail-test-", suffix=".yml")[1]
     )
@@ -636,6 +661,7 @@ def _run_nsjail_harness_in_docker_or_skip(
                 "      - SYS_ADMIN",
                 "    security_opt:",
                 "      - seccomp:unconfined",
+                *device_lines,
                 "    volumes:",
                 f"      - {json.dumps(tests_mount)}",
                 "    environment:",
@@ -669,6 +695,7 @@ def _run_nsjail_harness_in_docker_or_skip(
                 f"uv run python -m tests.unit.test_agent_sandbox_litellm {cli_flag}",
             ],
             cwd=repo_root,
+            env=compose_env,
             capture_output=True,
             text=True,
             timeout=180,
@@ -693,6 +720,25 @@ def _run_nsjail_harness_smoke_from_cli() -> None:
                 disable_nsjail_mode=False,
                 monkeypatch=monkeypatch,
                 tmp_path=tmp_path,
+            )
+        finally:
+            monkeypatch.undo()
+            shutil.rmtree(tmp_path, ignore_errors=True)
+
+    asyncio.run(run())
+
+
+def _run_nsjail_pasta_smoke_from_cli() -> None:
+    async def run() -> None:
+        monkeypatch = pytest.MonkeyPatch()
+        tmp_path = Path(tempfile.mkdtemp(prefix="tracecat-agent-nsjail-pasta-"))
+        try:
+            _set_disable_nsjail_mode(monkeypatch, False)
+            await _run_full_claude_harness_runtime_case(
+                disable_nsjail_mode=False,
+                monkeypatch=monkeypatch,
+                tmp_path=tmp_path,
+                enable_internet_access=True,
             )
         finally:
             monkeypatch.undo()
@@ -1307,6 +1353,30 @@ async def test_run_agent_activity_spawns_full_claude_harness_runtime_in_each_san
 
 
 @pytest.mark.anyio
+async def test_run_agent_activity_spawns_full_claude_harness_runtime_with_pasta_in_nsjail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    if not _agent_nsjail_available():
+        _run_nsjail_harness_in_docker_or_skip(
+            cli_flag="--run-nsjail-pasta-smoke",
+            failure_label="Dockerized nsjail pasta smoke fallback failed.",
+            requires_tun=True,
+        )
+        return
+    if not Path("/dev/net/tun").exists():
+        pytest.skip("agent nsjail pasta smoke requires /dev/net/tun")
+
+    _set_disable_nsjail_mode(monkeypatch, False)
+    await _run_full_claude_harness_runtime_case(
+        disable_nsjail_mode=False,
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+        enable_internet_access=True,
+    )
+
+
+@pytest.mark.anyio
 async def test_executor_always_starts_llm_socket_proxy(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1486,10 +1556,13 @@ async def test_sandbox_shim_starts_bridge_and_sets_child_base_url(
 if __name__ == "__main__":
     if sys.argv[1:] == ["--run-nsjail-harness-smoke"]:
         _run_nsjail_harness_smoke_from_cli()
+    elif sys.argv[1:] == ["--run-nsjail-pasta-smoke"]:
+        _run_nsjail_pasta_smoke_from_cli()
     elif sys.argv[1:] == ["--run-nsjail-skills-smoke"]:
         _run_nsjail_skills_smoke_from_cli()
     else:
         raise SystemExit(
             "Usage: python -m tests.unit.test_agent_sandbox_litellm "
-            "[--run-nsjail-harness-smoke|--run-nsjail-skills-smoke]"
+            "[--run-nsjail-harness-smoke|--run-nsjail-pasta-smoke|"
+            "--run-nsjail-skills-smoke]"
         )

--- a/tests/unit/test_sandbox_networking.py
+++ b/tests/unit/test_sandbox_networking.py
@@ -61,6 +61,8 @@ def test_agent_nsjail_config_keeps_network_isolated_without_pasta(
 
     assert "clone_newnet: true" in config_text
     assert "user_net {" not in config_text
+    assert 'src: "/proc"' not in config_text
+    assert 'dst: "/proc" fstype: "proc"' in config_text
 
 
 def test_agent_nsjail_config_enables_pasta_for_internet_access(
@@ -113,8 +115,12 @@ def test_python_sandbox_execute_phase_respects_network_flag(tmp_path: Path) -> N
 
     assert "clone_newnet: true" in isolated_config
     assert "user_net {" not in isolated_config
+    assert 'src: "/proc"' not in isolated_config
+    assert 'dst: "/proc" fstype: "proc"' in isolated_config
     assert "clone_newnet: true" in networked_config
     assert "user_net {" in networked_config
+    assert 'src: "/proc"' not in networked_config
+    assert 'dst: "/proc" fstype: "proc"' in networked_config
 
 
 def test_action_sandbox_config_enables_pasta(tmp_path: Path) -> None:
@@ -131,3 +137,5 @@ def test_action_sandbox_config_enables_pasta(tmp_path: Path) -> None:
     assert "clone_newnet: true" in config_text
     assert "user_net {" in config_text
     assert f'src: "{tmp_path}/job/resolv.conf"' in config_text
+    assert 'src: "/proc"' not in config_text
+    assert 'dst: "/proc" fstype: "proc"' in config_text

--- a/tests/unit/test_sandbox_networking.py
+++ b/tests/unit/test_sandbox_networking.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tracecat.agent.sandbox.config import AgentSandboxConfig, build_agent_nsjail_config
+from tracecat.sandbox.executor import ActionSandboxConfig, NsjailExecutor
+from tracecat.sandbox.networking import (
+    PASTA_GATEWAY_IP,
+    build_pasta_resolv_conf,
+    write_pasta_network_files,
+)
+from tracecat.sandbox.types import SandboxConfig
+
+
+def test_build_pasta_resolv_conf_preserves_search_and_options(tmp_path: Path) -> None:
+    host_resolv = tmp_path / "host-resolv.conf"
+    host_resolv.write_text(
+        "\n".join(
+            [
+                "# managed by runtime",
+                "nameserver 10.0.0.10",
+                "search default.svc.cluster.local svc.cluster.local",
+                "options ndots:5 timeout:2 attempts:3",
+                "",
+            ]
+        )
+    )
+
+    resolv_conf = build_pasta_resolv_conf(host_resolv)
+
+    assert resolv_conf == (
+        f"nameserver {PASTA_GATEWAY_IP}\n"
+        "search default.svc.cluster.local svc.cluster.local\n"
+        "options ndots:5 timeout:2 attempts:3\n"
+    )
+
+
+def test_write_pasta_network_files_writes_hostname_resolution_files(
+    tmp_path: Path,
+) -> None:
+    network_files = write_pasta_network_files(tmp_path)
+
+    assert network_files.resolv_conf.read_text().startswith(
+        f"nameserver {PASTA_GATEWAY_IP}\n"
+    )
+    assert "127.0.0.1\tlocalhost" in network_files.hosts.read_text()
+    assert "hosts:          files dns" in network_files.nsswitch_conf.read_text()
+
+
+def test_agent_nsjail_config_keeps_network_isolated_without_pasta(
+    tmp_path: Path,
+) -> None:
+    config_text = build_agent_nsjail_config(
+        rootfs=tmp_path / "rootfs",
+        job_dir=tmp_path / "job",
+        socket_dir=tmp_path / "socket",
+        config=AgentSandboxConfig(),
+        site_packages_dir=tmp_path / "site-packages",
+        llm_socket_path=tmp_path / "llm.sock",
+    )
+
+    assert "clone_newnet: true" in config_text
+    assert "user_net {" not in config_text
+
+
+def test_agent_nsjail_config_enables_pasta_for_internet_access(
+    tmp_path: Path,
+) -> None:
+    config_text = build_agent_nsjail_config(
+        rootfs=tmp_path / "rootfs",
+        job_dir=tmp_path / "job",
+        socket_dir=tmp_path / "socket",
+        config=AgentSandboxConfig(),
+        site_packages_dir=tmp_path / "site-packages",
+        llm_socket_path=tmp_path / "llm.sock",
+        enable_internet_access=True,
+    )
+
+    assert "clone_newnet: true" in config_text
+    assert "user_net {" in config_text
+    assert f'gw: "{PASTA_GATEWAY_IP}"' in config_text
+    assert f'src: "{tmp_path}/socket/resolv.conf"' in config_text
+    assert 'src: "/etc/resolv.conf"' not in config_text
+
+
+def test_python_sandbox_install_phase_enables_pasta(tmp_path: Path) -> None:
+    executor = NsjailExecutor(rootfs_path=str(tmp_path / "rootfs"))
+
+    config_text = executor._build_config(
+        job_dir=tmp_path / "job",
+        phase="install",
+        config=SandboxConfig(network_enabled=False),
+    )
+
+    assert "clone_newnet: true" in config_text
+    assert "user_net {" in config_text
+    assert f'src: "{tmp_path}/job/resolv.conf"' in config_text
+
+
+def test_python_sandbox_execute_phase_respects_network_flag(tmp_path: Path) -> None:
+    executor = NsjailExecutor(rootfs_path=str(tmp_path / "rootfs"))
+
+    isolated_config = executor._build_config(
+        job_dir=tmp_path / "isolated-job",
+        phase="execute",
+        config=SandboxConfig(network_enabled=False),
+    )
+    networked_config = executor._build_config(
+        job_dir=tmp_path / "networked-job",
+        phase="execute",
+        config=SandboxConfig(network_enabled=True),
+    )
+
+    assert "clone_newnet: true" in isolated_config
+    assert "user_net {" not in isolated_config
+    assert "clone_newnet: true" in networked_config
+    assert "user_net {" in networked_config
+
+
+def test_action_sandbox_config_enables_pasta(tmp_path: Path) -> None:
+    executor = NsjailExecutor(rootfs_path=str(tmp_path / "rootfs"))
+
+    config_text = executor._build_action_config(
+        job_dir=tmp_path / "job",
+        config=ActionSandboxConfig(
+            registry_paths=[tmp_path / "registry"],
+            tracecat_app_dir=tmp_path / "app",
+        ),
+    )
+
+    assert "clone_newnet: true" in config_text
+    assert "user_net {" in config_text
+    assert f'src: "{tmp_path}/job/resolv.conf"' in config_text

--- a/tracecat/agent/sandbox/config.py
+++ b/tracecat/agent/sandbox/config.py
@@ -7,7 +7,7 @@ Security model:
 - Network namespace always isolated for private loopback; pasta enables outbound access
 - LLM access via internal bridge (localhost:4100) proxied through Unix socket to host LLM gateway
 - Namespace isolation (PID, user, mount, IPC, UTS namespaces)
-- /proc read-only, PID namespace isolated (process only sees itself)
+- Fresh read-only /proc inside the jail PID namespace
 - All tool execution via MCP socket to trusted server outside sandbox
 - Uses same base rootfs as action sandbox (Python 3.12)
 - Site-packages or a minimal Claude SDK subtree mounted read-only
@@ -332,15 +332,14 @@ def build_agent_nsjail_config(
         network_files = write_pasta_network_files(socket_dir)
         lines.extend(pasta_dns_mount_config_lines(network_files))
 
-    # Bind mount /proc from host (read-only) instead of creating new procfs.
-    # New procfs mount fails in Docker due to masked paths in /proc
-    # (e.g., /dev/null on /proc/kcore). Combined with clone_newpid: true,
-    # PID namespace isolation limits visibility of sandbox processes.
+    # Fresh procfs avoids leaking executor-container process metadata. Docker
+    # runtimes must run these containers with systempaths=unconfined; otherwise
+    # masked proc entries like /proc/kcore prevent nested procfs mounts.
     lines.extend(
         [
             "",
-            "# /proc - read-only bind mount (fresh procfs fails in Docker due to overmounts)",
-            'mount { src: "/proc" dst: "/proc" is_bind: true rw: false }',
+            "# /proc - fresh read-only procfs scoped to the jail PID namespace",
+            'mount { dst: "/proc" fstype: "proc" rw: false }',
             "",
             "# /dev essentials",
             'mount { src: "/dev/null" dst: "/dev/null" is_bind: true rw: true }',

--- a/tracecat/agent/sandbox/config.py
+++ b/tracecat/agent/sandbox/config.py
@@ -4,7 +4,7 @@ This module generates protobuf-format nsjail configurations specifically
 for running the agent runtime in an isolated sandbox.
 
 Security model:
-- Network enabled (clone_newnet: false) - direct internet access for API calls
+- Network namespace always isolated for private loopback; pasta enables outbound access
 - LLM access via internal bridge (localhost:4100) proxied through Unix socket to host LLM gateway
 - Namespace isolation (PID, user, mount, IPC, UTS namespaces)
 - /proc read-only, PID namespace isolated (process only sees itself)
@@ -37,21 +37,6 @@ from tracecat.agent.common.exceptions import AgentSandboxValidationError
 
 # Valid environment variable name pattern (POSIX compliant)
 _ENV_VAR_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_PASTA_GATEWAY_IP = "10.255.255.1"
-
-
-def build_sandbox_resolv_conf() -> str:
-    """Build sandbox resolv.conf with pasta DNS plus host search/options lines."""
-    lines = [f"nameserver {_PASTA_GATEWAY_IP}"]
-    try:
-        host_resolv = Path("/etc/resolv.conf").read_text()
-        for line in host_resolv.splitlines():
-            stripped = line.strip()
-            if stripped.startswith("search ") or stripped.startswith("options "):
-                lines.append(stripped)
-    except OSError:
-        pass
-    return "\n".join(lines) + "\n"
 
 
 def _contains_dangerous_chars(value: str) -> tuple[bool, str | None]:
@@ -247,9 +232,9 @@ def build_agent_nsjail_config(
             and mount_control_socket is True, defaults to socket_dir/control.sock.
         session_home_dir: Optional host directory mounted as the jailed Claude home.
         session_project_dir: Optional host directory mounted as the jailed project.
-        enable_internet_access: If True, disables network isolation to allow
-            direct internet access. Required for MCP stdio servers that need
-            to call external APIs. Default is False (network isolated).
+        enable_internet_access: If True, enables pasta userspace networking for
+            outbound internet access. Default is False (network isolated with
+            private loopback only).
         skills_dir: Optional host path containing staged workspace skills.
 
     Returns:
@@ -260,6 +245,11 @@ def build_agent_nsjail_config(
     """
     # Import lazily so sandboxed runtime imports of this module do not require
     # the full tracecat.sandbox package to be mounted inside the jail.
+    from tracecat.sandbox.networking import (
+        pasta_dns_mount_config_lines,
+        pasta_user_net_config_lines,
+        write_pasta_network_files,
+    )
     from tracecat.sandbox.seccomp import build_untrusted_seccomp_policy
 
     # Validate inputs to prevent injection into protobuf config
@@ -291,9 +281,9 @@ def build_agent_nsjail_config(
     # JAILED_LLM_SOCKET_PATH is a constant, no validation needed.
 
     # Network behavior:
-    # - internet enabled: share pod netns (no pasta) for host DNS/routing reliability
-    # - internet disabled: isolate netns
-    clone_newnet = not enable_internet_access
+    # - always isolate network namespace for private loopback
+    # - internet enabled: add pasta userspace networking for outbound access
+    # - internet disabled: no route out of the isolated namespace
     lines = [
         'name: "agent_sandbox"',
         "mode: ONCE",
@@ -301,7 +291,7 @@ def build_agent_nsjail_config(
         "keep_env: false",
         "",
         "# Namespace isolation",
-        f"clone_newnet: {'true' if clone_newnet else 'false'}",
+        "clone_newnet: true",
         "clone_newuser: true",
         "clone_newns: true",
         "clone_newpid: true",
@@ -322,6 +312,9 @@ def build_agent_nsjail_config(
         f'mount {{ src: "{rootfs}/etc" dst: "/etc" is_bind: true rw: false }}',
     ]
 
+    if enable_internet_access:
+        lines.extend(pasta_user_net_config_lines())
+
     # Optional mounts - only include if the directories exist in rootfs
     lib64_path = rootfs / "lib64"
     if lib64_path.exists():
@@ -336,15 +329,8 @@ def build_agent_nsjail_config(
         )
 
     if enable_internet_access:
-        lines.extend(
-            [
-                "",
-                "# DNS config - use pod resolver files directly",
-                'mount { src: "/etc/resolv.conf" dst: "/etc/resolv.conf" is_bind: true rw: false }',
-                'mount { src: "/etc/hosts" dst: "/etc/hosts" is_bind: true rw: false }',
-                'mount { src: "/etc/nsswitch.conf" dst: "/etc/nsswitch.conf" is_bind: true rw: false }',
-            ]
-        )
+        network_files = write_pasta_network_files(socket_dir)
+        lines.extend(pasta_dns_mount_config_lines(network_files))
 
     # Bind mount /proc from host (read-only) instead of creating new procfs.
     # New procfs mount fails in Docker due to masked paths in /proc

--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -273,7 +273,8 @@ class NsjailExecutor:
                 "",
                 "# Temporary filesystems",
                 'mount { dst: "/tmp" fstype: "tmpfs" rw: true options: "size=256M" }',
-                'mount { src: "/proc" dst: "/proc" is_bind: true rw: false }',
+                "# Fresh procfs requires Docker systempaths=unconfined for nested nsjail.",
+                'mount { dst: "/proc" fstype: "proc" rw: false }',
             ]
         )
 
@@ -690,6 +691,7 @@ class NsjailExecutor:
                 "",
                 "# Temporary filesystems",
                 'mount { dst: "/tmp" fstype: "tmpfs" rw: true options: "size=256M" }',
+                "# Fresh procfs requires Docker systempaths=unconfined for nested nsjail.",
                 'mount { dst: "/proc" fstype: "proc" rw: false }',
                 "",
                 "# Action execution mounts",

--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -18,6 +18,11 @@ from tracecat.config import (
 )
 from tracecat.logger import logger
 from tracecat.sandbox.exceptions import SandboxTimeoutError, SandboxValidationError
+from tracecat.sandbox.networking import (
+    pasta_dns_mount_config_lines,
+    pasta_user_net_config_lines,
+    write_pasta_network_files,
+)
 from tracecat.sandbox.seccomp import build_untrusted_seccomp_policy
 from tracecat.sandbox.types import ResourceLimits, SandboxConfig, SandboxResult
 
@@ -62,28 +67,6 @@ SANDBOX_BASE_ENV = {
     "LANG": "C.UTF-8",
     "LC_ALL": "C.UTF-8",
 }
-
-_PASTA_GATEWAY_IP = "10.255.255.1"
-
-
-def build_sandbox_resolv_conf() -> str:
-    """Build sandbox resolv.conf with pasta DNS plus host search/options lines.
-
-    In Kubernetes, short service names rely on search domains like
-    `*.svc.cluster.local` and resolver options from the pod's /etc/resolv.conf.
-    Preserve those lines while forcing nameserver to pasta's DNS gateway.
-    """
-    lines = [f"nameserver {_PASTA_GATEWAY_IP}"]
-    try:
-        host_resolv = Path("/etc/resolv.conf").read_text()
-        for line in host_resolv.splitlines():
-            stripped = line.strip()
-            if stripped.startswith("search ") or stripped.startswith("options "):
-                lines.append(stripped)
-    except OSError:
-        pass
-    return "\n".join(lines) + "\n"
-
 
 _NSJAIL_HINT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
@@ -223,8 +206,9 @@ class NsjailExecutor:
         network_enabled = phase == "install" or config.network_enabled
 
         # Network behavior:
-        # - network enabled: share pod netns (no pasta) for host DNS/routing reliability
-        # - network disabled: isolate netns
+        # - always isolate network namespace for private loopback
+        # - network enabled: add pasta userspace networking for outbound access
+        # - network disabled: no route out of the isolated namespace
         lines = [
             'name: "python_sandbox"',
             "mode: ONCE",
@@ -232,13 +216,16 @@ class NsjailExecutor:
             "keep_env: false",
             "",
             "# Namespace isolation",
-            f"clone_newnet: {'false' if network_enabled else 'true'}",
+            "clone_newnet: true",
             "clone_newuser: true",
             "clone_newns: true",
             "clone_newpid: true",
             "clone_newipc: true",
             "clone_newuts: true",
         ]
+
+        if network_enabled:
+            lines.extend(pasta_user_net_config_lines())
 
         lines.extend(
             [
@@ -272,15 +259,8 @@ class NsjailExecutor:
             )
 
         if network_enabled:
-            lines.extend(
-                [
-                    "",
-                    "# DNS config - use pod resolver files directly",
-                    'mount { src: "/etc/resolv.conf" dst: "/etc/resolv.conf" is_bind: true rw: false }',
-                    'mount { src: "/etc/hosts" dst: "/etc/hosts" is_bind: true rw: false }',
-                    'mount { src: "/etc/nsswitch.conf" dst: "/etc/nsswitch.conf" is_bind: true rw: false }',
-                ]
-            )
+            network_files = write_pasta_network_files(job_dir)
+            lines.extend(pasta_dns_mount_config_lines(network_files))
 
         lines.extend(
             [
@@ -659,8 +639,8 @@ class NsjailExecutor:
             'hostname: "sandbox"',
             "keep_env: false",
             "",
-            "# Namespace isolation (share pod network namespace for reliability)",
-            "clone_newnet: false",
+            "# Namespace isolation",
+            "clone_newnet: true",
             "clone_newuser: true",
             "clone_newns: true",
             "clone_newpid: true",
@@ -681,6 +661,8 @@ class NsjailExecutor:
             f'mount {{ src: "{self.rootfs}/etc" dst: "/etc" is_bind: true rw: false }}',
         ]
 
+        lines.extend(pasta_user_net_config_lines())
+
         # Optional mounts - only include if the directories exist in rootfs
         lib64_path = self.rootfs / "lib64"
         if lib64_path.exists():
@@ -694,15 +676,8 @@ class NsjailExecutor:
                 f'mount {{ src: "{sbin_path}" dst: "/sbin" is_bind: true rw: false }}'
             )
 
-        lines.extend(
-            [
-                "",
-                "# DNS config - use pod resolver files directly",
-                'mount { src: "/etc/resolv.conf" dst: "/etc/resolv.conf" is_bind: true rw: false }',
-                'mount { src: "/etc/hosts" dst: "/etc/hosts" is_bind: true rw: false }',
-                'mount { src: "/etc/nsswitch.conf" dst: "/etc/nsswitch.conf" is_bind: true rw: false }',
-            ]
-        )
+        network_files = write_pasta_network_files(job_dir)
+        lines.extend(pasta_dns_mount_config_lines(network_files))
 
         lines.extend(
             [

--- a/tracecat/sandbox/networking.py
+++ b/tracecat/sandbox/networking.py
@@ -1,0 +1,93 @@
+"""Network configuration helpers for nsjail sandboxes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+PASTA_GUEST_IP = "10.255.255.2"
+PASTA_GATEWAY_IP = "10.255.255.1"
+PASTA_GUEST_IP6 = "fc00::2"
+PASTA_GATEWAY_IP6 = "fc00::1"
+
+
+@dataclass(frozen=True)
+class PastaNetworkFiles:
+    """Host paths for generated network files mounted into a jail."""
+
+    resolv_conf: Path
+    hosts: Path
+    nsswitch_conf: Path
+
+
+def pasta_user_net_config_lines() -> list[str]:
+    """Return nsjail config lines for pasta-backed userspace networking."""
+    return [
+        "",
+        "# Userspace networking via pasta - outbound access with network isolation",
+        "user_net {",
+        "  enable: true",
+        f'  ip: "{PASTA_GUEST_IP}"',
+        f'  gw: "{PASTA_GATEWAY_IP}"',
+        f'  ip6: "{PASTA_GUEST_IP6}"',
+        f'  gw6: "{PASTA_GATEWAY_IP6}"',
+        "  enable_dns: true",
+        "}",
+    ]
+
+
+def build_pasta_resolv_conf(
+    host_resolv_path: Path = Path("/etc/resolv.conf"),
+) -> str:
+    """Build resolv.conf for pasta DNS while preserving resolver search options."""
+    lines = [f"nameserver {PASTA_GATEWAY_IP}"]
+    try:
+        host_resolv = host_resolv_path.read_text()
+    except OSError:
+        host_resolv = ""
+
+    for line in host_resolv.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("search ") or stripped.startswith("options "):
+            lines.append(stripped)
+    return "\n".join(lines) + "\n"
+
+
+def write_pasta_network_files(target_dir: Path) -> PastaNetworkFiles:
+    """Write generated network config files for a pasta-enabled jail."""
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    resolv_conf = target_dir / "resolv.conf"
+    hosts = target_dir / "hosts"
+    nsswitch_conf = target_dir / "nsswitch.conf"
+
+    resolv_conf.write_text(build_pasta_resolv_conf())
+    hosts.write_text(
+        "127.0.0.1\tlocalhost\n::1\tlocalhost ip6-localhost ip6-loopback\n"
+    )
+    nsswitch_conf.write_text(
+        "passwd:         files\n"
+        "group:          files\n"
+        "shadow:         files\n"
+        "hosts:          files dns\n"
+        "networks:       files\n"
+        "protocols:      files\n"
+        "services:       files\n"
+    )
+
+    return PastaNetworkFiles(
+        resolv_conf=resolv_conf,
+        hosts=hosts,
+        nsswitch_conf=nsswitch_conf,
+    )
+
+
+def pasta_dns_mount_config_lines(files: PastaNetworkFiles) -> list[str]:
+    """Return nsjail mount config lines for generated pasta DNS files."""
+    return [
+        "",
+        "# Network config - DNS and hostname resolution via pasta",
+        f'mount {{ src: "{files.resolv_conf}" dst: "/etc/resolv.conf" is_bind: true rw: false }}',
+        f'mount {{ src: "{files.hosts}" dst: "/etc/hosts" is_bind: true rw: false }}',
+        f'mount {{ src: "{files.nsswitch_conf}" dst: "/etc/nsswitch.conf" is_bind: true rw: false }}',
+    ]


### PR DESCRIPTION
## Summary
- Add shared pasta/nsjail networking helpers and enable `clone_newnet` for agent, Python, and action sandboxes.
- Enable pasta only when the sandbox needs outbound network access, while preserving private loopback-only networking otherwise.
- Generate sandbox-local resolver, hosts, and nsswitch files for pasta-backed DNS instead of bind-mounting host resolver files.
- Mount a fresh read-only procfs inside nsjail PID namespaces instead of bind-mounting host `/proc`.

## Notes
- The local `docker-compose.dev.yml` changes used for manual cluster testing are intentionally not included in this PR.
- Nested procfs mounting under Docker requires the runtime to allow unmasked system paths; the Dockerized test override now uses `systempaths=unconfined` for that path.

## Validation
- `TRACECAT__SERVICE_KEY=test-service-key uv run ruff check tracecat/agent/sandbox/config.py tracecat/sandbox/executor.py tracecat/sandbox/networking.py tests/unit/test_agent_sandbox_config.py tests/unit/test_sandbox_networking.py tests/unit/test_agent_sandbox_litellm.py`
- `TRACECAT__SERVICE_KEY=test-service-key uv run basedpyright tracecat/agent/sandbox/config.py tracecat/sandbox/executor.py tracecat/sandbox/networking.py tests/unit/test_agent_sandbox_config.py tests/unit/test_sandbox_networking.py tests/unit/test_agent_sandbox_litellm.py`
- Dockerized nsjail harness via `_run_nsjail_harness_in_docker_or_skip()` passed.
- Pasta Docker smoke skipped locally because this host does not expose `/dev/net/tun`.
- Focused pytest collection for the new config tests failed before test execution because the repo's session DB fixture tried to connect to Postgres on `localhost:5432` and it was unavailable.

## Coverage Review
The committed unit coverage gives good confidence that generated nsjail configs now always clone a network namespace, only add pasta when internet access is requested, use generated pasta DNS mounts, and mount fresh procfs instead of host `/proc`.

The current coverage is not enough by itself for a high-confidence production rollout of pasta-backed outbound internet access. The missing piece is an integration test on a Linux runner or node with `/dev/net/tun`, `CAP_SYS_ADMIN`, unconfined seccomp, and unmasked proc system paths that verifies real outbound DNS/connectivity through pasta while the jail remains isolated from the host network. A full agent-path assertion that jailed `/proc` only exposes jail PIDs would also reduce risk.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `pasta` userspace networking to `nsjail` sandboxes with always-isolated network namespaces; `pasta` is enabled only when outbound internet access is requested. Replace host `/proc` bind mounts with a fresh read-only procfs and generate sandbox-local DNS files for reliable `pasta`-backed resolution.

- **New Features**
  - Always isolate net namespaces; enable `pasta` only when internet is requested for agent, Python, and action sandboxes.
  - Generate sandbox-local `resolv.conf`, `hosts`, and `nsswitch.conf`; stop bind-mounting host resolver files.
  - New helpers in `tracecat/sandbox/networking.py` and focused unit tests, plus Dockerized smoke test for `pasta`.

- **Migration**
  - Docker runtime must allow nested procfs: add `security_opt: ["seccomp:unconfined", "systempaths=unconfined"]`.
  - Internet-enabled runs/tests require host `/dev/net/tun` to be available.

<sup>Written for commit 85f829edf85659882ef953f2f83b3ddb055b79b8. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2571?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

