### PR TITLE
feat(registry): add agent skill CRUD UDFs

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/presets.py
+++ b/packages/tracecat-registry/tracecat_registry/core/presets.py
@@ -79,6 +79,12 @@ async def create_preset(
             "List of action identifiers that the agent can use as tools. Format: 'namespace.action' (e.g., ['core.cases.create_case', 'core.cases.update_case']). These actions become available to the agent during execution."
         ),
     ] = None,
+    skills: Annotated[
+        list[dict[str, str]] | None,
+        Doc(
+            "List of skill bindings to attach to the preset. Each entry must include 'skill_id' and 'skill_version_id' UUID strings for a published skill version."
+        ),
+    ] = None,
 ) -> dict[str, Any]:
     # Build kwargs, only including non-None values
     kwargs: dict[str, Any] = {
@@ -98,6 +104,8 @@ async def create_preset(
         kwargs["output_type"] = output_type
     if actions is not None:
         kwargs["actions"] = actions
+    if skills is not None:
+        kwargs["skills"] = skills
 
     return await get_context().agents.create_preset(**kwargs)
 
@@ -189,6 +197,12 @@ async def update_preset(
             "The updated list of action identifiers that the agent can use as tools. Format: 'namespace.action' (e.g., ['core.cases.create_case'])."
         ),
     ] = None,
+    skills: Annotated[
+        list[dict[str, str]] | None,
+        Doc(
+            "The updated skill bindings for the preset. Each entry must include 'skill_id' and 'skill_version_id' UUID strings for a published skill version."
+        ),
+    ] = None,
 ) -> dict[str, Any]:
     # Build kwargs, only including non-None values
     kwargs: dict[str, Any] = {}
