### PR TITLE
fix(agents): propagate errors from mcp and litellm to the client

### DIFF
--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import cast
 
@@ -110,6 +111,8 @@ async def test_forward_request_streams_litellm_response(
 async def test_forward_request_returns_upstream_error_response(
     tmp_path: Path,
 ) -> None:
+    errors: list[str] = []
+
     async def handler(request: httpx.Request) -> httpx.Response:
         assert str(request.url) == "http://litellm:4000/v1/messages/count_tokens"
         return httpx.Response(
@@ -121,6 +124,7 @@ async def test_forward_request_returns_upstream_error_response(
     socket_proxy = LLMSocketProxy(
         socket_path=tmp_path / "llm.sock",
         upstream_url="http://litellm:4000",
+        on_error=errors.append,
     )
     socket_proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     writer = _FakeWriter()
@@ -146,6 +150,90 @@ async def test_forward_request_returns_upstream_error_response(
     assert response_text.startswith("HTTP/1.1 400 Bad Request")
     assert "X-Request-ID:" in response_text
     assert "bad request" in response_text
+    assert errors == []
+
+
+@pytest.mark.anyio
+async def test_forward_request_emits_error_for_critical_upstream_http_error(
+    tmp_path: Path,
+) -> None:
+    errors: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "http://litellm:4000/v1/messages"
+        return httpx.Response(
+            429,
+            headers={"Content-Type": "application/json"},
+            json={"error": {"message": "provider quota exhausted"}},
+        )
+
+    socket_proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        upstream_url="http://litellm:4000",
+        on_error=errors.append,
+    )
+    socket_proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    writer = _FakeWriter()
+
+    try:
+        await socket_proxy._forward_request(
+            {
+                "method": "POST",
+                "path": "/v1/messages",
+                "headers": {
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer llm-token",
+                    "X-Request-ID": "trace-test-123",
+                },
+                "body": b'{"messages":[{"role":"user","content":"hello"}]}',
+            },
+            cast(asyncio.StreamWriter, writer),
+        )
+    finally:
+        if socket_proxy._client is not None:
+            await socket_proxy._client.aclose()
+
+    response_text = writer.buffer.decode("utf-8")
+    assert response_text.startswith("HTTP/1.1 429 Too Many Requests")
+    assert "provider quota exhausted" in response_text
+    assert len(errors) == 1
+    assert "LiteLLM request failed (429 Too Many Requests)" in errors[0]
+    assert "Rate limit exceeded" in errors[0]
+    assert "provider quota exhausted" in errors[0]
+    assert "request_id=trace-test-123" in errors[0]
+
+
+@pytest.mark.anyio
+async def test_write_stream_response_emits_error_after_headers_sent(
+    tmp_path: Path,
+) -> None:
+    errors: list[str] = []
+    socket_proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        upstream_url="http://litellm:4000",
+        on_error=errors.append,
+    )
+    writer = _FakeWriter()
+
+    async def broken_stream() -> AsyncIterator[bytes]:
+        yield b'event: message_start\ndata: {"type":"message_start"}\n\n'
+        raise RuntimeError("provider stream disconnected")
+
+    await socket_proxy._write_response(
+        cast(asyncio.StreamWriter, writer),
+        status_code=200,
+        reason_phrase="OK",
+        headers={"Content-Type": "text/event-stream"},
+        body_chunks=broken_stream(),
+        trace_request_id="trace-test-456",
+        path="/v1/messages",
+    )
+
+    response_text = writer.buffer.decode("utf-8")
+    assert response_text.startswith("HTTP/1.1 200 OK")
+    assert "event: error" in response_text
+    assert "provider stream disconnected" in response_text
+    assert errors == ["LiteLLM stream failed: provider stream disconnected"]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_mcp_proxy_server.py
+++ b/tests/unit/test_agent_mcp_proxy_server.py
@@ -149,6 +149,98 @@ async def test_registry_proxy_handler_strips_metadata_and_forwards_tool_call_id(
 
 
 @pytest.mark.anyio
+async def test_proxy_handler_returns_mcp_error_result_when_trusted_tool_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    call_tool = AsyncMock(
+        return_value=SimpleNamespace(
+            content=[SimpleNamespace(text="external MCP rejected")],
+            is_error=True,
+        )
+    )
+
+    class _FakeClient:
+        def __init__(self, transport):
+            self.transport = transport
+
+        async def __aenter__(self):
+            return SimpleNamespace(call_tool=call_tool)
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    monkeypatch.setattr(proxy_server, "_create_uds_transport", lambda _: object())
+    monkeypatch.setattr(proxy_server, "Client", _FakeClient)
+
+    handler = proxy_server._make_tool_handler(
+        "execute_user_mcp_tool",
+        {"server_name": "Jira", "tool_name": "getIssue"},
+        "auth-token",
+        {"tool_type": "user_mcp", "server_name": "Jira", "tool_name": "getIssue"},
+    )
+
+    result = await handler({"issueKey": "ENG-1"})
+
+    assert result == {
+        "content": [{"type": "text", "text": "external MCP rejected"}],
+        "is_error": True,
+    }
+
+
+@pytest.mark.anyio
+async def test_proxy_mcp_server_preserves_handler_error_as_mcp_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    call_tool = AsyncMock(side_effect=RuntimeError("trusted MCP unavailable"))
+
+    class _FakeClient:
+        def __init__(self, transport):
+            self.transport = transport
+
+        async def __aenter__(self):
+            return SimpleNamespace(call_tool=call_tool)
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    monkeypatch.setattr(proxy_server, "_create_uds_transport", lambda _: object())
+    monkeypatch.setattr(proxy_server, "Client", _FakeClient)
+
+    server_config = await proxy_server.create_proxy_mcp_server(
+        allowed_actions={
+            "mcp__Jira__getIssue": MCPToolDefinition(
+                name="mcp__Jira__getIssue",
+                description="Get issue",
+                parameters_json_schema={
+                    "type": "object",
+                    "properties": {"issueKey": {"type": "string"}},
+                    "required": ["issueKey"],
+                    "additionalProperties": False,
+                },
+            )
+        },
+        auth_token="auth-token",
+    )
+
+    server = server_config["instance"]
+    response = await server.request_handlers[mt.CallToolRequest](
+        mt.CallToolRequest(
+            params=mt.CallToolRequestParams(
+                name="mcp__Jira__getIssue",
+                arguments={"issueKey": "ENG-1"},
+            )
+        )
+    )
+
+    result = cast(mt.CallToolResult, response.root)
+    assert result.isError is True
+    assert result.content
+    first_block = result.content[0]
+    assert isinstance(first_block, mt.TextContent)
+    assert first_block.text == "trusted MCP unavailable"
+
+
+@pytest.mark.anyio
 async def test_registry_proxy_server_accepts_hook_injected_metadata_during_tool_call(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tracecat/agent/mcp/proxy_server.py
+++ b/tracecat/agent/mcp/proxy_server.py
@@ -11,7 +11,6 @@ Handles two types of tools:
 from __future__ import annotations
 
 import copy
-import json
 from collections.abc import Callable, Coroutine
 from typing import Any
 
@@ -156,33 +155,34 @@ def _make_tool_handler(
                 first_block = call_result.content[0]
                 result_text = getattr(first_block, "text", str(first_block))
 
-            # Check if the tool call returned an error
-            # Return structured JSON so frontend can detect errors
             if call_result.is_error:
                 logger.error(
                     "Tool call returned error", error=result_text, **log_context
                 )
-                error_response = json.dumps(
-                    {
-                        "success": False,
-                        "error": result_text or "Tool execution failed",
-                    }
-                )
-                return {"content": [{"type": "text", "text": error_response}]}
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": result_text or "Tool execution failed",
+                        }
+                    ],
+                    "is_error": True,
+                }
 
             return {"content": [{"type": "text", "text": result_text}]}
 
         except Exception as e:
-            # Unexpected exceptions - return structured error response
             error_msg = str(e)
             logger.error("Proxy request failed", error=error_msg, **log_context)
-            error_response = json.dumps(
-                {
-                    "success": False,
-                    "error": error_msg or "Tool execution failed",
-                }
-            )
-            return {"content": [{"type": "text", "text": error_response}]}
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": error_msg or "Tool execution failed",
+                    }
+                ],
+                "is_error": True,
+            }
 
     return _handler
 

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -53,6 +53,7 @@ _ERROR_MESSAGES = {
     504: "LLM provider request timed out",
     529: "LLM provider is overloaded - please try again shortly",
 }
