### PR TITLE
docs: add GitHub Copilot MCP setup to installation snippets

### DIFF
--- a/docs/snippets/mcp-installation-self-hosted.mdx
+++ b/docs/snippets/mcp-installation-self-hosted.mdx
@@ -18,6 +18,34 @@ Replace `<your-tracecat-url>` with your `PUBLIC_APP_URL` (e.g. `http://localhost
     ```
   </Tab>
 
+  <Tab title="GitHub Copilot" icon="https://cdn.simpleicons.org/github">
+
+    ```bash
+    copilot
+    /mcp add
+    # Server Name: tracecat
+    # Server Type: HTTP
+    # URL: <your-tracecat-url>/mcp
+    # Tools: *
+    ```
+
+    Follow [GitHub Copilot MCP setup](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers) for the latest CLI prompts.
+
+    Or add this server to `~/.copilot/mcp-config.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "tracecat": {
+          "type": "http",
+          "url": "<your-tracecat-url>/mcp",
+          "tools": ["*"]
+        }
+      }
+    }
+    ```
+  </Tab>
+
   <Tab title="Cursor" icon="https://cdn.simpleicons.org/cursor">
 
     Configure in `.cursor/mcp.json`:

--- a/docs/snippets/mcp-installation.mdx
+++ b/docs/snippets/mcp-installation.mdx
@@ -16,6 +16,34 @@
     ```
   </Tab>
 
+  <Tab title="GitHub Copilot" icon="https://cdn.simpleicons.org/github">
+
+    ```bash
+    copilot
+    /mcp add
+    # Server Name: tracecat
+    # Server Type: HTTP
+    # URL: https://platform.tracecat.com/mcp
+    # Tools: *
+    ```
+
+    Follow [GitHub Copilot MCP setup](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers) for the latest CLI prompts.
+
+    Or add this server to `~/.copilot/mcp-config.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "tracecat": {
+          "type": "http",
+          "url": "https://platform.tracecat.com/mcp",
+          "tools": ["*"]
+        }
+      }
+    }
+    ```
+  </Tab>
+
   <Tab title="Cursor" icon="https://cdn.simpleicons.org/cursor">
 
     Click this link [Add Tracecat to Cursor](https://cursor.com/en/install-mcp?name=tracecat&config=eyJ1cmwiOiJodHRwczovL3BsYXRmb3JtLnRyYWNlY2F0LmNvbS9tY3AifQ)


### PR DESCRIPTION
### Motivation

- Add explicit instructions for configuring GitHub Copilot as an MCP client alongside existing Claude, OpenAI Codex, and Cursor examples to improve developer onboarding.

### Description

- Added a new `GitHub Copilot` `<Tab>` in `docs/snippets/mcp-installation.mdx` with CLI prompts and an example `~/.copilot/mcp-config.json` entry pointing at `https://platform.tracecat.com/mcp`.
- Added the same `GitHub Copilot` `<Tab>` to `docs/snippets/mcp-installation-self-hosted.mdx` with CLI prompts and an example `~/.copilot/mcp-config.json` entry referencing `<your-tracecat-url>/mcp`.
- Included a link to the official GitHub Copilot MCP setup docs and ensured the examples specify `type: "http"` and `tools: ["*"]` for parity with other examples.

### Testing

- No automated tests were added or run for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8a7d162883339f6fb4d04f6556fe)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added GitHub Copilot MCP setup to the installation snippets, with CLI steps and a `~/.copilot/mcp-config.json` example for both cloud (`https://platform.tracecat.com/mcp`) and self-hosted (`<your-tracecat-url>/mcp`). This lets users add Tracecat as an MCP server in Copilot quickly, consistent with other client examples.

<sup>Written for commit ff1d43fce13087b3a116bd5cc245b7d7ccd32ff5. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2572?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

