### PR TITLE
fix: Preserve legacy case duration anchors

### DIFF
--- a/tests/integration/test_case_duration_benchmarks.py
+++ b/tests/integration/test_case_duration_benchmarks.py
@@ -425,6 +425,7 @@ async def test_case_duration_update_burst_health_latency(
         assert len(update_latencies) + update_errors == attempted_updates
         assert update_latencies
         assert health_latencies["baseline"]
-        assert health_latencies["burst"] or health_errors["burst"] > 0
+        assert health_errors["burst"] == 0
+        assert health_latencies["burst"]
     finally:
         await async_engine.dispose()

--- a/tests/unit/test_case_duration_service.py
+++ b/tests/unit/test_case_duration_service.py
@@ -1189,6 +1189,60 @@ async def test_legacy_empty_field_filters_match_any_field_change(
 
 
 @pytest.mark.anyio
+async def test_legacy_scalar_filter_matches_value_collected_from_list(
+    session: AsyncSession, svc_role
+) -> None:
+    cases_service = CasesService(session=session, role=svc_role)
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    case = await cases_service.create_case(make_case_create())
+    case_created_result = await session.execute(
+        select(CaseEvent).where(
+            CaseEvent.case_id == case.id,
+            CaseEvent.type == CaseEventType.CASE_CREATED,
+        )
+    )
+    created_event = case_created_result.scalar_one()
+    nonmatching_event = CaseEvent(
+        workspace_id=case.workspace_id,
+        case_id=case.id,
+        type=CaseEventType.STATUS_CHANGED,
+        data={"items": [{"name": "bar"}]},
+        created_at=created_event.created_at + timedelta(seconds=1),
+    )
+    matching_event = CaseEvent(
+        workspace_id=case.workspace_id,
+        case_id=case.id,
+        type=CaseEventType.STATUS_CHANGED,
+        data={"items": [{"name": "foo"}]},
+        created_at=created_event.created_at + timedelta(seconds=2),
+    )
+    session.add_all([nonmatching_event, matching_event])
+
+    assert svc_role.workspace_id is not None
+    definition = CaseDurationDefinitionDB(
+        workspace_id=svc_role.workspace_id,
+        name="Legacy scalar filter duration",
+        start_event_type=CaseEventType.CASE_CREATED,
+        start_timestamp_path="created_at",
+        start_field_filters={},
+        start_selection=CaseDurationAnchorSelection.FIRST,
+        end_event_type=CaseEventType.STATUS_CHANGED,
+        end_timestamp_path="created_at",
+        end_field_filters={"data.items.name": "foo"},
+        end_selection=CaseDurationAnchorSelection.FIRST,
+    )
+    session.add(definition)
+    await session.flush()
+
+    values = await duration_service.compute_duration(case)
+
+    assert len(values) == 1
+    assert values[0].end_event_id == matching_event.id
+    assert values[0].duration == matching_event.created_at - created_event.created_at
+
+
+@pytest.mark.anyio
 async def test_legacy_custom_timestamp_path_uses_event_scan_fallback(
     session: AsyncSession, svc_role
 ) -> None:

--- a/tests/unit/test_case_duration_service.py
+++ b/tests/unit/test_case_duration_service.py
@@ -1085,6 +1085,7 @@ async def test_duration_storage_allows_empty_legacy_filters(
     session: AsyncSession, svc_role
 ) -> None:
     definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
+    duration_service = CaseDurationService(session=session, role=svc_role)
     assert svc_role.workspace_id is not None
     entity = CaseDurationDefinitionDB(
         workspace_id=svc_role.workspace_id,
@@ -1101,9 +1102,11 @@ async def test_duration_storage_allows_empty_legacy_filters(
 
     anchor = definition_service._anchor_from_entity(entity, "start")
 
-    assert anchor._has_unsupported_filters
+    assert not anchor._has_unsupported_filters
+    assert anchor._allow_empty_required_filters
     assert anchor.filters == CaseDurationEventFilters()
     assert anchor._legacy_field_filters == {}
+    assert not duration_service._anchor_requires_event_scan(anchor)
 
 
 @pytest.mark.anyio
@@ -1200,19 +1203,31 @@ async def test_legacy_custom_timestamp_path_uses_event_scan_fallback(
         )
     )
     created_event = case_created_result.scalar_one()
-    custom_end = created_event.created_at + timedelta(hours=2)
-    status_event = CaseEvent(
+    first_custom_end = created_event.created_at + timedelta(hours=1)
+    later_custom_end = created_event.created_at + timedelta(hours=2)
+    later_created_event = CaseEvent(
         workspace_id=case.workspace_id,
         case_id=case.id,
         type=CaseEventType.STATUS_CHANGED,
         data={
             "old": CaseStatus.NEW.value,
             "new": CaseStatus.RESOLVED.value,
-            "resolved_at": custom_end.isoformat(),
+            "resolved_at": later_custom_end.isoformat(),
         },
         created_at=created_event.created_at + timedelta(seconds=1),
     )
-    session.add(status_event)
+    first_custom_event = CaseEvent(
+        workspace_id=case.workspace_id,
+        case_id=case.id,
+        type=CaseEventType.STATUS_CHANGED,
+        data={
+            "old": CaseStatus.IN_PROGRESS.value,
+            "new": CaseStatus.RESOLVED.value,
+            "resolved_at": first_custom_end.isoformat(),
+        },
+        created_at=created_event.created_at + timedelta(seconds=2),
+    )
+    session.add_all([later_created_event, first_custom_event])
 
     assert svc_role.workspace_id is not None
     definition = CaseDurationDefinitionDB(
@@ -1234,6 +1249,6 @@ async def test_legacy_custom_timestamp_path_uses_event_scan_fallback(
 
     assert len(values) == 1
     value = values[0]
-    assert value.end_event_id == status_event.id
-    assert value.ended_at == custom_end
-    assert value.duration == custom_end - created_event.created_at
+    assert value.end_event_id == first_custom_event.id
+    assert value.ended_at == first_custom_end
+    assert value.duration == first_custom_end - created_event.created_at

--- a/tests/unit/test_case_duration_service.py
+++ b/tests/unit/test_case_duration_service.py
@@ -1046,7 +1046,7 @@ async def test_duration_storage_marks_arbitrary_legacy_filters_unsupported(
 
 
 @pytest.mark.anyio
-async def test_duration_storage_marks_invalid_legacy_anchor_unsupported(
+async def test_duration_storage_allows_empty_legacy_filters(
     session: AsyncSession, svc_role
 ) -> None:
     definition_service = CaseDurationDefinitionService(session=session, role=svc_role)
@@ -1066,5 +1066,138 @@ async def test_duration_storage_marks_invalid_legacy_anchor_unsupported(
 
     anchor = definition_service._anchor_from_entity(entity, "start")
 
-    assert anchor._has_unsupported_filters
+    assert not anchor._has_unsupported_filters
     assert anchor.filters == CaseDurationEventFilters()
+
+
+@pytest.mark.anyio
+async def test_legacy_empty_status_filters_match_any_status_change(
+    session: AsyncSession, svc_role
+) -> None:
+    cases_service = CasesService(session=session, role=svc_role)
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    assert svc_role.workspace_id is not None
+    definition = CaseDurationDefinitionDB(
+        workspace_id=svc_role.workspace_id,
+        name="Any status duration",
+        start_event_type=CaseEventType.CASE_CREATED,
+        start_timestamp_path="created_at",
+        start_field_filters={},
+        start_selection=CaseDurationAnchorSelection.FIRST,
+        end_event_type=CaseEventType.STATUS_CHANGED,
+        end_timestamp_path="created_at",
+        end_field_filters={},
+        end_selection=CaseDurationAnchorSelection.FIRST,
+    )
+    session.add(definition)
+    await session.flush()
+
+    case = await cases_service.create_case(make_case_create())
+    case = await cases_service.update_case(
+        case,
+        CaseUpdate(status=CaseStatus.IN_PROGRESS),
+    )
+
+    values = await duration_service.compute_duration(case)
+
+    assert len(values) == 1
+    assert values[0].end_event_id is not None
+    assert values[0].ended_at is not None
+    assert values[0].duration is not None
+
+
+@pytest.mark.anyio
+async def test_legacy_empty_field_filters_match_any_field_change(
+    session: AsyncSession, svc_role
+) -> None:
+    cases_service = CasesService(session=session, role=svc_role)
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    assert svc_role.workspace_id is not None
+    definition = CaseDurationDefinitionDB(
+        workspace_id=svc_role.workspace_id,
+        name="Any field duration",
+        start_event_type=CaseEventType.CASE_CREATED,
+        start_timestamp_path="created_at",
+        start_field_filters={},
+        start_selection=CaseDurationAnchorSelection.FIRST,
+        end_event_type=CaseEventType.FIELDS_CHANGED,
+        end_timestamp_path="created_at",
+        end_field_filters={},
+        end_selection=CaseDurationAnchorSelection.FIRST,
+    )
+    session.add(definition)
+    await session.flush()
+
+    case = await cases_service.create_case(make_case_create())
+    field_event = CaseEvent(
+        workspace_id=case.workspace_id,
+        case_id=case.id,
+        type=CaseEventType.FIELDS_CHANGED,
+        data={"changes": [{"field": "legacy_field", "old": None, "new": "value"}]},
+        created_at=datetime.now(UTC) + timedelta(seconds=1),
+    )
+    session.add(field_event)
+    await session.flush()
+
+    values = await duration_service.compute_duration(case)
+
+    assert len(values) == 1
+    assert values[0].end_event_id == field_event.id
+    assert values[0].ended_at == field_event.created_at
+    assert values[0].duration is not None
+
+
+@pytest.mark.anyio
+async def test_legacy_custom_timestamp_path_uses_event_scan_fallback(
+    session: AsyncSession, svc_role
+) -> None:
+    cases_service = CasesService(session=session, role=svc_role)
+    duration_service = CaseDurationService(session=session, role=svc_role)
+
+    case = await cases_service.create_case(make_case_create())
+    case_created_result = await session.execute(
+        select(CaseEvent).where(
+            CaseEvent.case_id == case.id,
+            CaseEvent.type == CaseEventType.CASE_CREATED,
+        )
+    )
+    created_event = case_created_result.scalar_one()
+    custom_end = created_event.created_at + timedelta(hours=2)
+    status_event = CaseEvent(
+        workspace_id=case.workspace_id,
+        case_id=case.id,
+        type=CaseEventType.STATUS_CHANGED,
+        data={
+            "old": CaseStatus.NEW.value,
+            "new": CaseStatus.RESOLVED.value,
+            "resolved_at": custom_end.isoformat(),
+        },
+        created_at=created_event.created_at + timedelta(seconds=1),
+    )
+    session.add(status_event)
+
+    assert svc_role.workspace_id is not None
+    definition = CaseDurationDefinitionDB(
+        workspace_id=svc_role.workspace_id,
+        name="Legacy custom timestamp duration",
+        start_event_type=CaseEventType.CASE_CREATED,
+        start_timestamp_path="created_at",
+        start_field_filters={},
+        start_selection=CaseDurationAnchorSelection.FIRST,
+        end_event_type=CaseEventType.STATUS_CHANGED,
+        end_timestamp_path="data.resolved_at",
+        end_field_filters={"data.new": CaseStatus.RESOLVED.value},
+        end_selection=CaseDurationAnchorSelection.FIRST,
+    )
+    session.add(definition)
+    await session.flush()
+
+    values = await duration_service.compute_duration(case)
+
+    assert len(values) == 1
+    value = values[0]
+    assert value.end_event_id == status_event.id
+    assert value.ended_at == custom_end
+    assert value.duration == custom_end - created_event.created_at

--- a/tests/unit/test_case_duration_service.py
+++ b/tests/unit/test_case_duration_service.py
@@ -1015,6 +1015,41 @@ def test_duration_anchor_rejects_custom_timestamp_paths() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        CaseEventType.PRIORITY_CHANGED,
+        CaseEventType.SEVERITY_CHANGED,
+        CaseEventType.STATUS_CHANGED,
+        CaseEventType.TAG_ADDED,
+        CaseEventType.TAG_REMOVED,
+        CaseEventType.FIELDS_CHANGED,
+        CaseEventType.DROPDOWN_VALUE_CHANGED,
+    ],
+)
+def test_duration_anchor_rejects_empty_required_filters(
+    event_type: CaseEventType,
+) -> None:
+    with pytest.raises(ValidationError):
+        CaseDurationEventAnchor(event_type=event_type)
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        CaseEventType.CASE_CREATED,
+        CaseEventType.CASE_CLOSED,
+        CaseEventType.CASE_REOPENED,
+    ],
+)
+def test_duration_anchor_allows_empty_filters_for_unfiltered_events(
+    event_type: CaseEventType,
+) -> None:
+    anchor = CaseDurationEventAnchor(event_type=event_type)
+
+    assert anchor.filters == CaseDurationEventFilters()
+
+
 @pytest.mark.anyio
 async def test_duration_storage_maps_known_legacy_ui_filters(
     session: AsyncSession, svc_role
@@ -1066,8 +1101,9 @@ async def test_duration_storage_allows_empty_legacy_filters(
 
     anchor = definition_service._anchor_from_entity(entity, "start")
 
-    assert not anchor._has_unsupported_filters
+    assert anchor._has_unsupported_filters
     assert anchor.filters == CaseDurationEventFilters()
+    assert anchor._legacy_field_filters == {}
 
 
 @pytest.mark.anyio

--- a/tracecat/cases/durations/schemas.py
+++ b/tracecat/cases/durations/schemas.py
@@ -83,10 +83,10 @@ class CaseDurationEventAnchor(BaseModel):
 
     @model_validator(mode="after")
     def validate_filters_for_event_type(self) -> CaseDurationEventAnchor:
-        filters = self.filters
-        if filters.is_empty():
+        if self._has_unsupported_filters:
             return self
 
+        filters = self.filters
         allowed_fields = _allowed_filter_fields_for_event_type(self.event_type)
         active_fields = _active_filter_fields(filters)
         unsupported = active_fields - allowed_fields

--- a/tracecat/cases/durations/schemas.py
+++ b/tracecat/cases/durations/schemas.py
@@ -78,13 +78,13 @@ class CaseDurationEventAnchor(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     _has_unsupported_filters: bool = PrivateAttr(default=False)
+    _timestamp_path: str = PrivateAttr(default="created_at")
+    _legacy_field_filters: dict[str, Any] = PrivateAttr(default_factory=dict)
 
     @model_validator(mode="after")
     def validate_filters_for_event_type(self) -> CaseDurationEventAnchor:
         filters = self.filters
         if filters.is_empty():
-            if self.event_type in _FILTER_REQUIRED_EVENT_TYPES:
-                raise ValueError(f"{self.event_type.value} requires filters")
             return self
 
         allowed_fields = _allowed_filter_fields_for_event_type(self.event_type)
@@ -121,11 +121,6 @@ _CATEGORY_FILTER_EVENT_TYPES = frozenset(
 )
 _TAG_FILTER_EVENT_TYPES = frozenset(
     {CaseEventType.TAG_ADDED, CaseEventType.TAG_REMOVED}
-)
-_FILTER_REQUIRED_EVENT_TYPES = (
-    _CATEGORY_FILTER_EVENT_TYPES
-    | _TAG_FILTER_EVENT_TYPES
-    | {CaseEventType.FIELDS_CHANGED, CaseEventType.DROPDOWN_VALUE_CHANGED}
 )
 
 

--- a/tracecat/cases/durations/schemas.py
+++ b/tracecat/cases/durations/schemas.py
@@ -78,12 +78,15 @@ class CaseDurationEventAnchor(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     _has_unsupported_filters: bool = PrivateAttr(default=False)
+    _allow_empty_required_filters: bool = PrivateAttr(default=False)
     _timestamp_path: str = PrivateAttr(default="created_at")
     _legacy_field_filters: dict[str, Any] = PrivateAttr(default_factory=dict)
 
     @model_validator(mode="after")
     def validate_filters_for_event_type(self) -> CaseDurationEventAnchor:
-        if self._has_unsupported_filters:
+        if self._has_unsupported_filters or (
+            self._allow_empty_required_filters and self.filters.is_empty()
+        ):
             return self
 
         filters = self.filters

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -50,6 +50,7 @@ from tracecat.exceptions import (
     TracecatValidationError,
 )
 from tracecat.service import BaseWorkspaceService, requires_entitlement
+from tracecat.tables.common import coerce_to_utc_datetime
 from tracecat.tiers.enums import Entitlement
 
 type _DurationEventMatch = tuple[uuid.UUID, datetime]
@@ -198,6 +199,7 @@ class CaseDurationDefinitionService(BaseWorkspaceService):
         raw_filters = dict(getattr(entity, f"{prefix}_field_filters") or {})
         event_type = getattr(entity, f"{prefix}_event_type")
         selection = getattr(entity, f"{prefix}_selection")
+        timestamp_path = getattr(entity, f"{prefix}_timestamp_path") or "created_at"
         filters, has_unsupported_filters = self._filters_from_storage(
             event_type, raw_filters
         )
@@ -222,6 +224,8 @@ class CaseDurationDefinitionService(BaseWorkspaceService):
                     selection=selection,
                 )
         anchor._has_unsupported_filters = has_unsupported_filters
+        anchor._timestamp_path = timestamp_path
+        anchor._legacy_field_filters = raw_filters
         return anchor
 
     def _anchor_attributes(
@@ -230,7 +234,7 @@ class CaseDurationDefinitionService(BaseWorkspaceService):
         filters = self._filters_to_storage(anchor.filters)
         return {
             f"{prefix}_event_type": anchor.event_type,
-            f"{prefix}_timestamp_path": "created_at",
+            f"{prefix}_timestamp_path": anchor._timestamp_path,
             f"{prefix}_field_filters": filters,
             f"{prefix}_selection": anchor.selection,
         }
@@ -588,6 +592,51 @@ class CaseDurationService(BaseWorkspaceService):
         case_ids: Sequence[uuid.UUID],
         definitions: Sequence[CaseDurationDefinitionRead],
     ) -> dict[uuid.UUID, list[CaseDurationComputation]]:
+        fallback_definitions = [
+            definition
+            for definition in definitions
+            if self._definition_requires_event_scan(definition)
+        ]
+        if not fallback_definitions:
+            return await self._compute_durations_fast_from_db_for_cases(
+                case_ids,
+                definitions,
+            )
+
+        fast_definitions = [
+            definition
+            for definition in definitions
+            if not self._definition_requires_event_scan(definition)
+        ]
+        fast_results = await self._compute_durations_fast_from_db_for_cases(
+            case_ids,
+            fast_definitions,
+        )
+        fallback_results = await self._compute_durations_from_events_for_cases(
+            case_ids,
+            fallback_definitions,
+        )
+
+        merged_by_case: dict[uuid.UUID, list[CaseDurationComputation]] = {}
+        for case_id in case_ids:
+            by_definition = {
+                computation.duration_id: computation
+                for computation in (
+                    fast_results.get(case_id, []) + fallback_results.get(case_id, [])
+                )
+            }
+            merged_by_case[case_id] = [
+                by_definition[definition.id]
+                for definition in definitions
+                if definition.id in by_definition
+            ]
+        return merged_by_case
+
+    async def _compute_durations_fast_from_db_for_cases(
+        self,
+        case_ids: Sequence[uuid.UUID],
+        definitions: Sequence[CaseDurationDefinitionRead],
+    ) -> dict[uuid.UUID, list[CaseDurationComputation]]:
         results_by_case: dict[uuid.UUID, list[CaseDurationComputation]] = {
             case_id: [] for case_id in case_ids
         }
@@ -659,6 +708,211 @@ class CaseDurationService(BaseWorkspaceService):
                 )
 
         return results_by_case
+
+    def _definition_requires_event_scan(
+        self, definition: CaseDurationDefinitionRead
+    ) -> bool:
+        return self._anchor_requires_event_scan(
+            definition.start_anchor
+        ) or self._anchor_requires_event_scan(definition.end_anchor)
+
+    def _anchor_requires_event_scan(self, anchor: CaseDurationEventAnchor) -> bool:
+        return anchor._timestamp_path != "created_at" or anchor._has_unsupported_filters
+
+    async def _compute_durations_from_events_for_cases(
+        self,
+        case_ids: Sequence[uuid.UUID],
+        definitions: Sequence[CaseDurationDefinitionRead],
+    ) -> dict[uuid.UUID, list[CaseDurationComputation]]:
+        if not case_ids:
+            return {}
+
+        events_by_case = await self._list_case_events_for_cases(case_ids)
+        return {
+            case_id: self._compute_durations_from_events(
+                events_by_case.get(case_id, []),
+                definitions,
+            )
+            for case_id in case_ids
+        }
+
+    async def _list_case_events_for_cases(
+        self, case_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, list[CaseEvent]]:
+        stmt = (
+            select(CaseEvent)
+            .where(
+                CaseEvent.workspace_id == self.workspace_id,
+                CaseEvent.case_id.in_(case_ids),
+            )
+            .order_by(
+                CaseEvent.case_id.asc(),
+                CaseEvent.created_at.asc(),
+                CaseEvent.surrogate_id.asc(),
+            )
+        )
+        result = await self.session.execute(stmt)
+        events_by_case: dict[uuid.UUID, list[CaseEvent]] = {
+            case_id: [] for case_id in case_ids
+        }
+        for event in result.scalars().all():
+            events_by_case[event.case_id].append(event)
+        return events_by_case
+
+    def _compute_durations_from_events(
+        self,
+        events: Sequence[CaseEvent],
+        definitions: Sequence[CaseDurationDefinitionRead],
+    ) -> list[CaseDurationComputation]:
+        results: list[CaseDurationComputation] = []
+        for definition in definitions:
+            start_match = self._find_matching_event(events, definition.start_anchor)
+            end_match = self._find_matching_event(
+                events,
+                definition.end_anchor,
+                earliest_after=start_match[1] if start_match else None,
+            )
+
+            started_at = start_match[1] if start_match else None
+            ended_at = end_match[1] if end_match else None
+            if started_at and ended_at and ended_at < started_at:
+                end_match = None
+                ended_at = None
+            duration = ended_at - started_at if started_at and ended_at else None
+
+            results.append(
+                CaseDurationComputation(
+                    duration_id=definition.id,
+                    name=definition.name,
+                    description=definition.description,
+                    start_event_id=start_match[0].id if start_match else None,
+                    end_event_id=end_match[0].id if end_match else None,
+                    started_at=started_at,
+                    ended_at=ended_at,
+                    duration=duration,
+                )
+            )
+
+        return results
+
+    def _find_matching_event(
+        self,
+        events: Sequence[CaseEvent],
+        anchor: CaseDurationEventAnchor,
+        *,
+        earliest_after: datetime | None = None,
+    ) -> tuple[CaseEvent, datetime] | None:
+        candidates: list[tuple[CaseEvent, datetime]] = []
+        for event in events:
+            if anchor.event_type is CaseEventType.STATUS_CHANGED:
+                if event.type not in (
+                    CaseEventType.STATUS_CHANGED,
+                    CaseEventType.CASE_CLOSED,
+                    CaseEventType.CASE_REOPENED,
+                ):
+                    continue
+            elif event.type != anchor.event_type:
+                continue
+            if not self._matches_anchor_filters(event, anchor):
+                continue
+            timestamp = self._extract_timestamp(event, anchor)
+            if timestamp is None:
+                continue
+            if earliest_after and timestamp < earliest_after:
+                continue
+            candidates.append((event, timestamp))
+
+        if not candidates:
+            return None
+        candidates.sort(key=lambda item: item[1])
+        if anchor.selection is CaseDurationAnchorSelection.LAST:
+            return candidates[-1]
+        return candidates[0]
+
+    def _matches_anchor_filters(
+        self, event: CaseEvent, anchor: CaseDurationEventAnchor
+    ) -> bool:
+        field_filters = (
+            anchor._legacy_field_filters
+            if anchor._has_unsupported_filters
+            else self._anchor_filters_to_field_filters(anchor)
+        )
+        return self._matches_filters(event, field_filters)
+
+    def _anchor_filters_to_field_filters(
+        self, anchor: CaseDurationEventAnchor
+    ) -> dict[str, Any]:
+        filters = anchor.filters
+        field_filters: dict[str, Any] = {}
+        if filters.new_values:
+            field_filters["data.new"] = filters.new_values
+        if filters.tag_refs:
+            field_filters["data.tag_ref"] = filters.tag_refs
+        if filters.field_ids:
+            field_filters["data.changes.field"] = filters.field_ids
+        if filters.dropdown_definition_id is not None:
+            field_filters["data.definition_id"] = filters.dropdown_definition_id
+        if filters.dropdown_option_ids:
+            field_filters["data.new_option_id"] = filters.dropdown_option_ids
+        return field_filters
+
+    def _matches_filters(self, event: CaseEvent, filters: dict[str, Any]) -> bool:
+        for path, expected in filters.items():
+            actual = self._resolve_field(event, path)
+            actual_normalized = self._normalize_filter_value(actual)
+            expected_normalized = self._normalize_filter_value(expected)
+            if isinstance(expected_normalized, list):
+                if actual_normalized is None:
+                    return False
+                if isinstance(actual_normalized, list):
+                    if not any(
+                        item in expected_normalized for item in actual_normalized
+                    ):
+                        return False
+                elif actual_normalized not in expected_normalized:
+                    return False
+            elif actual_normalized != expected_normalized:
+                return False
+        return True
+
+    def _normalize_filter_value(self, value: Any) -> Any:
+        if isinstance(value, Enum):
+            return value.value
+        if isinstance(value, list | tuple | set):
+            return [self._normalize_filter_value(item) for item in value]
+        return value
+
+    def _extract_timestamp(
+        self, event: CaseEvent, anchor: CaseDurationEventAnchor
+    ) -> datetime | None:
+        value = self._resolve_field(event, anchor._timestamp_path)
+        try:
+            return coerce_to_utc_datetime(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+
+    def _resolve_field(self, event: CaseEvent, path: str) -> Any:
+        value: Any = event
+        for part in path.split("."):
+            if isinstance(value, list):
+                collected = []
+                for item in value:
+                    if isinstance(item, dict):
+                        resolved = item.get(part)
+                    else:
+                        resolved = getattr(item, part, None)
+                    if resolved is not None:
+                        collected.append(resolved)
+                if not collected:
+                    return None
+                value = collected
+            elif isinstance(value, dict):
+                value = value.get(part)
+            else:
+                value = getattr(value, part, None)
+            if value is None:
+                return None
+        return value
 
     async def _find_matching_events_db(
         self,

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -896,6 +896,9 @@ class CaseDurationService(BaseWorkspaceService):
                         return False
                 elif actual_normalized not in expected_normalized:
                     return False
+            elif isinstance(actual_normalized, list):
+                if expected_normalized not in actual_normalized:
+                    return False
             elif actual_normalized != expected_normalized:
                 return False
         return True

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -203,6 +203,7 @@ class CaseDurationDefinitionService(BaseWorkspaceService):
         filters, has_unsupported_filters = self._filters_from_storage(
             event_type, raw_filters
         )
+        allow_empty_required_filters = False
         if has_unsupported_filters:
             anchor = CaseDurationEventAnchor.model_construct(
                 event_type=event_type,
@@ -217,13 +218,17 @@ class CaseDurationDefinitionService(BaseWorkspaceService):
                     selection=selection,
                 )
             except ValueError:
-                has_unsupported_filters = True
+                if not raw_filters and filters.is_empty():
+                    allow_empty_required_filters = True
+                else:
+                    has_unsupported_filters = True
                 anchor = CaseDurationEventAnchor.model_construct(
                     event_type=event_type,
                     filters=filters,
                     selection=selection,
                 )
         anchor._has_unsupported_filters = has_unsupported_filters
+        anchor._allow_empty_required_filters = allow_empty_required_filters
         anchor._timestamp_path = timestamp_path
         anchor._legacy_field_filters = raw_filters
         return anchor
@@ -805,8 +810,16 @@ class CaseDurationService(BaseWorkspaceService):
         *,
         earliest_after: datetime | None = None,
     ) -> tuple[CaseEvent, datetime] | None:
-        candidates: list[tuple[CaseEvent, datetime]] = []
-        async for event in cooperative_every(events, every=128):
+        best_match: tuple[CaseEvent, datetime] | None = None
+        created_at_ordered = anchor._timestamp_path == "created_at"
+        reverse_scan = (
+            created_at_ordered and anchor.selection is CaseDurationAnchorSelection.LAST
+        )
+        event_iter = reversed(events) if reverse_scan else events
+
+        async for event in cooperative_every(event_iter, every=128):
+            if reverse_scan and earliest_after and event.created_at < earliest_after:
+                break
             if anchor.event_type is CaseEventType.STATUS_CHANGED:
                 if event.type not in (
                     CaseEventType.STATUS_CHANGED,
@@ -823,14 +836,23 @@ class CaseDurationService(BaseWorkspaceService):
                 continue
             if earliest_after and timestamp < earliest_after:
                 continue
-            candidates.append((event, timestamp))
+            if created_at_ordered:
+                return event, timestamp
 
-        if not candidates:
-            return None
-        candidates.sort(key=lambda item: item[1])
-        if anchor.selection is CaseDurationAnchorSelection.LAST:
-            return candidates[-1]
-        return candidates[0]
+            if (
+                best_match is None
+                or (
+                    anchor.selection is CaseDurationAnchorSelection.FIRST
+                    and timestamp < best_match[1]
+                )
+                or (
+                    anchor.selection is CaseDurationAnchorSelection.LAST
+                    and timestamp >= best_match[1]
+                )
+            ):
+                best_match = (event, timestamp)
+
+        return best_match
 
     def _matches_anchor_filters(
         self, event: CaseEvent, anchor: CaseDurationEventAnchor

--- a/tracecat/cases/durations/service.py
+++ b/tracecat/cases/durations/service.py
@@ -728,13 +728,13 @@ class CaseDurationService(BaseWorkspaceService):
             return {}
 
         events_by_case = await self._list_case_events_for_cases(case_ids)
-        return {
-            case_id: self._compute_durations_from_events(
+        results_by_case: dict[uuid.UUID, list[CaseDurationComputation]] = {}
+        async for case_id in cooperative_every(case_ids, every=8):
+            results_by_case[case_id] = await self._compute_durations_from_events(
                 events_by_case.get(case_id, []),
                 definitions,
             )
-            for case_id in case_ids
-        }
+        return results_by_case
 
     async def _list_case_events_for_cases(
         self, case_ids: Sequence[uuid.UUID]
@@ -759,15 +759,18 @@ class CaseDurationService(BaseWorkspaceService):
             events_by_case[event.case_id].append(event)
         return events_by_case
 
-    def _compute_durations_from_events(
+    async def _compute_durations_from_events(
         self,
         events: Sequence[CaseEvent],
         definitions: Sequence[CaseDurationDefinitionRead],
     ) -> list[CaseDurationComputation]:
         results: list[CaseDurationComputation] = []
-        for definition in definitions:
-            start_match = self._find_matching_event(events, definition.start_anchor)
-            end_match = self._find_matching_event(
+        async for definition in cooperative_every(definitions, every=32):
+            start_match = await self._find_matching_event(
+                events,
+                definition.start_anchor,
+            )
+            end_match = await self._find_matching_event(
                 events,
                 definition.end_anchor,
                 earliest_after=start_match[1] if start_match else None,
@@ -795,7 +798,7 @@ class CaseDurationService(BaseWorkspaceService):
 
         return results
 
-    def _find_matching_event(
+    async def _find_matching_event(
         self,
         events: Sequence[CaseEvent],
         anchor: CaseDurationEventAnchor,
@@ -803,7 +806,7 @@ class CaseDurationService(BaseWorkspaceService):
         earliest_after: datetime | None = None,
     ) -> tuple[CaseEvent, datetime] | None:
         candidates: list[tuple[CaseEvent, datetime]] = []
-        for event in events:
+        async for event in cooperative_every(events, every=128):
             if anchor.event_type is CaseEventType.STATUS_CHANGED:
                 if event.type not in (
                     CaseEventType.STATUS_CHANGED,


### PR DESCRIPTION
## Summary

- Restore required-filter validation for newly authored case duration anchors so empty required filters are rejected on create/update payloads.
- Preserve legacy stored definitions with empty filters by treating them as match-any anchors without relaxing public API validation.
- Keep SQL-compatible legacy empty-filter anchors on the SQL path, and reserve the event-scan fallback for custom timestamp paths or genuinely unsupported legacy filters.
- Add cooperative checkpoints to the legacy fallback scan so compatibility work yields back to the event loop during large in-memory scans.
- Tighten the opt-in case-duration burst benchmark so burst healthcheck errors fail the test.

## Review Map

Before the original perf change in `2dec4719e` / #2558, duration computation looked roughly like this:

```text
load definitions
load case events ordered by created_at
for each definition:
  start = scan events with anchor.event_type + anchor.field_filters
  end = scan events after start with anchor.event_type + anchor.field_filters
  timestamp = resolve anchor.timestamp_path from the event
  sort candidates by resolved timestamp
```

That old path was slower under bursts because every computation scanned ORM-loaded events in Python, but it also had two broad legacy behaviors:

```text
field_filters = {}            -> match any event of the configured type
timestamp_path = data.foo     -> use event.data.foo, not event.created_at
```

After #2558, the normal path became SQL-first and much faster:

```text
for each definition:
  query first/last start match in SQL
  query first/last end match in SQL with per-case start bound
```

The regression risk was that SQL only understood the newer typed filter model and `created_at` anchors. Stored legacy rows with `{}` filters or custom timestamp paths could therefore stop matching the way they did before.

This PR keeps the #2558 SQL fast path, and adds a compatibility split:

```text
typed filters + created_at
  -> SQL fast path

legacy {} filters + created_at
  -> SQL fast path as match-any event type

custom timestamp path or unsupported legacy filters
  -> event-scan compatibility fallback
```

## Compatibility Notes

This PR separates new payload validation from legacy stored-row reconstruction:

- New create/update payloads still reject empty required filters for `status_changed`, priority/severity changes, tag events, field changes, and dropdown value changes.
- Stored legacy rows with `{}` filters are reconstructed with an internal compatibility marker so they continue to match any event of the configured type.
- Stored rows with custom timestamp paths, such as `data.resolved_at`, continue to use that extracted timestamp for first/last selection instead of silently falling back to `created_at`.

## Performance Notes

The main SQL fast path remains unchanged for normal typed-filter definitions.

The fallback path is now narrower and cheaper:

- Empty legacy filters with `created_at` stay on SQL because SQL can already express “match any event of this type.”
- Python event scanning is reserved for custom timestamp paths or legacy filters that cannot be represented by the typed SQL filters.
- The remaining event scan selects the best match incrementally instead of collecting and sorting all candidate events.
- For `created_at`-ordered anchors, the scanner can return early for first-match scans and scan in reverse for last-match scans.
- The fallback stays on the event loop because it works with ORM-loaded models, but it uses `cooperative_every` checkpoints to avoid monopolizing the API loop during rare large legacy scans.

## Validation

- `uv run pytest tests/unit/test_case_duration_service.py tests/unit/test_concurrency.py`
- `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/test_case_duration_service.py`
- `uv run ruff check tracecat/cases/durations/service.py tracecat/cases/durations/schemas.py tests/unit/test_case_duration_service.py tests/integration/test_case_duration_benchmarks.py`
- `uv run basedpyright tracecat/cases/durations/service.py tracecat/cases/durations/schemas.py tests/unit/test_case_duration_service.py tests/integration/test_case_duration_benchmarks.py`
- `uv run ruff format --check tracecat/cases/durations/service.py tracecat/cases/durations/schemas.py tests/unit/test_case_duration_service.py tests/integration/test_case_duration_benchmarks.py`
- `TRACECAT_RUN_CASE_DURATION_BENCHMARKS=1 TRACECAT_CASE_DURATION_BENCHMARK_OUTPUT=/tmp/tracecat-case-duration-benchmark-after-fix.json uv run pytest tests/integration/test_case_duration_benchmarks.py -s`

Benchmark run: burst health errors `0`, burst health p95 `135.3ms`, max `219.2ms`.

## Additional QA - April 30, 2026

Last-mile QA was run against the current branch in an isolated local Tracecat stack:

- Started `just cluster up -d` for worktree `codex-case-duration-compat`, cluster `codex-case-duration-compat-2`.
- Used local API `http://localhost:180/api` and seeded workspace `299ec1da-4ed0-4418-b26e-51b119d8ad2f`.
- Created a temporary workspace service account with `case:read`, `case:create`, `case:update`, and `case:delete`, then used its bearer key for the API checks.
- Verified normal duration computation via API: `case_created` -> `status_changed` filtered to `resolved` computed and persisted.
- Verified status alias behavior via API:
  - `status_changed` filtered to `closed` matched a `case_closed` event.
  - `status_changed` filtered to `in_progress` matched a `case_reopened` event.
- Verified dropdown duration filters via API by creating a temporary dropdown, setting a case dropdown value, and confirming `dropdown_value_changed` with `dropdown_definition_id` + `dropdown_option_ids` computed.
- Verified public API validation rejects newly authored incompatible anchors:
  - Empty required `status_changed` filters returned `422`.
  - Custom `timestamp_path` returned `422`.
- Verified legacy DB compatibility through API-triggered sync:
  - Stored legacy `{}` status filters still matched any status change.
  - Stored legacy `data.resolved_at` timestamp path used the extracted timestamp and selected by custom timestamp order, not `created_at` order.
  - Stored arbitrary legacy field filter `data.items.name` used the event-scan fallback and matched the expected event.
- Cleanup completed: 7 temporary cases deleted, 7 temporary duration definitions deleted, 1 temporary dropdown definition deleted, and temporary service account `8964e7d6-2576-470d-9544-5e38e8d0752c` disabled.
- Post-cleanup DB check found 0 remaining QA cases, 0 duration definitions, 0 dropdown definitions, and 0 active QA service accounts for run `codex-qa-0f6e96ea`.
- Stopped the local cluster with `just cluster down` without removing volumes.

Additional verification from this QA pass:

- `uv run pytest tests/unit/test_case_duration_service.py` -> 36 passed.
- `TRACECAT_RUN_CASE_DURATION_BENCHMARKS=1 TRACECAT_CASE_DURATION_BENCHMARK_OUTPUT=/tmp/case-duration-benchmark-codex-qa.json uv run pytest tests/integration/test_case_duration_benchmarks.py -s` -> 3 passed.
- Benchmark run: burst health errors `0`, burst health p95 `62.8ms`, max `125.8ms`; update errors `0`; update p95/max `686.0ms`.
- `uv run ruff check tracecat/cases/durations/schemas.py tracecat/cases/durations/service.py tests/unit/test_case_duration_service.py tests/integration/test_case_duration_benchmarks.py`
- `uv run basedpyright tracecat/cases/durations/schemas.py tracecat/cases/durations/service.py tests/unit/test_case_duration_service.py tests/integration/test_case_duration_benchmarks.py`
- `git diff --check main...HEAD`
