### PR TITLE
chore(deps): bump litellm to 1.83.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "httpx==0.28.1",
     "jsonpath_ng==1.7.0",
     "lark==1.1.9",
-    "litellm[proxy]==1.83.4",
+    "litellm[proxy]==1.83.7",
     "loguru==0.7.3",
     "minio==7.2.18",
     "orjson==3.11.7",

--- a/uv.lock
+++ b/uv.lock
@@ -2137,7 +2137,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.4"
+version = "1.83.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2153,9 +2153,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/c4/30469c06ae7437a4406bc11e3c433cfd380a6771068cca15ea918dcd158f/litellm-1.83.4.tar.gz", hash = "sha256:6458d2030a41229460b321adee00517a91dbd8e63213cc953d355cb41d16f2d4", size = 17733899, upload-time = "2026-04-07T04:33:47.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/2b/b58bf6bbcbc3d0e55d0a84fdf9128e5b1436517f46fce89b1cd8948ebb81/litellm-1.83.7.tar.gz", hash = "sha256:e2f2cb99df2e2b2eab63f1354faa45c88dd7c8d40c18eb648afb1b349c689633", size = 17791694, upload-time = "2026-04-13T17:35:01.606Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/bd/df19d3f8f6654535ee343a341fd921f81c411abf601a53e3eaef58129b02/litellm-1.83.4-py3-none-any.whl", hash = "sha256:17d7b4d48d47aca988ea4f762ddda5e7bd72cda3270192b22813d0330869d7b4", size = 16015555, upload-time = "2026-04-07T04:33:44.268Z" },
+    { url = "https://files.pythonhosted.org/packages/75/80/caeb4cdcad96451ba83ad3ba2a9da08b1e1a915fa845c489f56ea044488b/litellm-1.83.7-py3-none-any.whl", hash = "sha256:5784a1d9a9a4a8acd6ca1e347003a5e2e1b3c749b4d41e7da4904577adade111", size = 16069807, upload-time = "2026-04-13T17:34:58.36Z" },
 ]
 
 [package.optional-dependencies]
@@ -4485,7 +4485,7 @@ requires-dist = [
     { name = "httpx", specifier = "==0.28.1" },
     { name = "jsonpath-ng", specifier = "==1.7.0" },
     { name = "lark", specifier = "==1.1.9" },
-    { name = "litellm", extras = ["proxy"], specifier = "==1.83.4" },
+    { name = "litellm", extras = ["proxy"], specifier = "==1.83.7" },
     { name = "loguru", specifier = "==0.7.3" },
     { name = "minio", specifier = "==7.2.18" },
     { name = "orjson", specifier = "==3.11.7" },


### PR DESCRIPTION
## Summary

- Bumps the pinned `litellm[proxy]` dependency from `1.83.4` to `1.83.7`.
- Refreshes `uv.lock` with the updated LiteLLM artifact URLs and hashes.

## Impact

Keeps the managed LiteLLM proxy dependency pinned while moving it to the requested patch release.

## Validation

- `uv lock --upgrade-package litellm`
- `uv run ruff check .`
- `uv lock --check`
- `git diff --check -- pyproject.toml uv.lock`
- `uv run python -c "from importlib.metadata import version; print(version('litellm'))"`

Note: `basedpyright` has no meaningful Python target for this dependency-only TOML/lockfile change; running it against the changed files treats TOML as Python.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `litellm[proxy]` from 1.83.4 to 1.83.7 and refresh `uv.lock` with the new artifact URLs and hashes. Pins the LiteLLM proxy to the latest patch release.

<sup>Written for commit 869ea6c573a1fbefe6cc7e6cd7ba45b7bcb7d106. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2583?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

