### PR TITLE
feat(ui): expose action output masking in UI

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -105,6 +105,13 @@ export const $ActionControlFlow = {
       title: "Environment",
       description: "Override environment for this action's execution",
     },
+    mask_output: {
+      type: "boolean",
+      title: "Mask Output",
+      description:
+        "If true, redact this action's result in workflow execution API responses while preserving internal workflow data flow between actions.",
+      default: false,
+    },
   },
   type: "object",
   title: "ActionControlFlow",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -29,6 +29,10 @@ export type ActionControlFlow = {
    * Override environment for this action's execution
    */
   environment?: string | null
+  /**
+   * If true, redact this action's result in workflow execution API responses while preserving internal workflow data flow between actions.
+   */
+  mask_output?: boolean
 }
 
 export type ActionCreate = {

--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -189,6 +189,7 @@ const actionFormSchema = z.object({
     .max(1000, "Environment must be less than 1000 characters")
     .transform((val) => normalizeOptionalExpression(val))
     .optional(),
+  mask_output: z.boolean().default(false),
   is_interactive: z.boolean().default(false),
   interaction: z
     .discriminatedUnion("type", [
@@ -327,6 +328,7 @@ function ActionPanelContent({
       join_strategy: actionControlFlow?.join_strategy,
       wait_until: actionControlFlow?.wait_until || undefined,
       environment: actionControlFlow?.environment || undefined,
+      mask_output: actionControlFlow?.mask_output ?? false,
       is_interactive: action?.is_interactive ?? false,
       interaction: action?.interaction ?? undefined,
     }),
@@ -345,6 +347,7 @@ function ActionPanelContent({
       actionControlFlow?.join_strategy,
       actionControlFlow?.wait_until,
       actionControlFlow?.environment,
+      actionControlFlow?.mask_output,
     ]
   )
 
@@ -589,6 +592,7 @@ function ActionPanelContent({
             join_strategy: values.join_strategy,
             wait_until: values.wait_until,
             environment: values.environment,
+            mask_output: values.mask_output ?? false,
           },
           is_interactive: values.is_interactive,
           interaction: values.interaction,
@@ -1460,6 +1464,32 @@ function ActionPanelContent({
                                   placeholder="Type @ to begin an expression..."
                                 />
                               </FormControl>
+                            </FormItem>
+                          )}
+                        />
+                      </ControlFlowField>
+
+                      <ControlFlowField
+                        label="Mask output"
+                        description="Redact this action's result in workflow execution API responses while keeping downstream workflow data unchanged."
+                      >
+                        <FormField
+                          name="mask_output"
+                          control={methods.control}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormMessage className="whitespace-pre-line" />
+                              <div className="flex items-center gap-2">
+                                <FormControl>
+                                  <Switch
+                                    checked={field.value ?? false}
+                                    onCheckedChange={field.onChange}
+                                  />
+                                </FormControl>
+                                <span className="text-xs text-muted-foreground">
+                                  {field.value ? "Enabled" : "Disabled"}
+                                </span>
+                              </div>
                             </FormItem>
                           )}
                         />

--- a/tests/unit/test_view.py
+++ b/tests/unit/test_view.py
@@ -1790,6 +1790,7 @@ def test_build_action_statements_simple_sequence():
         type="udf",
         title="Action A",
         ref="action_a",
+        control_flow={"mask_output": True},
         upstream_edges=[
             {"source_id": trigger_id, "source_type": "trigger"},
         ],
@@ -1831,6 +1832,8 @@ def test_build_action_statements_simple_sequence():
     assert stmts_by_ref["action_a"].depends_on == []  # A is entrypoint
     assert stmts_by_ref["action_b"].depends_on == ["action_a"]  # B depends on A
     assert stmts_by_ref["action_c"].depends_on == ["action_b"]  # C depends on B
+    assert stmts_by_ref["action_a"].mask_output is True
+    assert stmts_by_ref["action_b"].mask_output is False
 
 
 def test_build_action_statements_diamond():

--- a/tests/unit/test_workflow_import_service.py
+++ b/tests/unit/test_workflow_import_service.py
@@ -58,6 +58,7 @@ def sample_dsl() -> DSLInput:
                 action="core.transform.transform",
                 args={"value": "test_value", "format": "json"},
                 description="Transforms test data",
+                mask_output=True,
             ),
             ActionStatement(
                 ref="second_action",
@@ -519,6 +520,7 @@ class TestWorkflowImportService:
             else action1.control_flow
         )
         assert isinstance(control_flow1, dict)
+        assert control_flow1["mask_output"] is True
 
         # Verify second action
         action2 = actions[1]

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -1330,6 +1330,7 @@ def build_action_statements_from_actions(
             join_strategy=control_flow.join_strategy,
             interaction=interaction,
             environment=control_flow.environment,
+            mask_output=control_flow.mask_output,
         )
         statements.append(action_stmt)
     return statements

--- a/tracecat/workflow/actions/schemas.py
+++ b/tracecat/workflow/actions/schemas.py
@@ -58,6 +58,13 @@ class ActionControlFlow(Schema):
         default=None,
         description="Override environment for this action's execution",
     )
+    mask_output: bool = Field(
+        default=False,
+        description=(
+            "If true, redact this action's result in workflow execution API "
+            "responses while preserving internal workflow data flow between actions."
+        ),
+    )
 
     @field_validator("wait_until", mode="before")
     def validate_wait_until(cls, v: str | None) -> str | None:

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -1160,6 +1160,7 @@ class WorkflowsManagementService(BaseWorkspaceService):
                 start_delay=act_stmt.start_delay,
                 wait_until=act_stmt.wait_until,
                 join_strategy=act_stmt.join_strategy,
+                mask_output=act_stmt.mask_output,
             )
             pos = (action_positions or {}).get(act_stmt.ref)
             new_action = Action(


### PR DESCRIPTION
## Summary

- Add `mask_output` to action control-flow schema and generated frontend client types.
- Surface a Mask output switch in the action panel control-flow settings.
- Preserve `mask_output` through workflow import/export action conversion paths.

## Why

The original masking behavior was merged, but these follow-up UI/control-flow propagation changes were left as local worktree changes on the old branch. This PR applies that missing diff on top of current `main`.

## Validation

- `uv run pytest tests/unit/test_view.py::test_build_action_statements_simple_sequence tests/unit/test_workflow_import_service.py`
- `uv run ruff check tracecat/dsl/common.py tracecat/workflow/actions/schemas.py tracecat/workflow/management/management.py tests/unit/test_view.py tests/unit/test_workflow_import_service.py`
- `uv run ruff format --check tracecat/dsl/common.py tracecat/workflow/actions/schemas.py tracecat/workflow/management/management.py tests/unit/test_view.py tests/unit/test_workflow_import_service.py`
- `uv run basedpyright --warnings --threads 4 tracecat/dsl/common.py tracecat/workflow/actions/schemas.py tracecat/workflow/management/management.py tests/unit/test_view.py tests/unit/test_workflow_import_service.py`
- `pnpm -C frontend exec biome check src/components/builder/panel/action-panel.tsx src/client/schemas.gen.ts src/client/types.gen.ts`
- `pnpm -C frontend run typecheck`
- commit hooks passed