+_ERROR_BODY_PREVIEW_BYTES = 2048
 _proxy_load_tracker = get_load_tracker("llm_socket_proxy")
 _TRACE_REQUEST_ID_HEADER = "x-request-id"
 
@@ -80,6 +81,66 @@ def _get_or_create_trace_request_id(headers: dict[str, str]) -> str:
         if key.lower() == _TRACE_REQUEST_ID_HEADER and value:
             return value
     return str(uuid4())
+
+
+def _is_non_critical_path(path: str) -> bool:
+    return path.split("?", 1)[0] in _NON_CRITICAL_PATHS
+
+
+def _coerce_error_detail(value: object) -> str | None:
+    if isinstance(value, str):
+        detail = value.strip()
+        return detail or None
+    if isinstance(value, dict):
+        for key in ("message", "detail", "error"):
+            if detail := _coerce_error_detail(value.get(key)):
+                return detail
+        return orjson.dumps(value).decode("utf-8")
+    if isinstance(value, list):
+        return orjson.dumps(value).decode("utf-8")
+    return None
+
+
+def _extract_error_detail(body: bytes) -> str | None:
+    if not body:
+        return None
+
+    if len(body) <= _ERROR_BODY_PREVIEW_BYTES:
+        try:
+            parsed = orjson.loads(body)
+        except orjson.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            for key in ("error", "detail", "message"):
+                if detail := _coerce_error_detail(parsed.get(key)):
+                    return detail
+
+    preview = body[:_ERROR_BODY_PREVIEW_BYTES].decode("utf-8", errors="replace")
+    detail = preview.strip()
+    if not detail:
+        return None
+    if len(body) > _ERROR_BODY_PREVIEW_BYTES:
+        return f"{detail}..."
+    return detail
+
+
+def _format_litellm_http_error(
+    *,
+    status_code: int,
+    reason_phrase: str,
+    body: bytes,
+    trace_request_id: str,
+) -> str:
+    reason = reason_phrase or "Unknown"
+    message = _ERROR_MESSAGES.get(status_code)
+    detail = _extract_error_detail(body)
+    parts = [f"LiteLLM request failed ({status_code} {reason})"]
+    if message:
+        parts.append(message)
+    if detail and detail != message:
+        parts.append(detail)
+    parts.append(f"request_id={trace_request_id}")
+    return ": ".join(parts)
 
 
 class LLMSocketProxy:
