### PR TITLE
fix(frontend): make agent preset use latest select newest version

### DIFF
--- a/frontend/src/components/agents/agent-preset-version-select.tsx
+++ b/frontend/src/components/agents/agent-preset-version-select.tsx
@@ -14,6 +14,12 @@ import { cn } from "@/lib/utils"
 
 const CURRENT_VERSION_VALUE = "__current__"
 
+export function getAgentPresetVersionIdFromSelectValue(
+  selectValue: string
+): string | null {
+  return selectValue === CURRENT_VERSION_VALUE ? null : selectValue
+}
+
 export function getAgentPresetVersionNumber(
   versions: AgentPresetVersionReadMinimal[] | undefined,
   versionId: string | null | undefined
@@ -114,7 +120,6 @@ export function AgentPresetVersionSelect({
   triggerClassName,
   allowCurrent = true,
 }: AgentPresetVersionSelectProps) {
-  const latestVersionId = versions?.[0]?.id ?? null
   const value =
     selectedVersionId ?? (allowCurrent ? CURRENT_VERSION_VALUE : undefined)
   const currentVersionNumber = getAgentPresetVersionNumber(
@@ -129,15 +134,9 @@ export function AgentPresetVersionSelect({
   return (
     <Select
       value={value}
-      onValueChange={(nextValue) => {
-        if (nextValue === CURRENT_VERSION_VALUE) {
-          if (latestVersionId) {
-            void onSelect(latestVersionId)
-          }
-          return
-        }
-        void onSelect(nextValue)
-      }}
+      onValueChange={(nextValue) =>
+        void onSelect(getAgentPresetVersionIdFromSelectValue(nextValue))
+      }
       disabled={disabled}
     >
       <SelectTrigger
@@ -188,12 +187,9 @@ export function AgentPresetVersionSelect({
             Failed to load versions
           </SelectItem>
         ) : null}
-        {!versionsIsLoading &&
-        !versionsError &&
-        allowCurrent &&
-        latestVersionId ? (
+        {!versionsIsLoading && !versionsError && allowCurrent ? (
           <SelectItem value={CURRENT_VERSION_VALUE}>
-            <VersionLabel label="Use latest" />
+            <VersionLabel label="Use current" />
           </SelectItem>
         ) : null}
         {!versionsIsLoading &&

--- a/frontend/src/components/agents/agent-preset-version-select.tsx
+++ b/frontend/src/components/agents/agent-preset-version-select.tsx
@@ -114,6 +114,7 @@ export function AgentPresetVersionSelect({
   triggerClassName,
   allowCurrent = true,
 }: AgentPresetVersionSelectProps) {
+  const latestVersionId = versions?.[0]?.id ?? null
   const value =
     selectedVersionId ?? (allowCurrent ? CURRENT_VERSION_VALUE : undefined)
   const currentVersionNumber = getAgentPresetVersionNumber(
@@ -128,9 +129,15 @@ export function AgentPresetVersionSelect({
   return (
     <Select
       value={value}
-      onValueChange={(nextValue) =>
-        void onSelect(nextValue === CURRENT_VERSION_VALUE ? null : nextValue)
-      }
+      onValueChange={(nextValue) => {
+        if (nextValue === CURRENT_VERSION_VALUE) {
+          if (latestVersionId) {
+            void onSelect(latestVersionId)
+          }
+          return
+        }
+        void onSelect(nextValue)
+      }}
       disabled={disabled}
     >
       <SelectTrigger
@@ -181,7 +188,10 @@ export function AgentPresetVersionSelect({
             Failed to load versions
           </SelectItem>
         ) : null}
-        {!versionsIsLoading && !versionsError && allowCurrent ? (
+        {!versionsIsLoading &&
+        !versionsError &&
+        allowCurrent &&
+        latestVersionId ? (
           <SelectItem value={CURRENT_VERSION_VALUE}>
             <VersionLabel label="Use latest" />
           </SelectItem>

--- a/frontend/tests/agent-preset-version-select.test.tsx
+++ b/frontend/tests/agent-preset-version-select.test.tsx
@@ -1,9 +1,17 @@
 import {
   formatAgentPresetVersionLabel,
   getAgentPresetVersionFallbackLabel,
+  getAgentPresetVersionIdFromSelectValue,
 } from "@/components/agents/agent-preset-version-select"
 
 describe("agent preset version select labels", () => {
+  it("maps the current option to an unpinned preset version", () => {
+    expect(getAgentPresetVersionIdFromSelectValue("__current__")).toBeNull()
+    expect(getAgentPresetVersionIdFromSelectValue("version-2")).toBe(
+      "version-2"
+    )
+  })
+
   it("uses a non-current fallback for pinned versions when the version number is missing", () => {
     expect(
       getAgentPresetVersionFallbackLabel({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the agent preset version selector so “Use latest” selects and saves the newest version ID, making the choice predictable and persistent.

- **Bug Fixes**
  - Map “Use latest” to the newest `version.id` instead of `null`.
  - Show “Use latest” only when versions are loaded and a newest ID exists.

<sup>Written for commit 32c30c02e705fc11dba67d23bdac785acbbad823. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2575?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