@@ -210,6 +224,8 @@ async def update_preset(
         kwargs["output_type"] = output_type
     if actions is not None:
         kwargs["actions"] = actions
+    if skills is not None:
+        kwargs["skills"] = skills
 
     return await get_context().agents.update_preset(slug, **kwargs)
 

--- a/packages/tracecat-registry/tracecat_registry/core/skills.py
+++ b/packages/tracecat-registry/tracecat_registry/core/skills.py
@@ -1,0 +1,106 @@
+"""Core registry UDFs for managing workspace agent skills."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from typing_extensions import Doc
+
+from tracecat_registry import registry
+from tracecat_registry.context import get_context
+
+
+@registry.register(
+    default_title="List agent skills",
+    display_group="Agent Skills",
+    description="List workspace agent skills with cursor pagination.",
+    namespace="ai.skill",
+    required_entitlements=["agent_addons"],
+)
+async def list_skills(
+    limit: Annotated[int, Doc("Page size.")] = 20,
+    cursor: Annotated[
+        str | None, Doc("Optional cursor from a previous response.")
+    ] = None,
+    reverse: Annotated[bool, Doc("Whether to reverse sort order.")] = False,
+) -> dict[str, Any]:
+    return await get_context().agents.list_skills(
+        limit=limit, cursor=cursor, reverse=reverse
+    )
+
+
+@registry.register(
+    default_title="Create agent skill",
+    display_group="Agent Skills",
+    description="Create a new workspace agent skill with an empty draft.",
+    namespace="ai.skill",
+    required_entitlements=["agent_addons"],
+)
+async def create_skill(
+    name: Annotated[str, Doc("Skill name in kebab-case (e.g., 'triage-assistant').")],
+    description: Annotated[str | None, Doc("Optional skill description.")] = None,
+) -> dict[str, Any]:
+    return await get_context().agents.create_skill(name=name, description=description)
+
+
+@registry.register(
+    default_title="Get agent skill",
+    display_group="Agent Skills",
+    description="Get one workspace agent skill by ID.",
+    namespace="ai.skill",
+    required_entitlements=["agent_addons"],
+)
+async def get_skill(skill_id: Annotated[str, Doc("Skill UUID.")]) -> dict[str, Any]:
+    return await get_context().agents.get_skill(skill_id)
+
+
+@registry.register(
+    default_title="Get agent skill draft",
+    display_group="Agent Skills",
+    description="Get the mutable draft manifest for a workspace skill.",
+    namespace="ai.skill",
+    required_entitlements=["agent_addons"],
+)
+async def get_skill_draft(
+    skill_id: Annotated[str, Doc("Skill UUID.")],
+) -> dict[str, Any]:
+    return await get_context().agents.get_skill_draft(skill_id)
+
+
+@registry.register(
+    default_title="Patch agent skill draft",
+    display_group="Agent Skills",
+    description="Apply optimistic-concurrency draft operations to a workspace skill.",
+    namespace="ai.skill",
+    required_entitlements=["agent_addons"],
+)
+async def patch_skill_draft(
+    skill_id: Annotated[str, Doc("Skill UUID.")],
+    base_revision: Annotated[int, Doc("Current draft revision to patch from.")],
+    operations: Annotated[list[dict[str, Any]], Doc("Draft operations list.")],
+) -> dict[str, Any]:
+    return await get_context().agents.patch_skill_draft(
+        skill_id=skill_id, base_revision=base_revision, operations=operations
+    )
+
+
+@registry.register(
+    default_title="Publish agent skill",
+    display_group="Agent Skills",
+    description="Publish the current draft into a new immutable skill version.",
+    namespace="ai.skill",
+    required_entitlements=["agent_addons"],
+)
+async def publish_skill(skill_id: Annotated[str, Doc("Skill UUID.")]) -> dict[str, Any]:
+    return await get_context().agents.publish_skill(skill_id)
+
+
+@registry.register(
+    default_title="Archive agent skill",
+    display_group="Agent Skills",
+    description="Archive (delete) a workspace skill.",
+    namespace="ai.skill",
+    required_entitlements=["agent_addons"],
+)
+async def archive_skill(skill_id: Annotated[str, Doc("Skill UUID.")]) -> None:
+    await get_context().agents.archive_skill(skill_id)

--- a/packages/tracecat-registry/tracecat_registry/core/skills.py
+++ b/packages/tracecat-registry/tracecat_registry/core/skills.py
@@ -91,7 +91,7 @@ async def list_skill_versions(
 @registry.register(
     default_title="Get agent skill version",
     display_group="Agent Skills",
-    description="Get one immutable published skill version by ID.",
+    description="Get one immutable published skill version by ID, including publish-compatible file contents.",
     namespace="ai.skill",
     required_entitlements=["agent_addons"],
 )

--- a/packages/tracecat-registry/tracecat_registry/core/skills.py
+++ b/packages/tracecat-registry/tracecat_registry/core/skills.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import Annotated, Any
 
 from typing_extensions import Doc
@@ -47,12 +48,65 @@ async def create_skill(
 @registry.register(
     default_title="Get agent skill",
     display_group="Agent Skills",
-    description="Get one workspace agent skill by ID.",
+    description="Get one workspace agent skill by skill ID, with an optional UUID override.",
     namespace="ai.skill",
     required_entitlements=["agent_addons"],
 )
-async def get_skill(skill_id: Annotated[str, Doc("Skill UUID.")]) -> dict[str, Any]:
-    return await get_context().agents.get_skill(skill_id)
+async def get_skill(
+    skill_id: Annotated[str, Doc("Skill ID/name in kebab-case.")],
+    skill_uuid: Annotated[
+        uuid.UUID | None, Doc("Optional canonical skill UUID.")
+    ] = None,
+) -> dict[str, Any]:
+    return await get_context().agents.get_skill(skill_id, skill_uuid=skill_uuid)
+
+
+@registry.register(
+    default_title="List agent skill versions",
+    display_group="Agent Skills",
+    description="List immutable published versions for a workspace agent skill.",
+    namespace="ai.skill",
+    required_entitlements=["agent_addons"],
+)
+async def list_skill_versions(
+    skill_id: Annotated[str, Doc("Skill ID/name in kebab-case.")],
+    skill_uuid: Annotated[
+        uuid.UUID | None, Doc("Optional canonical skill UUID.")
+    ] = None,
+    limit: Annotated[int, Doc("Page size.")] = 20,
+    cursor: Annotated[
+        str | None, Doc("Optional cursor from a previous response.")
+    ] = None,
+    reverse: Annotated[bool, Doc("Whether to reverse sort order.")] = False,
+) -> CursorPage:
+    return await get_context().agents.list_skill_versions(
+        skill_id=skill_id,
+        skill_uuid=skill_uuid,
+        limit=limit,
+        cursor=cursor,
+        reverse=reverse,
+    )
+
+
+@registry.register(
+    default_title="Get agent skill version",
+    display_group="Agent Skills",
+    description="Get one immutable published skill version by ID.",
+    namespace="ai.skill",
+    required_entitlements=["agent_addons"],
+)
+async def get_skill_version(
+    skill_id: Annotated[str, Doc("Skill ID/name in kebab-case.")],
+    version_id: Annotated[uuid.UUID, Doc("Skill version UUID.")],
+    skill_uuid: Annotated[
+        uuid.UUID | None, Doc("Optional canonical skill UUID.")
+    ] = None,
+) -> dict[str, Any]:
+    return await get_context().agents.get_skill_version(
+        skill_id=skill_id,
+        skill_uuid=skill_uuid,
+        version_id=version_id,
+    )
 
 
 @registry.register(
@@ -63,7 +117,7 @@ async def get_skill(skill_id: Annotated[str, Doc("Skill UUID.")]) -> dict[str, A
     required_entitlements=["agent_addons"],
 )
 async def publish_skill_version(
-    skill_id: Annotated[str, Doc("Skill UUID.")],
+    skill_id: Annotated[str, Doc("Skill ID/name in kebab-case.")],
     files: Annotated[
         list[dict[str, Any]],
         Doc(
@@ -76,11 +130,36 @@ async def publish_skill_version(
             "Current version UUID observed before publishing. Omit or use null for the first version."
         ),
     ] = None,
+    skill_uuid: Annotated[
+        uuid.UUID | None, Doc("Optional canonical skill UUID.")
+    ] = None,
 ) -> dict[str, Any]:
     return await get_context().agents.publish_skill_version(
         skill_id=skill_id,
+        skill_uuid=skill_uuid,
         base_version_id=base_version_id,
         files=files,
+    )
+
+
+@registry.register(
+    default_title="Restore agent skill version",
+    display_group="Agent Skills",
+    description="Restore a historical published version as the current skill version.",
+    namespace="ai.skill",
+    required_entitlements=["agent_addons"],
+)
+async def restore_skill_version(
+    skill_id: Annotated[str, Doc("Skill ID/name in kebab-case.")],
+    version_id: Annotated[uuid.UUID, Doc("Skill version UUID.")],
+    skill_uuid: Annotated[
+        uuid.UUID | None, Doc("Optional canonical skill UUID.")
+    ] = None,
+) -> dict[str, Any]:
+    return await get_context().agents.restore_skill_version(
+        skill_id=skill_id,
+        skill_uuid=skill_uuid,
+        version_id=version_id,
     )
 
 
@@ -91,5 +170,10 @@ async def publish_skill_version(
     namespace="ai.skill",
     required_entitlements=["agent_addons"],
 )
-async def archive_skill(skill_id: Annotated[str, Doc("Skill UUID.")]) -> None:
-    await get_context().agents.archive_skill(skill_id)
+async def archive_skill(
+    skill_id: Annotated[str, Doc("Skill ID/name in kebab-case.")],
+    skill_uuid: Annotated[
+        uuid.UUID | None, Doc("Optional canonical skill UUID.")
+    ] = None,
+) -> None:
+    await get_context().agents.archive_skill(skill_id, skill_uuid=skill_uuid)

--- a/packages/tracecat-registry/tracecat_registry/core/skills.py
+++ b/packages/tracecat-registry/tracecat_registry/core/skills.py
@@ -33,7 +33,7 @@ async def list_skills(
 @registry.register(
     default_title="Create agent skill",
     display_group="Agent Skills",
-    description="Create a new workspace agent skill with an empty draft.",
+    description="Create a workspace agent skill shell before publishing a version.",
     namespace="ai.skill",
     required_entitlements=["agent_addons"],
 )
@@ -56,14 +56,32 @@ async def get_skill(skill_id: Annotated[str, Doc("Skill UUID.")]) -> dict[str, A
 
 
 @registry.register(
-    default_title="Publish agent skill",
+    default_title="Publish agent skill version",
     display_group="Agent Skills",
-    description="Publish the current draft into a new immutable skill version.",
+    description="Publish a complete file set as a new immutable skill version.",
     namespace="ai.skill",
     required_entitlements=["agent_addons"],
 )
-async def publish_skill(skill_id: Annotated[str, Doc("Skill UUID.")]) -> dict[str, Any]:
-    return await get_context().agents.publish_skill(skill_id)
+async def publish_skill_version(
+    skill_id: Annotated[str, Doc("Skill UUID.")],
+    base_version_id: Annotated[
+        str | None,
+        Doc(
+            "Current version UUID observed before publishing. Use null for the first version."
+        ),
+    ],
+    files: Annotated[
+        list[dict[str, Any]],
+        Doc(
+            "Complete version file set. Each file requires path and content_base64, with optional content_type."
+        ),
+    ],
+) -> dict[str, Any]:
+    return await get_context().agents.publish_skill_version(
+        skill_id=skill_id,
+        base_version_id=base_version_id,
+        files=files,
+    )
 
 
 @registry.register(

--- a/packages/tracecat-registry/tracecat_registry/core/skills.py
+++ b/packages/tracecat-registry/tracecat_registry/core/skills.py
@@ -64,18 +64,18 @@ async def get_skill(skill_id: Annotated[str, Doc("Skill UUID.")]) -> dict[str, A
 )
 async def publish_skill_version(
     skill_id: Annotated[str, Doc("Skill UUID.")],
-    base_version_id: Annotated[
-        str | None,
-        Doc(
-            "Current version UUID observed before publishing. Use null for the first version."
-        ),
-    ],
     files: Annotated[
         list[dict[str, Any]],
         Doc(
             "Complete version file set. Each file requires path and content_base64, with optional content_type."
         ),
     ],
+    base_version_id: Annotated[
+        str | None,
+        Doc(
+            "Current version UUID observed before publishing. Omit or use null for the first version."
+        ),
+    ] = None,
 ) -> dict[str, Any]:
     return await get_context().agents.publish_skill_version(
         skill_id=skill_id,

--- a/packages/tracecat-registry/tracecat_registry/core/skills.py
+++ b/packages/tracecat-registry/tracecat_registry/core/skills.py
@@ -8,6 +8,7 @@ from typing_extensions import Doc
 
 from tracecat_registry import registry
 from tracecat_registry.context import get_context
+from tracecat_registry.sdk.agents import CursorPage
 
 
 @registry.register(
@@ -23,7 +24,7 @@ async def list_skills(
         str | None, Doc("Optional cursor from a previous response.")
     ] = None,
     reverse: Annotated[bool, Doc("Whether to reverse sort order.")] = False,
-) -> dict[str, Any]:
+) -> CursorPage:
     return await get_context().agents.list_skills(
         limit=limit, cursor=cursor, reverse=reverse
     )

--- a/packages/tracecat-registry/tracecat_registry/core/skills.py
+++ b/packages/tracecat-registry/tracecat_registry/core/skills.py
@@ -56,36 +56,6 @@ async def get_skill(skill_id: Annotated[str, Doc("Skill UUID.")]) -> dict[str, A
 
 
 @registry.register(
-    default_title="Get agent skill draft",
-    display_group="Agent Skills",
-    description="Get the mutable draft manifest for a workspace skill.",
-    namespace="ai.skill",
-    required_entitlements=["agent_addons"],
-)
-async def get_skill_draft(
-    skill_id: Annotated[str, Doc("Skill UUID.")],
-) -> dict[str, Any]:
-    return await get_context().agents.get_skill_draft(skill_id)
-
-
-@registry.register(
-    default_title="Patch agent skill draft",
-    display_group="Agent Skills",
-    description="Apply optimistic-concurrency draft operations to a workspace skill.",
-    namespace="ai.skill",
-    required_entitlements=["agent_addons"],
-)
-async def patch_skill_draft(
-    skill_id: Annotated[str, Doc("Skill UUID.")],
-    base_revision: Annotated[int, Doc("Current draft revision to patch from.")],
-    operations: Annotated[list[dict[str, Any]], Doc("Draft operations list.")],
-) -> dict[str, Any]:
-    return await get_context().agents.patch_skill_draft(
-        skill_id=skill_id, base_revision=base_revision, operations=operations
-    )
-
-
-@registry.register(
     default_title="Publish agent skill",
     display_group="Agent Skills",
     description="Publish the current draft into a new immutable skill version.",

--- a/packages/tracecat-registry/tracecat_registry/sdk/agents.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/agents.py
@@ -495,17 +495,6 @@ class AgentsClient:
     async def get_skill(self, skill_id: str) -> dict[str, Any]:
         return await self._client.get(f"/agent/skills/{skill_id}")
 
-    async def get_skill_draft(self, skill_id: str) -> dict[str, Any]:
-        return await self._client.get(f"/agent/skills/{skill_id}/draft")
-
-    async def patch_skill_draft(
-        self, *, skill_id: str, base_revision: int, operations: list[dict[str, Any]]
-    ) -> dict[str, Any]:
-        return await self._client.patch(
-            f"/agent/skills/{skill_id}/draft",
-            json={"base_revision": base_revision, "operations": operations},
-        )
-
     async def publish_skill(self, skill_id: str) -> dict[str, Any]:
         return await self._client.post(f"/agent/skills/{skill_id}/publish")
 

--- a/packages/tracecat-registry/tracecat_registry/sdk/agents.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/agents.py
@@ -60,6 +60,14 @@ class AgentPresetSkillBinding(TypedDict):
     skill_version_id: str
 
 
+class SkillPublishFile(TypedDict):
+    """File payload for publishing a workspace skill version."""
+
+    path: str
+    content_base64: str
+    content_type: NotRequired[str | None]
+
+
 class RankableItem(TypedDict):
     id: str | int
     text: str
@@ -495,8 +503,17 @@ class AgentsClient:
     async def get_skill(self, skill_id: str) -> dict[str, Any]:
         return await self._client.get(f"/agent/skills/{skill_id}")
 
-    async def publish_skill(self, skill_id: str) -> dict[str, Any]:
-        return await self._client.post(f"/agent/skills/{skill_id}/publish")
+    async def publish_skill_version(
+        self,
+        *,
+        skill_id: str,
+        base_version_id: str | None,
+        files: list[SkillPublishFile] | list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        return await self._client.post(
+            f"/agent/skills/{skill_id}/versions",
+            json={"base_version_id": base_version_id, "files": files},
+        )
 
     async def archive_skill(self, skill_id: str) -> None:
         await self._client.delete(f"/agent/skills/{skill_id}")

--- a/packages/tracecat-registry/tracecat_registry/sdk/agents.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/agents.py
@@ -507,12 +507,15 @@ class AgentsClient:
         self,
         *,
         skill_id: str,
-        base_version_id: str | None,
         files: list[SkillPublishFile] | list[dict[str, Any]],
+        base_version_id: str | None = None,
     ) -> dict[str, Any]:
+        data: dict[str, Any] = {"files": files}
+        if base_version_id is not None:
+            data["base_version_id"] = base_version_id
         return await self._client.post(
             f"/agent/skills/{skill_id}/versions",
-            json={"base_version_id": base_version_id, "files": files},
+            json=data,
         )
 
     async def archive_skill(self, skill_id: str) -> None:

--- a/packages/tracecat-registry/tracecat_registry/sdk/agents.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/agents.py
@@ -68,6 +68,10 @@ class SkillPublishFile(TypedDict):
     content_type: NotRequired[str | None]
 
 
+def _skill_identifier(skill_id: str, skill_uuid: str | uuid.UUID | None = None) -> str:
+    return str(skill_uuid) if skill_uuid is not None else skill_id
+
+
 class RankableItem(TypedDict):
     id: str | int
     text: str
@@ -500,26 +504,75 @@ class AgentsClient:
             data["description"] = description
         return await self._client.post("/agent/skills", json=data)
 
-    async def get_skill(self, skill_id: str) -> dict[str, Any]:
-        return await self._client.get(f"/agent/skills/{skill_id}")
+    async def get_skill(
+        self, skill_id: str, *, skill_uuid: str | uuid.UUID | None = None
+    ) -> dict[str, Any]:
+        identifier = _skill_identifier(skill_id, skill_uuid)
+        return await self._client.get(f"/agent/skills/{identifier}")
+
+    async def list_skill_versions(
+        self,
+        *,
+        skill_id: str,
+        skill_uuid: str | uuid.UUID | None = None,
+        limit: int = 20,
+        cursor: str | None = None,
+        reverse: bool = False,
+    ) -> CursorPage:
+        identifier = _skill_identifier(skill_id, skill_uuid)
+        params: dict[str, Any] = {"limit": limit, "reverse": reverse}
+        if cursor is not None:
+            params["cursor"] = cursor
+        return await self._client.get(
+            f"/agent/skills/{identifier}/versions", params=params
+        )
+
+    async def get_skill_version(
+        self,
+        *,
+        skill_id: str,
+        version_id: str | uuid.UUID,
+        skill_uuid: str | uuid.UUID | None = None,
+    ) -> dict[str, Any]:
+        identifier = _skill_identifier(skill_id, skill_uuid)
+        return await self._client.get(
+            f"/agent/skills/{identifier}/versions/{version_id}"
+        )
 
     async def publish_skill_version(
         self,
         *,
         skill_id: str,
         files: list[SkillPublishFile] | list[dict[str, Any]],
+        skill_uuid: str | uuid.UUID | None = None,
         base_version_id: str | None = None,
     ) -> dict[str, Any]:
+        identifier = _skill_identifier(skill_id, skill_uuid)
         data: dict[str, Any] = {"files": files}
         if base_version_id is not None:
             data["base_version_id"] = base_version_id
         return await self._client.post(
-            f"/agent/skills/{skill_id}/versions",
+            f"/agent/skills/{identifier}/versions",
             json=data,
         )
 
-    async def archive_skill(self, skill_id: str) -> None:
-        await self._client.delete(f"/agent/skills/{skill_id}")
+    async def restore_skill_version(
+        self,
+        *,
+        skill_id: str,
+        version_id: str | uuid.UUID,
+        skill_uuid: str | uuid.UUID | None = None,
+    ) -> dict[str, Any]:
+        identifier = _skill_identifier(skill_id, skill_uuid)
+        return await self._client.post(
+            f"/agent/skills/{identifier}/versions/{version_id}/restore"
+        )
+
+    async def archive_skill(
+        self, skill_id: str, *, skill_uuid: str | uuid.UUID | None = None
+    ) -> None:
+        identifier = _skill_identifier(skill_id, skill_uuid)
+        await self._client.delete(f"/agent/skills/{identifier}")
 
     # --- Preset methods ---
 

--- a/packages/tracecat-registry/tracecat_registry/sdk/agents.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/agents.py
@@ -47,6 +47,13 @@ class MCPServerConfig(TypedDict):
     """Optional: Transport type. Defaults to 'http'."""
 
 
+class AgentPresetSkillBinding(TypedDict):
+    """Skill binding for attaching a published skill version to an agent preset."""
+
+    skill_id: str
+    skill_version_id: str
+
+
 class RankableItem(TypedDict):
     id: str | int
     text: str
@@ -483,6 +490,7 @@ class AgentsClient:
         base_url: str | Unset = UNSET,
         output_type: str | dict[str, Any] | Unset = UNSET,
         actions: list[str] | Unset = UNSET,
+        skills: list[AgentPresetSkillBinding] | Unset = UNSET,
     ) -> dict[str, Any]:
         """Create a new agent preset.
 
@@ -517,6 +525,8 @@ class AgentsClient:
             data["output_type"] = output_type
         if is_set(actions):
             data["actions"] = actions
+        if is_set(skills):
+            data["skills"] = skills
         return await self._client.post("/agent/presets", json=data)
 
     async def get_preset(self, slug: str) -> dict[str, Any]:
@@ -546,6 +556,7 @@ class AgentsClient:
         base_url: str | Unset = UNSET,
         output_type: str | dict[str, Any] | Unset = UNSET,
         actions: list[str] | Unset = UNSET,
+        skills: list[AgentPresetSkillBinding] | Unset = UNSET,
     ) -> dict[str, Any]:
         """Update an existing agent preset.
 
@@ -586,6 +597,8 @@ class AgentsClient:
             data["output_type"] = output_type
         if is_set(actions):
             data["actions"] = actions
+        if is_set(skills):
+            data["skills"] = skills
         return await self._client.patch(f"/agent/presets/by-slug/{slug}", json=data)
 
     async def delete_preset(self, slug: str) -> None:
@@ -605,6 +618,7 @@ __all__ = [
     "AgentOutput",
     "AgentsClient",
     "MCPServerConfig",
+    "AgentPresetSkillBinding",
     "OutputType",
     "RankableItem",
     "rank_items",

--- a/packages/tracecat-registry/tracecat_registry/sdk/agents.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/agents.py
@@ -47,6 +47,12 @@ class MCPServerConfig(TypedDict):
     """Optional: Transport type. Defaults to 'http'."""
 
 
+class CursorPage(TypedDict):
+    items: list[dict[str, Any]]
+    next_cursor: str | None
+    has_more: bool
+
+
 class AgentPresetSkillBinding(TypedDict):
     """Skill binding for attaching a published skill version to an agent preset."""
 
@@ -468,6 +474,44 @@ class AgentsClient:
 
         return await self._client.post("/agent/rank-pairwise", json=data)
 
+    # --- Skill methods ---
+
+    async def list_skills(
+        self, *, limit: int = 20, cursor: str | None = None, reverse: bool = False
+    ) -> CursorPage:
+        params: dict[str, Any] = {"limit": limit, "reverse": reverse}
+        if cursor is not None:
+            params["cursor"] = cursor
+        return await self._client.get("/agent/skills", params=params)
+
+    async def create_skill(
+        self, *, name: str, description: str | None = None
+    ) -> dict[str, Any]:
+        data: dict[str, Any] = {"name": name}
+        if description is not None:
+            data["description"] = description
+        return await self._client.post("/agent/skills", json=data)
+
+    async def get_skill(self, skill_id: str) -> dict[str, Any]:
+        return await self._client.get(f"/agent/skills/{skill_id}")
+
+    async def get_skill_draft(self, skill_id: str) -> dict[str, Any]:
+        return await self._client.get(f"/agent/skills/{skill_id}/draft")
+
+    async def patch_skill_draft(
+        self, *, skill_id: str, base_revision: int, operations: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        return await self._client.patch(
+            f"/agent/skills/{skill_id}/draft",
+            json={"base_revision": base_revision, "operations": operations},
+        )
+
+    async def publish_skill(self, skill_id: str) -> dict[str, Any]:
+        return await self._client.post(f"/agent/skills/{skill_id}/publish")
+
+    async def archive_skill(self, skill_id: str) -> None:
+        await self._client.delete(f"/agent/skills/{skill_id}")
+
     # --- Preset methods ---
 
     async def list_presets(self) -> list[dict[str, Any]]:
@@ -619,6 +663,7 @@ __all__ = [
     "AgentsClient",
     "MCPServerConfig",
     "AgentPresetSkillBinding",
+    "CursorPage",
     "OutputType",
     "RankableItem",
     "rank_items",

--- a/tests/registry/test_agents_sdk.py
+++ b/tests/registry/test_agents_sdk.py
@@ -13,6 +13,7 @@ from tracecat_registry.sdk.agents import AgentConfig, AgentsClient
 @pytest.fixture
 def mock_tracecat_client() -> MagicMock:
     client = MagicMock()
+    client.get = AsyncMock()
     client.post = AsyncMock()
     return client
 
@@ -90,3 +91,85 @@ def test_agent_config_rejects_agents_option() -> None:
 
     with pytest.raises(TypeError, match="agents"):
         AgentConfig(**config_kwargs)
+
+
+@pytest.mark.anyio
+async def test_list_skill_versions_builds_cursor_params(
+    agents_client: AgentsClient,
+    mock_tracecat_client: MagicMock,
+) -> None:
+    mock_tracecat_client.get.return_value = {
+        "items": [],
+        "next_cursor": None,
+        "has_more": False,
+    }
+
+    result = await agents_client.list_skill_versions(
+        skill_id="skill-id",
+        limit=50,
+        cursor="cursor-1",
+        reverse=True,
+    )
+
+    assert result == {"items": [], "next_cursor": None, "has_more": False}
+    mock_tracecat_client.get.assert_awaited_once_with(
+        "/agent/skills/skill-id/versions",
+        params={"limit": 50, "reverse": True, "cursor": "cursor-1"},
+    )
+
+
+@pytest.mark.anyio
+async def test_list_skill_versions_prefers_skill_uuid(
+    agents_client: AgentsClient,
+    mock_tracecat_client: MagicMock,
+) -> None:
+    skill_uuid = uuid.uuid4()
+    mock_tracecat_client.get.return_value = {
+        "items": [],
+        "next_cursor": None,
+        "has_more": False,
+    }
+
+    await agents_client.list_skill_versions(
+        skill_id="skill-id",
+        skill_uuid=skill_uuid,
+    )
+
+    mock_tracecat_client.get.assert_awaited_once_with(
+        f"/agent/skills/{skill_uuid}/versions",
+        params={"limit": 20, "reverse": False},
+    )
+
+
+@pytest.mark.anyio
+async def test_get_skill_version_uses_version_endpoint(
+    agents_client: AgentsClient,
+    mock_tracecat_client: MagicMock,
+) -> None:
+    mock_tracecat_client.get.return_value = {"id": "version-id"}
+
+    result = await agents_client.get_skill_version(
+        skill_id="skill-id", version_id="version-id"
+    )
+
+    assert result == {"id": "version-id"}
+    mock_tracecat_client.get.assert_awaited_once_with(
+        "/agent/skills/skill-id/versions/version-id"
+    )
+
+
+@pytest.mark.anyio
+async def test_restore_skill_version_uses_restore_endpoint(
+    agents_client: AgentsClient,
+    mock_tracecat_client: MagicMock,
+) -> None:
+    mock_tracecat_client.post.return_value = {"current_version_id": "version-id"}
+
+    result = await agents_client.restore_skill_version(
+        skill_id="skill-id", version_id="version-id"
+    )
+
+    assert result == {"current_version_id": "version-id"}
+    mock_tracecat_client.post.assert_awaited_once_with(
+        "/agent/skills/skill-id/versions/version-id/restore"
+    )

--- a/tests/registry/test_core_skills.py
+++ b/tests/registry/test_core_skills.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from tracecat_registry.context import RegistryContext, clear_context, set_context
+from tracecat_registry.core.skills import (
+    get_skill_version,
+    list_skill_versions,
+    restore_skill_version,
+)
+
+
+@pytest.fixture
+async def skill_registry_context() -> AsyncIterator[MagicMock]:
+    ctx = MagicMock()
+    ctx.agents = MagicMock()
+    set_context(cast(RegistryContext, ctx))
+    try:
+        yield ctx
+    finally:
+        clear_context()
+
+
+@pytest.mark.anyio
+async def test_list_skill_versions_delegates_to_agents_sdk(
+    skill_registry_context: MagicMock,
+) -> None:
+    skill_uuid = uuid.uuid4()
+    skill_registry_context.agents.list_skill_versions = AsyncMock(
+        return_value={"items": [], "next_cursor": None, "has_more": False}
+    )
+
+    result = await list_skill_versions(
+        skill_id="skill-id",
+        skill_uuid=skill_uuid,
+        limit=10,
+        cursor="cursor-1",
+        reverse=True,
+    )
+
+    assert result == {"items": [], "next_cursor": None, "has_more": False}
+    skill_registry_context.agents.list_skill_versions.assert_awaited_once_with(
+        skill_id="skill-id",
+        skill_uuid=skill_uuid,
+        limit=10,
+        cursor="cursor-1",
+        reverse=True,
+    )
+
+
+@pytest.mark.anyio
+async def test_get_skill_version_delegates_to_agents_sdk(
+    skill_registry_context: MagicMock,
+) -> None:
+    skill_uuid = uuid.uuid4()
+    version_id = uuid.uuid4()
+    skill_registry_context.agents.get_skill_version = AsyncMock(
+        return_value={"id": "version-id"}
+    )
+
+    result = await get_skill_version(
+        skill_id="skill-id", skill_uuid=skill_uuid, version_id=version_id
+    )
+
+    assert result == {"id": "version-id"}
+    skill_registry_context.agents.get_skill_version.assert_awaited_once_with(
+        skill_id="skill-id",
+        skill_uuid=skill_uuid,
+        version_id=version_id,
+    )
+
+
+@pytest.mark.anyio
+async def test_restore_skill_version_delegates_to_agents_sdk(
+    skill_registry_context: MagicMock,
+) -> None:
+    skill_uuid = uuid.uuid4()
+    version_id = uuid.uuid4()
+    skill_registry_context.agents.restore_skill_version = AsyncMock(
+        return_value={"current_version_id": "version-id"}
+    )
+
+    result = await restore_skill_version(
+        skill_id="skill-id", skill_uuid=skill_uuid, version_id=version_id
+    )
+
+    assert result == {"current_version_id": "version-id"}
+    skill_registry_context.agents.restore_skill_version.assert_awaited_once_with(
+        skill_id="skill-id",
+        skill_uuid=skill_uuid,
+        version_id=version_id,
+    )

--- a/tests/unit/test_agent_skill_internal_router.py
+++ b/tests/unit/test_agent_skill_internal_router.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from tracecat.agent.skill.internal_router import list_skill_versions
+from tracecat.auth.types import Role
+from tracecat.exceptions import TracecatValidationError
+
+
+def _executor_role() -> Role:
+    return Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        scopes=frozenset({"agent:read"}),
+    )
+
+
+@pytest.mark.anyio
+async def test_list_skill_versions_converts_invalid_cursor_to_http_400() -> None:
+    skill_id = uuid.uuid4()
+    mock_service = AsyncMock()
+    mock_service.get_skill.return_value = object()
+    mock_service.list_versions.side_effect = TracecatValidationError(
+        "Invalid cursor for skill versions"
+    )
+
+    with patch(
+        "tracecat.agent.skill.internal_router.SkillService",
+        return_value=mock_service,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            raw_list_skill_versions = cast(Any, list_skill_versions).__wrapped__
+            await raw_list_skill_versions(
+                skill_id=skill_id,
+                role=_executor_role(),
+                session=AsyncMock(),
+                limit=10,
+                cursor="not-a-valid-cursor",
+                reverse=False,
+            )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Invalid cursor for skill versions"

--- a/tests/unit/test_agent_skill_internal_router.py
+++ b/tests/unit/test_agent_skill_internal_router.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import HTTPException
 
-from tracecat.agent.skill.internal_router import list_skill_versions, list_skills
+from tracecat.agent.skill.internal_router import (
+    list_skill_versions,
+    list_skills,
+    publish_skill_version,
+)
 from tracecat.auth.types import Role
 from tracecat.exceptions import TracecatValidationError
 
@@ -73,3 +77,33 @@ async def test_list_skill_versions_converts_invalid_cursor_to_http_400() -> None
 
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail == "Invalid cursor for skill versions"
+
+
+@pytest.mark.anyio
+async def test_publish_skill_version_converts_version_conflict_to_http_409() -> None:
+    current_version_id = uuid.uuid4()
+    detail = {
+        "code": "skill_version_conflict",
+        "current_version_id": str(current_version_id),
+    }
+    mock_service = AsyncMock()
+    mock_service.publish_skill_version.side_effect = TracecatValidationError(
+        "Skill version conflict",
+        detail=detail,
+    )
+
+    with patch(
+        "tracecat.agent.skill.internal_router.SkillService",
+        return_value=mock_service,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            raw_publish_skill_version = cast(Any, publish_skill_version).__wrapped__
+            await raw_publish_skill_version(
+                skill_id=uuid.uuid4(),
+                params=cast(Any, object()),
+                role=_executor_role(),
+                session=AsyncMock(),
+            )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == detail

--- a/tests/unit/test_agent_skill_internal_router.py
+++ b/tests/unit/test_agent_skill_internal_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
@@ -8,6 +9,7 @@ import pytest
 from fastapi import HTTPException
 
 from tracecat.agent.skill.internal_router import (
+    get_skill,
     list_skill_versions,
     list_skills,
     publish_skill_version,
@@ -55,7 +57,7 @@ async def test_list_skills_converts_invalid_cursor_to_http_400() -> None:
 async def test_list_skill_versions_converts_invalid_cursor_to_http_400() -> None:
     skill_id = uuid.uuid4()
     mock_service = AsyncMock()
-    mock_service.get_skill.return_value = object()
+    mock_service.get_skill_by_identifier.return_value = SimpleNamespace(id=skill_id)
     mock_service.list_versions.side_effect = TracecatValidationError(
         "Invalid cursor for skill versions"
     )
@@ -80,6 +82,31 @@ async def test_list_skill_versions_converts_invalid_cursor_to_http_400() -> None
 
 
 @pytest.mark.anyio
+async def test_get_skill_resolves_slug_identifier() -> None:
+    resolved_skill_id = uuid.uuid4()
+    mock_service = AsyncMock()
+    mock_service.get_skill_by_identifier.return_value = SimpleNamespace(
+        id=resolved_skill_id
+    )
+    mock_service.get_skill_read.return_value = {"id": str(resolved_skill_id)}
+
+    with patch(
+        "tracecat.agent.skill.internal_router.SkillService",
+        return_value=mock_service,
+    ):
+        raw_get_skill = cast(Any, get_skill).__wrapped__
+        result = await raw_get_skill(
+            skill_id="triage-helper",
+            role=_executor_role(),
+            session=AsyncMock(),
+        )
+
+    assert result == {"id": str(resolved_skill_id)}
+    mock_service.get_skill_by_identifier.assert_awaited_once_with("triage-helper")
+    mock_service.get_skill_read.assert_awaited_once_with(resolved_skill_id)
+
+
+@pytest.mark.anyio
 async def test_publish_skill_version_converts_version_conflict_to_http_409() -> None:
     current_version_id = uuid.uuid4()
     detail = {
@@ -87,6 +114,7 @@ async def test_publish_skill_version_converts_version_conflict_to_http_409() -> 
         "current_version_id": str(current_version_id),
     }
     mock_service = AsyncMock()
+    mock_service.get_skill_by_identifier.return_value = SimpleNamespace(id=uuid.uuid4())
     mock_service.publish_skill_version.side_effect = TracecatValidationError(
         "Skill version conflict",
         detail=detail,

--- a/tests/unit/test_agent_skill_internal_router.py
+++ b/tests/unit/test_agent_skill_internal_router.py
@@ -11,6 +11,7 @@ from fastapi.routing import APIRoute
 
 from tracecat.agent.skill.internal_router import (
     get_skill,
+    get_skill_version,
     list_skill_versions,
     list_skills,
     publish_skill_version,
@@ -118,6 +119,37 @@ async def test_get_skill_resolves_slug_identifier() -> None:
     assert result == {"id": str(resolved_skill_id)}
     mock_service.get_skill_by_identifier.assert_awaited_once_with("triage-helper")
     mock_service.get_skill_read.assert_awaited_once_with(resolved_skill_id)
+
+
+@pytest.mark.anyio
+async def test_get_skill_version_returns_snapshot_for_udfs() -> None:
+    resolved_skill_id = uuid.uuid4()
+    version_id = uuid.uuid4()
+    snapshot = {"id": str(version_id), "files": [{"content_base64": "dmVyc2lvbg=="}]}
+    mock_service = AsyncMock()
+    mock_service.get_skill_by_identifier.return_value = SimpleNamespace(
+        id=resolved_skill_id
+    )
+    mock_service.get_version_snapshot_read.return_value = snapshot
+
+    with patch(
+        "tracecat.agent.skill.internal_router.SkillService",
+        return_value=mock_service,
+    ):
+        raw_get_skill_version = cast(Any, get_skill_version).__wrapped__
+        result = await raw_get_skill_version(
+            skill_id="triage-helper",
+            version_id=version_id,
+            role=_executor_role(),
+            session=AsyncMock(),
+        )
+
+    assert result == snapshot
+    mock_service.get_skill_by_identifier.assert_awaited_once_with("triage-helper")
+    mock_service.get_version_snapshot_read.assert_awaited_once_with(
+        skill_id=resolved_skill_id,
+        version_id=version_id,
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_skill_internal_router.py
+++ b/tests/unit/test_agent_skill_internal_router.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import HTTPException
 
-from tracecat.agent.skill.internal_router import list_skill_versions
+from tracecat.agent.skill.internal_router import list_skill_versions, list_skills
 from tracecat.auth.types import Role
 from tracecat.exceptions import TracecatValidationError
 
@@ -20,6 +20,31 @@ def _executor_role() -> Role:
         organization_id=uuid.uuid4(),
         scopes=frozenset({"agent:read"}),
     )
+
+
+@pytest.mark.anyio
+async def test_list_skills_converts_invalid_cursor_to_http_400() -> None:
+    mock_service = AsyncMock()
+    mock_service.list_skills.side_effect = TracecatValidationError(
+        "Invalid cursor for skills"
+    )
+
+    with patch(
+        "tracecat.agent.skill.internal_router.SkillService",
+        return_value=mock_service,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            raw_list_skills = cast(Any, list_skills).__wrapped__
+            await raw_list_skills(
+                role=_executor_role(),
+                session=AsyncMock(),
+                limit=10,
+                cursor="not-a-valid-cursor",
+                reverse=False,
+            )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Invalid cursor for skills"
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_skill_internal_router.py
+++ b/tests/unit/test_agent_skill_internal_router.py
@@ -7,12 +7,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException
+from fastapi.routing import APIRoute
 
 from tracecat.agent.skill.internal_router import (
     get_skill,
     list_skill_versions,
     list_skills,
     publish_skill_version,
+    router,
 )
 from tracecat.auth.types import Role
 from tracecat.exceptions import TracecatValidationError
@@ -26,6 +28,18 @@ def _executor_role() -> Role:
         organization_id=uuid.uuid4(),
         scopes=frozenset({"agent:read"}),
     )
+
+
+def test_internal_router_does_not_expose_draft_publish() -> None:
+    routes = {
+        (route.path, method)
+        for route in router.routes
+        if isinstance(route, APIRoute)
+        for method in route.methods
+    }
+
+    assert ("/internal/agent/skills/{skill_id}/publish", "POST") not in routes
+    assert ("/internal/agent/skills/{skill_id}/versions", "POST") in routes
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -542,6 +542,18 @@ class TestSkillService:
         assert by_name is not None
         assert by_name.id == created.id
 
+    async def test_get_skill_by_identifier_falls_back_to_uuid_like_name(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        uuid_like_name = "00000000-0000-4000-8000-000000000001"
+        created = await skill_service.create_skill(SkillCreate(name=uuid_like_name))
+
+        by_uuid_like_name = await skill_service.get_skill_by_identifier(uuid_like_name)
+
+        assert by_uuid_like_name is not None
+        assert by_uuid_like_name.id == created.id
+
     async def test_get_skill_by_identifier_rejects_ambiguous_names(
         self,
         skill_service: SkillService,

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -33,6 +33,7 @@ from tracecat.agent.skill.schemas import (
     SkillUpload,
     SkillUploadFile,
     SkillUploadSessionCreate,
+    SkillVersionPublish,
     SkillVersionReadMinimal,
 )
 from tracecat.agent.skill.service import SkillService
@@ -1274,6 +1275,108 @@ class TestSkillService:
 
         with pytest.raises(TracecatValidationError, match="failed validation"):
             await skill_service.publish_skill(created.id)
+
+    async def test_publish_skill_version_uses_files_without_rewriting_draft(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        """Workflow publishes should create versions without mutating the draft."""
+
+        created = await skill_service.create_skill(SkillCreate(name="reflect-skill"))
+        draft_before = await skill_service.get_draft(created.id)
+        assert draft_before is not None
+
+        published = await skill_service.publish_skill_version(
+            skill_id=created.id,
+            params=SkillVersionPublish(
+                base_version_id=None,
+                files=[
+                    SkillUploadFile(
+                        path="SKILL.md",
+                        content_base64=base64.b64encode(
+                            b"---\n"
+                            b"name: reflected-skill\n"
+                            b"description: Learned from signals\n"
+                            b"---\n\n"
+                            b"# reflected-skill\n"
+                        ).decode(),
+                        content_type="text/markdown; charset=utf-8",
+                    ),
+                    SkillUploadFile(
+                        path="signals.md",
+                        content_base64=base64.b64encode(
+                            b"Escalate correlated endpoint alerts."
+                        ).decode(),
+                        content_type="text/markdown; charset=utf-8",
+                    ),
+                ],
+            ),
+        )
+        draft_after = await skill_service.get_draft(created.id)
+        version_file = await skill_service.get_version_file(
+            skill_id=created.id,
+            version_id=published.id,
+            path="signals.md",
+        )
+        skill_read = await skill_service.get_skill_read(created.id)
+
+        assert published.version == 1
+        assert published.name == "reflected-skill"
+        assert published.description == "Learned from signals"
+        assert draft_after is not None
+        assert draft_after.draft_revision == draft_before.draft_revision
+        assert draft_after.name == draft_before.name
+        assert version_file is not None
+        assert version_file.kind == "inline"
+        assert version_file.text_content == "Escalate correlated endpoint alerts."
+        assert skill_read is not None
+        assert skill_read.current_version_id == published.id
+        assert skill_read.name == "reflected-skill"
+
+    async def test_publish_skill_version_rejects_stale_base_version(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        """Workflow publishes require the caller's observed current version."""
+
+        created = await skill_service.create_skill(SkillCreate(name="conflict-skill"))
+        first = await skill_service.publish_skill_version(
+            skill_id=created.id,
+            params=SkillVersionPublish(
+                base_version_id=None,
+                files=[
+                    SkillUploadFile(
+                        path="SKILL.md",
+                        content_base64=base64.b64encode(
+                            b"---\nname: conflict-one\n---\n\n# conflict-one\n"
+                        ).decode(),
+                        content_type="text/markdown; charset=utf-8",
+                    )
+                ],
+            ),
+        )
+
+        with pytest.raises(TracecatValidationError) as exc_info:
+            await skill_service.publish_skill_version(
+                skill_id=created.id,
+                params=SkillVersionPublish(
+                    base_version_id=None,
+                    files=[
+                        SkillUploadFile(
+                            path="SKILL.md",
+                            content_base64=base64.b64encode(
+                                b"---\nname: conflict-two\n---\n\n# conflict-two\n"
+                            ).decode(),
+                            content_type="text/markdown; charset=utf-8",
+                        )
+                    ],
+                ),
+            )
+
+        assert exc_info.value.detail == {
+            "code": "skill_version_conflict",
+            "current_version_id": str(first.id),
+        }
 
     async def test_publish_skill_concurrently_allocates_unique_versions(
         self,

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -1719,6 +1719,21 @@ class TestSkillService:
             "SKILL.md",
             "references/guide.md",
         ]
