### PR TITLE
feat(api): add disable_github_workflow_pulls org flag

### DIFF
--- a/alembic/versions/0d0a196bb07d_add_disable_github_workflow_pulls_to_organization.py
+++ b/alembic/versions/0d0a196bb07d_add_disable_github_workflow_pulls_to_organization.py
@@ -1,0 +1,35 @@
+"""add disable_github_workflow_pulls to organization
+
+Revision ID: 0d0a196bb07d
+Revises: 96470fdcc686
+Create Date: 2026-04-29 20:13:22.674875
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0d0a196bb07d"
+down_revision: str | None = "96470fdcc686"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "organization",
+        sa.Column(
+            "disable_github_workflow_pulls",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("organization", "disable_github_workflow_pulls")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -14512,6 +14512,17 @@ export const $OrgUpdate = {
       ],
       title: "Is Active",
     },
+    disable_github_workflow_pulls: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Disable Github Workflow Pulls",
+    },
   },
   type: "object",
   title: "OrgUpdate",
@@ -28058,9 +28069,13 @@ export const $tracecat__organization__schemas__OrgRead = {
       type: "string",
       title: "Name",
     },
+    disable_github_workflow_pulls: {
+      type: "boolean",
+      title: "Disable Github Workflow Pulls",
+    },
   },
   type: "object",
-  required: ["id", "name"],
+  required: ["id", "name", "disable_github_workflow_pulls"],
   title: "OrgRead",
 } as const
 
@@ -28318,6 +28333,10 @@ export const $tracecat_ee__admin__organizations__schemas__OrgRead = {
       type: "boolean",
       title: "Is Active",
     },
+    disable_github_workflow_pulls: {
+      type: "boolean",
+      title: "Disable Github Workflow Pulls",
+    },
     created_at: {
       type: "string",
       format: "date-time",
@@ -28337,7 +28356,14 @@ export const $tracecat_ee__admin__organizations__schemas__OrgRead = {
     },
   },
   type: "object",
-  required: ["id", "name", "slug", "is_active", "created_at"],
+  required: [
+    "id",
+    "name",
+    "slug",
+    "is_active",
+    "disable_github_workflow_pulls",
+    "created_at",
+  ],
   title: "OrgRead",
   description: "Organization response.",
 } as const

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4521,6 +4521,7 @@ export type OrgUpdate = {
   name?: string | null
   slug?: string | null
   is_active?: boolean | null
+  disable_github_workflow_pulls?: boolean | null
 }
 
 /**
@@ -8413,6 +8414,7 @@ export type tracecat__organization__schemas__OrgDomainRead = {
 export type tracecat__organization__schemas__OrgRead = {
   id: string
   name: string
+  disable_github_workflow_pulls: boolean
 }
 
 /**
@@ -8476,6 +8478,7 @@ export type tracecat_ee__admin__organizations__schemas__OrgRead = {
   name: string
   slug: string
   is_active: boolean
+  disable_github_workflow_pulls: boolean
   created_at: string
   updated_at?: string | null
 }

--- a/frontend/src/components/admin/admin-organization-edit-dialog.tsx
+++ b/frontend/src/components/admin/admin-organization-edit-dialog.tsx
@@ -39,6 +39,7 @@ const formSchema = z.object({
       "Slug must contain only lowercase letters, numbers, and hyphens"
     ),
   is_active: z.boolean(),
+  disable_github_workflow_pulls: z.boolean(),
 })
 
 type FormValues = z.infer<typeof formSchema>
@@ -74,6 +75,7 @@ export function AdminOrganizationEditDialog({
       name: "",
       slug: "",
       is_active: true,
+      disable_github_workflow_pulls: false,
     },
   })
 
@@ -83,6 +85,8 @@ export function AdminOrganizationEditDialog({
         name: organization.name,
         slug: organization.slug,
         is_active: organization.is_active,
+        disable_github_workflow_pulls:
+          organization.disable_github_workflow_pulls,
       })
     }
   }, [organization, form, dialogOpen])
@@ -173,6 +177,27 @@ export function AdminOrganizationEditDialog({
                     <FormLabel className="font-normal">Active</FormLabel>
                     <FormDescription className="ml-4">
                       Inactive organizations cannot be accessed by users.
+                    </FormDescription>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="disable_github_workflow_pulls"
+                render={({ field }) => (
+                  <FormItem className="flex items-center gap-2 space-y-0">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                    <FormLabel className="font-normal">
+                      Disable GitHub Workflow pulls
+                    </FormLabel>
+                    <FormDescription className="ml-4">
+                      Hide the pull workflows UI in workspaces and reject Git
+                      pull requests from this organization.
                     </FormDescription>
                   </FormItem>
                 )}

--- a/frontend/src/components/settings/workspace-sync-settings.tsx
+++ b/frontend/src/components/settings/workspace-sync-settings.tsx
@@ -17,6 +17,7 @@ import {
   FormMessage,
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
+import { useOrganization } from "@/hooks/use-organization"
 import { validateGitSshUrl } from "@/lib/git"
 import { useWorkspaceSettings } from "@/lib/hooks"
 import { WorkflowPullDialog } from "../organization/workflow-pull-dialog"
@@ -40,6 +41,8 @@ export function WorkspaceSyncSettings({
 }: WorkspaceSyncSettingsProps) {
   const [pullDialogOpen, setPullDialogOpen] = useState(false)
   const { updateWorkspace, isUpdating } = useWorkspaceSettings(workspace.id)
+  const { organization } = useOrganization()
+  const pullsDisabled = organization?.disable_github_workflow_pulls ?? false
 
   const form = useForm<SyncSettingsForm>({
     resolver: zodResolver(syncSettingsSchema),
@@ -92,7 +95,7 @@ export function WorkspaceSyncSettings({
         </form>
       </Form>
 
-      {persistedGitUrl && (
+      {persistedGitUrl && !pullsDisabled && (
         <div className="rounded-lg border bg-muted/30 p-4">
           <div className="mb-4 flex items-center justify-between">
             <div>

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -163,6 +163,7 @@ export function useAdminOrganization(orgId: string) {
           queryKey: ["admin", "organizations", orgId],
         })
         queryClient.invalidateQueries({ queryKey: ["admin", "organizations"] })
+        queryClient.invalidateQueries({ queryKey: ["current-organization"] })
       },
     })
 

--- a/packages/tracecat-ee/tracecat_ee/admin/organizations/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/organizations/schemas.py
@@ -32,6 +32,7 @@ class OrgUpdate(Schema):
     name: str | None = Field(None, min_length=1, max_length=255)
     slug: str | None = Field(None, min_length=1, max_length=63, pattern=r"^[a-z0-9-]+$")
     is_active: bool | None = None
+    disable_github_workflow_pulls: bool | None = None
 
 
 class OrgRead(Schema):
@@ -41,6 +42,7 @@ class OrgRead(Schema):
     name: str
     slug: str
     is_active: bool
+    disable_github_workflow_pulls: bool
     created_at: datetime
     updated_at: datetime | None = None
 

--- a/tests/unit/api/test_api_admin_organizations.py
+++ b/tests/unit/api/test_api_admin_organizations.py
@@ -23,13 +23,18 @@ from tracecat.invitations.enums import InvitationStatus
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 
 
-def _org_read(org_id: uuid.UUID | None = None) -> OrgRead:
+def _org_read(
+    org_id: uuid.UUID | None = None,
+    *,
+    disable_github_workflow_pulls: bool = False,
+) -> OrgRead:
     now = datetime(2024, 1, 1, tzinfo=UTC)
     return OrgRead(
         id=org_id or uuid.uuid4(),
         name="Test Org",
         slug="test-org",
         is_active=True,
+        disable_github_workflow_pulls=disable_github_workflow_pulls,
         created_at=now,
         updated_at=now,
     )
@@ -153,6 +158,30 @@ async def test_update_organization_conflict(
         )
 
     assert response.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.anyio
+async def test_update_organization_disable_github_workflow_pulls(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    org_id = uuid.uuid4()
+    updated = _org_read(org_id, disable_github_workflow_pulls=True)
+
+    with patch.object(organizations_router, "AdminOrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.update_organization.return_value = updated
+        MockService.return_value = mock_svc
+
+        response = client.patch(
+            f"/admin/organizations/{org_id}",
+            json={"disable_github_workflow_pulls": True},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["disable_github_workflow_pulls"] is True
+    args = mock_svc.update_organization.await_args.args
+    assert args[0] == org_id
+    assert args[1].disable_github_workflow_pulls is True
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_organization.py
+++ b/tests/unit/api/test_api_organization.py
@@ -1,0 +1,123 @@
+"""HTTP-level tests for the organization API endpoint.
+
+Exercises ``GET /organization`` and verifies the response shape, including
+the ``disable_github_workflow_pulls`` flag that workspace members rely on
+to gate the workspace Git sync Pull UI.
+"""
+
+import uuid
+from typing import get_args
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.api.app import app
+from tracecat.auth.types import Role
+from tracecat.contexts import ctx_role
+from tracecat.db.engine import get_async_session
+from tracecat.organization import router as organization_router
+
+
+def _override_role_dependency() -> Role:
+    role = ctx_role.get()
+    if role is None:
+        raise RuntimeError("No role set in ctx_role context")
+    return role
+
+
+@pytest.fixture(autouse=True)
+def _override_organization_role_dependencies(  # pyright: ignore[reportUnusedFunction]
+    client: TestClient,
+):
+    role_dependencies = [
+        organization_router.OrgActorRole,
+        organization_router.OrgUserRole,
+    ]
+
+    for annotated_type in role_dependencies:
+        metadata = get_args(annotated_type)
+        if metadata and hasattr(metadata[1], "dependency"):
+            dependency = metadata[1].dependency
+            app.dependency_overrides[dependency] = _override_role_dependency
+
+    yield
+
+    for annotated_type in role_dependencies:
+        metadata = get_args(annotated_type)
+        if metadata and hasattr(metadata[1], "dependency"):
+            dependency = metadata[1].dependency
+            app.dependency_overrides.pop(dependency, None)
+
+
+def _stub_organization(
+    org_id: uuid.UUID,
+    *,
+    disable_github_workflow_pulls: bool = False,
+) -> Mock:
+    org = Mock()
+    org.id = org_id
+    org.name = "Test Organization"
+    org.disable_github_workflow_pulls = disable_github_workflow_pulls
+    return org
+
+
+@pytest.mark.anyio
+async def test_get_organization_exposes_disable_github_workflow_pulls_default(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    """A workspace member sees ``disable_github_workflow_pulls=False`` by default."""
+    org = _stub_organization(test_admin_role.organization_id or uuid.uuid4())
+
+    org_result = Mock()
+    org_result.scalar_one_or_none.return_value = org
+
+    mock_session = await app.dependency_overrides[get_async_session]()
+    mock_session.execute = AsyncMock(return_value=org_result)
+
+    response = client.get("/organization")
+
+    assert response.status_code == status.HTTP_200_OK
+    payload = response.json()
+    assert payload["id"] == str(org.id)
+    assert payload["name"] == org.name
+    assert payload["disable_github_workflow_pulls"] is False
+
+
+@pytest.mark.anyio
+async def test_get_organization_exposes_disable_github_workflow_pulls_when_set(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    """When the org admin enables the flag, workspace members see ``True``."""
+    org = _stub_organization(
+        test_admin_role.organization_id or uuid.uuid4(),
+        disable_github_workflow_pulls=True,
+    )
+
+    org_result = Mock()
+    org_result.scalar_one_or_none.return_value = org
+
+    mock_session = await app.dependency_overrides[get_async_session]()
+    mock_session.execute = AsyncMock(return_value=org_result)
+
+    response = client.get("/organization")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["disable_github_workflow_pulls"] is True
+
+
+@pytest.mark.anyio
+async def test_get_organization_returns_404_when_org_missing(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    """Bogus ``organization_id`` from the role context surfaces a 404."""
+    org_result = Mock()
+    org_result.scalar_one_or_none.return_value = None
+
+    mock_session = await app.dependency_overrides[get_async_session]()
+    mock_session.execute = AsyncMock(return_value=org_result)
+
+    response = client.get("/organization")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/unit/api/test_api_workflow_store_publish.py
+++ b/tests/unit/api/test_api_workflow_store_publish.py
@@ -7,7 +7,9 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
+from tracecat.api.app import app
 from tracecat.auth.types import Role
+from tracecat.db.engine import get_async_session, get_async_session_bypass_rls
 from tracecat.exceptions import TracecatValidationError
 from tracecat.registry.repositories.schemas import GitBranchInfo
 from tracecat.vcs.github.app import GitHubAppError
@@ -232,6 +234,74 @@ async def test_list_workflow_branches_missing_repo_returns_400(
         response = client.get(
             "/workflows/sync/branches",
             params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Git repository URL not configured" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_pull_workflows_blocked_when_org_flag_set(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """POST /workflows/sync/pull returns 403 when the org has pulls disabled."""
+    org_result = Mock()
+    org_result.scalar_one_or_none.return_value = True
+
+    session_mock = AsyncMock(name="org_disabled_session")
+    session_mock.execute = AsyncMock(return_value=org_result)
+
+    async def _override_session() -> AsyncMock:
+        return session_mock
+
+    app.dependency_overrides[get_async_session] = _override_session
+    app.dependency_overrides[get_async_session_bypass_rls] = _override_session
+
+    response = client.post(
+        "/workflows/sync/pull",
+        params={"workspace_id": str(test_admin_role.workspace_id)},
+        json={"commit_sha": "abc1234567890", "dry_run": False},
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "disabled by your organization administrator" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_pull_workflows_passes_gate_when_org_flag_unset(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """POST /workflows/sync/pull proceeds past the gate when the flag is off."""
+    org_result = Mock()
+    org_result.scalar_one_or_none.return_value = False
+
+    session_mock = AsyncMock(name="org_allowed_session")
+    session_mock.execute = AsyncMock(return_value=org_result)
+
+    async def _override_session() -> AsyncMock:
+        return session_mock
+
+    app.dependency_overrides[get_async_session] = _override_session
+    app.dependency_overrides[get_async_session_bypass_rls] = _override_session
+
+    with (
+        patch("tracecat.workflow.store.router.WorkspaceService") as mock_workspace_cls,
+        patch("tracecat.workflow.store.router.WorkflowSyncService") as mock_sync_cls,
+    ):
+        mock_workspace_svc = AsyncMock()
+        mock_workspace = Mock()
+        mock_workspace.settings = {"git_repo_url": ""}
+        mock_workspace_svc.get_workspace.return_value = mock_workspace
+        mock_workspace_cls.return_value = mock_workspace_svc
+
+        mock_sync_cls.return_value = AsyncMock()
+
+        response = client.post(
+            "/workflows/sync/pull",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"commit_sha": "abc1234567890", "dry_run": False},
         )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/unit/test_admin_org_service.py
+++ b/tests/unit/test_admin_org_service.py
@@ -1,0 +1,110 @@
+"""Tests for the platform-level ``AdminOrgService.update_organization``.
+
+These exercise the dynamic ``setattr`` field-propagation loop, which is the
+mechanism that surfaces ``disable_github_workflow_pulls`` (and any future
+columns added to the Organization model) on the EE admin write path.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from tracecat_ee.admin.organizations.schemas import OrgUpdate
+from tracecat_ee.admin.organizations.service import AdminOrgService
+
+from tracecat.auth.types import PlatformRole
+from tracecat.db.models import Organization
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+def platform_role() -> PlatformRole:
+    return PlatformRole(
+        type="user",
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+    )
+
+
+@pytest.fixture
+async def organization(session: AsyncSession) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Acme Org",
+        slug=f"acme-org-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session.add(org)
+    await session.commit()
+    await session.refresh(org)
+    return org
+
+
+@pytest.mark.anyio
+async def test_new_organization_defaults_disable_pulls_to_false(
+    organization: Organization,
+) -> None:
+    """The DB default keeps existing pull behavior unchanged."""
+    assert organization.disable_github_workflow_pulls is False
+
+
+@pytest.mark.anyio
+async def test_update_organization_enables_disable_github_workflow_pulls(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    organization: Organization,
+) -> None:
+    service = AdminOrgService(session, role=platform_role)
+
+    updated = await service.update_organization(
+        organization.id,
+        OrgUpdate(name=None, slug=None, disable_github_workflow_pulls=True),
+    )
+
+    assert updated.disable_github_workflow_pulls is True
+    await session.refresh(organization)
+    assert organization.disable_github_workflow_pulls is True
+
+
+@pytest.mark.anyio
+async def test_update_organization_disables_disable_github_workflow_pulls(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    organization: Organization,
+) -> None:
+    """Re-enabling pulls clears the flag without touching other fields."""
+    organization.disable_github_workflow_pulls = True
+    await session.commit()
+
+    service = AdminOrgService(session, role=platform_role)
+    updated = await service.update_organization(
+        organization.id,
+        OrgUpdate(name=None, slug=None, disable_github_workflow_pulls=False),
+    )
+
+    assert updated.disable_github_workflow_pulls is False
+    assert updated.is_active is True
+    assert updated.name == organization.name
+
+
+@pytest.mark.anyio
+async def test_update_organization_only_touches_set_fields(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    organization: Organization,
+) -> None:
+    """An ``OrgUpdate`` without the new field leaves the flag untouched."""
+    organization.disable_github_workflow_pulls = True
+    await session.commit()
+
+    service = AdminOrgService(session, role=platform_role)
+    updated = await service.update_organization(
+        organization.id,
+        OrgUpdate(name="Renamed Org", slug=None),
+    )
+
+    assert updated.name == "Renamed Org"
+    assert updated.disable_github_workflow_pulls is True

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -206,6 +206,12 @@ class Organization(Base, TimestampMixin):
     name: Mapped[str] = mapped_column(String, index=True)
     slug: Mapped[str] = mapped_column(String, unique=True, index=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    disable_github_workflow_pulls: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default=text("false"),
+        nullable=False,
+    )
 
     # Relationships
     members: Mapped[list[User]] = relationship(

--- a/tracecat/organization/router.py
+++ b/tracecat/organization/router.py
@@ -93,7 +93,11 @@ async def get_organization(
             detail="Organization not found",
         )
 
-    return OrgRead(id=org.id, name=org.name)
+    return OrgRead(
+        id=org.id,
+        name=org.name,
+        disable_github_workflow_pulls=org.disable_github_workflow_pulls,
+    )
 
 
 @router.get("/domains", response_model=list[OrgDomainRead])

--- a/tracecat/organization/schemas.py
+++ b/tracecat/organization/schemas.py
@@ -51,6 +51,7 @@ class OrgMemberDetail(BaseModel):
 class OrgRead(BaseModel):
     id: UUID
     name: str
+    disable_github_workflow_pulls: bool
 
 
 class OrgDomainRead(BaseModel):

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -1,9 +1,11 @@
 from fastapi import APIRouter, HTTPException, Query, status
+from sqlalchemy import select
 
 from tracecat import config
 from tracecat.auth.dependencies import WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
+from tracecat.db.models import Organization
 from tracecat.dsl.common import DSLInput
 from tracecat.exceptions import (
     TracecatCredentialsNotFoundError,
@@ -263,6 +265,22 @@ async def pull_workflows(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Workspace ID is required",
+        )
+    if not role.organization_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Organization context is required",
+        )
+
+    org_result = await session.execute(
+        select(Organization.disable_github_workflow_pulls).where(
+            Organization.id == role.organization_id
+        )
+    )
+    if org_result.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Workflow pulls are disabled by your organization administrator",
         )
 
     repository_url = None  # Initialize to avoid UnboundLocalError in exception handlers


