### PR TITLE
feat(ee): Gate service accounts behind entitlement

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -10369,6 +10369,12 @@ export const $EffectiveEntitlements = {
         "Whether RBAC add-ons are enabled (custom roles, groups, and assignments)",
       default: false,
     },
+    service_accounts: {
+      type: "boolean",
+      title: "Service Accounts",
+      description: "Whether service accounts for API key access are enabled",
+      default: false,
+    },
     watchtower: {
       type: "boolean",
       title: "Watchtower",
@@ -10413,6 +10419,11 @@ export const $EntitlementsDict = {
       title: "Rbac Addons",
       description:
         "Whether RBAC add-ons are enabled (custom roles, groups, and assignments)",
+    },
+    service_accounts: {
+      type: "boolean",
+      title: "Service Accounts",
+      description: "Whether service accounts for API key access are enabled",
     },
     watchtower: {
       type: "boolean",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3124,6 +3124,10 @@ export type EffectiveEntitlements = {
    */
   rbac_addons?: boolean
   /**
+   * Whether service accounts for API key access are enabled
+   */
+  service_accounts?: boolean
+  /**
    * Whether Watchtower agent monitoring is enabled (agent sessions, tool-call telemetry, and controls)
    */
   watchtower?: boolean
@@ -3155,6 +3159,10 @@ export type EntitlementsDict = {
    * Whether RBAC add-ons are enabled (custom roles, groups, and assignments)
    */
   rbac_addons?: boolean
+  /**
+   * Whether service accounts for API key access are enabled
+   */
+  service_accounts?: boolean
   /**
    * Whether Watchtower agent monitoring is enabled (agent sessions, tool-call telemetry, and controls)
    */

--- a/frontend/src/components/organization/org-settings-service-accounts.tsx
+++ b/frontend/src/components/organization/org-settings-service-accounts.tsx
@@ -4,8 +4,10 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { useCallback } from "react"
 import { serviceAccountsListOrganizationServiceAccountApiKeys } from "@/client"
 import { useScopeCheck } from "@/components/auth/scope-guard"
+import { EntitlementRequiredEmptyState } from "@/components/entitlement-required-empty-state"
 import { AlertNotification } from "@/components/notifications"
 import { ServiceAccountsManager } from "@/components/organization/service-accounts-manager"
+import { useEntitlements } from "@/hooks/use-entitlements"
 import {
   useOrganizationServiceAccountScopes,
   useOrganizationServiceAccounts,
@@ -20,11 +22,15 @@ export function OrgSettingsServiceAccounts() {
   const canCreate = useScopeCheck("org:service_account:create")
   const canUpdate = useScopeCheck("org:service_account:update")
   const canDisable = useScopeCheck("org:service_account:disable")
+  const { hasEntitlement, isLoading: entitlementsLoading } = useEntitlements()
+  const serviceAccountsEnabled = hasEntitlement("service_accounts")
   const {
     scopes,
     isLoading: scopesLoading,
     error: scopesError,
-  } = useOrganizationServiceAccountScopes()
+  } = useOrganizationServiceAccountScopes({
+    enabled: serviceAccountsEnabled,
+  })
   const {
     serviceAccounts,
     nextCursor,
@@ -42,7 +48,9 @@ export function OrgSettingsServiceAccounts() {
     issueApiKeyPending,
     revokeApiKey,
     revokeApiKeyPending,
-  } = useOrganizationServiceAccounts()
+  } = useOrganizationServiceAccounts({
+    enabled: serviceAccountsEnabled,
+  })
 
   const handleCreateSignalConsumed = useCallback(() => {
     if (!pathname || !searchParams?.get(CREATE_SERVICE_ACCOUNT_PARAM)) {
@@ -59,6 +67,17 @@ export function OrgSettingsServiceAccounts() {
       <AlertNotification
         level="error"
         message={`Error loading scopes: ${scopesError.message}`}
+      />
+    )
+  }
+  if (entitlementsLoading) {
+    return null
+  }
+  if (!serviceAccountsEnabled) {
+    return (
+      <EntitlementRequiredEmptyState
+        title="Service accounts unavailable"
+        description="Service account access is not enabled for this organization."
       />
     )
   }

--- a/frontend/src/components/organization/workspace-service-accounts.tsx
+++ b/frontend/src/components/organization/workspace-service-accounts.tsx
@@ -4,8 +4,10 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { useCallback } from "react"
 import { serviceAccountsListWorkspaceServiceAccountApiKeys } from "@/client"
 import { useScopeCheck } from "@/components/auth/scope-guard"
+import { EntitlementRequiredEmptyState } from "@/components/entitlement-required-empty-state"
 import { AlertNotification } from "@/components/notifications"
 import { ServiceAccountsManager } from "@/components/organization/service-accounts-manager"
+import { useEntitlements } from "@/hooks/use-entitlements"
 import {
   useWorkspaceServiceAccountScopes,
   useWorkspaceServiceAccounts,
@@ -22,12 +24,16 @@ export function WorkspaceServiceAccounts() {
   const canCreate = useScopeCheck("workspace:service_account:create")
   const canUpdate = useScopeCheck("workspace:service_account:update")
   const canDisable = useScopeCheck("workspace:service_account:disable")
+  const { hasEntitlement, isLoading: entitlementsLoading } = useEntitlements()
+  const serviceAccountsEnabled = hasEntitlement("service_accounts")
 
   const {
     scopes,
     isLoading: scopesLoading,
     error: scopesError,
-  } = useWorkspaceServiceAccountScopes(workspaceId)
+  } = useWorkspaceServiceAccountScopes(workspaceId, {
+    enabled: serviceAccountsEnabled,
+  })
   const {
     serviceAccounts,
     nextCursor,
@@ -45,7 +51,9 @@ export function WorkspaceServiceAccounts() {
     issueApiKeyPending,
     revokeApiKey,
     revokeApiKeyPending,
-  } = useWorkspaceServiceAccounts(workspaceId)
+  } = useWorkspaceServiceAccounts(workspaceId, {
+    enabled: serviceAccountsEnabled,
+  })
 
   const handleCreateSignalConsumed = useCallback(() => {
     if (!pathname || !searchParams?.get(CREATE_SERVICE_ACCOUNT_PARAM)) {
@@ -62,6 +70,17 @@ export function WorkspaceServiceAccounts() {
       <AlertNotification
         level="error"
         message={`Error loading scopes: ${scopesError.message}`}
+      />
+    )
+  }
+  if (entitlementsLoading) {
+    return null
+  }
+  if (!serviceAccountsEnabled) {
+    return (
+      <EntitlementRequiredEmptyState
+        title="Service accounts unavailable"
+        description="Service account access is not enabled for this organization."
       />
     )
   }

--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -125,6 +125,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     enabled: shouldLoadAgentEntitlements,
   })
   const agentAddonsEnabled = hasEntitlement("agent_addons")
+  const serviceAccountsEnabled = hasEntitlement("service_accounts")
   const { presets, presetsIsLoading } = useAgentPresets(workspaceId, {
     enabled: shouldLoadAgentsSection && agentAddonsEnabled,
   })
@@ -453,7 +454,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   isActive: pathname?.startsWith(`${basePath}/members`),
                 }
               : null,
-            canViewServiceAccounts === true
+            canViewServiceAccounts === true && serviceAccountsEnabled
               ? {
                   title: "Service accounts",
                   href: `${basePath}/service-accounts`,

--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -118,11 +118,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const canViewMembers = useScopeCheck("workspace:member:read")
   const canViewServiceAccounts = useScopeCheck("workspace:service_account:read")
   const canViewCases = useScopeCheck("case:read")
-  const shouldLoadAgentEntitlements = canViewAgents === true
+  const shouldLoadEntitlements =
+    canViewAgents === true || canViewServiceAccounts === true
   const shouldLoadAgentsSection =
-    shouldLoadAgentEntitlements && (agentsSectionOpen || isAgentsRoute)
+    canViewAgents === true && (agentsSectionOpen || isAgentsRoute)
   const { hasEntitlement, isLoading: entitlementsIsLoading } = useEntitlements({
-    enabled: shouldLoadAgentEntitlements,
+    enabled: shouldLoadEntitlements,
   })
   const agentAddonsEnabled = hasEntitlement("agent_addons")
   const serviceAccountsEnabled = hasEntitlement("service_accounts")

--- a/frontend/src/components/sidebar/organization-sidebar.tsx
+++ b/frontend/src/components/sidebar/organization-sidebar.tsx
@@ -38,6 +38,7 @@ export function OrganizationSidebar({
   const { hasEntitlement } = useEntitlements()
   const customRegistryEnabled = hasEntitlement("custom_registry")
   const gitSyncEnabled = hasEntitlement("git_sync")
+  const serviceAccountsEnabled = hasEntitlement("service_accounts")
 
   // Scope checks for org sidebar items
   const canViewSettings = useScopeCheck("org:settings:read")
@@ -140,7 +141,7 @@ export function OrganizationSidebar({
       url: "/organization/settings/service-accounts",
       icon: KeyRoundIcon,
       isActive: pathname?.includes("/organization/settings/service-accounts"),
-      visible: canViewServiceAccounts === true,
+      visible: canViewServiceAccounts === true && serviceAccountsEnabled,
     },
   ]
 

--- a/frontend/src/hooks/use-service-accounts.ts
+++ b/frontend/src/hooks/use-service-accounts.ts
@@ -55,7 +55,11 @@ function workspaceServiceAccountApiKeysQueryKey(
   ] as const
 }
 
-export function useOrganizationServiceAccounts() {
+export function useOrganizationServiceAccounts({
+  enabled = true,
+}: {
+  enabled?: boolean
+} = {}) {
   const queryClient = useQueryClient()
 
   const {
@@ -66,6 +70,7 @@ export function useOrganizationServiceAccounts() {
     queryKey: organizationServiceAccountsQueryKey(),
     queryFn: async () =>
       await serviceAccountsListOrganizationServiceAccounts({ limit: 100 }),
+    enabled,
   })
 
   function invalidate() {
@@ -199,7 +204,11 @@ export function useOrganizationServiceAccountApiKeys(
   }
 }
 
-export function useOrganizationServiceAccountScopes() {
+export function useOrganizationServiceAccountScopes({
+  enabled = true,
+}: {
+  enabled?: boolean
+} = {}) {
   const {
     data: response,
     isLoading,
@@ -208,6 +217,7 @@ export function useOrganizationServiceAccountScopes() {
     queryKey: ["organization-service-account-scopes"],
     queryFn: async () =>
       await serviceAccountsListOrganizationServiceAccountScopes(),
+    enabled,
   })
 
   return {
@@ -217,7 +227,10 @@ export function useOrganizationServiceAccountScopes() {
   }
 }
 
-export function useWorkspaceServiceAccounts(workspaceId: string) {
+export function useWorkspaceServiceAccounts(
+  workspaceId: string,
+  { enabled = true }: { enabled?: boolean } = {}
+) {
   const queryClient = useQueryClient()
 
   const {
@@ -231,7 +244,7 @@ export function useWorkspaceServiceAccounts(workspaceId: string) {
         workspaceId,
         limit: 100,
       }),
-    enabled: Boolean(workspaceId),
+    enabled: enabled && Boolean(workspaceId),
   })
 
   function invalidate() {
@@ -384,7 +397,10 @@ export function useWorkspaceServiceAccountApiKeys(
   }
 }
 
-export function useWorkspaceServiceAccountScopes(workspaceId: string) {
+export function useWorkspaceServiceAccountScopes(
+  workspaceId: string,
+  { enabled = true }: { enabled?: boolean } = {}
+) {
   const {
     data: response,
     isLoading,
@@ -393,7 +409,7 @@ export function useWorkspaceServiceAccountScopes(workspaceId: string) {
     queryKey: ["workspace-service-account-scopes", workspaceId],
     queryFn: async () =>
       await serviceAccountsListWorkspaceServiceAccountScopes({ workspaceId }),
-    enabled: Boolean(workspaceId),
+    enabled: enabled && Boolean(workspaceId),
   })
 
   return {

--- a/tests/integration/test_service_account_api_keys.py
+++ b/tests/integration/test_service_account_api_keys.py
@@ -19,8 +19,20 @@ from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import Scope, ServiceAccount, ServiceAccountApiKey, Workspace
 from tracecat.service_accounts.constants import API_KEY_HEADER_NAME
 from tracecat.service_accounts.router import WorkspaceUserOnlyInPath
+from tracecat.tiers import defaults as tier_defaults
 
 pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture(autouse=True)
+def enable_service_accounts_entitlement(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        tier_defaults,
+        "DEFAULT_ENTITLEMENTS",
+        tier_defaults.DEFAULT_ENTITLEMENTS.model_copy(
+            update={"service_accounts": True}
+        ),
+    )
 
 
 def _dependency_for_role(role_type: Any) -> Callable[..., Any]:

--- a/tests/unit/api/test_api_service_accounts.py
+++ b/tests/unit/api/test_api_service_accounts.py
@@ -19,6 +19,18 @@ from tracecat.service_accounts.schemas import (
     ServiceAccountApiKeyRead,
     ServiceAccountScopeRead,
 )
+from tracecat.tiers import defaults as tier_defaults
+
+
+@pytest.fixture(autouse=True)
+def enable_service_accounts_entitlement(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        tier_defaults,
+        "DEFAULT_ENTITLEMENTS",
+        tier_defaults.DEFAULT_ENTITLEMENTS.model_copy(
+            update={"service_accounts": True}
+        ),
+    )
 
 
 def _scope_read(name: str, *, action: str = "read") -> ServiceAccountScopeRead:

--- a/tests/unit/test_auth_credentials_api_keys.py
+++ b/tests/unit/test_auth_credentials_api_keys.py
@@ -17,6 +17,18 @@ from tracecat.db.models import (
     ServiceAccountApiKey,
     Workspace,
 )
+from tracecat.tiers import defaults as tier_defaults
+
+
+@pytest.fixture(autouse=True)
+def enable_service_accounts_entitlement(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        tier_defaults,
+        "DEFAULT_ENTITLEMENTS",
+        tier_defaults.DEFAULT_ENTITLEMENTS.model_copy(
+            update={"service_accounts": True}
+        ),
+    )
 
 
 async def _get_scopes(session, *names: str) -> list[Scope]:
@@ -145,6 +157,75 @@ async def test_authenticate_org_service_account_key_rejects_workspace_outside_or
         )
 
     assert exc_info.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_authenticate_api_key_checks_entitlement_before_workspace_resolution(
+    session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    organization = Organization(
+        name="Unentitled auth org",
+        slug="unentitled-auth-org",
+        is_active=True,
+    )
+    session.add(organization)
+    await session.flush()
+    workspace = Workspace(
+        name="Unentitled auth workspace",
+        organization_id=organization.id,
+    )
+    session.add(workspace)
+    await session.flush()
+
+    await seed_system_scopes(session)
+    scopes = await _get_scopes(session, "workflow:read")
+    generated = generate_managed_api_key(prefix="tc_org_sk_")
+    service_account = ServiceAccount(
+        organization_id=organization.id,
+        name="Unentitled automation",
+        scopes=scopes,
+    )
+    session.add(service_account)
+    await session.flush()
+    session.add(
+        ServiceAccountApiKey(
+            service_account_id=service_account.id,
+            name="Primary",
+            key_id=generated.key_id,
+            hashed=generated.hashed,
+            salt=generated.salt_b64,
+            preview=generated.preview(),
+        )
+    )
+    await session.commit()
+
+    @asynccontextmanager
+    async def _session_cm():
+        yield session
+
+    get_workspace_org_id = AsyncMock(return_value=organization.id)
+    monkeypatch.setattr(
+        "tracecat.auth.credentials.get_async_session_bypass_rls_context_manager",
+        _session_cm,
+    )
+    monkeypatch.setattr(
+        "tracecat.auth.credentials.is_org_entitled",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        "tracecat.auth.credentials._get_workspace_org_id",
+        get_workspace_org_id,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _authenticate_api_key(
+            api_key=generated.raw,
+            workspace_id=workspace.id,
+        )
+
+    assert exc_info.value.status_code == 401
+    get_workspace_org_id.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_service_accounts_audit.py
+++ b/tests/unit/test_service_accounts_audit.py
@@ -17,10 +17,22 @@ from tracecat.service_accounts.service import (
     OrganizationServiceAccountService,
     WorkspaceServiceAccountService,
 )
+from tracecat.tiers import defaults as tier_defaults
 
 type ServiceAccountServiceClass = (
     type[OrganizationServiceAccountService] | type[WorkspaceServiceAccountService]
 )
+
+
+@pytest.fixture(autouse=True)
+def enable_service_accounts_entitlement(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        tier_defaults,
+        "DEFAULT_ENTITLEMENTS",
+        tier_defaults.DEFAULT_ENTITLEMENTS.model_copy(
+            update={"service_accounts": True}
+        ),
+    )
 
 
 def test_issued_service_account_api_key_result_exposes_api_key_id() -> None:

--- a/tests/unit/test_service_accounts_pagination.py
+++ b/tests/unit/test_service_accounts_pagination.py
@@ -17,6 +17,18 @@ from tracecat.service_accounts.service import (
     _paginate_service_account_api_keys,
     _paginate_service_accounts,
 )
+from tracecat.tiers import defaults as tier_defaults
+
+
+@pytest.fixture(autouse=True)
+def enable_service_accounts_entitlement(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        tier_defaults,
+        "DEFAULT_ENTITLEMENTS",
+        tier_defaults.DEFAULT_ENTITLEMENTS.model_copy(
+            update={"service_accounts": True}
+        ),
+    )
 
 
 class _ScalarResult:

--- a/tests/unit/test_service_accounts_update.py
+++ b/tests/unit/test_service_accounts_update.py
@@ -15,6 +15,18 @@ from tracecat.authz.enums import ScopeSource
 from tracecat.db.models import Scope
 from tracecat.exceptions import TracecatAuthorizationError
 from tracecat.service_accounts.service import OrganizationServiceAccountService
+from tracecat.tiers import defaults as tier_defaults
+
+
+@pytest.fixture(autouse=True)
+def enable_service_accounts_entitlement(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        tier_defaults,
+        "DEFAULT_ENTITLEMENTS",
+        tier_defaults.DEFAULT_ENTITLEMENTS.model_copy(
+            update={"service_accounts": True}
+        ),
+    )
 
 
 class _NoopSession:

--- a/tests/unit/test_tier_defaults.py
+++ b/tests/unit/test_tier_defaults.py
@@ -13,6 +13,7 @@ def test_resolve_oss_default_entitlements_fresh_install() -> None:
     assert entitlements.git_sync is False
     assert entitlements.agent_addons is False
     assert entitlements.case_addons is False
+    assert entitlements.service_accounts is False
     assert entitlements.watchtower is False
 
 
@@ -25,6 +26,7 @@ def test_resolve_oss_default_entitlements_maps_legacy_feature_flags() -> None:
     assert entitlements.git_sync is True
     assert entitlements.agent_addons is True
     assert entitlements.case_addons is True
+    assert entitlements.service_accounts is False
     assert entitlements.watchtower is False
 
 
@@ -37,6 +39,7 @@ def test_resolve_oss_default_entitlements_normalizes_and_ignores_unknown() -> No
     assert entitlements.git_sync is True
     assert entitlements.agent_addons is False
     assert entitlements.case_addons is True
+    assert entitlements.service_accounts is False
     assert entitlements.watchtower is False
 
 

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -65,6 +65,8 @@ from tracecat.identifiers import InternalServiceID
 from tracecat.logger import logger
 from tracecat.organization.management import get_default_organization_id
 from tracecat.service_accounts.constants import API_KEY_HEADER_NAME
+from tracecat.tiers.access import is_org_entitled
+from tracecat.tiers.enums import Entitlement
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token", auto_error=False)
 internal_service_key_header_scheme = APIKeyHeader(
@@ -358,6 +360,10 @@ async def _authenticate_api_key(
             raise UNAUTHORIZED_EXCEPTION
         service_account = record.service_account
         if service_account.disabled_at is not None:
+            raise UNAUTHORIZED_EXCEPTION
+        if not await is_org_entitled(
+            session, service_account.organization_id, Entitlement.SERVICE_ACCOUNTS
+        ):
             raise UNAUTHORIZED_EXCEPTION
 
         # `workspace_id` is the effective request context. `bound_workspace_id`

--- a/tracecat/service_accounts/router.py
+++ b/tracecat/service_accounts/router.py
@@ -43,24 +43,6 @@ from tracecat.service_accounts.service import (
 from tracecat.tiers.entitlements import check_entitlement
 from tracecat.tiers.enums import Entitlement
 
-
-async def _require_service_accounts_entitlement(
-    *, role: Role, session: AsyncDBSession
-) -> None:
-    await check_entitlement(session, role, Entitlement.SERVICE_ACCOUNTS)
-
-
-org_router = APIRouter(
-    prefix="/organization/service-accounts",
-    tags=["service_accounts"],
-    dependencies=[Depends(_require_service_accounts_entitlement)],
-)
-workspace_router = APIRouter(
-    prefix="/workspaces/{workspace_id}/service-accounts",
-    tags=["service_accounts"],
-    dependencies=[Depends(_require_service_accounts_entitlement)],
-)
-
 WorkspaceUserOnlyInPath = Annotated[
     Role,
     RoleACL(
@@ -71,6 +53,30 @@ WorkspaceUserOnlyInPath = Annotated[
         workspace_id_in_path=True,
     ),
 ]
+
+
+async def _require_org_service_accounts_entitlement(
+    *, role: OrgUserOnlyRole, session: AsyncDBSession
+) -> None:
+    await check_entitlement(session, role, Entitlement.SERVICE_ACCOUNTS)
+
+
+async def _require_workspace_service_accounts_entitlement(
+    *, role: WorkspaceUserOnlyInPath, session: AsyncDBSession
+) -> None:
+    await check_entitlement(session, role, Entitlement.SERVICE_ACCOUNTS)
+
+
+org_router = APIRouter(
+    prefix="/organization/service-accounts",
+    tags=["service_accounts"],
+    dependencies=[Depends(_require_org_service_accounts_entitlement)],
+)
+workspace_router = APIRouter(
+    prefix="/workspaces/{workspace_id}/service-accounts",
+    tags=["service_accounts"],
+    dependencies=[Depends(_require_workspace_service_accounts_entitlement)],
+)
 
 
 def _translate_error(exc: Exception) -> HTTPException:

--- a/tracecat/service_accounts/router.py
+++ b/tracecat/service_accounts/router.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Annotated, Any, cast
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 
 from tracecat.auth.credentials import RoleACL
@@ -40,12 +40,25 @@ from tracecat.service_accounts.service import (
     get_service_account_api_key_counts,
     get_service_account_last_used_at,
 )
+from tracecat.tiers.entitlements import check_entitlement
+from tracecat.tiers.enums import Entitlement
+
+
+async def _require_service_accounts_entitlement(
+    *, role: Role, session: AsyncDBSession
+) -> None:
+    await check_entitlement(session, role, Entitlement.SERVICE_ACCOUNTS)
+
 
 org_router = APIRouter(
-    prefix="/organization/service-accounts", tags=["service_accounts"]
+    prefix="/organization/service-accounts",
+    tags=["service_accounts"],
+    dependencies=[Depends(_require_service_accounts_entitlement)],
 )
 workspace_router = APIRouter(
-    prefix="/workspaces/{workspace_id}/service-accounts", tags=["service_accounts"]
+    prefix="/workspaces/{workspace_id}/service-accounts",
+    tags=["service_accounts"],
+    dependencies=[Depends(_require_service_accounts_entitlement)],
 )
 
 WorkspaceUserOnlyInPath = Annotated[

--- a/tracecat/service_accounts/service.py
+++ b/tracecat/service_accounts/service.py
@@ -30,11 +30,12 @@ from tracecat.pagination import (
     CursorPaginatedResponse,
     CursorPaginationParams,
 )
-from tracecat.service import BaseOrgService, BaseWorkspaceService
+from tracecat.service import BaseOrgService, BaseWorkspaceService, requires_entitlement
 from tracecat.service_accounts.constants import (
     is_org_service_account_assignable_scope,
     is_workspace_service_account_assignable_scope,
 )
+from tracecat.tiers.enums import Entitlement
 
 ServiceAccountScopeValidator = Callable[..., bool]
 
@@ -604,6 +605,7 @@ class OrganizationServiceAccountService(BaseOrgService, BaseServiceAccountServic
     scope_validator = staticmethod(is_org_service_account_assignable_scope)
 
     @require_scope("org:service_account:read")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     async def list_service_accounts(
         self,
         params: CursorPaginationParams,
@@ -611,6 +613,7 @@ class OrganizationServiceAccountService(BaseOrgService, BaseServiceAccountServic
         return await self._list_service_accounts(params)
 
     @require_scope("org:service_account:read")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     async def list_service_account_api_keys(
         self,
         service_account_id: uuid.UUID,
@@ -619,6 +622,7 @@ class OrganizationServiceAccountService(BaseOrgService, BaseServiceAccountServic
         return await self._list_service_account_api_keys(service_account_id, params)
 
     @require_scope("org:service_account:create")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     @audit_log(
         resource_type="service_account",
         action="create",
@@ -640,6 +644,7 @@ class OrganizationServiceAccountService(BaseOrgService, BaseServiceAccountServic
         )
 
     @require_scope("org:service_account:update")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     @audit_log(
         resource_type="service_account",
         action="update",
@@ -663,6 +668,7 @@ class OrganizationServiceAccountService(BaseOrgService, BaseServiceAccountServic
         )
 
     @require_scope("org:service_account:disable")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     @audit_log(
         resource_type="service_account",
         action="update",
@@ -672,6 +678,7 @@ class OrganizationServiceAccountService(BaseOrgService, BaseServiceAccountServic
         await self._set_service_account_disabled(service_account_id, disabled=True)
 
     @require_scope("org:service_account:disable")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     @audit_log(
         resource_type="service_account",
         action="update",
@@ -681,6 +688,7 @@ class OrganizationServiceAccountService(BaseOrgService, BaseServiceAccountServic
         await self._set_service_account_disabled(service_account_id, disabled=False)
 
     @require_scope("org:service_account:update")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     @audit_log(
         resource_type="service_account_api_key",
         action="create",
@@ -695,6 +703,7 @@ class OrganizationServiceAccountService(BaseOrgService, BaseServiceAccountServic
         return await self._issue_api_key(service_account_id, name=name)
 
     @require_scope("org:service_account:update")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     @audit_log(
         resource_type="service_account_api_key",
         action="revoke",
@@ -716,6 +725,7 @@ class WorkspaceServiceAccountService(BaseWorkspaceService, BaseServiceAccountSer
     scope_validator = staticmethod(is_workspace_service_account_assignable_scope)
 
     @require_scope("workspace:service_account:read")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     async def list_service_accounts(
         self,
         params: CursorPaginationParams,
@@ -723,6 +733,7 @@ class WorkspaceServiceAccountService(BaseWorkspaceService, BaseServiceAccountSer
         return await self._list_service_accounts(params)
 
     @require_scope("workspace:service_account:read")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     async def list_service_account_api_keys(
         self,
         service_account_id: uuid.UUID,
@@ -731,6 +742,7 @@ class WorkspaceServiceAccountService(BaseWorkspaceService, BaseServiceAccountSer
         return await self._list_service_account_api_keys(service_account_id, params)
 
     @require_scope("workspace:service_account:create")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     @audit_log(
         resource_type="service_account",
         action="create",
@@ -752,6 +764,7 @@ class WorkspaceServiceAccountService(BaseWorkspaceService, BaseServiceAccountSer
         )
 
     @require_scope("workspace:service_account:update")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     @audit_log(
         resource_type="service_account",
         action="update",
@@ -775,6 +788,7 @@ class WorkspaceServiceAccountService(BaseWorkspaceService, BaseServiceAccountSer
         )
 
     @require_scope("workspace:service_account:disable")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     @audit_log(
         resource_type="service_account",
         action="update",
@@ -784,6 +798,7 @@ class WorkspaceServiceAccountService(BaseWorkspaceService, BaseServiceAccountSer
         await self._set_service_account_disabled(service_account_id, disabled=True)
 
     @require_scope("workspace:service_account:disable")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     @audit_log(
         resource_type="service_account",
         action="update",
@@ -793,6 +808,7 @@ class WorkspaceServiceAccountService(BaseWorkspaceService, BaseServiceAccountSer
         await self._set_service_account_disabled(service_account_id, disabled=False)
 
     @require_scope("workspace:service_account:update")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     @audit_log(
         resource_type="service_account_api_key",
         action="create",
@@ -807,6 +823,7 @@ class WorkspaceServiceAccountService(BaseWorkspaceService, BaseServiceAccountSer
         return await self._issue_api_key(service_account_id, name=name)
 
     @require_scope("workspace:service_account:update")
+    @requires_entitlement(Entitlement.SERVICE_ACCOUNTS)
     @audit_log(
         resource_type="service_account_api_key",
         action="revoke",

--- a/tracecat/tiers/defaults.py
+++ b/tracecat/tiers/defaults.py
@@ -54,6 +54,7 @@ def resolve_oss_default_entitlements(
             agent_addons=False,
             case_addons=False,
             rbac_addons=False,
+            service_accounts=False,
             watchtower=False,
         )
 
@@ -85,6 +86,7 @@ def resolve_oss_default_entitlements(
         agent_addons=agent_addons_enabled,
         case_addons=case_addons_enabled,
         rbac_addons=rbac_enabled,
+        service_accounts=False,
         watchtower=False,
     )
 

--- a/tracecat/tiers/enums.py
+++ b/tracecat/tiers/enums.py
@@ -11,4 +11,5 @@ class Entitlement(StrEnum):
     AGENT_ADDONS = "agent_addons"
     CASE_ADDONS = "case_addons"
     RBAC_ADDONS = "rbac_addons"
+    SERVICE_ACCOUNTS = "service_accounts"
     WATCHTOWER = "watchtower"

--- a/tracecat/tiers/schemas.py
+++ b/tracecat/tiers/schemas.py
@@ -62,6 +62,10 @@ class EffectiveEntitlements(Schema):
         description="Whether RBAC add-ons are enabled"
         " (custom roles, groups, and assignments)",
     )
+    service_accounts: bool = Field(
+        default=False,
+        description="Whether service accounts for API key access are enabled",
+    )
     watchtower: bool = Field(
         default=False,
         description="Whether Watchtower agent monitoring is enabled"

--- a/tracecat/tiers/service.py
+++ b/tracecat/tiers/service.py
@@ -173,5 +173,6 @@ class TierService(BaseService):
             agent_addons=resolve_entitlement("agent_addons"),
             case_addons=resolve_entitlement("case_addons"),
             rbac_addons=resolve_entitlement("rbac_addons"),
+            service_accounts=resolve_entitlement("service_accounts"),
             watchtower=resolve_entitlement("watchtower"),
         )

--- a/tracecat/tiers/types.py
+++ b/tracecat/tiers/types.py
@@ -39,6 +39,12 @@ class EntitlementsDict(TypedDict, total=False):
             " (custom roles, groups, and assignments)"
         ),
     ]
+    service_accounts: Annotated[
+        bool,
+        Field(
+            description="Whether service accounts for API key access are enabled"
+        ),
+    ]
     watchtower: Annotated[
         bool,
         Field(

--- a/tracecat/tiers/types.py
+++ b/tracecat/tiers/types.py
@@ -41,9 +41,7 @@ class EntitlementsDict(TypedDict, total=False):
     ]
     service_accounts: Annotated[
         bool,
-        Field(
-            description="Whether service accounts for API key access are enabled"
-        ),
+        Field(description="Whether service accounts for API key access are enabled"),
     ]
     watchtower: Annotated[
         bool,


### PR DESCRIPTION
### Motivation

- Introduce a feature flag/entitlement for service accounts so the capability can be enabled/disabled per-organization/tier.
- Prevent UI and API access to service accounts when the organization's `service_accounts` entitlement is not enabled.

### Description

- Frontend: added entitlement checks via `useEntitlements`, render `EntitlementRequiredEmptyState` when service accounts are disabled, and pass `enabled` flags to service account hooks (`useOrganizationServiceAccounts`, `useWorkspaceServiceAccounts`, `useOrganizationServiceAccountScopes`, `useWorkspaceServiceAccountScopes`) to avoid unnecessary queries.
- Frontend: hide Service Accounts links in `AppSidebar` and `OrganizationSidebar` unless `service_accounts` entitlement is present and entitlements have finished loading.
- Backend: added `SERVICE_ACCOUNTS` to `Entitlement` enum and included `service_accounts` in entitlement schemas and defaults (`tiers/schemas.py`, `tiers/enums.py`, `tiers/defaults.py`, `tiers/types.py`).
- Backend: enforced entitlement checks for service account endpoints and operations by wiring a router-level dependency and applying `@requires_entitlement(Entitlement.SERVICE_ACCOUNTS)` on service methods, and by blocking API key auth if the organization is not entitled (`auth/credentials.py`, `service_accounts/router.py`, `service_accounts/service.py`).

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29dd08cc48320826b85aa65b3626a)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate service accounts behind the org `service_accounts` entitlement across UI and API. When not entitled, the UI hides service accounts and API key auth for service accounts is rejected to meet the API key access gating requirement.

- **New Features**
  - Added `Entitlement.SERVICE_ACCOUNTS` and wired `service_accounts` through tier schemas, types, defaults, and resolver.
  - Enforced entitlement on service account routes via a router `Depends` and on service methods via `@requires_entitlement(Entitlement.SERVICE_ACCOUNTS)`.
  - Blocked API key authentication for service accounts when the org lacks `service_accounts`.
  - Frontend: hide Service Accounts in sidebars; show `EntitlementRequiredEmptyState` on settings pages; service account hooks accept an `enabled` flag to skip queries when not entitled.

- **Migration**
  - Enable `service_accounts` for tiers/orgs that should use service accounts (defaults remain false, including OSS).

<sup>Written for commit 1614bb502079e36659fc7004f022eca39c2b10c9. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2582?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