+        assert not hasattr(detailed_version.files[0], "content_base64")
+
+        snapshot = await skill_service.get_version_snapshot_read(
+            skill_id=created.id,
+            version_id=published.id,
+        )
+        snapshot_files = {file.path: file for file in snapshot.files}
+        assert sorted(snapshot_files) == ["SKILL.md", "references/guide.md"]
+        assert (
+            base64.b64decode(snapshot_files["references/guide.md"].content_base64)
+            == b"Version one"
+        )
+        assert snapshot_files["references/guide.md"].content_type.startswith(
+            "text/plain"
+        )
 
     async def test_archived_skill_hides_published_version_reads(
         self,

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -1289,7 +1289,6 @@ class TestSkillService:
         published = await skill_service.publish_skill_version(
             skill_id=created.id,
             params=SkillVersionPublish(
-                base_version_id=None,
                 files=[
                     SkillUploadFile(
                         path="SKILL.md",

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -525,6 +525,38 @@ class TestSkillService:
         assert listing.items[0].id == active.id
         assert listing.items[0].name == active.name
 
+    async def test_get_skill_by_identifier_accepts_uuid_or_name(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        created = await skill_service.create_skill(SkillCreate(name="lookup-skill"))
+
+        by_uuid = await skill_service.get_skill_by_identifier(created.id)
+        by_uuid_string = await skill_service.get_skill_by_identifier(str(created.id))
+        by_name = await skill_service.get_skill_by_identifier("lookup-skill")
+
+        assert by_uuid is not None
+        assert by_uuid.id == created.id
+        assert by_uuid_string is not None
+        assert by_uuid_string.id == created.id
+        assert by_name is not None
+        assert by_name.id == created.id
+
+    async def test_get_skill_by_identifier_rejects_ambiguous_names(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        await skill_service.create_skill(SkillCreate(name="duplicate-skill"))
+        await skill_service.create_skill(SkillCreate(name="duplicate-skill"))
+
+        with pytest.raises(TracecatValidationError) as exc_info:
+            await skill_service.get_skill_by_identifier("duplicate-skill")
+
+        assert exc_info.value.detail == {
+            "code": "ambiguous_skill_id",
+            "skill_id": "duplicate-skill",
+        }
+
     async def test_patch_draft_enforces_revision(
         self,
         skill_service: SkillService,

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -569,6 +569,24 @@ class TestSkillService:
             "skill_id": "duplicate-skill",
         }
 
+    async def test_get_skill_by_identifier_rejects_id_name_collision(
+        self,
+        skill_service: SkillService,
+    ) -> None:
+        """A UUID-like identifier matching one skill's id and a different
+        skill's name must be reported as ambiguous, not silently resolved."""
+
+        by_id = await skill_service.create_skill(SkillCreate(name="collision-id"))
+        await skill_service.create_skill(SkillCreate(name=str(by_id.id)))
+
+        with pytest.raises(TracecatValidationError) as exc_info:
+            await skill_service.get_skill_by_identifier(str(by_id.id))
+
+        assert exc_info.value.detail == {
+            "code": "ambiguous_skill_id",
+            "skill_id": str(by_id.id),
+        }
+
     async def test_patch_draft_enforces_revision(
         self,
         skill_service: SkillService,

--- a/tracecat/agent/skill/internal_router.py
+++ b/tracecat/agent/skill/internal_router.py
@@ -1,0 +1,266 @@
+"""Internal router for workspace skill operations (SDK/UDF use)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Never
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from tracecat import config
+from tracecat.agent.skill.schemas import (
+    SkillCreate,
+    SkillDraftFileRead,
+    SkillDraftPatch,
+    SkillDraftRead,
+    SkillRead,
+    SkillReadMinimal,
+    SkillUpload,
+    SkillVersionRead,
+    SkillVersionReadMinimal,
+)
+from tracecat.agent.skill.service import SkillService
+from tracecat.auth.dependencies import ExecutorWorkspaceRole
+from tracecat.authz.controls import require_scope
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
+
+router = APIRouter(
+    prefix="/internal/agent/skills",
+    tags=["internal-agent-skills"],
+    include_in_schema=False,
+)
+
+
+def _raise_skill_validation_error(exc: TracecatValidationError) -> Never:
+    status_code = status.HTTP_400_BAD_REQUEST
+    if isinstance(exc.detail, dict) and exc.detail.get("code") in {
+        "draft_revision_conflict",
+        "skill_in_use",
+    }:
+        status_code = status.HTTP_409_CONFLICT
+    raise HTTPException(
+        status_code=status_code,
+        detail=exc.detail if exc.detail is not None else str(exc),
+    ) from exc
+
+
+@router.get("", response_model=CursorPaginatedResponse[SkillReadMinimal])
+@require_scope("agent:read")
+async def list_skills(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    limit: int = Query(
+        default=config.TRACECAT__LIMIT_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+    ),
+    cursor: str | None = Query(default=None),
+    reverse: bool = Query(default=False),
+) -> CursorPaginatedResponse[SkillReadMinimal]:
+    service = SkillService(session, role=role)
+    return await service.list_skills(
+        CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse)
+    )
+
+
+@router.post("", response_model=SkillRead, status_code=status.HTTP_201_CREATED)
+@require_scope("agent:create")
+async def create_skill(
+    *,
+    params: SkillCreate,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+) -> SkillRead:
+    service = SkillService(session, role=role)
+    try:
+        return await service.create_skill(params)
+    except TracecatValidationError as exc:
+        _raise_skill_validation_error(exc)
+
+
+@router.post(":upload", response_model=SkillRead, status_code=status.HTTP_201_CREATED)
+@require_scope("agent:create")
+async def upload_skill(
+    *,
+    params: SkillUpload,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+) -> SkillRead:
+    service = SkillService(session, role=role)
+    try:
+        return await service.upload_skill(params)
+    except TracecatValidationError as exc:
+        _raise_skill_validation_error(exc)
+
+
+@router.get("/{skill_id}", response_model=SkillRead)
+@require_scope("agent:read")
+async def get_skill(
+    *, skill_id: uuid.UUID, role: ExecutorWorkspaceRole, session: AsyncDBSession
+) -> SkillRead:
+    service = SkillService(session, role=role)
+    if (skill := await service.get_skill_read(skill_id)) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Skill '{skill_id}' not found",
+        )
+    return skill
+
+
+@router.patch("/{skill_id}/draft", response_model=SkillDraftRead)
+@require_scope("agent:update")
+async def patch_skill_draft(
+    *,
+    skill_id: uuid.UUID,
+    params: SkillDraftPatch,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+) -> SkillDraftRead:
+    service = SkillService(session, role=role)
+    try:
+        return await service.patch_draft(skill_id=skill_id, params=params)
+    except TracecatValidationError as exc:
+        _raise_skill_validation_error(exc)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+
+
+@router.post("/{skill_id}/publish", response_model=SkillVersionRead)
+@require_scope("agent:update")
+async def publish_skill(
+    *, skill_id: uuid.UUID, role: ExecutorWorkspaceRole, session: AsyncDBSession
+) -> SkillVersionRead:
+    service = SkillService(session, role=role)
+    try:
+        return await service.publish_skill(skill_id)
+    except TracecatValidationError as exc:
+        _raise_skill_validation_error(exc)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+
+
+@router.get("/{skill_id}/draft", response_model=SkillDraftRead)
+@require_scope("agent:read")
+async def get_skill_draft(
+    *, skill_id: uuid.UUID, role: ExecutorWorkspaceRole, session: AsyncDBSession
+) -> SkillDraftRead:
+    service = SkillService(session, role=role)
+    if (draft := await service.get_draft(skill_id)) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Skill '{skill_id}' not found",
+        )
+    return draft
+
+
+@router.get("/{skill_id}/draft/file", response_model=SkillDraftFileRead)
+@require_scope("agent:read")
+async def get_skill_draft_file(
+    *,
+    skill_id: uuid.UUID,
+    path: str = Query(...),
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+) -> SkillDraftFileRead:
+    service = SkillService(session, role=role)
+    try:
+        draft_file = await service.get_draft_file(skill_id=skill_id, path=path)
+    except TracecatValidationError as exc:
+        _raise_skill_validation_error(exc)
+    if draft_file is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Draft file '{path}' not found",
+        )
+    return draft_file
+
+
+@router.get(
+    "/{skill_id}/versions",
+    response_model=CursorPaginatedResponse[SkillVersionReadMinimal],
+)
+@require_scope("agent:read")
+async def list_skill_versions(
+    *,
+    skill_id: uuid.UUID,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    limit: int = Query(
+        default=config.TRACECAT__LIMIT_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+    ),
+    cursor: str | None = Query(default=None),
+    reverse: bool = Query(default=False),
+) -> CursorPaginatedResponse[SkillVersionReadMinimal]:
+    service = SkillService(session, role=role)
+    if await service.get_skill(skill_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Skill '{skill_id}' not found",
+        )
+    return await service.list_versions(
+        skill_id=skill_id,
+        params=CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse),
+    )
+
+
+@router.get("/{skill_id}/versions/{version_id}", response_model=SkillVersionRead)
+@require_scope("agent:read")
+async def get_skill_version(
+    *,
+    skill_id: uuid.UUID,
+    version_id: uuid.UUID,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+) -> SkillVersionRead:
+    service = SkillService(session, role=role)
+    try:
+        return await service.get_version_read(skill_id=skill_id, version_id=version_id)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+
+
+@router.post(
+    "/{skill_id}/versions/{version_id}/restore", response_model=SkillReadMinimal
+)
+@require_scope("agent:update")
+async def restore_skill_version(
+    *,
+    skill_id: uuid.UUID,
+    version_id: uuid.UUID,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+) -> SkillReadMinimal:
+    service = SkillService(session, role=role)
+    try:
+        return await service.restore_version(skill_id=skill_id, version_id=version_id)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+
+
+@router.delete("/{skill_id}", status_code=status.HTTP_204_NO_CONTENT)
+@require_scope("agent:delete")
+async def archive_skill(
+    *, skill_id: uuid.UUID, role: ExecutorWorkspaceRole, session: AsyncDBSession
+) -> None:
+    service = SkillService(session, role=role)
+    try:
+        await service.archive_skill(skill_id)
+    except TracecatValidationError as exc:
+        _raise_skill_validation_error(exc)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc

--- a/tracecat/agent/skill/internal_router.py
+++ b/tracecat/agent/skill/internal_router.py
@@ -152,23 +152,6 @@ async def patch_skill_draft(
         ) from exc
 
 
-@router.post("/{skill_id}/publish", response_model=SkillVersionRead)
-@require_scope("agent:update")
-async def publish_skill(
-    *, skill_id: str, role: ExecutorWorkspaceRole, session: AsyncDBSession
-) -> SkillVersionRead:
-    service = SkillService(session, role=role)
-    resolved_skill_id = await _resolve_skill_id(service, skill_id)
-    try:
-        return await service.publish_skill(resolved_skill_id)
-    except TracecatValidationError as exc:
-        _raise_skill_validation_error(exc)
-    except TracecatNotFoundError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
-        ) from exc
-
-
 @router.post(
     "/{skill_id}/versions",
     response_model=SkillVersionRead,

--- a/tracecat/agent/skill/internal_router.py
+++ b/tracecat/agent/skill/internal_router.py
@@ -61,9 +61,12 @@ async def list_skills(
     reverse: bool = Query(default=False),
 ) -> CursorPaginatedResponse[SkillReadMinimal]:
     service = SkillService(session, role=role)
-    return await service.list_skills(
-        CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse)
-    )
+    try:
+        return await service.list_skills(
+            CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse)
+        )
+    except TracecatValidationError as exc:
+        _raise_skill_validation_error(exc)
 
 
 @router.post("", response_model=SkillRead, status_code=status.HTTP_201_CREATED)

--- a/tracecat/agent/skill/internal_router.py
+++ b/tracecat/agent/skill/internal_router.py
@@ -16,6 +16,7 @@ from tracecat.agent.skill.schemas import (
     SkillRead,
     SkillReadMinimal,
     SkillUpload,
+    SkillVersionPublish,
     SkillVersionRead,
     SkillVersionReadMinimal,
 )
@@ -37,6 +38,7 @@ def _raise_skill_validation_error(exc: TracecatValidationError) -> Never:
     status_code = status.HTTP_400_BAD_REQUEST
     if isinstance(exc.detail, dict) and exc.detail.get("code") in {
         "draft_revision_conflict",
+        "skill_version_conflict",
         "skill_in_use",
     }:
         status_code = status.HTTP_409_CONFLICT
@@ -141,6 +143,30 @@ async def publish_skill(
     service = SkillService(session, role=role)
     try:
         return await service.publish_skill(skill_id)
+    except TracecatValidationError as exc:
+        _raise_skill_validation_error(exc)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+
+
+@router.post(
+    "/{skill_id}/versions",
+    response_model=SkillVersionRead,
+    status_code=status.HTTP_201_CREATED,
+)
+@require_scope("agent:update")
+async def publish_skill_version(
+    *,
+    skill_id: uuid.UUID,
+    params: SkillVersionPublish,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+) -> SkillVersionRead:
+    service = SkillService(session, role=role)
+    try:
+        return await service.publish_skill_version(skill_id=skill_id, params=params)
     except TracecatValidationError as exc:
         _raise_skill_validation_error(exc)
     except TracecatNotFoundError as exc:

--- a/tracecat/agent/skill/internal_router.py
+++ b/tracecat/agent/skill/internal_router.py
@@ -19,6 +19,7 @@ from tracecat.agent.skill.schemas import (
     SkillVersionPublish,
     SkillVersionRead,
     SkillVersionReadMinimal,
+    SkillVersionSnapshotRead,
 )
 from tracecat.agent.skill.service import SkillService
 from tracecat.auth.dependencies import ExecutorWorkspaceRole
@@ -246,7 +247,9 @@ async def list_skill_versions(
         _raise_skill_validation_error(exc)
 
 
-@router.get("/{skill_id}/versions/{version_id}", response_model=SkillVersionRead)
+@router.get(
+    "/{skill_id}/versions/{version_id}", response_model=SkillVersionSnapshotRead
+)
 @require_scope("agent:read")
 async def get_skill_version(
     *,
@@ -254,11 +257,11 @@ async def get_skill_version(
     version_id: uuid.UUID,
     role: ExecutorWorkspaceRole,
     session: AsyncDBSession,
-) -> SkillVersionRead:
+) -> SkillVersionSnapshotRead:
     service = SkillService(session, role=role)
     resolved_skill_id = await _resolve_skill_id(service, skill_id)
     try:
-        return await service.get_version_read(
+        return await service.get_version_snapshot_read(
             skill_id=resolved_skill_id, version_id=version_id
         )
     except TracecatNotFoundError as exc:

--- a/tracecat/agent/skill/internal_router.py
+++ b/tracecat/agent/skill/internal_router.py
@@ -48,6 +48,21 @@ def _raise_skill_validation_error(exc: TracecatValidationError) -> Never:
     ) from exc
 
 
+async def _resolve_skill_id(
+    service: SkillService, skill_id: str | uuid.UUID
+) -> uuid.UUID:
+    try:
+        skill = await service.get_skill_by_identifier(skill_id)
+    except TracecatValidationError as exc:
+        _raise_skill_validation_error(exc)
+    if skill is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Skill '{skill_id}' not found",
+        )
+    return skill.id
+
+
 @router.get("", response_model=CursorPaginatedResponse[SkillReadMinimal])
 @require_scope("agent:read")
 async def list_skills(
@@ -104,10 +119,11 @@ async def upload_skill(
 @router.get("/{skill_id}", response_model=SkillRead)
 @require_scope("agent:read")
 async def get_skill(
-    *, skill_id: uuid.UUID, role: ExecutorWorkspaceRole, session: AsyncDBSession
+    *, skill_id: str, role: ExecutorWorkspaceRole, session: AsyncDBSession
 ) -> SkillRead:
     service = SkillService(session, role=role)
-    if (skill := await service.get_skill_read(skill_id)) is None:
+    resolved_skill_id = await _resolve_skill_id(service, skill_id)
+    if (skill := await service.get_skill_read(resolved_skill_id)) is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Skill '{skill_id}' not found",
@@ -119,14 +135,15 @@ async def get_skill(
 @require_scope("agent:update")
 async def patch_skill_draft(
     *,
-    skill_id: uuid.UUID,
+    skill_id: str,
     params: SkillDraftPatch,
     role: ExecutorWorkspaceRole,
     session: AsyncDBSession,
 ) -> SkillDraftRead:
     service = SkillService(session, role=role)
+    resolved_skill_id = await _resolve_skill_id(service, skill_id)
     try:
-        return await service.patch_draft(skill_id=skill_id, params=params)
+        return await service.patch_draft(skill_id=resolved_skill_id, params=params)
     except TracecatValidationError as exc:
         _raise_skill_validation_error(exc)
     except TracecatNotFoundError as exc:
@@ -138,11 +155,12 @@ async def patch_skill_draft(
 @router.post("/{skill_id}/publish", response_model=SkillVersionRead)
 @require_scope("agent:update")
 async def publish_skill(
-    *, skill_id: uuid.UUID, role: ExecutorWorkspaceRole, session: AsyncDBSession
+    *, skill_id: str, role: ExecutorWorkspaceRole, session: AsyncDBSession
 ) -> SkillVersionRead:
     service = SkillService(session, role=role)
+    resolved_skill_id = await _resolve_skill_id(service, skill_id)
     try:
-        return await service.publish_skill(skill_id)
+        return await service.publish_skill(resolved_skill_id)
     except TracecatValidationError as exc:
         _raise_skill_validation_error(exc)
     except TracecatNotFoundError as exc:
@@ -159,14 +177,17 @@ async def publish_skill(
 @require_scope("agent:update")
 async def publish_skill_version(
     *,
-    skill_id: uuid.UUID,
+    skill_id: str,
     params: SkillVersionPublish,
     role: ExecutorWorkspaceRole,
     session: AsyncDBSession,
 ) -> SkillVersionRead:
     service = SkillService(session, role=role)
+    resolved_skill_id = await _resolve_skill_id(service, skill_id)
     try:
-        return await service.publish_skill_version(skill_id=skill_id, params=params)
+        return await service.publish_skill_version(
+            skill_id=resolved_skill_id, params=params
+        )
     except TracecatValidationError as exc:
         _raise_skill_validation_error(exc)
     except TracecatNotFoundError as exc:
@@ -178,10 +199,11 @@ async def publish_skill_version(
 @router.get("/{skill_id}/draft", response_model=SkillDraftRead)
 @require_scope("agent:read")
 async def get_skill_draft(
-    *, skill_id: uuid.UUID, role: ExecutorWorkspaceRole, session: AsyncDBSession
+    *, skill_id: str, role: ExecutorWorkspaceRole, session: AsyncDBSession
 ) -> SkillDraftRead:
     service = SkillService(session, role=role)
-    if (draft := await service.get_draft(skill_id)) is None:
+    resolved_skill_id = await _resolve_skill_id(service, skill_id)
+    if (draft := await service.get_draft(resolved_skill_id)) is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Skill '{skill_id}' not found",
@@ -193,14 +215,15 @@ async def get_skill_draft(
 @require_scope("agent:read")
 async def get_skill_draft_file(
     *,
-    skill_id: uuid.UUID,
+    skill_id: str,
     path: str = Query(...),
     role: ExecutorWorkspaceRole,
     session: AsyncDBSession,
 ) -> SkillDraftFileRead:
     service = SkillService(session, role=role)
+    resolved_skill_id = await _resolve_skill_id(service, skill_id)
     try:
-        draft_file = await service.get_draft_file(skill_id=skill_id, path=path)
+        draft_file = await service.get_draft_file(skill_id=resolved_skill_id, path=path)
     except TracecatValidationError as exc:
         _raise_skill_validation_error(exc)
     if draft_file is None:
@@ -218,7 +241,7 @@ async def get_skill_draft_file(
 @require_scope("agent:read")
 async def list_skill_versions(
     *,
-    skill_id: uuid.UUID,
+    skill_id: str,
     role: ExecutorWorkspaceRole,
     session: AsyncDBSession,
     limit: int = Query(
@@ -230,14 +253,10 @@ async def list_skill_versions(
     reverse: bool = Query(default=False),
 ) -> CursorPaginatedResponse[SkillVersionReadMinimal]:
     service = SkillService(session, role=role)
-    if await service.get_skill(skill_id) is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Skill '{skill_id}' not found",
-        )
+    resolved_skill_id = await _resolve_skill_id(service, skill_id)
     try:
         return await service.list_versions(
-            skill_id=skill_id,
+            skill_id=resolved_skill_id,
             params=CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse),
         )
     except TracecatValidationError as exc:
@@ -248,14 +267,17 @@ async def list_skill_versions(
 @require_scope("agent:read")
 async def get_skill_version(
     *,
-    skill_id: uuid.UUID,
+    skill_id: str,
     version_id: uuid.UUID,
     role: ExecutorWorkspaceRole,
     session: AsyncDBSession,
 ) -> SkillVersionRead:
     service = SkillService(session, role=role)
+    resolved_skill_id = await _resolve_skill_id(service, skill_id)
     try:
-        return await service.get_version_read(skill_id=skill_id, version_id=version_id)
+        return await service.get_version_read(
+            skill_id=resolved_skill_id, version_id=version_id
+        )
     except TracecatNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
@@ -268,14 +290,17 @@ async def get_skill_version(
 @require_scope("agent:update")
 async def restore_skill_version(
     *,
-    skill_id: uuid.UUID,
+    skill_id: str,
     version_id: uuid.UUID,
     role: ExecutorWorkspaceRole,
     session: AsyncDBSession,
 ) -> SkillReadMinimal:
     service = SkillService(session, role=role)
+    resolved_skill_id = await _resolve_skill_id(service, skill_id)
     try:
-        return await service.restore_version(skill_id=skill_id, version_id=version_id)
+        return await service.restore_version(
+            skill_id=resolved_skill_id, version_id=version_id
+        )
     except TracecatNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
@@ -285,11 +310,12 @@ async def restore_skill_version(
 @router.delete("/{skill_id}", status_code=status.HTTP_204_NO_CONTENT)
 @require_scope("agent:delete")
 async def archive_skill(
-    *, skill_id: uuid.UUID, role: ExecutorWorkspaceRole, session: AsyncDBSession
+    *, skill_id: str, role: ExecutorWorkspaceRole, session: AsyncDBSession
 ) -> None:
     service = SkillService(session, role=role)
+    resolved_skill_id = await _resolve_skill_id(service, skill_id)
     try:
-        await service.archive_skill(skill_id)
+        await service.archive_skill(resolved_skill_id)
     except TracecatValidationError as exc:
         _raise_skill_validation_error(exc)
     except TracecatNotFoundError as exc:

--- a/tracecat/agent/skill/internal_router.py
+++ b/tracecat/agent/skill/internal_router.py
@@ -206,10 +206,13 @@ async def list_skill_versions(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Skill '{skill_id}' not found",
         )
-    return await service.list_versions(
-        skill_id=skill_id,
-        params=CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse),
-    )
+    try:
+        return await service.list_versions(
+            skill_id=skill_id,
+            params=CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse),
+        )
+    except TracecatValidationError as exc:
+        _raise_skill_validation_error(exc)
 
 
 @router.get("/{skill_id}/versions/{version_id}", response_model=SkillVersionRead)

--- a/tracecat/agent/skill/schemas.py
+++ b/tracecat/agent/skill/schemas.py
@@ -250,6 +250,36 @@ class SkillVersionRead(Schema):
     model_config = ConfigDict(from_attributes=True)
 
 
+class SkillVersionFileContent(Schema):
+    """Published skill file content in a publish-compatible shape."""
+
+    path: str
+    content_base64: str
+    content_type: str
+    sha256: str
+    size_bytes: int
+    blob_id: uuid.UUID
+
+
+class SkillVersionSnapshotRead(Schema):
+    """Published skill version response including full file contents."""
+
+    id: uuid.UUID
+    skill_id: uuid.UUID
+    workspace_id: WorkspaceID
+    version: int
+    manifest_sha256: str
+    file_count: int
+    total_size_bytes: int
+    name: str
+    description: str | None = Field(default=None)
+    created_at: datetime
+    updated_at: datetime
+    files: list[SkillVersionFileContent] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class SkillVersionReadMinimal(Schema):
     """Summary response model for published skill versions in list endpoints."""
 

--- a/tracecat/agent/skill/schemas.py
+++ b/tracecat/agent/skill/schemas.py
@@ -116,6 +116,13 @@ class SkillUpload(Schema):
     files: list[SkillUploadFile] = Field(min_length=1)
 
 
+class SkillVersionPublish(Schema):
+    """Payload for atomically publishing a skill version from files."""
+
+    base_version_id: uuid.UUID | None
+    files: list[SkillUploadFile] = Field(min_length=1)
+
+
 class SkillDraftRead(Schema):
     """Current mutable draft state for a skill."""
 

--- a/tracecat/agent/skill/schemas.py
+++ b/tracecat/agent/skill/schemas.py
@@ -119,7 +119,7 @@ class SkillUpload(Schema):
 class SkillVersionPublish(Schema):
     """Payload for atomically publishing a skill version from files."""
 
-    base_version_id: uuid.UUID | None
+    base_version_id: uuid.UUID | None = Field(default=None)
     files: list[SkillUploadFile] = Field(min_length=1)
 
 

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -40,9 +40,11 @@ from tracecat.agent.skill.schemas import (
     SkillUploadSessionCreate,
     SkillUploadSessionRead,
     SkillValidationErrorDetail,
+    SkillVersionFileContent,
     SkillVersionPublish,
     SkillVersionRead,
     SkillVersionReadMinimal,
+    SkillVersionSnapshotRead,
 )
 from tracecat.agent.skill.types import ResolvedSkillRef
 from tracecat.authz.controls import require_scope
@@ -1999,6 +2001,46 @@ class SkillService(BaseWorkspaceService):
                 )
                 for version_file, blob_row in rows
             ],
+        )
+
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def get_version_snapshot_read(
+        self, *, skill_id: uuid.UUID, version_id: uuid.UUID
+    ) -> SkillVersionSnapshotRead:
+        """Return a published skill version with publish-compatible file contents."""
+
+        version = await self._get_active_version(
+            skill_id=skill_id, version_id=version_id
+        )
+        if version is None:
+            raise TracecatNotFoundError(f"Skill version '{version_id}' not found")
+        rows = await self._list_version_rows(version.id)
+        files: list[SkillVersionFileContent] = []
+        for version_file, blob_row in rows:
+            content = await blob.download_file(key=blob_row.key, bucket=blob_row.bucket)
+            files.append(
+                SkillVersionFileContent(
+                    path=version_file.path,
+                    content_base64=base64.b64encode(content).decode("ascii"),
+                    content_type=version_file.content_type,
+                    sha256=blob_row.sha256,
+                    size_bytes=blob_row.size_bytes,
+                    blob_id=blob_row.id,
+                )
+            )
+        return SkillVersionSnapshotRead(
+            id=version.id,
+            skill_id=version.skill_id,
+            workspace_id=version.workspace_id,
+            version=version.version,
+            manifest_sha256=version.manifest_sha256,
+            file_count=version.file_count,
+            total_size_bytes=version.total_size_bytes,
+            name=version.name,
+            description=version.description,
+            created_at=version.created_at,
+            updated_at=version.updated_at,
+            files=files,
         )
 
     @require_scope("agent:update")

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -1095,6 +1095,40 @@ class SkillService(BaseWorkspaceService):
         )
         return (await self.session.execute(stmt)).scalar_one_or_none()
 
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def get_skill_by_identifier(
+        self, skill_id: str | uuid.UUID, *, include_archived: bool = False
+    ) -> Skill | None:
+        """Return a skill by UUID or kebab-case skill name."""
+
+        if isinstance(skill_id, uuid.UUID):
+            return await self.get_skill(skill_id, include_archived=include_archived)
+        try:
+            parsed_skill_id = uuid.UUID(skill_id)
+        except ValueError:
+            try:
+                skill_name = SKILL_NAME_ADAPTER.validate_python(skill_id)
+            except ValidationError:
+                return None
+            predicates = [
+                Skill.workspace_id == self.workspace_id,
+                Skill.name == skill_name,
+            ]
+            if not include_archived:
+                predicates.append(Skill.archived_at.is_(None))
+            stmt = select(Skill).where(*predicates)
+            skills = (await self.session.execute(stmt)).scalars().all()
+            if len(skills) > 1:
+                raise TracecatValidationError(
+                    "Skill identifier is ambiguous",
+                    detail={
+                        "code": "ambiguous_skill_id",
+                        "skill_id": skill_name,
+                    },
+                ) from None
+            return skills[0] if skills else None
+        return await self.get_skill(parsed_skill_id, include_archived=include_archived)
+
     async def _get_active_version(
         self, *, skill_id: uuid.UUID, version_id: uuid.UUID
     ) -> SkillVersion | None:

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -36,9 +36,11 @@ from tracecat.agent.skill.schemas import (
     SkillRead,
     SkillReadMinimal,
     SkillUpload,
+    SkillUploadFile,
     SkillUploadSessionCreate,
     SkillUploadSessionRead,
     SkillValidationErrorDetail,
+    SkillVersionPublish,
     SkillVersionRead,
     SkillVersionReadMinimal,
 )
@@ -866,6 +868,99 @@ class SkillService(BaseWorkspaceService):
             )
         return result
 
+    def _prepare_upload_files(
+        self, files: Sequence[SkillUploadFile]
+    ) -> list[PreparedSkillUploadFile]:
+        """Normalize and decode file payloads before validation."""
+
+        prepared_files: list[PreparedSkillUploadFile] = []
+        for file_payload in files:
+            path = self._normalize_path(file_payload.path)
+            try:
+                content = base64.b64decode(file_payload.content_base64, validate=True)
+            except ValueError as exc:
+                raise TracecatValidationError(
+                    f"Invalid base64 content for skill path {path!r}",
+                    detail={"code": "invalid_base64", "path": path},
+                ) from exc
+            content_type = self._normalize_content_type(
+                file_payload.content_type or self._guess_content_type(path)
+            )
+            prepared_files.append(
+                PreparedSkillUploadFile(
+                    path=path,
+                    content=content,
+                    content_type=content_type,
+                )
+            )
+        return prepared_files
+
+    async def _create_version_from_blob_refs(
+        self,
+        *,
+        skill: Skill,
+        file_refs: Sequence[tuple[str, SkillFileBlobRef]],
+        validation: ManifestValidationResult,
+    ) -> SkillVersionRead:
+        """Create a new immutable version from validated skill files."""
+
+        if validation.name is None:
+            self._raise_missing_draft_name(operation="publish")
+        manifest_name = validation.name
+        sorted_file_refs = sorted(file_refs, key=lambda item: item[0])
+        manifest_payload = [
+            {
+                "path": path,
+                "sha256": file_ref.blob.sha256,
+                "size_bytes": file_ref.blob.size_bytes,
+                "content_type": file_ref.content_type,
+            }
+            for path, file_ref in sorted_file_refs
+        ]
+        manifest_sha256 = self._compute_sha256(orjson.dumps(manifest_payload))
+
+        stmt = (
+            select(SkillVersion.version)
+            .where(
+                SkillVersion.workspace_id == self.workspace_id,
+                SkillVersion.skill_id == skill.id,
+            )
+            .order_by(SkillVersion.version.desc())
+            .limit(1)
+        )
+        current_version_number = (await self.session.execute(stmt)).scalar_one_or_none()
+        next_version = (current_version_number or 0) + 1
+        version = SkillVersion(
+            workspace_id=self.workspace_id,
+            skill_id=skill.id,
+            version=next_version,
+            manifest_sha256=manifest_sha256,
+            file_count=len(sorted_file_refs),
+            total_size_bytes=sum(
+                file_ref.blob.size_bytes for _, file_ref in sorted_file_refs
+            ),
+            name=manifest_name,
+            description=validation.description,
+        )
+        self.session.add(version)
+        await self.session.flush()
+        for path, file_ref in sorted_file_refs:
+            self.session.add(
+                SkillVersionFile(
+                    workspace_id=self.workspace_id,
+                    skill_version_id=version.id,
+                    path=path,
+                    blob_id=file_ref.blob.id,
+                    content_type=file_ref.content_type,
+                )
+            )
+        skill.current_version_id = version.id
+        skill.name = manifest_name
+        skill.description = validation.description
+        self.session.add(skill)
+        await self.session.commit()
+        return await self.get_version_read(skill_id=skill.id, version_id=version.id)
+
     async def _build_draft_read(self, skill: Skill) -> SkillDraftRead:
         """Build the current draft response for a skill."""
 
@@ -1131,27 +1226,7 @@ class SkillService(BaseWorkspaceService):
             The created skill summary.
         """
 
-        prepared_files: list[PreparedSkillUploadFile] = []
-        for file_payload in params.files:
-            path = self._normalize_path(file_payload.path)
-            try:
-                content = base64.b64decode(file_payload.content_base64, validate=True)
-            except ValueError as exc:
-                raise TracecatValidationError(
-                    f"Invalid base64 content for skill path {path!r}",
-                    detail={"code": "invalid_base64", "path": path},
-                ) from exc
-            content_type = self._normalize_content_type(
-                file_payload.content_type or self._guess_content_type(path)
-            )
-            prepared_files.append(
-                PreparedSkillUploadFile(
-                    path=path,
-                    content=content,
-                    content_type=content_type,
-                )
-            )
-
+        prepared_files = self._prepare_upload_files(params.files)
         validation = self._validate_prepared_upload_files(prepared_files)
         if validation.errors:
             raise TracecatValidationError(
@@ -1696,60 +1771,71 @@ class SkillService(BaseWorkspaceService):
                     ],
                 },
             )
-        if validation.name is None:
-            self._raise_missing_draft_name(operation="publish")
-        manifest_name = validation.name
-
-        manifest_payload = [
-            {
-                "path": draft_file.path,
-                "sha256": blob_row.sha256,
-                "size_bytes": blob_row.size_bytes,
-                "content_type": draft_file.content_type,
-            }
-            for draft_file, blob_row in rows
-        ]
-        manifest_sha256 = self._compute_sha256(orjson.dumps(manifest_payload))
-
-        stmt = (
-            select(SkillVersion.version)
-            .where(
-                SkillVersion.workspace_id == self.workspace_id,
-                SkillVersion.skill_id == skill.id,
-            )
-            .order_by(SkillVersion.version.desc())
-            .limit(1)
-        )
-        current_version_number = (await self.session.execute(stmt)).scalar_one_or_none()
-        next_version = (current_version_number or 0) + 1
-        version = SkillVersion(
-            workspace_id=self.workspace_id,
-            skill_id=skill.id,
-            version=next_version,
-            manifest_sha256=manifest_sha256,
-            file_count=len(rows),
-            total_size_bytes=sum(blob_row.size_bytes for _, blob_row in rows),
-            name=manifest_name,
-            description=validation.description,
-        )
-        self.session.add(version)
-        await self.session.flush()
-        for draft_file, _blob_row in rows:
-            self.session.add(
-                SkillVersionFile(
-                    workspace_id=self.workspace_id,
-                    skill_version_id=version.id,
-                    path=draft_file.path,
-                    blob_id=draft_file.blob_id,
-                    content_type=draft_file.content_type,
+        return await self._create_version_from_blob_refs(
+            skill=skill,
+            file_refs=[
+                (
+                    draft_file.path,
+                    SkillFileBlobRef(
+                        blob=blob_row,
+                        content_type=draft_file.content_type,
+                    ),
                 )
+                for draft_file, blob_row in rows
+            ],
+            validation=validation,
+        )
+
+    @require_scope("agent:update")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def publish_skill_version(
+        self, *, skill_id: uuid.UUID, params: SkillVersionPublish
+    ) -> SkillVersionRead:
+        """Atomically publish a new immutable skill version from a file set."""
+
+        skill = await self._get_skill_for_update(skill_id)
+        if skill is None:
+            raise TracecatNotFoundError(f"Skill '{skill_id}' not found")
+        if skill.current_version_id != params.base_version_id:
+            raise TracecatValidationError(
+                "Skill version conflict",
+                detail={
+                    "code": "skill_version_conflict",
+                    "current_version_id": (
+                        str(skill.current_version_id)
+                        if skill.current_version_id is not None
+                        else None
+                    ),
+                },
             )
-        skill.current_version_id = version.id
-        skill.name = manifest_name
-        skill.description = validation.description
-        self.session.add(skill)
-        await self.session.commit()
-        return await self.get_version_read(skill_id=skill.id, version_id=version.id)
+
+        prepared_files = self._prepare_upload_files(params.files)
+        validation = self._validate_prepared_upload_files(prepared_files)
+        if validation.errors:
+            raise TracecatValidationError(
+                "Skill version failed validation",
+                detail={
+                    "code": "skill_version_validation_failed",
+                    "errors": [
+                        error.model_dump(mode="json") for error in validation.errors
+                    ],
+                },
+            )
+        file_refs = [
+            (
+                file.path,
+                SkillFileBlobRef(
+                    blob=await self._get_or_create_blob(content=file.content),
+                    content_type=file.content_type,
+                ),
+            )
+            for file in prepared_files
+        ]
+        return await self._create_version_from_blob_refs(
+            skill=skill,
+            file_refs=file_refs,
+            validation=validation,
+        )
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def list_versions(

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -1109,16 +1109,17 @@ class SkillService(BaseWorkspaceService):
             parsed_skill_id = uuid.UUID(skill_id)
         except ValueError:
             parsed_skill_id = None
-        if parsed_skill_id is not None and (
-            skill := await self.get_skill(
+
+        uuid_match: Skill | None = None
+        if parsed_skill_id is not None:
+            uuid_match = await self.get_skill(
                 parsed_skill_id, include_archived=include_archived
             )
-        ):
-            return skill
+
         try:
             skill_name = SKILL_NAME_ADAPTER.validate_python(skill_id)
         except ValidationError:
-            return None
+            return uuid_match
         predicates = [
             Skill.workspace_id == self.workspace_id,
             Skill.name == skill_name,
@@ -1127,7 +1128,14 @@ class SkillService(BaseWorkspaceService):
             predicates.append(Skill.archived_at.is_(None))
         stmt = select(Skill).where(*predicates)
         skills = (await self.session.execute(stmt)).scalars().all()
-        if len(skills) > 1:
+
+        # A UUID string is also a valid skill name and names are not unique, so
+        # the identifier is ambiguous if multiple skills share the name, or if
+        # the id match and a name match point at different skills.
+        resolved_ids = {skill.id for skill in skills}
+        if uuid_match is not None:
+            resolved_ids.add(uuid_match.id)
+        if len(resolved_ids) > 1:
             raise TracecatValidationError(
                 "Skill identifier is ambiguous",
                 detail={
@@ -1135,7 +1143,7 @@ class SkillService(BaseWorkspaceService):
                     "skill_id": skill_name,
                 },
             ) from None
-        return skills[0] if skills else None
+        return uuid_match or (skills[0] if skills else None)
 
     async def _get_active_version(
         self, *, skill_id: uuid.UUID, version_id: uuid.UUID

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -1106,28 +1106,34 @@ class SkillService(BaseWorkspaceService):
         try:
             parsed_skill_id = uuid.UUID(skill_id)
         except ValueError:
-            try:
-                skill_name = SKILL_NAME_ADAPTER.validate_python(skill_id)
-            except ValidationError:
-                return None
-            predicates = [
-                Skill.workspace_id == self.workspace_id,
-                Skill.name == skill_name,
-            ]
-            if not include_archived:
-                predicates.append(Skill.archived_at.is_(None))
-            stmt = select(Skill).where(*predicates)
-            skills = (await self.session.execute(stmt)).scalars().all()
-            if len(skills) > 1:
-                raise TracecatValidationError(
-                    "Skill identifier is ambiguous",
-                    detail={
-                        "code": "ambiguous_skill_id",
-                        "skill_id": skill_name,
-                    },
-                ) from None
-            return skills[0] if skills else None
-        return await self.get_skill(parsed_skill_id, include_archived=include_archived)
+            parsed_skill_id = None
+        if parsed_skill_id is not None and (
+            skill := await self.get_skill(
+                parsed_skill_id, include_archived=include_archived
+            )
+        ):
+            return skill
+        try:
+            skill_name = SKILL_NAME_ADAPTER.validate_python(skill_id)
+        except ValidationError:
+            return None
+        predicates = [
+            Skill.workspace_id == self.workspace_id,
+            Skill.name == skill_name,
+        ]
+        if not include_archived:
+            predicates.append(Skill.archived_at.is_(None))
+        stmt = select(Skill).where(*predicates)
+        skills = (await self.session.execute(stmt)).scalars().all()
+        if len(skills) > 1:
+            raise TracecatValidationError(
+                "Skill identifier is ambiguous",
+                detail={
+                    "code": "ambiguous_skill_id",
+                    "skill_id": skill_name,
+                },
+            ) from None
+        return skills[0] if skills else None
 
     async def _get_active_version(
         self, *, skill_id: uuid.UUID, version_id: uuid.UUID

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -44,6 +44,7 @@ from tracecat.agent.provider.router import router as agent_custom_provider_route
 from tracecat.agent.router import router as agent_router
 from tracecat.agent.router import workspace_router as agent_workspace_router
 from tracecat.agent.session.router import router as agent_session_router
+from tracecat.agent.skill.internal_router import router as internal_agent_skill_router
 from tracecat.agent.skill.router import router as agent_skill_router
 from tracecat.agent.tags.definitions_router import (
     router as agent_tag_definitions_router,
@@ -594,6 +595,7 @@ def create_app(**kwargs) -> FastAPI:
     # Internal routers
     app.include_router(internal_agent_router)
     app.include_router(internal_agent_preset_router)
+    app.include_router(internal_agent_skill_router)
     app.include_router(internal_case_attachments_router)
     app.include_router(internal_cases_router)
     app.include_router(internal_deduplicate_router)

--- a/tracecat/executor/action_gateway/app.py
+++ b/tracecat/executor/action_gateway/app.py
@@ -113,6 +113,9 @@ def _include_internal_routers(app: FastAPI) -> None:
     from tracecat.agent.preset.internal_router import (
         router as internal_agent_preset_router,
     )
+    from tracecat.agent.skill.internal_router import (
+        router as internal_agent_skill_router,
+    )
     from tracecat.cases.attachments.internal_router import (
         router as internal_case_attachments_router,
     )
@@ -136,6 +139,7 @@ def _include_internal_routers(app: FastAPI) -> None:
 
     app.include_router(internal_agent_router)
     app.include_router(internal_agent_preset_router)
+    app.include_router(internal_agent_skill_router)
     app.include_router(internal_case_attachments_router)
     app.include_router(internal_cases_router)
     app.include_router(internal_deduplicate_router)


### PR DESCRIPTION
### Motivation
- Let workflows manage workspace agent skills for field-driven reflection loops: list or create a skill, read its current published state, generate or inspect published versions, publish a new immutable version from signals, roll back when needed, and bind that version onto an agent preset.
- Keep mutable drafts as an app/editor concern while giving registry workflows an atomic version-publish path that does not expose draft mutation UDFs.

### Description
- Add built-in `ai.skill` registry actions for listing, creating, reading, publishing versions for, restoring versions for, and archiving workspace agent skills.
- Add registry SDK helpers for internal workspace skill operations, including version list/get/restore helpers and `POST /internal/agent/skills/{skill_id}/versions` for direct version publishing.
- Resolve internal skill SDK paths by workflow-facing `skill_id` (the kebab-case skill name/ID) while allowing callers to pass an optional typed `skill_uuid` when they need to target the canonical UUID directly.
- Mount the internal agent skill router and translate validation failures into appropriate API responses, including `400` for invalid cursors or ambiguous skill identifiers and `409` for version conflicts or in-use archive attempts.
- Refactor skill publishing so draft publish and direct publish share validation, blob reuse, manifest hashing, and version creation logic.
- Publish direct versions from a complete file set with optimistic concurrency: omit `base_version_id` for the first version, and pass the observed `current_version_id` for later updates.
- Keep draft read/patch APIs available to backend/UI paths, but do not expose draft helpers through registry UDFs or the registry SDK.
- Preserve agent preset skill bindings so `ai.agent.create_preset` and `ai.agent.update_preset` can attach published skill versions.

### UDFs Added
- `ai.skill.list_skills`
- `ai.skill.create_skill`
- `ai.skill.get_skill`
- `ai.skill.list_skill_versions`
- `ai.skill.get_skill_version`
- `ai.skill.publish_skill_version`
- `ai.skill.restore_skill_version`
- `ai.skill.archive_skill`

### Rationale
- Workflows should not mutate long-lived drafts: that makes self-updating skill flows harder to reason about and exposes editor semantics to automation.
- Direct version publishing matches the workflow use case better. A workflow can call `get_skill`, use `current_version_id` as `base_version_id` when present, submit a full replacement file set, and receive `409` if another update won the race.
- Allowing `base_version_id` to be omitted for the first publish keeps the initial skill bootstrap path simple while preserving concurrency protection for subsequent publishes.
- Requiring a complete file set keeps published versions immutable and reproducible, while still supporting field users who want custom skill-update workflows.
- Using skill names as the workflow-facing `skill_id` keeps workflow definitions readable, while optional `skill_uuid` preserves an explicit disambiguation path.

### Testing
- `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/registry/test_agents_sdk.py tests/registry/test_core_skills.py tests/unit/test_agent_skill_internal_router.py tests/unit/test_skill_service.py::TestSkillService::test_get_skill_by_identifier_accepts_uuid_or_name tests/unit/test_skill_service.py::TestSkillService::test_get_skill_by_identifier_rejects_ambiguous_names -q`
- `uv run ruff check tracecat/agent/skill/service.py tracecat/agent/skill/internal_router.py packages/tracecat-registry/tracecat_registry/core/skills.py packages/tracecat-registry/tracecat_registry/sdk/agents.py tests/registry/test_agents_sdk.py tests/registry/test_core_skills.py tests/unit/test_agent_skill_internal_router.py tests/unit/test_skill_service.py`
- `uv run ruff format --check tracecat/agent/skill/service.py tracecat/agent/skill/internal_router.py packages/tracecat-registry/tracecat_registry/core/skills.py packages/tracecat-registry/tracecat_registry/sdk/agents.py tests/registry/test_agents_sdk.py tests/registry/test_core_skills.py tests/unit/test_agent_skill_internal_router.py tests/unit/test_skill_service.py`
- `uv run basedpyright tracecat/agent/skill/service.py tracecat/agent/skill/internal_router.py packages/tracecat-registry/tracecat_registry/core/skills.py packages/tracecat-registry/tracecat_registry/sdk/agents.py tests/registry/test_agents_sdk.py tests/registry/test_core_skills.py tests/unit/test_agent_skill_internal_router.py tests/unit/test_skill_service.py`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3bab7c374832088ae2f0f8df496a3)
