### PR TITLE
feat(workflow): restore workflows to previous versions

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -771,6 +771,8 @@ import type {
   WorkflowsPullWorkflowsResponse,
   WorkflowsRemoveTagData,
   WorkflowsRemoveTagResponse,
+  WorkflowsRestoreWorkflowDefinitionData,
+  WorkflowsRestoreWorkflowDefinitionResponse,
   WorkflowsUpdateWorkflowData,
   WorkflowsUpdateWorkflowResponse,
   WorkflowsValidateWorkflowEntrypointData,
@@ -1918,6 +1920,35 @@ export const workflowsListWorkflowDefinitions = (
     method: "GET",
     url: "/workflows/{workflow_id}/definitions",
     path: {
+      workflow_id: data.workflowId,
+    },
+    query: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Restore Workflow Definition
+ * Restore a saved workflow definition as the current published version.
+ * @param data The data for the request.
+ * @param data.version
+ * @param data.workflowId
+ * @param data.workspaceId
+ * @returns WorkflowRead Successful Response
+ * @throws ApiError
+ */
+export const workflowsRestoreWorkflowDefinition = (
+  data: WorkflowsRestoreWorkflowDefinitionData
+): CancelablePromise<WorkflowsRestoreWorkflowDefinitionResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workflows/{workflow_id}/definitions/{version}/restore",
+    path: {
+      version: data.version,
       workflow_id: data.workflowId,
     },
     query: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -8836,6 +8836,14 @@ export type WorkflowsListWorkflowDefinitionsData = {
 export type WorkflowsListWorkflowDefinitionsResponse =
   Array<WorkflowDefinitionRead>
 
+export type WorkflowsRestoreWorkflowDefinitionData = {
+  version: number
+  workflowId: string
+  workspaceId: string
+}
+
+export type WorkflowsRestoreWorkflowDefinitionResponse = WorkflowRead
+
 export type WorkflowsGetWorkflowDefinitionData = {
   version?: number | null
   workflowId: string
@@ -12356,6 +12364,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: Array<WorkflowDefinitionRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workflows/{workflow_id}/definitions/{version}/restore": {
+    post: {
+      req: WorkflowsRestoreWorkflowDefinitionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: WorkflowRead
         /**
          * Validation Error
          */

--- a/frontend/src/components/builder/panel/workflow-panel.tsx
+++ b/frontend/src/components/builder/panel/workflow-panel.tsx
@@ -6,19 +6,36 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import "@radix-ui/react-dialog"
 
-import { FileTextIcon, Info, LayoutListIcon } from "lucide-react"
+import {
+  FileTextIcon,
+  History,
+  Info,
+  LayoutListIcon,
+  RotateCcw,
+} from "lucide-react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 import {
   ApiError,
   type ExpectedField_Input,
+  type WorkflowDefinitionRead,
   type WorkflowRead,
   type WorkflowUpdate,
   workflowsValidateWorkflowEntrypoint,
 } from "@/client"
 import { ControlledYamlField } from "@/components/builder/panel/action-panel-fields"
 import { CopyButton } from "@/components/copy-button"
+import { CenteredSpinner } from "@/components/loading/spinner"
 import { SimpleEditor } from "@/components/tiptap-templates/simple/simple-editor"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
 import {
   Form,
   FormControl,
@@ -33,12 +50,24 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card"
 import { Input } from "@/components/ui/input"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import {
+  useRestoreWorkflowDefinition,
+  useWorkflowDefinitions,
+} from "@/hooks/use-workflow-definitions"
 import {
   isRequestValidationErrorArray,
   type TracecatApiError,
 } from "@/lib/errors"
+import { getRelativeTime } from "@/lib/event-history"
 import { useWorkflow } from "@/providers/workflow"
 
 const createWorkflowUpdateFormSchema = (workspaceId: string) =>
@@ -134,7 +163,7 @@ const workflowReadmeSchema = z
   .string()
   .max(1000, { message: "README cannot exceed 1000 characters" })
 
-type WorkflowPanelTab = "workflow" | "readme"
+type WorkflowPanelTab = "workflow" | "readme" | "versions"
 
 export function WorkflowPanel({
   workflow,
@@ -168,6 +197,13 @@ export function WorkflowPanel({
                 <FileTextIcon className="mr-2 size-4" />
                 <span>README</span>
               </TabsTrigger>
+              <TabsTrigger
+                className="flex h-full min-w-24 items-center justify-center rounded-none px-5 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                value="versions"
+              >
+                <History className="mr-2 size-4" />
+                <span>Versions</span>
+              </TabsTrigger>
             </TabsList>
           </div>
           <Separator />
@@ -179,9 +215,148 @@ export function WorkflowPanel({
           <TabsContent value="readme" className="mt-0 h-full">
             <WorkflowReadmePanel workflow={workflow} />
           </TabsContent>
+          <TabsContent value="versions" className="mt-0 h-full">
+            <WorkflowVersionsPanel workflow={workflow} />
+          </TabsContent>
         </div>
       </Tabs>
     </div>
+  )
+}
+
+function WorkflowVersionsPanel({
+  workflow,
+}: {
+  workflow: WorkflowRead
+}): React.JSX.Element {
+  const { workspaceId, workflowId } = useWorkflow()
+  const { definitions, definitionsIsLoading, definitionsError } =
+    useWorkflowDefinitions(workspaceId, workflowId)
+  const { restoreWorkflowDefinition, restoreWorkflowDefinitionIsPending } =
+    useRestoreWorkflowDefinition(workspaceId, workflowId)
+
+  async function handleRestore(version: number) {
+    await restoreWorkflowDefinition({ version })
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-10 items-center justify-between border-b px-3">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <History className="size-3.5" />
+          <span>Workflow history</span>
+        </div>
+        {workflow.version ? (
+          <Badge variant="secondary">{`Current v${workflow.version}`}</Badge>
+        ) : null}
+      </div>
+      <ScrollArea className="flex-1">
+        <WorkflowVersionsHistory
+          definitions={definitions}
+          definitionsIsLoading={definitionsIsLoading}
+          definitionsError={definitionsError}
+          currentVersion={workflow.version ?? null}
+          restorePending={restoreWorkflowDefinitionIsPending}
+          onRestore={handleRestore}
+        />
+      </ScrollArea>
+    </div>
+  )
+}
+
+function WorkflowVersionsHistory({
+  definitions,
+  definitionsIsLoading,
+  definitionsError,
+  currentVersion,
+  restorePending,
+  onRestore,
+}: {
+  definitions?: WorkflowDefinitionRead[]
+  definitionsIsLoading: boolean
+  definitionsError: unknown
+  currentVersion: number | null
+  restorePending: boolean
+  onRestore: (version: number) => Promise<void>
+}): React.JSX.Element {
+  if (definitionsIsLoading) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <CenteredSpinner />
+      </div>
+    )
+  }
+
+  if (definitionsError) {
+    return (
+      <div className="px-4 py-6 text-sm text-destructive">
+        Failed to load workflow versions.
+      </div>
+    )
+  }
+
+  if (!definitions?.length) {
+    return (
+      <div className="flex h-full items-center justify-center px-4">
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <History />
+            </EmptyMedia>
+            <EmptyTitle>Versions</EmptyTitle>
+            <EmptyDescription>
+              Save the workflow to start tracking versions.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      </div>
+    )
+  }
+
+  return (
+    <TooltipProvider>
+      <div className="flex flex-col">
+        {definitions.map((definition, index) => {
+          const isCurrent = definition.version === currentVersion
+          return (
+            <div key={definition.id}>
+              <div className="flex items-center gap-3 px-4 py-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{`v${definition.version}`}</span>
+                    {isCurrent ? (
+                      <Badge variant="secondary">Current</Badge>
+                    ) : null}
+                  </div>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {getRelativeTime(new Date(definition.created_at))}
+                  </div>
+                </div>
+                {!isCurrent ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-8"
+                        disabled={restorePending}
+                        onClick={() => void onRestore(definition.version)}
+                        aria-label={`Restore v${definition.version}`}
+                      >
+                        <RotateCcw className="size-3.5" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Restore</TooltipContent>
+                  </Tooltip>
+                ) : null}
+              </div>
+              {index < definitions.length - 1 ? <Separator /> : null}
+            </div>
+          )
+        })}
+      </div>
+    </TooltipProvider>
   )
 }
 

--- a/frontend/src/components/builder/panel/workflow-panel.tsx
+++ b/frontend/src/components/builder/panel/workflow-panel.tsx
@@ -27,6 +27,16 @@ import { ControlledYamlField } from "@/components/builder/panel/action-panel-fie
 import { CopyButton } from "@/components/copy-button"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { SimpleEditor } from "@/components/tiptap-templates/simple/simple-editor"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -234,8 +244,18 @@ function WorkflowVersionsPanel({
     useWorkflowDefinitions(workspaceId, workflowId)
   const { restoreWorkflowDefinition, restoreWorkflowDefinitionIsPending } =
     useRestoreWorkflowDefinition(workspaceId, workflowId)
+  const [confirmVersion, setConfirmVersion] = useState<number | null>(null)
 
-  async function handleRestore(version: number) {
+  function handleRestore(version: number) {
+    setConfirmVersion(version)
+  }
+
+  async function handleConfirmRestore() {
+    if (confirmVersion === null) {
+      return
+    }
+    const version = confirmVersion
+    setConfirmVersion(null)
     await restoreWorkflowDefinition({ version })
   }
 
@@ -260,6 +280,31 @@ function WorkflowVersionsPanel({
           onRestore={handleRestore}
         />
       </ScrollArea>
+      <AlertDialog
+        open={confirmVersion !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirmVersion(null)
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Restore workflow version?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirmVersion !== null
+                ? `Restoring v${confirmVersion} will overwrite your current draft. Any uncommitted changes will be discarded.`
+                : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => void handleConfirmRestore()}>
+              Restore
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }
@@ -277,7 +322,7 @@ function WorkflowVersionsHistory({
   definitionsError: unknown
   currentVersion: number | null
   restorePending: boolean
-  onRestore: (version: number) => Promise<void>
+  onRestore: (version: number) => void
 }): React.JSX.Element {
   if (definitionsIsLoading) {
     return (
@@ -345,7 +390,7 @@ function WorkflowVersionsHistory({
                         size="icon"
                         className="size-8"
                         disabled={restorePending}
-                        onClick={() => void onRestore(definition.version)}
+                        onClick={() => onRestore(definition.version)}
                         aria-label={`Restore v${definition.version}`}
                       >
                         <RotateCcw className="size-3.5" />

--- a/frontend/src/components/builder/panel/workflow-panel.tsx
+++ b/frontend/src/components/builder/panel/workflow-panel.tsx
@@ -313,11 +313,14 @@ function WorkflowVersionsHistory({
     )
   }
 
+  const latestVersion = definitions[0]?.version ?? null
+
   return (
     <TooltipProvider>
       <div className="flex flex-col">
         {definitions.map((definition, index) => {
           const isCurrent = definition.version === currentVersion
+          const isLatest = definition.version === latestVersion
           return (
             <div key={definition.id}>
               <div className="flex items-center gap-3 px-4 py-3">
@@ -327,6 +330,7 @@ function WorkflowVersionsHistory({
                     {isCurrent ? (
                       <Badge variant="secondary">Current</Badge>
                     ) : null}
+                    {isLatest ? <Badge variant="outline">Latest</Badge> : null}
                   </div>
                   <div className="mt-1 text-xs text-muted-foreground">
                     {getRelativeTime(new Date(definition.created_at))}

--- a/frontend/src/hooks/use-workflow-definitions.ts
+++ b/frontend/src/hooks/use-workflow-definitions.ts
@@ -1,0 +1,102 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  type WorkflowDefinitionRead,
+  type WorkflowRead,
+  workflowsListWorkflowDefinitions,
+  workflowsRestoreWorkflowDefinition,
+} from "@/client"
+import { toast } from "@/components/ui/use-toast"
+import { retryHandler, type TracecatApiError } from "@/lib/errors"
+
+export function useWorkflowDefinitions(
+  workspaceId: string,
+  workflowId?: string | null,
+  { enabled = true }: { enabled?: boolean } = {}
+) {
+  const {
+    data: definitions,
+    isLoading: definitionsIsLoading,
+    error: definitionsError,
+    refetch: refetchDefinitions,
+  } = useQuery<WorkflowDefinitionRead[], TracecatApiError>({
+    queryKey: ["workflow-definitions", workspaceId, workflowId],
+    queryFn: async () => {
+      if (!workspaceId || !workflowId) {
+        throw new Error("workspaceId and workflowId are required")
+      }
+      const definitions = await workflowsListWorkflowDefinitions({
+        workspaceId,
+        workflowId,
+      })
+      return [...definitions].sort((a, b) => b.version - a.version)
+    },
+    enabled: enabled && Boolean(workspaceId) && Boolean(workflowId),
+    retry: retryHandler,
+  })
+
+  return {
+    definitions,
+    definitionsIsLoading,
+    definitionsError,
+    refetchDefinitions,
+  }
+}
+
+export function useRestoreWorkflowDefinition(
+  workspaceId: string,
+  workflowId?: string | null
+) {
+  const queryClient = useQueryClient()
+
+  const {
+    mutateAsync: restoreWorkflowDefinition,
+    isPending: restoreWorkflowDefinitionIsPending,
+    error: restoreWorkflowDefinitionError,
+  } = useMutation<WorkflowRead, TracecatApiError, { version: number }>({
+    mutationFn: async ({ version }) => {
+      if (!workspaceId || !workflowId) {
+        throw new Error("workspaceId and workflowId are required")
+      }
+      return await workflowsRestoreWorkflowDefinition({
+        workspaceId,
+        workflowId,
+        version,
+      })
+    },
+    onSuccess: (workflow, variables) => {
+      if (!workflowId) {
+        return
+      }
+      queryClient.setQueryData(["workflow", workflowId], workflow)
+      queryClient.invalidateQueries({ queryKey: ["workflow", workflowId] })
+      queryClient.invalidateQueries({
+        queryKey: ["graph", workspaceId, workflowId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["workflow-definitions", workspaceId, workflowId],
+      })
+      queryClient.invalidateQueries({ queryKey: ["workflows"] })
+      toast({
+        title: "Version restored",
+        description: `${workflow.title} now points to v${variables.version}.`,
+      })
+    },
+    onError: (error) => {
+      const detail =
+        typeof error.body?.detail === "string"
+          ? error.body.detail
+          : "Failed to restore workflow version."
+      toast({
+        title: "Restore failed",
+        description: detail,
+        variant: "destructive",
+      })
+    },
+  })
+
+  return {
+    restoreWorkflowDefinition,
+    restoreWorkflowDefinitionIsPending,
+    restoreWorkflowDefinitionError,
+  }
+}

--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -12,6 +12,7 @@ import os
 import re
 import uuid
 from collections.abc import AsyncGenerator, Callable, Mapping
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -26,6 +27,7 @@ pytestmark = [
     pytest.mark.usefixtures("registry_version_with_manifest"),
 ]
 from pydantic import SecretStr, TypeAdapter, ValidationError
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from temporalio.api.enums.v1 import EventType
 from temporalio.client import Client, WorkflowExecutionStatus, WorkflowFailureError
@@ -40,7 +42,13 @@ from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.concurrency import GatheringTaskGroup
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_context_manager
-from tracecat.db.models import Schedule, Workflow
+from tracecat.db.models import (
+    PlatformRegistryRepository,
+    PlatformRegistryVersion,
+    Schedule,
+    Workflow,
+    WorkflowDefinition,
+)
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import (
     RETRY_POLICIES,
@@ -75,6 +83,9 @@ from tracecat.identifiers.workflow import (
 )
 from tracecat.logger import logger
 from tracecat.pagination import CursorPaginationParams
+from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
+from tracecat.registry.lock.service import RegistryLockService
+from tracecat.registry.lock.types import RegistryLock
 from tracecat.secrets.schemas import SecretCreate, SecretKeyValue
 from tracecat.secrets.service import SecretsService
 from tracecat.storage.object import (
@@ -2163,6 +2174,256 @@ async def test_pull_based_workflow_fetches_latest_version(
         f"{wf_exec_id}:second", run_args, worker, executor_worker
     )
     assert await to_data(result) == "__EXPECTED_SECOND_RESULT__"
+
+
+async def _clone_builtin_registry_version(
+    session: AsyncSession, version: str
+) -> tuple[PlatformRegistryVersion, RegistryLock]:
+    repo = await session.scalar(
+        select(PlatformRegistryRepository).where(
+            PlatformRegistryRepository.origin == DEFAULT_REGISTRY_ORIGIN
+        )
+    )
+    if repo is None or repo.current_version_id is None:
+        return pytest.fail("Builtin platform registry was not seeded")
+
+    current = await session.scalar(
+        select(PlatformRegistryVersion).where(
+            PlatformRegistryVersion.id == repo.current_version_id
+        )
+    )
+    if current is None:
+        return pytest.fail("Builtin platform registry current version was not found")
+
+    cloned = PlatformRegistryVersion(
+        repository_id=repo.id,
+        version=version,
+        manifest=deepcopy(current.manifest),
+        tarball_uri=current.tarball_uri,
+    )
+    session.add(cloned)
+    await session.flush()
+    return cloned, RegistryLock(
+        origins={DEFAULT_REGISTRY_ORIGIN: version},
+        actions={"core.transform.reshape": DEFAULT_REGISTRY_ORIGIN},
+    )
+
+
+def _restore_version_dsl(*, title: str, value: str) -> DSLInput:
+    return DSLInput(
+        title=title,
+        description="Restore version regression workflow",
+        entrypoint=DSLEntrypoint(ref="a", expects={}),
+        actions=[
+            ActionStatement(
+                ref="a",
+                action="core.transform.reshape",
+                args={"value": value},
+                depends_on=[],
+            )
+        ],
+        returns="${{ ACTIONS.a.result }}",
+        triggers=[],
+    )
+
+
+async def _run_child_by_alias(
+    *,
+    temporal_client: Client,
+    test_worker_factory: WorkerFactory,
+    test_executor_worker_factory: WorkerFactory,
+    test_role: Role,
+    alias: str,
+    wf_exec_id: str,
+) -> Any:
+    parent_dsl = DSLInput(
+        title="Restore parent",
+        description="Runs restored child by alias",
+        entrypoint=DSLEntrypoint(ref="run_child", expects={}),
+        actions=[
+            ActionStatement(
+                ref="run_child",
+                action="core.workflow.execute",
+                args={
+                    "workflow_alias": alias,
+                    "wait_strategy": WaitStrategy.WAIT.value,
+                },
+                depends_on=[],
+            )
+        ],
+        returns="${{ ACTIONS.run_child.result }}",
+        triggers=[],
+    )
+    run_args = DSLRunArgs(
+        dsl=parent_dsl,
+        role=test_role,
+        wf_id=WorkflowUUID.new("wf-00000000000000000000000000000002"),
+    )
+    worker = test_worker_factory(temporal_client)
+    executor_worker = test_executor_worker_factory(temporal_client)
+    return await _run_workflow(wf_exec_id, run_args, worker, executor_worker)
+
+
+@pytest.mark.anyio
+async def test_restored_workflow_definition_is_current_and_next_save_appends(
+    temporal_client: Client,
+    test_role: Role,
+    test_worker_factory: WorkerFactory,
+    test_executor_worker_factory: WorkerFactory,
+) -> None:
+    """Restoring v2 from v7 must not overwrite v3-v7, and next save creates v8."""
+    test_name = (
+        test_restored_workflow_definition_is_current_and_next_save_appends.__name__
+    )
+    alias = f"restore_child_{uuid.uuid4().hex}"
+    wf_exec_id = generate_test_exec_id(test_name)
+    definition_snapshots: dict[int, tuple[dict[str, Any], dict[str, Any] | None]] = {}
+
+    async with get_async_session_context_manager() as session:
+        mgmt_service = WorkflowsManagementService(session, role=test_role)
+        defn_service = WorkflowDefinitionsService(session, role=test_role)
+
+        lock_rows = {}
+        locks = {}
+        for version in range(1, 9):
+            lock_rows[version], locks[version] = await _clone_builtin_registry_version(
+                session, f"{test_name}-{version}-{uuid.uuid4().hex}"
+            )
+
+        first_dsl = _restore_version_dsl(title=f"{test_name}:v1", value="one")
+        res = await mgmt_service.create_workflow_from_dsl(
+            first_dsl.model_dump(), skip_secret_validation=True
+        )
+        workflow = res.workflow
+        if workflow is None:
+            return pytest.fail("Workflow wasn't created")
+        workflow_id = WorkflowUUID.new(workflow.id)
+        await mgmt_service.update_workflow(workflow_id, WorkflowUpdate(alias=alias))
+        await session.refresh(workflow)
+
+        definitions = []
+        for version in range(1, 8):
+            dsl = _restore_version_dsl(
+                title=f"{test_name}:v{version}", value=f"value-{version}"
+            )
+            defn = await defn_service.create_workflow_definition(
+                workflow_id=workflow_id,
+                dsl=dsl,
+                alias=alias,
+                registry_lock=locks[version],
+                commit=False,
+            )
+            definitions.append(defn)
+            definition_snapshots[version] = (
+                deepcopy(defn.content),
+                deepcopy(defn.registry_lock),
+            )
+
+        workflow.version = 7
+        workflow.registry_lock = definitions[6].registry_lock
+        session.add(workflow)
+        await session.commit()
+
+    result = await _run_child_by_alias(
+        temporal_client=temporal_client,
+        test_worker_factory=test_worker_factory,
+        test_executor_worker_factory=test_executor_worker_factory,
+        test_role=test_role,
+        alias=alias,
+        wf_exec_id=f"{wf_exec_id}:v7",
+    )
+    assert await to_data(result) == "value-7"
+
+    async with get_async_session_context_manager() as session:
+        mgmt_service = WorkflowsManagementService(session, role=test_role)
+        defn_service = WorkflowDefinitionsService(session, role=test_role)
+
+        workflow = await mgmt_service.get_workflow(workflow_id)
+        if workflow is None:
+            return pytest.fail("Workflow wasn't found")
+        version_two = await defn_service.get_definition_by_workflow_id(
+            workflow_id, version=2
+        )
+        if version_two is None:
+            return pytest.fail("Workflow definition v2 wasn't found")
+
+        restored = await mgmt_service.restore_workflow_definition(workflow, version_two)
+        assert restored.version == 2
+        assert restored.registry_lock == definition_snapshots[2][1]
+        assert restored.graph_version == 2
+
+        rows = (
+            await session.execute(
+                select(WorkflowDefinition).where(
+                    WorkflowDefinition.workflow_id == workflow_id
+                )
+            )
+        ).scalars()
+        by_version = {row.version: row for row in rows}
+        assert set(by_version) == set(range(1, 8))
+        for version in range(3, 8):
+            assert by_version[version].content == definition_snapshots[version][0]
+            assert by_version[version].registry_lock == definition_snapshots[version][1]
+
+    result = await _run_child_by_alias(
+        temporal_client=temporal_client,
+        test_worker_factory=test_worker_factory,
+        test_executor_worker_factory=test_executor_worker_factory,
+        test_role=test_role,
+        alias=alias,
+        wf_exec_id=f"{wf_exec_id}:restored-v2",
+    )
+    assert await to_data(result) == "value-2"
+
+    async with get_async_session_context_manager() as session:
+        repo = await session.scalar(
+            select(PlatformRegistryRepository).where(
+                PlatformRegistryRepository.origin == DEFAULT_REGISTRY_ORIGIN
+            )
+        )
+        if repo is None:
+            return pytest.fail("Builtin platform registry was not found")
+        repo.current_version_id = lock_rows[8].id
+        session.add(repo)
+        await session.commit()
+
+        mgmt_service = WorkflowsManagementService(session, role=test_role)
+        workflow = await mgmt_service.get_workflow(workflow_id)
+        if workflow is None:
+            return pytest.fail("Workflow wasn't found")
+        restored_dsl = await mgmt_service.build_dsl_from_workflow(workflow)
+        fresh_lock = await RegistryLockService(
+            session, role=test_role
+        ).resolve_lock_with_bindings({"core.transform.reshape"})
+        new_defn = await WorkflowDefinitionsService(
+            session, role=test_role
+        ).create_workflow_definition(
+            workflow_id=workflow_id,
+            dsl=restored_dsl,
+            alias=alias,
+            registry_lock=fresh_lock,
+            commit=False,
+        )
+        workflow.version = new_defn.version
+        workflow.registry_lock = new_defn.registry_lock
+        session.add(workflow)
+        await session.commit()
+
+        assert new_defn.version == 8
+        assert new_defn.content["actions"][0]["args"]["value"] == "value-2"
+        assert new_defn.registry_lock != definition_snapshots[2][1]
+        rows = (
+            await session.execute(
+                select(WorkflowDefinition).where(
+                    WorkflowDefinition.workflow_id == workflow_id
+                )
+            )
+        ).scalars()
+        by_version = {row.version: row for row in rows}
+        assert set(by_version) == set(range(1, 9))
+        for version in range(3, 8):
+            assert by_version[version].content == definition_snapshots[version][0]
+            assert by_version[version].registry_lock == definition_snapshots[version][1]
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_workflows.py
+++ b/tests/unit/api/test_api_workflows.py
@@ -664,6 +664,50 @@ async def test_update_workflow_duplicate_alias(
 
 
 @pytest.mark.anyio
+async def test_restore_workflow_definition_duplicate_alias_returns_conflict(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow: Workflow,
+) -> None:
+    """Test restore maps duplicate alias constraint violations to 409."""
+    with (
+        patch(
+            "tracecat.workflow.management.router.WorkflowsManagementService"
+        ) as MockManagementService,
+        patch(
+            "tracecat.workflow.management.router.WorkflowDefinitionsService"
+        ) as MockDefinitionsService,
+    ):
+        definition = SimpleNamespace(
+            workflow_id=mock_workflow.id,
+            version=1,
+        )
+        unique_error = AsyncpgUniqueViolationError("uq_workflow_alias_workspace_id")
+        integrity_error = IntegrityError("", {}, unique_error)
+        integrity_error.__cause__ = unique_error
+
+        mock_mgmt = AsyncMock()
+        mock_mgmt.get_workflow.return_value = mock_workflow
+        mock_mgmt.restore_workflow_definition.side_effect = integrity_error
+        MockManagementService.return_value = mock_mgmt
+
+        mock_definitions = AsyncMock()
+        mock_definitions.get_definition_by_workflow_id.return_value = definition
+        MockDefinitionsService.return_value = mock_definitions
+
+        response = client.post(
+            f"/workflows/{mock_workflow.id}/definitions/1/restore",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert (
+        response.json()["detail"]
+        == "Workflow alias must be unique within the workspace."
+    )
+
+
+@pytest.mark.anyio
 async def test_delete_workflow_success(
     client: TestClient,
     test_admin_role: Role,

--- a/tests/unit/api/test_api_workflows.py
+++ b/tests/unit/api/test_api_workflows.py
@@ -708,6 +708,21 @@ async def test_restore_workflow_definition_duplicate_alias_returns_conflict(
 
 
 @pytest.mark.anyio
+async def test_restore_workflow_definition_rejects_non_positive_version(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow: Workflow,
+) -> None:
+    """Test restore rejects invalid definition versions before service lookup."""
+    response = client.post(
+        f"/workflows/{mock_workflow.id}/definitions/0/restore",
+        params={"workspace_id": str(test_admin_role.workspace_id)},
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.anyio
 async def test_delete_workflow_success(
     client: TestClient,
     test_admin_role: Role,

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -40,6 +40,7 @@ from tracecat.validation.schemas import (
     ValidationResult,
     ValidationResultType,
 )
+from tracecat.workflow.management import layout as layout_module
 
 _original_create_mcp_auth = mcp_auth.create_mcp_auth
 try:
@@ -466,13 +467,13 @@ async def test_validate_template_action_remote_rejects_client_mismatch(monkeypat
 
 
 def test_auto_generate_layout_handles_cycles():
-    actions: list[mcp_server.WorkflowActionLayoutInput] = [
+    actions: list[layout_module.WorkflowActionLayoutInput] = [
         {"ref": "start", "depends_on": []},
         {"ref": "middle", "depends_on": ["start", "end"]},
         {"ref": "end", "depends_on": ["middle"]},
     ]
 
-    layout = mcp_server._auto_generate_layout(actions)
+    layout = layout_module.auto_generate_layout(actions)
     refs = {item["ref"] for item in layout["actions"]}
 
     assert refs == {"start", "middle", "end"}
@@ -525,11 +526,11 @@ def test_extract_layout_positions_nested_position_shape():
 
 def test_auto_generate_layout_round_trips_through_extract():
     """Auto-generated layout can be extracted into position tuples."""
-    actions: list[mcp_server.WorkflowActionLayoutInput] = [
+    actions: list[layout_module.WorkflowActionLayoutInput] = [
         {"ref": "step1", "depends_on": []},
         {"ref": "step2", "depends_on": ["step1"]},
     ]
-    layout_data = mcp_server._auto_generate_layout(actions)
+    layout_data = layout_module.auto_generate_layout(actions)
     trigger, viewport, action_positions = mcp_server._extract_layout_positions(
         layout_data
     )

--- a/tests/unit/test_workflow_definitions_service.py
+++ b/tests/unit/test_workflow_definitions_service.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import pytest
 import yaml
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.types import Role
@@ -42,6 +43,94 @@ async def workflow_id(
     finally:
         await session.delete(workflow)
         await session.commit()
+
+
+def _dsl_input(marker: str) -> DSLInput:
+    return DSLInput.model_validate(
+        {
+            "title": f"Test Workflow {marker}",
+            "description": "Test workflow for definitions testing",
+            "entrypoint": {"ref": "test_action"},
+            "actions": [
+                {
+                    "ref": "test_action",
+                    "action": "core.transform.transform",
+                    "args": {"value": marker},
+                }
+            ],
+        }
+    )
+
+
+@pytest.mark.anyio
+async def test_get_definition_prefers_workflow_current_version(
+    definitions_service: WorkflowDefinitionsService,
+    workflow_id: WorkflowUUID,
+    session: AsyncSession,
+):
+    version_one = await definitions_service.create_workflow_definition(
+        workflow_id=workflow_id,
+        dsl=_dsl_input("v1"),
+        commit=True,
+    )
+    version_two = await definitions_service.create_workflow_definition(
+        workflow_id=workflow_id,
+        dsl=_dsl_input("v2"),
+        commit=True,
+    )
+
+    workflow = await session.scalar(select(Workflow).where(Workflow.id == workflow_id))
+    assert workflow is not None
+    workflow.version = version_one.version
+    await session.commit()
+
+    current = await definitions_service.get_definition_by_workflow_id(workflow_id)
+    assert current is not None
+    assert current.id == version_one.id
+
+    explicit = await definitions_service.get_definition_by_workflow_id(
+        workflow_id, version=version_two.version
+    )
+    assert explicit is not None
+    assert explicit.id == version_two.id
+
+
+@pytest.mark.anyio
+async def test_get_definition_falls_back_to_latest_when_current_version_missing(
+    definitions_service: WorkflowDefinitionsService,
+    workflow_id: WorkflowUUID,
+    session: AsyncSession,
+):
+    await definitions_service.create_workflow_definition(
+        workflow_id=workflow_id,
+        dsl=_dsl_input("v1"),
+        commit=True,
+    )
+    version_two = await definitions_service.create_workflow_definition(
+        workflow_id=workflow_id,
+        dsl=_dsl_input("v2"),
+        commit=True,
+    )
+
+    workflow = await session.scalar(select(Workflow).where(Workflow.id == workflow_id))
+    assert workflow is not None
+    workflow.version = version_two.version + 10
+    await session.commit()
+
+    stale_pointer_result = await definitions_service.get_definition_by_workflow_id(
+        workflow_id
+    )
+    assert stale_pointer_result is not None
+    assert stale_pointer_result.id == version_two.id
+
+    workflow.version = None
+    await session.commit()
+
+    null_pointer_result = await definitions_service.get_definition_by_workflow_id(
+        workflow_id
+    )
+    assert null_pointer_result is not None
+    assert null_pointer_result.id == version_two.id
 
 
 @pytest.mark.anyio

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -18,16 +18,7 @@ from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from io import StringIO
 from pathlib import PurePosixPath
-from typing import (
-    Annotated,
-    Any,
-    Literal,
-    NotRequired,
-    Protocol,
-    TypedDict,
-    cast,
-    get_args,
-)
+from typing import Annotated, Any, Literal, Protocol, TypedDict, cast, get_args
 
 import orjson
 import sqlalchemy as sa
@@ -238,6 +229,10 @@ from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.executions.service import WorkflowExecutionsService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.folders.service import WorkflowFolderService
+from tracecat.workflow.management.layout import (
+    WorkflowActionLayoutInput,
+    auto_generate_layout,
+)
 from tracecat.workflow.management.management import WorkflowsManagementService
 from tracecat.workflow.management.schemas import WorkflowCreate, WorkflowUpdate
 from tracecat.workflow.schedules.schemas import (
@@ -733,33 +728,6 @@ class ActionSecretRequirementPayload(TypedDict):
     required_keys: list[str]
     optional_keys: list[str]
     optional: bool
-
-
-class WorkflowActionLayoutInput(TypedDict):
-    """Minimal action shape needed to auto-generate workflow layout."""
-
-    ref: str
-    depends_on: NotRequired[list[str]]
-
-
-class GeneratedLayoutPoint(TypedDict):
-    """Generated x/y layout coordinates."""
-
-    x: float
-    y: float
-
-
-class GeneratedLayoutAction(GeneratedLayoutPoint):
-    """Generated action layout coordinates."""
-
-    ref: str
-
-
-class GeneratedWorkflowLayout(TypedDict):
-    """Generated workflow layout payload."""
-
-    trigger: GeneratedLayoutPoint
-    actions: list[GeneratedLayoutAction]
 
 
 class WorkflowSummaryResponse(BaseModel):
@@ -2540,86 +2508,6 @@ def _ensure_inline_workflow_yaml_size(definition_yaml: str) -> None:
         )
 
 
-def _auto_generate_layout(
-    actions: Sequence[WorkflowActionLayoutInput],
-) -> GeneratedWorkflowLayout:
-    """Generate a top-down layout for workflow actions when none is provided.
-
-    Walks the dependency graph to assign each action a depth (row), then
-    spreads siblings horizontally. The trigger node sits at the top.
-    """
-    NODE_HEIGHT = 300  # vertical spacing between rows
-    NODE_WIDTH = 300  # horizontal spacing between columns
-
-    # Build dependency graph
-    dependents: dict[str, list[str]] = {a["ref"]: [] for a in actions}
-    deps: dict[str, list[str]] = {}
-    for a in actions:
-        deps[a["ref"]] = a.get("depends_on", []) or []
-        for dep in deps[a["ref"]]:
-            if dep in dependents:
-                dependents[dep].append(a["ref"])
-
-    # Assign depth via BFS from roots
-    depth: dict[str, int] = {}
-    roots = [ref for ref, d in deps.items() if not d]
-    # If no roots found (cycle?), just use insertion order
-    if not roots:
-        for i, a in enumerate(actions):
-            depth[a["ref"]] = i
-    else:
-        queue = deque(roots)
-        max_depth = max(len(actions) - 1, 0)
-        for r in roots:
-            depth[r] = 0
-        while queue:
-            ref = queue.popleft()
-            for child in dependents.get(ref, []):
-                new_depth = depth[ref] + 1
-                if new_depth > max_depth:
-                    continue
-                if child not in depth or new_depth > depth[child]:
-                    depth[child] = new_depth
-                    queue.append(child)
-    if len(depth) < len(actions):
-        next_depth = max(depth.values(), default=-1) + 1
-        for action in actions:
-            ref = action["ref"]
-            if ref not in depth:
-                depth[ref] = next_depth
-                next_depth += 1
-
-    # Group actions by depth
-    rows: dict[int, list[str]] = {}
-    for ref, d in depth.items():
-        rows.setdefault(d, []).append(ref)
-
-    # Sort refs within each row for deterministic output
-    for d in rows:
-        rows[d].sort()
-
-    # Position: trigger at top, then each row below
-    layout: GeneratedWorkflowLayout = {
-        "trigger": {"x": 0, "y": 0},
-        "actions": [],
-    }
-    for d in sorted(rows.keys()):
-        refs_in_row = rows[d]
-        total_width = (len(refs_in_row) - 1) * NODE_WIDTH
-        start_x = -total_width / 2
-        y = (d + 1) * NODE_HEIGHT  # +1 to leave room for trigger
-        for i, ref in enumerate(refs_in_row):
-            layout["actions"].append(
-                {
-                    "ref": ref,
-                    "x": start_x + i * NODE_WIDTH,
-                    "y": y,
-                }
-            )
-
-    return layout
-
-
 async def _replace_workflow_definition_from_dsl(
     service: WorkflowsManagementService,
     workflow: Workflow,
@@ -2849,7 +2737,7 @@ def _build_import_data_from_workflow_yaml(
     if not layout:
         actions = definition.get("actions", [])
         if actions:
-            normalized["layout"] = _auto_generate_layout(
+            normalized["layout"] = auto_generate_layout(
                 cast(Sequence[WorkflowActionLayoutInput], actions)
             )
     return normalized
@@ -2900,7 +2788,7 @@ async def _apply_workflow_yaml_update(
         defn_raw = raw.get("definition", raw) if isinstance(raw, dict) else {}
         actions_raw = defn_raw.get("actions", [])
         if actions_raw:
-            auto_layout = _auto_generate_layout(
+            auto_layout = auto_generate_layout(
                 cast(Sequence[WorkflowActionLayoutInput], actions_raw)
             )
             yaml_payload.layout = WorkflowLayout.model_validate(auto_layout)

--- a/tracecat/workflow/management/definitions.py
+++ b/tracecat/workflow/management/definitions.py
@@ -43,7 +43,22 @@ class WorkflowDefinitionsService(BaseWorkspaceService):
         if version:
             statement = statement.where(WorkflowDefinition.version == version)
         else:
-            # Get the latest version
+            version_stmt = select(Workflow.version).where(
+                Workflow.workspace_id == self.workspace_id,
+                Workflow.id == workflow_id,
+            )
+            current_version = (
+                await self.session.execute(version_stmt)
+            ).scalar_one_or_none()
+            if current_version:
+                current_statement = statement.where(
+                    WorkflowDefinition.version == current_version
+                )
+                current_result = await self.session.execute(current_statement)
+                if current_defn := current_result.scalars().first():
+                    return current_defn
+
+            # Legacy fallback for workflows without a current version pointer.
             statement = statement.order_by(WorkflowDefinition.version.desc())
 
         result = await self.session.execute(statement)

--- a/tracecat/workflow/management/definitions.py
+++ b/tracecat/workflow/management/definitions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import case, select
 from sqlalchemy.orm import selectinload
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
@@ -40,26 +40,21 @@ class WorkflowDefinitionsService(BaseWorkspaceService):
                 )
             )
         )
-        if version:
+        if version is not None:
             statement = statement.where(WorkflowDefinition.version == version)
         else:
-            version_stmt = select(Workflow.version).where(
-                Workflow.workspace_id == self.workspace_id,
-                Workflow.id == workflow_id,
-            )
-            current_version = (
-                await self.session.execute(version_stmt)
-            ).scalar_one_or_none()
-            if current_version:
-                current_statement = statement.where(
-                    WorkflowDefinition.version == current_version
+            current_version_sq = (
+                select(Workflow.version)
+                .where(
+                    Workflow.workspace_id == self.workspace_id,
+                    Workflow.id == workflow_id,
                 )
-                current_result = await self.session.execute(current_statement)
-                if current_defn := current_result.scalars().first():
-                    return current_defn
-
-            # Legacy fallback for workflows without a current version pointer.
-            statement = statement.order_by(WorkflowDefinition.version.desc())
+                .scalar_subquery()
+            )
+            statement = statement.order_by(
+                case((WorkflowDefinition.version == current_version_sq, 0), else_=1),
+                WorkflowDefinition.version.desc(),
+            ).limit(1)
 
         result = await self.session.execute(statement)
         return result.scalars().first()

--- a/tracecat/workflow/management/layout.py
+++ b/tracecat/workflow/management/layout.py
@@ -1,0 +1,109 @@
+"""Auto-layout helpers for workflow graphs."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Sequence
+from typing import NotRequired, TypedDict
+
+
+class WorkflowActionLayoutInput(TypedDict):
+    """Minimal action shape needed to auto-generate workflow layout."""
+
+    ref: str
+    depends_on: NotRequired[list[str]]
+
+
+class GeneratedLayoutPoint(TypedDict):
+    """Generated x/y layout coordinates."""
+
+    x: float
+    y: float
+
+
+class GeneratedLayoutAction(GeneratedLayoutPoint):
+    """Generated action layout coordinates."""
+
+    ref: str
+
+
+class GeneratedWorkflowLayout(TypedDict):
+    """Generated workflow layout payload."""
+
+    trigger: GeneratedLayoutPoint
+    actions: list[GeneratedLayoutAction]
+
+
+NODE_HEIGHT = 300
+NODE_WIDTH = 300
+
+
+def auto_generate_layout(
+    actions: Sequence[WorkflowActionLayoutInput],
+) -> GeneratedWorkflowLayout:
+    """Generate a top-down layout for workflow actions when none is provided.
+
+    Walks the dependency graph to assign each action a depth (row), then
+    spreads siblings horizontally. The trigger node sits at the top.
+    """
+    dependents: dict[str, list[str]] = {a["ref"]: [] for a in actions}
+    deps: dict[str, list[str]] = {}
+    for a in actions:
+        deps[a["ref"]] = a.get("depends_on", []) or []
+        for dep in deps[a["ref"]]:
+            if dep in dependents:
+                dependents[dep].append(a["ref"])
+
+    depth: dict[str, int] = {}
+    roots = [ref for ref, d in deps.items() if not d]
+    if not roots:
+        for i, a in enumerate(actions):
+            depth[a["ref"]] = i
+    else:
+        queue = deque(roots)
+        max_depth = max(len(actions) - 1, 0)
+        for r in roots:
+            depth[r] = 0
+        while queue:
+            ref = queue.popleft()
+            for child in dependents.get(ref, []):
+                new_depth = depth[ref] + 1
+                if new_depth > max_depth:
+                    continue
+                if child not in depth or new_depth > depth[child]:
+                    depth[child] = new_depth
+                    queue.append(child)
+    if len(depth) < len(actions):
+        next_depth = max(depth.values(), default=-1) + 1
+        for action in actions:
+            ref = action["ref"]
+            if ref not in depth:
+                depth[ref] = next_depth
+                next_depth += 1
+
+    rows: dict[int, list[str]] = {}
+    for ref, d in depth.items():
+        rows.setdefault(d, []).append(ref)
+
+    for d in rows:
+        rows[d].sort()
+
+    layout: GeneratedWorkflowLayout = {
+        "trigger": {"x": 0, "y": 0},
+        "actions": [],
+    }
+    for d in sorted(rows.keys()):
+        refs_in_row = rows[d]
+        total_width = (len(refs_in_row) - 1) * NODE_WIDTH
+        start_x = -total_width / 2
+        y = (d + 1) * NODE_HEIGHT
+        for i, ref in enumerate(refs_in_row):
+            layout["actions"].append(
+                {
+                    "ref": ref,
+                    "x": start_x + i * NODE_WIDTH,
+                    "y": y,
+                }
+            )
+
+    return layout

--- a/tracecat/workflow/management/layout.py
+++ b/tracecat/workflow/management/layout.py
@@ -51,8 +51,9 @@ def auto_generate_layout(
     for a in actions:
         deps[a["ref"]] = a.get("depends_on", []) or []
         for dep in deps[a["ref"]]:
-            if dep in dependents:
-                dependents[dep].append(a["ref"])
+            src = dep.split(".", 1)[0]
+            if src in dependents:
+                dependents[src].append(a["ref"])
 
     depth: dict[str, int] = {}
     roots = [ref for ref, d in deps.items() if not d]

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -699,8 +699,11 @@ class WorkflowsManagementService(BaseWorkspaceService):
             # Legacy fallback for workflows without a current version pointer.
             statement = (
                 select(WorkflowDefinition.workflow_id)
+                .join(Workflow, Workflow.id == WorkflowDefinition.workflow_id)
                 .where(
                     WorkflowDefinition.workspace_id == self.workspace_id,
+                    Workflow.workspace_id == self.workspace_id,
+                    Workflow.version.is_(None),
                     WorkflowDefinition.alias == alias,
                 )
                 .order_by(WorkflowDefinition.version.desc())

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -678,6 +678,10 @@ class WorkflowsManagementService(BaseWorkspaceService):
                     WorkflowDefinition.workspace_id == self.workspace_id,
                     WorkflowDefinition.alias == alias,
                 )
+                .order_by(
+                    WorkflowDefinition.created_at.desc(),
+                    WorkflowDefinition.workflow_id.desc(),
+                )
                 .limit(1)
             )
             result = await self.session.execute(statement)

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -929,9 +929,8 @@ class WorkflowsManagementService(BaseWorkspaceService):
             )
         )
         await self.create_actions_from_dsl(dsl, workflow.id)
-        await self.session.commit()
-        await self.session.refresh(workflow)
-        await self.session.refresh(workflow, ["actions", "webhook", "schedules"])
+        await self.session.flush()
+        await self.session.refresh(workflow, ["actions"])
 
         layout = auto_generate_layout(
             [
@@ -969,7 +968,8 @@ class WorkflowsManagementService(BaseWorkspaceService):
                 ),
             ],
         )
-        await self.session.refresh(workflow, ["actions"])
+        await self.session.refresh(workflow)
+        await self.session.refresh(workflow, ["actions", "webhook", "schedules"])
         return workflow
 
     @require_scope("workflow:create")

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 import sqlalchemy as sa
 import yaml
+from fastapi import HTTPException, status
 from pydantic import ValidationError
 from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import selectinload
@@ -908,6 +909,30 @@ class WorkflowsManagementService(BaseWorkspaceService):
         if definition.workflow_id != workflow.id:
             raise TracecatValidationError(
                 "Workflow definition does not belong to the selected workflow"
+            )
+
+        # Re-read the row under FOR UPDATE so concurrent graph mutations
+        # cannot race the action rewrite below. The expected `graph_version`
+        # is whatever the caller observed; if the DB has moved on, abort.
+        expected_graph_version = workflow.graph_version
+        locked = await self.session.execute(
+            select(Workflow.graph_version)
+            .where(
+                Workflow.workspace_id == self.workspace_id,
+                Workflow.id == workflow.id,
+            )
+            .with_for_update()
+        )
+        current_graph_version = locked.scalar_one_or_none()
+        if current_graph_version is None:
+            raise TracecatValidationError("Workflow no longer exists")
+        if current_graph_version != expected_graph_version:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "message": "This workflow has been edited since you opened it. Refresh to see the latest version before restoring.",
+                    "current_version": current_graph_version,
+                },
             )
 
         dsl = DSLInput.model_validate(definition.content)

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -664,7 +664,27 @@ class WorkflowsManagementService(BaseWorkspaceService):
                            If False, resolve from draft Workflow aliases (for draft executions).
         """
         if use_committed:
-            # For published executions: resolve from the latest committed definition with this alias
+            # For published executions: resolve from the current committed definition.
+            statement = (
+                select(WorkflowDefinition.workflow_id)
+                .join(
+                    Workflow,
+                    and_(
+                        Workflow.id == WorkflowDefinition.workflow_id,
+                        Workflow.version == WorkflowDefinition.version,
+                    ),
+                )
+                .where(
+                    WorkflowDefinition.workspace_id == self.workspace_id,
+                    WorkflowDefinition.alias == alias,
+                )
+                .limit(1)
+            )
+            result = await self.session.execute(statement)
+            if res := result.scalar_one_or_none():
+                return WorkflowUUID.new(res)
+
+            # Legacy fallback for workflows without a current version pointer.
             statement = (
                 select(WorkflowDefinition.workflow_id)
                 .where(
@@ -868,6 +888,40 @@ class WorkflowsManagementService(BaseWorkspaceService):
             returns=workflow.returns,
             error_handler=workflow.error_handler,
         )
+
+    @require_scope("workflow:update")
+    async def restore_workflow_definition(
+        self, workflow: Workflow, definition: WorkflowDefinition
+    ) -> Workflow:
+        """Restore a workflow definition as the current mutable draft."""
+        if definition.workflow_id != workflow.id:
+            raise TracecatValidationError(
+                "Workflow definition does not belong to the selected workflow"
+            )
+
+        dsl = DSLInput.model_validate(definition.content)
+        workflow.title = dsl.title
+        workflow.description = dsl.description
+        workflow.expects = dsl.entrypoint.expects or {}
+        workflow.returns = dsl.returns
+        workflow.config = dsl.config.model_dump()
+        workflow.error_handler = dsl.error_handler
+        workflow.alias = definition.alias
+        workflow.version = definition.version
+        workflow.registry_lock = definition.registry_lock
+        workflow.graph_version += 1
+
+        await self.session.execute(
+            sa.delete(Action).where(
+                Action.workspace_id == self.workspace_id,
+                Action.workflow_id == workflow.id,
+            )
+        )
+        await self.create_actions_from_dsl(dsl, workflow.id)
+        await self.session.commit()
+        await self.session.refresh(workflow)
+        await self.session.refresh(workflow, ["actions", "webhook", "schedules"])
+        return workflow
 
     @require_scope("workflow:create")
     async def create_workflow_from_external_definition(

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -59,10 +59,17 @@ from tracecat.validation.service import validate_dsl
 from tracecat.workflow.actions.schemas import ActionControlFlow, ActionEdge
 from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.executions.enums import ExecutionType
+from tracecat.workflow.graph.service import WorkflowGraphService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
+from tracecat.workflow.management.layout import (
+    WorkflowActionLayoutInput,
+    auto_generate_layout,
+)
 from tracecat.workflow.management.schemas import (
     ExternalWorkflowDefinition,
     GetErrorHandlerWorkflowIDActivityInputs,
+    GraphOperation,
+    GraphOperationType,
     ResolveWorkflowAliasActivityInputs,
     WorkflowCreate,
     WorkflowDSLCreateResponse,
@@ -925,6 +932,44 @@ class WorkflowsManagementService(BaseWorkspaceService):
         await self.session.commit()
         await self.session.refresh(workflow)
         await self.session.refresh(workflow, ["actions", "webhook", "schedules"])
+
+        layout = auto_generate_layout(
+            [
+                WorkflowActionLayoutInput(
+                    ref=action.ref, depends_on=list(action.depends_on)
+                )
+                for action in dsl.actions
+            ]
+        )
+        ref_to_action_id = {action.ref: str(action.id) for action in workflow.actions}
+        positions = [
+            {
+                "action_id": ref_to_action_id[item["ref"]],
+                "x": item["x"],
+                "y": item["y"],
+            }
+            for item in layout["actions"]
+            if item["ref"] in ref_to_action_id
+        ]
+        graph_service = WorkflowGraphService(self.session, role=self.role)
+        await graph_service.apply_operations(
+            workflow_id=WorkflowUUID.new(workflow.id),
+            base_version=workflow.graph_version,
+            operations=[
+                GraphOperation(
+                    type=GraphOperationType.MOVE_NODES,
+                    payload={"positions": positions},
+                ),
+                GraphOperation(
+                    type=GraphOperationType.UPDATE_TRIGGER_POSITION,
+                    payload={
+                        "x": layout["trigger"]["x"],
+                        "y": layout["trigger"]["y"],
+                    },
+                ),
+            ],
+        )
+        await self.session.refresh(workflow, ["actions"])
         return workflow
 
     @require_scope("workflow:create")

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -711,6 +711,62 @@ async def list_workflow_definitions(
     return WorkflowDefinitionRead.list_adapter().validate_python(defns)
 
 
+@router.post(
+    "/{workflow_id}/definitions/{version}/restore",
+    tags=["workflows"],
+    response_model=WorkflowRead,
+)
+@require_scope("workflow:update")
+async def restore_workflow_definition(
+    role: WorkspaceActorRole,
+    session: AsyncDBSession,
+    workflow_id: AnyWorkflowIDPath,
+    version: int,
+) -> WorkflowRead:
+    """Restore a saved workflow definition as the current published version."""
+    mgmt_service = WorkflowsManagementService(session, role=role)
+    workflow = await mgmt_service.get_workflow(workflow_id)
+    if workflow is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Workflow not found",
+        )
+
+    defn_service = WorkflowDefinitionsService(session, role=role)
+    definition = await defn_service.get_definition_by_workflow_id(
+        workflow_id, version=version
+    )
+    if definition is None or definition.workflow_id != workflow.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Workflow definition not found",
+        )
+
+    try:
+        await mgmt_service.restore_workflow_definition(workflow, definition)
+    except (TracecatValidationError, ValidationError) as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except IntegrityError as e:
+        while cause := e.__cause__:
+            e = cause
+        if isinstance(
+            e, UniqueViolationError
+        ) and DBConstraints.WORKFLOW_ALIAS_UNIQUE_IN_WORKSPACE in str(e):
+            logger.warning("Unique violation error", error=e)
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=DBConstraints.WORKFLOW_ALIAS_UNIQUE_IN_WORKSPACE.msg(),
+            ) from e
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Workflow already exists",
+        ) from e
+    return await get_workflow(role=role, session=session, workflow_id=workflow_id)
+
+
 @router.get("/{workflow_id}/definition", tags=["workflows"])
 @require_scope("workflow:read")
 async def get_workflow_definition(

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -11,6 +11,7 @@ from fastapi import (
     File,
     Form,
     HTTPException,
+    Path,
     Query,
     Response,
     UploadFile,
@@ -721,7 +722,7 @@ async def restore_workflow_definition(
     role: WorkspaceActorRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
-    version: int,
+    version: int = Path(..., ge=1),
 ) -> WorkflowRead:
     """Restore a saved workflow definition as the current published version."""
     mgmt_service = WorkflowsManagementService(session, role=role)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore a workflow to any saved version without altering history. Adds a Versions tab in the builder and an API to set the current published version.

- **New Features**
  - API: POST `/workflows/{workflow_id}/definitions/{version}/restore` returns `WorkflowRead`; maps duplicate alias to HTTP 409; rejects non-positive `version` with HTTP 422.
  - Backend: `restore_workflow_definition` sets `version` and `registry_lock`, updates fields, rebuilds actions, and bumps `graph_version`.
  - Frontend: Versions tab lists history and lets you restore; shows “Current vX”, relative timestamps, loading states, tooltips, and toasts.
  - Hooks/client: `useWorkflowDefinitions`, `useRestoreWorkflowDefinition`, and `workflowsRestoreWorkflowDefinition` with types.
  - Tests: ensure restoring (e.g., v2 from v7) keeps v3–v7 intact; next save becomes v8; execution by alias runs the restored version; API returns 409 on alias conflicts and 422 for invalid versions.

- **Refactors**
  - Definition fetching and alias resolution now prefer the workflow’s `version` pointer; fall back to latest for legacy workflows.

<sup>Written for commit c17808d701acab815bd6d8804f031762a85e5b04. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2581?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<img width="1031" height="716" alt="image" src="https://github.com/user-attachments/assets/1f01d450-6f05-4d8f-bec9-644b921c9562" />

