### PR TITLE
refactor: Use bearer auth for service account keys

### DIFF
--- a/tests/integration/test_service_account_api_keys.py
+++ b/tests/integration/test_service_account_api_keys.py
@@ -17,7 +17,6 @@ from tracecat.authz.seeding import seed_system_scopes
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import Scope, ServiceAccount, ServiceAccountApiKey, Workspace
-from tracecat.service_accounts.constants import API_KEY_HEADER_NAME
 from tracecat.service_accounts.router import WorkspaceUserOnlyInPath
 from tracecat.tiers import defaults as tier_defaults
 
@@ -122,7 +121,7 @@ async def _request_with_service_account_key(
                 method,
                 path,
                 params=params,
-                headers={API_KEY_HEADER_NAME: raw_key},
+                headers={"Authorization": f"Bearer {raw_key}"},
             )
     finally:
         ctx_role.reset(token)
@@ -214,7 +213,7 @@ async def test_service_account_key_created_over_http_authenticates_separate_clie
                     method,
                     path,
                     params=params,
-                    headers={API_KEY_HEADER_NAME: raw_key},
+                    headers={"Authorization": f"Bearer {raw_key}"},
                 )
                 assert response.status_code == status.HTTP_200_OK
 
@@ -223,7 +222,7 @@ async def test_service_account_key_created_over_http_authenticates_separate_clie
                 denied_method,
                 denied_path,
                 params=denied_params,
-                headers={API_KEY_HEADER_NAME: raw_key},
+                headers={"Authorization": f"Bearer {raw_key}"},
             )
             assert denied_response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -243,7 +242,7 @@ async def test_service_account_key_created_over_http_authenticates_separate_clie
                 allowed_requests[0][0],
                 allowed_requests[0][1],
                 params=allowed_requests[0][2],
-                headers={API_KEY_HEADER_NAME: raw_key},
+                headers={"Authorization": f"Bearer {raw_key}"},
             )
 
         assert after_disable_response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/unit/test_role_acl.py
+++ b/tests/unit/test_role_acl.py
@@ -13,7 +13,6 @@ from tracecat.auth.credentials import RoleACL
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session
-from tracecat.service_accounts.constants import API_KEY_HEADER_NAME
 
 
 @pytest.fixture
