### PR TITLE
feat(engine): Add ActionStatement mask_output flag to redact action results in execution API

### DIFF
--- a/docs/automations/actions.mdx
+++ b/docs/automations/actions.mdx
@@ -54,6 +54,21 @@ You can configure how an action runs from the "Control flow" tab in the action p
 
 ![Action control flow](/img/automations/actions/control-flow.png)
 
+### Mask output
+
+Use `mask_output` to hide an action's result in workflow execution views and execution API responses. Tracecat keeps the object and array shape, but replaces each individual value with `[REDACTED]`.
+
+You can still copy JSONPath references from the displayed structure. `mask_output` only affects display; downstream actions can still use the original result with expressions such as `${{ ACTIONS.lookup_user.result.id }}`.
+
+```yaml
+- ref: lookup_user
+  action: core.http_request
+  mask_output: true
+  args:
+    url: "https://api.example.com/users/${{ TRIGGER.user_id }}"
+    method: GET
+```
+
 ### Run if
 
 Use `run_if` to execute an action only when a condition evaluates to a truthy value. If the condition is falsy, Tracecat skips the action.

--- a/docs/automations/core-concepts/workflow-definition.mdx
+++ b/docs/automations/core-concepts/workflow-definition.mdx
@@ -143,6 +143,10 @@ Join behavior for downstream actions. Use `all` to wait for all upstream branche
 Per-action override for the secrets environment.
 </ResponseField>
 
+<ResponseField name="mask_output" type="boolean">
+Redacts this action's result in workflow execution views and execution API responses. Tracecat keeps object and array structure but replaces each individual value, so JSONPath references remain visible. Downstream actions still receive the original result.
+</ResponseField>
+
 <ResponseField name="interaction" type="object">
 Marks an action as interactive. `interaction` cannot be combined with `for_each`.
 </ResponseField>

--- a/docs/automations/workflows.mdx
+++ b/docs/automations/workflows.mdx
@@ -202,6 +202,8 @@ The copy icon copies the value of the action result itself.
 
 ![Copy action result](/img/automations/workflows/copy-action-result.png)
 
+When an action uses `mask_output`, the workflow execution UI keeps object and array structure but shows `[REDACTED]` for each individual value. You can still copy JSONPath references from the displayed shape, and downstream actions still receive the original result.
+
 ## Workflow definition
 
 All workflows are stored, exported, and versioned as YAML-based workflow definitions.

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -607,6 +607,13 @@ export const $ActionStatement = {
       description:
         "Override environment for this action's execution. Can be a template expression.",
     },
+    mask_output: {
+      type: "boolean",
+      title: "Mask Output",
+      description:
+        "If true, redact this action's result in workflow execution API responses while preserving internal workflow data flow between actions.",
+      default: false,
+    },
   },
   type: "object",
   required: ["ref", "action"],

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -177,6 +177,10 @@ export type ActionStatement = {
    * Override environment for this action's execution. Can be a template expression.
    */
   environment?: string | null
+  /**
+   * If true, redact this action's result in workflow execution API responses while preserving internal workflow data flow between actions.
+   */
+  mask_output?: boolean
 }
 
 export type ActionStep = {

--- a/tests/unit/test_dsl_converter.py
+++ b/tests/unit/test_dsl_converter.py
@@ -101,6 +101,28 @@ async def test_agent_action_memo_logging_omits_raw_payload(
 
 
 @pytest.mark.anyio
+async def test_agent_action_memo_decodes_mask_output() -> None:
+    """Agent child workflow memos preserve output redaction metadata."""
+    memo = temporalio.api.common.v1.Memo(
+        fields={
+            "action_ref": Payload(
+                metadata={"encoding": b"json/plain"},
+                data=b'"masked_agent"',
+            ),
+            "mask_output": Payload(
+                metadata={"encoding": b"json/plain"},
+                data=b"true",
+            ),
+        }
+    )
+
+    agent_memo = await AgentActionMemo.from_temporal(memo)
+
+    assert agent_memo.action_ref == "masked_agent"
+    assert agent_memo.mask_output is True
+
+
+@pytest.mark.anyio
 async def test_child_workflow_memo_decode_failure_keeps_best_effort_defaults(
     monkeypatch,
 ) -> None:
@@ -134,6 +156,10 @@ async def test_child_workflow_memo_decode_failure_keeps_best_effort_defaults(
                 metadata={"encoding": b"json/plain"},
                 data=b'"child-stream"',
             ),
+            "mask_output": Payload(
+                metadata={"encoding": b"json/plain"},
+                data=b"true",
+            ),
         }
     )
 
