### PR TITLE
Support optional explicit role_id when creating workspace memberships (API, service, and UI)

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -25074,6 +25074,17 @@ export const $WorkspaceMembershipCreate = {
       format: "uuid",
       title: "User Id",
     },
+    role_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Role Id",
+    },
   },
   type: "object",
   required: ["user_id"],

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -7645,6 +7645,7 @@ export type WorkspaceMember = {
 
 export type WorkspaceMembershipCreate = {
   user_id: string
+  role_id?: string | null
 }
 
 export type WorkspaceMembershipRead = {

--- a/frontend/src/components/workspaces/add-workspace-member.tsx
+++ b/frontend/src/components/workspaces/add-workspace-member.tsx
@@ -40,7 +40,7 @@ import { useRbacRoles } from "@/lib/hooks"
 
 const addUserSchema = z.object({
   email: z.string().email(),
-  role: z.string(), // legacy role for membership creation
+  roleId: z.string().uuid("Please select a role"),
 })
 type AddUser = z.infer<typeof addUserSchema>
 
@@ -62,7 +62,7 @@ export function AddWorkspaceMember({
     resolver: zodResolver(addUserSchema),
     defaultValues: {
       email: "",
-      role: "editor",
+      roleId: "",
     },
   })
 
@@ -95,9 +95,11 @@ export function AddWorkspaceMember({
         workspaceId: workspace.id,
         requestBody: {
           user_id: userToAdd.id,
+          role_id: values.roleId,
         },
       })
       setShowDialog(false)
+      form.reset({ email: "", roleId: "" })
     } catch (e) {
       console.error("Error adding user to workspace", e)
       form.setError("email", {
@@ -150,16 +152,13 @@ export function AddWorkspaceMember({
               )}
             />
             <FormField
-              key="role"
+              key="roleId"
               control={form.control}
-              name="role"
+              name="roleId"
               render={({ field }) => (
                 <FormItem>
                   <FormLabel className="text-sm">Role</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
+                  <Select onValueChange={field.onChange} value={field.value}>
                     <FormControl>
                       <SelectTrigger>
                         <SelectValue placeholder="Select a role" />
@@ -167,7 +166,7 @@ export function AddWorkspaceMember({
                     </FormControl>
                     <SelectContent>
                       {workspaceRoles.map((role) => (
-                        <SelectItem key={role.id} value={role.slug ?? role.id}>
+                        <SelectItem key={role.id} value={role.id}>
                           {role.name}
                         </SelectItem>
                       ))}

--- a/tests/unit/test_authz_membership_service.py
+++ b/tests/unit/test_authz_membership_service.py
@@ -19,6 +19,7 @@ from tracecat.db.models import (
     Workspace,
 )
 from tracecat.db.models import Role as DBRole
+from tracecat.exceptions import TracecatValidationError
 from tracecat.workspaces.schemas import WorkspaceMembershipCreate
 
 pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("db")]
@@ -99,6 +100,24 @@ async def workspace_editor_role(
         name="Workspace Editor",
         slug="workspace-editor",
         description="Default editor role",
+        organization_id=organization.id,
+    )
+    session.add(role)
+    await session.commit()
+    await session.refresh(role)
+    return role
+
+
+@pytest.fixture
+async def workspace_admin_role(
+    session: AsyncSession, organization: Organization
+) -> DBRole:
+    """Create a workspace-admin role for custom role assignment tests."""
+    role = DBRole(
+        id=uuid.uuid4(),
+        name="Workspace Admin",
+        slug="workspace-admin",
+        description="Admin role",
         organization_id=organization.id,
     )
     session.add(role)
@@ -283,4 +302,76 @@ async def test_create_membership_duplicate_raises_integrity_error(
         await membership_service.create_membership(
             workspace_id=workspace.id,
             params=WorkspaceMembershipCreate(user_id=member_user.id),
+        )
+
+
+async def test_create_membership_with_explicit_role_id(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    actor_user: User,
+    workspace_editor_role: DBRole,
+    workspace_admin_role: DBRole,
+) -> None:
+    """Create should assign the explicitly requested workspace role."""
+    assert workspace_editor_role.slug == "workspace-editor"
+
+    await membership_service.create_membership(
+        workspace_id=workspace.id,
+        params=WorkspaceMembershipCreate(
+            user_id=member_user.id,
+            role_id=str(workspace_admin_role.id),
+        ),
+    )
+
+    assignment = await session.scalar(
+        select(UserRoleAssignment).where(
+            UserRoleAssignment.workspace_id == workspace.id,
+            UserRoleAssignment.user_id == member_user.id,
+        )
+    )
+
+    assert assignment is not None
+    assert assignment.organization_id == organization.id
+    assert assignment.role_id == workspace_admin_role.id
+    assert assignment.assigned_by == actor_user.id
+
+
+async def test_create_membership_rejects_role_outside_organization(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    workspace: Workspace,
+    member_user: User,
+    workspace_editor_role: DBRole,
+) -> None:
+    """Create should reject role IDs that do not belong to the workspace org."""
+    assert workspace_editor_role.slug == "workspace-editor"
+
+    other_org = Organization(
+        id=uuid.uuid4(),
+        name="Other Org",
+        slug=f"other-org-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    other_role = DBRole(
+        id=uuid.uuid4(),
+        name="Other Workspace Admin",
+        slug="workspace-admin",
+        description="Other org admin",
+        organization_id=other_org.id,
+    )
+    session.add_all([other_org, other_role])
+    await session.commit()
+
+    with pytest.raises(
+        TracecatValidationError, match="Role not found for organization"
+    ):
+        await membership_service.create_membership(
+            workspace_id=workspace.id,
+            params=WorkspaceMembershipCreate(
+                user_id=member_user.id,
+                role_id=str(other_role.id),
+            ),
         )

--- a/tracecat/authz/service.py
+++ b/tracecat/authz/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -139,22 +140,33 @@ class MembershipService(BaseService):
         Note: The authorization cache is request-scoped, so changes will be
         reflected in subsequent requests automatically.
         """
-        # Resolve workspace org + default role in one DB read.
-        org_role_stmt = (
-            select(Workspace.organization_id, DBRole.id)
-            .join(
-                DBRole,
-                and_(
-                    DBRole.organization_id == Workspace.organization_id,
-                    DBRole.slug == "workspace-editor",
-                ),
-            )
-            .where(Workspace.id == workspace_id)
+        org_id_stmt = select(Workspace.organization_id).where(
+            Workspace.id == workspace_id
         )
-        org_role_row = (await self.session.execute(org_role_stmt)).first()
-        if org_role_row is None:
-            raise TracecatValidationError("Workspace or default role not found")
-        organization_id, role_id = org_role_row
+        organization_id = await self.session.scalar(org_id_stmt)
+        if organization_id is None:
+            raise TracecatValidationError("Workspace not found")
+
+        if params.role_id:
+            try:
+                selected_role_id = uuid.UUID(params.role_id)
+            except ValueError as e:
+                raise TracecatValidationError("Invalid role ID format") from e
+            role_stmt = select(DBRole.id).where(
+                DBRole.id == selected_role_id,
+                DBRole.organization_id == organization_id,
+            )
+            role_id = await self.session.scalar(role_stmt)
+            if role_id is None:
+                raise TracecatValidationError("Role not found for organization")
+        else:
+            default_role_stmt = select(DBRole.id).where(
+                DBRole.organization_id == organization_id,
+                DBRole.slug == "workspace-editor",
+            )
+            role_id = await self.session.scalar(default_role_stmt)
+            if role_id is None:
+                raise TracecatValidationError("Workspace default role not found")
 
         # Heal stale direct assignments left behind by prior failed remove flows.
         await self.session.execute(

--- a/tracecat/workspaces/schemas.py
+++ b/tracecat/workspaces/schemas.py
@@ -133,6 +133,7 @@ WorkspaceSettingsUpdate.model_rebuild()
 # === Membership === #
 class WorkspaceMembershipCreate(Schema):
     user_id: UserID
+    role_id: str | None = None
 
 
 class WorkspaceMembershipRead(Schema):


### PR DESCRIPTION
### Motivation

- Allow callers to specify an explicit workspace role when creating a membership instead of always using the default "workspace-editor" role.
- Wire the backend support through the API schema and client, and update the Add Member UI to pass a role ID instead of a role slug.

### Description

- Backend: `MembershipService.create_membership` now accepts an optional `role_id` on `WorkspaceMembershipCreate` and will assign the requested role if it belongs to the workspace organization; otherwise it falls back to the default `workspace-editor` role and raises `TracecatValidationError` for missing/invalid workspace or role conditions.
- Schemas: `WorkspaceMembershipCreate` schema in `tracecat/workspaces/schemas.py` was extended with `role_id: str | None = None` to support the optional role selection.
- Tests: Added `workspace_admin_role` fixture and two unit tests in `tests/unit/test_authz_membership_service.py`: `test_create_membership_with_explicit_role_id` and `test_create_membership_rejects_role_outside_organization` to verify explicit role assignment and validation when a role belongs to a different organization.
- Frontend: Generated client types/schemas (`frontend/src/client/types.gen.ts` and `schemas.gen.ts`) now include optional `role_id` for `WorkspaceMembershipCreate`, and the Add Member dialog (`frontend/src/components/workspaces/add-workspace-member.tsx`) was updated to use `roleId` (UUID) as the Select value, submit `role_id` in the request body, and reset the form after successful add.

### Testing

- Ran unit tests in `tests/unit/test_authz_membership_service.py` including the new tests `test_create_membership_with_explicit_role_id` and `test_create_membership_rejects_role_outside_organization`, and they passed.
- Ran the membership-related test suite with `pytest -q tests/unit/test_authz_membership_service.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b307f1bca48320ad3f352f63cfbd33)