### PR TITLE
fix(cases): resolve option_ref in closure validator and return 400 fr…

### DIFF
--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -138,6 +138,7 @@ async def _create_dropdown_with_option(
     definition_ref: str,
     option_label: str,
     option_ref: str,
+    required_on_closure: bool = False,
 ):
     definitions_service = CaseDropdownDefinitionsService(
         session=cases_service.session, role=cases_service.role
@@ -148,6 +149,7 @@ async def _create_dropdown_with_option(
             ref=definition_ref,
             is_ordered=False,
             options=[],
+            required_on_closure=required_on_closure,
         )
     )
     option = await definitions_service.add_option(
@@ -890,6 +892,43 @@ class TestCasesService:
         assert len(values) == 1
         assert values[0].definition_id == definition.id
         assert values[0].option_id == target_option.id
+
+    async def test_update_case_close_with_dropdown_refs_satisfies_closure_requirements(
+        self, cases_service: CasesService, case_create_params: CaseCreate
+    ) -> None:
+        """Closing a case while supplying a required dropdown via refs must succeed."""
+        definition, option = await _create_dropdown_with_option(
+            cases_service,
+            definition_name="Classification",
+            definition_ref="classification",
+            option_label="False positive",
+            option_ref="false_positive",
+            required_on_closure=True,
+        )
+
+        created_case = await cases_service.create_case(case_create_params)
+
+        await cases_service.update_case(
+            created_case,
+            CaseUpdate(
+                status=CaseStatus.CLOSED,
+                dropdown_values=[
+                    CaseDropdownValueInput(
+                        definition_ref="classification",
+                        option_ref="false_positive",
+                    )
+                ],
+            ),
+        )
+
+        assert created_case.status == CaseStatus.CLOSED
+        dropdowns_service = CaseDropdownValuesService(
+            session=cases_service.session, role=cases_service.role
+        )
+        values = await dropdowns_service.list_values_for_case(created_case.id)
+        assert len(values) == 1
+        assert values[0].definition_id == definition.id
+        assert values[0].option_id == option.id
 
     async def test_delete_case(
         self, cases_service: CasesService, case_create_params: CaseCreate

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -1299,6 +1299,11 @@ async def update_case_simple(
             status_code=HTTP_400_BAD_REQUEST,
             detail=str(e),
         ) from e
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
     except ValueError as e:
         raise HTTPException(
             status_code=HTTP_400_BAD_REQUEST,

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -928,13 +928,9 @@ class CasesService(BaseWorkspaceService):
                     missing_fields.append(name)
 
         # --- Dropdown definitions ---
-        stmt = (
-            select(CaseDropdownDefinition)
-            .where(
-                CaseDropdownDefinition.workspace_id == self.workspace_id,
-                CaseDropdownDefinition.required_on_closure.is_(True),
-            )
-            .options(selectinload(CaseDropdownDefinition.options))
+        stmt = select(CaseDropdownDefinition).where(
+            CaseDropdownDefinition.workspace_id == self.workspace_id,
+            CaseDropdownDefinition.required_on_closure.is_(True),
         )
         result = await self.session.execute(stmt)
         required_defs = result.scalars().all()
@@ -956,7 +952,15 @@ class CasesService(BaseWorkspaceService):
                                 def_id = rd.id
                                 break
                     if def_id is not None:
-                        current_dropdown_map[def_id] = validated.option_id
+                        option_id = validated.option_id
+                        if option_id is None and validated.option_ref is not None:
+                            option_id = await self.session.scalar(
+                                select(CaseDropdownOption.id).where(
+                                    CaseDropdownOption.definition_id == def_id,
+                                    CaseDropdownOption.ref == validated.option_ref,
+                                )
+                            )
+                        current_dropdown_map[def_id] = option_id
 
             for defn in required_defs:
                 if not current_dropdown_map.get(defn.id):


### PR DESCRIPTION
## Problem                                                                                                                                                      
                                                                                                                                                                
  `core.cases.update_case` returned HTTP 500 when a workflow closed a case and supplied required dropdowns by `definition_ref`/`option_ref` in the same payload.  

  Two issues:                                                                                                                                                     
                                                                                                                                                                  
  1. The closure-requirements validator resolved `definition_ref` but not `option_ref`, so it wrote `option_id=None` into the merged map and falsely flagged the  
  dropdown as missing.                                                                                                                                            
  2. `update_case_simple` didn't catch `TracecatValidationError`, so it bubbled to the global handler as a 500 instead of a 4xx.                                  
                                                                                                                                                                  
  ## Solution
                                                                                                                                                                  
  - Resolve `option_ref` → `option_id` inside the validator before merging.                                                                                     
  - Catch `TracecatValidationError` in `update_case_simple` and return 400, matching the file's existing convention for validation failures.
  - Add a regression test that closes a case using `definition_ref` + `option_ref` for a required-on-closure dropdown.                     

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix case closure validation to accept dropdown refs and return clear 400 errors for invalid closure data. You can now close a case by sending `definition_ref` + `option_ref` for required dropdowns.

- **Bug Fixes**
  - Resolve `option_ref` to option ID when validating required dropdowns on close.
  - Map `TracecatValidationError` to HTTP 400 in `update_case_simple`.
  - Add unit test to verify closing with dropdown refs satisfies closure requirements.

<sup>Written for commit aa4dd2914506a518ddaad6e7970e8c1e031ded2e. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2576?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