@@ -485,12 +546,27 @@ class LLMSocketProxy:
                 headers=forward_headers,
                 content=body if body else None,
             ) as response:
+                body_chunks: AsyncIterable[bytes] | list[bytes]
+                if response.status_code >= 400 and not _is_non_critical_path(path):
+                    error_body = await response.aread()
+                    self._emit_error(
+                        _format_litellm_http_error(
+                            status_code=response.status_code,
+                            reason_phrase=response.reason_phrase,
+                            body=error_body,
+                            trace_request_id=trace_request_id,
+                        )
+                    )
+                    body_chunks = [error_body]
+                else:
+                    body_chunks = response.aiter_bytes()
+
                 await self._write_response(
                     writer,
                     status_code=response.status_code,
                     reason_phrase=response.reason_phrase,
                     headers=dict(response.headers),
-                    body_chunks=response.aiter_bytes(),
+                    body_chunks=body_chunks,
                     trace_request_id=trace_request_id,
                     started_at=started_at,
                     request_counter=request_counter,
@@ -505,7 +581,7 @@ class LLMSocketProxy:
                 request_counter=request_counter,
                 trace_request_id=trace_request_id,
             )
-            if path.split("?", 1)[0] not in _NON_CRITICAL_PATHS:
+            if not _is_non_critical_path(path):
                 self._emit_error(f"LiteLLM unavailable: {exc}")
         except httpx.TimeoutException as exc:
             await self._write_error_response(
@@ -515,7 +591,7 @@ class LLMSocketProxy:
                 request_counter=request_counter,
                 trace_request_id=trace_request_id,
             )
-            if path.split("?", 1)[0] not in _NON_CRITICAL_PATHS:
+            if not _is_non_critical_path(path):
                 self._emit_error(f"Gateway timeout ({type(exc).__name__}): {exc}")
 
     async def _write_response(
@@ -605,6 +681,8 @@ class LLMSocketProxy:
                     detail=detail,
                     trace_request_id=trace_request_id,
                 )
+                if path is not None and not _is_non_critical_path(path):
+                    self._emit_error(f"LiteLLM stream failed: {detail}")
                 error_payload = orjson.dumps(
                     {
                         "type": "error",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes error propagation from MCP tools and `litellm` so clients see real failure details and observers receive clear error events.

- Bug Fixes
  - MCP proxy: return tool failures as `{"content":[{"type":"text","text":...}],"is_error":true}` and preserve exception messages; removed JSON-wrapped `success:false` payloads.
  - LLM proxy: on critical paths (e.g., `/v1/messages`), emit `on_error` for upstream HTTP errors (>=400) and forward the upstream body; messages include status, a friendly hint, extracted detail, and `x-request-id`.
  - LLM streaming: when the provider stream fails after headers, send an SSE `error` event to the client and emit `on_error`.
  - Error parsing: extract details from JSON (`error`, `detail`, `message`) or a 2KB body preview for clearer messages; non-critical endpoints (e.g., `/v1/models`, `/v1/messages/count_tokens`) are not treated as errors.
  - Tests: added unit tests covering upstream 429 handling, stream failure emission, MCP tool error passthrough, and MCP exceptions surfaced as tool errors.

<sup>Written for commit db85228269c94c797384dcc33da65795fdaee27c. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2574?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