@@ -112,7 +111,7 @@ def test_role_acl_threads_tracecat_api_key_and_workspace_query(
     response = TestClient(role_acl_app).get(
         "/api-key",
         params={"workspace_id": str(workspace_id)},
-        headers={API_KEY_HEADER_NAME: "managed-api-key"},
+        headers={"Authorization": "Bearer tc_ws_sk_managed-api-key_secret"},
     )
 
     assert response.status_code == 200
@@ -121,9 +120,35 @@ def test_role_acl_threads_tracecat_api_key_and_workspace_query(
         "workspace_id": str(workspace_id),
     }
     authenticate_api_key.assert_awaited_once_with(
-        api_key="managed-api-key",
+        api_key="tc_ws_sk_managed-api-key_secret",
         workspace_id=workspace_id,
     )
+
+
+def test_role_acl_rejects_legacy_tracecat_api_key_header(
+    role_acl_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authenticate_api_key = AsyncMock()
+    monkeypatch.setattr(credentials, "_authenticate_api_key", authenticate_api_key)
+
+    @role_acl_app.get("/api-key-legacy")
+    async def api_key_legacy_route(  # pyright: ignore[reportUnusedFunction] - route handler
+        role: Role = RoleACL(
+            allow_user=False,
+            allow_api_key=True,
+            require_workspace="no",
+        ),
+    ) -> dict[str, str]:
+        return {"role_type": role.type}
+
+    response = TestClient(role_acl_app).get(
+        "/api-key-legacy",
+        headers={"x-tracecat-api-key": "tc_ws_sk_managed-api-key_secret"},
+    )
+
+    assert response.status_code == 403
+    authenticate_api_key.assert_not_awaited()
 
 
 def test_role_acl_combined_service_and_api_key_route_uses_service_key_fallback(
@@ -198,7 +223,7 @@ def test_role_acl_prefers_tracecat_api_key_when_both_headers_are_present(
     response = TestClient(role_acl_app).get(
         "/either-priority",
         headers={
-            API_KEY_HEADER_NAME: "managed-api-key",
+            "Authorization": "Bearer tc_org_sk_managed-api-key_secret",
             "x-tracecat-service-key": "service-secret",
             "x-tracecat-role-service-id": "tracecat-service",
         },
@@ -210,7 +235,7 @@ def test_role_acl_prefers_tracecat_api_key_when_both_headers_are_present(
         "service_id": "tracecat-api",
     }
     authenticate_api_key.assert_awaited_once_with(
-        api_key="managed-api-key",
+        api_key="tc_org_sk_managed-api-key_secret",
         workspace_id=None,
     )
     authenticate_service.assert_not_awaited()

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -19,7 +19,12 @@ from fastapi import (
     Security,
     status,
 )
-from fastapi.security import APIKeyHeader, OAuth2PasswordBearer
+from fastapi.security import (
+    APIKeyHeader,
+    HTTPAuthorizationCredentials,
+    HTTPBearer,
+    OAuth2PasswordBearer,
+)
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -64,7 +69,6 @@ from tracecat.db.rls import set_rls_context, set_rls_context_from_role
 from tracecat.identifiers import InternalServiceID
 from tracecat.logger import logger
 from tracecat.organization.management import get_default_organization_id
-from tracecat.service_accounts.constants import API_KEY_HEADER_NAME
 from tracecat.tiers.access import is_org_entitled
 from tracecat.tiers.enums import Entitlement
 
@@ -72,8 +76,9 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token", auto_error=False)
 internal_service_key_header_scheme = APIKeyHeader(
     name="x-tracecat-service-key", auto_error=False
 )
-tracecat_api_key_header_scheme = APIKeyHeader(
-    name=API_KEY_HEADER_NAME,
+service_account_api_key_bearer_scheme = HTTPBearer(
+    scheme_name="ServiceAccountApiKeyBearer",
+    description="Tracecat service account API key.",
     auto_error=False,
 )
 
@@ -243,9 +248,27 @@ def _get_bearer_token(request: Request) -> str | None:
     if not auth_header:
         return None
     scheme, _, token = auth_header.partition(" ")
+    token = token.strip()
     if scheme.lower() != "bearer" or not token:
         return None
     return token
+
+
+ServiceAccountApiKeyBearerCredentialsDep = Annotated[
+    HTTPAuthorizationCredentials | None,
+    Security(service_account_api_key_bearer_scheme),
+]
+
+
+def _get_service_account_api_key_from_bearer(
+    credentials: ServiceAccountApiKeyBearerCredentialsDep,
+) -> str | None:
+    if credentials is None:
+        return None
+    token = credentials.credentials.strip()
+    if token.startswith((ORG_API_KEY_PREFIX, WORKSPACE_API_KEY_PREFIX)):
+        return token
+    return None
 
 
 async def _authenticate_service(
@@ -446,7 +469,7 @@ OptionalInternalServiceKeyDep = Annotated[
     str | None, Security(internal_service_key_header_scheme)
 ]
 OptionalTracecatApiKeyDep = Annotated[
-    str | None, Security(tracecat_api_key_header_scheme)
+    str | None, Depends(_get_service_account_api_key_from_bearer)
 ]
 
 

--- a/tracecat/service_accounts/constants.py
+++ b/tracecat/service_accounts/constants.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from tracecat.authz.enums import ScopeSource
 
-API_KEY_HEADER_NAME = "x-tracecat-api-key"
-
 WORKSPACE_SERVICE_ACCOUNT_ASSIGNABLE_SCOPES: frozenset[str] = frozenset(
     {
         "agent:read",


### PR DESCRIPTION
## Summary

- Switch managed service-account API key authentication to `Authorization: Bearer <key>`.
- Use a dedicated FastAPI `HTTPBearer` dependency for service-account keys while leaving executor bearer-token auth on its existing path.
- Remove the service-account-specific `x-tracecat-api-key` constant and update tests to cover bearer auth plus legacy-header rejection.

## Impact

Service accounts have not been released broadly, so this hard migration makes bearer auth the canonical and only supported REST API path for service-account keys. Webhook API keys still use `x-tracecat-api-key` and are unchanged.

## Validation

- `uv run pytest tests/unit/test_role_acl.py`
- `uv run pytest tests/integration/test_service_account_api_keys.py`
- `uv run ruff check tracecat/auth/credentials.py tracecat/service_accounts/constants.py tests/unit/test_role_acl.py tests/integration/test_service_account_api_keys.py`
- `uv run ruff format --check tracecat/auth/credentials.py tracecat/service_accounts/constants.py tests/unit/test_role_acl.py tests/integration/test_service_account_api_keys.py`
- `uv run basedpyright tracecat/auth/credentials.py tracecat/service_accounts/constants.py tests/unit/test_role_acl.py tests/integration/test_service_account_api_keys.py`