### PR TITLE
fix(agents): route custom model providers via hosted_vllm to restore …

### DIFF
--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -182,7 +182,7 @@ def test_bedrock_rejects_ambient_credential_fallback() -> None:
     assert "resolved before request dispatch" in exc_info.value.message
 
 
-def test_litellm_config_routes_provider_placeholders_before_openai_catch_all() -> None:
+def test_litellm_config_routes_provider_placeholders_before_catch_all() -> None:
     config_path = (
         Path(__file__).resolve().parents[2]
         / "tracecat"
@@ -206,8 +206,9 @@ def test_litellm_config_routes_provider_placeholders_before_openai_catch_all() -
     assert resolved_model("vertex_ai/*") == "vertex_ai/*"
     assert resolved_model("azure/*") == "azure/*"
     assert resolved_model("azure_ai/*") == "azure_ai/*"
-    # Unqualified names fall through to the OpenAI catch-all
-    assert resolved_model("custom") == "openai/custom"
+    # Unqualified names fall through to the hosted_vllm catch-all so custom
+    # providers bridge to Chat Completions instead of the Responses API.
+    assert resolved_model("custom") == "hosted_vllm/custom"
 
 
 def _make_request(

--- a/tracecat/agent/litellm_config.yaml
+++ b/tracecat/agent/litellm_config.yaml
@@ -32,10 +32,10 @@ model_list:
     litellm_params:
       model: openai/*
 
-  # Catch-all: unqualified model names are routed to OpenAI.
+  # Catch-all: unqualified model names are routed to OpenAI's Chat Completions API.
   - model_name: "*"
     litellm_params:
-      model: openai/*
+      model: hosted_vllm/*
 
 general_settings:
   custom_auth: tracecat.agent.gateway.user_api_key_auth


### PR DESCRIPTION
## Summary
Route custom model providers (non-passthrough) through ``/chat/completions`` via the ``hosted_vllm`` prefix in litellm.