### PR TITLE
fix(agent): treat override approval decisions as tool approvals

### DIFF
--- a/tests/unit/test_agent_session_approval_sink.py
+++ b/tests/unit/test_agent_session_approval_sink.py
@@ -12,6 +12,7 @@ from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import AgentConfig
+from tracecat.agent.types import ToolApproved
 from tracecat.auth.types import Role
 from tracecat.chat.enums import MessageKind
 from tracecat.chat.schemas import ApprovalDecision, BasicChatRequest, ContinueRunRequest
@@ -239,6 +240,73 @@ async def test_run_turn_continue_with_inbox_source_for_non_external_session(
     assert result is None
     get_workflow_handle_for.assert_called_once()
     fake_handle.execute_update.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_run_turn_continue_override_maps_to_tool_approved(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Preset chat",
+        workspace_id=svc_role.workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        curr_run_id=uuid.uuid4(),
+    )
+    session.add(agent_session)
+    session.add(
+        Approval(
+            workspace_id=svc_role.workspace_id,
+            session_id=agent_session.id,
+            tool_call_id="tool_call_123",
+            tool_name="core.http_request",
+            tool_call_args={"url": "https://example.com"},
+            status=ApprovalStatus.PENDING,
+        )
+    )
+    await session.commit()
+    await session.refresh(agent_session)
+
+    service = AgentSessionService(session=session, role=svc_role)
+    continuation = ContinueRunRequest(
+        decisions=[
+            ApprovalDecision(
+                tool_call_id="tool_call_123",
+                action="override",
+                override_args={"url": "https://modified.example.com"},
+            )
+        ],
+        source="inbox",
+    )
+
+    fake_handle = SimpleNamespace(execute_update=AsyncMock(return_value=None))
+    get_workflow_handle_for = Mock(return_value=fake_handle)
+    fake_client = SimpleNamespace(get_workflow_handle_for=get_workflow_handle_for)
+    fake_redis = SimpleNamespace(
+        set_if_not_exists=AsyncMock(return_value=True),
+        xadd=AsyncMock(return_value="1-0"),
+        delete=AsyncMock(return_value=1),
+    )
+    with (
+        patch(
+            "tracecat.agent.session.service.get_temporal_client",
+            AsyncMock(return_value=fake_client),
+        ),
+        patch(
+            "tracecat.agent.session.service.get_redis_client",
+            AsyncMock(return_value=fake_redis),
+        ),
+    ):
+        result = await service.run_turn(agent_session.id, continuation)
+
+    assert result is None
+    fake_handle.execute_update.assert_awaited_once()
+    submission = fake_handle.execute_update.await_args.args[1]
+    decision = submission.approvals["tool_call_123"]
+    assert isinstance(decision, ToolApproved)
+    assert decision.override_args == {"url": "https://modified.example.com"}
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_session_approval_sink.py
+++ b/tests/unit/test_agent_session_approval_sink.py
@@ -6,13 +6,13 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from pydantic_ai.tools import ToolApproved
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import AgentConfig
-from tracecat.agent.types import ToolApproved
 from tracecat.auth.types import Role
 from tracecat.chat.enums import MessageKind
 from tracecat.chat.schemas import ApprovalDecision, BasicChatRequest, ContinueRunRequest

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -1117,13 +1117,21 @@ class AgentSessionService(BaseWorkspaceService):
         decision_metadata: dict[str, dict[str, Any]] = {}
         for decision in request.decisions:
             if decision.action == "approve":
-                if decision.override_args:
-                    approval_map[decision.tool_call_id] = ToolApproved(
-                        override_args=decision.override_args
-                    )
-                else:
-                    approval_map[decision.tool_call_id] = True
+                approval_map[decision.tool_call_id] = True
+            elif decision.action == "override":
+                approval_map[decision.tool_call_id] = ToolApproved(
+                    override_args=decision.override_args or {}
+                )
+            elif decision.action == "deny":
+                approval_map[decision.tool_call_id] = ToolDenied(
+                    message=decision.reason or "Tool denied by user"
+                )
             else:
+                logger.warning(
+                    "Unknown approval decision action; defaulting to deny",
+                    action=decision.action,
+                    tool_call_id=decision.tool_call_id,
+                )
                 approval_map[decision.tool_call_id] = ToolDenied(
                     message=decision.reason or "Tool denied by user"
                 )


### PR DESCRIPTION
### Motivation

- Fix a bug in the session continuation path where `ApprovalDecision(action="override")` was being treated as a denial instead of an approval, causing edited+approved tool calls to be rejected.

### Description

- Change `AgentSessionService._continue_run()` decision mapping to treat `action == "approve"` as `True`, `action == "override"` as `ToolApproved(override_args=...)`, and `action == "deny"` as `ToolDenied(...)`.
- Add a defensive `else` branch that logs unknown `action` values and defaults to denial for safety.
- Add a unit test `test_run_turn_continue_override_maps_to_tool_approved` in `tests/unit/test_agent_session_approval_sink.py` that submits a `ContinueRunRequest` with `ApprovalDecision(action="override", override_args=...)` and asserts the Temporal submission contains a `ToolApproved` with preserved `override_args`.
- Update imports in the test to reference `ToolApproved` from `tracecat.agent.types`.

### Testing

- Added unit coverage: `tests/unit/test_agent_session_approval_sink.py::test_run_turn_continue_override_maps_to_tool_approved` asserting `ToolApproved` is sent to the workflow handle with preserved `override_args`.
- Ran a focused pytest invocation (`uv run pytest tests/unit/test_agent_session_approval_sink.py -k "continue_override_maps_to_tool_approved or continue_with_inbox_source_for_non_external_session"`) in this environment but it could not complete due to an environment PostgreSQL connection error (`psycopg.OperationalError: connection to server at "127.0.0.1", port 5432 failed: Connection refused`), so tests should be verified in CI or a developer environment with the test DB available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3cfcc29048320ac3d50159a623d87)