### PR TITLE
feat(api): Add workspace-scoped route aliases

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -752,6 +752,8 @@ import type {
   WorkflowExecutionsCreateDraftWorkflowExecutionResponse,
   WorkflowExecutionsCreateWorkflowExecutionData,
   WorkflowExecutionsCreateWorkflowExecutionResponse,
+  WorkflowExecutionsGetWorkflowExecutionByWorkflowIdData,
+  WorkflowExecutionsGetWorkflowExecutionByWorkflowIdResponse,
   WorkflowExecutionsGetWorkflowExecutionCollectionPageData,
   WorkflowExecutionsGetWorkflowExecutionCollectionPageResponse,
   WorkflowExecutionsGetWorkflowExecutionCompactData,
@@ -2300,6 +2302,33 @@ export const workflowsMoveWorkflowToFolder = (
     },
     body: data.requestBody,
     mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Workflow Execution By Workflow Id
+ * Get a workflow execution by workflow ID and execution suffix.
+ * @param data The data for the request.
+ * @param data.executionId
+ * @param data.workspaceId
+ * @param data.workflowId
+ * @returns WorkflowExecutionRead Successful Response
+ * @throws ApiError
+ */
+export const workflowExecutionsGetWorkflowExecutionByWorkflowId = (
+  data: WorkflowExecutionsGetWorkflowExecutionByWorkflowIdData
+): CancelablePromise<WorkflowExecutionsGetWorkflowExecutionByWorkflowIdResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/executions/{execution_id}",
+    path: {
+      execution_id: data.executionId,
+      workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
+    },
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -339,6 +339,7 @@ import type {
   DeleteCustomProviderResponse,
   DisableModelData,
   DisableModelResponse,
+  EditorFieldSchemaData,
   EditorFieldSchemaResponse,
   EditorListActionsData,
   EditorListActionsResponse,
@@ -2312,8 +2313,8 @@ export const workflowsMoveWorkflowToFolder = (
  * Returns the graph built from Actions (single source of truth),
  * not from Workflow.object.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns GraphResponse Successful Response
  * @throws ApiError
  */
@@ -2322,12 +2323,10 @@ export const graphGetGraph = (
 ): CancelablePromise<GraphGetGraphResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflows/{workflow_id}/graph",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/graph",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -2342,8 +2341,8 @@ export const graphGetGraph = (
  * Validates base_version matches current graph_version.
  * Returns 409 Conflict with latest graph if versions mismatch.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @param data.requestBody
  * @returns GraphResponse Successful Response
  * @throws ApiError
@@ -2353,12 +2352,10 @@ export const graphApplyGraphOperations = (
 ): CancelablePromise<GraphApplyGraphOperationsResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/workflows/{workflow_id}/graph",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/graph",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -2385,11 +2382,13 @@ export const workflowExecutionsListWorkflowExecutions = (
 ): CancelablePromise<WorkflowExecutionsListWorkflowExecutionsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflow-executions",
+    url: "/workspaces/{workspace_id}/workflow-executions",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       trigger: data.trigger,
       limit: data.limit,
-      workspace_id: data.workspaceId,
       workflow_id: data.workflowId,
       user_id: data.userId,
     },
@@ -2413,8 +2412,8 @@ export const workflowExecutionsCreateWorkflowExecution = (
 ): CancelablePromise<WorkflowExecutionsCreateWorkflowExecutionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflow-executions",
-    query: {
+    url: "/workspaces/{workspace_id}/workflow-executions",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -2453,7 +2452,10 @@ export const workflowExecutionsSearchWorkflowExecutions = (
 ): CancelablePromise<WorkflowExecutionsSearchWorkflowExecutionsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflow-executions/search",
+    url: "/workspaces/{workspace_id}/workflow-executions/search",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       trigger: data.trigger,
       status: data.status,
@@ -2466,7 +2468,6 @@ export const workflowExecutionsSearchWorkflowExecutions = (
       duration_lte_seconds: data.durationLteSeconds,
       search_term: data.searchTerm,
       relation: data.relation,
-      workspace_id: data.workspaceId,
       workflow_id: data.workflowId,
       limit: data.limit,
       cursor: data.cursor,
@@ -2482,8 +2483,8 @@ export const workflowExecutionsSearchWorkflowExecutions = (
 /**
  * List Workflow Execution Reset Points
  * @param data The data for the request.
- * @param data.executionId
  * @param data.workspaceId
+ * @param data.executionId
  * @param data.limit
  * @returns WorkflowExecutionResetPointRead Successful Response
  * @throws ApiError
@@ -2493,13 +2494,13 @@ export const workflowExecutionsListWorkflowExecutionResetPoints = (
 ): CancelablePromise<WorkflowExecutionsListWorkflowExecutionResetPointsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflow-executions/{execution_id}/reset-points",
+    url: "/workspaces/{workspace_id}/workflow-executions/{execution_id}/reset-points",
     path: {
+      workspace_id: data.workspaceId,
       execution_id: data.executionId,
     },
     query: {
       limit: data.limit,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -2510,8 +2511,8 @@ export const workflowExecutionsListWorkflowExecutionResetPoints = (
 /**
  * Reset Workflow Execution
  * @param data The data for the request.
- * @param data.executionId
  * @param data.workspaceId
+ * @param data.executionId
  * @param data.requestBody
  * @returns WorkflowExecutionResetResponse Successful Response
  * @throws ApiError
@@ -2521,12 +2522,10 @@ export const workflowExecutionsResetWorkflowExecution = (
 ): CancelablePromise<WorkflowExecutionsResetWorkflowExecutionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflow-executions/{execution_id}/reset",
+    url: "/workspaces/{workspace_id}/workflow-executions/{execution_id}/reset",
     path: {
-      execution_id: data.executionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      execution_id: data.executionId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -2549,8 +2548,8 @@ export const workflowExecutionsBulkResetWorkflowExecutions = (
 ): CancelablePromise<WorkflowExecutionsBulkResetWorkflowExecutionsResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflow-executions/reset/bulk",
-    query: {
+    url: "/workspaces/{workspace_id}/workflow-executions/reset/bulk",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -2565,8 +2564,8 @@ export const workflowExecutionsBulkResetWorkflowExecutions = (
  * Get Workflow Execution
  * Get a workflow execution.
  * @param data The data for the request.
- * @param data.executionId
  * @param data.workspaceId
+ * @param data.executionId
  * @returns WorkflowExecutionRead Successful Response
  * @throws ApiError
  */
@@ -2575,12 +2574,10 @@ export const workflowExecutionsGetWorkflowExecution = (
 ): CancelablePromise<WorkflowExecutionsGetWorkflowExecutionResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflow-executions/{execution_id}",
+    url: "/workspaces/{workspace_id}/workflow-executions/{execution_id}",
     path: {
-      execution_id: data.executionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      execution_id: data.executionId,
     },
     errors: {
       422: "Validation Error",
@@ -2592,8 +2589,8 @@ export const workflowExecutionsGetWorkflowExecution = (
  * Get Workflow Execution Compact
  * Get a workflow execution.
  * @param data The data for the request.
- * @param data.executionId
  * @param data.workspaceId
+ * @param data.executionId
  * @returns WorkflowExecutionReadCompact_Any__Union_AgentOutput__Any___Any_ Successful Response
  * @throws ApiError
  */
@@ -2602,12 +2599,10 @@ export const workflowExecutionsGetWorkflowExecutionCompact = (
 ): CancelablePromise<WorkflowExecutionsGetWorkflowExecutionCompactResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflow-executions/{execution_id}/compact",
+    url: "/workspaces/{workspace_id}/workflow-executions/{execution_id}/compact",
     path: {
-      execution_id: data.executionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      execution_id: data.executionId,
     },
     errors: {
       422: "Validation Error",
@@ -2619,8 +2614,8 @@ export const workflowExecutionsGetWorkflowExecutionCompact = (
  * Get Workflow Execution Object Download
  * Generate a presigned download URL for a workflow execution result object.
  * @param data The data for the request.
- * @param data.executionId
  * @param data.workspaceId
+ * @param data.executionId
  * @param data.requestBody
  * @returns WorkflowExecutionObjectDownloadResponse Successful Response
  * @throws ApiError
@@ -2630,12 +2625,10 @@ export const workflowExecutionsGetWorkflowExecutionObjectDownload = (
 ): CancelablePromise<WorkflowExecutionsGetWorkflowExecutionObjectDownloadResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflow-executions/{execution_id}/objects/download",
+    url: "/workspaces/{workspace_id}/workflow-executions/{execution_id}/objects/download",
     path: {
-      execution_id: data.executionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      execution_id: data.executionId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -2649,8 +2642,8 @@ export const workflowExecutionsGetWorkflowExecutionObjectDownload = (
  * Get Workflow Execution Object Preview
  * Fetch a bounded text preview for a workflow execution result object.
  * @param data The data for the request.
- * @param data.executionId
  * @param data.workspaceId
+ * @param data.executionId
  * @param data.requestBody
  * @returns WorkflowExecutionObjectPreviewResponse Successful Response
  * @throws ApiError
@@ -2660,12 +2653,10 @@ export const workflowExecutionsGetWorkflowExecutionObjectPreview = (
 ): CancelablePromise<WorkflowExecutionsGetWorkflowExecutionObjectPreviewResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflow-executions/{execution_id}/objects/preview",
+    url: "/workspaces/{workspace_id}/workflow-executions/{execution_id}/objects/preview",
     path: {
-      execution_id: data.executionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      execution_id: data.executionId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -2679,8 +2670,8 @@ export const workflowExecutionsGetWorkflowExecutionObjectPreview = (
  * Get Workflow Execution Collection Page
  * Fetch a bounded page of collection item descriptors.
  * @param data The data for the request.
- * @param data.executionId
  * @param data.workspaceId
+ * @param data.executionId
  * @param data.requestBody
  * @returns WorkflowExecutionCollectionPageResponse Successful Response
  * @throws ApiError
@@ -2690,12 +2681,10 @@ export const workflowExecutionsGetWorkflowExecutionCollectionPage = (
 ): CancelablePromise<WorkflowExecutionsGetWorkflowExecutionCollectionPageResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflow-executions/{execution_id}/objects/collection/page",
+    url: "/workspaces/{workspace_id}/workflow-executions/{execution_id}/objects/collection/page",
     path: {
-      execution_id: data.executionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      execution_id: data.executionId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -2722,8 +2711,8 @@ export const workflowExecutionsCreateDraftWorkflowExecution = (
 ): CancelablePromise<WorkflowExecutionsCreateDraftWorkflowExecutionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflow-executions/draft",
-    query: {
+    url: "/workspaces/{workspace_id}/workflow-executions/draft",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -2738,8 +2727,8 @@ export const workflowExecutionsCreateDraftWorkflowExecution = (
  * Cancel Workflow Execution
  * Get a workflow execution.
  * @param data The data for the request.
- * @param data.executionId
  * @param data.workspaceId
+ * @param data.executionId
  * @returns void Successful Response
  * @throws ApiError
  */
@@ -2748,12 +2737,10 @@ export const workflowExecutionsCancelWorkflowExecution = (
 ): CancelablePromise<WorkflowExecutionsCancelWorkflowExecutionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflow-executions/{execution_id}/cancel",
+    url: "/workspaces/{workspace_id}/workflow-executions/{execution_id}/cancel",
     path: {
-      execution_id: data.executionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      execution_id: data.executionId,
     },
     errors: {
       422: "Validation Error",
@@ -2765,8 +2752,8 @@ export const workflowExecutionsCancelWorkflowExecution = (
  * Terminate Workflow Execution
  * Get a workflow execution.
  * @param data The data for the request.
- * @param data.executionId
  * @param data.workspaceId
+ * @param data.executionId
  * @param data.requestBody
  * @returns void Successful Response
  * @throws ApiError
@@ -2776,12 +2763,10 @@ export const workflowExecutionsTerminateWorkflowExecution = (
 ): CancelablePromise<WorkflowExecutionsTerminateWorkflowExecutionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflow-executions/{execution_id}/terminate",
+    url: "/workspaces/{workspace_id}/workflow-executions/{execution_id}/terminate",
     path: {
-      execution_id: data.executionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      execution_id: data.executionId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -2809,9 +2794,11 @@ export const actionsBatchUpdatePositions = (
 ): CancelablePromise<ActionsBatchUpdatePositionsResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/actions/batch-positions",
-    query: {
+    url: "/workspaces/{workspace_id}/actions/batch-positions",
+    path: {
       workspace_id: data.workspaceId,
+    },
+    query: {
       workflow_id: data.workflowId,
     },
     body: data.requestBody,
@@ -2836,9 +2823,11 @@ export const actionsListActions = (
 ): CancelablePromise<ActionsListActionsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/actions",
-    query: {
+    url: "/workspaces/{workspace_id}/actions",
+    path: {
       workspace_id: data.workspaceId,
+    },
+    query: {
       workflow_id: data.workflowId,
     },
     errors: {
@@ -2861,8 +2850,8 @@ export const actionsCreateAction = (
 ): CancelablePromise<ActionsCreateActionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/actions",
-    query: {
+    url: "/workspaces/{workspace_id}/actions",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -2877,8 +2866,8 @@ export const actionsCreateAction = (
  * Get Action
  * Get an action.
  * @param data The data for the request.
- * @param data.actionId
  * @param data.workspaceId
+ * @param data.actionId
  * @param data.workflowId
  * @returns ActionRead Successful Response
  * @throws ApiError
@@ -2888,12 +2877,12 @@ export const actionsGetAction = (
 ): CancelablePromise<ActionsGetActionResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/actions/{action_id}",
+    url: "/workspaces/{workspace_id}/actions/{action_id}",
     path: {
+      workspace_id: data.workspaceId,
       action_id: data.actionId,
     },
     query: {
-      workspace_id: data.workspaceId,
       workflow_id: data.workflowId,
     },
     errors: {
@@ -2906,8 +2895,8 @@ export const actionsGetAction = (
  * Update Action
  * Update an action.
  * @param data The data for the request.
- * @param data.actionId
  * @param data.workspaceId
+ * @param data.actionId
  * @param data.workflowId
  * @param data.requestBody
  * @returns ActionRead Successful Response
@@ -2918,12 +2907,12 @@ export const actionsUpdateAction = (
 ): CancelablePromise<ActionsUpdateActionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/actions/{action_id}",
+    url: "/workspaces/{workspace_id}/actions/{action_id}",
     path: {
+      workspace_id: data.workspaceId,
       action_id: data.actionId,
     },
     query: {
-      workspace_id: data.workspaceId,
       workflow_id: data.workflowId,
     },
     body: data.requestBody,
@@ -2938,8 +2927,8 @@ export const actionsUpdateAction = (
  * Delete Action
  * Delete an action.
  * @param data The data for the request.
- * @param data.actionId
  * @param data.workspaceId
+ * @param data.actionId
  * @param data.workflowId
  * @returns void Successful Response
  * @throws ApiError
@@ -2949,12 +2938,12 @@ export const actionsDeleteAction = (
 ): CancelablePromise<ActionsDeleteActionResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/actions/{action_id}",
+    url: "/workspaces/{workspace_id}/actions/{action_id}",
     path: {
+      workspace_id: data.workspaceId,
       action_id: data.actionId,
     },
     query: {
-      workspace_id: data.workspaceId,
       workflow_id: data.workflowId,
     },
     errors: {
@@ -2967,8 +2956,8 @@ export const actionsDeleteAction = (
  * List Tags
  * List all tags for a workflow.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns TagRead Successful Response
  * @throws ApiError
  */
@@ -2977,12 +2966,10 @@ export const workflowsListTags = (
 ): CancelablePromise<WorkflowsListTagsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflows/{workflow_id}/tags",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/tags",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -2994,8 +2981,8 @@ export const workflowsListTags = (
  * Add Tag
  * Add a tag to a workflow.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @param data.requestBody
  * @returns unknown Successful Response
  * @throws ApiError
@@ -3005,12 +2992,10 @@ export const workflowsAddTag = (
 ): CancelablePromise<WorkflowsAddTagResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflows/{workflow_id}/tags",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/tags",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -3024,8 +3009,8 @@ export const workflowsAddTag = (
  * Remove Tag
  * @param data The data for the request.
  * @param data.tagId
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns void Successful Response
  * @throws ApiError
  */
@@ -3034,13 +3019,11 @@ export const workflowsRemoveTag = (
 ): CancelablePromise<WorkflowsRemoveTagResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/workflows/{workflow_id}/tags/{tag_id}",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/tags/{tag_id}",
     path: {
       tag_id: data.tagId,
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -3051,8 +3034,8 @@ export const workflowsRemoveTag = (
 /**
  * Publish Workflow
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @param data.requestBody
  * @returns WorkflowDslPublishResult Successful Response
  * @throws ApiError
@@ -3062,12 +3045,10 @@ export const workflowsPublishWorkflow = (
 ): CancelablePromise<WorkflowsPublishWorkflowResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflows/{workflow_id}/publish",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/publish",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -3095,11 +3076,13 @@ export const workflowsListWorkflowCommits = (
 ): CancelablePromise<WorkflowsListWorkflowCommitsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflows/sync/commits",
+    url: "/workspaces/{workspace_id}/workflows/sync/commits",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       branch: data.branch,
       limit: data.limit,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -3121,10 +3104,12 @@ export const workflowsListWorkflowBranches = (
 ): CancelablePromise<WorkflowsListWorkflowBranchesResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflows/sync/branches",
+    url: "/workspaces/{workspace_id}/workflows/sync/branches",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       limit: data.limit,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -3150,8 +3135,8 @@ export const workflowsPullWorkflows = (
 ): CancelablePromise<WorkflowsPullWorkflowsResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflows/sync/pull",
-    query: {
+    url: "/workspaces/{workspace_id}/workflows/sync/pull",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -3166,8 +3151,8 @@ export const workflowsPullWorkflows = (
  * Search Secrets
  * Search secrets.
  * @param data The data for the request.
- * @param data.environment
  * @param data.workspaceId
+ * @param data.environment
  * @param data.name Filter by secret name
  * @param data.id Filter by secret ID
  * @param data.type Filter by secret type
@@ -3179,13 +3164,15 @@ export const secretsSearchSecrets = (
 ): CancelablePromise<SecretsSearchSecretsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/secrets/search",
+    url: "/workspaces/{workspace_id}/secrets/search",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       environment: data.environment,
       name: data.name,
       id: data.id,
       type: data.type,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -3207,10 +3194,12 @@ export const secretsListSecrets = (
 ): CancelablePromise<SecretsListSecretsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/secrets",
+    url: "/workspaces/{workspace_id}/secrets",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       type: data.type,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -3232,8 +3221,8 @@ export const secretsCreateSecret = (
 ): CancelablePromise<SecretsCreateSecretResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/secrets",
-    query: {
+    url: "/workspaces/{workspace_id}/secrets",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -3257,8 +3246,8 @@ export const secretsListSecretDefinitions = (
 ): CancelablePromise<SecretsListSecretDefinitionsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/secrets/definitions",
-    query: {
+    url: "/workspaces/{workspace_id}/secrets/definitions",
+    path: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -3280,8 +3269,8 @@ export const secretsGetAwsAssumeRoleAccess = (
 ): CancelablePromise<SecretsGetAwsAssumeRoleAccessResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/secrets/aws-assume-role",
-    query: {
+    url: "/workspaces/{workspace_id}/secrets/aws-assume-role",
+    path: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -3304,11 +3293,9 @@ export const secretsGetSecretByName = (
 ): CancelablePromise<SecretsGetSecretByNameResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/secrets/{secret_name}",
+    url: "/workspaces/{workspace_id}/secrets/{secret_name}",
     path: {
       secret_name: data.secretName,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -3321,8 +3308,8 @@ export const secretsGetSecretByName = (
  * Update Secret By Id
  * Update a secret by ID.
  * @param data The data for the request.
- * @param data.secretId
  * @param data.workspaceId
+ * @param data.secretId
  * @param data.requestBody
  * @returns void Successful Response
  * @throws ApiError
@@ -3332,12 +3319,10 @@ export const secretsUpdateSecretById = (
 ): CancelablePromise<SecretsUpdateSecretByIdResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/secrets/{secret_id}",
+    url: "/workspaces/{workspace_id}/secrets/{secret_id}",
     path: {
-      secret_id: data.secretId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      secret_id: data.secretId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -3351,8 +3336,8 @@ export const secretsUpdateSecretById = (
  * Delete Secret By Id
  * Delete a secret by ID.
  * @param data The data for the request.
- * @param data.secretId
  * @param data.workspaceId
+ * @param data.secretId
  * @returns void Successful Response
  * @throws ApiError
  */
@@ -3361,12 +3346,10 @@ export const secretsDeleteSecretById = (
 ): CancelablePromise<SecretsDeleteSecretByIdResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/secrets/{secret_id}",
+    url: "/workspaces/{workspace_id}/secrets/{secret_id}",
     path: {
-      secret_id: data.secretId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      secret_id: data.secretId,
     },
     errors: {
       422: "Validation Error",
@@ -3389,12 +3372,14 @@ export const variablesSearchVariables = (
 ): CancelablePromise<VariablesSearchVariablesResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/variables/search",
+    url: "/workspaces/{workspace_id}/variables/search",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       environment: data.environment,
       name: data.name,
       id: data.id,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -3415,10 +3400,12 @@ export const variablesListVariables = (
 ): CancelablePromise<VariablesListVariablesResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/variables",
+    url: "/workspaces/{workspace_id}/variables",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       environment: data.environment,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -3439,8 +3426,8 @@ export const variablesCreateVariable = (
 ): CancelablePromise<VariablesCreateVariableResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/variables",
-    query: {
+    url: "/workspaces/{workspace_id}/variables",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -3465,13 +3452,13 @@ export const variablesGetVariableByName = (
 ): CancelablePromise<VariablesGetVariableByNameResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/variables/{variable_name}",
+    url: "/workspaces/{workspace_id}/variables/{variable_name}",
     path: {
       variable_name: data.variableName,
+      workspace_id: data.workspaceId,
     },
     query: {
       environment: data.environment,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -3493,11 +3480,9 @@ export const variablesUpdateVariableById = (
 ): CancelablePromise<VariablesUpdateVariableByIdResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/variables/{variable_id}",
+    url: "/workspaces/{workspace_id}/variables/{variable_id}",
     path: {
       variable_id: data.variableId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -3521,11 +3506,9 @@ export const variablesDeleteVariableById = (
 ): CancelablePromise<VariablesDeleteVariableByIdResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/variables/{variable_id}",
+    url: "/workspaces/{workspace_id}/variables/{variable_id}",
     path: {
       variable_id: data.variableId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -3547,9 +3530,11 @@ export const schedulesListSchedules = (
 ): CancelablePromise<SchedulesListSchedulesResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/schedules",
-    query: {
+    url: "/workspaces/{workspace_id}/schedules",
+    path: {
       workspace_id: data.workspaceId,
+    },
+    query: {
       workflow_id: data.workflowId,
     },
     errors: {
@@ -3572,8 +3557,8 @@ export const schedulesCreateSchedule = (
 ): CancelablePromise<SchedulesCreateScheduleResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/schedules",
-    query: {
+    url: "/workspaces/{workspace_id}/schedules",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -3588,8 +3573,8 @@ export const schedulesCreateSchedule = (
  * Get Schedule
  * Get a schedule from a workflow.
  * @param data The data for the request.
- * @param data.scheduleId
  * @param data.workspaceId
+ * @param data.scheduleId
  * @returns ScheduleRead Successful Response
  * @throws ApiError
  */
@@ -3598,12 +3583,10 @@ export const schedulesGetSchedule = (
 ): CancelablePromise<SchedulesGetScheduleResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/schedules/{schedule_id}",
+    url: "/workspaces/{workspace_id}/schedules/{schedule_id}",
     path: {
-      schedule_id: data.scheduleId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      schedule_id: data.scheduleId,
     },
     errors: {
       422: "Validation Error",
@@ -3615,8 +3598,8 @@ export const schedulesGetSchedule = (
  * Update Schedule
  * Update a schedule from a workflow. You cannot update the Workflow Definition, but you can update other fields.
  * @param data The data for the request.
- * @param data.scheduleId
  * @param data.workspaceId
+ * @param data.scheduleId
  * @param data.requestBody
  * @returns ScheduleRead Successful Response
  * @throws ApiError
@@ -3626,12 +3609,10 @@ export const schedulesUpdateSchedule = (
 ): CancelablePromise<SchedulesUpdateScheduleResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/schedules/{schedule_id}",
+    url: "/workspaces/{workspace_id}/schedules/{schedule_id}",
     path: {
-      schedule_id: data.scheduleId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      schedule_id: data.scheduleId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -3645,8 +3626,8 @@ export const schedulesUpdateSchedule = (
  * Delete Schedule
  * Delete a schedule from a workflow.
  * @param data The data for the request.
- * @param data.scheduleId
  * @param data.workspaceId
+ * @param data.scheduleId
  * @returns void Successful Response
  * @throws ApiError
  */
@@ -3655,12 +3636,10 @@ export const schedulesDeleteSchedule = (
 ): CancelablePromise<SchedulesDeleteScheduleResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/schedules/{schedule_id}",
+    url: "/workspaces/{workspace_id}/schedules/{schedule_id}",
     path: {
-      schedule_id: data.scheduleId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      schedule_id: data.scheduleId,
     },
     errors: {
       422: "Validation Error",
@@ -3682,8 +3661,8 @@ export const schedulesSearchSchedules = (
 ): CancelablePromise<SchedulesSearchSchedulesResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/schedules/search",
-    query: {
+    url: "/workspaces/{workspace_id}/schedules/search",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -3707,8 +3686,8 @@ export const tagsListTags = (
 ): CancelablePromise<TagsListTagsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/tags",
-    query: {
+    url: "/workspaces/{workspace_id}/tags",
+    path: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -3731,8 +3710,8 @@ export const tagsCreateTag = (
 ): CancelablePromise<TagsCreateTagResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/tags",
-    query: {
+    url: "/workspaces/{workspace_id}/tags",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -3757,11 +3736,9 @@ export const tagsGetTag = (
 ): CancelablePromise<TagsGetTagResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/tags/{tag_id}",
+    url: "/workspaces/{workspace_id}/tags/{tag_id}",
     path: {
       tag_id: data.tagId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -3785,11 +3762,9 @@ export const tagsUpdateTag = (
 ): CancelablePromise<TagsUpdateTagResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/tags/{tag_id}",
+    url: "/workspaces/{workspace_id}/tags/{tag_id}",
     path: {
       tag_id: data.tagId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -3814,11 +3789,9 @@ export const tagsDeleteTag = (
 ): CancelablePromise<TagsDeleteTagResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/tags/{tag_id}",
+    url: "/workspaces/{workspace_id}/tags/{tag_id}",
     path: {
       tag_id: data.tagId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -4653,29 +4626,6 @@ export const agentSetDefaultModelSelection = (
 }
 
 /**
- * Get Workspace Providers Status
- * Get workspace credential status for all providers.
- * @param data The data for the request.
- * @param data.workspaceId
- * @returns boolean Successful Response
- * @throws ApiError
- */
-export const agentGetWorkspaceProvidersStatus = (
-  data: AgentGetWorkspaceProvidersStatusData
-): CancelablePromise<AgentGetWorkspaceProvidersStatusResponse> => {
-  return __request(OpenAPI, {
-    method: "GET",
-    url: "/agent/workspace/providers/status",
-    query: {
-      workspace_id: data.workspaceId,
-    },
-    errors: {
-      422: "Validation Error",
-    },
-  })
-}
-
-/**
  * List Catalog
  * List catalog entries with optional filtering and pagination.
  * @param data The data for the request.
@@ -5064,6 +5014,29 @@ export const validateCustomProviderConnection = (
 }
 
 /**
+ * Get Workspace Providers Status
+ * Get workspace credential status for all providers.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @returns boolean Successful Response
+ * @throws ApiError
+ */
+export const agentGetWorkspaceProvidersStatus = (
+  data: AgentGetWorkspaceProvidersStatusData
+): CancelablePromise<AgentGetWorkspaceProvidersStatusResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/agent/workspace/providers/status",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
  * Create Channel Token
  * @param data The data for the request.
  * @param data.workspaceId
@@ -5076,8 +5049,8 @@ export const agentChannelsCreateChannelToken = (
 ): CancelablePromise<AgentChannelsCreateChannelTokenResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/agent/channels/tokens",
-    query: {
+    url: "/workspaces/{workspace_id}/agent/channels/tokens",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -5102,11 +5075,13 @@ export const agentChannelsListChannelTokens = (
 ): CancelablePromise<AgentChannelsListChannelTokensResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/channels/tokens",
+    url: "/workspaces/{workspace_id}/agent/channels/tokens",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       agent_preset_id: data.agentPresetId,
       channel_type: data.channelType,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -5128,11 +5103,9 @@ export const agentChannelsUpdateChannelToken = (
 ): CancelablePromise<AgentChannelsUpdateChannelTokenResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/agent/channels/tokens/{token_id}",
+    url: "/workspaces/{workspace_id}/agent/channels/tokens/{token_id}",
     path: {
       token_id: data.tokenId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -5156,11 +5129,9 @@ export const agentChannelsDeleteChannelToken = (
 ): CancelablePromise<AgentChannelsDeleteChannelTokenResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/agent/channels/tokens/{token_id}",
+    url: "/workspaces/{workspace_id}/agent/channels/tokens/{token_id}",
     path: {
       token_id: data.tokenId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5182,11 +5153,9 @@ export const agentChannelsRotateChannelToken = (
 ): CancelablePromise<AgentChannelsRotateChannelTokenResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/agent/channels/tokens/{token_id}/rotate",
+    url: "/workspaces/{workspace_id}/agent/channels/tokens/{token_id}/rotate",
     path: {
       token_id: data.tokenId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5208,8 +5177,8 @@ export const agentChannelsStartSlackOauth = (
 ): CancelablePromise<AgentChannelsStartSlackOauthResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/agent/channels/tokens/slack/oauth/start",
-    query: {
+    url: "/workspaces/{workspace_id}/agent/channels/tokens/slack/oauth/start",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -5233,8 +5202,8 @@ export const agentPresetsListAgentPresets = (
 ): CancelablePromise<AgentPresetsListAgentPresetsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/presets",
-    query: {
+    url: "/workspaces/{workspace_id}/agent/presets",
+    path: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5257,8 +5226,8 @@ export const agentPresetsCreateAgentPreset = (
 ): CancelablePromise<AgentPresetsCreateAgentPresetResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/agent/presets",
-    query: {
+    url: "/workspaces/{workspace_id}/agent/presets",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -5283,11 +5252,9 @@ export const agentPresetsGetAgentPreset = (
 ): CancelablePromise<AgentPresetsGetAgentPresetResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/presets/{preset_id}",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}",
     path: {
       preset_id: data.presetId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5311,11 +5278,9 @@ export const agentPresetsUpdateAgentPreset = (
 ): CancelablePromise<AgentPresetsUpdateAgentPresetResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/agent/presets/{preset_id}",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}",
     path: {
       preset_id: data.presetId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -5340,11 +5305,9 @@ export const agentPresetsDeleteAgentPreset = (
 ): CancelablePromise<AgentPresetsDeleteAgentPresetResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/agent/presets/{preset_id}",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}",
     path: {
       preset_id: data.presetId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5367,11 +5330,9 @@ export const agentPresetsGetAgentPresetBySlug = (
 ): CancelablePromise<AgentPresetsGetAgentPresetBySlugResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/presets/by-slug/{slug}",
+    url: "/workspaces/{workspace_id}/agent/presets/by-slug/{slug}",
     path: {
       slug: data.slug,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5397,15 +5358,15 @@ export const agentPresetsListAgentPresetVersions = (
 ): CancelablePromise<AgentPresetsListAgentPresetVersionsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/presets/{preset_id}/versions",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}/versions",
     path: {
       preset_id: data.presetId,
+      workspace_id: data.workspaceId,
     },
     query: {
       limit: data.limit,
       cursor: data.cursor,
       reverse: data.reverse,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -5428,12 +5389,10 @@ export const agentPresetsGetAgentPresetVersion = (
 ): CancelablePromise<AgentPresetsGetAgentPresetVersionResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/presets/{preset_id}/versions/{version_id}",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}/versions/{version_id}",
     path: {
       preset_id: data.presetId,
       version_id: data.versionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5448,8 +5407,8 @@ export const agentPresetsGetAgentPresetVersion = (
  * @param data The data for the request.
  * @param data.presetId
  * @param data.versionId
- * @param data.compareTo Version ID to compare against
  * @param data.workspaceId
+ * @param data.compareTo Version ID to compare against
  * @returns AgentPresetVersionDiff Successful Response
  * @throws ApiError
  */
@@ -5458,14 +5417,14 @@ export const agentPresetsCompareAgentPresetVersions = (
 ): CancelablePromise<AgentPresetsCompareAgentPresetVersionsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/presets/{preset_id}/versions/{version_id}/compare",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}/versions/{version_id}/compare",
     path: {
       preset_id: data.presetId,
       version_id: data.versionId,
+      workspace_id: data.workspaceId,
     },
     query: {
       compare_to: data.compareTo,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -5488,12 +5447,10 @@ export const agentPresetsRestoreAgentPresetVersion = (
 ): CancelablePromise<AgentPresetsRestoreAgentPresetVersionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/agent/presets/{preset_id}/versions/{version_id}/restore",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}/versions/{version_id}/restore",
     path: {
       preset_id: data.presetId,
       version_id: data.versionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5518,12 +5475,14 @@ export const agentSkillsListSkills = (
 ): CancelablePromise<AgentSkillsListSkillsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/skills",
+    url: "/workspaces/{workspace_id}/agent/skills",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       limit: data.limit,
       cursor: data.cursor,
       reverse: data.reverse,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -5545,8 +5504,8 @@ export const agentSkillsCreateSkill = (
 ): CancelablePromise<AgentSkillsCreateSkillResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/agent/skills",
-    query: {
+    url: "/workspaces/{workspace_id}/agent/skills",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -5571,8 +5530,8 @@ export const agentSkillsUploadSkill = (
 ): CancelablePromise<AgentSkillsUploadSkillResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/agent/skills:upload",
-    query: {
+    url: "/workspaces/{workspace_id}/agent/skills:upload",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -5597,11 +5556,9 @@ export const agentSkillsGetSkill = (
 ): CancelablePromise<AgentSkillsGetSkillResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/skills/{skill_id}",
+    url: "/workspaces/{workspace_id}/agent/skills/{skill_id}",
     path: {
       skill_id: data.skillId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5624,11 +5581,9 @@ export const agentSkillsArchiveSkill = (
 ): CancelablePromise<AgentSkillsArchiveSkillResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/agent/skills/{skill_id}",
+    url: "/workspaces/{workspace_id}/agent/skills/{skill_id}",
     path: {
       skill_id: data.skillId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5651,11 +5606,9 @@ export const agentSkillsGetSkillDraft = (
 ): CancelablePromise<AgentSkillsGetSkillDraftResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/skills/{skill_id}/draft",
+    url: "/workspaces/{workspace_id}/agent/skills/{skill_id}/draft",
     path: {
       skill_id: data.skillId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5679,11 +5632,9 @@ export const agentSkillsPatchSkillDraft = (
 ): CancelablePromise<AgentSkillsPatchSkillDraftResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/agent/skills/{skill_id}/draft",
+    url: "/workspaces/{workspace_id}/agent/skills/{skill_id}/draft",
     path: {
       skill_id: data.skillId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -5699,8 +5650,8 @@ export const agentSkillsPatchSkillDraft = (
  * Return one draft file inline or as a presigned download.
  * @param data The data for the request.
  * @param data.skillId
- * @param data.path
  * @param data.workspaceId
+ * @param data.path
  * @returns SkillDraftFileRead Successful Response
  * @throws ApiError
  */
@@ -5709,13 +5660,13 @@ export const agentSkillsGetSkillDraftFile = (
 ): CancelablePromise<AgentSkillsGetSkillDraftFileResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/skills/{skill_id}/draft/file",
+    url: "/workspaces/{workspace_id}/agent/skills/{skill_id}/draft/file",
     path: {
       skill_id: data.skillId,
+      workspace_id: data.workspaceId,
     },
     query: {
       path: data.path,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -5738,11 +5689,9 @@ export const agentSkillsCreateSkillDraftUpload = (
 ): CancelablePromise<AgentSkillsCreateSkillDraftUploadResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/agent/skills/{skill_id}/draft/uploads",
+    url: "/workspaces/{workspace_id}/agent/skills/{skill_id}/draft/uploads",
     path: {
       skill_id: data.skillId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -5767,11 +5716,9 @@ export const agentSkillsPublishSkill = (
 ): CancelablePromise<AgentSkillsPublishSkillResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/agent/skills/{skill_id}/publish",
+    url: "/workspaces/{workspace_id}/agent/skills/{skill_id}/publish",
     path: {
       skill_id: data.skillId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5797,15 +5744,15 @@ export const agentSkillsListSkillVersions = (
 ): CancelablePromise<AgentSkillsListSkillVersionsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/skills/{skill_id}/versions",
+    url: "/workspaces/{workspace_id}/agent/skills/{skill_id}/versions",
     path: {
       skill_id: data.skillId,
+      workspace_id: data.workspaceId,
     },
     query: {
       limit: data.limit,
       cursor: data.cursor,
       reverse: data.reverse,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -5828,12 +5775,10 @@ export const agentSkillsGetSkillVersion = (
 ): CancelablePromise<AgentSkillsGetSkillVersionResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/skills/{skill_id}/versions/{version_id}",
+    url: "/workspaces/{workspace_id}/agent/skills/{skill_id}/versions/{version_id}",
     path: {
       skill_id: data.skillId,
       version_id: data.versionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5848,8 +5793,8 @@ export const agentSkillsGetSkillVersion = (
  * @param data The data for the request.
  * @param data.skillId
  * @param data.versionId
- * @param data.path
  * @param data.workspaceId
+ * @param data.path
  * @returns SkillDraftFileRead Successful Response
  * @throws ApiError
  */
@@ -5858,14 +5803,14 @@ export const agentSkillsGetSkillVersionFile = (
 ): CancelablePromise<AgentSkillsGetSkillVersionFileResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/skills/{skill_id}/versions/{version_id}/file",
+    url: "/workspaces/{workspace_id}/agent/skills/{skill_id}/versions/{version_id}/file",
     path: {
       skill_id: data.skillId,
       version_id: data.versionId,
+      workspace_id: data.workspaceId,
     },
     query: {
       path: data.path,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -5888,12 +5833,10 @@ export const agentSkillsRestoreSkillVersion = (
 ): CancelablePromise<AgentSkillsRestoreSkillVersionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/agent/skills/{skill_id}/versions/{version_id}/restore",
+    url: "/workspaces/{workspace_id}/agent/skills/{skill_id}/versions/{version_id}/restore",
     path: {
       skill_id: data.skillId,
       version_id: data.versionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -5916,8 +5859,8 @@ export const agentSessionsCreateSession = (
 ): CancelablePromise<AgentSessionsCreateSessionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/agent/sessions",
-    query: {
+    url: "/workspaces/{workspace_id}/agent/sessions",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -5949,14 +5892,16 @@ export const agentSessionsListSessions = (
 ): CancelablePromise<AgentSessionsListSessionsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/sessions",
+    url: "/workspaces/{workspace_id}/agent/sessions",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       entity_type: data.entityType,
       entity_id: data.entityId,
       exclude_entity_types: data.excludeEntityTypes,
       parent_session_id: data.parentSessionId,
       limit: data.limit,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -5980,11 +5925,9 @@ export const agentSessionsGetSession = (
 ): CancelablePromise<AgentSessionsGetSessionResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/sessions/{session_id}",
+    url: "/workspaces/{workspace_id}/agent/sessions/{session_id}",
     path: {
       session_id: data.sessionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -6008,11 +5951,9 @@ export const agentSessionsUpdateSession = (
 ): CancelablePromise<AgentSessionsUpdateSessionResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/agent/sessions/{session_id}",
+    url: "/workspaces/{workspace_id}/agent/sessions/{session_id}",
     path: {
       session_id: data.sessionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -6037,11 +5978,9 @@ export const agentSessionsDeleteSession = (
 ): CancelablePromise<AgentSessionsDeleteSessionResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/agent/sessions/{session_id}",
+    url: "/workspaces/{workspace_id}/agent/sessions/{session_id}",
     path: {
       session_id: data.sessionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -6066,11 +6005,9 @@ export const agentSessionsGetSessionVercel = (
 ): CancelablePromise<AgentSessionsGetSessionVercelResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/sessions/{session_id}/vercel",
+    url: "/workspaces/{workspace_id}/agent/sessions/{session_id}/vercel",
     path: {
       session_id: data.sessionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -6100,11 +6037,9 @@ export const agentSessionsSendMessage = (
 ): CancelablePromise<AgentSessionsSendMessageResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/agent/sessions/{session_id}/messages",
+    url: "/workspaces/{workspace_id}/agent/sessions/{session_id}/messages",
     path: {
       session_id: data.sessionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -6134,13 +6069,13 @@ export const agentSessionsStreamSessionEvents = (
 ): CancelablePromise<AgentSessionsStreamSessionEventsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/agent/sessions/{session_id}/stream",
+    url: "/workspaces/{workspace_id}/agent/sessions/{session_id}/stream",
     path: {
       session_id: data.sessionId,
+      workspace_id: data.workspaceId,
     },
     query: {
       format: data.format,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -6168,11 +6103,9 @@ export const agentSessionsForkSession = (
 ): CancelablePromise<AgentSessionsForkSessionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/agent/sessions/{session_id}/fork",
+    url: "/workspaces/{workspace_id}/agent/sessions/{session_id}/fork",
     path: {
       session_id: data.sessionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -6212,11 +6145,9 @@ export const approvalsSubmitApprovals = (
 ): CancelablePromise<ApprovalsSubmitApprovalsResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/approvals/{session_id}",
+    url: "/workspaces/{workspace_id}/approvals/{session_id}",
     path: {
       session_id: data.sessionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -7345,14 +7276,16 @@ export const inboxListItems = (
 ): CancelablePromise<InboxListItemsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/inbox/items",
+    url: "/workspaces/{workspace_id}/inbox/items",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       limit: data.limit,
       cursor: data.cursor,
       reverse: data.reverse,
       order_by: data.orderBy,
       sort: data.sort,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -7372,8 +7305,8 @@ export const editorListFunctions = (
 ): CancelablePromise<EditorListFunctionsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/editor/functions",
-    query: {
+    url: "/workspaces/{workspace_id}/editor/functions",
+    path: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -7395,9 +7328,11 @@ export const editorListActions = (
 ): CancelablePromise<EditorListActionsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/editor/actions",
-    query: {
+    url: "/workspaces/{workspace_id}/editor/actions",
+    path: {
       workspace_id: data.workspaceId,
+    },
+    query: {
       workflow_id: data.workflowId,
     },
     errors: {
@@ -7423,8 +7358,8 @@ export const editorValidateExpression = (
 ): CancelablePromise<EditorValidateExpressionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/editor/expressions/validate",
-    query: {
+    url: "/workspaces/{workspace_id}/editor/expressions/validate",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -7437,16 +7372,25 @@ export const editorValidateExpression = (
 
 /**
  * Field Schema
+ * @param data The data for the request.
+ * @param data.workspaceId
  * @returns EditorComponent Successful Response
  * @throws ApiError
  */
-export const editorFieldSchema =
-  (): CancelablePromise<EditorFieldSchemaResponse> => {
-    return __request(OpenAPI, {
-      method: "GET",
-      url: "/editor/field-schema",
-    })
-  }
+export const editorFieldSchema = (
+  data: EditorFieldSchemaData
+): CancelablePromise<EditorFieldSchemaResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/editor/field-schema",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
 
 /**
  * Sync Registry Repository
@@ -8144,8 +8088,8 @@ export const tablesListTables = (
 ): CancelablePromise<TablesListTablesResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/tables",
-    query: {
+    url: "/workspaces/{workspace_id}/tables",
+    path: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -8168,8 +8112,8 @@ export const tablesCreateTable = (
 ): CancelablePromise<TablesCreateTableResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/tables",
-    query: {
+    url: "/workspaces/{workspace_id}/tables",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -8194,11 +8138,9 @@ export const tablesGetTable = (
 ): CancelablePromise<TablesGetTableResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/tables/{table_id}",
+    url: "/workspaces/{workspace_id}/tables/{table_id}",
     path: {
       table_id: data.tableId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -8222,11 +8164,9 @@ export const tablesUpdateTable = (
 ): CancelablePromise<TablesUpdateTableResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/tables/{table_id}",
+    url: "/workspaces/{workspace_id}/tables/{table_id}",
     path: {
       table_id: data.tableId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -8251,11 +8191,9 @@ export const tablesDeleteTable = (
 ): CancelablePromise<TablesDeleteTableResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/tables/{table_id}",
+    url: "/workspaces/{workspace_id}/tables/{table_id}",
     path: {
       table_id: data.tableId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -8279,11 +8217,9 @@ export const tablesCreateColumn = (
 ): CancelablePromise<TablesCreateColumnResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/tables/{table_id}/columns",
+    url: "/workspaces/{workspace_id}/tables/{table_id}/columns",
     path: {
       table_id: data.tableId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -8310,12 +8246,10 @@ export const tablesUpdateColumn = (
 ): CancelablePromise<TablesUpdateColumnResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/tables/{table_id}/columns/{column_id}",
+    url: "/workspaces/{workspace_id}/tables/{table_id}/columns/{column_id}",
     path: {
       table_id: data.tableId,
       column_id: data.columnId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -8341,12 +8275,10 @@ export const tablesDeleteColumn = (
 ): CancelablePromise<TablesDeleteColumnResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/tables/{table_id}/columns/{column_id}",
+    url: "/workspaces/{workspace_id}/tables/{table_id}/columns/{column_id}",
     path: {
       table_id: data.tableId,
       column_id: data.columnId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -8374,9 +8306,10 @@ export const tablesListRows = (
 ): CancelablePromise<TablesListRowsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/tables/{table_id}/rows",
+    url: "/workspaces/{workspace_id}/tables/{table_id}/rows",
     path: {
       table_id: data.tableId,
+      workspace_id: data.workspaceId,
     },
     query: {
       limit: data.limit,
@@ -8384,7 +8317,6 @@ export const tablesListRows = (
       reverse: data.reverse,
       order_by: data.orderBy,
       sort: data.sort,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -8407,11 +8339,9 @@ export const tablesInsertRow = (
 ): CancelablePromise<TablesInsertRowResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/tables/{table_id}/rows",
+    url: "/workspaces/{workspace_id}/tables/{table_id}/rows",
     path: {
       table_id: data.tableId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -8437,12 +8367,10 @@ export const tablesGetRow = (
 ): CancelablePromise<TablesGetRowResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/tables/{table_id}/rows/{row_id}",
+    url: "/workspaces/{workspace_id}/tables/{table_id}/rows/{row_id}",
     path: {
       table_id: data.tableId,
       row_id: data.rowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -8466,12 +8394,10 @@ export const tablesDeleteRow = (
 ): CancelablePromise<TablesDeleteRowResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/tables/{table_id}/rows/{row_id}",
+    url: "/workspaces/{workspace_id}/tables/{table_id}/rows/{row_id}",
     path: {
       table_id: data.tableId,
       row_id: data.rowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -8496,12 +8422,10 @@ export const tablesUpdateRow = (
 ): CancelablePromise<TablesUpdateRowResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/tables/{table_id}/rows/{row_id}",
+    url: "/workspaces/{workspace_id}/tables/{table_id}/rows/{row_id}",
     path: {
       table_id: data.tableId,
       row_id: data.rowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -8530,11 +8454,9 @@ export const tablesBatchInsertRows = (
 ): CancelablePromise<TablesBatchInsertRowsResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/tables/{table_id}/rows/batch",
+    url: "/workspaces/{workspace_id}/tables/{table_id}/rows/batch",
     path: {
       table_id: data.tableId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -8560,11 +8482,9 @@ export const tablesBatchDeleteRows = (
 ): CancelablePromise<TablesBatchDeleteRowsResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/tables/{table_id}/rows/batch-delete",
+    url: "/workspaces/{workspace_id}/tables/{table_id}/rows/batch-delete",
     path: {
       table_id: data.tableId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -8590,11 +8510,9 @@ export const tablesBatchUpdateRows = (
 ): CancelablePromise<TablesBatchUpdateRowsResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/tables/{table_id}/rows/batch-update",
+    url: "/workspaces/{workspace_id}/tables/{table_id}/rows/batch-update",
     path: {
       table_id: data.tableId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -8619,8 +8537,8 @@ export const tablesImportTableFromCsv = (
 ): CancelablePromise<TablesImportTableFromCsvResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/tables/import",
-    query: {
+    url: "/workspaces/{workspace_id}/tables/import",
+    path: {
       workspace_id: data.workspaceId,
     },
     formData: data.formData,
@@ -8646,11 +8564,9 @@ export const tablesImportCsv = (
 ): CancelablePromise<TablesImportCsvResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/tables/{table_id}/import",
+    url: "/workspaces/{workspace_id}/tables/{table_id}/import",
     path: {
       table_id: data.tableId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     formData: data.formData,
@@ -8682,7 +8598,10 @@ export const casesListCases = (
 ): CancelablePromise<CasesListCasesResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases",
+    url: "/workspaces/{workspace_id}/cases",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       limit: data.limit,
       cursor: data.cursor,
@@ -8692,7 +8611,6 @@ export const casesListCases = (
       include_rows: data.includeRows,
       field_ids: data.fieldIds,
       include_durations: data.includeDurations,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -8714,8 +8632,8 @@ export const casesCreateCase = (
 ): CancelablePromise<CasesCreateCaseResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/cases",
-    query: {
+    url: "/workspaces/{workspace_id}/cases",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -8759,7 +8677,10 @@ export const casesSearchCases = (
 ): CancelablePromise<CasesSearchCasesResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/search",
+    url: "/workspaces/{workspace_id}/cases/search",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       limit: data.limit,
       cursor: data.cursor,
@@ -8781,7 +8702,6 @@ export const casesSearchCases = (
       include_rows: data.includeRows,
       field_ids: data.fieldIds,
       include_durations: data.includeDurations,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -8813,7 +8733,10 @@ export const casesSearchCaseAggregates = (
 ): CancelablePromise<CasesSearchCaseAggregatesResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/search/aggregate",
+    url: "/workspaces/{workspace_id}/cases/search/aggregate",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       search_term: data.searchTerm,
       status: data.status,
@@ -8826,7 +8749,6 @@ export const casesSearchCaseAggregates = (
       updated_after: data.updatedAfter,
       updated_before: data.updatedBefore,
       assignee_id: data.assigneeId,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -8849,13 +8771,13 @@ export const casesGetCase = (
 ): CancelablePromise<CasesGetCaseResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/{case_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}",
     path: {
       case_id: data.caseId,
+      workspace_id: data.workspaceId,
     },
     query: {
       include_rows: data.includeRows,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -8878,11 +8800,9 @@ export const casesUpdateCase = (
 ): CancelablePromise<CasesUpdateCaseResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/cases/{case_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -8907,11 +8827,9 @@ export const casesDeleteCase = (
 ): CancelablePromise<CasesDeleteCaseResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/cases/{case_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -8934,11 +8852,9 @@ export const casesListComments = (
 ): CancelablePromise<CasesListCommentsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/{case_id}/comments",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/comments",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -8962,11 +8878,9 @@ export const casesCreateComment = (
 ): CancelablePromise<CasesCreateCommentResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/cases/{case_id}/comments",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/comments",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -8991,11 +8905,9 @@ export const casesListCommentThreads = (
 ): CancelablePromise<CasesListCommentThreadsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/{case_id}/comments/threads",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/comments/threads",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9020,12 +8932,10 @@ export const casesUpdateComment = (
 ): CancelablePromise<CasesUpdateCommentResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/cases/{case_id}/comments/{comment_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/comments/{comment_id}",
     path: {
       case_id: data.caseId,
       comment_id: data.commentId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9051,12 +8961,10 @@ export const casesDeleteComment = (
 ): CancelablePromise<CasesDeleteCommentResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/cases/{case_id}/comments/{comment_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/comments/{comment_id}",
     path: {
       case_id: data.caseId,
       comment_id: data.commentId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9079,11 +8987,9 @@ export const casesListEventsWithUsers = (
 ): CancelablePromise<CasesListEventsWithUsersResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/{case_id}/events",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/events",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9106,11 +9012,9 @@ export const casesListTasks = (
 ): CancelablePromise<CasesListTasksResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/{case_id}/tasks",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/tasks",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9134,11 +9038,9 @@ export const casesCreateTask = (
 ): CancelablePromise<CasesCreateTaskResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/cases/{case_id}/tasks",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/tasks",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9165,12 +9067,10 @@ export const casesUpdateTask = (
 ): CancelablePromise<CasesUpdateTaskResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/cases/{case_id}/tasks/{task_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/tasks/{task_id}",
     path: {
       case_id: data.caseId,
       task_id: data.taskId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9196,12 +9096,10 @@ export const casesDeleteTask = (
 ): CancelablePromise<CasesDeleteTaskResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/cases/{case_id}/tasks/{task_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/tasks/{task_id}",
     path: {
       case_id: data.caseId,
       task_id: data.taskId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9226,15 +9124,15 @@ export const casesListCaseRows = (
 ): CancelablePromise<CasesListCaseRowsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/{case_id}/rows",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/rows",
     path: {
       case_id: data.caseId,
+      workspace_id: data.workspaceId,
     },
     query: {
       limit: data.limit,
       cursor: data.cursor,
       reverse: data.reverse,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -9256,11 +9154,9 @@ export const casesLinkCaseRow = (
 ): CancelablePromise<CasesLinkCaseRowResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/cases/{case_id}/rows",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/rows",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9285,11 +9181,9 @@ export const casesInsertCaseRow = (
 ): CancelablePromise<CasesInsertCaseRowResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/cases/{case_id}/rows/insert",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/rows/insert",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9315,13 +9209,11 @@ export const casesUnlinkCaseRow = (
 ): CancelablePromise<CasesUnlinkCaseRowResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/cases/{case_id}/rows/{table_id}/{row_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/rows/{table_id}/{row_id}",
     path: {
       case_id: data.caseId,
       table_id: data.tableId,
       row_id: data.rowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9343,8 +9235,8 @@ export const casesListFields = (
 ): CancelablePromise<CasesListFieldsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/case-fields",
-    query: {
+    url: "/workspaces/{workspace_id}/case-fields",
+    path: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9367,8 +9259,8 @@ export const casesCreateField = (
 ): CancelablePromise<CasesCreateFieldResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/case-fields",
-    query: {
+    url: "/workspaces/{workspace_id}/case-fields",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9394,11 +9286,9 @@ export const casesUpdateField = (
 ): CancelablePromise<CasesUpdateFieldResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/case-fields/{field_id}",
+    url: "/workspaces/{workspace_id}/case-fields/{field_id}",
     path: {
       field_id: data.fieldId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9423,11 +9313,9 @@ export const casesDeleteField = (
 ): CancelablePromise<CasesDeleteFieldResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/case-fields/{field_id}",
+    url: "/workspaces/{workspace_id}/case-fields/{field_id}",
     path: {
       field_id: data.fieldId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9450,11 +9338,9 @@ export const casesListTags = (
 ): CancelablePromise<CasesListTagsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/{case_id}/tags",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/tags",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9478,11 +9364,9 @@ export const casesAddTag = (
 ): CancelablePromise<CasesAddTagResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/cases/{case_id}/tags",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/tags",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9508,12 +9392,10 @@ export const casesRemoveTag = (
 ): CancelablePromise<CasesRemoveTagResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/cases/{case_id}/tags/{tag_identifier}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/tags/{tag_identifier}",
     path: {
       case_id: data.caseId,
       tag_identifier: data.tagIdentifier,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9535,8 +9417,8 @@ export const caseTagsListCaseTags = (
 ): CancelablePromise<CaseTagsListCaseTagsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/case-tags",
-    query: {
+    url: "/workspaces/{workspace_id}/case-tags",
+    path: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9559,8 +9441,8 @@ export const caseTagsCreateCaseTag = (
 ): CancelablePromise<CaseTagsCreateCaseTagResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/case-tags",
-    query: {
+    url: "/workspaces/{workspace_id}/case-tags",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9585,11 +9467,9 @@ export const caseTagsGetCaseTag = (
 ): CancelablePromise<CaseTagsGetCaseTagResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/case-tags/{tag_id}",
+    url: "/workspaces/{workspace_id}/case-tags/{tag_id}",
     path: {
       tag_id: data.tagId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9613,11 +9493,9 @@ export const caseTagsUpdateCaseTag = (
 ): CancelablePromise<CaseTagsUpdateCaseTagResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/case-tags/{tag_id}",
+    url: "/workspaces/{workspace_id}/case-tags/{tag_id}",
     path: {
       tag_id: data.tagId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9642,11 +9520,9 @@ export const caseTagsDeleteCaseTag = (
 ): CancelablePromise<CaseTagsDeleteCaseTagResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/case-tags/{tag_id}",
+    url: "/workspaces/{workspace_id}/case-tags/{tag_id}",
     path: {
       tag_id: data.tagId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9669,11 +9545,9 @@ export const caseAttachmentsListAttachments = (
 ): CancelablePromise<CaseAttachmentsListAttachmentsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/{case_id}/attachments",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/attachments",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9697,11 +9571,9 @@ export const caseAttachmentsCreateAttachment = (
 ): CancelablePromise<CaseAttachmentsCreateAttachmentResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/cases/{case_id}/attachments",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/attachments",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     formData: data.formData,
@@ -9728,14 +9600,14 @@ export const caseAttachmentsDownloadAttachment = (
 ): CancelablePromise<CaseAttachmentsDownloadAttachmentResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/{case_id}/attachments/{attachment_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/attachments/{attachment_id}",
     path: {
       case_id: data.caseId,
       attachment_id: data.attachmentId,
+      workspace_id: data.workspaceId,
     },
     query: {
       preview: data.preview,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -9758,12 +9630,10 @@ export const caseAttachmentsDeleteAttachment = (
 ): CancelablePromise<CaseAttachmentsDeleteAttachmentResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/cases/{case_id}/attachments/{attachment_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/attachments/{attachment_id}",
     path: {
       case_id: data.caseId,
       attachment_id: data.attachmentId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9785,8 +9655,8 @@ export const caseDropdownsListDropdownDefinitions = (
 ): CancelablePromise<CaseDropdownsListDropdownDefinitionsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/case-dropdowns",
-    query: {
+    url: "/workspaces/{workspace_id}/case-dropdowns",
+    path: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9809,8 +9679,8 @@ export const caseDropdownsCreateDropdownDefinition = (
 ): CancelablePromise<CaseDropdownsCreateDropdownDefinitionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/case-dropdowns",
-    query: {
+    url: "/workspaces/{workspace_id}/case-dropdowns",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9835,11 +9705,9 @@ export const caseDropdownsGetDropdownDefinition = (
 ): CancelablePromise<CaseDropdownsGetDropdownDefinitionResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/case-dropdowns/{definition_id}",
+    url: "/workspaces/{workspace_id}/case-dropdowns/{definition_id}",
     path: {
       definition_id: data.definitionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9863,11 +9731,9 @@ export const caseDropdownsUpdateDropdownDefinition = (
 ): CancelablePromise<CaseDropdownsUpdateDropdownDefinitionResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/case-dropdowns/{definition_id}",
+    url: "/workspaces/{workspace_id}/case-dropdowns/{definition_id}",
     path: {
       definition_id: data.definitionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9892,11 +9758,9 @@ export const caseDropdownsDeleteDropdownDefinition = (
 ): CancelablePromise<CaseDropdownsDeleteDropdownDefinitionResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/case-dropdowns/{definition_id}",
+    url: "/workspaces/{workspace_id}/case-dropdowns/{definition_id}",
     path: {
       definition_id: data.definitionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -9920,11 +9784,9 @@ export const caseDropdownsAddDropdownOption = (
 ): CancelablePromise<CaseDropdownsAddDropdownOptionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/case-dropdowns/{definition_id}/options",
+    url: "/workspaces/{workspace_id}/case-dropdowns/{definition_id}/options",
     path: {
       definition_id: data.definitionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9951,12 +9813,10 @@ export const caseDropdownsUpdateDropdownOption = (
 ): CancelablePromise<CaseDropdownsUpdateDropdownOptionResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/case-dropdowns/{definition_id}/options/{option_id}",
+    url: "/workspaces/{workspace_id}/case-dropdowns/{definition_id}/options/{option_id}",
     path: {
       definition_id: data.definitionId,
       option_id: data.optionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -9982,12 +9842,10 @@ export const caseDropdownsDeleteDropdownOption = (
 ): CancelablePromise<CaseDropdownsDeleteDropdownOptionResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/case-dropdowns/{definition_id}/options/{option_id}",
+    url: "/workspaces/{workspace_id}/case-dropdowns/{definition_id}/options/{option_id}",
     path: {
       definition_id: data.definitionId,
       option_id: data.optionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -10011,11 +9869,9 @@ export const caseDropdownsReorderDropdownOptions = (
 ): CancelablePromise<CaseDropdownsReorderDropdownOptionsResponse> => {
   return __request(OpenAPI, {
     method: "PUT",
-    url: "/case-dropdowns/{definition_id}/options/reorder",
+    url: "/workspaces/{workspace_id}/case-dropdowns/{definition_id}/options/reorder",
     path: {
       definition_id: data.definitionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -10040,11 +9896,9 @@ export const casesListCaseDropdownValues = (
 ): CancelablePromise<CasesListCaseDropdownValuesResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/{case_id}/dropdowns",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/dropdowns",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -10069,12 +9923,10 @@ export const casesSetCaseDropdownValue = (
 ): CancelablePromise<CasesSetCaseDropdownValueResponse> => {
   return __request(OpenAPI, {
     method: "PUT",
-    url: "/cases/{case_id}/dropdowns/{definition_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/dropdowns/{definition_id}",
     path: {
       case_id: data.caseId,
       definition_id: data.definitionId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -10098,8 +9950,8 @@ export const caseDurationsListCaseDurationDefinitions = (
 ): CancelablePromise<CaseDurationsListCaseDurationDefinitionsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/case-durations",
-    query: {
+    url: "/workspaces/{workspace_id}/case-durations",
+    path: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -10122,8 +9974,8 @@ export const caseDurationsCreateCaseDurationDefinition = (
 ): CancelablePromise<CaseDurationsCreateCaseDurationDefinitionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/case-durations",
-    query: {
+    url: "/workspaces/{workspace_id}/case-durations",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -10148,11 +10000,9 @@ export const caseDurationsGetCaseDurationDefinition = (
 ): CancelablePromise<CaseDurationsGetCaseDurationDefinitionResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/case-durations/{duration_id}",
+    url: "/workspaces/{workspace_id}/case-durations/{duration_id}",
     path: {
       duration_id: data.durationId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -10176,11 +10026,9 @@ export const caseDurationsUpdateCaseDurationDefinition = (
 ): CancelablePromise<CaseDurationsUpdateCaseDurationDefinitionResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/case-durations/{duration_id}",
+    url: "/workspaces/{workspace_id}/case-durations/{duration_id}",
     path: {
       duration_id: data.durationId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -10205,11 +10053,9 @@ export const caseDurationsDeleteCaseDurationDefinition = (
 ): CancelablePromise<CaseDurationsDeleteCaseDurationDefinitionResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/case-durations/{duration_id}",
+    url: "/workspaces/{workspace_id}/case-durations/{duration_id}",
     path: {
       duration_id: data.durationId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -10232,11 +10078,9 @@ export const caseDurationsListCaseDurations = (
 ): CancelablePromise<CaseDurationsListCaseDurationsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/{case_id}/durations",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/durations",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -10260,11 +10104,9 @@ export const caseDurationsCreateCaseDuration = (
 ): CancelablePromise<CaseDurationsCreateCaseDurationResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/cases/{case_id}/durations",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/durations",
     path: {
       case_id: data.caseId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -10290,12 +10132,10 @@ export const caseDurationsGetCaseDuration = (
 ): CancelablePromise<CaseDurationsGetCaseDurationResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/cases/{case_id}/durations/{duration_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/durations/{duration_id}",
     path: {
       case_id: data.caseId,
       duration_id: data.durationId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -10320,12 +10160,10 @@ export const caseDurationsUpdateCaseDuration = (
 ): CancelablePromise<CaseDurationsUpdateCaseDurationResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/cases/{case_id}/durations/{duration_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/durations/{duration_id}",
     path: {
       case_id: data.caseId,
       duration_id: data.durationId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -10351,12 +10189,10 @@ export const caseDurationsDeleteCaseDuration = (
 ): CancelablePromise<CaseDurationsDeleteCaseDurationResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/cases/{case_id}/durations/{duration_id}",
+    url: "/workspaces/{workspace_id}/cases/{case_id}/durations/{duration_id}",
     path: {
       case_id: data.caseId,
       duration_id: data.durationId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -10379,10 +10215,12 @@ export const foldersGetDirectory = (
 ): CancelablePromise<FoldersGetDirectoryResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/folders/directory",
+    url: "/workspaces/{workspace_id}/folders/directory",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       path: data.path,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -10406,10 +10244,12 @@ export const foldersListFolders = (
 ): CancelablePromise<FoldersListFoldersResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/folders",
+    url: "/workspaces/{workspace_id}/folders",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       parent_path: data.parentPath,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -10431,8 +10271,8 @@ export const foldersCreateFolder = (
 ): CancelablePromise<FoldersCreateFolderResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/folders",
-    query: {
+    url: "/workspaces/{workspace_id}/folders",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -10457,11 +10297,9 @@ export const foldersGetFolder = (
 ): CancelablePromise<FoldersGetFolderResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/folders/{folder_id}",
+    url: "/workspaces/{workspace_id}/folders/{folder_id}",
     path: {
       folder_id: data.folderId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -10485,11 +10323,9 @@ export const foldersUpdateFolder = (
 ): CancelablePromise<FoldersUpdateFolderResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/folders/{folder_id}",
+    url: "/workspaces/{workspace_id}/folders/{folder_id}",
     path: {
       folder_id: data.folderId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -10518,11 +10354,9 @@ export const foldersDeleteFolder = (
 ): CancelablePromise<FoldersDeleteFolderResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/folders/{folder_id}",
+    url: "/workspaces/{workspace_id}/folders/{folder_id}",
     path: {
       folder_id: data.folderId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -10548,11 +10382,9 @@ export const foldersMoveFolder = (
 ): CancelablePromise<FoldersMoveFolderResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/folders/{folder_id}/move",
+    url: "/workspaces/{workspace_id}/folders/{folder_id}/move",
     path: {
       folder_id: data.folderId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -10604,8 +10436,8 @@ export const integrationsListIntegrations = (
 ): CancelablePromise<IntegrationsListIntegrationsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/integrations",
-    query: {
+    url: "/workspaces/{workspace_id}/integrations",
+    path: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -10618,8 +10450,8 @@ export const integrationsListIntegrations = (
  * Get Integration
  * Get integration for the specified provider.
  * @param data The data for the request.
- * @param data.providerId
  * @param data.workspaceId
+ * @param data.providerId
  * @param data.grantType
  * @returns IntegrationRead Successful Response
  * @throws ApiError
@@ -10629,12 +10461,12 @@ export const integrationsGetIntegration = (
 ): CancelablePromise<IntegrationsGetIntegrationResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/integrations/{provider_id}",
+    url: "/workspaces/{workspace_id}/integrations/{provider_id}",
     path: {
+      workspace_id: data.workspaceId,
       provider_id: data.providerId,
     },
     query: {
-      workspace_id: data.workspaceId,
       grant_type: data.grantType,
     },
     errors: {
@@ -10647,8 +10479,8 @@ export const integrationsGetIntegration = (
  * Delete Integration
  * Delete integration for the specified provider (removes the integration record completely).
  * @param data The data for the request.
- * @param data.providerId
  * @param data.workspaceId
+ * @param data.providerId
  * @param data.grantType
  * @returns void Successful Response
  * @throws ApiError
@@ -10658,12 +10490,12 @@ export const integrationsDeleteIntegration = (
 ): CancelablePromise<IntegrationsDeleteIntegrationResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/integrations/{provider_id}",
+    url: "/workspaces/{workspace_id}/integrations/{provider_id}",
     path: {
+      workspace_id: data.workspaceId,
       provider_id: data.providerId,
     },
     query: {
-      workspace_id: data.workspaceId,
       grant_type: data.grantType,
     },
     errors: {
@@ -10676,8 +10508,8 @@ export const integrationsDeleteIntegration = (
  * Update Integration
  * Update OAuth client credentials for the specified provider integration.
  * @param data The data for the request.
- * @param data.providerId
  * @param data.workspaceId
+ * @param data.providerId
  * @param data.requestBody
  * @param data.grantType
  * @returns void Successful Response
@@ -10688,12 +10520,12 @@ export const integrationsUpdateIntegration = (
 ): CancelablePromise<IntegrationsUpdateIntegrationResponse> => {
   return __request(OpenAPI, {
     method: "PUT",
-    url: "/integrations/{provider_id}",
+    url: "/workspaces/{workspace_id}/integrations/{provider_id}",
     path: {
+      workspace_id: data.workspaceId,
       provider_id: data.providerId,
     },
     query: {
-      workspace_id: data.workspaceId,
       grant_type: data.grantType,
     },
     body: data.requestBody,
@@ -10711,8 +10543,8 @@ export const integrationsUpdateIntegration = (
  * Creates a secure state parameter stored in the database to prevent CSRF attacks.
  * The state is validated on the callback to ensure it was issued by our server.
  * @param data The data for the request.
- * @param data.providerId
  * @param data.workspaceId
+ * @param data.providerId
  * @returns IntegrationOAuthConnect Successful Response
  * @throws ApiError
  */
@@ -10721,12 +10553,10 @@ export const integrationsConnectProvider = (
 ): CancelablePromise<IntegrationsConnectProviderResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/integrations/{provider_id}/connect",
+    url: "/workspaces/{workspace_id}/integrations/{provider_id}/connect",
     path: {
-      provider_id: data.providerId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      provider_id: data.providerId,
     },
     errors: {
       422: "Validation Error",
@@ -10738,8 +10568,8 @@ export const integrationsConnectProvider = (
  * Disconnect Integration
  * Disconnect integration for the specified provider (revokes tokens but keeps configuration).
  * @param data The data for the request.
- * @param data.providerId
  * @param data.workspaceId
+ * @param data.providerId
  * @param data.grantType
  * @returns void Successful Response
  * @throws ApiError
@@ -10749,12 +10579,12 @@ export const integrationsDisconnectIntegration = (
 ): CancelablePromise<IntegrationsDisconnectIntegrationResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/integrations/{provider_id}/disconnect",
+    url: "/workspaces/{workspace_id}/integrations/{provider_id}/disconnect",
     path: {
+      workspace_id: data.workspaceId,
       provider_id: data.providerId,
     },
     query: {
-      workspace_id: data.workspaceId,
       grant_type: data.grantType,
     },
     errors: {
@@ -10767,8 +10597,8 @@ export const integrationsDisconnectIntegration = (
  * Test Connection
  * Test client credentials connection for the specified provider.
  * @param data The data for the request.
- * @param data.providerId
  * @param data.workspaceId
+ * @param data.providerId
  * @returns IntegrationTestConnectionResponse Successful Response
  * @throws ApiError
  */
@@ -10777,12 +10607,10 @@ export const integrationsTestConnection = (
 ): CancelablePromise<IntegrationsTestConnectionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/integrations/{provider_id}/test",
+    url: "/workspaces/{workspace_id}/integrations/{provider_id}/test",
     path: {
-      provider_id: data.providerId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      provider_id: data.providerId,
     },
     errors: {
       422: "Validation Error",
@@ -10803,8 +10631,8 @@ export const providersCreateCustomProvider = (
 ): CancelablePromise<ProvidersCreateCustomProviderResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/providers",
-    query: {
+    url: "/workspaces/{workspace_id}/providers",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -10827,8 +10655,8 @@ export const providersListProviders = (
 ): CancelablePromise<ProvidersListProvidersResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/providers",
-    query: {
+    url: "/workspaces/{workspace_id}/providers",
+    path: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -10841,8 +10669,8 @@ export const providersListProviders = (
  * Get Provider
  * Get provider metadata, scopes, and schema.
  * @param data The data for the request.
- * @param data.providerId
  * @param data.workspaceId
+ * @param data.providerId
  * @param data.grantType
  * @returns ProviderRead Successful Response
  * @throws ApiError
@@ -10852,12 +10680,12 @@ export const providersGetProvider = (
 ): CancelablePromise<ProvidersGetProviderResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/providers/{provider_id}",
+    url: "/workspaces/{workspace_id}/providers/{provider_id}",
     path: {
+      workspace_id: data.workspaceId,
       provider_id: data.providerId,
     },
     query: {
-      workspace_id: data.workspaceId,
       grant_type: data.grantType,
     },
     errors: {
@@ -10880,8 +10708,8 @@ export const mcpIntegrationsCreateMcpIntegration = (
 ): CancelablePromise<McpIntegrationsCreateMcpIntegrationResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/mcp-integrations",
-    query: {
+    url: "/workspaces/{workspace_id}/mcp-integrations",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -10905,8 +10733,8 @@ export const mcpIntegrationsListMcpIntegrations = (
 ): CancelablePromise<McpIntegrationsListMcpIntegrationsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/mcp-integrations",
-    query: {
+    url: "/workspaces/{workspace_id}/mcp-integrations",
+    path: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -10929,11 +10757,9 @@ export const mcpIntegrationsGetMcpIntegration = (
 ): CancelablePromise<McpIntegrationsGetMcpIntegrationResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/mcp-integrations/{mcp_integration_id}",
+    url: "/workspaces/{workspace_id}/mcp-integrations/{mcp_integration_id}",
     path: {
       mcp_integration_id: data.mcpIntegrationId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {
@@ -10957,11 +10783,9 @@ export const mcpIntegrationsUpdateMcpIntegration = (
 ): CancelablePromise<McpIntegrationsUpdateMcpIntegrationResponse> => {
   return __request(OpenAPI, {
     method: "PUT",
-    url: "/mcp-integrations/{mcp_integration_id}",
+    url: "/workspaces/{workspace_id}/mcp-integrations/{mcp_integration_id}",
     path: {
       mcp_integration_id: data.mcpIntegrationId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -10986,11 +10810,9 @@ export const mcpIntegrationsDeleteMcpIntegration = (
 ): CancelablePromise<McpIntegrationsDeleteMcpIntegrationResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/mcp-integrations/{mcp_integration_id}",
+    url: "/workspaces/{workspace_id}/mcp-integrations/{mcp_integration_id}",
     path: {
       mcp_integration_id: data.mcpIntegrationId,
-    },
-    query: {
       workspace_id: data.workspaceId,
     },
     errors: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -1717,13 +1717,15 @@ export const workflowsListWorkflows = (
 ): CancelablePromise<WorkflowsListWorkflowsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflows",
+    url: "/workspaces/{workspace_id}/workflows",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     query: {
       tag: data.tag,
       limit: data.limit,
       cursor: data.cursor,
       reverse: data.reverse,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -1748,8 +1750,8 @@ export const workflowsCreateWorkflow = (
 ): CancelablePromise<WorkflowsCreateWorkflowResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflows",
-    query: {
+    url: "/workspaces/{workspace_id}/workflows",
+    path: {
       workspace_id: data.workspaceId,
     },
     formData: data.formData,
@@ -1774,8 +1776,8 @@ export const workflowsValidateWorkflowEntrypoint = (
 ): CancelablePromise<WorkflowsValidateWorkflowEntrypointResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflows/validate-entrypoint",
-    query: {
+    url: "/workspaces/{workspace_id}/workflows/validate-entrypoint",
+    path: {
       workspace_id: data.workspaceId,
     },
     body: data.requestBody,
@@ -1790,8 +1792,8 @@ export const workflowsValidateWorkflowEntrypoint = (
  * Get Workflow
  * Return Workflow as title, description, list of Action JSONs, adjacency list of Action IDs.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns WorkflowRead Successful Response
  * @throws ApiError
  */
@@ -1800,12 +1802,10 @@ export const workflowsGetWorkflow = (
 ): CancelablePromise<WorkflowsGetWorkflowResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflows/{workflow_id}",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -1817,8 +1817,8 @@ export const workflowsGetWorkflow = (
  * Update Workflow
  * Update a workflow.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @param data.requestBody
  * @returns void Successful Response
  * @throws ApiError
@@ -1828,12 +1828,10 @@ export const workflowsUpdateWorkflow = (
 ): CancelablePromise<WorkflowsUpdateWorkflowResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/workflows/{workflow_id}",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -1847,8 +1845,8 @@ export const workflowsUpdateWorkflow = (
  * Delete Workflow
  * Delete a workflow.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns void Successful Response
  * @throws ApiError
  */
@@ -1857,12 +1855,10 @@ export const workflowsDeleteWorkflow = (
 ): CancelablePromise<WorkflowsDeleteWorkflowResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/workflows/{workflow_id}",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -1876,8 +1872,8 @@ export const workflowsDeleteWorkflow = (
  *
  * This deploys the workflow and updates its version. If a YAML file is provided, it will override the workflow in the database.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns WorkflowCommitResponse Successful Response
  * @throws ApiError
  */
@@ -1886,12 +1882,10 @@ export const workflowsCommitWorkflow = (
 ): CancelablePromise<WorkflowsCommitWorkflowResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflows/{workflow_id}/commit",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/commit",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -1909,8 +1903,8 @@ export const workflowsCommitWorkflow = (
  * without requiring a saved definition. When `draft=False` (default), exports
  * from a saved workflow definition version.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @param data.format Export format: 'json' or 'yaml'
  * @param data.version Workflow definition version. If not provided, the latest version is exported.
  * @param data.draft Export current draft state instead of saved definition.
@@ -1922,15 +1916,15 @@ export const workflowsExportWorkflow = (
 ): CancelablePromise<WorkflowsExportWorkflowResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflows/{workflow_id}/export",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/export",
     path: {
+      workspace_id: data.workspaceId,
       workflow_id: data.workflowId,
     },
     query: {
       format: data.format,
       version: data.version,
       draft: data.draft,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -1942,8 +1936,8 @@ export const workflowsExportWorkflow = (
  * List Workflow Definitions
  * List all workflow definitions for a Workflow.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns WorkflowDefinitionRead Successful Response
  * @throws ApiError
  */
@@ -1952,12 +1946,10 @@ export const workflowsListWorkflowDefinitions = (
 ): CancelablePromise<WorkflowsListWorkflowDefinitionsResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflows/{workflow_id}/definitions",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/definitions",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -1970,8 +1962,8 @@ export const workflowsListWorkflowDefinitions = (
  * Restore a saved workflow definition as the current published version.
  * @param data The data for the request.
  * @param data.version
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns WorkflowRead Successful Response
  * @throws ApiError
  */
@@ -1980,13 +1972,11 @@ export const workflowsRestoreWorkflowDefinition = (
 ): CancelablePromise<WorkflowsRestoreWorkflowDefinitionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflows/{workflow_id}/definitions/{version}/restore",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/definitions/{version}/restore",
     path: {
       version: data.version,
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -1998,8 +1988,8 @@ export const workflowsRestoreWorkflowDefinition = (
  * Get Workflow Definition
  * Get the latest version of a workflow definition.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @param data.version
  * @returns WorkflowDefinitionRead Successful Response
  * @throws ApiError
@@ -2009,13 +1999,13 @@ export const workflowsGetWorkflowDefinition = (
 ): CancelablePromise<WorkflowsGetWorkflowDefinitionResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflows/{workflow_id}/definition",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/definition",
     path: {
+      workspace_id: data.workspaceId,
       workflow_id: data.workflowId,
     },
     query: {
       version: data.version,
-      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",
@@ -2027,8 +2017,8 @@ export const workflowsGetWorkflowDefinition = (
  * Create Workflow Definition
  * Get the latest version of a workflow definition.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns WorkflowDefinitionRead Successful Response
  * @throws ApiError
  */
@@ -2037,12 +2027,10 @@ export const workflowsCreateWorkflowDefinition = (
 ): CancelablePromise<WorkflowsCreateWorkflowDefinitionResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflows/{workflow_id}/definition",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/definition",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -2054,8 +2042,8 @@ export const workflowsCreateWorkflowDefinition = (
  * Create Webhook
  * Create a webhook for a workflow.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @param data.requestBody
  * @returns unknown Successful Response
  * @throws ApiError
@@ -2065,12 +2053,10 @@ export const triggersCreateWebhook = (
 ): CancelablePromise<TriggersCreateWebhookResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflows/{workflow_id}/webhook",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/webhook",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -2084,8 +2070,8 @@ export const triggersCreateWebhook = (
  * Get Webhook
  * Get the webhook from a workflow.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns WebhookRead Successful Response
  * @throws ApiError
  */
@@ -2094,12 +2080,10 @@ export const triggersGetWebhook = (
 ): CancelablePromise<TriggersGetWebhookResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflows/{workflow_id}/webhook",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/webhook",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -2111,8 +2095,8 @@ export const triggersGetWebhook = (
  * Update Webhook
  * Update the webhook for a workflow. We currently supprt only one webhook per workflow.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @param data.requestBody
  * @returns void Successful Response
  * @throws ApiError
@@ -2122,12 +2106,10 @@ export const triggersUpdateWebhook = (
 ): CancelablePromise<TriggersUpdateWebhookResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/workflows/{workflow_id}/webhook",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/webhook",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -2141,8 +2123,8 @@ export const triggersUpdateWebhook = (
  * Create Case Trigger
  * Create or replace the case trigger configuration for a workflow.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @param data.requestBody
  * @returns CaseTriggerRead Successful Response
  * @throws ApiError
@@ -2152,12 +2134,10 @@ export const triggersCreateCaseTrigger = (
 ): CancelablePromise<TriggersCreateCaseTriggerResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflows/{workflow_id}/case-trigger",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/case-trigger",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -2171,8 +2151,8 @@ export const triggersCreateCaseTrigger = (
  * Get Case Trigger
  * Get the case trigger configuration for a workflow.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns CaseTriggerRead Successful Response
  * @throws ApiError
  */
@@ -2181,12 +2161,10 @@ export const triggersGetCaseTrigger = (
 ): CancelablePromise<TriggersGetCaseTriggerResponse> => {
   return __request(OpenAPI, {
     method: "GET",
-    url: "/workflows/{workflow_id}/case-trigger",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/case-trigger",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -2198,8 +2176,8 @@ export const triggersGetCaseTrigger = (
  * Update Case Trigger
  * Update the case trigger configuration for a workflow.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @param data.requestBody
  * @returns void Successful Response
  * @throws ApiError
@@ -2209,12 +2187,10 @@ export const triggersUpdateCaseTrigger = (
 ): CancelablePromise<TriggersUpdateCaseTriggerResponse> => {
   return __request(OpenAPI, {
     method: "PATCH",
-    url: "/workflows/{workflow_id}/case-trigger",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/case-trigger",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     body: data.requestBody,
     mediaType: "application/json",
@@ -2228,8 +2204,8 @@ export const triggersUpdateCaseTrigger = (
  * Generate Webhook Api Key
  * Create or rotate the API key for a webhook.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns WebhookApiKeyGenerateResponse Successful Response
  * @throws ApiError
  */
@@ -2238,12 +2214,10 @@ export const triggersGenerateWebhookApiKey = (
 ): CancelablePromise<TriggersGenerateWebhookApiKeyResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflows/{workflow_id}/webhook/api-key",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/webhook/api-key",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -2255,8 +2229,8 @@ export const triggersGenerateWebhookApiKey = (
  * Delete Webhook Api Key
  * Delete the current API key for a webhook.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns void Successful Response
  * @throws ApiError
  */
@@ -2265,12 +2239,10 @@ export const triggersDeleteWebhookApiKey = (
 ): CancelablePromise<TriggersDeleteWebhookApiKeyResponse> => {
   return __request(OpenAPI, {
     method: "DELETE",
-    url: "/workflows/{workflow_id}/webhook/api-key",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/webhook/api-key",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -2282,8 +2254,8 @@ export const triggersDeleteWebhookApiKey = (
  * Revoke Webhook Api Key
  * Revoke the current API key for a webhook.
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @returns void Successful Response
  * @throws ApiError
  */
@@ -2292,12 +2264,10 @@ export const triggersRevokeWebhookApiKey = (
 ): CancelablePromise<TriggersRevokeWebhookApiKeyResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflows/{workflow_id}/webhook/api-key/revoke",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/webhook/api-key/revoke",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     errors: {
       422: "Validation Error",
@@ -2311,8 +2281,8 @@ export const triggersRevokeWebhookApiKey = (
  *
  * If folder_id is null, the workflow will be moved to the root (no folder).
  * @param data The data for the request.
- * @param data.workflowId
  * @param data.workspaceId
+ * @param data.workflowId
  * @param data.requestBody
  * @returns void Successful Response
  * @throws ApiError
@@ -2322,12 +2292,10 @@ export const workflowsMoveWorkflowToFolder = (
 ): CancelablePromise<WorkflowsMoveWorkflowToFolderResponse> => {
   return __request(OpenAPI, {
     method: "POST",
-    url: "/workflows/{workflow_id}/move",
+    url: "/workspaces/{workspace_id}/workflows/{workflow_id}/move",
     path: {
-      workflow_id: data.workflowId,
-    },
-    query: {
       workspace_id: data.workspaceId,
+      workflow_id: data.workflowId,
     },
     body: data.requestBody,
     mediaType: "application/json",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -9115,6 +9115,15 @@ export type WorkflowsMoveWorkflowToFolderData = {
 
 export type WorkflowsMoveWorkflowToFolderResponse = void
 
+export type WorkflowExecutionsGetWorkflowExecutionByWorkflowIdData = {
+  executionId: string
+  workflowId: string
+  workspaceId: string
+}
+
+export type WorkflowExecutionsGetWorkflowExecutionByWorkflowIdResponse =
+  WorkflowExecutionRead
+
 export type GraphGetGraphData = {
   workflowId: string
   workspaceId: string
@@ -12852,6 +12861,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/executions/{execution_id}": {
+    get: {
+      req: WorkflowExecutionsGetWorkflowExecutionByWorkflowIdData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: WorkflowExecutionRead
         /**
          * Validation Error
          */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -9808,14 +9808,6 @@ export type AgentSetDefaultModelSelectionData = {
 
 export type AgentSetDefaultModelSelectionResponse = DefaultModelSelection
 
-export type AgentGetWorkspaceProvidersStatusData = {
-  workspaceId: string
-}
-
-export type AgentGetWorkspaceProvidersStatusResponse = {
-  [key: string]: boolean
-}
-
 export type ListCatalogData = {
   cursor?: string | null
   limit?: number
@@ -9927,6 +9919,14 @@ export type ValidateCustomProviderConnectionData = {
 }
 
 export type ValidateCustomProviderConnectionResponse = {
+  [key: string]: boolean
+}
+
+export type AgentGetWorkspaceProvidersStatusData = {
+  workspaceId: string
+}
+
+export type AgentGetWorkspaceProvidersStatusResponse = {
   [key: string]: boolean
 }
 
@@ -10642,6 +10642,10 @@ export type EditorValidateExpressionData = {
 }
 
 export type EditorValidateExpressionResponse = ExpressionValidationResponse
+
+export type EditorFieldSchemaData = {
+  workspaceId: string
+}
 
 export type EditorFieldSchemaResponse = EditorComponent
 
@@ -12855,7 +12859,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/graph": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/graph": {
     get: {
       req: GraphGetGraphData
       res: {
@@ -12883,7 +12887,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflow-executions": {
+  "/workspaces/{workspace_id}/workflow-executions": {
     get: {
       req: WorkflowExecutionsListWorkflowExecutionsData
       res: {
@@ -12911,7 +12915,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflow-executions/search": {
+  "/workspaces/{workspace_id}/workflow-executions/search": {
     get: {
       req: WorkflowExecutionsSearchWorkflowExecutionsData
       res: {
@@ -12926,7 +12930,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflow-executions/{execution_id}/reset-points": {
+  "/workspaces/{workspace_id}/workflow-executions/{execution_id}/reset-points": {
     get: {
       req: WorkflowExecutionsListWorkflowExecutionResetPointsData
       res: {
@@ -12941,7 +12945,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflow-executions/{execution_id}/reset": {
+  "/workspaces/{workspace_id}/workflow-executions/{execution_id}/reset": {
     post: {
       req: WorkflowExecutionsResetWorkflowExecutionData
       res: {
@@ -12956,7 +12960,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflow-executions/reset/bulk": {
+  "/workspaces/{workspace_id}/workflow-executions/reset/bulk": {
     post: {
       req: WorkflowExecutionsBulkResetWorkflowExecutionsData
       res: {
@@ -12971,7 +12975,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflow-executions/{execution_id}": {
+  "/workspaces/{workspace_id}/workflow-executions/{execution_id}": {
     get: {
       req: WorkflowExecutionsGetWorkflowExecutionData
       res: {
@@ -12986,7 +12990,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflow-executions/{execution_id}/compact": {
+  "/workspaces/{workspace_id}/workflow-executions/{execution_id}/compact": {
     get: {
       req: WorkflowExecutionsGetWorkflowExecutionCompactData
       res: {
@@ -13001,7 +13005,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflow-executions/{execution_id}/objects/download": {
+  "/workspaces/{workspace_id}/workflow-executions/{execution_id}/objects/download": {
     post: {
       req: WorkflowExecutionsGetWorkflowExecutionObjectDownloadData
       res: {
@@ -13016,7 +13020,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflow-executions/{execution_id}/objects/preview": {
+  "/workspaces/{workspace_id}/workflow-executions/{execution_id}/objects/preview": {
     post: {
       req: WorkflowExecutionsGetWorkflowExecutionObjectPreviewData
       res: {
@@ -13031,7 +13035,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflow-executions/{execution_id}/objects/collection/page": {
+  "/workspaces/{workspace_id}/workflow-executions/{execution_id}/objects/collection/page": {
     post: {
       req: WorkflowExecutionsGetWorkflowExecutionCollectionPageData
       res: {
@@ -13046,7 +13050,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflow-executions/draft": {
+  "/workspaces/{workspace_id}/workflow-executions/draft": {
     post: {
       req: WorkflowExecutionsCreateDraftWorkflowExecutionData
       res: {
@@ -13061,7 +13065,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflow-executions/{execution_id}/cancel": {
+  "/workspaces/{workspace_id}/workflow-executions/{execution_id}/cancel": {
     post: {
       req: WorkflowExecutionsCancelWorkflowExecutionData
       res: {
@@ -13076,7 +13080,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflow-executions/{execution_id}/terminate": {
+  "/workspaces/{workspace_id}/workflow-executions/{execution_id}/terminate": {
     post: {
       req: WorkflowExecutionsTerminateWorkflowExecutionData
       res: {
@@ -13091,7 +13095,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/actions/batch-positions": {
+  "/workspaces/{workspace_id}/actions/batch-positions": {
     post: {
       req: ActionsBatchUpdatePositionsData
       res: {
@@ -13106,7 +13110,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/actions": {
+  "/workspaces/{workspace_id}/actions": {
     get: {
       req: ActionsListActionsData
       res: {
@@ -13134,7 +13138,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/actions/{action_id}": {
+  "/workspaces/{workspace_id}/actions/{action_id}": {
     get: {
       req: ActionsGetActionData
       res: {
@@ -13175,7 +13179,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/tags": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/tags": {
     get: {
       req: WorkflowsListTagsData
       res: {
@@ -13203,7 +13207,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/tags/{tag_id}": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/tags/{tag_id}": {
     delete: {
       req: WorkflowsRemoveTagData
       res: {
@@ -13218,7 +13222,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/publish": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/publish": {
     post: {
       req: WorkflowsPublishWorkflowData
       res: {
@@ -13233,7 +13237,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/sync/commits": {
+  "/workspaces/{workspace_id}/workflows/sync/commits": {
     get: {
       req: WorkflowsListWorkflowCommitsData
       res: {
@@ -13248,7 +13252,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/sync/branches": {
+  "/workspaces/{workspace_id}/workflows/sync/branches": {
     get: {
       req: WorkflowsListWorkflowBranchesData
       res: {
@@ -13263,7 +13267,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/sync/pull": {
+  "/workspaces/{workspace_id}/workflows/sync/pull": {
     post: {
       req: WorkflowsPullWorkflowsData
       res: {
@@ -13278,7 +13282,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/secrets/search": {
+  "/workspaces/{workspace_id}/secrets/search": {
     get: {
       req: SecretsSearchSecretsData
       res: {
@@ -13293,7 +13297,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/secrets": {
+  "/workspaces/{workspace_id}/secrets": {
     get: {
       req: SecretsListSecretsData
       res: {
@@ -13321,7 +13325,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/secrets/definitions": {
+  "/workspaces/{workspace_id}/secrets/definitions": {
     get: {
       req: SecretsListSecretDefinitionsData
       res: {
@@ -13336,7 +13340,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/secrets/aws-assume-role": {
+  "/workspaces/{workspace_id}/secrets/aws-assume-role": {
     get: {
       req: SecretsGetAwsAssumeRoleAccessData
       res: {
@@ -13351,7 +13355,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/secrets/{secret_name}": {
+  "/workspaces/{workspace_id}/secrets/{secret_name}": {
     get: {
       req: SecretsGetSecretByNameData
       res: {
@@ -13366,7 +13370,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/secrets/{secret_id}": {
+  "/workspaces/{workspace_id}/secrets/{secret_id}": {
     post: {
       req: SecretsUpdateSecretByIdData
       res: {
@@ -13394,7 +13398,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/variables/search": {
+  "/workspaces/{workspace_id}/variables/search": {
     get: {
       req: VariablesSearchVariablesData
       res: {
@@ -13409,7 +13413,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/variables": {
+  "/workspaces/{workspace_id}/variables": {
     get: {
       req: VariablesListVariablesData
       res: {
@@ -13437,7 +13441,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/variables/{variable_name}": {
+  "/workspaces/{workspace_id}/variables/{variable_name}": {
     get: {
       req: VariablesGetVariableByNameData
       res: {
@@ -13452,7 +13456,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/variables/{variable_id}": {
+  "/workspaces/{workspace_id}/variables/{variable_id}": {
     post: {
       req: VariablesUpdateVariableByIdData
       res: {
@@ -13480,7 +13484,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/schedules": {
+  "/workspaces/{workspace_id}/schedules": {
     get: {
       req: SchedulesListSchedulesData
       res: {
@@ -13508,7 +13512,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/schedules/{schedule_id}": {
+  "/workspaces/{workspace_id}/schedules/{schedule_id}": {
     get: {
       req: SchedulesGetScheduleData
       res: {
@@ -13549,7 +13553,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/schedules/search": {
+  "/workspaces/{workspace_id}/schedules/search": {
     get: {
       req: SchedulesSearchSchedulesData
       res: {
@@ -13564,7 +13568,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/tags": {
+  "/workspaces/{workspace_id}/tags": {
     get: {
       req: TagsListTagsData
       res: {
@@ -13592,7 +13596,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/tags/{tag_id}": {
+  "/workspaces/{workspace_id}/tags/{tag_id}": {
     get: {
       req: TagsGetTagData
       res: {
@@ -14159,23 +14163,6 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/workspace/providers/status": {
-    get: {
-      req: AgentGetWorkspaceProvidersStatusData
-      res: {
-        /**
-         * Successful Response
-         */
-        200: {
-          [key: string]: boolean
-        }
-        /**
-         * Validation Error
-         */
-        422: HTTPValidationError
-      }
-    }
-  }
   "/organization/agent-catalog": {
     get: {
       req: ListCatalogData
@@ -14404,7 +14391,24 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/channels/tokens": {
+  "/workspaces/{workspace_id}/agent/workspace/providers/status": {
+    get: {
+      req: AgentGetWorkspaceProvidersStatusData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: {
+          [key: string]: boolean
+        }
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/channels/tokens": {
     post: {
       req: AgentChannelsCreateChannelTokenData
       res: {
@@ -14432,7 +14436,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/channels/tokens/{token_id}": {
+  "/workspaces/{workspace_id}/agent/channels/tokens/{token_id}": {
     patch: {
       req: AgentChannelsUpdateChannelTokenData
       res: {
@@ -14460,7 +14464,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/channels/tokens/{token_id}/rotate": {
+  "/workspaces/{workspace_id}/agent/channels/tokens/{token_id}/rotate": {
     post: {
       req: AgentChannelsRotateChannelTokenData
       res: {
@@ -14475,7 +14479,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/channels/tokens/slack/oauth/start": {
+  "/workspaces/{workspace_id}/agent/channels/tokens/slack/oauth/start": {
     post: {
       req: AgentChannelsStartSlackOauthData
       res: {
@@ -14490,7 +14494,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/presets": {
+  "/workspaces/{workspace_id}/agent/presets": {
     get: {
       req: AgentPresetsListAgentPresetsData
       res: {
@@ -14518,7 +14522,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/presets/{preset_id}": {
+  "/workspaces/{workspace_id}/agent/presets/{preset_id}": {
     get: {
       req: AgentPresetsGetAgentPresetData
       res: {
@@ -14559,7 +14563,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/presets/by-slug/{slug}": {
+  "/workspaces/{workspace_id}/agent/presets/by-slug/{slug}": {
     get: {
       req: AgentPresetsGetAgentPresetBySlugData
       res: {
@@ -14574,7 +14578,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/presets/{preset_id}/versions": {
+  "/workspaces/{workspace_id}/agent/presets/{preset_id}/versions": {
     get: {
       req: AgentPresetsListAgentPresetVersionsData
       res: {
@@ -14589,7 +14593,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/presets/{preset_id}/versions/{version_id}": {
+  "/workspaces/{workspace_id}/agent/presets/{preset_id}/versions/{version_id}": {
     get: {
       req: AgentPresetsGetAgentPresetVersionData
       res: {
@@ -14604,7 +14608,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/presets/{preset_id}/versions/{version_id}/compare": {
+  "/workspaces/{workspace_id}/agent/presets/{preset_id}/versions/{version_id}/compare": {
     get: {
       req: AgentPresetsCompareAgentPresetVersionsData
       res: {
@@ -14619,7 +14623,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/presets/{preset_id}/versions/{version_id}/restore": {
+  "/workspaces/{workspace_id}/agent/presets/{preset_id}/versions/{version_id}/restore": {
     post: {
       req: AgentPresetsRestoreAgentPresetVersionData
       res: {
@@ -14634,7 +14638,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/skills": {
+  "/workspaces/{workspace_id}/agent/skills": {
     get: {
       req: AgentSkillsListSkillsData
       res: {
@@ -14662,7 +14666,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/skills:upload": {
+  "/workspaces/{workspace_id}/agent/skills:upload": {
     post: {
       req: AgentSkillsUploadSkillData
       res: {
@@ -14677,7 +14681,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/skills/{skill_id}": {
+  "/workspaces/{workspace_id}/agent/skills/{skill_id}": {
     get: {
       req: AgentSkillsGetSkillData
       res: {
@@ -14705,7 +14709,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/skills/{skill_id}/draft": {
+  "/workspaces/{workspace_id}/agent/skills/{skill_id}/draft": {
     get: {
       req: AgentSkillsGetSkillDraftData
       res: {
@@ -14733,7 +14737,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/skills/{skill_id}/draft/file": {
+  "/workspaces/{workspace_id}/agent/skills/{skill_id}/draft/file": {
     get: {
       req: AgentSkillsGetSkillDraftFileData
       res: {
@@ -14748,7 +14752,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/skills/{skill_id}/draft/uploads": {
+  "/workspaces/{workspace_id}/agent/skills/{skill_id}/draft/uploads": {
     post: {
       req: AgentSkillsCreateSkillDraftUploadData
       res: {
@@ -14763,7 +14767,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/skills/{skill_id}/publish": {
+  "/workspaces/{workspace_id}/agent/skills/{skill_id}/publish": {
     post: {
       req: AgentSkillsPublishSkillData
       res: {
@@ -14778,7 +14782,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/skills/{skill_id}/versions": {
+  "/workspaces/{workspace_id}/agent/skills/{skill_id}/versions": {
     get: {
       req: AgentSkillsListSkillVersionsData
       res: {
@@ -14793,7 +14797,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/skills/{skill_id}/versions/{version_id}": {
+  "/workspaces/{workspace_id}/agent/skills/{skill_id}/versions/{version_id}": {
     get: {
       req: AgentSkillsGetSkillVersionData
       res: {
@@ -14808,7 +14812,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/skills/{skill_id}/versions/{version_id}/file": {
+  "/workspaces/{workspace_id}/agent/skills/{skill_id}/versions/{version_id}/file": {
     get: {
       req: AgentSkillsGetSkillVersionFileData
       res: {
@@ -14823,7 +14827,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/skills/{skill_id}/versions/{version_id}/restore": {
+  "/workspaces/{workspace_id}/agent/skills/{skill_id}/versions/{version_id}/restore": {
     post: {
       req: AgentSkillsRestoreSkillVersionData
       res: {
@@ -14838,7 +14842,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/sessions": {
+  "/workspaces/{workspace_id}/agent/sessions": {
     post: {
       req: AgentSessionsCreateSessionData
       res: {
@@ -14866,7 +14870,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/sessions/{session_id}": {
+  "/workspaces/{workspace_id}/agent/sessions/{session_id}": {
     get: {
       req: AgentSessionsGetSessionData
       res: {
@@ -14907,7 +14911,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/sessions/{session_id}/vercel": {
+  "/workspaces/{workspace_id}/agent/sessions/{session_id}/vercel": {
     get: {
       req: AgentSessionsGetSessionVercelData
       res: {
@@ -14922,7 +14926,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/sessions/{session_id}/messages": {
+  "/workspaces/{workspace_id}/agent/sessions/{session_id}/messages": {
     post: {
       req: AgentSessionsSendMessageData
       res: {
@@ -14937,7 +14941,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/sessions/{session_id}/stream": {
+  "/workspaces/{workspace_id}/agent/sessions/{session_id}/stream": {
     get: {
       req: AgentSessionsStreamSessionEventsData
       res: {
@@ -14952,7 +14956,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/agent/sessions/{session_id}/fork": {
+  "/workspaces/{workspace_id}/agent/sessions/{session_id}/fork": {
     post: {
       req: AgentSessionsForkSessionData
       res: {
@@ -14967,7 +14971,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/approvals/{session_id}": {
+  "/workspaces/{workspace_id}/approvals/{session_id}": {
     post: {
       req: ApprovalsSubmitApprovalsData
       res: {
@@ -15623,7 +15627,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/inbox/items": {
+  "/workspaces/{workspace_id}/inbox/items": {
     get: {
       req: InboxListItemsData
       res: {
@@ -15638,7 +15642,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/editor/functions": {
+  "/workspaces/{workspace_id}/editor/functions": {
     get: {
       req: EditorListFunctionsData
       res: {
@@ -15653,7 +15657,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/editor/actions": {
+  "/workspaces/{workspace_id}/editor/actions": {
     get: {
       req: EditorListActionsData
       res: {
@@ -15668,7 +15672,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/editor/expressions/validate": {
+  "/workspaces/{workspace_id}/editor/expressions/validate": {
     post: {
       req: EditorValidateExpressionData
       res: {
@@ -15683,13 +15687,18 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/editor/field-schema": {
+  "/workspaces/{workspace_id}/editor/field-schema": {
     get: {
+      req: EditorFieldSchemaData
       res: {
         /**
          * Successful Response
          */
         200: EditorComponent
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
       }
     }
   }
@@ -16086,7 +16095,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/tables": {
+  "/workspaces/{workspace_id}/tables": {
     get: {
       req: TablesListTablesData
       res: {
@@ -16114,7 +16123,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/tables/{table_id}": {
+  "/workspaces/{workspace_id}/tables/{table_id}": {
     get: {
       req: TablesGetTableData
       res: {
@@ -16155,7 +16164,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/tables/{table_id}/columns": {
+  "/workspaces/{workspace_id}/tables/{table_id}/columns": {
     post: {
       req: TablesCreateColumnData
       res: {
@@ -16170,7 +16179,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/tables/{table_id}/columns/{column_id}": {
+  "/workspaces/{workspace_id}/tables/{table_id}/columns/{column_id}": {
     patch: {
       req: TablesUpdateColumnData
       res: {
@@ -16198,7 +16207,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/tables/{table_id}/rows": {
+  "/workspaces/{workspace_id}/tables/{table_id}/rows": {
     get: {
       req: TablesListRowsData
       res: {
@@ -16226,7 +16235,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/tables/{table_id}/rows/{row_id}": {
+  "/workspaces/{workspace_id}/tables/{table_id}/rows/{row_id}": {
     get: {
       req: TablesGetRowData
       res: {
@@ -16267,7 +16276,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/tables/{table_id}/rows/batch": {
+  "/workspaces/{workspace_id}/tables/{table_id}/rows/batch": {
     post: {
       req: TablesBatchInsertRowsData
       res: {
@@ -16282,7 +16291,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/tables/{table_id}/rows/batch-delete": {
+  "/workspaces/{workspace_id}/tables/{table_id}/rows/batch-delete": {
     post: {
       req: TablesBatchDeleteRowsData
       res: {
@@ -16297,7 +16306,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/tables/{table_id}/rows/batch-update": {
+  "/workspaces/{workspace_id}/tables/{table_id}/rows/batch-update": {
     post: {
       req: TablesBatchUpdateRowsData
       res: {
@@ -16312,7 +16321,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/tables/import": {
+  "/workspaces/{workspace_id}/tables/import": {
     post: {
       req: TablesImportTableFromCsvData
       res: {
@@ -16327,7 +16336,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/tables/{table_id}/import": {
+  "/workspaces/{workspace_id}/tables/{table_id}/import": {
     post: {
       req: TablesImportCsvData
       res: {
@@ -16342,7 +16351,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases": {
+  "/workspaces/{workspace_id}/cases": {
     get: {
       req: CasesListCasesData
       res: {
@@ -16370,7 +16379,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/search": {
+  "/workspaces/{workspace_id}/cases/search": {
     get: {
       req: CasesSearchCasesData
       res: {
@@ -16385,7 +16394,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/search/aggregate": {
+  "/workspaces/{workspace_id}/cases/search/aggregate": {
     get: {
       req: CasesSearchCaseAggregatesData
       res: {
@@ -16400,7 +16409,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}": {
+  "/workspaces/{workspace_id}/cases/{case_id}": {
     get: {
       req: CasesGetCaseData
       res: {
@@ -16441,7 +16450,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/comments": {
+  "/workspaces/{workspace_id}/cases/{case_id}/comments": {
     get: {
       req: CasesListCommentsData
       res: {
@@ -16469,7 +16478,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/comments/threads": {
+  "/workspaces/{workspace_id}/cases/{case_id}/comments/threads": {
     get: {
       req: CasesListCommentThreadsData
       res: {
@@ -16484,7 +16493,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/comments/{comment_id}": {
+  "/workspaces/{workspace_id}/cases/{case_id}/comments/{comment_id}": {
     patch: {
       req: CasesUpdateCommentData
       res: {
@@ -16512,7 +16521,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/events": {
+  "/workspaces/{workspace_id}/cases/{case_id}/events": {
     get: {
       req: CasesListEventsWithUsersData
       res: {
@@ -16527,7 +16536,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/tasks": {
+  "/workspaces/{workspace_id}/cases/{case_id}/tasks": {
     get: {
       req: CasesListTasksData
       res: {
@@ -16555,7 +16564,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/tasks/{task_id}": {
+  "/workspaces/{workspace_id}/cases/{case_id}/tasks/{task_id}": {
     patch: {
       req: CasesUpdateTaskData
       res: {
@@ -16583,7 +16592,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/rows": {
+  "/workspaces/{workspace_id}/cases/{case_id}/rows": {
     get: {
       req: CasesListCaseRowsData
       res: {
@@ -16611,7 +16620,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/rows/insert": {
+  "/workspaces/{workspace_id}/cases/{case_id}/rows/insert": {
     post: {
       req: CasesInsertCaseRowData
       res: {
@@ -16626,7 +16635,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/rows/{table_id}/{row_id}": {
+  "/workspaces/{workspace_id}/cases/{case_id}/rows/{table_id}/{row_id}": {
     delete: {
       req: CasesUnlinkCaseRowData
       res: {
@@ -16641,7 +16650,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/case-fields": {
+  "/workspaces/{workspace_id}/case-fields": {
     get: {
       req: CasesListFieldsData
       res: {
@@ -16669,7 +16678,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/case-fields/{field_id}": {
+  "/workspaces/{workspace_id}/case-fields/{field_id}": {
     patch: {
       req: CasesUpdateFieldData
       res: {
@@ -16697,7 +16706,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/tags": {
+  "/workspaces/{workspace_id}/cases/{case_id}/tags": {
     get: {
       req: CasesListTagsData
       res: {
@@ -16725,7 +16734,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/tags/{tag_identifier}": {
+  "/workspaces/{workspace_id}/cases/{case_id}/tags/{tag_identifier}": {
     delete: {
       req: CasesRemoveTagData
       res: {
@@ -16740,7 +16749,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/case-tags": {
+  "/workspaces/{workspace_id}/case-tags": {
     get: {
       req: CaseTagsListCaseTagsData
       res: {
@@ -16768,7 +16777,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/case-tags/{tag_id}": {
+  "/workspaces/{workspace_id}/case-tags/{tag_id}": {
     get: {
       req: CaseTagsGetCaseTagData
       res: {
@@ -16809,7 +16818,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/attachments": {
+  "/workspaces/{workspace_id}/cases/{case_id}/attachments": {
     get: {
       req: CaseAttachmentsListAttachmentsData
       res: {
@@ -16837,7 +16846,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/attachments/{attachment_id}": {
+  "/workspaces/{workspace_id}/cases/{case_id}/attachments/{attachment_id}": {
     get: {
       req: CaseAttachmentsDownloadAttachmentData
       res: {
@@ -16865,7 +16874,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/case-dropdowns": {
+  "/workspaces/{workspace_id}/case-dropdowns": {
     get: {
       req: CaseDropdownsListDropdownDefinitionsData
       res: {
@@ -16893,7 +16902,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/case-dropdowns/{definition_id}": {
+  "/workspaces/{workspace_id}/case-dropdowns/{definition_id}": {
     get: {
       req: CaseDropdownsGetDropdownDefinitionData
       res: {
@@ -16934,7 +16943,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/case-dropdowns/{definition_id}/options": {
+  "/workspaces/{workspace_id}/case-dropdowns/{definition_id}/options": {
     post: {
       req: CaseDropdownsAddDropdownOptionData
       res: {
@@ -16949,7 +16958,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/case-dropdowns/{definition_id}/options/{option_id}": {
+  "/workspaces/{workspace_id}/case-dropdowns/{definition_id}/options/{option_id}": {
     patch: {
       req: CaseDropdownsUpdateDropdownOptionData
       res: {
@@ -16977,7 +16986,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/case-dropdowns/{definition_id}/options/reorder": {
+  "/workspaces/{workspace_id}/case-dropdowns/{definition_id}/options/reorder": {
     put: {
       req: CaseDropdownsReorderDropdownOptionsData
       res: {
@@ -16992,7 +17001,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/dropdowns": {
+  "/workspaces/{workspace_id}/cases/{case_id}/dropdowns": {
     get: {
       req: CasesListCaseDropdownValuesData
       res: {
@@ -17007,7 +17016,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/dropdowns/{definition_id}": {
+  "/workspaces/{workspace_id}/cases/{case_id}/dropdowns/{definition_id}": {
     put: {
       req: CasesSetCaseDropdownValueData
       res: {
@@ -17022,7 +17031,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/case-durations": {
+  "/workspaces/{workspace_id}/case-durations": {
     get: {
       req: CaseDurationsListCaseDurationDefinitionsData
       res: {
@@ -17050,7 +17059,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/case-durations/{duration_id}": {
+  "/workspaces/{workspace_id}/case-durations/{duration_id}": {
     get: {
       req: CaseDurationsGetCaseDurationDefinitionData
       res: {
@@ -17091,7 +17100,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/durations": {
+  "/workspaces/{workspace_id}/cases/{case_id}/durations": {
     get: {
       req: CaseDurationsListCaseDurationsData
       res: {
@@ -17119,7 +17128,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/cases/{case_id}/durations/{duration_id}": {
+  "/workspaces/{workspace_id}/cases/{case_id}/durations/{duration_id}": {
     get: {
       req: CaseDurationsGetCaseDurationData
       res: {
@@ -17160,7 +17169,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/folders/directory": {
+  "/workspaces/{workspace_id}/folders/directory": {
     get: {
       req: FoldersGetDirectoryData
       res: {
@@ -17175,7 +17184,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/folders": {
+  "/workspaces/{workspace_id}/folders": {
     get: {
       req: FoldersListFoldersData
       res: {
@@ -17203,7 +17212,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/folders/{folder_id}": {
+  "/workspaces/{workspace_id}/folders/{folder_id}": {
     get: {
       req: FoldersGetFolderData
       res: {
@@ -17244,7 +17253,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/folders/{folder_id}/move": {
+  "/workspaces/{workspace_id}/folders/{folder_id}/move": {
     post: {
       req: FoldersMoveFolderData
       res: {
@@ -17274,7 +17283,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/integrations": {
+  "/workspaces/{workspace_id}/integrations": {
     get: {
       req: IntegrationsListIntegrationsData
       res: {
@@ -17289,7 +17298,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/integrations/{provider_id}": {
+  "/workspaces/{workspace_id}/integrations/{provider_id}": {
     get: {
       req: IntegrationsGetIntegrationData
       res: {
@@ -17330,7 +17339,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/integrations/{provider_id}/connect": {
+  "/workspaces/{workspace_id}/integrations/{provider_id}/connect": {
     post: {
       req: IntegrationsConnectProviderData
       res: {
@@ -17345,7 +17354,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/integrations/{provider_id}/disconnect": {
+  "/workspaces/{workspace_id}/integrations/{provider_id}/disconnect": {
     post: {
       req: IntegrationsDisconnectIntegrationData
       res: {
@@ -17360,7 +17369,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/integrations/{provider_id}/test": {
+  "/workspaces/{workspace_id}/integrations/{provider_id}/test": {
     post: {
       req: IntegrationsTestConnectionData
       res: {
@@ -17375,7 +17384,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/providers": {
+  "/workspaces/{workspace_id}/providers": {
     post: {
       req: ProvidersCreateCustomProviderData
       res: {
@@ -17403,7 +17412,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/providers/{provider_id}": {
+  "/workspaces/{workspace_id}/providers/{provider_id}": {
     get: {
       req: ProvidersGetProviderData
       res: {
@@ -17418,7 +17427,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/mcp-integrations": {
+  "/workspaces/{workspace_id}/mcp-integrations": {
     post: {
       req: McpIntegrationsCreateMcpIntegrationData
       res: {
@@ -17446,7 +17455,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/mcp-integrations/{mcp_integration_id}": {
+  "/workspaces/{workspace_id}/mcp-integrations/{mcp_integration_id}": {
     get: {
       req: McpIntegrationsGetMcpIntegrationData
       res: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -12543,7 +12543,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows": {
+  "/workspaces/{workspace_id}/workflows": {
     get: {
       req: WorkflowsListWorkflowsData
       res: {
@@ -12571,7 +12571,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/validate-entrypoint": {
+  "/workspaces/{workspace_id}/workflows/validate-entrypoint": {
     post: {
       req: WorkflowsValidateWorkflowEntrypointData
       res: {
@@ -12586,7 +12586,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}": {
     get: {
       req: WorkflowsGetWorkflowData
       res: {
@@ -12627,7 +12627,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/commit": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/commit": {
     post: {
       req: WorkflowsCommitWorkflowData
       res: {
@@ -12642,7 +12642,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/export": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/export": {
     get: {
       req: WorkflowsExportWorkflowData
       res: {
@@ -12657,7 +12657,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/definitions": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/definitions": {
     get: {
       req: WorkflowsListWorkflowDefinitionsData
       res: {
@@ -12672,7 +12672,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/definitions/{version}/restore": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/definitions/{version}/restore": {
     post: {
       req: WorkflowsRestoreWorkflowDefinitionData
       res: {
@@ -12687,7 +12687,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/definition": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/definition": {
     get: {
       req: WorkflowsGetWorkflowDefinitionData
       res: {
@@ -12715,7 +12715,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/webhook": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/webhook": {
     post: {
       req: TriggersCreateWebhookData
       res: {
@@ -12756,7 +12756,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/case-trigger": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/case-trigger": {
     post: {
       req: TriggersCreateCaseTriggerData
       res: {
@@ -12797,7 +12797,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/webhook/api-key": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/webhook/api-key": {
     post: {
       req: TriggersGenerateWebhookApiKeyData
       res: {
@@ -12825,7 +12825,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/webhook/api-key/revoke": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/webhook/api-key/revoke": {
     post: {
       req: TriggersRevokeWebhookApiKeyData
       res: {
@@ -12840,7 +12840,7 @@ export type $OpenApiTs = {
       }
     }
   }
-  "/workflows/{workflow_id}/move": {
+  "/workspaces/{workspace_id}/workflows/{workflow_id}/move": {
     post: {
       req: WorkflowsMoveWorkflowToFolderData
       res: {

--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.types import ToolApproved, ToolDenied
-from tracecat.auth.dependencies import WorkspaceUserRole
+from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUserRole
 from tracecat.chat.schemas import ApprovalDecision, ContinueRunRequest
 from tracecat.db.engine import get_async_session
 from tracecat.exceptions import TracecatNotFoundError

--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.types import ToolApproved, ToolDenied
-from tracecat.auth.dependencies import WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.chat.schemas import ApprovalDecision, ContinueRunRequest
 from tracecat.db.engine import get_async_session
 from tracecat.exceptions import TracecatNotFoundError
@@ -72,7 +72,7 @@ def _to_approval_decisions(approvals: ApprovalMap) -> list[ApprovalDecision]:
 @router.post("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def submit_approvals(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session_id: uuid.UUID,
     payload: ApprovalSubmission,
     session: AsyncSession = Depends(get_async_session),

--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.types import ToolApproved, ToolDenied
-from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUserRole
+from tracecat.auth.dependencies import WorkspaceUser
 from tracecat.chat.schemas import ApprovalDecision, ContinueRunRequest
 from tracecat.db.engine import get_async_session
 from tracecat.exceptions import TracecatNotFoundError
@@ -72,7 +72,7 @@ def _to_approval_decisions(approvals: ApprovalMap) -> list[ApprovalDecision]:
 @router.post("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def submit_approvals(
     *,
-    role: WorkspaceUserRole,
+    role: WorkspaceUser,
     session_id: uuid.UUID,
     payload: ApprovalSubmission,
     session: AsyncSession = Depends(get_async_session),

--- a/packages/tracecat-ee/tracecat_ee/agent/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/router.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.types import ToolApproved, ToolDenied
-from tracecat.auth.dependencies import WorkspaceUserRole
+from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUserRole
 from tracecat.chat.schemas import ApprovalDecision, ContinueRunRequest
 from tracecat.db.engine import get_async_session
 from tracecat.exceptions import TracecatNotFoundError

--- a/packages/tracecat-ee/tracecat_ee/agent/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/router.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.types import ToolApproved, ToolDenied
-from tracecat.auth.dependencies import WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.chat.schemas import ApprovalDecision, ContinueRunRequest
 from tracecat.db.engine import get_async_session
 from tracecat.exceptions import TracecatNotFoundError
@@ -72,7 +72,7 @@ def _to_approval_decisions(approvals: ApprovalMap) -> list[ApprovalDecision]:
 @router.post("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def submit_approvals(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session_id: uuid.UUID,
     payload: ApprovalSubmission,
     session: AsyncSession = Depends(get_async_session),

--- a/packages/tracecat-ee/tracecat_ee/agent/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/router.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.types import ToolApproved, ToolDenied
-from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUserRole
+from tracecat.auth.dependencies import WorkspaceUser
 from tracecat.chat.schemas import ApprovalDecision, ContinueRunRequest
 from tracecat.db.engine import get_async_session
 from tracecat.exceptions import TracecatNotFoundError
@@ -72,7 +72,7 @@ def _to_approval_decisions(approvals: ApprovalMap) -> list[ApprovalDecision]:
 @router.post("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def submit_approvals(
     *,
-    role: WorkspaceUserRole,
+    role: WorkspaceUser,
     session_id: uuid.UUID,
     payload: ApprovalSubmission,
     session: AsyncSession = Depends(get_async_session),

--- a/tests/registry/test_cases_characterization.py
+++ b/tests/registry/test_cases_characterization.py
@@ -64,6 +64,7 @@ from tracecat.auth.dependencies import (
     ExecutorWorkspaceRole,
     OrgUserRole,
     ServiceRole,
+    WorkspaceActor,
     WorkspaceUserRole,
 )
 from tracecat.auth.executor_tokens import mint_executor_token
@@ -75,7 +76,6 @@ from tracecat.cases.durations.schemas import (
 )
 from tracecat.cases.durations.service import CaseDurationDefinitionService
 from tracecat.cases.enums import CaseEventType
-from tracecat.cases.router import WorkspaceActor
 from tracecat.cases.service import CaseFieldsService
 from tracecat.contexts import ctx_role
 from tracecat.db.dependencies import get_async_session

--- a/tests/registry/test_cases_characterization.py
+++ b/tests/registry/test_cases_characterization.py
@@ -64,7 +64,7 @@ from tracecat.auth.dependencies import (
     ExecutorWorkspaceRole,
     OrgUserRole,
     ServiceRole,
-    WorkspaceActor,
+    WorkspaceActorRouteRole,
     WorkspaceUserRole,
 )
 from tracecat.auth.executor_tokens import mint_executor_token
@@ -168,7 +168,7 @@ async def cases_ctx(
     role_dependencies = [
         ExecutorWorkspaceRole,
         WorkspaceUserRole,
-        WorkspaceActor,
+        WorkspaceActorRouteRole,
         ServiceRole,
         OrgUserRole,
     ]

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -18,8 +18,10 @@ from tracecat.auth.dependencies import (
     OrgUserOnlyRole,
     OrgUserRole,
     WorkspaceActorRole,
+    WorkspaceActorRouteRole,
     WorkspaceServiceAccountRole,
     WorkspaceUserRole,
+    WorkspaceUserRouteRole,
 )
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import (
@@ -86,7 +88,9 @@ def client(request: FixtureRequest) -> Generator[TestClient, None, None]:
     # List of Annotated role dependencies to override
     role_dependencies = [
         WorkspaceUserRole,
+        WorkspaceUserRouteRole,
         WorkspaceActorRole,
+        WorkspaceActorRouteRole,
         WorkspaceServiceAccountRole,
         ExecutorWorkspaceRole,
         WorkspaceActor,

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -17,11 +17,11 @@ from tracecat.auth.dependencies import (
     OrganizationServiceAccountRole,
     OrgUserOnlyRole,
     OrgUserRole,
-    WorkspaceActor,
     WorkspaceActorRole,
+    WorkspaceActorRouteRole,
     WorkspaceServiceAccountRole,
-    WorkspaceUser,
     WorkspaceUserRole,
+    WorkspaceUserRouteRole,
 )
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import (
@@ -81,9 +81,9 @@ def client(request: FixtureRequest) -> Generator[TestClient, None, None]:
     # List of Annotated role dependencies to override
     role_dependencies = [
         WorkspaceUserRole,
-        WorkspaceUser,
+        WorkspaceUserRouteRole,
         WorkspaceActorRole,
-        WorkspaceActor,
+        WorkspaceActorRouteRole,
         WorkspaceServiceAccountRole,
         ExecutorWorkspaceRole,
         SuperuserRole,

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -17,11 +17,11 @@ from tracecat.auth.dependencies import (
     OrganizationServiceAccountRole,
     OrgUserOnlyRole,
     OrgUserRole,
+    WorkspaceActor,
     WorkspaceActorRole,
-    WorkspaceActorRouteRole,
     WorkspaceServiceAccountRole,
+    WorkspaceUser,
     WorkspaceUserRole,
-    WorkspaceUserRouteRole,
 )
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import (
@@ -29,17 +29,10 @@ from tracecat.authz.scopes import (
     ORG_ADMIN_SCOPES,
     SERVICE_PRINCIPAL_SCOPES,
 )
-from tracecat.cases.router import WorkspaceActor
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session, get_async_session_bypass_rls
 from tracecat.db.models import Workspace
 from tracecat.service_accounts.router import WorkspaceUserOnlyInPath
-from tracecat.tables.router import (
-    WorkspaceEditorUser as TablesWorkspaceEditorUser,
-)
-from tracecat.tables.router import (
-    WorkspaceUser as TablesWorkspaceUser,
-)
 from tracecat.workspaces.router import (
     WorkspaceUserInPath,
 )
@@ -88,20 +81,17 @@ def client(request: FixtureRequest) -> Generator[TestClient, None, None]:
     # List of Annotated role dependencies to override
     role_dependencies = [
         WorkspaceUserRole,
-        WorkspaceUserRouteRole,
+        WorkspaceUser,
         WorkspaceActorRole,
-        WorkspaceActorRouteRole,
+        WorkspaceActor,
         WorkspaceServiceAccountRole,
         ExecutorWorkspaceRole,
-        WorkspaceActor,
         SuperuserRole,
         AuthenticatedUserOnly,
         OrgActorRole,
         OrganizationServiceAccountRole,
         OrgUserOnlyRole,
         OrgUserRole,
-        TablesWorkspaceUser,
-        TablesWorkspaceEditorUser,
         WorkspaceUserInPath,
         WorkspaceUserOnlyInPath,
     ]

--- a/tests/unit/api/test_api_actor_roles.py
+++ b/tests/unit/api/test_api_actor_roles.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
+from temporalio.client import WorkflowExecutionStatus
 
 from tracecat.agent import router as agent_router
 from tracecat.auth.dependencies import (
@@ -340,6 +341,60 @@ async def test_service_account_can_search_workflow_executions_without_user_filte
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["items"] == []
+
+
+@pytest.mark.anyio
+async def test_service_account_can_get_workflow_execution_by_workflow_route(
+    client: TestClient,
+    workspace_targeted_service_account_role: Role,
+) -> None:
+    workflow_id = "wf_4itKqkgCZrLhgYiq5L211X"
+    execution_id = "exec_def"
+    wf_exec_id = f"{workflow_id}/{execution_id}"
+    mock_execution = SimpleNamespace(
+        id=wf_exec_id,
+        run_id="run_123",
+        start_time=datetime(2024, 1, 1, tzinfo=UTC),
+        execution_time=None,
+        close_time=None,
+        status=WorkflowExecutionStatus.RUNNING,
+        workflow_type="DSLWorkflow",
+        task_queue="tracecat-task-queue",
+        history_length=0,
+        typed_search_attributes={},
+    )
+    mock_service = AsyncMock()
+    mock_service.get_execution.return_value = mock_execution
+    mock_service.list_workflow_execution_events.return_value = []
+
+    with (
+        patch.object(
+            WorkflowExecutionsService, "connect", new_callable=AsyncMock
+        ) as mock_connect,
+        patch.object(
+            workflow_executions_router,
+            "_list_interactions",
+            new_callable=AsyncMock,
+        ) as mock_list_interactions,
+    ):
+        mock_connect.return_value = mock_service
+        mock_list_interactions.return_value = []
+
+        token = ctx_role.set(workspace_targeted_service_account_role)
+        try:
+            response = client.get(
+                "/workspaces/"
+                f"{workspace_targeted_service_account_role.workspace_id}"
+                f"/workflows/{workflow_id}/executions/{execution_id}",
+            )
+        finally:
+            ctx_role.reset(token)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["id"] == wf_exec_id
+    mock_service.get_execution.assert_awaited_once_with(wf_exec_id)
+    mock_service.list_workflow_execution_events.assert_awaited_once_with(wf_exec_id)
+    mock_list_interactions.assert_awaited_once()
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_actor_roles.py
+++ b/tests/unit/api/test_api_actor_roles.py
@@ -11,7 +11,12 @@ from fastapi import status
 from fastapi.testclient import TestClient
 
 from tracecat.agent import router as agent_router
-from tracecat.auth.dependencies import WorkspaceActorRole, WorkspaceUserRole
+from tracecat.auth.dependencies import (
+    WorkspaceActorRole,
+    WorkspaceActorRouteRole,
+    WorkspaceUserRole,
+    WorkspaceUserRouteRole,
+)
 from tracecat.auth.types import Role
 from tracecat.cases import router as cases_router
 from tracecat.contexts import ctx_role
@@ -513,7 +518,7 @@ def test_draft_workflow_execution_route_remains_user_only() -> None:
         include_extras=True,
     )["role"]
 
-    assert draft_role == WorkspaceActorRole
+    assert draft_role == WorkspaceActorRouteRole
     assert draft_execution_role == WorkspaceUserRole
 
 
@@ -522,7 +527,7 @@ def test_workflow_detail_route_remains_user_only() -> None:
         workflow_management_router.get_workflow, include_extras=True
     )["role"]
 
-    assert workflow_detail_role == WorkspaceUserRole
+    assert workflow_detail_role == WorkspaceUserRouteRole
 
 
 def test_webhook_api_key_revocation_route_remains_user_only() -> None:
@@ -536,6 +541,6 @@ def test_webhook_api_key_revocation_route_remains_user_only() -> None:
         workflow_management_router.delete_webhook_api_key, include_extras=True
     )["role"]
 
-    assert get_webhook_role == WorkspaceUserRole
-    assert revoke_role == WorkspaceUserRole
-    assert delete_role == WorkspaceUserRole
+    assert get_webhook_role == WorkspaceUserRouteRole
+    assert revoke_role == WorkspaceUserRouteRole
+    assert delete_role == WorkspaceUserRouteRole

--- a/tests/unit/api/test_api_actor_roles.py
+++ b/tests/unit/api/test_api_actor_roles.py
@@ -12,9 +12,7 @@ from fastapi.testclient import TestClient
 
 from tracecat.agent import router as agent_router
 from tracecat.auth.dependencies import (
-    WorkspaceActorRole,
     WorkspaceActorRouteRole,
-    WorkspaceUserRole,
     WorkspaceUserRouteRole,
 )
 from tracecat.auth.types import Role
@@ -431,9 +429,9 @@ def test_integration_route_role_boundaries_are_explicit() -> None:
         integrations_router.test_connection, include_extras=True
     )["role"]
 
-    assert list_integrations_role == WorkspaceUserRole
-    assert list_providers_role == WorkspaceActorRole
-    assert test_connection_role == WorkspaceActorRole
+    assert list_integrations_role == WorkspaceUserRouteRole
+    assert list_providers_role == WorkspaceActorRouteRole
+    assert test_connection_role == WorkspaceActorRouteRole
 
 
 def test_cases_route_role_boundary_accepts_workspace_actors() -> None:
@@ -492,7 +490,7 @@ def test_org_agent_routes_remain_user_only() -> None:
     workspace_status_role = get_type_hints(
         agent_router.get_workspace_providers_status, include_extras=True
     )["role"]
-    assert workspace_status_role == WorkspaceActorRole
+    assert workspace_status_role == WorkspaceActorRouteRole
 
 
 def test_github_manifest_flow_routes_remain_user_only() -> None:
@@ -519,7 +517,7 @@ def test_draft_workflow_execution_route_remains_user_only() -> None:
     )["role"]
 
     assert draft_role == WorkspaceActorRouteRole
-    assert draft_execution_role == WorkspaceUserRole
+    assert draft_execution_role == WorkspaceUserRouteRole
 
 
 def test_workflow_detail_route_remains_user_only() -> None:

--- a/tests/unit/api/test_api_actor_roles.py
+++ b/tests/unit/api/test_api_actor_roles.py
@@ -13,8 +13,8 @@ from temporalio.client import WorkflowExecutionStatus
 
 from tracecat.agent import router as agent_router
 from tracecat.auth.dependencies import (
-    WorkspaceActor,
-    WorkspaceUser,
+    WorkspaceActorRouteRole,
+    WorkspaceUserRouteRole,
 )
 from tracecat.auth.types import Role
 from tracecat.cases import router as cases_router
@@ -484,9 +484,9 @@ def test_integration_route_role_boundaries_are_explicit() -> None:
         integrations_router.test_connection, include_extras=True
     )["role"]
 
-    assert list_integrations_role == WorkspaceUser
-    assert list_providers_role == WorkspaceActor
-    assert test_connection_role == WorkspaceActor
+    assert list_integrations_role == WorkspaceUserRouteRole
+    assert list_providers_role == WorkspaceActorRouteRole
+    assert test_connection_role == WorkspaceActorRouteRole
 
 
 def test_cases_route_role_boundary_accepts_workspace_actors() -> None:
@@ -494,7 +494,7 @@ def test_cases_route_role_boundary_accepts_workspace_actors() -> None:
         "role"
     ]
 
-    assert list_cases_role == WorkspaceActor
+    assert list_cases_role == WorkspaceActorRouteRole
 
 
 def test_delete_organization_route_remains_user_only() -> None:
@@ -545,7 +545,7 @@ def test_org_agent_routes_remain_user_only() -> None:
     workspace_status_role = get_type_hints(
         agent_router.get_workspace_providers_status, include_extras=True
     )["role"]
-    assert workspace_status_role == WorkspaceActor
+    assert workspace_status_role == WorkspaceActorRouteRole
 
 
 def test_github_manifest_flow_routes_remain_user_only() -> None:
@@ -571,8 +571,8 @@ def test_draft_workflow_execution_route_remains_user_only() -> None:
         include_extras=True,
     )["role"]
 
-    assert draft_role == WorkspaceActor
-    assert draft_execution_role == WorkspaceUser
+    assert draft_role == WorkspaceActorRouteRole
+    assert draft_execution_role == WorkspaceUserRouteRole
 
 
 def test_workflow_detail_route_remains_user_only() -> None:
@@ -580,7 +580,7 @@ def test_workflow_detail_route_remains_user_only() -> None:
         workflow_management_router.get_workflow, include_extras=True
     )["role"]
 
-    assert workflow_detail_role == WorkspaceUser
+    assert workflow_detail_role == WorkspaceUserRouteRole
 
 
 def test_webhook_api_key_revocation_route_remains_user_only() -> None:
@@ -594,6 +594,6 @@ def test_webhook_api_key_revocation_route_remains_user_only() -> None:
         workflow_management_router.delete_webhook_api_key, include_extras=True
     )["role"]
 
-    assert get_webhook_role == WorkspaceUser
-    assert revoke_role == WorkspaceUser
-    assert delete_role == WorkspaceUser
+    assert get_webhook_role == WorkspaceUserRouteRole
+    assert revoke_role == WorkspaceUserRouteRole
+    assert delete_role == WorkspaceUserRouteRole

--- a/tests/unit/api/test_api_actor_roles.py
+++ b/tests/unit/api/test_api_actor_roles.py
@@ -13,8 +13,8 @@ from temporalio.client import WorkflowExecutionStatus
 
 from tracecat.agent import router as agent_router
 from tracecat.auth.dependencies import (
-    WorkspaceActorRouteRole,
-    WorkspaceUserRouteRole,
+    WorkspaceActor,
+    WorkspaceUser,
 )
 from tracecat.auth.types import Role
 from tracecat.cases import router as cases_router
@@ -484,9 +484,9 @@ def test_integration_route_role_boundaries_are_explicit() -> None:
         integrations_router.test_connection, include_extras=True
     )["role"]
 
-    assert list_integrations_role == WorkspaceUserRouteRole
-    assert list_providers_role == WorkspaceActorRouteRole
-    assert test_connection_role == WorkspaceActorRouteRole
+    assert list_integrations_role == WorkspaceUser
+    assert list_providers_role == WorkspaceActor
+    assert test_connection_role == WorkspaceActor
 
 
 def test_cases_route_role_boundary_accepts_workspace_actors() -> None:
@@ -494,7 +494,7 @@ def test_cases_route_role_boundary_accepts_workspace_actors() -> None:
         "role"
     ]
 
-    assert list_cases_role == cases_router.WorkspaceActor
+    assert list_cases_role == WorkspaceActor
 
 
 def test_delete_organization_route_remains_user_only() -> None:
@@ -545,7 +545,7 @@ def test_org_agent_routes_remain_user_only() -> None:
     workspace_status_role = get_type_hints(
         agent_router.get_workspace_providers_status, include_extras=True
     )["role"]
-    assert workspace_status_role == WorkspaceActorRouteRole
+    assert workspace_status_role == WorkspaceActor
 
 
 def test_github_manifest_flow_routes_remain_user_only() -> None:
@@ -571,8 +571,8 @@ def test_draft_workflow_execution_route_remains_user_only() -> None:
         include_extras=True,
     )["role"]
 
-    assert draft_role == WorkspaceActorRouteRole
-    assert draft_execution_role == WorkspaceUserRouteRole
+    assert draft_role == WorkspaceActor
+    assert draft_execution_role == WorkspaceUser
 
 
 def test_workflow_detail_route_remains_user_only() -> None:
@@ -580,7 +580,7 @@ def test_workflow_detail_route_remains_user_only() -> None:
         workflow_management_router.get_workflow, include_extras=True
     )["role"]
 
-    assert workflow_detail_role == WorkspaceUserRouteRole
+    assert workflow_detail_role == WorkspaceUser
 
 
 def test_webhook_api_key_revocation_route_remains_user_only() -> None:
@@ -594,6 +594,6 @@ def test_webhook_api_key_revocation_route_remains_user_only() -> None:
         workflow_management_router.delete_webhook_api_key, include_extras=True
     )["role"]
 
-    assert get_webhook_role == WorkspaceUserRouteRole
-    assert revoke_role == WorkspaceUserRouteRole
-    assert delete_role == WorkspaceUserRouteRole
+    assert get_webhook_role == WorkspaceUser
+    assert revoke_role == WorkspaceUser
+    assert delete_role == WorkspaceUser

--- a/tests/unit/api/test_api_workflows.py
+++ b/tests/unit/api/test_api_workflows.py
@@ -131,6 +131,33 @@ async def test_list_workflows_success(
 
 
 @pytest.mark.anyio
+async def test_list_workflows_accepts_workspace_scoped_path(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_workflow: Workflow,
+) -> None:
+    """Test GET /workspaces/{workspace_id}/workflows resolves workspace context from the path."""
+    with patch.object(
+        workflow_management_router, "WorkflowsManagementService"
+    ) as MockService:
+        mock_svc = AsyncMock()
+        mock_response = CursorPaginatedResponse(
+            items=[(mock_workflow, None)],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        mock_svc.list_workflows.return_value = mock_response
+        MockService.return_value = mock_svc
+
+        response = client.get(f"/workspaces/{test_admin_role.workspace_id}/workflows")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["items"][0]["title"] == "Test Workflow"
+
+
+@pytest.mark.anyio
 async def test_list_workflows_with_pagination(
     client: TestClient,
     test_admin_role: Role,

--- a/tests/unit/api/test_workspace_scoped_routes.py
+++ b/tests/unit/api/test_workspace_scoped_routes.py
@@ -1,0 +1,193 @@
+from typing import get_type_hints
+
+from fastapi.routing import APIRoute
+
+from tracecat.api.app import app
+from tracecat.auth.dependencies import (
+    WorkspaceActorRouteRole,
+    WorkspaceUserRouteRole,
+    require_workspace_id_path,
+)
+
+WORKSPACE_ROUTE_PREFIXES = [
+    "/actions",
+    "/agent/channels/tokens",
+    "/agent/presets",
+    "/agent/sessions",
+    "/agent/skills",
+    "/agent/workspace/providers/status",
+    "/approvals",
+    "/case-dropdowns",
+    "/case-durations",
+    "/case-fields",
+    "/case-tags",
+    "/cases",
+    "/editor",
+    "/folders",
+    "/inbox",
+    "/integrations",
+    "/mcp-integrations",
+    "/providers",
+    "/schedules",
+    "/secrets",
+    "/tables",
+    "/tags",
+    "/variables",
+    "/workflow-executions",
+    "/workflows",
+]
+
+WORKSPACE_ROUTE_ROLE_TYPES = (WorkspaceActorRouteRole, WorkspaceUserRouteRole)
+WORKSPACE_ROUTE_AUTH_EXEMPTIONS = {
+    ("/workspaces/{workspace_id}/editor/field-schema", frozenset({"GET"})),
+}
+OPENAPI_LEGACY_EXCEPTIONS = {
+    "/integrations": {"/integrations/callback"},
+}
+
+
+def _is_workspace_scoped_public_route(path: str) -> bool:
+    if not path.startswith("/workspaces/{workspace_id}"):
+        return False
+    suffix = path.removeprefix("/workspaces/{workspace_id}")
+    return any(
+        suffix == prefix or suffix.startswith(f"{prefix}/")
+        for prefix in WORKSPACE_ROUTE_PREFIXES
+    )
+
+
+def _route_key(route: APIRoute) -> tuple[str, frozenset[str]]:
+    return route.path, frozenset(route.methods or ())
+
+
+def _legacy_route_key(route: APIRoute) -> tuple[str, frozenset[str]]:
+    return (
+        route.path.removeprefix("/workspaces/{workspace_id}"),
+        frozenset(route.methods or ()),
+    )
+
+
+def _uses_route_workspace_role_dependency(route: APIRoute) -> bool:
+    return any(
+        getattr(dependency.call, "__name__", "").startswith(
+            "role_dependency_req_ws_auto"
+        )
+        for dependency in route.dependant.dependencies
+    )
+
+
+def _has_workspace_path_dependency(route: APIRoute) -> bool:
+    return any(
+        dependency.call is require_workspace_id_path
+        for dependency in route.dependant.dependencies
+    )
+
+
+def _workspace_role_hint(route: APIRoute):
+    hints = get_type_hints(route.endpoint, include_extras=True)
+    return hints.get("role") or hints.get("_role")
+
+
+def _is_workspace_route_role(role_hint) -> bool:
+    return any(role_hint == route_role for route_role in WORKSPACE_ROUTE_ROLE_TYPES)
+
+
+def test_workspace_scoped_public_routes_are_canonical_in_openapi() -> None:
+    app.openapi_schema = None
+    paths = set(app.openapi()["paths"])
+
+    for prefix in WORKSPACE_ROUTE_PREFIXES:
+        legacy_paths = [
+            path for path in paths if path == prefix or path.startswith(f"{prefix}/")
+        ]
+        canonical_prefix = f"/workspaces/{{workspace_id}}{prefix}"
+        canonical_paths = [
+            path
+            for path in paths
+            if path == canonical_prefix or path.startswith(f"{canonical_prefix}/")
+        ]
+        expected_legacy_paths = OPENAPI_LEGACY_EXCEPTIONS.get(prefix, set())
+        assert set(legacy_paths) == expected_legacy_paths, (
+            f"Unexpected legacy workspace routes in OpenAPI: {prefix}"
+        )
+        assert canonical_paths, f"Missing canonical workspace route: {canonical_prefix}"
+
+    integration_legacy_paths = [
+        path
+        for path in paths
+        if path == "/integrations" or path.startswith("/integrations/")
+    ]
+    assert integration_legacy_paths == ["/integrations/callback"]
+    assert "/workspaces/{workspace_id}/integrations" in paths
+    assert "/workspaces/{workspace_id}/mcp-integrations" in paths
+
+
+def test_workspace_scoped_public_route_aliases_share_handlers_and_auth() -> None:
+    routes = [route for route in app.routes if isinstance(route, APIRoute)]
+    routes_by_key = {_route_key(route): route for route in routes}
+    canonical_routes = [
+        route for route in routes if _is_workspace_scoped_public_route(route.path)
+    ]
+
+    assert canonical_routes
+
+    for canonical_route in canonical_routes:
+        legacy_route = routes_by_key.get(_legacy_route_key(canonical_route))
+
+        assert legacy_route is not None, (
+            f"Missing hidden legacy alias for {canonical_route.path}"
+        )
+        assert canonical_route.include_in_schema, (
+            f"Canonical workspace route is hidden: {canonical_route.path}"
+        )
+        assert not legacy_route.include_in_schema, (
+            f"Legacy workspace route is still visible: {legacy_route.path}"
+        )
+        assert canonical_route.endpoint is legacy_route.endpoint, (
+            f"Route aliases use different handlers: {canonical_route.path}"
+        )
+        assert _has_workspace_path_dependency(canonical_route), (
+            f"Canonical route does not validate workspace_id path: {canonical_route.path}"
+        )
+        assert not _has_workspace_path_dependency(legacy_route), (
+            f"Legacy route unexpectedly validates workspace_id path: {legacy_route.path}"
+        )
+
+        role_hint = _workspace_role_hint(canonical_route)
+        if role_hint is None:
+            assert _route_key(canonical_route) in WORKSPACE_ROUTE_AUTH_EXEMPTIONS, (
+                f"Workspace route missing role dependency: {canonical_route.path}"
+            )
+            continue
+
+        assert _is_workspace_route_role(role_hint), (
+            f"Workspace route is not using a route-aware role: {canonical_route.path}"
+        )
+        assert _uses_route_workspace_role_dependency(canonical_route), (
+            f"Canonical route is not using path-or-query RoleACL: {canonical_route.path}"
+        )
+        assert _uses_route_workspace_role_dependency(legacy_route), (
+            f"Legacy route is not using path-or-query RoleACL: {legacy_route.path}"
+        )
+
+
+def test_workspace_route_migration_does_not_prefix_excluded_routes() -> None:
+    app.openapi_schema = None
+    paths = set(app.openapi()["paths"])
+
+    assert "/integrations/callback" in paths
+    assert "/workspaces/{workspace_id}/integrations/callback" not in paths
+
+    assert "/agent/channels/{channel_type}/{token}" in paths
+    assert (
+        "/workspaces/{workspace_id}/agent/channels/{channel_type}/{token}" not in paths
+    )
+
+    assert "/agent/channels/slack/oauth/callback" in paths
+    assert "/workspaces/{workspace_id}/agent/channels/slack/oauth/callback" not in paths
+
+    assert "/webhooks/{workflow_id}/{secret}" in paths
+    assert "/workspaces/{workspace_id}/webhooks/{workflow_id}/{secret}" not in paths
+
+    assert "/organization" in paths
+    assert "/workspaces/{workspace_id}/organization" not in paths

--- a/tests/unit/api/test_workspace_scoped_routes.py
+++ b/tests/unit/api/test_workspace_scoped_routes.py
@@ -4,8 +4,8 @@ from fastapi.routing import APIRoute
 
 from tracecat.api.app import app
 from tracecat.auth.dependencies import (
-    WorkspaceActor,
-    WorkspaceUser,
+    WorkspaceActorRouteRole,
+    WorkspaceUserRouteRole,
     require_workspace_id_path,
 )
 
@@ -37,7 +37,7 @@ WORKSPACE_ROUTE_PREFIXES = [
     "/workflows",
 ]
 
-WORKSPACE_ROUTE_ROLE_TYPES = (WorkspaceActor, WorkspaceUser)
+WORKSPACE_ROUTE_ROLE_TYPES = (WorkspaceActorRouteRole, WorkspaceUserRouteRole)
 WORKSPACE_ROUTE_AUTH_EXEMPTIONS = {
     ("/workspaces/{workspace_id}/editor/field-schema", frozenset({"GET"})),
 }

--- a/tests/unit/api/test_workspace_scoped_routes.py
+++ b/tests/unit/api/test_workspace_scoped_routes.py
@@ -4,8 +4,8 @@ from fastapi.routing import APIRoute
 
 from tracecat.api.app import app
 from tracecat.auth.dependencies import (
-    WorkspaceActorRouteRole,
-    WorkspaceUserRouteRole,
+    WorkspaceActor,
+    WorkspaceUser,
     require_workspace_id_path,
 )
 
@@ -37,7 +37,7 @@ WORKSPACE_ROUTE_PREFIXES = [
     "/workflows",
 ]
 
-WORKSPACE_ROUTE_ROLE_TYPES = (WorkspaceActorRouteRole, WorkspaceUserRouteRole)
+WORKSPACE_ROUTE_ROLE_TYPES = (WorkspaceActor, WorkspaceUser)
 WORKSPACE_ROUTE_AUTH_EXEMPTIONS = {
     ("/workspaces/{workspace_id}/editor/field-schema", frozenset({"GET"})),
 }

--- a/tests/unit/test_role_acl.py
+++ b/tests/unit/test_role_acl.py
@@ -151,6 +151,85 @@ def test_role_acl_rejects_legacy_tracecat_api_key_header(
     authenticate_api_key.assert_not_awaited()
 
 
+def test_role_acl_auto_workspace_uses_path_context(
+    role_acl_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    service_account_role = Role(
+        type="service_account",
+        service_id="tracecat-api",
+        organization_id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        bound_workspace_id=workspace_id,
+        service_account_id=uuid.uuid4(),
+        scopes=frozenset({"workflow:read"}),
+    )
+    authenticate_api_key = AsyncMock(return_value=service_account_role)
+    monkeypatch.setattr(credentials, "_authenticate_api_key", authenticate_api_key)
+
+    @role_acl_app.get("/workspaces/{workspace_id}/api-key")
+    async def api_key_path_route(  # pyright: ignore[reportUnusedFunction] - route handler
+        role: Role = RoleACL(
+            allow_user=False,
+            allow_api_key=True,
+            require_workspace="yes",
+            workspace_id_in_path="auto",
+        ),
+    ) -> dict[str, str]:
+        assert role.workspace_id is not None
+        return {
+            "role_type": role.type,
+            "workspace_id": str(role.workspace_id),
+        }
+
+    response = TestClient(role_acl_app).get(
+        f"/workspaces/{workspace_id}/api-key",
+        headers={"Authorization": "Bearer tc_ws_sk_managed-api-key_secret"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "role_type": "service_account",
+        "workspace_id": str(workspace_id),
+    }
+    authenticate_api_key.assert_awaited_once_with(
+        api_key="tc_ws_sk_managed-api-key_secret",
+        workspace_id=workspace_id,
+    )
+
+
+def test_role_acl_auto_workspace_rejects_path_query_conflict(
+    role_acl_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path_workspace_id = uuid.uuid4()
+    query_workspace_id = uuid.uuid4()
+    authenticate_api_key = AsyncMock()
+    monkeypatch.setattr(credentials, "_authenticate_api_key", authenticate_api_key)
+
+    @role_acl_app.get("/workspaces/{workspace_id}/api-key-conflict")
+    async def api_key_conflict_route(  # pyright: ignore[reportUnusedFunction] - route handler
+        role: Role = RoleACL(
+            allow_user=False,
+            allow_api_key=True,
+            require_workspace="yes",
+            workspace_id_in_path="auto",
+        ),
+    ) -> dict[str, str]:
+        return {"role_type": role.type}
+
+    response = TestClient(role_acl_app).get(
+        f"/workspaces/{path_workspace_id}/api-key-conflict",
+        params={"workspace_id": str(query_workspace_id)},
+        headers={"Authorization": "Bearer tc_ws_sk_managed-api-key_secret"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Path and query workspace_id values must match"
+    authenticate_api_key.assert_not_awaited()
+
+
 def test_role_acl_combined_service_and_api_key_route_uses_service_key_fallback(
     role_acl_app: FastAPI,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_role_acl.py
+++ b/tests/unit/test_role_acl.py
@@ -230,6 +230,34 @@ def test_role_acl_auto_workspace_rejects_path_query_conflict(
     authenticate_api_key.assert_not_awaited()
 
 
+def test_role_acl_auto_workspace_requires_workspace_context(
+    role_acl_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authenticate_api_key = AsyncMock()
+    monkeypatch.setattr(credentials, "_authenticate_api_key", authenticate_api_key)
+
+    @role_acl_app.get("/api-key-missing-workspace")
+    async def api_key_missing_workspace_route(  # pyright: ignore[reportUnusedFunction] - route handler
+        role: Role = RoleACL(
+            allow_user=False,
+            allow_api_key=True,
+            require_workspace="yes",
+            workspace_id_in_path="auto",
+        ),
+    ) -> dict[str, str]:
+        return {"role_type": role.type}
+
+    response = TestClient(role_acl_app).get(
+        "/api-key-missing-workspace",
+        headers={"Authorization": "Bearer tc_ws_sk_managed-api-key_secret"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "workspace_id is required"
+    authenticate_api_key.assert_not_awaited()
+
+
 def test_role_acl_combined_service_and_api_key_route_uses_service_key_fallback(
     role_acl_app: FastAPI,
     monkeypatch: pytest.MonkeyPatch,

--- a/tracecat/agent/channels/management_router.py
+++ b/tracecat/agent/channels/management_router.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import uuid
-from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
@@ -17,8 +16,7 @@ from tracecat.agent.channels.schemas import (
     SlackOAuthStartResponse,
 )
 from tracecat.agent.channels.service import PENDING_SLACK_BOT_TOKEN, AgentChannelService
-from tracecat.auth.credentials import RoleACL
-from tracecat.auth.types import Role
+from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceEditorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
@@ -39,15 +37,6 @@ router = APIRouter(
     tags=["agent-channels"],
     dependencies=[Depends(_require_agent_channels_enabled)],
 )
-
-WorkspaceEditorRole = Annotated[
-    Role,
-    RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="yes",
-    ),
-]
 
 
 @router.post(

--- a/tracecat/agent/channels/management_router.py
+++ b/tracecat/agent/channels/management_router.py
@@ -16,7 +16,7 @@ from tracecat.agent.channels.schemas import (
     SlackOAuthStartResponse,
 )
 from tracecat.agent.channels.service import PENDING_SLACK_BOT_TOKEN, AgentChannelService
-from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceEditorRole
+from tracecat.auth.dependencies import WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
@@ -46,7 +46,7 @@ router = APIRouter(
 async def create_channel_token(
     *,
     params: AgentChannelTokenCreate,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> AgentChannelTokenRead:
     service = AgentChannelService(session, role=role)
@@ -69,7 +69,7 @@ async def create_channel_token(
 @require_scope("agent:read")
 async def list_channel_tokens(
     *,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     agent_preset_id: uuid.UUID | None = Query(
         default=None, description="Filter by agent preset"
@@ -92,7 +92,7 @@ async def update_channel_token(
     *,
     token_id: uuid.UUID,
     params: AgentChannelTokenUpdate,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> AgentChannelTokenRead:
     service = AgentChannelService(session, role=role)
@@ -117,7 +117,7 @@ async def update_channel_token(
 async def rotate_channel_token(
     *,
     token_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> AgentChannelTokenRead:
     service = AgentChannelService(session, role=role)
@@ -136,7 +136,7 @@ async def rotate_channel_token(
 async def delete_channel_token(
     *,
     token_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> None:
     service = AgentChannelService(session, role=role)
@@ -154,7 +154,7 @@ async def delete_channel_token(
 async def start_slack_oauth(
     *,
     params: SlackOAuthStartRequest,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> SlackOAuthStartResponse:
     if role.workspace_id is None:

--- a/tracecat/agent/channels/management_router.py
+++ b/tracecat/agent/channels/management_router.py
@@ -16,7 +16,7 @@ from tracecat.agent.channels.schemas import (
     SlackOAuthStartResponse,
 )
 from tracecat.agent.channels.service import PENDING_SLACK_BOT_TOKEN, AgentChannelService
-from tracecat.auth.dependencies import WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
@@ -46,7 +46,7 @@ router = APIRouter(
 async def create_channel_token(
     *,
     params: AgentChannelTokenCreate,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentChannelTokenRead:
     service = AgentChannelService(session, role=role)
@@ -69,7 +69,7 @@ async def create_channel_token(
 @require_scope("agent:read")
 async def list_channel_tokens(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     agent_preset_id: uuid.UUID | None = Query(
         default=None, description="Filter by agent preset"
@@ -92,7 +92,7 @@ async def update_channel_token(
     *,
     token_id: uuid.UUID,
     params: AgentChannelTokenUpdate,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentChannelTokenRead:
     service = AgentChannelService(session, role=role)
@@ -117,7 +117,7 @@ async def update_channel_token(
 async def rotate_channel_token(
     *,
     token_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentChannelTokenRead:
     service = AgentChannelService(session, role=role)
@@ -136,7 +136,7 @@ async def rotate_channel_token(
 async def delete_channel_token(
     *,
     token_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> None:
     service = AgentChannelService(session, role=role)
@@ -154,7 +154,7 @@ async def delete_channel_token(
 async def start_slack_oauth(
     *,
     params: SlackOAuthStartRequest,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> SlackOAuthStartResponse:
     if role.workspace_id is None:

--- a/tracecat/agent/preset/router.py
+++ b/tracecat/agent/preset/router.py
@@ -1,5 +1,4 @@
 import uuid
-from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query, status
 
@@ -14,23 +13,13 @@ from tracecat.agent.preset.schemas import (
     AgentPresetVersionReadMinimal,
 )
 from tracecat.agent.preset.service import AgentPresetService
-from tracecat.auth.credentials import RoleACL
-from tracecat.auth.types import Role
+from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceEditorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatValidationError
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 
 router = APIRouter(prefix="/agent/presets", tags=["agent-presets"])
-
-WorkspaceEditorRole = Annotated[
-    Role,
-    RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="yes",
-    ),
-]
 
 
 @router.get("", response_model=list[AgentPresetReadMinimal])

--- a/tracecat/agent/preset/router.py
+++ b/tracecat/agent/preset/router.py
@@ -13,7 +13,7 @@ from tracecat.agent.preset.schemas import (
     AgentPresetVersionReadMinimal,
 )
 from tracecat.agent.preset.service import AgentPresetService
-from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceEditorRole
+from tracecat.auth.dependencies import WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatValidationError
@@ -26,7 +26,7 @@ router = APIRouter(prefix="/agent/presets", tags=["agent-presets"])
 @require_scope("agent:read")
 async def list_agent_presets(
     *,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> list[AgentPresetReadMinimal]:
     """List all agent presets for the current workspace."""
@@ -44,7 +44,7 @@ async def list_agent_presets(
 async def create_agent_preset(
     *,
     params: AgentPresetCreate,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> AgentPresetRead:
     """Create a new agent preset."""
@@ -64,7 +64,7 @@ async def create_agent_preset(
 async def get_agent_preset(
     *,
     preset_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> AgentPresetRead:
     """Retrieve an agent preset by ID."""
@@ -82,7 +82,7 @@ async def get_agent_preset(
 async def get_agent_preset_by_slug(
     *,
     slug: str,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> AgentPresetRead:
     """Retrieve an agent preset by slug."""
@@ -101,7 +101,7 @@ async def update_agent_preset(
     *,
     preset_id: uuid.UUID,
     params: AgentPresetUpdate,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> AgentPresetRead:
     """Update an existing agent preset."""
@@ -120,7 +120,7 @@ async def update_agent_preset(
 async def delete_agent_preset(
     *,
     preset_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> None:
     """Delete an agent preset."""
@@ -141,7 +141,7 @@ async def delete_agent_preset(
 async def list_agent_preset_versions(
     *,
     preset_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     limit: int = Query(
         default=config.TRACECAT__LIMIT_DEFAULT,
@@ -171,7 +171,7 @@ async def get_agent_preset_version(
     *,
     preset_id: uuid.UUID,
     version_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> AgentPresetVersionRead:
     """Retrieve an immutable agent preset version."""
@@ -195,7 +195,7 @@ async def compare_agent_preset_versions(
     preset_id: uuid.UUID,
     version_id: uuid.UUID,
     compare_to: uuid.UUID = Query(..., description="Version ID to compare against"),
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> AgentPresetVersionDiff:
     """Compare two preset versions belonging to the same preset."""
@@ -224,7 +224,7 @@ async def restore_agent_preset_version(
     *,
     preset_id: uuid.UUID,
     version_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> AgentPresetRead:
     """Restore a historical preset version as current."""

--- a/tracecat/agent/preset/router.py
+++ b/tracecat/agent/preset/router.py
@@ -13,7 +13,7 @@ from tracecat.agent.preset.schemas import (
     AgentPresetVersionReadMinimal,
 )
 from tracecat.agent.preset.service import AgentPresetService
-from tracecat.auth.dependencies import WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatValidationError
@@ -26,7 +26,7 @@ router = APIRouter(prefix="/agent/presets", tags=["agent-presets"])
 @require_scope("agent:read")
 async def list_agent_presets(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> list[AgentPresetReadMinimal]:
     """List all agent presets for the current workspace."""
@@ -44,7 +44,7 @@ async def list_agent_presets(
 async def create_agent_preset(
     *,
     params: AgentPresetCreate,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentPresetRead:
     """Create a new agent preset."""
@@ -64,7 +64,7 @@ async def create_agent_preset(
 async def get_agent_preset(
     *,
     preset_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentPresetRead:
     """Retrieve an agent preset by ID."""
@@ -82,7 +82,7 @@ async def get_agent_preset(
 async def get_agent_preset_by_slug(
     *,
     slug: str,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentPresetRead:
     """Retrieve an agent preset by slug."""
@@ -101,7 +101,7 @@ async def update_agent_preset(
     *,
     preset_id: uuid.UUID,
     params: AgentPresetUpdate,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentPresetRead:
     """Update an existing agent preset."""
@@ -120,7 +120,7 @@ async def update_agent_preset(
 async def delete_agent_preset(
     *,
     preset_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> None:
     """Delete an agent preset."""
@@ -141,7 +141,7 @@ async def delete_agent_preset(
 async def list_agent_preset_versions(
     *,
     preset_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     limit: int = Query(
         default=config.TRACECAT__LIMIT_DEFAULT,
@@ -171,7 +171,7 @@ async def get_agent_preset_version(
     *,
     preset_id: uuid.UUID,
     version_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentPresetVersionRead:
     """Retrieve an immutable agent preset version."""
@@ -195,7 +195,7 @@ async def compare_agent_preset_versions(
     preset_id: uuid.UUID,
     version_id: uuid.UUID,
     compare_to: uuid.UUID = Query(..., description="Version ID to compare against"),
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentPresetVersionDiff:
     """Compare two preset versions belonging to the same preset."""
@@ -224,7 +224,7 @@ async def restore_agent_preset_version(
     *,
     preset_id: uuid.UUID,
     version_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentPresetRead:
     """Restore a historical preset version as current."""

--- a/tracecat/agent/router.py
+++ b/tracecat/agent/router.py
@@ -9,12 +9,14 @@ from tracecat.agent.schemas import (
     ProviderCredentialConfig,
 )
 from tracecat.agent.service import AgentManagementService
-from tracecat.auth.dependencies import OrgUserRole, WorkspaceActorRole
+from tracecat.auth.dependencies import OrgUserRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError
 
 router = APIRouter(prefix="/agent", tags=["agent"])
+workspace_router = APIRouter(prefix="/agent", tags=["agent"])
 
 
 @router.get("/models")
@@ -212,7 +214,7 @@ async def set_default_model_selection(
         ) from e
 
 
-@router.get("/workspace/providers/status")
+@workspace_router.get("/workspace/providers/status")
 @require_scope("agent:read")
 async def get_workspace_providers_status(
     *,

--- a/tracecat/agent/router.py
+++ b/tracecat/agent/router.py
@@ -9,8 +9,7 @@ from tracecat.agent.schemas import (
     ProviderCredentialConfig,
 )
 from tracecat.agent.service import AgentManagementService
-from tracecat.auth.dependencies import OrgUserRole
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import OrgUserRole, WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError
@@ -218,7 +217,7 @@ async def set_default_model_selection(
 @require_scope("agent:read")
 async def get_workspace_providers_status(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
 ) -> dict[str, bool]:
     """Get workspace credential status for all providers."""

--- a/tracecat/agent/router.py
+++ b/tracecat/agent/router.py
@@ -9,7 +9,7 @@ from tracecat.agent.schemas import (
     ProviderCredentialConfig,
 )
 from tracecat.agent.service import AgentManagementService
-from tracecat.auth.dependencies import OrgUserRole, WorkspaceActor
+from tracecat.auth.dependencies import OrgUserRole, WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError
@@ -217,7 +217,7 @@ async def set_default_model_selection(
 @require_scope("agent:read")
 async def get_workspace_providers_status(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> dict[str, bool]:
     """Get workspace credential status for all providers."""

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -4,7 +4,6 @@ This router consolidates chat and session endpoints into a unified /agent/sessio
 """
 
 import uuid
-from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
 from fastapi.responses import StreamingResponse
@@ -24,8 +23,7 @@ from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.stream.connector import AgentStream
 from tracecat.agent.stream.events import StreamFormat
 from tracecat.agent.types import StreamKey
-from tracecat.auth.credentials import RoleACL
-from tracecat.auth.types import Role
+from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.chat.schemas import (
     ChatRead,
@@ -39,15 +37,6 @@ from tracecat.exceptions import TracecatNotFoundError
 from tracecat.logger import logger
 
 router = APIRouter(prefix="/agent/sessions", tags=["agent-sessions"])
-
-WorkspaceUser = Annotated[
-    Role,
-    RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="yes",
-    ),
-]
 
 
 @router.post("")

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -23,7 +23,7 @@ from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.stream.connector import AgentStream
 from tracecat.agent.stream.events import StreamFormat
 from tracecat.agent.types import StreamKey
-from tracecat.auth.dependencies import WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.chat.schemas import (
     ChatRead,
@@ -43,7 +43,7 @@ router = APIRouter(prefix="/agent/sessions", tags=["agent-sessions"])
 @require_scope("agent:execute")
 async def create_session(
     request: AgentSessionCreate,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentSessionRead:
     """Create a new agent session associated with an entity."""
@@ -55,7 +55,7 @@ async def create_session(
 @router.get("")
 @require_scope("agent:read")
 async def list_sessions(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     entity_type: AgentSessionEntity | None = Query(
         None, description="Filter by entity type"
@@ -100,7 +100,7 @@ async def list_sessions(
 @require_scope("agent:read")
 async def get_session(
     session_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentSessionReadWithMessages | ChatRead:
     """Get an agent session or legacy chat with its message history.
@@ -164,7 +164,7 @@ async def get_session(
 @require_scope("agent:read")
 async def get_session_vercel(
     session_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentSessionReadVercel | ChatReadVercel:
     """Get an agent session or legacy chat with message history in Vercel format.
@@ -227,7 +227,7 @@ async def get_session_vercel(
 async def update_session(
     session_id: uuid.UUID,
     params: AgentSessionUpdate,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> AgentSessionRead:
     """Update session properties."""
@@ -255,7 +255,7 @@ async def update_session(
 @require_scope("agent:execute")
 async def delete_session(
     session_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> None:
     """Delete an agent session."""
@@ -283,7 +283,7 @@ async def delete_session(
 async def send_message(
     session_id: uuid.UUID,
     request: ChatRequest,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     http_request: Request,
 ) -> StreamingResponse:
     """Send a message to the agent session with streaming response.
@@ -378,7 +378,7 @@ async def send_message(
 @router.get("/{session_id}/stream")
 @require_scope("agent:read")
 async def stream_session_events(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     request: Request,
     session_id: uuid.UUID,
     format: StreamFormat = Query(
@@ -436,7 +436,7 @@ async def stream_session_events(
 @require_scope("agent:execute")
 async def fork_session(
     session_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     request: AgentSessionForkRequest | None = None,
 ) -> AgentSessionRead:

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -23,7 +23,7 @@ from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.stream.connector import AgentStream
 from tracecat.agent.stream.events import StreamFormat
 from tracecat.agent.types import StreamKey
-from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.chat.schemas import (
     ChatRead,

--- a/tracecat/agent/skill/router.py
+++ b/tracecat/agent/skill/router.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Annotated, Never
+from typing import Never
 
 from fastapi import APIRouter, HTTPException, Query, status
 
@@ -22,23 +22,13 @@ from tracecat.agent.skill.schemas import (
     SkillVersionReadMinimal,
 )
 from tracecat.agent.skill.service import SkillService
-from tracecat.auth.credentials import RoleACL
-from tracecat.auth.types import Role
+from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceEditorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 
 router = APIRouter(prefix="/agent/skills", tags=["agent-skills"])
-
-WorkspaceEditorRole = Annotated[
-    Role,
-    RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="yes",
-    ),
-]
 
 
 def _raise_skill_validation_error(exc: TracecatValidationError) -> Never:

--- a/tracecat/agent/skill/router.py
+++ b/tracecat/agent/skill/router.py
@@ -22,7 +22,7 @@ from tracecat.agent.skill.schemas import (
     SkillVersionReadMinimal,
 )
 from tracecat.agent.skill.service import SkillService
-from tracecat.auth.dependencies import WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
@@ -50,7 +50,7 @@ def _raise_skill_validation_error(exc: TracecatValidationError) -> Never:
 @require_scope("agent:read")
 async def list_skills(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     limit: int = Query(
         default=config.TRACECAT__LIMIT_DEFAULT,
@@ -73,7 +73,7 @@ async def list_skills(
 async def create_skill(
     *,
     params: SkillCreate,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> SkillRead:
     """Create a new logical skill and seed its draft."""
@@ -90,7 +90,7 @@ async def create_skill(
 async def upload_skill(
     *,
     params: SkillUpload,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> SkillRead:
     """Create a new skill by importing a full draft file tree."""
@@ -107,7 +107,7 @@ async def upload_skill(
 async def get_skill(
     *,
     skill_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> SkillRead:
     """Return a skill summary including draft and current version status."""
@@ -126,7 +126,7 @@ async def get_skill(
 async def get_skill_draft(
     *,
     skill_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> SkillDraftRead:
     """Return the mutable draft manifest for a skill."""
@@ -146,7 +146,7 @@ async def get_skill_draft_file(
     *,
     skill_id: uuid.UUID,
     path: str = Query(...),
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> SkillDraftFileRead:
     """Return one draft file inline or as a presigned download."""
@@ -171,7 +171,7 @@ async def patch_skill_draft(
     *,
     skill_id: uuid.UUID,
     params: SkillDraftPatch,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> SkillDraftRead:
     """Apply optimistic-concurrency mutations to a draft."""
@@ -198,7 +198,7 @@ async def create_skill_draft_upload(
     *,
     skill_id: uuid.UUID,
     params: SkillUploadSessionCreate,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> SkillUploadSessionRead:
     """Create a staged upload session for a draft file blob."""
@@ -220,7 +220,7 @@ async def create_skill_draft_upload(
 async def publish_skill(
     *,
     skill_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> SkillVersionRead:
     """Publish the current draft into a new immutable version."""
@@ -245,7 +245,7 @@ async def publish_skill(
 async def list_skill_versions(
     *,
     skill_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     limit: int = Query(
         default=config.TRACECAT__LIMIT_DEFAULT,
@@ -278,7 +278,7 @@ async def get_skill_version(
     *,
     skill_id: uuid.UUID,
     version_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> SkillVersionRead:
     """Return one immutable skill version manifest."""
@@ -300,7 +300,7 @@ async def get_skill_version_file(
     skill_id: uuid.UUID,
     version_id: uuid.UUID,
     path: str = Query(...),
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> SkillDraftFileRead:
     """Return one published version file inline or as a presigned download."""
@@ -331,7 +331,7 @@ async def restore_skill_version(
     *,
     skill_id: uuid.UUID,
     version_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> SkillReadMinimal:
     """Restore a historical version as the current selected skill version."""
@@ -351,7 +351,7 @@ async def restore_skill_version(
 async def archive_skill(
     *,
     skill_id: uuid.UUID,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> None:
     """Archive a logical skill."""

--- a/tracecat/agent/skill/router.py
+++ b/tracecat/agent/skill/router.py
@@ -22,7 +22,7 @@ from tracecat.agent.skill.schemas import (
     SkillVersionReadMinimal,
 )
 from tracecat.agent.skill.service import SkillService
-from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceEditorRole
+from tracecat.auth.dependencies import WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
@@ -50,7 +50,7 @@ def _raise_skill_validation_error(exc: TracecatValidationError) -> Never:
 @require_scope("agent:read")
 async def list_skills(
     *,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     limit: int = Query(
         default=config.TRACECAT__LIMIT_DEFAULT,
@@ -73,7 +73,7 @@ async def list_skills(
 async def create_skill(
     *,
     params: SkillCreate,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> SkillRead:
     """Create a new logical skill and seed its draft."""
@@ -90,7 +90,7 @@ async def create_skill(
 async def upload_skill(
     *,
     params: SkillUpload,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> SkillRead:
     """Create a new skill by importing a full draft file tree."""
@@ -107,7 +107,7 @@ async def upload_skill(
 async def get_skill(
     *,
     skill_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> SkillRead:
     """Return a skill summary including draft and current version status."""
@@ -126,7 +126,7 @@ async def get_skill(
 async def get_skill_draft(
     *,
     skill_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> SkillDraftRead:
     """Return the mutable draft manifest for a skill."""
@@ -146,7 +146,7 @@ async def get_skill_draft_file(
     *,
     skill_id: uuid.UUID,
     path: str = Query(...),
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> SkillDraftFileRead:
     """Return one draft file inline or as a presigned download."""
@@ -171,7 +171,7 @@ async def patch_skill_draft(
     *,
     skill_id: uuid.UUID,
     params: SkillDraftPatch,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> SkillDraftRead:
     """Apply optimistic-concurrency mutations to a draft."""
@@ -198,7 +198,7 @@ async def create_skill_draft_upload(
     *,
     skill_id: uuid.UUID,
     params: SkillUploadSessionCreate,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> SkillUploadSessionRead:
     """Create a staged upload session for a draft file blob."""
@@ -220,7 +220,7 @@ async def create_skill_draft_upload(
 async def publish_skill(
     *,
     skill_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> SkillVersionRead:
     """Publish the current draft into a new immutable version."""
@@ -245,7 +245,7 @@ async def publish_skill(
 async def list_skill_versions(
     *,
     skill_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     limit: int = Query(
         default=config.TRACECAT__LIMIT_DEFAULT,
@@ -278,7 +278,7 @@ async def get_skill_version(
     *,
     skill_id: uuid.UUID,
     version_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> SkillVersionRead:
     """Return one immutable skill version manifest."""
@@ -300,7 +300,7 @@ async def get_skill_version_file(
     skill_id: uuid.UUID,
     version_id: uuid.UUID,
     path: str = Query(...),
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> SkillDraftFileRead:
     """Return one published version file inline or as a presigned download."""
@@ -331,7 +331,7 @@ async def restore_skill_version(
     *,
     skill_id: uuid.UUID,
     version_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> SkillReadMinimal:
     """Restore a historical version as the current selected skill version."""
@@ -351,7 +351,7 @@ async def restore_skill_version(
 async def archive_skill(
     *,
     skill_id: uuid.UUID,
-    role: WorkspaceEditorRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
 ) -> None:
     """Archive a logical skill."""

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -166,7 +166,12 @@ from tracecat.workflow.actions.router import router as workflow_actions_router
 from tracecat.workflow.executions.internal_router import (
     router as internal_workflows_router,
 )
-from tracecat.workflow.executions.router import router as workflow_executions_router
+from tracecat.workflow.executions.router import (
+    router as workflow_executions_router,
+)
+from tracecat.workflow.executions.router import (
+    workflow_router as workflow_executions_workflow_router,
+)
 from tracecat.workflow.graph.router import router as workflow_graph_router
 from tracecat.workflow.management.folders.router import (
     router as workflow_folders_router,
@@ -494,6 +499,7 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(workspaces_router)
     app.include_router(workspace_service_accounts_router)
     _include_workspace_scoped_router(app, workflow_management_router)
+    _include_workspace_scoped_router(app, workflow_executions_workflow_router)
     _include_workspace_scoped_router(app, workflow_graph_router)
     _include_workspace_scoped_router(app, workflow_executions_router)
     _include_workspace_scoped_router(app, workflow_actions_router)

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -46,6 +46,7 @@ from tracecat.api.common import (
 from tracecat.auth.credentials import authenticated_user_only
 from tracecat.auth.dependencies import (
     require_any_auth_type_enabled,
+    require_workspace_id_path,
 )
 from tracecat.auth.discovery import router as auth_discovery_router
 from tracecat.auth.enums import AuthType
@@ -471,7 +472,12 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(agent_channels_router)
     app.include_router(workspaces_router)
     app.include_router(workspace_service_accounts_router)
-    app.include_router(workflow_management_router)
+    app.include_router(workflow_management_router, include_in_schema=False)
+    app.include_router(
+        workflow_management_router,
+        prefix="/workspaces/{workspace_id}",
+        dependencies=[Depends(require_workspace_id_path)],
+    )
     app.include_router(workflow_graph_router)
     app.include_router(workflow_executions_router)
     app.include_router(workflow_actions_router)

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -3,7 +3,15 @@ from collections.abc import Callable
 from contextlib import asynccontextmanager
 
 import tracecat_registry
-from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    FastAPI,
+    HTTPException,
+    Request,
+    Response,
+    status,
+)
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse
@@ -33,6 +41,7 @@ from tracecat.agent.preset.internal_router import (
 from tracecat.agent.preset.router import router as agent_preset_router
 from tracecat.agent.provider.router import router as agent_custom_provider_router
 from tracecat.agent.router import router as agent_router
+from tracecat.agent.router import workspace_router as agent_workspace_router
 from tracecat.agent.session.router import router as agent_session_router
 from tracecat.agent.skill.router import router as agent_skill_router
 from tracecat.api.common import (
@@ -114,6 +123,9 @@ from tracecat.integrations.router import (
     integrations_router,
     mcp_router,
     providers_router,
+)
+from tracecat.integrations.router import (
+    oauth_router as integrations_oauth_router,
 )
 from tracecat.logger import logger
 from tracecat.mcp.oidc import router as mcp_oidc_router
@@ -429,6 +441,15 @@ def feature_flag_dep(flag: FlagLike) -> Callable[..., None]:
     return _is_feature_enabled
 
 
+def _include_workspace_scoped_router(app: FastAPI, router: APIRouter) -> None:
+    app.include_router(router, include_in_schema=False)
+    app.include_router(
+        router,
+        prefix="/workspaces/{workspace_id}",
+        dependencies=[Depends(require_workspace_id_path)],
+    )
+
+
 def create_app(**kwargs) -> FastAPI:
     if config.TRACECAT__ALLOW_ORIGINS is not None:
         allow_origins = config.TRACECAT__ALLOW_ORIGINS.split(",")
@@ -472,21 +493,16 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(agent_channels_router)
     app.include_router(workspaces_router)
     app.include_router(workspace_service_accounts_router)
-    app.include_router(workflow_management_router, include_in_schema=False)
-    app.include_router(
-        workflow_management_router,
-        prefix="/workspaces/{workspace_id}",
-        dependencies=[Depends(require_workspace_id_path)],
-    )
-    app.include_router(workflow_graph_router)
-    app.include_router(workflow_executions_router)
-    app.include_router(workflow_actions_router)
-    app.include_router(workflow_tags_router)
-    app.include_router(workflow_store_router)
-    app.include_router(secrets_router)
-    app.include_router(variables_router)
-    app.include_router(schedules_router)
-    app.include_router(tags_router)
+    _include_workspace_scoped_router(app, workflow_management_router)
+    _include_workspace_scoped_router(app, workflow_graph_router)
+    _include_workspace_scoped_router(app, workflow_executions_router)
+    _include_workspace_scoped_router(app, workflow_actions_router)
+    _include_workspace_scoped_router(app, workflow_tags_router)
+    _include_workspace_scoped_router(app, workflow_store_router)
+    _include_workspace_scoped_router(app, secrets_router)
+    _include_workspace_scoped_router(app, variables_router)
+    _include_workspace_scoped_router(app, schedules_router)
+    _include_workspace_scoped_router(app, tags_router)
     app.include_router(users_router)
     app.include_router(org_router)
     app.include_router(org_service_accounts_router)
@@ -494,35 +510,37 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(agent_catalog_router)
     app.include_router(agent_model_access_router)
     app.include_router(agent_custom_provider_router)
-    app.include_router(agent_channels_management_router)
-    app.include_router(agent_preset_router)
-    app.include_router(agent_skill_router)
-    app.include_router(agent_session_router)
-    app.include_router(approvals_router)
+    _include_workspace_scoped_router(app, agent_workspace_router)
+    _include_workspace_scoped_router(app, agent_channels_management_router)
+    _include_workspace_scoped_router(app, agent_preset_router)
+    _include_workspace_scoped_router(app, agent_skill_router)
+    _include_workspace_scoped_router(app, agent_session_router)
+    _include_workspace_scoped_router(app, approvals_router)
     app.include_router(watchtower_router)
     app.include_router(admin_router)
     app.include_router(admin_agent_router, prefix="/admin")
     app.include_router(admin_registry_router, prefix="/admin")
-    app.include_router(inbox_router)
-    app.include_router(editor_router)
+    _include_workspace_scoped_router(app, inbox_router)
+    _include_workspace_scoped_router(app, editor_router)
     app.include_router(registry_repos_router)
     app.include_router(registry_actions_router)
     app.include_router(org_settings_router)
     app.include_router(org_secrets_router)
-    app.include_router(tables_router)
-    app.include_router(cases_router)
-    app.include_router(case_rows_router)
-    app.include_router(case_fields_router)
-    app.include_router(case_tags_router)
-    app.include_router(case_tag_definitions_router)
-    app.include_router(case_attachments_router)
-    app.include_router(case_dropdowns_router)
-    app.include_router(case_dropdown_values_router)
-    app.include_router(case_durations_router)
-    app.include_router(workflow_folders_router)
-    app.include_router(integrations_router)
-    app.include_router(providers_router)
-    app.include_router(mcp_router)
+    _include_workspace_scoped_router(app, tables_router)
+    _include_workspace_scoped_router(app, cases_router)
+    _include_workspace_scoped_router(app, case_rows_router)
+    _include_workspace_scoped_router(app, case_fields_router)
+    _include_workspace_scoped_router(app, case_tags_router)
+    _include_workspace_scoped_router(app, case_tag_definitions_router)
+    _include_workspace_scoped_router(app, case_attachments_router)
+    _include_workspace_scoped_router(app, case_dropdowns_router)
+    _include_workspace_scoped_router(app, case_dropdown_values_router)
+    _include_workspace_scoped_router(app, case_durations_router)
+    _include_workspace_scoped_router(app, workflow_folders_router)
+    app.include_router(integrations_oauth_router)
+    _include_workspace_scoped_router(app, integrations_router)
+    _include_workspace_scoped_router(app, providers_router)
+    _include_workspace_scoped_router(app, mcp_router)
     app.include_router(mcp_oidc_router)
     app.include_router(feature_flags_router)
     app.include_router(vcs_router)

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -893,6 +893,37 @@ async def _role_dependency(
     return role
 
 
+def _resolve_workspace_id_from_path_or_query(
+    request: Request,
+    workspace_id_query: uuid.UUID | None,
+) -> uuid.UUID | None:
+    path_value = request.path_params.get("workspace_id")
+    path_workspace_id: uuid.UUID | None = None
+    if path_value is not None:
+        try:
+            path_workspace_id = (
+                path_value
+                if isinstance(path_value, uuid.UUID)
+                else uuid.UUID(str(path_value))
+            )
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Invalid workspace_id path parameter",
+            ) from e
+
+    if (
+        path_workspace_id is not None
+        and workspace_id_query is not None
+        and path_workspace_id != workspace_id_query
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Path and query workspace_id values must match",
+        )
+    return path_workspace_id or workspace_id_query
+
+
 def RoleACL(
     *,
     allow_user: bool = True,
@@ -900,7 +931,7 @@ def RoleACL(
     allow_api_key: bool = False,
     allow_executor: bool = False,
     require_workspace: Literal["yes", "no", "optional"] = "yes",
-    workspace_id_in_path: bool = False,
+    workspace_id_in_path: bool | Literal["auto"] = False,
 ) -> Any:
     """
     Factory for FastAPI dependency that enforces role-based access control.
@@ -920,7 +951,9 @@ def RoleACL(
             - "no": Workspace ID is not required.
             - "optional": Workspace ID may be omitted.
             Defaults to "yes".
-        workspace_id_in_path (bool, optional): Whether to extract `workspace_id` from the path rather than the query string.
+        workspace_id_in_path: Whether to extract `workspace_id` from the path
+            rather than the query string. When set to `"auto"`, resolves path
+            `workspace_id` first and falls back to the legacy query parameter.
             Defaults to False.
     Returns:
         Any: A FastAPI dependency that yields a `Role` instance upon successful
@@ -965,6 +998,133 @@ def RoleACL(
         return Depends(role_dependency_executor_only)
 
     if require_workspace == "yes":
+        if workspace_id_in_path == "auto":
+            if allow_service and allow_api_key:
+
+                async def role_dependency_req_ws_auto(
+                    request: Request,
+                    session: AsyncDBSession,
+                    workspace_id_query: uuid.UUID | None = Query(
+                        default=None,
+                        alias="workspace_id",
+                        include_in_schema=False,
+                    ),
+                    user: OptionalUserDep = None,
+                    internal_service_key: OptionalInternalServiceKeyDep = None,
+                    tracecat_api_key: OptionalTracecatApiKeyDep = None,
+                ) -> Role:
+                    workspace_id = _resolve_workspace_id_from_path_or_query(
+                        request, workspace_id_query
+                    )
+                    return await _role_dependency(
+                        request=request,
+                        session=session,
+                        workspace_id=workspace_id,
+                        user=user,
+                        internal_service_key=internal_service_key,
+                        tracecat_api_key=tracecat_api_key,
+                        allow_user=allow_user,
+                        allow_service=allow_service,
+                        allow_api_key=allow_api_key,
+                        allow_executor=allow_executor,
+                        require_workspace=require_workspace,
+                    )
+
+                return Depends(role_dependency_req_ws_auto)
+
+            if allow_service:
+
+                async def role_dependency_req_ws_auto_service(
+                    request: Request,
+                    session: AsyncDBSession,
+                    workspace_id_query: uuid.UUID | None = Query(
+                        default=None,
+                        alias="workspace_id",
+                        include_in_schema=False,
+                    ),
+                    user: OptionalUserDep = None,
+                    internal_service_key: OptionalInternalServiceKeyDep = None,
+                ) -> Role:
+                    workspace_id = _resolve_workspace_id_from_path_or_query(
+                        request, workspace_id_query
+                    )
+                    return await _role_dependency(
+                        request=request,
+                        session=session,
+                        workspace_id=workspace_id,
+                        user=user,
+                        internal_service_key=internal_service_key,
+                        tracecat_api_key=None,
+                        allow_user=allow_user,
+                        allow_service=allow_service,
+                        allow_api_key=allow_api_key,
+                        allow_executor=allow_executor,
+                        require_workspace=require_workspace,
+                    )
+
+                return Depends(role_dependency_req_ws_auto_service)
+
+            if allow_api_key:
+
+                async def role_dependency_req_ws_auto_api_key(
+                    request: Request,
+                    session: AsyncDBSession,
+                    workspace_id_query: uuid.UUID | None = Query(
+                        default=None,
+                        alias="workspace_id",
+                        include_in_schema=False,
+                    ),
+                    user: OptionalUserDep = None,
+                    tracecat_api_key: OptionalTracecatApiKeyDep = None,
+                ) -> Role:
+                    workspace_id = _resolve_workspace_id_from_path_or_query(
+                        request, workspace_id_query
+                    )
+                    return await _role_dependency(
+                        request=request,
+                        session=session,
+                        workspace_id=workspace_id,
+                        user=user,
+                        internal_service_key=None,
+                        tracecat_api_key=tracecat_api_key,
+                        allow_user=allow_user,
+                        allow_service=allow_service,
+                        allow_api_key=allow_api_key,
+                        allow_executor=allow_executor,
+                        require_workspace=require_workspace,
+                    )
+
+                return Depends(role_dependency_req_ws_auto_api_key)
+
+            async def role_dependency_req_ws_auto_user(
+                request: Request,
+                session: AsyncDBSession,
+                workspace_id_query: uuid.UUID | None = Query(
+                    default=None,
+                    alias="workspace_id",
+                    include_in_schema=False,
+                ),
+                user: OptionalUserDep = None,
+            ) -> Role:
+                workspace_id = _resolve_workspace_id_from_path_or_query(
+                    request, workspace_id_query
+                )
+                return await _role_dependency(
+                    request=request,
+                    session=session,
+                    workspace_id=workspace_id,
+                    user=user,
+                    internal_service_key=None,
+                    tracecat_api_key=None,
+                    allow_user=allow_user,
+                    allow_service=allow_service,
+                    allow_api_key=allow_api_key,
+                    allow_executor=allow_executor,
+                    require_workspace=require_workspace,
+                )
+
+            return Depends(role_dependency_req_ws_auto_user)
+
         GetWsDep = Path if workspace_id_in_path else Query
 
         if allow_service and allow_api_key:

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -896,7 +896,7 @@ async def _role_dependency(
 def _resolve_workspace_id_from_path_or_query(
     request: Request,
     workspace_id_query: uuid.UUID | None,
-) -> uuid.UUID | None:
+) -> uuid.UUID:
     path_value = request.path_params.get("workspace_id")
     path_workspace_id: uuid.UUID | None = None
     if path_value is not None:
@@ -921,7 +921,13 @@ def _resolve_workspace_id_from_path_or_query(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Path and query workspace_id values must match",
         )
-    return path_workspace_id or workspace_id_query
+    workspace_id = path_workspace_id or workspace_id_query
+    if workspace_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="workspace_id is required",
+        )
+    return workspace_id
 
 
 def RoleACL(

--- a/tracecat/auth/dependencies.py
+++ b/tracecat/auth/dependencies.py
@@ -1,7 +1,8 @@
+import uuid
 from collections.abc import Sequence
 from typing import Annotated, Any
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Path, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
@@ -38,6 +39,36 @@ WorkspaceActorRole = Annotated[
     ),
 ]
 """Dependency for a user or service-account role for a workspace."""
+
+WorkspaceActorRouteRole = Annotated[
+    Role,
+    RoleACL(
+        allow_user=True,
+        allow_service=False,
+        allow_api_key=True,
+        require_workspace="yes",
+        workspace_id_in_path="auto",
+    ),
+]
+"""Dependency for workspace routes that accept path-scoped canonical routes and legacy query-scoped routes."""
+
+WorkspaceUserRouteRole = Annotated[
+    Role,
+    RoleACL(
+        allow_user=True,
+        allow_service=False,
+        allow_api_key=False,
+        require_workspace="yes",
+        workspace_id_in_path="auto",
+    ),
+]
+"""Dependency for user-only workspace routes that accept path or legacy query workspace context."""
+
+
+async def require_workspace_id_path(workspace_id: uuid.UUID = Path(...)) -> uuid.UUID:
+    """Validate and document canonical workspace-scoped route prefixes."""
+    return workspace_id
+
 
 WorkspaceServiceAccountRole = Annotated[
     Role,

--- a/tracecat/auth/dependencies.py
+++ b/tracecat/auth/dependencies.py
@@ -40,7 +40,7 @@ WorkspaceActorRole = Annotated[
 ]
 """Dependency for a user or service-account role for a workspace."""
 
-WorkspaceActor = Annotated[
+WorkspaceActorRouteRole = Annotated[
     Role,
     RoleACL(
         allow_user=True,
@@ -52,7 +52,7 @@ WorkspaceActor = Annotated[
 ]
 """Dependency for workspace routes that accept path-scoped canonical routes and legacy query-scoped routes."""
 
-WorkspaceUser = Annotated[
+WorkspaceUserRouteRole = Annotated[
     Role,
     RoleACL(
         allow_user=True,
@@ -63,12 +63,6 @@ WorkspaceUser = Annotated[
     ),
 ]
 """Dependency for user-only workspace routes that accept path or legacy query workspace context."""
-
-WorkspaceActorRouteRole = WorkspaceActor
-"""Compatibility alias for the route-aware workspace actor dependency."""
-
-WorkspaceUserRouteRole = WorkspaceUser
-"""Compatibility alias for the route-aware workspace user dependency."""
 
 
 async def require_workspace_id_path(workspace_id: uuid.UUID = Path(...)) -> uuid.UUID:

--- a/tracecat/auth/dependencies.py
+++ b/tracecat/auth/dependencies.py
@@ -40,7 +40,7 @@ WorkspaceActorRole = Annotated[
 ]
 """Dependency for a user or service-account role for a workspace."""
 
-WorkspaceActorRouteRole = Annotated[
+WorkspaceActor = Annotated[
     Role,
     RoleACL(
         allow_user=True,
@@ -52,7 +52,7 @@ WorkspaceActorRouteRole = Annotated[
 ]
 """Dependency for workspace routes that accept path-scoped canonical routes and legacy query-scoped routes."""
 
-WorkspaceUserRouteRole = Annotated[
+WorkspaceUser = Annotated[
     Role,
     RoleACL(
         allow_user=True,
@@ -63,6 +63,12 @@ WorkspaceUserRouteRole = Annotated[
     ),
 ]
 """Dependency for user-only workspace routes that accept path or legacy query workspace context."""
+
+WorkspaceActorRouteRole = WorkspaceActor
+"""Compatibility alias for the route-aware workspace actor dependency."""
+
+WorkspaceUserRouteRole = WorkspaceUser
+"""Compatibility alias for the route-aware workspace user dependency."""
 
 
 async def require_workspace_id_path(workspace_id: uuid.UUID = Path(...)) -> uuid.UUID:

--- a/tracecat/cases/attachments/router.py
+++ b/tracecat/cases/attachments/router.py
@@ -2,13 +2,11 @@
 
 import hashlib
 import uuid
-from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query, Request, UploadFile, status
 
 from tracecat import config
-from tracecat.auth.credentials import RoleACL
-from tracecat.auth.types import Role
+from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.cases.attachments.schemas import (
     CaseAttachmentCreate,
@@ -28,15 +26,6 @@ from tracecat.storage.exceptions import (
 )
 
 router = APIRouter(tags=["case-attachments"], prefix="/cases/{case_id}/attachments")
-
-WorkspaceUser = Annotated[
-    Role,
-    RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="yes",
-    ),
-]
 
 
 @router.get("")

--- a/tracecat/cases/attachments/router.py
+++ b/tracecat/cases/attachments/router.py
@@ -6,7 +6,7 @@ import uuid
 from fastapi import APIRouter, HTTPException, Query, Request, UploadFile, status
 
 from tracecat import config
-from tracecat.auth.dependencies import WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.cases.attachments.schemas import (
     CaseAttachmentCreate,
@@ -32,7 +32,7 @@ router = APIRouter(tags=["case-attachments"], prefix="/cases/{case_id}/attachmen
 @require_scope("case:read")
 async def list_attachments(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
 ) -> list[CaseAttachmentRead]:
@@ -71,7 +71,7 @@ async def list_attachments(
 @require_scope("case:update")
 async def create_attachment(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     file: UploadFile,
@@ -326,7 +326,7 @@ async def create_attachment(
 @require_scope("case:read")
 async def download_attachment(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     attachment_id: uuid.UUID,
@@ -396,7 +396,7 @@ async def download_attachment(
 @require_scope("case:update")
 async def delete_attachment(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     attachment_id: uuid.UUID,

--- a/tracecat/cases/attachments/router.py
+++ b/tracecat/cases/attachments/router.py
@@ -6,7 +6,7 @@ import uuid
 from fastapi import APIRouter, HTTPException, Query, Request, UploadFile, status
 
 from tracecat import config
-from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.cases.attachments.schemas import (
     CaseAttachmentCreate,

--- a/tracecat/cases/dropdowns/router.py
+++ b/tracecat/cases/dropdowns/router.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, Body, HTTPException, status
 from pydantic import UUID4
 
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.cases.dropdowns.schemas import (
     CaseDropdownDefinitionCreate,

--- a/tracecat/cases/dropdowns/router.py
+++ b/tracecat/cases/dropdowns/router.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, Body, HTTPException, status
 from pydantic import UUID4
 
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.cases.dropdowns.schemas import (
     CaseDropdownDefinitionCreate,
@@ -34,7 +34,7 @@ definitions_router = APIRouter(prefix="/case-dropdowns", tags=["case-dropdowns"]
 @require_scope("case:read")
 async def list_dropdown_definitions(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
 ) -> list[CaseDropdownDefinitionRead]:
     """List all dropdown definitions for the workspace."""
@@ -54,7 +54,7 @@ async def list_dropdown_definitions(
 @require_scope("case:create")
 async def create_dropdown_definition(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     params: CaseDropdownDefinitionCreate,
 ) -> CaseDropdownDefinitionRead:
@@ -74,7 +74,7 @@ async def create_dropdown_definition(
 @require_scope("case:read")
 async def get_dropdown_definition(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     definition_id: UUID4,
 ) -> CaseDropdownDefinitionRead:
@@ -93,7 +93,7 @@ async def get_dropdown_definition(
 @require_scope("case:update")
 async def update_dropdown_definition(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     definition_id: UUID4,
     params: CaseDropdownDefinitionUpdate,
@@ -120,7 +120,7 @@ async def update_dropdown_definition(
 @require_scope("case:delete")
 async def delete_dropdown_definition(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     definition_id: UUID4,
 ) -> None:
@@ -146,7 +146,7 @@ async def delete_dropdown_definition(
 @require_scope("case:create")
 async def add_dropdown_option(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     definition_id: UUID4,
     params: CaseDropdownOptionCreate,
@@ -177,7 +177,7 @@ async def add_dropdown_option(
 @require_scope("case:update")
 async def update_dropdown_option(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     definition_id: UUID4,
     option_id: UUID4,
@@ -213,7 +213,7 @@ async def update_dropdown_option(
 @require_scope("case:delete")
 async def delete_dropdown_option(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     definition_id: UUID4,
     option_id: UUID4,
@@ -242,7 +242,7 @@ async def delete_dropdown_option(
 @require_scope("case:update")
 async def reorder_dropdown_options(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     definition_id: UUID4,
     option_ids: Annotated[list[uuid.UUID], Body()],
@@ -267,7 +267,7 @@ values_router = APIRouter(prefix="/cases", tags=["cases"])
 @require_scope("case:read")
 async def list_case_dropdown_values(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     case_id: UUID4,
 ) -> list[CaseDropdownValueRead]:
@@ -283,7 +283,7 @@ async def list_case_dropdown_values(
 @require_scope("case:update")
 async def set_case_dropdown_value(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     case_id: UUID4,
     definition_id: UUID4,

--- a/tracecat/cases/dropdowns/router.py
+++ b/tracecat/cases/dropdowns/router.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, Body, HTTPException, status
 from pydantic import UUID4
 
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.cases.dropdowns.schemas import (
     CaseDropdownDefinitionCreate,
@@ -34,7 +34,7 @@ definitions_router = APIRouter(prefix="/case-dropdowns", tags=["case-dropdowns"]
 @require_scope("case:read")
 async def list_dropdown_definitions(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> list[CaseDropdownDefinitionRead]:
     """List all dropdown definitions for the workspace."""
@@ -54,7 +54,7 @@ async def list_dropdown_definitions(
 @require_scope("case:create")
 async def create_dropdown_definition(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     params: CaseDropdownDefinitionCreate,
 ) -> CaseDropdownDefinitionRead:
@@ -74,7 +74,7 @@ async def create_dropdown_definition(
 @require_scope("case:read")
 async def get_dropdown_definition(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     definition_id: UUID4,
 ) -> CaseDropdownDefinitionRead:
@@ -93,7 +93,7 @@ async def get_dropdown_definition(
 @require_scope("case:update")
 async def update_dropdown_definition(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     definition_id: UUID4,
     params: CaseDropdownDefinitionUpdate,
@@ -120,7 +120,7 @@ async def update_dropdown_definition(
 @require_scope("case:delete")
 async def delete_dropdown_definition(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     definition_id: UUID4,
 ) -> None:
@@ -146,7 +146,7 @@ async def delete_dropdown_definition(
 @require_scope("case:create")
 async def add_dropdown_option(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     definition_id: UUID4,
     params: CaseDropdownOptionCreate,
@@ -177,7 +177,7 @@ async def add_dropdown_option(
 @require_scope("case:update")
 async def update_dropdown_option(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     definition_id: UUID4,
     option_id: UUID4,
@@ -213,7 +213,7 @@ async def update_dropdown_option(
 @require_scope("case:delete")
 async def delete_dropdown_option(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     definition_id: UUID4,
     option_id: UUID4,
@@ -242,7 +242,7 @@ async def delete_dropdown_option(
 @require_scope("case:update")
 async def reorder_dropdown_options(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     definition_id: UUID4,
     option_ids: Annotated[list[uuid.UUID], Body()],
@@ -267,7 +267,7 @@ values_router = APIRouter(prefix="/cases", tags=["cases"])
 @require_scope("case:read")
 async def list_case_dropdown_values(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: UUID4,
 ) -> list[CaseDropdownValueRead]:
@@ -283,7 +283,7 @@ async def list_case_dropdown_values(
 @require_scope("case:update")
 async def set_case_dropdown_value(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: UUID4,
     definition_id: UUID4,

--- a/tracecat/cases/durations/router.py
+++ b/tracecat/cases/durations/router.py
@@ -6,7 +6,7 @@ import uuid
 
 from fastapi import APIRouter, HTTPException, status
 
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.cases.durations.schemas import (
     CaseDurationCreate,

--- a/tracecat/cases/durations/router.py
+++ b/tracecat/cases/durations/router.py
@@ -6,7 +6,7 @@ import uuid
 
 from fastapi import APIRouter, HTTPException, status
 
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.cases.durations.schemas import (
     CaseDurationCreate,
@@ -38,7 +38,7 @@ durations_router = APIRouter(
 @require_scope("case:read")
 async def list_case_duration_definitions(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> list[CaseDurationDefinitionRead]:
     """List all case duration definitions for the active workspace."""
@@ -50,7 +50,7 @@ async def list_case_duration_definitions(
 @require_scope("case:read")
 async def get_case_duration_definition(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     duration_id: uuid.UUID,
 ) -> CaseDurationDefinitionRead:
@@ -78,7 +78,7 @@ async def get_case_duration_definition(
 @require_scope("case:create")
 async def create_case_duration_definition(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     params: CaseDurationDefinitionCreate,
 ) -> CaseDurationDefinitionRead:
@@ -113,7 +113,7 @@ async def create_case_duration_definition(
 @require_scope("case:update")
 async def update_case_duration_definition(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     duration_id: uuid.UUID,
     params: CaseDurationDefinitionUpdate,
@@ -163,7 +163,7 @@ async def update_case_duration_definition(
 @require_scope("case:delete")
 async def delete_case_duration_definition(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     duration_id: uuid.UUID,
 ) -> None:
@@ -187,7 +187,7 @@ async def delete_case_duration_definition(
 @require_scope("case:read")
 async def list_case_durations(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
 ) -> list[CaseDurationRead]:
@@ -215,7 +215,7 @@ async def list_case_durations(
 @require_scope("case:read")
 async def get_case_duration(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     duration_id: uuid.UUID,
@@ -243,7 +243,7 @@ async def get_case_duration(
 @require_scope("case:create")
 async def create_case_duration(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     params: CaseDurationCreate,
@@ -280,7 +280,7 @@ async def create_case_duration(
 @require_scope("case:update")
 async def update_case_duration(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     duration_id: uuid.UUID,
@@ -321,7 +321,7 @@ async def update_case_duration(
 @require_scope("case:delete")
 async def delete_case_duration(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     duration_id: uuid.UUID,

--- a/tracecat/cases/durations/router.py
+++ b/tracecat/cases/durations/router.py
@@ -6,7 +6,7 @@ import uuid
 
 from fastapi import APIRouter, HTTPException, status
 
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.cases.durations.schemas import (
     CaseDurationCreate,
@@ -38,7 +38,7 @@ durations_router = APIRouter(
 @require_scope("case:read")
 async def list_case_duration_definitions(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
 ) -> list[CaseDurationDefinitionRead]:
     """List all case duration definitions for the active workspace."""
@@ -50,7 +50,7 @@ async def list_case_duration_definitions(
 @require_scope("case:read")
 async def get_case_duration_definition(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     duration_id: uuid.UUID,
 ) -> CaseDurationDefinitionRead:
@@ -78,7 +78,7 @@ async def get_case_duration_definition(
 @require_scope("case:create")
 async def create_case_duration_definition(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     params: CaseDurationDefinitionCreate,
 ) -> CaseDurationDefinitionRead:
@@ -113,7 +113,7 @@ async def create_case_duration_definition(
 @require_scope("case:update")
 async def update_case_duration_definition(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     duration_id: uuid.UUID,
     params: CaseDurationDefinitionUpdate,
@@ -163,7 +163,7 @@ async def update_case_duration_definition(
 @require_scope("case:delete")
 async def delete_case_duration_definition(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     duration_id: uuid.UUID,
 ) -> None:
@@ -187,7 +187,7 @@ async def delete_case_duration_definition(
 @require_scope("case:read")
 async def list_case_durations(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     case_id: uuid.UUID,
 ) -> list[CaseDurationRead]:
@@ -215,7 +215,7 @@ async def list_case_durations(
 @require_scope("case:read")
 async def get_case_duration(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     duration_id: uuid.UUID,
@@ -243,7 +243,7 @@ async def get_case_duration(
 @require_scope("case:create")
 async def create_case_duration(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     params: CaseDurationCreate,
@@ -280,7 +280,7 @@ async def create_case_duration(
 @require_scope("case:update")
 async def update_case_duration(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     duration_id: uuid.UUID,
@@ -321,7 +321,7 @@ async def update_case_duration(
 @require_scope("case:delete")
 async def delete_case_duration(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     duration_id: uuid.UUID,

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from typing import Annotated, Literal, NoReturn, TypedDict
+from typing import Literal, NoReturn, TypedDict
 
 from asyncpg import DuplicateColumnError
 from fastapi import APIRouter, HTTPException, Query
@@ -18,9 +18,8 @@ from starlette.status import (
 )
 
 from tracecat import config
-from tracecat.auth.credentials import RoleACL
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActor
 from tracecat.auth.schemas import UserRead
-from tracecat.auth.types import Role
 from tracecat.auth.users import search_users
 from tracecat.authz.controls import require_scope
 from tracecat.cases.dropdowns.service import CaseDropdownValuesService
@@ -73,17 +72,6 @@ from tracecat.tiers.enums import Entitlement
 
 cases_router = APIRouter(prefix="/cases", tags=["cases"])
 case_fields_router = APIRouter(prefix="/case-fields", tags=["cases"])
-
-
-WorkspaceActor = Annotated[
-    Role,
-    RoleACL(
-        allow_user=True,
-        allow_service=False,
-        allow_api_key=True,
-        require_workspace="yes",
-    ),
-]
 
 
 class ParsedCaseSearchFilters(TypedDict):

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -18,7 +18,7 @@ from starlette.status import (
 )
 
 from tracecat import config
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.auth.schemas import UserRead
 from tracecat.auth.users import search_users
 from tracecat.authz.controls import require_scope
@@ -116,7 +116,7 @@ def _parse_dropdown_filter(
 async def _resolve_tag_ids(
     *,
     tags: list[str] | None,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> list[uuid.UUID] | None:
     if not tags:
@@ -135,7 +135,7 @@ async def _resolve_tag_ids(
 
 async def _parse_case_search_filters(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     assignee_id: list[str] | None,
     tags: list[str] | None,
@@ -158,7 +158,7 @@ async def _parse_case_search_filters(
 @require_scope("case:read")
 async def list_cases(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     limit: int = Query(
         config.TRACECAT__LIMIT_DEFAULT,
@@ -260,7 +260,7 @@ async def list_cases(
 @require_scope("case:read")
 async def search_cases(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     limit: int = Query(
         config.TRACECAT__LIMIT_DEFAULT,
@@ -423,7 +423,7 @@ async def search_cases(
 @require_scope("case:read")
 async def search_case_aggregates(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     search_term: str | None = Query(
         None,
@@ -504,7 +504,7 @@ async def search_case_aggregates(
 @require_scope("case:read")
 async def get_case(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     include_rows: bool = Query(False, description="Include linked table rows"),
@@ -573,7 +573,7 @@ async def get_case(
 @require_scope("case:create")
 async def create_case(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     params: CaseCreate,
 ) -> None:
@@ -592,7 +592,7 @@ async def create_case(
 @require_scope("case:update")
 async def update_case(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     params: CaseUpdate,
     case_id: uuid.UUID,
@@ -629,7 +629,7 @@ async def update_case(
 @require_scope("case:delete")
 async def delete_case(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
 ) -> None:
@@ -651,7 +651,7 @@ async def delete_case(
 @require_scope("case:read")
 async def list_comments(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
 ) -> list[CaseCommentRead]:
@@ -673,7 +673,7 @@ async def list_comments(
 @require_scope("case:read")
 async def list_comment_threads(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
 ) -> list[CaseCommentThreadRead]:
@@ -693,7 +693,7 @@ async def list_comment_threads(
 @require_scope("case:update")
 async def create_comment(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     params: CaseCommentCreate,
@@ -720,7 +720,7 @@ async def create_comment(
 @require_scope("case:update")
 async def update_comment(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     comment_id: uuid.UUID,
@@ -753,7 +753,7 @@ async def update_comment(
 @require_scope("case:delete")
 async def delete_comment(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     comment_id: uuid.UUID,
@@ -786,7 +786,7 @@ async def delete_comment(
 @require_scope("case:read")
 async def list_fields(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> list[CaseFieldReadMinimal]:
     """List all case fields."""
@@ -803,7 +803,7 @@ async def list_fields(
 @require_scope("case:create")
 async def create_field(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     params: CaseFieldCreate,
 ) -> None:
@@ -829,7 +829,7 @@ async def create_field(
 @require_scope("case:update")
 async def update_field(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     field_id: str,
     params: CaseFieldUpdate,
@@ -855,7 +855,7 @@ async def update_field(
 @require_scope("case:delete")
 async def delete_field(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     field_id: str,
 ) -> None:
@@ -878,7 +878,7 @@ async def delete_field(
 @require_scope("case:read")
 async def list_events_with_users(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
 ) -> CaseEventsWithUsers:
@@ -942,7 +942,7 @@ async def list_events_with_users(
 @require_scope("case:read")
 async def list_tasks(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
 ) -> list[CaseTaskRead]:
@@ -978,7 +978,7 @@ async def list_tasks(
 @require_scope("case:create")
 async def create_task(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     params: CaseTaskCreate,
@@ -1024,7 +1024,7 @@ async def create_task(
 @require_scope("case:update")
 async def update_task(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     task_id: uuid.UUID,
@@ -1074,7 +1074,7 @@ async def update_task(
 @require_scope("case:delete")
 async def delete_task(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     task_id: uuid.UUID,

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -18,7 +18,7 @@ from starlette.status import (
 )
 
 from tracecat import config
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.auth.schemas import UserRead
 from tracecat.auth.users import search_users
 from tracecat.authz.controls import require_scope

--- a/tracecat/cases/rows/router.py
+++ b/tracecat/cases/rows/router.py
@@ -1,5 +1,4 @@
 import uuid
-from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query
 from starlette.status import (
@@ -10,8 +9,7 @@ from starlette.status import (
 )
 
 from tracecat import config
-from tracecat.auth.credentials import RoleACL
-from tracecat.auth.types import Role
+from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.cases.rows.schemas import (
     CaseTableRowInsertCreate,
@@ -24,15 +22,6 @@ from tracecat.exceptions import TracecatNotFoundError
 from tracecat.pagination import CursorPaginatedResponse
 
 router = APIRouter(prefix="/cases", tags=["cases"])
-
-WorkspaceUser = Annotated[
-    Role,
-    RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="yes",
-    ),
-]
 
 
 @router.get("/{case_id}/rows")

--- a/tracecat/cases/rows/router.py
+++ b/tracecat/cases/rows/router.py
@@ -9,7 +9,7 @@ from starlette.status import (
 )
 
 from tracecat import config
-from tracecat.auth.dependencies import WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.cases.rows.schemas import (
     CaseTableRowInsertCreate,
@@ -28,7 +28,7 @@ router = APIRouter(prefix="/cases", tags=["cases"])
 @require_scope("case:read")
 async def list_case_rows(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     limit: int = Query(
@@ -59,7 +59,7 @@ async def list_case_rows(
 @require_scope("case:update")
 async def link_case_row(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     params: CaseTableRowLinkCreate,
@@ -80,7 +80,7 @@ async def link_case_row(
 @require_scope("case:update")
 async def insert_case_row(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     params: CaseTableRowInsertCreate,
@@ -101,7 +101,7 @@ async def insert_case_row(
 @require_scope("case:update")
 async def unlink_case_row(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
     table_id: uuid.UUID,

--- a/tracecat/cases/rows/router.py
+++ b/tracecat/cases/rows/router.py
@@ -9,7 +9,7 @@ from starlette.status import (
 )
 
 from tracecat import config
-from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.cases.rows.schemas import (
     CaseTableRowInsertCreate,

--- a/tracecat/cases/tag_definitions/router.py
+++ b/tracecat/cases/tag_definitions/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, status
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService

--- a/tracecat/cases/tag_definitions/router.py
+++ b/tracecat/cases/tag_definitions/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, status
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/case-tags", tags=["case-tags"])
 @require_scope("case:read")
 async def list_case_tags(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
 ) -> list[CaseTagRead]:
     """List all case tags available in the current workspace."""
@@ -29,7 +29,7 @@ async def list_case_tags(
 @require_scope("case:read")
 async def get_case_tag(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     tag_id: CaseTagID,
 ) -> CaseTagRead:
@@ -49,7 +49,7 @@ async def get_case_tag(
 @require_scope("case:create")
 async def create_case_tag(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     params: TagCreate,
 ) -> CaseTagRead:
@@ -74,7 +74,7 @@ async def create_case_tag(
 @require_scope("case:update")
 async def update_case_tag(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     tag_id: CaseTagID,
     params: TagUpdate,
@@ -107,7 +107,7 @@ async def update_case_tag(
 @require_scope("case:delete")
 async def delete_case_tag(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     tag_id: CaseTagID,
 ) -> None:

--- a/tracecat/cases/tag_definitions/router.py
+++ b/tracecat/cases/tag_definitions/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, status
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/case-tags", tags=["case-tags"])
 @require_scope("case:read")
 async def list_case_tags(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> list[CaseTagRead]:
     """List all case tags available in the current workspace."""
@@ -29,7 +29,7 @@ async def list_case_tags(
 @require_scope("case:read")
 async def get_case_tag(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     tag_id: CaseTagID,
 ) -> CaseTagRead:
@@ -49,7 +49,7 @@ async def get_case_tag(
 @require_scope("case:create")
 async def create_case_tag(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     params: TagCreate,
 ) -> CaseTagRead:
@@ -74,7 +74,7 @@ async def create_case_tag(
 @require_scope("case:update")
 async def update_case_tag(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     tag_id: CaseTagID,
     params: TagUpdate,
@@ -107,7 +107,7 @@ async def update_case_tag(
 @require_scope("case:delete")
 async def delete_case_tag(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     tag_id: CaseTagID,
 ) -> None:

--- a/tracecat/cases/tags/router.py
+++ b/tracecat/cases/tags/router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, status
 from pydantic import UUID4
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.cases.tags.schemas import CaseTagCreate, CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService

--- a/tracecat/cases/tags/router.py
+++ b/tracecat/cases/tags/router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, status
 from pydantic import UUID4
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.cases.tags.schemas import CaseTagCreate, CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/cases", tags=["cases"])
 @router.get("/{case_id}/tags", response_model=list[CaseTagRead])
 @require_scope("case:read")
 async def list_tags(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: UUID4,
 ) -> list[CaseTagRead]:
@@ -33,7 +33,7 @@ async def list_tags(
 )
 @require_scope("case:update")
 async def add_tag(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: UUID4,
     params: CaseTagCreate,
@@ -62,7 +62,7 @@ async def add_tag(
 )
 @require_scope("case:update")
 async def remove_tag(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     case_id: UUID4,
     tag_identifier: str,  # Can be UUID or ref

--- a/tracecat/cases/tags/router.py
+++ b/tracecat/cases/tags/router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, status
 from pydantic import UUID4
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.cases.tags.schemas import CaseTagCreate, CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/cases", tags=["cases"])
 @router.get("/{case_id}/tags", response_model=list[CaseTagRead])
 @require_scope("case:read")
 async def list_tags(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     case_id: UUID4,
 ) -> list[CaseTagRead]:
@@ -33,7 +33,7 @@ async def list_tags(
 )
 @require_scope("case:update")
 async def add_tag(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     case_id: UUID4,
     params: CaseTagCreate,
@@ -62,7 +62,7 @@ async def add_tag(
 )
 @require_scope("case:update")
 async def remove_tag(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     case_id: UUID4,
     tag_identifier: str,  # Can be UUID or ref

--- a/tracecat/editor/router.py
+++ b/tracecat/editor/router.py
@@ -7,7 +7,7 @@ from lark import Lark, LarkError, Token, Tree
 from lark.visitors import Interpreter
 from pydantic import BaseModel
 
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.editor.schemas import (

--- a/tracecat/editor/router.py
+++ b/tracecat/editor/router.py
@@ -7,7 +7,7 @@ from lark import Lark, LarkError, Token, Tree
 from lark.visitors import Interpreter
 from pydantic import BaseModel
 
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.editor.schemas import (
@@ -141,7 +141,7 @@ def format_type(type_hint: Any) -> str:
 @router.get("/functions", response_model=list[EditorFunctionRead])
 @require_scope("workflow:read")
 async def list_functions(
-    _role: WorkspaceActor,
+    _role: WorkspaceActorRouteRole,
 ):
     functions = []
 
@@ -188,7 +188,7 @@ async def list_functions(
 @require_scope("workflow:read")
 async def list_actions(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDQuery,
 ):
@@ -220,7 +220,7 @@ async def list_actions(
 @require_scope("workflow:read")
 async def validate_expression(
     request: ExpressionValidationRequest,
-    _role: WorkspaceActor,
+    _role: WorkspaceActorRouteRole,
 ):
     """
     LSP endpoint for validating template expressions using the Lark grammar.

--- a/tracecat/editor/router.py
+++ b/tracecat/editor/router.py
@@ -7,7 +7,7 @@ from lark import Lark, LarkError, Token, Tree
 from lark.visitors import Interpreter
 from pydantic import BaseModel
 
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.editor.schemas import (
@@ -141,7 +141,7 @@ def format_type(type_hint: Any) -> str:
 @router.get("/functions", response_model=list[EditorFunctionRead])
 @require_scope("workflow:read")
 async def list_functions(
-    _role: WorkspaceActorRole,
+    _role: WorkspaceActor,
 ):
     functions = []
 
@@ -188,7 +188,7 @@ async def list_functions(
 @require_scope("workflow:read")
 async def list_actions(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDQuery,
 ):
@@ -220,7 +220,7 @@ async def list_actions(
 @require_scope("workflow:read")
 async def validate_expression(
     request: ExpressionValidationRequest,
-    _role: WorkspaceActorRole,
+    _role: WorkspaceActor,
 ):
     """
     LSP endpoint for validating template expressions using the Lark grammar.

--- a/tracecat/inbox/router.py
+++ b/tracecat/inbox/router.py
@@ -1,12 +1,11 @@
 """Inbox API router."""
 
-from typing import Annotated, Literal
+from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Query, status
 
 from tracecat import config
-from tracecat.auth.credentials import RoleACL
-from tracecat.auth.types import Role
+from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.inbox.dependencies import get_inbox_providers
@@ -16,15 +15,6 @@ from tracecat.logger import logger
 from tracecat.pagination import CursorPaginatedResponse
 
 router = APIRouter(prefix="/inbox", tags=["inbox"])
-
-WorkspaceUser = Annotated[
-    Role,
-    RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="yes",
-    ),
-]
 
 
 @router.get("/items")

--- a/tracecat/inbox/router.py
+++ b/tracecat/inbox/router.py
@@ -5,7 +5,7 @@ from typing import Literal
 from fastapi import APIRouter, HTTPException, Query, status
 
 from tracecat import config
-from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.inbox.dependencies import get_inbox_providers

--- a/tracecat/inbox/router.py
+++ b/tracecat/inbox/router.py
@@ -5,7 +5,7 @@ from typing import Literal
 from fastapi import APIRouter, HTTPException, Query, status
 
 from tracecat import config
-from tracecat.auth.dependencies import WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.inbox.dependencies import get_inbox_providers
@@ -20,7 +20,7 @@ router = APIRouter(prefix="/inbox", tags=["inbox"])
 @router.get("/items")
 @require_scope("inbox:read")
 async def list_items(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     limit: int = Query(
         default=config.TRACECAT__LIMIT_DEFAULT,

--- a/tracecat/integrations/dependencies.py
+++ b/tracecat/integrations/dependencies.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, Path, Query, status
 from pydantic import BaseModel
 
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.integrations.enums import OAuthGrantType
 from tracecat.integrations.providers.base import (

--- a/tracecat/integrations/dependencies.py
+++ b/tracecat/integrations/dependencies.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, Path, Query, status
 from pydantic import BaseModel
 
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.integrations.enums import OAuthGrantType
 from tracecat.integrations.providers.base import (
@@ -21,7 +21,7 @@ async def _resolve_provider_info(
     *,
     provider_id: str,
     grant_type: OAuthGrantType,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> ProviderInfo[type[BaseOAuthProvider]]:
     key = ProviderKey(id=provider_id, grant_type=grant_type)
@@ -36,7 +36,7 @@ async def _resolve_provider_info(
 
 
 async def get_provider_impl(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     provider_id: str = Path(...),
     grant_type: OAuthGrantType = Query(default=OAuthGrantType.AUTHORIZATION_CODE),
@@ -65,7 +65,7 @@ async def get_provider_impl(
 
 async def get_ac_provider_impl(
     provider_id: str,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> ProviderInfo[type[AuthorizationCodeOAuthProvider]]:
     """
@@ -98,7 +98,7 @@ async def get_ac_provider_impl(
 
 async def get_cc_provider_impl(
     provider_id: str,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> ProviderInfo[type[ClientCredentialsOAuthProvider]]:
     """

--- a/tracecat/integrations/dependencies.py
+++ b/tracecat/integrations/dependencies.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, Path, Query, status
 from pydantic import BaseModel
 
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.integrations.enums import OAuthGrantType
 from tracecat.integrations.providers.base import (
@@ -21,7 +21,7 @@ async def _resolve_provider_info(
     *,
     provider_id: str,
     grant_type: OAuthGrantType,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
 ) -> ProviderInfo[type[BaseOAuthProvider]]:
     key = ProviderKey(id=provider_id, grant_type=grant_type)
@@ -36,7 +36,7 @@ async def _resolve_provider_info(
 
 
 async def get_provider_impl(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     provider_id: str = Path(...),
     grant_type: OAuthGrantType = Query(default=OAuthGrantType.AUTHORIZATION_CODE),
@@ -65,7 +65,7 @@ async def get_provider_impl(
 
 async def get_ac_provider_impl(
     provider_id: str,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
 ) -> ProviderInfo[type[AuthorizationCodeOAuthProvider]]:
     """
@@ -98,7 +98,7 @@ async def get_ac_provider_impl(
 
 async def get_cc_provider_impl(
     provider_id: str,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
 ) -> ProviderInfo[type[ClientCredentialsOAuthProvider]]:
     """

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -10,7 +10,12 @@ from sqlalchemy import delete
 
 from tracecat import config
 from tracecat.auth.credentials import RoleACL
-from tracecat.auth.dependencies import WorkspaceActorRole, WorkspaceUserRole
+from tracecat.auth.dependencies import (
+    WorkspaceActorRouteRole as WorkspaceActorRole,
+)
+from tracecat.auth.dependencies import (
+    WorkspaceUserRouteRole as WorkspaceUserRole,
+)
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
 from tracecat.contexts import ctx_role
@@ -55,6 +60,9 @@ from tracecat.logger import logger
 integrations_router = APIRouter(prefix="/integrations", tags=["integrations"])
 """Routes for managing dynamic integration states."""
 
+oauth_router = APIRouter(prefix="/integrations", tags=["integrations"])
+"""Routes for integration OAuth callbacks that resolve workspace context from state."""
+
 providers_router = APIRouter(prefix="/providers", tags=["providers"])
 """Routes for managing static provider metadata."""
 
@@ -62,7 +70,7 @@ mcp_router = APIRouter(prefix="/mcp-integrations", tags=["mcp-integrations"])
 """Routes for managing MCP integrations."""
 
 
-@integrations_router.get("/callback")
+@oauth_router.get("/callback")
 async def oauth_callback(
     *,
     session: AsyncDBSession,

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -11,10 +11,8 @@ from sqlalchemy import delete
 from tracecat import config
 from tracecat.auth.credentials import RoleACL
 from tracecat.auth.dependencies import (
-    WorkspaceActorRouteRole as WorkspaceActorRole,
-)
-from tracecat.auth.dependencies import (
-    WorkspaceUserRouteRole as WorkspaceUserRole,
+    WorkspaceActor,
+    WorkspaceUser,
 )
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
@@ -264,7 +262,7 @@ async def oauth_callback(
 @integrations_router.get("")
 @require_scope("integration:read")
 async def list_integrations(
-    role: WorkspaceUserRole, session: AsyncDBSession
+    role: WorkspaceUser, session: AsyncDBSession
 ) -> list[IntegrationReadMinimal]:
     """List all integrations for the current user."""
     if role.workspace_id is None:
@@ -291,7 +289,7 @@ async def list_integrations(
 @integrations_router.get("/{provider_id}")
 @require_scope("integration:read")
 async def get_integration(
-    role: WorkspaceUserRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     provider_info: ProviderInfoDep,
 ) -> IntegrationRead:
@@ -366,7 +364,7 @@ async def get_integration(
 @require_scope("integration:update")
 async def connect_provider(
     *,
-    role: WorkspaceUserRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     provider_info: ACProviderInfoDep,
 ) -> IntegrationOAuthConnect:
@@ -506,7 +504,7 @@ async def connect_provider(
 @require_scope("integration:update")
 async def disconnect_integration(
     *,
-    role: WorkspaceUserRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     provider_info: ProviderInfoDep,
 ) -> None:
@@ -531,7 +529,7 @@ async def disconnect_integration(
 @require_scope("integration:delete")
 async def delete_integration(
     *,
-    role: WorkspaceUserRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     provider_info: ProviderInfoDep,
 ) -> None:
@@ -562,7 +560,7 @@ async def delete_integration(
 @require_scope("integration:update")
 async def test_connection(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     provider_info: CCProviderInfoDep,
 ) -> IntegrationTestConnectionResponse:
@@ -640,7 +638,7 @@ async def test_connection(
 @require_scope("integration:update")
 async def update_integration(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     params: IntegrationUpdate,
     provider_info: ProviderInfoDep,
@@ -688,7 +686,7 @@ async def update_integration(
 @providers_router.post("", status_code=status.HTTP_201_CREATED)
 @require_scope("integration:create")
 async def create_custom_provider(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     params: CustomOAuthProviderCreate,
 ) -> ProviderReadMinimal:
@@ -734,7 +732,7 @@ async def create_custom_provider(
 @providers_router.get("")
 @require_scope("integration:read")
 async def list_providers(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
 ) -> list[ProviderReadMinimal]:
     svc = IntegrationService(session, role=role)
@@ -781,7 +779,7 @@ async def list_providers(
 @providers_router.get("/{provider_id}")
 @require_scope("integration:read")
 async def get_provider(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     provider_info: ProviderInfoDep,
 ) -> ProviderRead:
@@ -816,7 +814,7 @@ async def get_provider(
 @mcp_router.post("", status_code=status.HTTP_201_CREATED)
 @require_scope("integration:create")
 async def create_mcp_integration(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     params: Annotated[MCPIntegrationCreate, Body(...)],
 ) -> MCPIntegrationRead:
@@ -858,7 +856,7 @@ async def create_mcp_integration(
 @mcp_router.get("")
 @require_scope("integration:read")
 async def list_mcp_integrations(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
 ) -> list[MCPIntegrationRead]:
     """List all MCP integrations for the workspace."""
@@ -896,7 +894,7 @@ async def list_mcp_integrations(
 @mcp_router.get("/{mcp_integration_id}")
 @require_scope("integration:read")
 async def get_mcp_integration(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     mcp_integration_id: uuid.UUID,
 ) -> MCPIntegrationRead:
@@ -937,7 +935,7 @@ async def get_mcp_integration(
 @mcp_router.put("/{mcp_integration_id}")
 @require_scope("integration:update")
 async def update_mcp_integration(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     mcp_integration_id: uuid.UUID,
     params: MCPIntegrationUpdate,
@@ -987,7 +985,7 @@ async def update_mcp_integration(
 @mcp_router.delete("/{mcp_integration_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("integration:delete")
 async def delete_mcp_integration(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     mcp_integration_id: uuid.UUID,
 ) -> None:

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -11,8 +11,8 @@ from sqlalchemy import delete
 from tracecat import config
 from tracecat.auth.credentials import RoleACL
 from tracecat.auth.dependencies import (
-    WorkspaceActor,
-    WorkspaceUser,
+    WorkspaceActorRouteRole,
+    WorkspaceUserRouteRole,
 )
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
@@ -262,7 +262,7 @@ async def oauth_callback(
 @integrations_router.get("")
 @require_scope("integration:read")
 async def list_integrations(
-    role: WorkspaceUser, session: AsyncDBSession
+    role: WorkspaceUserRouteRole, session: AsyncDBSession
 ) -> list[IntegrationReadMinimal]:
     """List all integrations for the current user."""
     if role.workspace_id is None:
@@ -289,7 +289,7 @@ async def list_integrations(
 @integrations_router.get("/{provider_id}")
 @require_scope("integration:read")
 async def get_integration(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     provider_info: ProviderInfoDep,
 ) -> IntegrationRead:
@@ -364,7 +364,7 @@ async def get_integration(
 @require_scope("integration:update")
 async def connect_provider(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     provider_info: ACProviderInfoDep,
 ) -> IntegrationOAuthConnect:
@@ -504,7 +504,7 @@ async def connect_provider(
 @require_scope("integration:update")
 async def disconnect_integration(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     provider_info: ProviderInfoDep,
 ) -> None:
@@ -529,7 +529,7 @@ async def disconnect_integration(
 @require_scope("integration:delete")
 async def delete_integration(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     provider_info: ProviderInfoDep,
 ) -> None:
@@ -560,7 +560,7 @@ async def delete_integration(
 @require_scope("integration:update")
 async def test_connection(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     provider_info: CCProviderInfoDep,
 ) -> IntegrationTestConnectionResponse:
@@ -638,7 +638,7 @@ async def test_connection(
 @require_scope("integration:update")
 async def update_integration(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     params: IntegrationUpdate,
     provider_info: ProviderInfoDep,
@@ -686,7 +686,7 @@ async def update_integration(
 @providers_router.post("", status_code=status.HTTP_201_CREATED)
 @require_scope("integration:create")
 async def create_custom_provider(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     params: CustomOAuthProviderCreate,
 ) -> ProviderReadMinimal:
@@ -732,7 +732,7 @@ async def create_custom_provider(
 @providers_router.get("")
 @require_scope("integration:read")
 async def list_providers(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> list[ProviderReadMinimal]:
     svc = IntegrationService(session, role=role)
@@ -779,7 +779,7 @@ async def list_providers(
 @providers_router.get("/{provider_id}")
 @require_scope("integration:read")
 async def get_provider(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     provider_info: ProviderInfoDep,
 ) -> ProviderRead:
@@ -814,7 +814,7 @@ async def get_provider(
 @mcp_router.post("", status_code=status.HTTP_201_CREATED)
 @require_scope("integration:create")
 async def create_mcp_integration(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     params: Annotated[MCPIntegrationCreate, Body(...)],
 ) -> MCPIntegrationRead:
@@ -856,7 +856,7 @@ async def create_mcp_integration(
 @mcp_router.get("")
 @require_scope("integration:read")
 async def list_mcp_integrations(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> list[MCPIntegrationRead]:
     """List all MCP integrations for the workspace."""
@@ -894,7 +894,7 @@ async def list_mcp_integrations(
 @mcp_router.get("/{mcp_integration_id}")
 @require_scope("integration:read")
 async def get_mcp_integration(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     mcp_integration_id: uuid.UUID,
 ) -> MCPIntegrationRead:
@@ -935,7 +935,7 @@ async def get_mcp_integration(
 @mcp_router.put("/{mcp_integration_id}")
 @require_scope("integration:update")
 async def update_mcp_integration(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     mcp_integration_id: uuid.UUID,
     params: MCPIntegrationUpdate,
@@ -985,7 +985,7 @@ async def update_mcp_integration(
 @mcp_router.delete("/{mcp_integration_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("integration:delete")
 async def delete_mcp_integration(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     mcp_integration_id: uuid.UUID,
 ) -> None:

--- a/tracecat/secrets/router.py
+++ b/tracecat/secrets/router.py
@@ -5,7 +5,8 @@ from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 
-from tracecat.auth.dependencies import OrgActorRole, WorkspaceActorRole
+from tracecat.auth.dependencies import OrgActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError

--- a/tracecat/secrets/router.py
+++ b/tracecat/secrets/router.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 
-from tracecat.auth.dependencies import OrgActorRole, WorkspaceActor
+from tracecat.auth.dependencies import OrgActorRole, WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError
@@ -69,7 +69,7 @@ def _serialize_secret_read_minimal(
 @require_scope("secret:read")
 async def search_secrets(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     environment: str = Query(...),
     names: set[str] | None = Query(
@@ -102,7 +102,7 @@ async def search_secrets(
 @require_scope("secret:read")
 async def list_secrets(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     types: set[SecretType] | None = Query(
         None, alias="type", description="Filter by secret type"
@@ -121,7 +121,7 @@ async def list_secrets(
 @require_scope("secret:read")
 async def list_secret_definitions(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> list[SecretDefinition]:
     """List aggregated secret definitions from the registry."""
@@ -137,7 +137,7 @@ async def list_secret_definitions(
 @require_scope("secret:read")
 async def get_aws_assume_role_access(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
 ) -> AwsAssumeRoleAccessRead:
     """Get workspace-scoped AWS AssumeRole details for credential setup."""
     workspace_id = role.workspace_id
@@ -164,7 +164,7 @@ async def get_aws_assume_role_access(
 @require_scope("secret:read")
 async def get_secret_by_name(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     secret_name: str,
 ) -> SecretRead:
@@ -184,7 +184,7 @@ async def get_secret_by_name(
 @require_scope("secret:create")
 async def create_secret(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     params: SecretCreate,
 ) -> None:
@@ -208,7 +208,7 @@ async def create_secret(
 @require_scope("secret:update")
 async def update_secret_by_id(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     secret_id: AnySecretIDPath,
     params: SecretUpdate,
@@ -238,7 +238,7 @@ async def update_secret_by_id(
 @require_scope("secret:delete")
 async def delete_secret_by_id(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     secret_id: AnySecretIDPath,
 ) -> None:

--- a/tracecat/secrets/router.py
+++ b/tracecat/secrets/router.py
@@ -5,8 +5,7 @@ from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 
-from tracecat.auth.dependencies import OrgActorRole
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import OrgActorRole, WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError
@@ -70,7 +69,7 @@ def _serialize_secret_read_minimal(
 @require_scope("secret:read")
 async def search_secrets(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     environment: str = Query(...),
     names: set[str] | None = Query(
@@ -103,7 +102,7 @@ async def search_secrets(
 @require_scope("secret:read")
 async def list_secrets(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     types: set[SecretType] | None = Query(
         None, alias="type", description="Filter by secret type"
@@ -122,7 +121,7 @@ async def list_secrets(
 @require_scope("secret:read")
 async def list_secret_definitions(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
 ) -> list[SecretDefinition]:
     """List aggregated secret definitions from the registry."""
@@ -138,7 +137,7 @@ async def list_secret_definitions(
 @require_scope("secret:read")
 async def get_aws_assume_role_access(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
 ) -> AwsAssumeRoleAccessRead:
     """Get workspace-scoped AWS AssumeRole details for credential setup."""
     workspace_id = role.workspace_id
@@ -165,7 +164,7 @@ async def get_aws_assume_role_access(
 @require_scope("secret:read")
 async def get_secret_by_name(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     secret_name: str,
 ) -> SecretRead:
@@ -185,7 +184,7 @@ async def get_secret_by_name(
 @require_scope("secret:create")
 async def create_secret(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     params: SecretCreate,
 ) -> None:
@@ -209,7 +208,7 @@ async def create_secret(
 @require_scope("secret:update")
 async def update_secret_by_id(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     secret_id: AnySecretIDPath,
     params: SecretUpdate,
@@ -239,7 +238,7 @@ async def update_secret_by_id(
 @require_scope("secret:delete")
 async def delete_secret_by_id(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     secret_id: AnySecretIDPath,
 ) -> None:

--- a/tracecat/tables/router.py
+++ b/tracecat/tables/router.py
@@ -1,6 +1,6 @@
 import csv
 from io import StringIO
-from typing import Annotated, Any, Literal, cast
+from typing import Any, Literal, cast
 from uuid import UUID
 
 import orjson
@@ -18,8 +18,7 @@ from fastapi import (
 from sqlalchemy.exc import DBAPIError, ProgrammingError
 
 from tracecat import config
-from tracecat.auth.credentials import RoleACL
-from tracecat.auth.types import Role
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatImportError, TracecatNotFoundError
@@ -52,22 +51,8 @@ from tracecat.tables.service import TablesService
 
 router = APIRouter(prefix="/tables", tags=["tables"])
 
-WorkspaceUser = Annotated[
-    Role,
-    RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="yes",
-    ),
-]
-WorkspaceEditorUser = Annotated[
-    Role,
-    RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="yes",
-    ),
-]
+WorkspaceUser = WorkspaceUserRouteRole
+WorkspaceEditorUser = WorkspaceUserRouteRole
 
 
 async def _read_csv_upload_with_limit(file: UploadFile, *, max_size: int) -> bytes:

--- a/tracecat/tables/router.py
+++ b/tracecat/tables/router.py
@@ -18,7 +18,7 @@ from fastapi import (
 from sqlalchemy.exc import DBAPIError, ProgrammingError
 
 from tracecat import config
-from tracecat.auth.dependencies import WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatImportError, TracecatNotFoundError
@@ -92,7 +92,7 @@ async def _read_csv_upload_with_limit(file: UploadFile, *, max_size: int) -> byt
 @router.get("")
 @require_scope("table:read")
 async def list_tables(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
 ) -> list[TableReadMinimal]:
     """List all tables."""
@@ -106,7 +106,7 @@ async def list_tables(
 @router.post("", status_code=status.HTTP_201_CREATED)
 @require_scope("table:create")
 async def create_table(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     params: TableCreate,
 ) -> None:
@@ -145,7 +145,7 @@ async def create_table(
 @router.get("/{table_id}", response_model=TableRead)
 @require_scope("table:read")
 async def get_table(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
 ) -> TableRead:
@@ -184,7 +184,7 @@ async def get_table(
 @router.patch("/{table_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("table:update")
 async def update_table(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
     params: TableUpdate,
@@ -218,7 +218,7 @@ async def update_table(
 @router.delete("/{table_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("table:delete")
 async def delete_table(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
 ) -> None:
@@ -237,7 +237,7 @@ async def delete_table(
 @router.post("/{table_id}/columns", status_code=status.HTTP_201_CREATED)
 @require_scope("table:create")
 async def create_column(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
     params: TableColumnCreate,
@@ -280,7 +280,7 @@ async def create_column(
 )
 @require_scope("table:update")
 async def update_column(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
     column_id: TableColumnID,
@@ -323,7 +323,7 @@ async def update_column(
 )
 @require_scope("table:delete")
 async def delete_column(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
     column_id: TableColumnID,
@@ -343,7 +343,7 @@ async def delete_column(
 @router.get("/{table_id}/rows")
 @require_scope("table:read")
 async def list_rows(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
     limit: int = Query(
@@ -404,7 +404,7 @@ async def list_rows(
 @router.get("/{table_id}/rows/{row_id}")
 @require_scope("table:read")
 async def get_row(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
     row_id: UUID,
@@ -426,7 +426,7 @@ async def get_row(
 @router.post("/{table_id}/rows", status_code=status.HTTP_201_CREATED)
 @require_scope("table:create")
 async def insert_row(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
     params: TableRowInsert,
@@ -457,7 +457,7 @@ async def insert_row(
 @router.delete("/{table_id}/rows/{row_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("table:delete")
 async def delete_row(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
     row_id: UUID,
@@ -477,7 +477,7 @@ async def delete_row(
 @router.patch("/{table_id}/rows/{row_id}")
 @require_scope("table:update")
 async def update_row(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
     row_id: UUID,
@@ -516,7 +516,7 @@ async def update_row(
 @router.post("/{table_id}/rows/batch", status_code=status.HTTP_201_CREATED)
 @require_scope("table:create")
 async def batch_insert_rows(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
     params: TableRowInsertBatch,
@@ -553,7 +553,7 @@ async def batch_insert_rows(
 
 @router.post("/{table_id}/rows/batch-delete")
 async def batch_delete_rows(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
     params: TableRowBatchDelete,
@@ -586,7 +586,7 @@ async def batch_delete_rows(
 
 @router.post("/{table_id}/rows/batch-update")
 async def batch_update_rows(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
     params: TableRowBatchUpdate,
@@ -630,7 +630,7 @@ async def get_column_mapping(column_mapping: str = Form(...)) -> dict[str, str]:
 @router.post("/import", status_code=status.HTTP_201_CREATED)
 @require_scope("table:create")
 async def import_table_from_csv(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     file: UploadFile = File(...),
     table_name: str | None = Form(default=None),
@@ -694,7 +694,7 @@ async def import_table_from_csv(
 @router.post("/{table_id}/import", status_code=status.HTTP_201_CREATED)
 @require_scope("table:create")
 async def import_csv(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     table_id: TableID,
     file: UploadFile = File(...),

--- a/tracecat/tables/router.py
+++ b/tracecat/tables/router.py
@@ -18,7 +18,7 @@ from fastapi import (
 from sqlalchemy.exc import DBAPIError, ProgrammingError
 
 from tracecat import config
-from tracecat.auth.dependencies import WorkspaceUserRouteRole
+from tracecat.auth.dependencies import WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatImportError, TracecatNotFoundError
@@ -50,9 +50,6 @@ from tracecat.tables.schemas import (
 from tracecat.tables.service import TablesService
 
 router = APIRouter(prefix="/tables", tags=["tables"])
-
-WorkspaceUser = WorkspaceUserRouteRole
-WorkspaceEditorUser = WorkspaceUserRouteRole
 
 
 async def _read_csv_upload_with_limit(file: UploadFile, *, max_size: int) -> bytes:
@@ -109,7 +106,7 @@ async def list_tables(
 @router.post("", status_code=status.HTTP_201_CREATED)
 @require_scope("table:create")
 async def create_table(
-    role: WorkspaceEditorUser,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     params: TableCreate,
 ) -> None:
@@ -187,7 +184,7 @@ async def get_table(
 @router.patch("/{table_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("table:update")
 async def update_table(
-    role: WorkspaceEditorUser,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     table_id: TableID,
     params: TableUpdate,
@@ -221,7 +218,7 @@ async def update_table(
 @router.delete("/{table_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("table:delete")
 async def delete_table(
-    role: WorkspaceEditorUser,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     table_id: TableID,
 ) -> None:
@@ -240,7 +237,7 @@ async def delete_table(
 @router.post("/{table_id}/columns", status_code=status.HTTP_201_CREATED)
 @require_scope("table:create")
 async def create_column(
-    role: WorkspaceEditorUser,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     table_id: TableID,
     params: TableColumnCreate,
@@ -283,7 +280,7 @@ async def create_column(
 )
 @require_scope("table:update")
 async def update_column(
-    role: WorkspaceEditorUser,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     table_id: TableID,
     column_id: TableColumnID,
@@ -326,7 +323,7 @@ async def update_column(
 )
 @require_scope("table:delete")
 async def delete_column(
-    role: WorkspaceEditorUser,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     table_id: TableID,
     column_id: TableColumnID,
@@ -460,7 +457,7 @@ async def insert_row(
 @router.delete("/{table_id}/rows/{row_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("table:delete")
 async def delete_row(
-    role: WorkspaceEditorUser,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     table_id: TableID,
     row_id: UUID,
@@ -480,7 +477,7 @@ async def delete_row(
 @router.patch("/{table_id}/rows/{row_id}")
 @require_scope("table:update")
 async def update_row(
-    role: WorkspaceEditorUser,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     table_id: TableID,
     row_id: UUID,
@@ -556,7 +553,7 @@ async def batch_insert_rows(
 
 @router.post("/{table_id}/rows/batch-delete")
 async def batch_delete_rows(
-    role: WorkspaceEditorUser,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     table_id: TableID,
     params: TableRowBatchDelete,
@@ -589,7 +586,7 @@ async def batch_delete_rows(
 
 @router.post("/{table_id}/rows/batch-update")
 async def batch_update_rows(
-    role: WorkspaceEditorUser,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     table_id: TableID,
     params: TableRowBatchUpdate,
@@ -633,7 +630,7 @@ async def get_column_mapping(column_mapping: str = Form(...)) -> dict[str, str]:
 @router.post("/import", status_code=status.HTTP_201_CREATED)
 @require_scope("table:create")
 async def import_table_from_csv(
-    role: WorkspaceEditorUser,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     file: UploadFile = File(...),
     table_name: str | None = Form(default=None),

--- a/tracecat/tags/router.py
+++ b/tracecat/tags/router.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from fastapi import APIRouter, HTTPException, status
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.models import WorkflowTag

--- a/tracecat/tags/router.py
+++ b/tracecat/tags/router.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from fastapi import APIRouter, HTTPException, status
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.models import WorkflowTag
@@ -19,7 +19,7 @@ router = APIRouter(prefix="/tags", tags=["tags"])
 @require_scope("tag:read")
 async def list_tags(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
 ) -> Sequence[WorkflowTag]:
     """List all tags for the current workspace."""
@@ -31,7 +31,7 @@ async def list_tags(
 @require_scope("tag:read")
 async def get_tag(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     tag_id: TagID,
 ) -> WorkflowTag:
@@ -50,7 +50,7 @@ async def get_tag(
 @require_scope("tag:create")
 async def create_tag(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     tag: TagCreate,
 ) -> WorkflowTag:
@@ -69,7 +69,7 @@ async def create_tag(
 @require_scope("tag:update")
 async def update_tag(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     tag_id: TagID,
     tag_update: TagUpdate,
@@ -90,7 +90,7 @@ async def update_tag(
 @require_scope("tag:delete")
 async def delete_tag(
     *,
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     tag_id: TagID,
 ) -> None:

--- a/tracecat/tags/router.py
+++ b/tracecat/tags/router.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from fastapi import APIRouter, HTTPException, status
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.models import WorkflowTag
@@ -19,7 +19,7 @@ router = APIRouter(prefix="/tags", tags=["tags"])
 @require_scope("tag:read")
 async def list_tags(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> Sequence[WorkflowTag]:
     """List all tags for the current workspace."""
@@ -31,7 +31,7 @@ async def list_tags(
 @require_scope("tag:read")
 async def get_tag(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     tag_id: TagID,
 ) -> WorkflowTag:
@@ -50,7 +50,7 @@ async def get_tag(
 @require_scope("tag:create")
 async def create_tag(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     tag: TagCreate,
 ) -> WorkflowTag:
@@ -69,7 +69,7 @@ async def create_tag(
 @require_scope("tag:update")
 async def update_tag(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     tag_id: TagID,
     tag_update: TagUpdate,
@@ -90,7 +90,7 @@ async def update_tag(
 @require_scope("tag:delete")
 async def delete_tag(
     *,
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     tag_id: TagID,
 ) -> None:

--- a/tracecat/variables/router.py
+++ b/tracecat/variables/router.py
@@ -1,10 +1,9 @@
-from typing import Annotated, Any
+from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError
 
-from tracecat.auth.credentials import RoleACL
-from tracecat.auth.types import Role
+from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError
@@ -20,15 +19,6 @@ from tracecat.variables.schemas import (
 from tracecat.variables.service import VariablesService
 
 router = APIRouter(prefix="/variables", tags=["variables"])
-
-WorkspaceUser = Annotated[
-    Role,
-    RoleACL(
-        allow_user=True,
-        allow_service=False,
-        require_workspace="yes",
-    ),
-]
 
 
 @router.get("/search", response_model=list[VariableRead])

--- a/tracecat/variables/router.py
+++ b/tracecat/variables/router.py
@@ -3,7 +3,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError
 
-from tracecat.auth.dependencies import WorkspaceUserRouteRole as WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUser
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError

--- a/tracecat/variables/router.py
+++ b/tracecat/variables/router.py
@@ -3,7 +3,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError
 
-from tracecat.auth.dependencies import WorkspaceUser
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError
@@ -25,7 +25,7 @@ router = APIRouter(prefix="/variables", tags=["variables"])
 @require_scope("variable:read")
 async def search_variables(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     environment: str | None = Query(None),
     names: set[str] | None = Query(
@@ -51,7 +51,7 @@ async def search_variables(
 @require_scope("variable:read")
 async def list_variables(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     environment: str | None = Query(None),
 ) -> list[VariableReadMinimal]:
@@ -73,7 +73,7 @@ async def list_variables(
 @require_scope("variable:read")
 async def get_variable_by_name(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     variable_name: str,
     environment: str | None = Query(None),
@@ -94,7 +94,7 @@ async def get_variable_by_name(
 @require_scope("variable:create")
 async def create_variable(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     params: VariableCreate,
 ) -> VariableRead:
@@ -114,7 +114,7 @@ async def create_variable(
 @require_scope("variable:update")
 async def update_variable_by_id(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     variable_id: VariableID,
     params: VariableUpdate,
@@ -140,7 +140,7 @@ async def update_variable_by_id(
 @require_scope("variable:delete")
 async def delete_variable_by_id(
     *,
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     variable_id: VariableID,
 ) -> None:

--- a/tracecat/workflow/actions/router.py
+++ b/tracecat/workflow/actions/router.py
@@ -3,7 +3,7 @@ from typing import cast
 from fastapi import APIRouter, HTTPException, status
 from pydantic import ValidationError
 
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatValidationError

--- a/tracecat/workflow/actions/router.py
+++ b/tracecat/workflow/actions/router.py
@@ -3,7 +3,7 @@ from typing import cast
 from fastapi import APIRouter, HTTPException, status
 from pydantic import ValidationError
 
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatValidationError
@@ -30,7 +30,7 @@ router = APIRouter(prefix="/actions", tags=["actions"])
 @router.post("/batch-positions", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("workflow:update")
 async def batch_update_positions(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     workflow_id: AnyWorkflowIDPath,
     params: BatchPositionUpdate,
     session: AsyncDBSession,
@@ -51,7 +51,7 @@ async def batch_update_positions(
 @router.get("")
 @require_scope("workflow:read")
 async def list_actions(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     workflow_id: AnyWorkflowIDPath,
     session: AsyncDBSession,
 ) -> list[ActionReadMinimal]:
@@ -75,7 +75,7 @@ async def list_actions(
 @router.post("")
 @require_scope("workflow:create")
 async def create_action(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     params: ActionCreate,
     session: AsyncDBSession,
 ) -> ActionReadMinimal:
@@ -107,7 +107,7 @@ async def create_action(
 @router.get("/{action_id}")
 @require_scope("workflow:read")
 async def get_action(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     action_id: AnyActionIDPath,
     workflow_id: AnyWorkflowIDPath,
     session: AsyncDBSession,
@@ -177,7 +177,7 @@ async def get_action(
 @router.post("/{action_id}")
 @require_scope("workflow:update")
 async def update_action(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     action_id: AnyActionIDPath,
     workflow_id: AnyWorkflowIDPath,
     params: ActionUpdate,
@@ -198,7 +198,7 @@ async def update_action(
 @router.delete("/{action_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("workflow:delete")
 async def delete_action(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     action_id: AnyActionIDPath,
     workflow_id: AnyWorkflowIDPath,
     session: AsyncDBSession,

--- a/tracecat/workflow/actions/router.py
+++ b/tracecat/workflow/actions/router.py
@@ -3,7 +3,7 @@ from typing import cast
 from fastapi import APIRouter, HTTPException, status
 from pydantic import ValidationError
 
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatValidationError
@@ -30,7 +30,7 @@ router = APIRouter(prefix="/actions", tags=["actions"])
 @router.post("/batch-positions", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("workflow:update")
 async def batch_update_positions(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     workflow_id: AnyWorkflowIDPath,
     params: BatchPositionUpdate,
     session: AsyncDBSession,
@@ -51,7 +51,7 @@ async def batch_update_positions(
 @router.get("")
 @require_scope("workflow:read")
 async def list_actions(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     workflow_id: AnyWorkflowIDPath,
     session: AsyncDBSession,
 ) -> list[ActionReadMinimal]:
@@ -75,7 +75,7 @@ async def list_actions(
 @router.post("")
 @require_scope("workflow:create")
 async def create_action(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     params: ActionCreate,
     session: AsyncDBSession,
 ) -> ActionReadMinimal:
@@ -107,7 +107,7 @@ async def create_action(
 @router.get("/{action_id}")
 @require_scope("workflow:read")
 async def get_action(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     action_id: AnyActionIDPath,
     workflow_id: AnyWorkflowIDPath,
     session: AsyncDBSession,
@@ -177,7 +177,7 @@ async def get_action(
 @router.post("/{action_id}")
 @require_scope("workflow:update")
 async def update_action(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     action_id: AnyActionIDPath,
     workflow_id: AnyWorkflowIDPath,
     params: ActionUpdate,
@@ -198,7 +198,7 @@ async def update_action(
 @router.delete("/{action_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("workflow:delete")
 async def delete_action(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     action_id: AnyActionIDPath,
     workflow_id: AnyWorkflowIDPath,
     session: AsyncDBSession,

--- a/tracecat/workflow/executions/dependencies.py
+++ b/tracecat/workflow/executions/dependencies.py
@@ -3,7 +3,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, Query, status
 
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.auth.enums import SpecialUserID
 from tracecat.identifiers import UserID
 from tracecat.identifiers.workflow import WorkflowExecutionID

--- a/tracecat/workflow/executions/dependencies.py
+++ b/tracecat/workflow/executions/dependencies.py
@@ -3,7 +3,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, Query, status
 
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.auth.enums import SpecialUserID
 from tracecat.identifiers import UserID
 from tracecat.identifiers.workflow import WorkflowExecutionID
@@ -18,7 +18,7 @@ UnquotedExecutionID = Annotated[WorkflowExecutionID, Depends(unquote_dep)]
 
 
 def resolve_triggered_by_user_id(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     triggered_by_user_id: UserID | SpecialUserID | None = Query(
         default=None,
         alias="user_id",

--- a/tracecat/workflow/executions/dependencies.py
+++ b/tracecat/workflow/executions/dependencies.py
@@ -3,7 +3,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, Query, status
 
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.auth.enums import SpecialUserID
 from tracecat.identifiers import UserID
 from tracecat.identifiers.workflow import WorkflowExecutionID
@@ -18,7 +18,7 @@ UnquotedExecutionID = Annotated[WorkflowExecutionID, Depends(unquote_dep)]
 
 
 def resolve_triggered_by_user_id(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     triggered_by_user_id: UserID | SpecialUserID | None = Query(
         default=None,
         alias="user_id",

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -14,7 +14,12 @@ import tracecat.agent.adapter.vercel
 from tracecat import config
 from tracecat.agent.schemas import AgentOutput
 from tracecat.agent.types import ClaudeSDKMessageTA
-from tracecat.auth.dependencies import WorkspaceActorRole, WorkspaceUserRole
+from tracecat.auth.dependencies import (
+    WorkspaceActorRouteRole as WorkspaceActorRole,
+)
+from tracecat.auth.dependencies import (
+    WorkspaceUserRouteRole as WorkspaceUserRole,
+)
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -34,7 +34,10 @@ from tracecat.ee.interactions.service import InteractionService
 from tracecat.exceptions import TracecatValidationError
 from tracecat.identifiers import UserID
 from tracecat.identifiers.workflow import (
+    AnyWorkflowIDPath,
     OptionalAnyWorkflowIDQuery,
+    WorkflowExecutionID,
+    WorkflowExecutionSuffixID,
     WorkflowIDShort,
     WorkflowUUID,
     exec_id_to_parts,
@@ -95,6 +98,7 @@ from tracecat.workflow.executions.service import (
 from tracecat.workflow.management.management import WorkflowsManagementService
 
 router = APIRouter(prefix="/workflow-executions", tags=["workflow-executions"])
+workflow_router = APIRouter(prefix="/workflows", tags=["workflow-executions"])
 PREVIEW_MAX_BYTES = 256 * 1024  # 256 KB
 COLLECTION_PAGE_PREVIEW_MAX_BYTES = 4 * 1024  # 4 KB per item preview in page responses
 
@@ -600,14 +604,11 @@ async def bulk_reset_workflow_executions(
     return WorkflowExecutionBulkResetResponse(results=results)
 
 
-@router.get("/{execution_id}")
-@require_scope("workflow:read")
-async def get_workflow_execution(
+async def _get_workflow_execution_response(
     role: WorkspaceActorRole,
-    execution_id: UnquotedExecutionID,
+    execution_id: WorkflowExecutionID,
     session: AsyncDBSession,
 ) -> WorkflowExecutionRead:
-    """Get a workflow execution."""
     logger.debug("Getting workflow execution", execution_id=execution_id)
     service = await WorkflowExecutionsService.connect(role=role)
     execution = await service.get_execution(execution_id)
@@ -637,6 +638,38 @@ async def get_workflow_execution(
         execution_type=get_execution_type_from_search_attr(
             execution.typed_search_attributes
         ),
+    )
+
+
+@workflow_router.get("/{workflow_id}/executions/{execution_id}")
+@require_scope("workflow:read")
+async def get_workflow_execution_by_workflow_id(
+    role: WorkspaceActorRole,
+    workflow_id: AnyWorkflowIDPath,
+    execution_id: WorkflowExecutionSuffixID,
+    session: AsyncDBSession,
+) -> WorkflowExecutionRead:
+    """Get a workflow execution by workflow ID and execution suffix."""
+    full_execution_id: WorkflowExecutionID = f"{workflow_id.short()}/{execution_id}"
+    return await _get_workflow_execution_response(
+        role=role,
+        execution_id=full_execution_id,
+        session=session,
+    )
+
+
+@router.get("/{execution_id}")
+@require_scope("workflow:read")
+async def get_workflow_execution(
+    role: WorkspaceActorRole,
+    execution_id: UnquotedExecutionID,
+    session: AsyncDBSession,
+) -> WorkflowExecutionRead:
+    """Get a workflow execution."""
+    return await _get_workflow_execution_response(
+        role=role,
+        execution_id=execution_id,
+        session=session,
     )
 
 

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -15,10 +15,8 @@ from tracecat import config
 from tracecat.agent.schemas import AgentOutput
 from tracecat.agent.types import ClaudeSDKMessageTA
 from tracecat.auth.dependencies import (
-    WorkspaceActorRouteRole as WorkspaceActorRole,
-)
-from tracecat.auth.dependencies import (
-    WorkspaceUserRouteRole as WorkspaceUserRole,
+    WorkspaceActor,
+    WorkspaceUser,
 )
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
@@ -375,7 +373,7 @@ def _to_workflow_run_read_minimal(
 @router.get("")
 @require_scope("workflow:read")
 async def list_workflow_executions(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     # Filters
     workflow_id: OptionalAnyWorkflowIDQuery,
     trigger_types: set[TriggerType] | None = Query(None, alias="trigger"),
@@ -416,7 +414,7 @@ async def list_workflow_executions(
 @router.get("/search")
 @require_scope("workflow:read")
 async def search_workflow_executions(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: OptionalAnyWorkflowIDQuery,
     pagination: CursorPaginationParams = Depends(
@@ -539,7 +537,7 @@ async def search_workflow_executions(
 @router.get("/{execution_id:path}/reset-points")
 @require_scope("workflow:read")
 async def list_workflow_execution_reset_points(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     execution_id: UnquotedExecutionID,
     limit: int = Query(default=100, ge=1, le=500),
 ) -> list[WorkflowExecutionResetPointRead]:
@@ -561,7 +559,7 @@ async def list_workflow_execution_reset_points(
 @router.post("/{execution_id:path}/reset")
 @require_scope("workflow:terminate")
 async def reset_workflow_execution(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     execution_id: UnquotedExecutionID,
     params: WorkflowExecutionResetRequest,
 ) -> WorkflowExecutionResetResponse:
@@ -591,7 +589,7 @@ async def reset_workflow_execution(
 @router.post("/reset/bulk")
 @require_scope("workflow:terminate")
 async def bulk_reset_workflow_executions(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     params: WorkflowExecutionBulkResetRequest,
 ) -> WorkflowExecutionBulkResetResponse:
     service = await WorkflowExecutionsService.connect(role=role)
@@ -605,7 +603,7 @@ async def bulk_reset_workflow_executions(
 
 
 async def _get_workflow_execution_response(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     execution_id: WorkflowExecutionID,
     session: AsyncDBSession,
 ) -> WorkflowExecutionRead:
@@ -644,7 +642,7 @@ async def _get_workflow_execution_response(
 @workflow_router.get("/{workflow_id}/executions/{execution_id}")
 @require_scope("workflow:read")
 async def get_workflow_execution_by_workflow_id(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     workflow_id: AnyWorkflowIDPath,
     execution_id: WorkflowExecutionSuffixID,
     session: AsyncDBSession,
@@ -661,7 +659,7 @@ async def get_workflow_execution_by_workflow_id(
 @router.get("/{execution_id}")
 @require_scope("workflow:read")
 async def get_workflow_execution(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     execution_id: UnquotedExecutionID,
     session: AsyncDBSession,
 ) -> WorkflowExecutionRead:
@@ -676,7 +674,7 @@ async def get_workflow_execution(
 @router.get("/{execution_id:path}/compact")
 @require_scope("workflow:read")
 async def get_workflow_execution_compact(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     execution_id: UnquotedExecutionID,
     session: AsyncDBSession,
 ) -> WorkflowExecutionReadCompact[Any, AgentOutput | Any, Any]:
@@ -745,7 +743,7 @@ async def get_workflow_execution_compact(
 @router.post("/{execution_id:path}/objects/download")
 @require_scope("workflow:read")
 async def get_workflow_execution_object_download(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     execution_id: UnquotedExecutionID,
     params: WorkflowExecutionObjectRequest,
 ) -> WorkflowExecutionObjectDownloadResponse:
@@ -830,7 +828,7 @@ async def get_workflow_execution_object_download(
 @router.post("/{execution_id:path}/objects/preview")
 @require_scope("workflow:read")
 async def get_workflow_execution_object_preview(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     execution_id: UnquotedExecutionID,
     params: WorkflowExecutionObjectRequest,
 ) -> WorkflowExecutionObjectPreviewResponse:
@@ -901,7 +899,7 @@ async def get_workflow_execution_object_preview(
 @router.post("/{execution_id:path}/objects/collection/page")
 @require_scope("workflow:read")
 async def get_workflow_execution_collection_page(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     execution_id: UnquotedExecutionID,
     params: WorkflowExecutionCollectionPageRequest,
 ) -> WorkflowExecutionCollectionPageResponse:
@@ -998,7 +996,7 @@ async def get_workflow_execution_collection_page(
 @router.post("")
 @require_scope("workflow:execute")
 async def create_workflow_execution(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     params: WorkflowExecutionCreate,
     session: AsyncDBSession,
 ) -> WorkflowExecutionCreateResponse:
@@ -1050,7 +1048,7 @@ async def create_workflow_execution(
 @router.post("/draft")
 @require_scope("workflow:execute")
 async def create_draft_workflow_execution(
-    role: WorkspaceUserRole,
+    role: WorkspaceUser,
     params: WorkflowExecutionCreate,
     session: AsyncDBSession,
 ) -> WorkflowExecutionCreateResponse:
@@ -1128,7 +1126,7 @@ async def create_draft_workflow_execution(
 )
 @require_scope("workflow:terminate")
 async def cancel_workflow_execution(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     execution_id: UnquotedExecutionID,
 ) -> None:
     """Get a workflow execution."""
@@ -1156,7 +1154,7 @@ async def cancel_workflow_execution(
 )
 @require_scope("workflow:terminate")
 async def terminate_workflow_execution(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     execution_id: UnquotedExecutionID,
     params: WorkflowExecutionTerminate,
 ) -> None:

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -15,8 +15,8 @@ from tracecat import config
 from tracecat.agent.schemas import AgentOutput
 from tracecat.agent.types import ClaudeSDKMessageTA
 from tracecat.auth.dependencies import (
-    WorkspaceActor,
-    WorkspaceUser,
+    WorkspaceActorRouteRole,
+    WorkspaceUserRouteRole,
 )
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
@@ -373,7 +373,7 @@ def _to_workflow_run_read_minimal(
 @router.get("")
 @require_scope("workflow:read")
 async def list_workflow_executions(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     # Filters
     workflow_id: OptionalAnyWorkflowIDQuery,
     trigger_types: set[TriggerType] | None = Query(None, alias="trigger"),
@@ -414,7 +414,7 @@ async def list_workflow_executions(
 @router.get("/search")
 @require_scope("workflow:read")
 async def search_workflow_executions(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: OptionalAnyWorkflowIDQuery,
     pagination: CursorPaginationParams = Depends(
@@ -537,7 +537,7 @@ async def search_workflow_executions(
 @router.get("/{execution_id:path}/reset-points")
 @require_scope("workflow:read")
 async def list_workflow_execution_reset_points(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     execution_id: UnquotedExecutionID,
     limit: int = Query(default=100, ge=1, le=500),
 ) -> list[WorkflowExecutionResetPointRead]:
@@ -559,7 +559,7 @@ async def list_workflow_execution_reset_points(
 @router.post("/{execution_id:path}/reset")
 @require_scope("workflow:terminate")
 async def reset_workflow_execution(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     execution_id: UnquotedExecutionID,
     params: WorkflowExecutionResetRequest,
 ) -> WorkflowExecutionResetResponse:
@@ -589,7 +589,7 @@ async def reset_workflow_execution(
 @router.post("/reset/bulk")
 @require_scope("workflow:terminate")
 async def bulk_reset_workflow_executions(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     params: WorkflowExecutionBulkResetRequest,
 ) -> WorkflowExecutionBulkResetResponse:
     service = await WorkflowExecutionsService.connect(role=role)
@@ -603,7 +603,7 @@ async def bulk_reset_workflow_executions(
 
 
 async def _get_workflow_execution_response(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     execution_id: WorkflowExecutionID,
     session: AsyncDBSession,
 ) -> WorkflowExecutionRead:
@@ -642,7 +642,7 @@ async def _get_workflow_execution_response(
 @workflow_router.get("/{workflow_id}/executions/{execution_id}")
 @require_scope("workflow:read")
 async def get_workflow_execution_by_workflow_id(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     workflow_id: AnyWorkflowIDPath,
     execution_id: WorkflowExecutionSuffixID,
     session: AsyncDBSession,
@@ -659,7 +659,7 @@ async def get_workflow_execution_by_workflow_id(
 @router.get("/{execution_id}")
 @require_scope("workflow:read")
 async def get_workflow_execution(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     execution_id: UnquotedExecutionID,
     session: AsyncDBSession,
 ) -> WorkflowExecutionRead:
@@ -674,7 +674,7 @@ async def get_workflow_execution(
 @router.get("/{execution_id:path}/compact")
 @require_scope("workflow:read")
 async def get_workflow_execution_compact(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     execution_id: UnquotedExecutionID,
     session: AsyncDBSession,
 ) -> WorkflowExecutionReadCompact[Any, AgentOutput | Any, Any]:
@@ -743,7 +743,7 @@ async def get_workflow_execution_compact(
 @router.post("/{execution_id:path}/objects/download")
 @require_scope("workflow:read")
 async def get_workflow_execution_object_download(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     execution_id: UnquotedExecutionID,
     params: WorkflowExecutionObjectRequest,
 ) -> WorkflowExecutionObjectDownloadResponse:
@@ -828,7 +828,7 @@ async def get_workflow_execution_object_download(
 @router.post("/{execution_id:path}/objects/preview")
 @require_scope("workflow:read")
 async def get_workflow_execution_object_preview(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     execution_id: UnquotedExecutionID,
     params: WorkflowExecutionObjectRequest,
 ) -> WorkflowExecutionObjectPreviewResponse:
@@ -899,7 +899,7 @@ async def get_workflow_execution_object_preview(
 @router.post("/{execution_id:path}/objects/collection/page")
 @require_scope("workflow:read")
 async def get_workflow_execution_collection_page(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     execution_id: UnquotedExecutionID,
     params: WorkflowExecutionCollectionPageRequest,
 ) -> WorkflowExecutionCollectionPageResponse:
@@ -996,7 +996,7 @@ async def get_workflow_execution_collection_page(
 @router.post("")
 @require_scope("workflow:execute")
 async def create_workflow_execution(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     params: WorkflowExecutionCreate,
     session: AsyncDBSession,
 ) -> WorkflowExecutionCreateResponse:
@@ -1048,7 +1048,7 @@ async def create_workflow_execution(
 @router.post("/draft")
 @require_scope("workflow:execute")
 async def create_draft_workflow_execution(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     params: WorkflowExecutionCreate,
     session: AsyncDBSession,
 ) -> WorkflowExecutionCreateResponse:
@@ -1126,7 +1126,7 @@ async def create_draft_workflow_execution(
 )
 @require_scope("workflow:terminate")
 async def cancel_workflow_execution(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     execution_id: UnquotedExecutionID,
 ) -> None:
     """Get a workflow execution."""
@@ -1154,7 +1154,7 @@ async def cancel_workflow_execution(
 )
 @require_scope("workflow:terminate")
 async def terminate_workflow_execution(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     execution_id: UnquotedExecutionID,
     params: WorkflowExecutionTerminate,
 ) -> None:

--- a/tracecat/workflow/graph/router.py
+++ b/tracecat/workflow/graph/router.py
@@ -7,7 +7,7 @@ This module provides the canonical graph API endpoints:
 
 from fastapi import APIRouter, HTTPException, status
 
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.identifiers.workflow import AnyWorkflowIDPath

--- a/tracecat/workflow/graph/router.py
+++ b/tracecat/workflow/graph/router.py
@@ -7,7 +7,7 @@ This module provides the canonical graph API endpoints:
 
 from fastapi import APIRouter, HTTPException, status
 
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.identifiers.workflow import AnyWorkflowIDPath
@@ -26,7 +26,7 @@ router = APIRouter(
 @router.get("")
 @require_scope("workflow:read")
 async def get_graph(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     workflow_id: AnyWorkflowIDPath,
     session: AsyncDBSession,
 ) -> GraphResponse:
@@ -48,7 +48,7 @@ async def get_graph(
 @router.patch("")
 @require_scope("workflow:update")
 async def apply_graph_operations(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     workflow_id: AnyWorkflowIDPath,
     request: GraphOperationsRequest,
     session: AsyncDBSession,

--- a/tracecat/workflow/graph/router.py
+++ b/tracecat/workflow/graph/router.py
@@ -7,7 +7,7 @@ This module provides the canonical graph API endpoints:
 
 from fastapi import APIRouter, HTTPException, status
 
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.identifiers.workflow import AnyWorkflowIDPath
@@ -26,7 +26,7 @@ router = APIRouter(
 @router.get("")
 @require_scope("workflow:read")
 async def get_graph(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     workflow_id: AnyWorkflowIDPath,
     session: AsyncDBSession,
 ) -> GraphResponse:
@@ -48,7 +48,7 @@ async def get_graph(
 @router.patch("")
 @require_scope("workflow:update")
 async def apply_graph_operations(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     workflow_id: AnyWorkflowIDPath,
     request: GraphOperationsRequest,
     session: AsyncDBSession,

--- a/tracecat/workflow/management/folders/router.py
+++ b/tracecat/workflow/management/folders/router.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError

--- a/tracecat/workflow/management/folders/router.py
+++ b/tracecat/workflow/management/folders/router.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
@@ -23,7 +23,7 @@ router = APIRouter(prefix="/folders", tags=["folders"])
 @router.get("/directory")
 @require_scope("workflow:read")
 async def get_directory(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     path: str = Query(default="/", description="Folder path"),
 ) -> list[DirectoryItem]:
@@ -39,7 +39,7 @@ async def get_directory(
 @router.get("")
 @require_scope("workflow:read")
 async def list_folders(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     parent_path: str = Query(default="/", description="Parent folder path"),
 ) -> list[WorkflowFolderRead]:
@@ -62,7 +62,7 @@ async def list_folders(
 @router.post("", status_code=status.HTTP_201_CREATED)
 @require_scope("workflow:create")
 async def create_folder(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     params: WorkflowFolderCreate,
 ) -> WorkflowFolderRead:
@@ -83,7 +83,7 @@ async def create_folder(
 @router.get("/{folder_id}")
 @require_scope("workflow:read")
 async def get_folder(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     folder_id: UUID,
 ) -> WorkflowFolderRead:
@@ -100,7 +100,7 @@ async def get_folder(
 @router.patch("/{folder_id}")
 @require_scope("workflow:update")
 async def update_folder(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     folder_id: UUID,
     params: WorkflowFolderUpdate,
@@ -131,7 +131,7 @@ async def update_folder(
 @router.delete("/{folder_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("workflow:delete")
 async def delete_folder(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     folder_id: UUID,
     params: WorkflowFolderDelete,
@@ -157,7 +157,7 @@ async def delete_folder(
 @router.post("/{folder_id}/move")
 @require_scope("workflow:update")
 async def move_folder(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     folder_id: UUID,
     params: WorkflowFolderMove,

--- a/tracecat/workflow/management/folders/router.py
+++ b/tracecat/workflow/management/folders/router.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
@@ -23,7 +23,7 @@ router = APIRouter(prefix="/folders", tags=["folders"])
 @router.get("/directory")
 @require_scope("workflow:read")
 async def get_directory(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     path: str = Query(default="/", description="Folder path"),
 ) -> list[DirectoryItem]:
@@ -39,7 +39,7 @@ async def get_directory(
 @router.get("")
 @require_scope("workflow:read")
 async def list_folders(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     parent_path: str = Query(default="/", description="Parent folder path"),
 ) -> list[WorkflowFolderRead]:
@@ -62,7 +62,7 @@ async def list_folders(
 @router.post("", status_code=status.HTTP_201_CREATED)
 @require_scope("workflow:create")
 async def create_folder(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     params: WorkflowFolderCreate,
 ) -> WorkflowFolderRead:
@@ -83,7 +83,7 @@ async def create_folder(
 @router.get("/{folder_id}")
 @require_scope("workflow:read")
 async def get_folder(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     folder_id: UUID,
 ) -> WorkflowFolderRead:
@@ -100,7 +100,7 @@ async def get_folder(
 @router.patch("/{folder_id}")
 @require_scope("workflow:update")
 async def update_folder(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     folder_id: UUID,
     params: WorkflowFolderUpdate,
@@ -131,7 +131,7 @@ async def update_folder(
 @router.delete("/{folder_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("workflow:delete")
 async def delete_folder(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     folder_id: UUID,
     params: WorkflowFolderDelete,
@@ -157,7 +157,7 @@ async def delete_folder(
 @router.post("/{folder_id}/move")
 @require_scope("workflow:update")
 async def move_folder(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     folder_id: UUID,
     params: WorkflowFolderMove,

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -24,7 +24,12 @@ from sqlalchemy.exc import IntegrityError, NoResultFound
 
 from tracecat import config
 from tracecat.auth.api_keys import generate_api_key
-from tracecat.auth.dependencies import WorkspaceActorRole, WorkspaceUserRole
+from tracecat.auth.dependencies import (
+    WorkspaceActorRouteRole as WorkspaceActorRole,
+)
+from tracecat.auth.dependencies import (
+    WorkspaceUserRouteRole as WorkspaceUserRole,
+)
 from tracecat.authz.controls import require_scope
 from tracecat.db.common import DBConstraints
 from tracecat.db.dependencies import AsyncDBSession

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -25,10 +25,8 @@ from sqlalchemy.exc import IntegrityError, NoResultFound
 from tracecat import config
 from tracecat.auth.api_keys import generate_api_key
 from tracecat.auth.dependencies import (
-    WorkspaceActorRouteRole as WorkspaceActorRole,
-)
-from tracecat.auth.dependencies import (
-    WorkspaceUserRouteRole as WorkspaceUserRole,
+    WorkspaceActor,
+    WorkspaceUser,
 )
 from tracecat.authz.controls import require_scope
 from tracecat.db.common import DBConstraints
@@ -100,7 +98,7 @@ router = APIRouter(prefix="/workflows")
 @router.get("", tags=["workflows"])
 @require_scope("workflow:read")
 async def list_workflows(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     filter_tags: list[str] | None = Query(
         default=None,
@@ -154,7 +152,7 @@ async def list_workflows(
 @router.post("/validate-entrypoint", tags=["workflows"])
 @require_scope("workflow:read")
 async def validate_workflow_entrypoint(
-    _role: WorkspaceActorRole,
+    _role: WorkspaceActor,
     payload: WorkflowEntrypointValidationRequest,
 ) -> WorkflowEntrypointValidationResponse:
     """Validate a workflow entrypoint expects definition."""
@@ -221,7 +219,7 @@ def wfs_and_defns_to_response(
 @router.post("", status_code=status.HTTP_201_CREATED, tags=["workflows"])
 @require_scope("workflow:create")
 async def create_workflow(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     title: str | None = Form(default=None, min_length=1, max_length=100),
     description: str | None = Form(default=None, max_length=1000),
@@ -337,7 +335,7 @@ async def create_workflow(
 @router.get("/{workflow_id}", tags=["workflows"])
 @require_scope("workflow:read")
 async def get_workflow(
-    role: WorkspaceUserRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> WorkflowRead:
@@ -394,7 +392,7 @@ async def get_workflow(
 )
 @require_scope("workflow:update")
 async def update_workflow(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: WorkflowUpdate,
@@ -431,7 +429,7 @@ async def update_workflow(
 )
 @require_scope("workflow:delete")
 async def delete_workflow(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> None:
@@ -449,7 +447,7 @@ async def delete_workflow(
 @router.post("/{workflow_id}/commit", tags=["workflows"])
 @require_scope("workflow:update")
 async def commit_workflow(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> WorkflowCommitResponse:
@@ -586,7 +584,7 @@ async def commit_workflow(
 @router.get("/{workflow_id}/export", tags=["workflows"])
 @require_scope("workflow:read")
 async def export_workflow(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     format: Literal["json", "yaml"] = Query(
@@ -707,7 +705,7 @@ async def export_workflow(
 @router.get("/{workflow_id}/definitions", tags=["workflows"])
 @require_scope("workflow:read")
 async def list_workflow_definitions(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> list[WorkflowDefinitionRead]:
@@ -724,7 +722,7 @@ async def list_workflow_definitions(
 )
 @require_scope("workflow:update")
 async def restore_workflow_definition(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     version: int = Path(..., ge=1),
@@ -776,7 +774,7 @@ async def restore_workflow_definition(
 @router.get("/{workflow_id}/definition", tags=["workflows"])
 @require_scope("workflow:read")
 async def get_workflow_definition(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     version: int | None = None,
@@ -796,7 +794,7 @@ async def get_workflow_definition(
 @router.post("/{workflow_id}/definition", tags=["workflows"])
 @require_scope("workflow:create")
 async def create_workflow_definition(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> WorkflowDefinitionRead:
@@ -814,7 +812,7 @@ async def create_workflow_definition(
 )
 @require_scope("workflow:update")
 async def create_webhook(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: WebhookCreate,
@@ -843,7 +841,7 @@ async def create_webhook(
 )
 @require_scope("workflow:read")
 async def get_webhook(
-    role: WorkspaceUserRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> WebhookRead:
@@ -871,7 +869,7 @@ async def get_webhook(
 )
 @require_scope("workflow:update")
 async def update_webhook(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: WebhookUpdate,
@@ -912,7 +910,7 @@ async def update_webhook(
 )
 @require_scope("workflow:create")
 async def create_case_trigger(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: CaseTriggerCreate,
@@ -937,7 +935,7 @@ async def create_case_trigger(
 )
 @require_scope("workflow:read")
 async def get_case_trigger(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> CaseTriggerRead:
@@ -957,7 +955,7 @@ async def get_case_trigger(
 )
 @require_scope("workflow:update")
 async def update_case_trigger(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: CaseTriggerUpdate,
@@ -981,7 +979,7 @@ async def update_case_trigger(
 )
 @require_scope("workflow:update")
 async def generate_webhook_api_key(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> WebhookApiKeyGenerateResponse:
@@ -1035,7 +1033,7 @@ async def generate_webhook_api_key(
 )
 @require_scope("workflow:update")
 async def revoke_webhook_api_key(
-    role: WorkspaceUserRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> None:
@@ -1071,7 +1069,7 @@ async def revoke_webhook_api_key(
 )
 @require_scope("workflow:delete")
 async def delete_webhook_api_key(
-    role: WorkspaceUserRole,
+    role: WorkspaceUser,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> None:
@@ -1100,7 +1098,7 @@ async def delete_webhook_api_key(
 )
 @require_scope("workflow:update")
 async def move_workflow_to_folder(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: WorkflowMoveToFolder,

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -25,8 +25,8 @@ from sqlalchemy.exc import IntegrityError, NoResultFound
 from tracecat import config
 from tracecat.auth.api_keys import generate_api_key
 from tracecat.auth.dependencies import (
-    WorkspaceActor,
-    WorkspaceUser,
+    WorkspaceActorRouteRole,
+    WorkspaceUserRouteRole,
 )
 from tracecat.authz.controls import require_scope
 from tracecat.db.common import DBConstraints
@@ -98,7 +98,7 @@ router = APIRouter(prefix="/workflows")
 @router.get("", tags=["workflows"])
 @require_scope("workflow:read")
 async def list_workflows(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     filter_tags: list[str] | None = Query(
         default=None,
@@ -152,7 +152,7 @@ async def list_workflows(
 @router.post("/validate-entrypoint", tags=["workflows"])
 @require_scope("workflow:read")
 async def validate_workflow_entrypoint(
-    _role: WorkspaceActor,
+    _role: WorkspaceActorRouteRole,
     payload: WorkflowEntrypointValidationRequest,
 ) -> WorkflowEntrypointValidationResponse:
     """Validate a workflow entrypoint expects definition."""
@@ -219,7 +219,7 @@ def wfs_and_defns_to_response(
 @router.post("", status_code=status.HTTP_201_CREATED, tags=["workflows"])
 @require_scope("workflow:create")
 async def create_workflow(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     title: str | None = Form(default=None, min_length=1, max_length=100),
     description: str | None = Form(default=None, max_length=1000),
@@ -335,7 +335,7 @@ async def create_workflow(
 @router.get("/{workflow_id}", tags=["workflows"])
 @require_scope("workflow:read")
 async def get_workflow(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> WorkflowRead:
@@ -392,7 +392,7 @@ async def get_workflow(
 )
 @require_scope("workflow:update")
 async def update_workflow(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: WorkflowUpdate,
@@ -429,7 +429,7 @@ async def update_workflow(
 )
 @require_scope("workflow:delete")
 async def delete_workflow(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> None:
@@ -447,7 +447,7 @@ async def delete_workflow(
 @router.post("/{workflow_id}/commit", tags=["workflows"])
 @require_scope("workflow:update")
 async def commit_workflow(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> WorkflowCommitResponse:
@@ -584,7 +584,7 @@ async def commit_workflow(
 @router.get("/{workflow_id}/export", tags=["workflows"])
 @require_scope("workflow:read")
 async def export_workflow(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     format: Literal["json", "yaml"] = Query(
@@ -705,7 +705,7 @@ async def export_workflow(
 @router.get("/{workflow_id}/definitions", tags=["workflows"])
 @require_scope("workflow:read")
 async def list_workflow_definitions(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> list[WorkflowDefinitionRead]:
@@ -722,7 +722,7 @@ async def list_workflow_definitions(
 )
 @require_scope("workflow:update")
 async def restore_workflow_definition(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     version: int = Path(..., ge=1),
@@ -774,7 +774,7 @@ async def restore_workflow_definition(
 @router.get("/{workflow_id}/definition", tags=["workflows"])
 @require_scope("workflow:read")
 async def get_workflow_definition(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     version: int | None = None,
@@ -794,7 +794,7 @@ async def get_workflow_definition(
 @router.post("/{workflow_id}/definition", tags=["workflows"])
 @require_scope("workflow:create")
 async def create_workflow_definition(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> WorkflowDefinitionRead:
@@ -812,7 +812,7 @@ async def create_workflow_definition(
 )
 @require_scope("workflow:update")
 async def create_webhook(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: WebhookCreate,
@@ -841,7 +841,7 @@ async def create_webhook(
 )
 @require_scope("workflow:read")
 async def get_webhook(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> WebhookRead:
@@ -869,7 +869,7 @@ async def get_webhook(
 )
 @require_scope("workflow:update")
 async def update_webhook(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: WebhookUpdate,
@@ -910,7 +910,7 @@ async def update_webhook(
 )
 @require_scope("workflow:create")
 async def create_case_trigger(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: CaseTriggerCreate,
@@ -935,7 +935,7 @@ async def create_case_trigger(
 )
 @require_scope("workflow:read")
 async def get_case_trigger(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> CaseTriggerRead:
@@ -955,7 +955,7 @@ async def get_case_trigger(
 )
 @require_scope("workflow:update")
 async def update_case_trigger(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: CaseTriggerUpdate,
@@ -979,7 +979,7 @@ async def update_case_trigger(
 )
 @require_scope("workflow:update")
 async def generate_webhook_api_key(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> WebhookApiKeyGenerateResponse:
@@ -1033,7 +1033,7 @@ async def generate_webhook_api_key(
 )
 @require_scope("workflow:update")
 async def revoke_webhook_api_key(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> None:
@@ -1069,7 +1069,7 @@ async def revoke_webhook_api_key(
 )
 @require_scope("workflow:delete")
 async def delete_webhook_api_key(
-    role: WorkspaceUser,
+    role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> None:
@@ -1098,7 +1098,7 @@ async def delete_webhook_api_key(
 )
 @require_scope("workflow:update")
 async def move_workflow_to_folder(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: WorkflowMoveToFolder,

--- a/tracecat/workflow/schedules/router.py
+++ b/tracecat/workflow/schedules/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, status
 from sqlalchemy import select
 
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.models import Schedule

--- a/tracecat/workflow/schedules/router.py
+++ b/tracecat/workflow/schedules/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, status
 from sqlalchemy import select
 
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.models import Schedule
@@ -24,7 +24,7 @@ router = APIRouter(prefix="/schedules", tags=["schedules"])
 @router.get("", response_model=list[ScheduleRead])
 @require_scope("schedule:read")
 async def list_schedules(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: OptionalAnyWorkflowIDQuery,
 ) -> list[ScheduleRead]:
@@ -36,7 +36,7 @@ async def list_schedules(
 @router.post("", response_model=ScheduleRead)
 @require_scope("schedule:create")
 async def create_schedule(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     params: ScheduleCreate,
 ) -> ScheduleRead:
@@ -68,7 +68,7 @@ async def create_schedule(
 @router.get("/{schedule_id}", response_model=ScheduleRead)
 @require_scope("schedule:read")
 async def get_schedule(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     schedule_id: AnyScheduleIDPath,
 ) -> ScheduleRead:
@@ -88,7 +88,7 @@ async def get_schedule(
 @router.post("/{schedule_id}", response_model=ScheduleRead)
 @require_scope("schedule:update")
 async def update_schedule(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     schedule_id: AnyScheduleIDPath,
     params: ScheduleUpdate,
@@ -114,7 +114,9 @@ async def update_schedule(
 @router.delete("/{schedule_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("schedule:delete")
 async def delete_schedule(
-    role: WorkspaceActorRole, session: AsyncDBSession, schedule_id: AnyScheduleIDPath
+    role: WorkspaceActor,
+    session: AsyncDBSession,
+    schedule_id: AnyScheduleIDPath,
 ) -> None:
     """Delete a schedule from a workflow."""
     service = WorkflowSchedulesService(session, role=role)
@@ -131,7 +133,7 @@ async def delete_schedule(
 @router.get("/search", response_model=list[ScheduleRead])
 @require_scope("schedule:read")
 async def search_schedules(
-    role: WorkspaceActorRole, session: AsyncDBSession, params: ScheduleSearch
+    role: WorkspaceActor, session: AsyncDBSession, params: ScheduleSearch
 ) -> list[ScheduleRead]:
     """**[WORK IN PROGRESS]** Search for schedules."""
     statement = select(Schedule).where(Schedule.workspace_id == role.workspace_id)

--- a/tracecat/workflow/schedules/router.py
+++ b/tracecat/workflow/schedules/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, status
 from sqlalchemy import select
 
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.models import Schedule
@@ -24,7 +24,7 @@ router = APIRouter(prefix="/schedules", tags=["schedules"])
 @router.get("", response_model=list[ScheduleRead])
 @require_scope("schedule:read")
 async def list_schedules(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: OptionalAnyWorkflowIDQuery,
 ) -> list[ScheduleRead]:
@@ -36,7 +36,7 @@ async def list_schedules(
 @router.post("", response_model=ScheduleRead)
 @require_scope("schedule:create")
 async def create_schedule(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     params: ScheduleCreate,
 ) -> ScheduleRead:
@@ -68,7 +68,7 @@ async def create_schedule(
 @router.get("/{schedule_id}", response_model=ScheduleRead)
 @require_scope("schedule:read")
 async def get_schedule(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     schedule_id: AnyScheduleIDPath,
 ) -> ScheduleRead:
@@ -88,7 +88,7 @@ async def get_schedule(
 @router.post("/{schedule_id}", response_model=ScheduleRead)
 @require_scope("schedule:update")
 async def update_schedule(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     schedule_id: AnyScheduleIDPath,
     params: ScheduleUpdate,
@@ -114,7 +114,7 @@ async def update_schedule(
 @router.delete("/{schedule_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("schedule:delete")
 async def delete_schedule(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     schedule_id: AnyScheduleIDPath,
 ) -> None:
@@ -133,7 +133,7 @@ async def delete_schedule(
 @router.get("/search", response_model=list[ScheduleRead])
 @require_scope("schedule:read")
 async def search_schedules(
-    role: WorkspaceActor, session: AsyncDBSession, params: ScheduleSearch
+    role: WorkspaceActorRouteRole, session: AsyncDBSession, params: ScheduleSearch
 ) -> list[ScheduleRead]:
     """**[WORK IN PROGRESS]** Search for schedules."""
     statement = select(Schedule).where(Schedule.workspace_id == role.workspace_id)

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, Query, status
 
 from tracecat import config
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.dsl.common import DSLInput

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, Query, status
 
 from tracecat import config
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.dsl.common import DSLInput
@@ -35,7 +35,7 @@ router = APIRouter(prefix="/workflows", tags=["workflows"])
 )
 @require_scope("workflow:update", "workflow:sync")
 async def publish_workflow(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: WorkflowDslPublish,
@@ -87,7 +87,7 @@ async def publish_workflow(
 @router.get("/sync/commits", response_model=list[GitCommitInfo])
 @require_scope("workflow:sync")
 async def list_workflow_commits(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     branch: str = Query(
         default="main",
@@ -179,7 +179,7 @@ async def list_workflow_commits(
 @router.get("/sync/branches", response_model=list[GitBranchInfo])
 @require_scope("workflow:sync")
 async def list_workflow_branches(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     limit: int = Query(
         default=config.TRACECAT__LIMIT_COMMITS_DEFAULT,
@@ -249,7 +249,7 @@ async def list_workflow_branches(
 @router.post("/sync/pull", response_model=PullResult)
 @require_scope("workflow:update", "workflow:sync")
 async def pull_workflows(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     params: WorkflowSyncPullRequest,
 ) -> PullResult:

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, Query, status
 
 from tracecat import config
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.dsl.common import DSLInput
@@ -35,7 +35,7 @@ router = APIRouter(prefix="/workflows", tags=["workflows"])
 )
 @require_scope("workflow:update", "workflow:sync")
 async def publish_workflow(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: WorkflowDslPublish,
@@ -87,7 +87,7 @@ async def publish_workflow(
 @router.get("/sync/commits", response_model=list[GitCommitInfo])
 @require_scope("workflow:sync")
 async def list_workflow_commits(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     branch: str = Query(
         default="main",
@@ -179,7 +179,7 @@ async def list_workflow_commits(
 @router.get("/sync/branches", response_model=list[GitBranchInfo])
 @require_scope("workflow:sync")
 async def list_workflow_branches(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     limit: int = Query(
         default=config.TRACECAT__LIMIT_COMMITS_DEFAULT,
@@ -249,7 +249,7 @@ async def list_workflow_branches(
 @router.post("/sync/pull", response_model=PullResult)
 @require_scope("workflow:update", "workflow:sync")
 async def pull_workflows(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     params: WorkflowSyncPullRequest,
 ) -> PullResult:

--- a/tracecat/workflow/tags/router.py
+++ b/tracecat/workflow/tags/router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, status
 from pydantic import UUID4
 from sqlalchemy.exc import NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.identifiers.workflow import AnyWorkflowIDPath

--- a/tracecat/workflow/tags/router.py
+++ b/tracecat/workflow/tags/router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, status
 from pydantic import UUID4
 from sqlalchemy.exc import NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActorRouteRole as WorkspaceActorRole
+from tracecat.auth.dependencies import WorkspaceActor
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.identifiers.workflow import AnyWorkflowIDPath
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/workflows", tags=["workflows"])
 @router.get("/{workflow_id}/tags", response_model=list[TagRead])
 @require_scope("workflow:read")
 async def list_tags(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> list[TagRead]:
@@ -30,7 +30,7 @@ async def list_tags(
 @router.post("/{workflow_id}/tags", status_code=status.HTTP_201_CREATED)
 @require_scope("workflow:update")
 async def add_tag(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: WorkflowTagCreate,
@@ -49,7 +49,7 @@ async def add_tag(
 @router.delete("/{workflow_id}/tags/{tag_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("workflow:update")
 async def remove_tag(
-    role: WorkspaceActorRole,
+    role: WorkspaceActor,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     tag_id: UUID4,

--- a/tracecat/workflow/tags/router.py
+++ b/tracecat/workflow/tags/router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, status
 from pydantic import UUID4
 from sqlalchemy.exc import NoResultFound
 
-from tracecat.auth.dependencies import WorkspaceActor
+from tracecat.auth.dependencies import WorkspaceActorRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.identifiers.workflow import AnyWorkflowIDPath
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/workflows", tags=["workflows"])
 @router.get("/{workflow_id}/tags", response_model=list[TagRead])
 @require_scope("workflow:read")
 async def list_tags(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
 ) -> list[TagRead]:
@@ -30,7 +30,7 @@ async def list_tags(
 @router.post("/{workflow_id}/tags", status_code=status.HTTP_201_CREATED)
 @require_scope("workflow:update")
 async def add_tag(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     params: WorkflowTagCreate,
@@ -49,7 +49,7 @@ async def add_tag(
 @router.delete("/{workflow_id}/tags/{tag_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("workflow:update")
 async def remove_tag(
-    role: WorkspaceActor,
+    role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
     workflow_id: AnyWorkflowIDPath,
     tag_id: UUID4,


### PR DESCRIPTION
## Summary

- Add canonical `/workspaces/{workspace_id}/...` aliases for workspace-scoped public API routes while keeping the legacy flat routes registered as hidden compatibility aliases.
- Move service account API key auth to `Authorization: Bearer ...` and keep it separate from executor bearer-token auth.
- Add route-shape regression tests that verify canonical and legacy aliases share handlers and use the path-or-query workspace `RoleACL` path.
- Regenerate the frontend API client for the new OpenAPI route shape.

## API surface changes

Workspace-scoped public routes now expose the workspace in the path. The old flat routes still work at runtime, but they are hidden from OpenAPI so generated clients move to the canonical workspace-scoped shape.

### Newly documented workspace aliases

This PR moves the public OpenAPI shape for these route prefixes under `/workspaces/{workspace_id}`:

```text
/workspaces/{workspace_id}/actions
/workspaces/{workspace_id}/agent/channels/tokens
/workspaces/{workspace_id}/agent/presets
/workspaces/{workspace_id}/agent/sessions
/workspaces/{workspace_id}/agent/skills
/workspaces/{workspace_id}/agent/skills:upload
/workspaces/{workspace_id}/agent/workspace/providers/status
/workspaces/{workspace_id}/approvals
/workspaces/{workspace_id}/case-dropdowns
/workspaces/{workspace_id}/case-durations
/workspaces/{workspace_id}/case-fields
/workspaces/{workspace_id}/case-tags
/workspaces/{workspace_id}/cases
/workspaces/{workspace_id}/editor
/workspaces/{workspace_id}/folders
/workspaces/{workspace_id}/inbox
/workspaces/{workspace_id}/integrations
/workspaces/{workspace_id}/mcp-integrations
/workspaces/{workspace_id}/providers
/workspaces/{workspace_id}/schedules
/workspaces/{workspace_id}/secrets
/workspaces/{workspace_id}/tables
/workspaces/{workspace_id}/tags
/workspaces/{workspace_id}/variables
/workspaces/{workspace_id}/workflow-executions
/workspaces/{workspace_id}/workflows
```

The EE approval route is included in this migration: `/approvals/{session_id}` is now documented as `/workspaces/{workspace_id}/approvals/{session_id}`.

### Existing workspace routes

These routes were already workspace-scoped before this PR and remain in OpenAPI as-is:

```text
/workspaces
/workspaces/search
/workspaces/{workspace_id}
/workspaces/{workspace_id}/agent-models
/workspaces/{workspace_id}/invitations
/workspaces/{workspace_id}/members
/workspaces/{workspace_id}/memberships
/workspaces/{workspace_id}/service-accounts
```

### Before and after examples

| Before | After |
| --- | --- |
| `GET /workflows` | `GET /workspaces/{workspace_id}/workflows` |
| `GET /cases/{case_id}` | `GET /workspaces/{workspace_id}/cases/{case_id}` |
| `POST /workflow-executions` | `POST /workspaces/{workspace_id}/workflow-executions` |
| `GET /workflow-executions/search?workspace_id=...` | `GET /workspaces/{workspace_id}/workflow-executions/search` |
| `POST /approvals/{session_id}` | `POST /workspaces/{workspace_id}/approvals/{session_id}` |
| `POST /agent/skills:upload` | `POST /workspaces/{workspace_id}/agent/skills:upload` |
| `GET /secrets` | `GET /workspaces/{workspace_id}/secrets` |
| `GET /integrations` | `GET /workspaces/{workspace_id}/integrations` |

### Workflow execution ID ergonomics

The old direct execution lookup took the full workflow execution ID as one path parameter:

```text
GET /workflow-executions/{execution_id}
```

For canonical execution IDs like `wf_abc/exec_def`, clients had to treat the slash as part of the path parameter, so generated clients and manual callers needed to URL-encode the full ID, for example:

```text
GET /workflow-executions/wf_abc%2Fexec_def
```

This PR adds a workflow-scoped read route that splits the workflow ID and execution suffix into separate path parameters:

```text
GET /workspaces/{workspace_id}/workflows/{workflow_id}/executions/{execution_id}
```

Example:

```text
GET /workspaces/ws_123/workflows/wf_abc/executions/exec_def
```

That route reconstructs the Temporal workflow execution ID as `wf_abc/exec_def` server-side, so clients no longer need to pass the slash-bearing full execution ID for the common read-by-workflow case. Direct execution routes still exist under the canonical workspace prefix for callers that already have the full execution ID.

### Routes intentionally left flat

Some routes are not workspace-prefixed because they are callbacks, public entrypoints, organization-level APIs, platform/admin APIs, or internal APIs. Notable examples:

- Callback and public entrypoints: `/integrations/callback`, `/agent/channels/{channel_type}/{token}`, `/agent/channels/slack/oauth/callback`, `/webhooks/{workflow_id}/{secret}`
- Organization-level routes: `/organization/...`, `/organization/service-accounts/...`, `/organization/secrets/...`, `/organization/vcs/...`
- Platform/ops routes: `/admin/...`, `/settings/...`, `/registry/...`, `/feature-flags`, `/health`, `/ready`
- EE platform routes: `/rbac/...`, `/watchtower/monitor/...`
- Internal routes: `/internal/...`

## Validation

- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run basedpyright ...`
- `TRACECAT__SERVICE_KEY=test-service-key TRACECAT__SIGNING_SECRET=test-signing-secret uv run pytest tests/unit/test_role_acl.py tests/unit/api`
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`
