### PR TITLE
fix(rbac): group assignment sync with memberships

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/rbac/service.py
+++ b/packages/tracecat-ee/tracecat_ee/rbac/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, select, union_all
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
@@ -17,6 +17,7 @@ from tracecat.db.models import (
     Group,
     GroupMember,
     GroupRoleAssignment,
+    Membership,
     OrganizationMembership,
     RoleScope,
     Scope,
@@ -328,6 +329,86 @@ class RBACService(BaseOrgService):
         if result.scalar_one_or_none() is None:
             raise TracecatNotFoundError("Role not found")
 
+    async def _assert_user_exists(self, user_id: UUID) -> None:
+        """Assert a user exists."""
+        if await self.session.scalar(select(User).filter_by(id=user_id)) is None:
+            raise TracecatNotFoundError("User not found")
+
+    async def _group_member_ids(self, group_id: UUID) -> set[UUID]:
+        result = await self.session.execute(
+            select(GroupMember.user_id).where(GroupMember.group_id == group_id)
+        )
+        return set(result.scalars().all())
+
+    async def _required_assignment_workspace_ids(
+        self, user_id: UUID
+    ) -> tuple[bool, set[UUID]]:
+        """Return (org_required, workspace_ids) implied by RBAC state."""
+        direct = select(UserRoleAssignment.workspace_id).where(
+            UserRoleAssignment.user_id == user_id,
+            UserRoleAssignment.organization_id == self.organization_id,
+        )
+        via_group = (
+            select(GroupRoleAssignment.workspace_id)
+            .join(Group, Group.id == GroupRoleAssignment.group_id)
+            .join(GroupMember, GroupMember.group_id == Group.id)
+            .where(
+                GroupMember.user_id == user_id,
+                GroupRoleAssignment.organization_id == self.organization_id,
+            )
+        )
+        result = await self.session.execute(union_all(direct, via_group))
+        workspace_ids = {ws_id for (ws_id,) in result.all()}
+        org_required = bool(workspace_ids)
+        workspace_ids.discard(None)
+        return org_required, workspace_ids
+
+    async def _sync_memberships(self, user_ids: set[UUID]) -> None:
+        """Sync org and workspace membership rows from current RBAC state."""
+        for user_id in user_ids:
+            (
+                org_required,
+                required_ws_ids,
+            ) = await self._required_assignment_workspace_ids(user_id)
+            org_membership = await self.session.scalar(
+                select(OrganizationMembership).where(
+                    OrganizationMembership.user_id == user_id,
+                    OrganizationMembership.organization_id == self.organization_id,
+                )
+            )
+            if org_required and org_membership is None:
+                self.session.add(
+                    OrganizationMembership(
+                        user_id=user_id,
+                        organization_id=self.organization_id,
+                    )
+                )
+            elif not org_required and org_membership is not None:
+                await self.session.delete(org_membership)
+
+            org_workspace_ids = select(Workspace.id).where(
+                Workspace.organization_id == self.organization_id
+            )
+            delete_stmt = delete(Membership).where(
+                Membership.user_id == user_id,
+                Membership.workspace_id.in_(org_workspace_ids),
+            )
+            if required_ws_ids:
+                delete_stmt = delete_stmt.where(
+                    ~Membership.workspace_id.in_(required_ws_ids)
+                )
+            await self.session.execute(delete_stmt)
+
+            for ws_id in required_ws_ids:
+                exists = await self.session.scalar(
+                    select(Membership.user_id).where(
+                        Membership.user_id == user_id,
+                        Membership.workspace_id == ws_id,
+                    )
+                )
+                if exists is None:
+                    self.session.add(Membership(user_id=user_id, workspace_id=ws_id))
+
     # =========================================================================
     # Group Management
     # =========================================================================
@@ -404,8 +485,11 @@ class RBACService(BaseOrgService):
     @audit_log(resource_type="rbac_group", action="delete", resource_id_attr="group_id")
     async def delete_group(self, group_id: UUID) -> None:
         """Delete a group."""
+        member_ids = await self._group_member_ids(group_id)
         group = await self.get_group(group_id)
         await self.session.delete(group)
+        await self.session.flush()
+        await self._sync_memberships(member_ids)
         await self.session.commit()
 
     @require_scope("org:rbac:update")
@@ -417,14 +501,9 @@ class RBACService(BaseOrgService):
         # Verify group exists
         await self._assert_group_exists(group_id)
 
-        # Verify user belongs to this organization
-        stmt = select(OrganizationMembership).where(
-            OrganizationMembership.user_id == user_id,
-            OrganizationMembership.organization_id == self.organization_id,
-        )
-        result = await self.session.execute(stmt)
-        if result.scalar_one_or_none() is None:
-            raise TracecatNotFoundError("User not found in organization")
+        # Verify user exists. RBAC sync creates org membership when assignments
+        # on this group require it.
+        await self._assert_user_exists(user_id)
 
         # Check if already a member
         stmt = select(GroupMember).where(
@@ -437,6 +516,8 @@ class RBACService(BaseOrgService):
 
         member = GroupMember(group_id=group_id, user_id=user_id)
         self.session.add(member)
+        await self.session.flush()
+        await self._sync_memberships({user_id})
         await self.session.commit()
 
     @require_scope("org:rbac:update")
@@ -460,6 +541,8 @@ class RBACService(BaseOrgService):
             raise TracecatNotFoundError("Group member not found")
 
         await self.session.delete(member)
+        await self.session.flush()
+        await self._sync_memberships({user_id})
         await self.session.commit()
 
     async def list_group_members(
@@ -571,6 +654,8 @@ class RBACService(BaseOrgService):
             assigned_by=self.role.user_id,
         )
         self.session.add(assignment)
+        await self.session.flush()
+        await self._sync_memberships(await self._group_member_ids(group_id))
         await self.session.commit()
         await self.session.refresh(assignment, ["group", "role", "workspace"])
         return assignment
@@ -594,6 +679,8 @@ class RBACService(BaseOrgService):
         await self._assert_role_exists(role_id)
 
         assignment.role_id = role_id
+        await self.session.flush()
+        await self._sync_memberships(await self._group_member_ids(assignment.group_id))
         await self.session.commit()
         await self.session.refresh(assignment, ["group", "role", "workspace"])
         return assignment
@@ -607,7 +694,10 @@ class RBACService(BaseOrgService):
     async def delete_group_role_assignment(self, assignment_id: UUID) -> None:
         """Delete a group assignment."""
         assignment = await self.get_group_role_assignment(assignment_id)
+        member_ids = await self._group_member_ids(assignment.group_id)
         await self.session.delete(assignment)
+        await self.session.flush()
+        await self._sync_memberships(member_ids)
         await self.session.commit()
 
     # =========================================================================
@@ -678,14 +768,9 @@ class RBACService(BaseOrgService):
         Returns:
             Created UserRoleAssignment
         """
-        # Verify user belongs to this organization
-        stmt = select(OrganizationMembership).where(
-            OrganizationMembership.user_id == user_id,
-            OrganizationMembership.organization_id == self.organization_id,
-        )
-        result = await self.session.execute(stmt)
-        if result.scalar_one_or_none() is None:
-            raise TracecatNotFoundError("User not found in organization")
+        # Verify user exists. RBAC sync creates org membership when the
+        # assignment requires it.
+        await self._assert_user_exists(user_id)
 
         # Verify role exists
         await self._assert_role_exists(role_id)
@@ -709,6 +794,8 @@ class RBACService(BaseOrgService):
         )
         self.session.add(assignment)
         try:
+            await self.session.flush()
+            await self._sync_memberships({user_id})
             await self.session.commit()
         except IntegrityError as e:
             await self.session.rollback()
@@ -737,6 +824,8 @@ class RBACService(BaseOrgService):
         await self._assert_role_exists(role_id)
 
         assignment.role_id = role_id
+        await self.session.flush()
+        await self._sync_memberships({assignment.user_id})
         await self.session.commit()
         await self.session.refresh(assignment, ["user", "role", "workspace"])
         return assignment
@@ -750,7 +839,10 @@ class RBACService(BaseOrgService):
     async def delete_user_assignment(self, assignment_id: UUID) -> None:
         """Delete a user role assignment."""
         assignment = await self.get_user_assignment(assignment_id)
+        user_id = assignment.user_id
         await self.session.delete(assignment)
+        await self.session.flush()
+        await self._sync_memberships({user_id})
         await self.session.commit()
 
     async def get_user_role_scopes(

--- a/tests/unit/test_rbac_service.py
+++ b/tests/unit/test_rbac_service.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat_ee.rbac.service import RBACService
 
+from tracecat.auth.credentials import _get_membership_with_cache
 from tracecat.auth.types import Role
 from tracecat.authz.enums import ScopeSource
 from tracecat.authz.scopes import ORG_ADMIN_SCOPES
@@ -16,6 +18,7 @@ from tracecat.authz.seeding import seed_system_scopes
 from tracecat.db.models import (
     Group,
     GroupMember,
+    Membership,
     Organization,
     OrganizationMembership,
     Scope,
@@ -96,6 +99,50 @@ def role(org: Organization, user: User) -> Role:
         service_id="tracecat-api",
         scopes=ORG_ADMIN_SCOPES,
     )
+
+
+async def _create_external_user(session: AsyncSession, prefix: str) -> User:
+    """Create a user without organization membership."""
+    user = User(
+        id=uuid.uuid4(),
+        email=f"{prefix}-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="test",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+async def _has_org_membership(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    org_id: uuid.UUID,
+) -> bool:
+    membership = await session.scalar(
+        select(OrganizationMembership).where(
+            OrganizationMembership.user_id == user_id,
+            OrganizationMembership.organization_id == org_id,
+        )
+    )
+    return membership is not None
+
+
+async def _has_workspace_membership(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    workspace_id: uuid.UUID,
+) -> bool:
+    membership = await session.scalar(
+        select(Membership).where(
+            Membership.user_id == user_id,
+            Membership.workspace_id == workspace_id,
+        )
+    )
+    return membership is not None
 
 
 @pytest.mark.anyio
@@ -523,30 +570,325 @@ class TestRBACServiceUserAssignments:
         assert assignment.role_id == custom_role.id
         assert assignment.organization_id == role.organization_id
 
-    async def test_create_user_assignment_rejects_non_member(
+    async def test_create_user_assignment_creates_org_membership_for_non_member(
         self,
         session: AsyncSession,
         role: Role,
+        org: Organization,
     ):
-        """Cannot assign org role to user outside organization."""
+        """Creating an org assignment creates org membership when missing."""
         service = RBACService(session, role=role)
         custom_role = await service.create_role(name="Direct User Role")
 
-        external_user = User(
-            id=uuid.uuid4(),
-            email="external@example.com",
-            hashed_password="test",
-        )
-        session.add(external_user)
-        await session.commit()
+        external_user = await _create_external_user(session, "external-direct")
 
-        with pytest.raises(
-            TracecatNotFoundError, match="User not found in organization"
-        ):
-            await service.create_user_assignment(
-                user_id=external_user.id,
-                role_id=custom_role.id,
-            )
+        await service.create_user_assignment(
+            user_id=external_user.id,
+            role_id=custom_role.id,
+        )
+
+        assert await _has_org_membership(session, external_user.id, org.id)
+
+
+@pytest.mark.anyio
+class TestRBACServiceMembershipSync:
+    """Test RBAC assignment mutations synchronize membership rows."""
+
+    async def test_workspace_group_assignment_creates_memberships_for_existing_members(
+        self,
+        session: AsyncSession,
+        role: Role,
+        org: Organization,
+        workspace: Workspace,
+    ):
+        """Workspace group assignment syncs existing group members."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(name="Workspace Group Role")
+        group = await service.create_group(name="Workspace Sync Group")
+        external_user = await _create_external_user(session, "group-existing")
+
+        await service.add_group_member(group.id, external_user.id)
+        assert not await _has_org_membership(session, external_user.id, org.id)
+
+        await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=custom_role.id,
+            workspace_id=workspace.id,
+        )
+
+        assert await _has_org_membership(session, external_user.id, org.id)
+        assert await _has_workspace_membership(session, external_user.id, workspace.id)
+
+    async def test_add_group_member_with_workspace_assignment_syncs_memberships(
+        self,
+        session: AsyncSession,
+        role: Role,
+        org: Organization,
+        workspace: Workspace,
+    ):
+        """Adding a member to a workspace-assigned group creates memberships."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(name="Existing Group Role")
+        group = await service.create_group(name="Existing Assignment Group")
+        external_user = await _create_external_user(session, "group-add")
+
+        await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=custom_role.id,
+            workspace_id=workspace.id,
+        )
+        await service.add_group_member(group.id, external_user.id)
+
+        assert await _has_org_membership(session, external_user.id, org.id)
+        assert await _has_workspace_membership(session, external_user.id, workspace.id)
+
+    async def test_remove_group_member_deletes_memberships_without_sources(
+        self,
+        session: AsyncSession,
+        role: Role,
+        org: Organization,
+        workspace: Workspace,
+    ):
+        """Removing a group member removes memberships when no RBAC source remains."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(name="Removal Group Role")
+        group = await service.create_group(name="Removal Group")
+        external_user = await _create_external_user(session, "group-remove")
+
+        await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=custom_role.id,
+            workspace_id=workspace.id,
+        )
+        await service.add_group_member(group.id, external_user.id)
+        await service.remove_group_member(group.id, external_user.id)
+
+        assert not await _has_workspace_membership(
+            session, external_user.id, workspace.id
+        )
+        assert not await _has_org_membership(session, external_user.id, org.id)
+
+    async def test_delete_workspace_group_assignment_syncs_all_group_members(
+        self,
+        session: AsyncSession,
+        role: Role,
+        org: Organization,
+        workspace: Workspace,
+    ):
+        """Deleting a workspace group assignment syncs every group member."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(name="Delete Assignment Role")
+        group = await service.create_group(name="Delete Assignment Group")
+        user_one = await _create_external_user(session, "group-delete-one")
+        user_two = await _create_external_user(session, "group-delete-two")
+
+        await service.add_group_member(group.id, user_one.id)
+        await service.add_group_member(group.id, user_two.id)
+        assignment = await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=custom_role.id,
+            workspace_id=workspace.id,
+        )
+
+        await service.delete_group_role_assignment(assignment.id)
+
+        for member in (user_one, user_two):
+            assert not await _has_workspace_membership(session, member.id, workspace.id)
+            assert not await _has_org_membership(session, member.id, org.id)
+
+    async def test_delete_group_syncs_previous_members(
+        self,
+        session: AsyncSession,
+        role: Role,
+        org: Organization,
+        workspace: Workspace,
+    ):
+        """Deleting a group removes memberships that only came from that group."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(name="Delete Group Role")
+        group = await service.create_group(name="Delete Group")
+        external_user = await _create_external_user(session, "group-delete")
+
+        await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=custom_role.id,
+            workspace_id=workspace.id,
+        )
+        await service.add_group_member(group.id, external_user.id)
+        await service.delete_group(group.id)
+
+        assert not await _has_workspace_membership(
+            session, external_user.id, workspace.id
+        )
+        assert not await _has_org_membership(session, external_user.id, org.id)
+
+    async def test_org_wide_group_assignment_creates_org_membership_only(
+        self,
+        session: AsyncSession,
+        role: Role,
+        org: Organization,
+        workspace: Workspace,
+    ):
+        """Org-wide group assignment does not create workspace memberships."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(name="Org Group Role")
+        group = await service.create_group(name="Org Assignment Group")
+        external_user = await _create_external_user(session, "group-org")
+
+        await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=custom_role.id,
+        )
+        await service.add_group_member(group.id, external_user.id)
+
+        assert await _has_org_membership(session, external_user.id, org.id)
+        assert not await _has_workspace_membership(
+            session, external_user.id, workspace.id
+        )
+
+    async def test_direct_org_assignment_syncs_create_update_delete(
+        self,
+        session: AsyncSession,
+        role: Role,
+        org: Organization,
+        workspace: Workspace,
+    ):
+        """Direct org assignment create, update, and delete sync memberships."""
+        service = RBACService(session, role=role)
+        first_role = await service.create_role(name="Direct Org Role 1")
+        second_role = await service.create_role(name="Direct Org Role 2")
+        external_user = await _create_external_user(session, "direct-org")
+
+        assignment = await service.create_user_assignment(
+            user_id=external_user.id,
+            role_id=first_role.id,
+        )
+        assert await _has_org_membership(session, external_user.id, org.id)
+        assert not await _has_workspace_membership(
+            session, external_user.id, workspace.id
+        )
+
+        updated = await service.update_user_assignment(
+            assignment.id,
+            role_id=second_role.id,
+        )
+        assert updated.role_id == second_role.id
+        assert await _has_org_membership(session, external_user.id, org.id)
+        assert not await _has_workspace_membership(
+            session, external_user.id, workspace.id
+        )
+
+        await service.delete_user_assignment(assignment.id)
+        assert not await _has_org_membership(session, external_user.id, org.id)
+        assert not await _has_workspace_membership(
+            session, external_user.id, workspace.id
+        )
+
+    async def test_direct_workspace_assignment_syncs_create_update_delete(
+        self,
+        session: AsyncSession,
+        role: Role,
+        org: Organization,
+        workspace: Workspace,
+    ):
+        """Direct workspace assignment create, update, and delete sync memberships."""
+        service = RBACService(session, role=role)
+        first_role = await service.create_role(name="Direct Workspace Role 1")
+        second_role = await service.create_role(name="Direct Workspace Role 2")
+        external_user = await _create_external_user(session, "direct-workspace")
+
+        assignment = await service.create_user_assignment(
+            user_id=external_user.id,
+            role_id=first_role.id,
+            workspace_id=workspace.id,
+        )
+        assert await _has_org_membership(session, external_user.id, org.id)
+        assert await _has_workspace_membership(session, external_user.id, workspace.id)
+
+        updated = await service.update_user_assignment(
+            assignment.id,
+            role_id=second_role.id,
+        )
+        assert updated.role_id == second_role.id
+        assert await _has_org_membership(session, external_user.id, org.id)
+        assert await _has_workspace_membership(session, external_user.id, workspace.id)
+
+        await service.delete_user_assignment(assignment.id)
+        assert not await _has_workspace_membership(
+            session, external_user.id, workspace.id
+        )
+        assert not await _has_org_membership(session, external_user.id, org.id)
+
+    async def test_overlapping_workspace_assignments_keep_membership_until_last_source_removed(
+        self,
+        session: AsyncSession,
+        role: Role,
+        org: Organization,
+        workspace: Workspace,
+    ):
+        """Overlapping direct and group assignments keep membership until both end."""
+        service = RBACService(session, role=role)
+        direct_role = await service.create_role(name="Overlap Direct Role")
+        group_role = await service.create_role(name="Overlap Group Role")
+        group = await service.create_group(name="Overlap Group")
+        external_user = await _create_external_user(session, "overlap")
+
+        await service.add_group_member(group.id, external_user.id)
+        direct_assignment = await service.create_user_assignment(
+            user_id=external_user.id,
+            role_id=direct_role.id,
+            workspace_id=workspace.id,
+        )
+        group_assignment = await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=group_role.id,
+            workspace_id=workspace.id,
+        )
+
+        await service.delete_user_assignment(direct_assignment.id)
+        assert await _has_org_membership(session, external_user.id, org.id)
+        assert await _has_workspace_membership(session, external_user.id, workspace.id)
+
+        await service.delete_group_role_assignment(group_assignment.id)
+        assert not await _has_workspace_membership(
+            session, external_user.id, workspace.id
+        )
+        assert not await _has_org_membership(session, external_user.id, org.id)
+
+    async def test_workspace_group_assignment_passes_workspace_membership_gate_after_sync(
+        self,
+        session: AsyncSession,
+        role: Role,
+        org: Organization,
+        workspace: Workspace,
+    ):
+        """Workspace group assignment creates the row used by the auth gate."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(name="Auth Gate Group Role")
+        group = await service.create_group(name="Auth Gate Group")
+        external_user = await _create_external_user(session, "auth-gate")
+
+        await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=custom_role.id,
+            workspace_id=workspace.id,
+        )
+        await service.add_group_member(group.id, external_user.id)
+
+        request = MagicMock()
+        request.state = MagicMock()
+        request.state.auth_cache = None
+
+        membership_with_org = await _get_membership_with_cache(
+            request=request,
+            session=session,
+            workspace_id=workspace.id,
+            user=external_user,
+        )
+
+        assert membership_with_org.org_id == org.id
+        assert membership_with_org.membership.user_id == external_user.id
+        assert membership_with_org.membership.workspace_id == workspace.id
 
 
 @pytest.mark.anyio


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Synchronizes RBAC role assignments with organization/workspace memberships to prevent stale rows and enable assigning roles to non-members by auto-creating required memberships. Ensures consistent access by keeping memberships in sync across direct and group assignments.

- **Bug Fixes**
  - Auto-sync `OrganizationMembership` and `Membership` after: add/remove group member; create/update/delete group role assignment; create/update/delete user role assignment; and group delete.
  - Membership rules: org-wide roles create only org membership; workspace roles create org + workspace membership; stale workspace memberships in the org are purged; overlapping direct/group sources keep membership until the last source is removed; validation now only asserts the user exists.

<sup>Written for commit 4483e40914813dc4568b33b0df14e31d006980cc. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2577?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