### PR DESCRIPTION
## Summary
- Add org-level `disable_github_workflow_pulls` flag (admin-controlled) that hides the workspace pull UI and rejects pulls at `tracecat/workflow/store`.
- Surface the field on the public `OrgRead` and EE admin `OrgRead`/`OrgUpdate` schemas; add a checkbox in the admin org edit dialog.
- Includes Alembic migration `0d0a196bb07d` (default `false`, server-side) and tests for the org service, admin update path, and pull rejection.

## Test plan
- [ ] `uv run pytest tests/unit/api/test_api_admin_organizations.py tests/unit/api/test_api_organization.py tests/unit/api/test_api_workflow_store_publish.py tests/unit/test_admin_org_service.py`
- [ ] `uv run alembic upgrade head` and confirm the new column on `organization`
- [ ] In admin UI: toggle the flag, verify the workspace pull dialog is hidden and the pull endpoint returns 403


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an org-level `disable_github_workflow_pulls` flag so admins can block GitHub workflow pulls. When enabled, the workspace pull UI is hidden and pull requests return 403.

- **New Features**
  - API: `GET /organization` now returns the flag; `POST /workflows/sync/pull` blocks when it’s true.
  - Schemas: flag exposed on public `OrgRead` and EE admin `OrgRead`/`OrgUpdate`.
  - UI: admin org edit dialog adds a checkbox; workspace settings hide the pull dialog when disabled.

- **Migration**
  - Run `alembic upgrade head` to add `disable_github_workflow_pulls` to `organization`.

<sup>Written for commit 0d8b4d5620bea14f50eeaaabe5915a7f97d7d3f2. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2580?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