@@ -143,6 +169,7 @@ async def test_child_workflow_memo_decode_failure_keeps_best_effort_defaults(
     assert child_memo.loop_index == 3
     assert child_memo.wait_strategy == WaitStrategy.DETACH
     assert child_memo.stream_id == "child-stream"
+    assert child_memo.mask_output is True
     assert any(
         warning["message"] == "Error decoding child workflow memo field"
         and warning["key"] == "action_ref"

--- a/tests/unit/test_workflow_execution_object_resolution.py
+++ b/tests/unit/test_workflow_execution_object_resolution.py
@@ -8,8 +8,14 @@ from temporalio.api.enums.v1 import EventType
 from temporalio.client import Client, WorkflowHandle
 
 from tracecat.identifiers.workflow import WorkflowExecutionID
-from tracecat.storage.object import CollectionObject, InlineObject, ObjectRef
+from tracecat.storage.object import (
+    CollectionObject,
+    ExternalObject,
+    InlineObject,
+    ObjectRef,
+)
 from tracecat.workflow.executions.service import (
+    WorkflowExecutionResultMaskedError,
     WorkflowExecutionResultNotFoundError,
     WorkflowExecutionsService,
 )
@@ -33,6 +39,25 @@ def create_mock_completed_event(*, event_id: int, scheduled_event_id: int) -> Mo
     completed_attrs.scheduled_event_id = scheduled_event_id
     event.activity_task_completed_event_attributes = completed_attrs
     return event
+
+
+def create_mock_scheduled_event(*, event_id: int) -> Mock:
+    event = Mock()
+    event.event_id = event_id
+    event.event_type = EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
+    return event
+
+
+def create_external_object() -> ExternalObject:
+    return ExternalObject(
+        ref=ObjectRef(
+            bucket="test-bucket",
+            key="wf/test/result.json",
+            size_bytes=128,
+            sha256="abc123",
+            content_type="application/json",
+        ),
+    )
 
 
 def create_collection_object(
@@ -78,6 +103,49 @@ class TestWorkflowExecutionObjectResolution:
         )
 
         assert matched is completed_event
+
+    async def test_get_external_action_result_rejects_masked_source_event(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        scheduled_event = create_mock_scheduled_event(event_id=3)
+        completed_event = create_mock_completed_event(event_id=11, scheduled_event_id=3)
+        external = create_external_object()
+        compact_event = Mock()
+        compact_event.should_mask_output = True
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**_kwargs: Any):
+            yield scheduled_event
+            yield completed_event
+
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        with (
+            patch.object(
+                workflow_executions_service,
+                "require_execution",
+                AsyncMock(return_value=Mock()),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.WorkflowExecutionEventCompact.from_source_event",
+                AsyncMock(return_value=compact_event),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.get_stored_result",
+                AsyncMock(return_value=external),
+            ),
+        ):
+            with pytest.raises(WorkflowExecutionResultMaskedError, match="mask_output"):
+                await workflow_executions_service.get_external_action_result(
+                    workflow_exec_id,
+                    3,
+                )
 
     async def test_resolve_completed_event_missing_raises_not_found_error(
         self,
@@ -136,6 +204,57 @@ class TestWorkflowExecutionObjectResolution:
         assert resolved_collection == collection
         assert items == [stored_item]
         mock_get_page.assert_awaited_once_with(collection, offset=0, limit=25)
+
+    async def test_get_collection_page_rejects_masked_source_event(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        scheduled_event = create_mock_scheduled_event(event_id=3)
+        completed_event = create_mock_completed_event(event_id=11, scheduled_event_id=3)
+        collection = create_collection_object(element_kind="stored_object")
+        compact_event = Mock()
+        compact_event.should_mask_output = True
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**_kwargs: Any):
+            yield scheduled_event
+            yield completed_event
+
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        with (
+            patch.object(
+                workflow_executions_service,
+                "require_execution",
+                AsyncMock(return_value=Mock()),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.WorkflowExecutionEventCompact.from_source_event",
+                AsyncMock(return_value=compact_event),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.get_stored_result",
+                AsyncMock(return_value=collection),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.get_storage_collection_page",
+                AsyncMock(return_value=[]),
+            ) as mock_get_page,
+        ):
+            with pytest.raises(WorkflowExecutionResultMaskedError, match="mask_output"):
+                await workflow_executions_service.get_collection_page(
+                    workflow_exec_id,
+                    3,
+                    offset=0,
+                    limit=25,
+                )
+
+        mock_get_page.assert_not_awaited()
 
     async def test_get_collection_item_for_object_ops_returns_stored_object_handle(
         self,

--- a/tests/unit/test_workflow_execution_object_resolution.py
+++ b/tests/unit/test_workflow_execution_object_resolution.py
@@ -147,6 +147,47 @@ class TestWorkflowExecutionObjectResolution:
                     3,
                 )
 
+    async def test_get_external_action_result_fails_closed_on_mask_metadata_error(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        scheduled_event = create_mock_scheduled_event(event_id=3)
+        completed_event = create_mock_completed_event(event_id=11, scheduled_event_id=3)
+        external = create_external_object()
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**_kwargs: Any):
+            yield scheduled_event
+            yield completed_event
+
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        with (
+            patch.object(
+                workflow_executions_service,
+                "require_execution",
+                AsyncMock(return_value=Mock()),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.WorkflowExecutionEventCompact.from_source_event",
+                AsyncMock(side_effect=ValueError("bad source metadata")),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.get_stored_result",
+                AsyncMock(return_value=external),
+            ),
+        ):
+            with pytest.raises(WorkflowExecutionResultMaskedError, match="mask_output"):
+                await workflow_executions_service.get_external_action_result(
+                    workflow_exec_id,
+                    3,
+                )
+
     async def test_resolve_completed_event_missing_raises_not_found_error(
         self,
         workflow_executions_service: WorkflowExecutionsService,

--- a/tests/unit/test_workflow_execution_object_resolution.py
+++ b/tests/unit/test_workflow_execution_object_resolution.py
@@ -188,6 +188,48 @@ class TestWorkflowExecutionObjectResolution:
                     3,
                 )
 
+    async def test_get_external_action_result_propagates_unexpected_metadata_error(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        scheduled_event = create_mock_scheduled_event(event_id=3)
+        completed_event = create_mock_completed_event(event_id=11, scheduled_event_id=3)
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**_kwargs: Any):
+            yield scheduled_event
+            yield completed_event
+
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        with (
+            patch.object(
+                workflow_executions_service,
+                "require_execution",
+                AsyncMock(return_value=Mock()),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.WorkflowExecutionEventCompact.from_source_event",
+                AsyncMock(side_effect=RuntimeError("metadata parser crashed")),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.get_stored_result",
+                AsyncMock(),
+            ) as mock_get_stored_result,
+        ):
+            with pytest.raises(RuntimeError, match="metadata parser crashed"):
+                await workflow_executions_service.get_external_action_result(
+                    workflow_exec_id,
+                    3,
+                )
+
+        mock_get_stored_result.assert_not_awaited()
+
     async def test_resolve_completed_event_missing_raises_not_found_error(
         self,
         workflow_executions_service: WorkflowExecutionsService,

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -1427,6 +1427,142 @@ class TestWorkflowExecutionEvents:
                     },
                 }
 
+    async def test_non_compact_masked_activity_result_redacts_leaf_values(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        """Masked activity outputs are redacted in the standard execution view."""
+        scheduled = create_mock_history_event(
+            event_id=1,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,  # type: ignore
+            activity_id="masked-action",
+            activity_name="execute_action_activity",
+        )
+        completed = create_mock_history_event(
+            event_id=11,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_COMPLETED,  # type: ignore
+            scheduled_event_id=1,
+        )
+        mock_handle = Mock(spec=WorkflowHandle)
+        mock_handle.fetch_history = AsyncMock(
+            return_value=Mock(events=[scheduled, completed])
+        )
+        mock_handle.describe = AsyncMock(return_value=Mock())
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+        action_name = "core.transform.reshape"
+        wf_id = WorkflowUUID.new_uuid4()
+        exec_id = ExecutionUUID.new_uuid4()
+        run_input = RunActionInput(
+            task=ActionStatement(
+                action=action_name,
+                args={"value": "visible-input"},
+                ref="masked_action",
+                mask_output=True,
+            ),
+            exec_context={"ACTIONS": {}, "TRIGGER": None},
+            run_context=RunContext(
+                wf_id=wf_id,
+                wf_exec_id=f"{wf_id.short()}/{exec_id.short()}",
+                wf_run_id=uuid.uuid4(),
+                environment="test",
+                logical_time=datetime.datetime.now(datetime.UTC),
+            ),
+            registry_lock=RegistryLock(
+                origins={"tracecat_registry": "test-version"},
+                actions={action_name: "tracecat_registry"},
+            ),
+        )
+
+        with (
+            patch(
+                "tracecat.workflow.executions.schemas.extract_first",
+                new_callable=AsyncMock,
+            ) as mock_source_extract_first,
+            patch(
+                "tracecat.workflow.executions.service.extract_first",
+                new_callable=AsyncMock,
+            ) as mock_result_extract_first,
+        ):
+            mock_source_extract_first.return_value = run_input.model_dump(mode="json")
+            mock_result_extract_first.return_value = {
+                "secret": "hidden-output",
+                "nested": {"token": "secret-token"},
+            }
+
+            events = await workflow_executions_service.list_workflow_execution_events(
+                workflow_exec_id
+            )
+
+        completed_event = next(
+            event
+            for event in events
+            if event.event_type == WorkflowEventType.ACTIVITY_TASK_COMPLETED
+        )
+        assert completed_event.result == {
+            "secret": "[REDACTED]",
+            "nested": {"token": "[REDACTED]"},
+        }
+
+    async def test_non_compact_masked_child_workflow_result_redacts_leaf_values(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        """Masked child workflow outputs are redacted in the standard execution view."""
+        initiated = create_mock_child_workflow_initiated_event(event_id=1)
+        completed = create_mock_child_workflow_completed_event(
+            event_id=11,
+            initiated_event_id=1,
+        )
+        unreadable = UnreadableTemporalPayload(
+            error_type="decode_error",
+            encoding="json/plain",
+            payload_size_bytes=0,
+        )
+        mock_handle = Mock(spec=WorkflowHandle)
+        mock_handle.fetch_history = AsyncMock(
+            return_value=Mock(events=[initiated, completed])
+        )
+        mock_handle.describe = AsyncMock(return_value=Mock())
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        with (
+            patch(
+                "tracecat.workflow.executions.schemas.ChildWorkflowMemo.from_temporal",
+                new_callable=AsyncMock,
+            ) as mock_memo,
+            patch(
+                "tracecat.workflow.executions.schemas.extract_first",
+                new_callable=AsyncMock,
+            ) as mock_source_extract_first,
+            patch(
+                "tracecat.workflow.executions.service.extract_first",
+                new_callable=AsyncMock,
+            ) as mock_result_extract_first,
+        ):
+            mock_memo.return_value = ChildWorkflowMemo(
+                action_ref="masked_child",
+                mask_output=True,
+            )
+            mock_source_extract_first.return_value = unreadable
+            mock_result_extract_first.return_value = {"secret": "child-output"}
+
+            events = await workflow_executions_service.list_workflow_execution_events(
+                workflow_exec_id
+            )
+
+        completed_event = next(
+            event
+            for event in events
+            if event.event_type == WorkflowEventType.CHILD_WORKFLOW_EXECUTION_COMPLETED
+        )
+        assert completed_event.result == {"secret": "[REDACTED]"}
+
     async def test_compact_duplicate_actions_latest_failure_wins(
         self,
         workflow_executions_service: WorkflowExecutionsService,

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -1213,12 +1213,12 @@ class TestWorkflowExecutionEvents:
         assert event.action_input == {"value": "visible-input"}
         assert event.should_mask_output is True
 
-    async def test_compact_masked_action_result_redacts_dict_action_input(
+    async def test_compact_masked_action_result_redacts_leaf_values(
         self,
         workflow_executions_service: WorkflowExecutionsService,
         workflow_exec_id: WorkflowExecutionID,
     ) -> None:
-        """Masked action results redact even when compact action_input is task args."""
+        """Masked action results preserve shape for JSONPath copy flows."""
         scheduled = create_mock_history_event(
             event_id=1,
             event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,  # type: ignore
@@ -1265,7 +1265,19 @@ class TestWorkflowExecutionEvents:
             with patch(
                 "tracecat.workflow.executions.service.get_result"
             ) as mock_get_result:
-                mock_get_result.return_value = {"secret": "hidden-output"}
+                mock_get_result.return_value = {
+                    "secret": "hidden-output",
+                    "nested": {
+                        "token": "secret-token",
+                        "none_value": None,
+                        "empty_object": {},
+                        "items": [
+                            "first",
+                            {"id": 123, "enabled": True},
+                            [],
+                        ],
+                    },
+                }
 
                 events = await workflow_executions_service.list_workflow_execution_events_compact(
                     workflow_exec_id
@@ -1274,7 +1286,19 @@ class TestWorkflowExecutionEvents:
                 assert len(events) == 1
                 event = events[0]
                 assert event.action_input == {"value": "visible-input"}
-                assert event.action_result == "[REDACTED]"
+                assert event.action_result == {
+                    "secret": "[REDACTED]",
+                    "nested": {
+                        "token": "[REDACTED]",
+                        "none_value": "[REDACTED]",
+                        "empty_object": {},
+                        "items": [
+                            "[REDACTED]",
+                            {"id": "[REDACTED]", "enabled": "[REDACTED]"},
+                            [],
+                        ],
+                    },
+                }
 
     async def test_compact_duplicate_actions_latest_failure_wins(
         self,

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -37,7 +37,12 @@ from tracecat.identifiers.workflow import (
 )
 from tracecat.pagination import CursorPaginationParams
 from tracecat.registry.lock.types import RegistryLock
-from tracecat.storage.object import ExternalObject, InlineObject, ObjectRef
+from tracecat.storage.object import (
+    CollectionObject,
+    ExternalObject,
+    InlineObject,
+    ObjectRef,
+)
 from tracecat.workflow.executions.common import UnreadableTemporalPayload
 from tracecat.workflow.executions.enums import (
     TriggerType,
@@ -53,6 +58,7 @@ from tracecat.workflow.executions.service import (
     WF_FAILURE_REF,
     WF_TRIGGER_REF,
     WorkflowExecutionsService,
+    _sanitize_action_result,
 )
 from tracecat.workspaces.service import WorkspaceService
 
@@ -1455,6 +1461,42 @@ class TestWorkflowExecutionEvents:
                         ],
                     },
                 }
+
+    async def test_masked_object_backed_results_preserve_object_shape(self) -> None:
+        """Masked StoredObject handles stay structured for API consumers."""
+        external = ExternalObject(
+            ref=ObjectRef(
+                bucket="test-bucket",
+                key="wf/test/result.json",
+                size_bytes=128,
+                sha256="abc123",
+                content_type="application/json",
+            ),
+        )
+        collection = CollectionObject(
+            manifest_ref=ObjectRef(
+                bucket="test-bucket",
+                key="wf/test/manifest.json",
+                size_bytes=256,
+                sha256="def456",
+            ),
+            count=3,
+            chunk_size=256,
+            element_kind="stored_object",
+        )
+
+        redacted = _sanitize_action_result(
+            True,
+            {
+                "external": external,
+                "collection": collection,
+            },
+        )
+
+        assert set(redacted["external"]) == set(external.model_dump(mode="json"))
+        assert redacted["external"]["ref"]["bucket"] == "[REDACTED]"
+        assert set(redacted["collection"]) == set(collection.model_dump(mode="json"))
+        assert redacted["collection"]["manifest_ref"]["key"] == "[REDACTED]"
 
     async def test_non_compact_masked_activity_result_redacts_leaf_values(
         self,

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -1302,6 +1302,35 @@ class TestWorkflowExecutionEvents:
         assert event.action_ref == "masked_child"
         assert event.should_mask_output is True
 
+    async def test_compact_child_workflow_defaults_when_memo_parse_fails(
+        self,
+    ) -> None:
+        """Malformed child workflow memo metadata should not break history views."""
+        initiated = create_mock_child_workflow_initiated_event(event_id=1)
+        unreadable = UnreadableTemporalPayload(
+            error_type="decode_error",
+            encoding="json/plain",
+            payload_size_bytes=0,
+        )
+
+        with (
+            patch(
+                "tracecat.workflow.executions.schemas.ChildWorkflowMemo.from_temporal",
+                AsyncMock(side_effect=ValueError("bad memo")),
+            ),
+            patch(
+                "tracecat.workflow.executions.schemas.extract_first",
+                AsyncMock(return_value=unreadable),
+            ),
+        ):
+            event = await WorkflowExecutionEventCompact.from_initiated_child_workflow(
+                initiated
+            )
+
+        assert event is not None
+        assert event.action_ref == "Unknown Child Workflow"
+        assert event.should_mask_output is False
+
     async def test_compact_agent_workflow_preserves_mask_output_metadata(
         self,
     ) -> None:
@@ -1562,6 +1591,58 @@ class TestWorkflowExecutionEvents:
             if event.event_type == WorkflowEventType.CHILD_WORKFLOW_EXECUTION_COMPLETED
         )
         assert completed_event.result == {"secret": "[REDACTED]"}
+
+    async def test_list_events_defaults_unmasked_when_child_memo_parse_fails(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        """Malformed child workflow memo metadata should not fail history responses."""
+        initiated = create_mock_child_workflow_initiated_event(event_id=1)
+        completed = create_mock_child_workflow_completed_event(
+            event_id=2,
+            initiated_event_id=1,
+        )
+        unreadable = UnreadableTemporalPayload(
+            error_type="decode_error",
+            encoding="json/plain",
+            payload_size_bytes=0,
+        )
+        mock_handle = Mock(spec=WorkflowHandle)
+        mock_handle.fetch_history = AsyncMock(
+            return_value=Mock(events=[initiated, completed])
+        )
+        mock_handle.describe = AsyncMock(return_value=Mock())
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        with (
+            patch(
+                "tracecat.workflow.executions.schemas.ChildWorkflowMemo.from_temporal",
+                AsyncMock(side_effect=ValueError("bad memo")),
+            ),
+            patch(
+                "tracecat.workflow.executions.schemas.extract_first",
+                AsyncMock(return_value=unreadable),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.extract_first",
+                AsyncMock(return_value={"secret": "child-output"}),
+            ),
+        ):
+            events = await workflow_executions_service.list_workflow_execution_events(
+                workflow_exec_id
+            )
+
+        completed_event = next(
+            event
+            for event in events
+            if event.event_type == WorkflowEventType.CHILD_WORKFLOW_EXECUTION_COMPLETED
+        )
+        assert completed_event.result == {"secret": "child-output"}
+        assert completed_event.event_group is not None
+        assert completed_event.event_group.should_mask_output is False
 
     async def test_compact_duplicate_actions_latest_failure_wins(
         self,

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -13,6 +13,7 @@ Objectives
 
 import datetime
 import hashlib
+import uuid
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -28,9 +29,14 @@ from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.db.models import Workspace
 from tracecat.dsl.common import DSLInput
-from tracecat.dsl.schemas import StreamID
-from tracecat.identifiers.workflow import WorkflowExecutionID, WorkflowUUID
+from tracecat.dsl.schemas import ActionStatement, RunActionInput, RunContext, StreamID
+from tracecat.identifiers.workflow import (
+    ExecutionUUID,
+    WorkflowExecutionID,
+    WorkflowUUID,
+)
 from tracecat.pagination import CursorPaginationParams
+from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage.object import ExternalObject, InlineObject, ObjectRef
 from tracecat.workflow.executions.common import UnreadableTemporalPayload
 from tracecat.workflow.executions.enums import (
@@ -1160,6 +1166,115 @@ class TestWorkflowExecutionEvents:
                 assert (
                     event.curr_event_type == WorkflowEventType.ACTIVITY_TASK_COMPLETED
                 )
+
+    async def test_compact_scheduled_activity_preserves_mask_output_metadata(
+        self,
+    ) -> None:
+        """Compact events keep redaction metadata while exposing only task args."""
+        scheduled = create_mock_history_event(
+            event_id=1,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,  # type: ignore
+            activity_id="masked-action",
+            activity_name="execute_action_activity",
+        )
+        action_name = "core.transform.reshape"
+        wf_id = WorkflowUUID.new_uuid4()
+        exec_id = ExecutionUUID.new_uuid4()
+        run_input = RunActionInput(
+            task=ActionStatement(
+                action=action_name,
+                args={"value": "visible-input"},
+                ref="masked_action",
+                mask_output=True,
+            ),
+            exec_context={"ACTIONS": {}, "TRIGGER": None},
+            run_context=RunContext(
+                wf_id=wf_id,
+                wf_exec_id=f"{wf_id.short()}/{exec_id.short()}",
+                wf_run_id=uuid.uuid4(),
+                environment="test",
+                logical_time=datetime.datetime.now(datetime.UTC),
+            ),
+            registry_lock=RegistryLock(
+                origins={"tracecat_registry": "test-version"},
+                actions={action_name: "tracecat_registry"},
+            ),
+        )
+
+        with patch(
+            "tracecat.workflow.executions.schemas.extract_first",
+            AsyncMock(return_value=run_input.model_dump(mode="json")),
+        ):
+            event = await WorkflowExecutionEventCompact.from_scheduled_activity(
+                scheduled
+            )
+
+        assert event is not None
+        assert event.action_input == {"value": "visible-input"}
+        assert event.should_mask_output is True
+
+    async def test_compact_masked_action_result_redacts_dict_action_input(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        """Masked action results redact even when compact action_input is task args."""
+        scheduled = create_mock_history_event(
+            event_id=1,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,  # type: ignore
+            activity_id="masked-action",
+            activity_name="execute_action_activity",
+        )
+        completed = create_mock_history_event(
+            event_id=11,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_COMPLETED,  # type: ignore
+            scheduled_event_id=1,
+        )
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**kwargs):
+            yield scheduled
+            yield completed
+
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        mock_handle.describe = AsyncMock(
+            return_value=Mock(raw_description=Mock(pending_activities=[]))
+        )
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+        root_stream = StreamID.new("<root>", 0)
+
+        source = WorkflowExecutionEventCompact(
+            source_event_id=1,
+            schedule_time=datetime.datetime.fromtimestamp(1640995200, tz=datetime.UTC),
+            curr_event_type=WorkflowEventType.ACTIVITY_TASK_SCHEDULED,
+            status=WorkflowExecutionEventStatus.SCHEDULED,
+            action_name="core.transform.reshape",
+            action_ref="masked_action",
+            action_input={"value": "visible-input"},
+            stream_id=root_stream,
+        )
+        source.set_mask_output(True)
+
+        with patch(
+            "tracecat.workflow.executions.service.WorkflowExecutionEventCompact.from_source_event"
+        ) as mock_from_source:
+            mock_from_source.return_value = source
+            with patch(
+                "tracecat.workflow.executions.service.get_result"
+            ) as mock_get_result:
+                mock_get_result.return_value = {"secret": "hidden-output"}
+
+                events = await workflow_executions_service.list_workflow_execution_events_compact(
+                    workflow_exec_id
+                )
+
+                assert len(events) == 1
+                event = events[0]
+                assert event.action_input == {"value": "visible-input"}
+                assert event.action_result == "[REDACTED]"
 
     async def test_compact_duplicate_actions_latest_failure_wins(
         self,

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import orjson
 import pytest
+from pydantic import BaseModel
 from temporalio.api.enums.v1 import EventType, ParentClosePolicy, PendingActivityState
 from temporalio.api.failure.v1 import Failure
 from temporalio.api.history.v1 import HistoryEvent
@@ -1530,6 +1531,26 @@ class TestWorkflowExecutionEvents:
         assert redacted["external"]["ref"]["bucket"] == "[REDACTED]"
         assert set(redacted["collection"]) == set(collection.model_dump(mode="json"))
         assert redacted["collection"]["manifest_ref"]["key"] == "[REDACTED]"
+
+    async def test_masked_model_results_preserve_python_container_shape(self) -> None:
+        """Pydantic model fields should be redacted before JSON conversion."""
+
+        class ModelResult(BaseModel):
+            values: tuple[str, int]
+            nested: dict[str, tuple[str, str]]
+
+        redacted = _sanitize_action_result(
+            True,
+            ModelResult(
+                values=("secret", 123),
+                nested={"tokens": ("first", "second")},
+            ),
+        )
+
+        assert redacted == {
+            "values": ("[REDACTED]", "[REDACTED]"),
+            "nested": {"tokens": ("[REDACTED]", "[REDACTED]")},
+        }
 
     async def test_non_compact_masked_activity_result_redacts_leaf_values(
         self,

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import orjson
 import pytest
-from temporalio.api.enums.v1 import EventType, PendingActivityState
+from temporalio.api.enums.v1 import EventType, ParentClosePolicy, PendingActivityState
 from temporalio.api.failure.v1 import Failure
 from temporalio.api.history.v1 import HistoryEvent
 from temporalio.client import Client, WorkflowHandle
@@ -28,7 +28,7 @@ from temporalio.converter import DefaultPayloadConverter
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.db.models import Workspace
-from tracecat.dsl.common import DSLInput
+from tracecat.dsl.common import AgentActionMemo, ChildWorkflowMemo, DSLInput
 from tracecat.dsl.schemas import ActionStatement, RunActionInput, RunContext, StreamID
 from tracecat.identifiers.workflow import (
     ExecutionUUID,
@@ -125,13 +125,10 @@ def create_mock_history_event(
     event = Mock()
     event.event_id = event_id
     event.event_type = event_type
+    event.task_id = attributes.get("task_id", event_id)
 
     # Mock timestamp
-    mock_timestamp = Mock()
-    mock_timestamp.ToDatetime.return_value = datetime.datetime.fromtimestamp(
-        event_time_seconds, tz=datetime.UTC
-    )
-    event.event_time = mock_timestamp
+    event.event_time = create_mock_timestamp(event_time_seconds)
 
     # Add attributes based on event type
     if event_type == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
@@ -174,6 +171,63 @@ def create_mock_history_event(
         started_attrs.input = attributes.get("workflow_input", Mock())
         event.workflow_execution_started_event_attributes = started_attrs
 
+    return event
+
+
+def create_mock_timestamp(event_time_seconds: int = 1640995200) -> Mock:
+    """Create a mock Temporal timestamp."""
+    mock_timestamp = Mock()
+    mock_timestamp.ToDatetime.return_value = datetime.datetime.fromtimestamp(
+        event_time_seconds, tz=datetime.UTC
+    )
+    return mock_timestamp
+
+
+def create_mock_child_workflow_initiated_event(
+    event_id: int,
+    *,
+    workflow_type_name: str = "DSLWorkflow",
+    workflow_id: WorkflowExecutionID | None = None,
+) -> Mock:
+    """Create a mock child workflow initiated event."""
+    if workflow_id is None:
+        wf_id = WorkflowUUID.new_uuid4()
+        exec_id = ExecutionUUID.new_uuid4()
+        workflow_id = cast(WorkflowExecutionID, f"{wf_id.short()}/{exec_id.short()}")
+
+    event = Mock()
+    event.event_id = event_id
+    event.event_type = EventType.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED
+    event.task_id = event_id
+    event.event_time = create_mock_timestamp()
+
+    attrs = Mock()
+    attrs.workflow_id = workflow_id
+    attrs.workflow_type = Mock()
+    attrs.workflow_type.name = workflow_type_name
+    attrs.parent_close_policy = ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE
+    attrs.memo = Mock()
+    attrs.input = Mock()
+    event.start_child_workflow_execution_initiated_event_attributes = attrs
+    return event
+
+
+def create_mock_child_workflow_completed_event(
+    event_id: int,
+    *,
+    initiated_event_id: int,
+) -> Mock:
+    """Create a mock child workflow completed event."""
+    event = Mock()
+    event.event_id = event_id
+    event.event_type = EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED
+    event.task_id = event_id
+    event.event_time = create_mock_timestamp()
+
+    attrs = Mock()
+    attrs.initiated_event_id = initiated_event_id
+    attrs.result = Mock()
+    event.child_workflow_execution_completed_event_attributes = attrs
     return event
 
 
@@ -1211,6 +1265,79 @@ class TestWorkflowExecutionEvents:
 
         assert event is not None
         assert event.action_input == {"value": "visible-input"}
+        assert event.should_mask_output is True
+
+    async def test_compact_child_workflow_preserves_mask_output_metadata(
+        self,
+    ) -> None:
+        """Child workflow compact events restore redaction metadata from memo."""
+        initiated = create_mock_child_workflow_initiated_event(event_id=1)
+        unreadable = UnreadableTemporalPayload(
+            error_type="decode_error",
+            encoding="json/plain",
+            payload_size_bytes=0,
+        )
+
+        with (
+            patch(
+                "tracecat.workflow.executions.schemas.ChildWorkflowMemo.from_temporal",
+                new_callable=AsyncMock,
+            ) as mock_memo,
+            patch(
+                "tracecat.workflow.executions.schemas.extract_first",
+                new_callable=AsyncMock,
+            ) as mock_extract_first,
+        ):
+            mock_memo.return_value = ChildWorkflowMemo(
+                action_ref="masked_child",
+                mask_output=True,
+            )
+            mock_extract_first.return_value = unreadable
+
+            event = await WorkflowExecutionEventCompact.from_initiated_child_workflow(
+                initiated
+            )
+
+        assert event is not None
+        assert event.action_ref == "masked_child"
+        assert event.should_mask_output is True
+
+    async def test_compact_agent_workflow_preserves_mask_output_metadata(
+        self,
+    ) -> None:
+        """Agent compact events restore redaction metadata from memo."""
+        initiated = create_mock_child_workflow_initiated_event(
+            event_id=1,
+            workflow_type_name="DurableAgentWorkflow",
+        )
+        unreadable = UnreadableTemporalPayload(
+            error_type="decode_error",
+            encoding="json/plain",
+            payload_size_bytes=0,
+        )
+
+        with (
+            patch(
+                "tracecat.workflow.executions.schemas.AgentActionMemo.from_temporal",
+                new_callable=AsyncMock,
+            ) as mock_memo,
+            patch(
+                "tracecat.workflow.executions.schemas.extract_first",
+                new_callable=AsyncMock,
+            ) as mock_extract_first,
+        ):
+            mock_memo.return_value = AgentActionMemo(
+                action_ref="masked_agent",
+                mask_output=True,
+            )
+            mock_extract_first.return_value = unreadable
+
+            event = await WorkflowExecutionEventCompact.from_initiated_child_workflow(
+                initiated
+            )
+
+        assert event is not None
+        assert event.action_ref == "masked_agent"
         assert event.should_mask_output is True
 
     async def test_compact_masked_action_result_redacts_leaf_values(

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -1308,10 +1308,10 @@ class TestWorkflowExecutionEvents:
         assert event.action_ref == "masked_child"
         assert event.should_mask_output is True
 
-    async def test_compact_child_workflow_defaults_when_memo_parse_fails(
+    async def test_compact_child_workflow_defaults_masked_when_memo_parse_fails(
         self,
     ) -> None:
-        """Malformed child workflow memo metadata should not break history views."""
+        """Malformed child workflow memo metadata should fail closed for results."""
         initiated = create_mock_child_workflow_initiated_event(event_id=1)
         unreadable = UnreadableTemporalPayload(
             error_type="decode_error",
@@ -1335,7 +1335,7 @@ class TestWorkflowExecutionEvents:
 
         assert event is not None
         assert event.action_ref == "Unknown Child Workflow"
-        assert event.should_mask_output is False
+        assert event.should_mask_output is True
 
     async def test_compact_agent_workflow_preserves_mask_output_metadata(
         self,
@@ -1634,12 +1634,12 @@ class TestWorkflowExecutionEvents:
         )
         assert completed_event.result == {"secret": "[REDACTED]"}
 
-    async def test_list_events_defaults_unmasked_when_child_memo_parse_fails(
+    async def test_list_events_defaults_masked_when_child_memo_parse_fails(
         self,
         workflow_executions_service: WorkflowExecutionsService,
         workflow_exec_id: WorkflowExecutionID,
     ) -> None:
-        """Malformed child workflow memo metadata should not fail history responses."""
+        """Malformed child workflow memo metadata should fail closed for results."""
         initiated = create_mock_child_workflow_initiated_event(event_id=1)
         completed = create_mock_child_workflow_completed_event(
             event_id=2,
@@ -1682,9 +1682,8 @@ class TestWorkflowExecutionEvents:
             for event in events
             if event.event_type == WorkflowEventType.CHILD_WORKFLOW_EXECUTION_COMPLETED
         )
-        assert completed_event.result == {"secret": "child-output"}
+        assert completed_event.result == {"secret": "[REDACTED]"}
         assert completed_event.event_group is not None
-        assert completed_event.event_group.should_mask_output is False
 
     async def test_compact_duplicate_actions_latest_failure_wins(
         self,

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -1375,6 +1375,39 @@ class TestWorkflowExecutionEvents:
         assert event.action_ref == "masked_agent"
         assert event.should_mask_output is True
 
+    async def test_compact_agent_workflow_defaults_masked_when_memo_parse_fails(
+        self,
+    ) -> None:
+        """Malformed agent memo metadata should fail closed for results."""
+        initiated = create_mock_child_workflow_initiated_event(
+            event_id=1,
+            workflow_type_name="DurableAgentWorkflow",
+            workflow_id=cast(WorkflowExecutionID, f"agent/{uuid.uuid4()}"),
+        )
+        unreadable = UnreadableTemporalPayload(
+            error_type="decode_error",
+            encoding="json/plain",
+            payload_size_bytes=0,
+        )
+
+        with (
+            patch(
+                "tracecat.workflow.executions.schemas.AgentActionMemo.from_temporal",
+                AsyncMock(side_effect=ValueError("bad memo")),
+            ),
+            patch(
+                "tracecat.workflow.executions.schemas.extract_first",
+                AsyncMock(return_value=unreadable),
+            ),
+        ):
+            event = await WorkflowExecutionEventCompact.from_initiated_child_workflow(
+                initiated
+            )
+
+        assert event is not None
+        assert event.action_ref == "unknown_agent_action"
+        assert event.should_mask_output is True
+
     async def test_compact_masked_action_result_redacts_leaf_values(
         self,
         workflow_executions_service: WorkflowExecutionsService,
@@ -1671,6 +1704,61 @@ class TestWorkflowExecutionEvents:
             patch(
                 "tracecat.workflow.executions.service.extract_first",
                 AsyncMock(return_value={"secret": "child-output"}),
+            ),
+        ):
+            events = await workflow_executions_service.list_workflow_execution_events(
+                workflow_exec_id
+            )
+
+        completed_event = next(
+            event
+            for event in events
+            if event.event_type == WorkflowEventType.CHILD_WORKFLOW_EXECUTION_COMPLETED
+        )
+        assert completed_event.result == {"secret": "[REDACTED]"}
+        assert completed_event.event_group is not None
+
+    async def test_list_events_defaults_masked_when_agent_memo_parse_fails(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        """Malformed agent memo metadata should fail closed for results."""
+        initiated = create_mock_child_workflow_initiated_event(
+            event_id=1,
+            workflow_type_name="DurableAgentWorkflow",
+            workflow_id=cast(WorkflowExecutionID, f"agent/{uuid.uuid4()}"),
+        )
+        completed = create_mock_child_workflow_completed_event(
+            event_id=2,
+            initiated_event_id=1,
+        )
+        unreadable = UnreadableTemporalPayload(
+            error_type="decode_error",
+            encoding="json/plain",
+            payload_size_bytes=0,
+        )
+        mock_handle = Mock(spec=WorkflowHandle)
+        mock_handle.fetch_history = AsyncMock(
+            return_value=Mock(events=[initiated, completed])
+        )
+        mock_handle.describe = AsyncMock(return_value=Mock())
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        with (
+            patch(
+                "tracecat.workflow.executions.schemas.AgentActionMemo.from_temporal",
+                AsyncMock(side_effect=ValueError("bad memo")),
+            ),
+            patch(
+                "tracecat.workflow.executions.schemas.extract_first",
+                AsyncMock(return_value=unreadable),
+            ),
+            patch(
+                "tracecat.workflow.executions.service.extract_first",
+                AsyncMock(return_value={"secret": "agent-output"}),
             ),
         ):
             events = await workflow_executions_service.list_workflow_execution_events(

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -1076,6 +1076,10 @@ class AgentActionMemo(BaseModel):
         default=ROOT_STREAM,
         description="The execution stream ID where the agent workflow was spawned.",
     )
+    mask_output: bool = Field(
+        default=False,
+        description="Whether to redact the child workflow result in execution APIs.",
+    )
 
     @classmethod
     async def from_temporal(
@@ -1119,6 +1123,10 @@ class ChildWorkflowMemo(BaseModel):
         default=ROOT_STREAM,
         description="The stream ID of the child workflow.",
     )
+    mask_output: bool = Field(
+        default=False,
+        description="Whether to redact the child workflow result in execution APIs.",
+    )
 
     @staticmethod
     async def from_temporal(memo: temporalio.api.common.v1.Memo) -> ChildWorkflowMemo:
@@ -1161,11 +1169,22 @@ class ChildWorkflowMemo(BaseModel):
         except Exception as e:
             logger.warning("Error parsing child workflow memo stream id", error=e)
             stream_id = ROOT_STREAM
+        try:
+            mask_output_payload = decoded_fields.get("mask_output")
+            mask_output = (
+                bool(orjson.loads(mask_output_payload.data))
+                if mask_output_payload is not None and mask_output_payload.data
+                else False
+            )
+        except Exception as e:
+            logger.warning("Error parsing child workflow memo mask output", error=e)
+            mask_output = False
         return ChildWorkflowMemo(
             action_ref=action_ref,
             loop_index=loop_index,
             wait_strategy=wait_strategy,
             stream_id=stream_id,
+            mask_output=mask_output,
         )
 
 

--- a/tracecat/dsl/schemas.py
+++ b/tracecat/dsl/schemas.py
@@ -363,6 +363,13 @@ class ActionStatement(BaseModel):
         default=None,
         description="Override environment for this action's execution. Can be a template expression.",
     )
+    mask_output: bool = Field(
+        default=False,
+        description=(
+            "If true, redact this action's result in workflow execution API responses "
+            "while preserving internal workflow data flow between actions."
+        ),
+    )
 
     @property
     def title(self) -> str:

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -975,6 +975,7 @@ class DSLWorkflow:
                             action_ref=task.ref,
                             action_title=task.title,
                             stream_id=stream_id or ROOT_STREAM,
+                            mask_output=task.mask_output,
                         ).model_dump(),
                     )
                 case PlatformAction.AI_ACTION:
@@ -1039,6 +1040,7 @@ class DSLWorkflow:
                             action_ref=task.ref,
                             action_title=task.title,
                             stream_id=stream_id or ROOT_STREAM,
+                            mask_output=task.mask_output,
                         ).model_dump(),
                     )
                 case PlatformAction.AI_PRESET_AGENT:
@@ -1119,6 +1121,7 @@ class DSLWorkflow:
                             action_ref=task.ref,
                             action_title=task.title,
                             stream_id=stream_id or ROOT_STREAM,
+                            mask_output=task.mask_output,
                         ).model_dump(),
                     )
                 case _:
@@ -1785,6 +1788,7 @@ class DSLWorkflow:
             loop_index=loop_index,
             wait_strategy=wait_strategy,
             stream_id=stream_id,
+            mask_output=task.mask_output,
         ).model_dump()
         self.logger.debug(
             "Dispatching child workflow",

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -83,6 +83,7 @@ from tracecat.workflow.executions.schemas import (
 )
 from tracecat.workflow.executions.service import (
     WorkflowExecutionNotFoundError,
+    WorkflowExecutionResultMaskedError,
     WorkflowExecutionResultNotFoundError,
     WorkflowExecutionsService,
 )
@@ -766,6 +767,11 @@ async def get_workflow_execution_object_download(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         ) from e
+    except WorkflowExecutionResultMaskedError as e:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(e),
+        ) from e
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -832,6 +838,11 @@ async def get_workflow_execution_object_preview(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         ) from e
+    except WorkflowExecutionResultMaskedError as e:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(e),
+        ) from e
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -881,6 +892,11 @@ async def get_workflow_execution_collection_page(
     except WorkflowExecutionResultNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from e
+    except WorkflowExecutionResultMaskedError as e:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
             detail=str(e),
         ) from e
     except ValueError as e:

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -358,6 +358,8 @@ EventInput = (
 
 
 class EventGroup[T: EventInput](BaseModel):
+    _mask_output: bool = PrivateAttr(default=False)
+
     event_id: int
     udf_namespace: str
     udf_name: str
@@ -373,6 +375,13 @@ class EventGroup[T: EventInput](BaseModel):
     start_delay: float = 0.0
     join_strategy: JoinStrategy = JoinStrategy.ALL
     related_wf_exec_id: WorkflowExecutionID | AgentWorkflowID | None = None
+
+    @property
+    def should_mask_output(self) -> bool:
+        return self._mask_output
+
+    def set_mask_output(self, mask_output: bool) -> None:
+        self._mask_output = mask_output
 
     @staticmethod
     async def from_scheduled_activity(
@@ -420,7 +429,7 @@ class EventGroup[T: EventInput](BaseModel):
         namespace, task_name = destructure_slugified_namespace(
             task.action, delimiter="."
         )
-        return EventGroup(
+        group = EventGroup(
             event_id=event.event_id,
             udf_namespace=namespace,
             udf_name=task_name,
@@ -434,6 +443,8 @@ class EventGroup[T: EventInput](BaseModel):
             start_delay=task.start_delay,
             join_strategy=task.join_strategy,
         )
+        group.set_mask_output(task.mask_output)
+        return group
 
     @staticmethod
     async def from_initiated_child_workflow(
@@ -450,9 +461,14 @@ class EventGroup[T: EventInput](BaseModel):
         match attrs.workflow_type.name:
             case "DSLWorkflow":
                 wf_exec_id: WorkflowExecutionID = attrs.workflow_id
+                try:
+                    memo = await ChildWorkflowMemo.from_temporal(attrs.memo)
+                except Exception as e:
+                    logger.error("Error parsing child workflow memo", error=e)
+                    raise e
                 input = await extract_first(attrs.input)
                 if is_unreadable_temporal_payload(input):
-                    return EventGroup(
+                    child_group = EventGroup(
                         event_id=event.event_id,
                         udf_namespace="core.workflow",
                         udf_name="execute",
@@ -461,6 +477,8 @@ class EventGroup[T: EventInput](BaseModel):
                         action_input=cast(EventInput, input),
                         related_wf_exec_id=wf_exec_id,
                     )
+                    child_group.set_mask_output(memo.mask_output)
+                    return child_group
 
                 dsl_run_args = DSLRunArgs(**input)
                 # Create an event group
@@ -473,7 +491,7 @@ class EventGroup[T: EventInput](BaseModel):
                     action_description = None
 
                 wf_id = WorkflowUUID.new(dsl_run_args.wf_id)
-                return EventGroup(
+                child_group: EventGroup[EventInput] = EventGroup(
                     event_id=event.event_id,
                     udf_namespace="core.workflow",
                     udf_name="execute",
@@ -482,15 +500,22 @@ class EventGroup[T: EventInput](BaseModel):
                     action_ref=None,
                     action_title=action_title,
                     action_description=action_description,
-                    action_input=dsl_run_args,
+                    action_input=cast(EventInput, dsl_run_args),
                     related_wf_exec_id=wf_exec_id,
                 )
+                child_group.set_mask_output(memo.mask_output)
+                return child_group
             case "DurableAgentWorkflow":
                 agent_wf_id = AgentWorkflowID.from_workflow_id(attrs.workflow_id)
+                try:
+                    memo = await AgentActionMemo.from_temporal(attrs.memo)
+                except Exception as e:
+                    logger.error("Error parsing agent action memo", error=e)
+                    raise e
                 input = await extract_first(attrs.input)
                 namespace, name = PlatformAction.AI_AGENT.value.split(".", 1)
                 if is_unreadable_temporal_payload(input):
-                    return EventGroup(
+                    agent_group = EventGroup(
                         event_id=event.event_id,
                         udf_namespace=namespace,
                         udf_name=name,
@@ -502,9 +527,11 @@ class EventGroup[T: EventInput](BaseModel):
                         action_input=cast(EventInput, input),
                         related_wf_exec_id=agent_wf_id,
                     )
+                    agent_group.set_mask_output(memo.mask_output)
+                    return agent_group
 
                 agent_run_args = AgentWorkflowArgs(**input)
-                return EventGroup(
+                agent_group: EventGroup[EventInput] = EventGroup(
                     event_id=event.event_id,
                     udf_namespace=namespace,
                     udf_name=name,
@@ -513,9 +540,11 @@ class EventGroup[T: EventInput](BaseModel):
                     action_ref=None,
                     action_title="AI Agent",
                     action_description="AI Agent",
-                    action_input=agent_run_args,
+                    action_input=cast(EventInput, agent_run_args),
                     related_wf_exec_id=agent_wf_id,
                 )
+                agent_group.set_mask_output(memo.mask_output)
+                return agent_group
             case _:
                 raise ValueError("Event is not a child workflow initiated event.")
 

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -119,7 +119,10 @@ async def _agent_action_memo_from_temporal_or_default(
         return await AgentActionMemo.from_temporal(memo)
     except Exception as e:
         logger.warning("Error parsing agent action memo", error=e)
-        return AgentActionMemo(action_ref=DEFAULT_AGENT_ACTION_REF)
+        return AgentActionMemo(
+            action_ref=DEFAULT_AGENT_ACTION_REF,
+            mask_output=True,
+        )
 
 
 class WorkflowExecutionBase(BaseModel):

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -465,7 +465,7 @@ class EventGroup[T: EventInput](BaseModel):
                     memo = await ChildWorkflowMemo.from_temporal(attrs.memo)
                 except Exception as e:
                     logger.error("Error parsing child workflow memo", error=e)
-                    raise e
+                    raise
                 input = await extract_first(attrs.input)
                 if is_unreadable_temporal_payload(input):
                     child_group = EventGroup(
@@ -511,7 +511,7 @@ class EventGroup[T: EventInput](BaseModel):
                     memo = await AgentActionMemo.from_temporal(attrs.memo)
                 except Exception as e:
                     logger.error("Error parsing agent action memo", error=e)
-                    raise e
+                    raise
                 input = await extract_first(attrs.input)
                 namespace, name = PlatformAction.AI_AGENT.value.split(".", 1)
                 if is_unreadable_temporal_payload(input):
@@ -915,7 +915,7 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
                     memo = await ChildWorkflowMemo.from_temporal(attrs.memo)
                 except Exception as e:
                     logger.error("Error parsing child workflow memo", error=e)
-                    raise e
+                    raise
 
                 if (
                     attrs.parent_close_policy
@@ -972,7 +972,7 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
                     memo = await AgentActionMemo.from_temporal(attrs.memo)
                 except Exception as e:
                     logger.error("Error parsing agent action memo", error=e)
-                    raise e
+                    raise
 
                 input_data = await extract_first(attrs.input)
                 if is_unreadable_temporal_payload(input_data):

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -12,6 +12,7 @@ from typing import (
     cast,
 )
 
+import temporalio.api.common.v1
 import temporalio.api.enums.v1
 import temporalio.api.history.v1
 from google.protobuf.json_format import MessageToDict
@@ -93,6 +94,29 @@ _SENSITIVE_ERROR_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
         r"\1[REDACTED]@",
     ),
 )
+
+DEFAULT_CHILD_WORKFLOW_ACTION_REF = "Unknown Child Workflow"
+DEFAULT_AGENT_ACTION_REF = "unknown_agent_action"
+
+
+async def _child_workflow_memo_from_temporal_or_default(
+    memo: temporalio.api.common.v1.Memo,
+) -> ChildWorkflowMemo:
+    try:
+        return await ChildWorkflowMemo.from_temporal(memo)
+    except Exception as e:
+        logger.warning("Error parsing child workflow memo", error=e)
+        return ChildWorkflowMemo(action_ref=DEFAULT_CHILD_WORKFLOW_ACTION_REF)
+
+
+async def _agent_action_memo_from_temporal_or_default(
+    memo: temporalio.api.common.v1.Memo,
+) -> AgentActionMemo:
+    try:
+        return await AgentActionMemo.from_temporal(memo)
+    except Exception as e:
+        logger.warning("Error parsing agent action memo", error=e)
+        return AgentActionMemo(action_ref=DEFAULT_AGENT_ACTION_REF)
 
 
 class WorkflowExecutionBase(BaseModel):
@@ -461,11 +485,7 @@ class EventGroup[T: EventInput](BaseModel):
         match attrs.workflow_type.name:
             case "DSLWorkflow":
                 wf_exec_id: WorkflowExecutionID = attrs.workflow_id
-                try:
-                    memo = await ChildWorkflowMemo.from_temporal(attrs.memo)
-                except Exception as e:
-                    logger.error("Error parsing child workflow memo", error=e)
-                    raise
+                memo = await _child_workflow_memo_from_temporal_or_default(attrs.memo)
                 input = await extract_first(attrs.input)
                 if is_unreadable_temporal_payload(input):
                     child_group = EventGroup(
@@ -507,11 +527,7 @@ class EventGroup[T: EventInput](BaseModel):
                 return child_group
             case "DurableAgentWorkflow":
                 agent_wf_id = AgentWorkflowID.from_workflow_id(attrs.workflow_id)
-                try:
-                    memo = await AgentActionMemo.from_temporal(attrs.memo)
-                except Exception as e:
-                    logger.error("Error parsing agent action memo", error=e)
-                    raise
+                memo = await _agent_action_memo_from_temporal_or_default(attrs.memo)
                 input = await extract_first(attrs.input)
                 namespace, name = PlatformAction.AI_AGENT.value.split(".", 1)
                 if is_unreadable_temporal_payload(input):
@@ -911,11 +927,7 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
         wf_exec_id: WorkflowExecutionID = attrs.workflow_id
         match attrs.workflow_type.name:
             case "DSLWorkflow":
-                try:
-                    memo = await ChildWorkflowMemo.from_temporal(attrs.memo)
-                except Exception as e:
-                    logger.error("Error parsing child workflow memo", error=e)
-                    raise
+                memo = await _child_workflow_memo_from_temporal_or_default(attrs.memo)
 
                 if (
                     attrs.parent_close_policy
@@ -968,11 +980,7 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
                 compact_event.set_mask_output(memo.mask_output)
                 return compact_event
             case "DurableAgentWorkflow":
-                try:
-                    memo = await AgentActionMemo.from_temporal(attrs.memo)
-                except Exception as e:
-                    logger.error("Error parsing agent action memo", error=e)
-                    raise
+                memo = await _agent_action_memo_from_temporal_or_default(attrs.memo)
 
                 input_data = await extract_first(attrs.input)
                 if is_unreadable_temporal_payload(input_data):

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -905,7 +905,7 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
 
                 input_data = await extract_first(attrs.input)
                 if is_unreadable_temporal_payload(input_data):
-                    return WorkflowExecutionEventCompact(
+                    compact_event = WorkflowExecutionEventCompact(
                         source_event_id=event.event_id,
                         schedule_time=event.event_time.ToDatetime(UTC),
                         curr_event_type=HISTORY_TO_WF_EVENT_TYPE[event.event_type],
@@ -918,10 +918,12 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
                         child_wf_wait_strategy=memo.wait_strategy,
                         stream_id=memo.stream_id,
                     )
+                    compact_event.set_mask_output(memo.mask_output)
+                    return compact_event
 
                 dsl_run_args = DSLRunArgs(**input_data)
 
-                return WorkflowExecutionEventCompact(
+                compact_event = WorkflowExecutionEventCompact(
                     source_event_id=event.event_id,
                     schedule_time=event.event_time.ToDatetime(UTC),
                     curr_event_type=HISTORY_TO_WF_EVENT_TYPE[event.event_type],
@@ -934,6 +936,8 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
                     child_wf_wait_strategy=memo.wait_strategy,
                     stream_id=memo.stream_id,
                 )
+                compact_event.set_mask_output(memo.mask_output)
+                return compact_event
             case "DurableAgentWorkflow":
                 try:
                     memo = await AgentActionMemo.from_temporal(attrs.memo)
@@ -943,7 +947,7 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
 
                 input_data = await extract_first(attrs.input)
                 if is_unreadable_temporal_payload(input_data):
-                    return WorkflowExecutionEventCompact(
+                    compact_event = WorkflowExecutionEventCompact(
                         source_event_id=event.event_id,
                         schedule_time=event.event_time.ToDatetime(UTC),
                         curr_event_type=HISTORY_TO_WF_EVENT_TYPE[event.event_type],
@@ -956,13 +960,15 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
                         stream_id=memo.stream_id,
                         session=None,
                     )
+                    compact_event.set_mask_output(memo.mask_output)
+                    return compact_event
 
                 agent_run_args = AgentWorkflowArgs(**input_data)
                 session = None
                 session_id = agent_run_args.agent_args.session_id
                 if session_id is not None:
                     session = Session(id=session_id)
-                return WorkflowExecutionEventCompact(
+                compact_event = WorkflowExecutionEventCompact(
                     source_event_id=event.event_id,
                     schedule_time=event.event_time.ToDatetime(UTC),
                     curr_event_type=HISTORY_TO_WF_EVENT_TYPE[event.event_type],
@@ -975,6 +981,8 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
                     stream_id=memo.stream_id,
                     session=session,
                 )
+                compact_event.set_mask_output(memo.mask_output)
+                return compact_event
             case _:
                 raise ValueError(
                     f"Unexpected child workflow type: {attrs.workflow_type.name}"

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -15,7 +15,14 @@ from typing import (
 import temporalio.api.enums.v1
 import temporalio.api.history.v1
 from google.protobuf.json_format import MessageToDict
-from pydantic import BaseModel, ConfigDict, Field, PlainSerializer, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PlainSerializer,
+    PrivateAttr,
+    model_validator,
+)
 from temporalio.api.failure.v1 import Failure
 from temporalio.client import WorkflowExecution, WorkflowExecutionStatus
 from tracecat_ee.agent.types import AgentWorkflowID
@@ -707,6 +714,8 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
 ):
     """A compact representation of a workflow execution event."""
 
+    _mask_output: bool = PrivateAttr(default=False)
+
     source_event_id: int
     """The event ID of the source event."""
     schedule_time: datetime
@@ -733,6 +742,13 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
     child_wf_wait_strategy: WaitStrategy | None = None
     # SSE streaming for agents
     session: Session[TSessionEvent] | None = None
+
+    @property
+    def should_mask_output(self) -> bool:
+        return self._mask_output
+
+    def set_mask_output(self, mask_output: bool) -> None:
+        self._mask_output = mask_output
 
     @staticmethod
     async def from_source_event(
@@ -801,7 +817,7 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
                 logger.debug("Scatter input task is None", event_id=event.event_id)
                 return None
 
-            return WorkflowExecutionEventCompact(
+            compact_event = WorkflowExecutionEventCompact(
                 source_event_id=event.event_id,
                 schedule_time=event.event_time.ToDatetime(UTC),
                 curr_event_type=HISTORY_TO_WF_EVENT_TYPE[event.event_type],
@@ -812,6 +828,8 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
                 stream_id=scatter_input.stream_id or ROOT_STREAM,
                 session=None,
             )
+            compact_event.set_mask_output(task.mask_output)
+            return compact_event
 
         # Handle RunActionInput for other action activities
         try:
@@ -828,7 +846,7 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
         if action_input.session_id is not None:
             session = Session(id=action_input.session_id)  # No events
 
-        return WorkflowExecutionEventCompact(
+        compact_event = WorkflowExecutionEventCompact(
             source_event_id=event.event_id,
             schedule_time=event.event_time.ToDatetime(UTC),
             curr_event_type=HISTORY_TO_WF_EVENT_TYPE[event.event_type],
@@ -839,6 +857,8 @@ class WorkflowExecutionEventCompact[TInput: Any, TResult: Any, TSessionEvent: An
             stream_id=action_input.stream_id,
             session=session,
         )
+        compact_event.set_mask_output(task.mask_output)
+        return compact_event
 
     @staticmethod
     async def from_initiated_child_workflow(

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -106,7 +106,10 @@ async def _child_workflow_memo_from_temporal_or_default(
         return await ChildWorkflowMemo.from_temporal(memo)
     except Exception as e:
         logger.warning("Error parsing child workflow memo", error=e)
-        return ChildWorkflowMemo(action_ref=DEFAULT_CHILD_WORKFLOW_ACTION_REF)
+        return ChildWorkflowMemo(
+            action_ref=DEFAULT_CHILD_WORKFLOW_ACTION_REF,
+            mask_output=True,
+        )
 
 
 async def _agent_action_memo_from_temporal_or_default(

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -37,7 +37,7 @@ from tracecat.db.models import Interaction
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import RETRY_POLICIES, DSLInput, DSLRunArgs
 from tracecat.dsl.enums import PlatformAction
-from tracecat.dsl.schemas import RunActionInput, TriggerInputs
+from tracecat.dsl.schemas import TriggerInputs
 from tracecat.dsl.types import Task
 from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.ee.interactions.schemas import InteractionInput
@@ -155,9 +155,9 @@ def _extract_while_metadata(
     return None, None
 
 
-def _sanitize_action_result(action_input: Any | None, action_result: Any) -> Any:
+def _sanitize_action_result(mask_output: bool, action_result: Any) -> Any:
     """Redact action output for API consumers when the statement opts in."""
-    if isinstance(action_input, RunActionInput) and action_input.task.mask_output:
+    if mask_output:
         return "[REDACTED]"
     return action_result
 
@@ -702,14 +702,12 @@ class WorkflowExecutionsService:
                     source.close_time = event.event_time.ToDatetime(datetime.UTC)
                     raw_result = await get_result(event)
                     source.action_result = _sanitize_action_result(
-                        source.action_input, raw_result
+                        source.should_mask_output, raw_result
                     )
                     (
                         source.while_iteration,
                         source.while_continue,
-                    ) = _extract_while_metadata(
-                        source.action_name, raw_result
-                    )
+                    ) = _extract_while_metadata(source.action_name, raw_result)
                 if is_error_event(event):
                     source.action_error = await EventFailure.from_history_event(event)
 

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -13,7 +13,7 @@ from typing import Any, cast
 
 import orjson
 import temporalio.api.enums.v1
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from temporalio.api.common.v1 import message_pb2
 from temporalio.api.enums.v1 import EventType, PendingActivityState, ResetReapplyType
 from temporalio.api.history.v1 import HistoryEvent
@@ -177,6 +177,8 @@ REDACTED_ACTION_RESULT = "[REDACTED]"
 
 def _redact_leaf_values(value: Any) -> Any:
     """Preserve result structure while redacting displayable values."""
+    if isinstance(value, BaseModel):
+        return _redact_leaf_values(value.model_dump(mode="json"))
     if isinstance(value, dict):
         return {key: _redact_leaf_values(child) for key, child in value.items()}
     if isinstance(value, list):

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -37,7 +37,7 @@ from tracecat.db.models import Interaction
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import RETRY_POLICIES, DSLInput, DSLRunArgs
 from tracecat.dsl.enums import PlatformAction
-from tracecat.dsl.schemas import TriggerInputs
+from tracecat.dsl.schemas import RunActionInput, TriggerInputs
 from tracecat.dsl.types import Task
 from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.ee.interactions.schemas import InteractionInput
@@ -153,6 +153,13 @@ def _extract_while_metadata(
         should_continue = payload.get("continue")
         return None, (should_continue if isinstance(should_continue, bool) else None)
     return None, None
+
+
+def _sanitize_action_result(action_input: Any | None, action_result: Any) -> Any:
+    """Redact action output for API consumers when the statement opts in."""
+    if isinstance(action_input, RunActionInput) and action_input.task.mask_output:
+        return "[REDACTED]"
+    return action_result
 
 
 async def _resolve_trigger_context(trigger_inputs: StoredObject | None) -> Any | None:
@@ -693,12 +700,15 @@ class WorkflowExecutionsService:
                     source.start_time = event.event_time.ToDatetime(datetime.UTC)
                 if is_close_event(event):
                     source.close_time = event.event_time.ToDatetime(datetime.UTC)
-                    source.action_result = await get_result(event)
+                    raw_result = await get_result(event)
+                    source.action_result = _sanitize_action_result(
+                        source.action_input, raw_result
+                    )
                     (
                         source.while_iteration,
                         source.while_continue,
                     ) = _extract_while_metadata(
-                        source.action_name, source.action_result
+                        source.action_name, raw_result
                     )
                 if is_error_event(event):
                     source.action_error = await EventFailure.from_history_event(event)

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -109,8 +109,25 @@ class WorkflowExecutionResultNotFoundError(ValueError):
     """Raised when no matching completed event exists for a given event ID."""
 
 
+class WorkflowExecutionResultMaskedError(PermissionError):
+    """Raised when a masked action result is requested through object APIs."""
+
+
 class WorkflowExecutionNotFoundError(ValueError):
     """Raised when a workflow execution is not visible in the current workspace."""
+
+
+@dataclass(frozen=True)
+class WorkflowExecutionResolvedEvent:
+    event: HistoryEvent
+    should_mask_output: bool
+
+
+@dataclass(frozen=True)
+class WorkflowExecutionStoredResult:
+    event: HistoryEvent
+    stored: StoredObject
+    should_mask_output: bool
 
 
 @dataclass(frozen=True)
@@ -813,17 +830,19 @@ class WorkflowExecutionsService:
         - the completed event ID (e.g. ACTIVITY_TASK_COMPLETED), or
         - the source scheduled event ID used by compact event payloads.
         """
-        source_match, stored = await self._get_stored_result_for_event(
+        stored_result = await self._get_stored_result_for_event(
             wf_exec_id=wf_exec_id,
             event_id=event_id,
         )
+        self._raise_if_result_masked(stored_result)
 
-        match stored:
+        match stored_result.stored:
             case ExternalObject() as external:
                 return external
             case _:
                 raise TypeError(
-                    f"Event {source_match.event_id} result is not external (got {stored.type})"
+                    f"Event {stored_result.event.event_id} result is not external "
+                    f"(got {stored_result.stored.type})"
                 )
 
     async def get_collection_action_result(
@@ -832,16 +851,19 @@ class WorkflowExecutionsService:
         event_id: int,
     ) -> CollectionObject:
         """Get a CollectionObject result for an event/source event ID."""
-        source_match, stored = await self._get_stored_result_for_event(
+        stored_result = await self._get_stored_result_for_event(
             wf_exec_id=wf_exec_id,
             event_id=event_id,
         )
-        match stored:
+        self._raise_if_result_masked(stored_result)
+
+        match stored_result.stored:
             case CollectionObject() as collection:
                 return collection
             case _:
                 raise TypeError(
-                    f"Event {source_match.event_id} result is not a collection (got {stored.type})"
+                    f"Event {stored_result.event.event_id} result is not a "
+                    f"collection (got {stored_result.stored.type})"
                 )
 
     async def get_collection_page(
@@ -897,18 +919,46 @@ class WorkflowExecutionsService:
         event_id: int,
     ) -> HistoryEvent:
         """Resolve a completed Temporal event by event ID or source event ID."""
+        resolved = await self._resolve_completed_event_with_metadata(
+            wf_exec_id,
+            event_id,
+        )
+        return resolved.event
+
+    async def _resolve_completed_event_with_metadata(
+        self,
+        wf_exec_id: WorkflowExecutionID,
+        event_id: int,
+    ) -> WorkflowExecutionResolvedEvent:
+        """Resolve a completed Temporal event with source-event display metadata."""
         await self.require_execution(wf_exec_id)
         handle = self.handle(wf_exec_id)
-        source_match: HistoryEvent | None = None
+        source_masks: dict[int, bool] = {}
+        source_match: WorkflowExecutionResolvedEvent | None = None
 
         async for event in handle.fetch_history_events():
+            if is_scheduled_event(event):
+                if source := await WorkflowExecutionEventCompact.from_source_event(
+                    event
+                ):
+                    source_masks[event.event_id] = source.should_mask_output
+
             if not is_close_event(event):
                 continue
+            source_event_id = get_source_event_id(event)
+            should_mask_output = (
+                source_masks.get(source_event_id, False)
+                if source_event_id is not None
+                else False
+            )
+            resolved = WorkflowExecutionResolvedEvent(
+                event=event,
+                should_mask_output=should_mask_output,
+            )
             if event.event_id == event_id:
-                source_match = event
-                break
-            if get_source_event_id(event) == event_id:
-                source_match = event
+                return resolved
+            if source_event_id == event_id:
+                source_match = resolved
 
         if source_match is None:
             raise WorkflowExecutionResultNotFoundError(
@@ -921,18 +971,30 @@ class WorkflowExecutionsService:
         *,
         wf_exec_id: WorkflowExecutionID,
         event_id: int,
-    ) -> tuple[HistoryEvent, StoredObject]:
+    ) -> WorkflowExecutionStoredResult:
         """Get a StoredObject from a completed event or its source event ID."""
-        source_match = await self._resolve_completed_event(
+        source_match = await self._resolve_completed_event_with_metadata(
             wf_exec_id=wf_exec_id,
             event_id=event_id,
         )
-        stored = await get_stored_result(source_match)
+        stored = await get_stored_result(source_match.event)
         if stored is None:
             raise TypeError(
-                f"Event {source_match.event_id} result is not a StoredObject"
+                f"Event {source_match.event.event_id} result is not a StoredObject"
             )
-        return source_match, stored
+        return WorkflowExecutionStoredResult(
+            event=source_match.event,
+            stored=stored,
+            should_mask_output=source_match.should_mask_output,
+        )
+
+    @staticmethod
+    def _raise_if_result_masked(stored_result: WorkflowExecutionStoredResult) -> None:
+        if stored_result.should_mask_output:
+            raise WorkflowExecutionResultMaskedError(
+                "Action result is masked by `mask_output` and cannot be retrieved "
+                "through object APIs."
+            )
 
     async def list_workflow_execution_events(
         self,

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -178,7 +178,7 @@ REDACTED_ACTION_RESULT = "[REDACTED]"
 def _redact_leaf_values(value: Any) -> Any:
     """Preserve result structure while redacting displayable values."""
     if isinstance(value, BaseModel):
-        return _redact_leaf_values(value.model_dump(mode="json"))
+        return _redact_leaf_values(value.model_dump(mode="python"))
     if isinstance(value, dict):
         return {key: _redact_leaf_values(child) for key, child in value.items()}
     if isinstance(value, list):

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -938,9 +938,20 @@ class WorkflowExecutionsService:
 
         async for event in handle.fetch_history_events():
             if is_scheduled_event(event):
-                if source := await WorkflowExecutionEventCompact.from_source_event(
-                    event
-                ):
+                try:
+                    source = await WorkflowExecutionEventCompact.from_source_event(
+                        event
+                    )
+                except Exception as e:
+                    self.logger.warning(
+                        "Failed to parse source event mask metadata; treating result as masked",
+                        event_id=event.event_id,
+                        error=e,
+                    )
+                    source_masks[event.event_id] = True
+                else:
+                    if source is None:
+                        continue
                     source_masks[event.event_id] = source.should_mask_output
 
             if not is_close_event(event):

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -944,7 +944,7 @@ class WorkflowExecutionsService:
                     source = await WorkflowExecutionEventCompact.from_source_event(
                         event
                     )
-                except Exception as e:
+                except (TypeError, ValueError, ValidationError) as e:
                     self.logger.warning(
                         "Failed to parse source event mask metadata; treating result as masked",
                         event_id=event.event_id,

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -983,11 +983,15 @@ class WorkflowExecutionsService:
                         )
                     )
                 case EventType.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED:
-                    result = await extract_first(
+                    raw_result = await extract_first(
                         event.child_workflow_execution_completed_event_attributes.result
                     )
                     initiator_event_id = event.child_workflow_execution_completed_event_attributes.initiated_event_id
                     group = event_group_names.get(initiator_event_id)
+                    result = _sanitize_action_result(
+                        group.should_mask_output if group else False,
+                        raw_result,
+                    )
                     events.append(
                         WorkflowExecutionEvent(
                             event_id=event.event_id,
@@ -1136,8 +1140,12 @@ class WorkflowExecutionsService:
                     if not (group := event_group_names.get(gparent_event_id)):
                         continue
                     event_group_names[event.event_id] = group
-                    result = await extract_first(
+                    raw_result = await extract_first(
                         event.activity_task_completed_event_attributes.result
+                    )
+                    result = _sanitize_action_result(
+                        group.should_mask_output,
+                        raw_result,
                     )
                     events.append(
                         WorkflowExecutionEvent(

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -155,10 +155,24 @@ def _extract_while_metadata(
     return None, None
 
 
+REDACTED_ACTION_RESULT = "[REDACTED]"
+
+
+def _redact_leaf_values(value: Any) -> Any:
+    """Preserve result structure while redacting displayable values."""
+    if isinstance(value, dict):
+        return {key: _redact_leaf_values(child) for key, child in value.items()}
+    if isinstance(value, list):
+        return [_redact_leaf_values(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_leaf_values(item) for item in value)
+    return REDACTED_ACTION_RESULT
+
+
 def _sanitize_action_result(mask_output: bool, action_result: Any) -> Any:
     """Redact action output for API consumers when the statement opts in."""
     if mask_output:
-        return "[REDACTED]"
+        return _redact_leaf_values(action_result)
     return action_result
 
 


### PR DESCRIPTION
### Motivation

- Some actions can return sensitive plaintext (e.g. tokens) and must not be exposed in API responses while still being usable internally by the workflow.
- Provide a minimal, boolean-based opt-in on `ActionStatement` so individual tasks can request redaction without changing runtime dataflow.

### Description

- Added `mask_output: bool = False` to `ActionStatement` in `tracecat/dsl/schemas.py` to mark actions whose results should be redacted in API responses.
- Imported `RunActionInput` and added `_sanitize_action_result(...)` in `tracecat/workflow/executions/service.py` to return `"[REDACTED]"` for client-facing result assembly when `task.mask_output` is true.
- Applied redaction during compact event assembly by using the raw result for internal metadata extraction but storing a sanitized value in `source.action_result` for API consumers.

### Screens

https://github.com/user-attachments/assets/07aa7069-2500-42dd-901d-f5c685c4870a



### Testing

- Ran `uv run ruff check tracecat/dsl/schemas.py tracecat/workflow/executions/service.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12768e61c8320a041b602328f7049)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `mask_output` flag to `ActionStatement` and applies structured redaction to action, child workflow, and agent results in both compact and standard execution API responses. Internal data flow, while-loop logic, and response shapes are preserved; only leaf values are replaced with "[REDACTED]".

- **New Features**
  - Added `mask_output: bool = False` to `ActionStatement`; surfaced in `frontend/src/client/schemas.gen.ts` and `frontend/src/client/types.gen.ts`.
  - Propagated `mask_output` through child workflow and agent memos; compact events and event groups store the flag.
  - Redaction now applies to both compact and non-compact execution endpoints.

- **Bug Fixes**
  - Preserve redaction metadata when building compact events from scheduled activities and initiated child workflows.
  - Redact only leaf values while keeping dict/list/tuple shape; use raw results for metadata and while-loop control.

<sup>Written for commit d4fa7f9038396570f0c9fd3014509c9691e6b7b5. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2578?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

