### PR TITLE
refactor: Avoid synthetic prompt for approval continuations

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -21,6 +21,7 @@ with workflow.unsafe.imports_passed_through():
         DeniedToolCall,
         run_agent_activity,
     )
+    from tracecat.agent.executor.schemas import ToolExecutionResult
     from tracecat.agent.mcp.executor import (
         AGENT_TOOL_PRIORITY,
         build_run_input,
@@ -550,12 +551,12 @@ class DurableAgentWorkflow:
                 # Persist approval decisions to DB (atomic with chat messages)
                 await self.approvals.handle_decisions()
 
-                # Execute approved tools and collect results
+                # Execute approved tools and reconcile the SDK transcript.
                 approved_tools, denied_tools = self._build_tool_lists_from_approvals(
                     result.approval_items or []
                 )
 
-                tool_results = None
+                tool_results: list[ToolExecutionResult] = []
                 if approved_tools or denied_tools:
                     tool_results = await self._execute_and_reconcile_approved_tools(
                         approved_tools=approved_tools,
@@ -582,7 +583,8 @@ class DurableAgentWorkflow:
                         sdk_session_id=self._sdk_session_id,
                     )
 
-                # Update executor input for resume (history now has proper tool_result)
+                # Update executor input for resume. Reconcile has removed the
+                # interrupt artifacts; the runtime sends tool_result as SDK input.
                 executor_input = AgentExecutorInput(
                     session_id=self.session_id,
                     workspace_id=self.workspace_id,
@@ -595,6 +597,8 @@ class DurableAgentWorkflow:
                     sdk_session_id=self._sdk_session_id,
                     sdk_session_data=self._sdk_session_data,
                     is_approval_continuation=True,
+                    approval_tool_results=tool_results,
+                    use_workspace_credentials=args.agent_args.use_workspace_credentials,
                 )
                 self._turn += 1
                 continue

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -598,7 +598,6 @@ class DurableAgentWorkflow:
                     sdk_session_id=self._sdk_session_id,
                     sdk_session_data=self._sdk_session_data,
                     is_approval_continuation=True,
-                    approval_tool_results=tool_results,
                 )
                 self._turn += 1
                 continue

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -583,8 +583,9 @@ class DurableAgentWorkflow:
                         sdk_session_id=self._sdk_session_id,
                     )
 
-                # Update executor input for resume. Reconcile has removed the
-                # interrupt artifacts; the runtime sends tool_result as SDK input.
+                # Update executor input for resume. Reconcile has replaced the
+                # interrupt artifacts with the real tool_result entry; the
+                # runtime only sends a hidden continuation tick.
                 executor_input = AgentExecutorInput(
                     session_id=self.session_id,
                     workspace_id=self.workspace_id,
@@ -598,7 +599,6 @@ class DurableAgentWorkflow:
                     sdk_session_data=self._sdk_session_data,
                     is_approval_continuation=True,
                     approval_tool_results=tool_results,
-                    use_workspace_credentials=args.agent_args.use_workspace_credentials,
                 )
                 self._turn += 1
                 continue

--- a/tests/integration/test_agent_worker.py
+++ b/tests/integration/test_agent_worker.py
@@ -28,20 +28,28 @@ from temporalio.worker import Worker
 from tracecat_ee.agent.activities import AgentActivities
 from tracecat_ee.agent.approvals.service import ApprovalManager
 from tracecat_ee.agent.types import AgentWorkflowID
-from tracecat_ee.agent.workflows.durable import AgentWorkflowArgs, DurableAgentWorkflow
+from tracecat_ee.agent.workflows.durable import (
+    AgentWorkflowArgs,
+    DurableAgentWorkflow,
+    WorkflowApprovalSubmission,
+)
 
 from tests.conftest import AGENT_TASK_QUEUE
 from tracecat import config
+from tracecat.agent.common.stream_types import ToolCallContent
 from tracecat.agent.executor.activity import (
     AgentExecutorInput,
     AgentExecutorResult,
 )
+from tracecat.agent.executor.schemas import ToolExecutionResult
 from tracecat.agent.schemas import RunAgentArgs
 from tracecat.agent.session.activities import (
     CreateSessionInput,
     CreateSessionResult,
     LoadSessionInput,
     LoadSessionResult,
+    ReconcileToolResultsInput,
+    ReconcileToolResultsResult,
     get_session_activities,
 )
 from tracecat.agent.session.types import AgentSessionEntity
@@ -50,6 +58,7 @@ from tracecat.auth.types import Role
 from tracecat.dsl.common import RETRY_POLICIES
 from tracecat.dsl.worker import new_sandbox_runner
 from tracecat.redis.client import get_redis_client
+from tracecat.storage.object import InlineObject
 
 # Use worker-specific queue from conftest for pytest-xdist isolation
 TEST_AGENT_QUEUE = AGENT_TASK_QUEUE
@@ -388,6 +397,168 @@ class TestAgentWorkerSingleTenant:
 
             # The error message is in the cause chain
             assert "Simulated agent error" in str(exc_info.value.cause)
+
+    @pytest.mark.anyio
+    @pytest.mark.integration
+    async def test_approval_continuation_sends_tool_result_as_next_input(
+        self,
+        svc_role: Role,
+        temporal_client: Client,
+        agent_worker_factory: Callable[..., Worker],
+    ) -> None:
+        """Approval continuation should resume before tool_result and pass it separately."""
+        session_id = uuid.uuid4()
+        queue = TEST_AGENT_QUEUE
+        approval_request_recorded = asyncio.Event()
+        captured_inputs: list[AgentExecutorInput] = []
+        sdk_history_without_tool_result = (
+            '{"type":"user","message":{"content":"Run approved tool"}}\n'
+            '{"type":"assistant","message":{"content":[{"type":"tool_use",'
+            '"id":"call_123","name":"core__http_request","input":{"url":'
+            '"https://example.com","method":"GET"}}]}}\n'
+        )
+
+        @activity.defn(name="create_session_activity")
+        async def mock_create_session_activity(
+            input: CreateSessionInput,
+        ) -> CreateSessionResult:
+            return CreateSessionResult(session_id=input.session_id, success=True)
+
+        load_session_call_count = 0
+
+        @activity.defn(name="load_session_activity")
+        async def mock_load_session_activity(
+            input: LoadSessionInput,
+        ) -> LoadSessionResult:
+            del input
+            nonlocal load_session_call_count
+            load_session_call_count += 1
+            if load_session_call_count == 1:
+                return LoadSessionResult(found=False)
+            return LoadSessionResult(
+                found=True,
+                sdk_session_id="sdk-session",
+                sdk_session_data=sdk_history_without_tool_result,
+            )
+
+        @activity.defn(name="record_approval_requests")
+        async def mock_record_approval_requests(input: Any) -> None:
+            del input
+            approval_request_recorded.set()
+
+        @activity.defn(name="apply_approval_decisions")
+        async def mock_apply_approval_decisions(input: Any) -> None:
+            del input
+
+        @activity.defn(name="execute_action_activity")
+        async def mock_execute_action_activity(
+            input: Any,
+            role: Role,
+        ) -> InlineObject[dict[str, str]]:
+            del input, role
+            return InlineObject(data={"status": "success"})
+
+        @activity.defn(name="reconcile_tool_results_activity")
+        async def mock_reconcile_tool_results_activity(
+            input: ReconcileToolResultsInput,
+        ) -> ReconcileToolResultsResult:
+            results = [
+                ToolExecutionResult(
+                    tool_call_id=pending.tool_call_id,
+                    tool_name=pending.tool_name,
+                    result=getattr(pending.stored_result, "data", pending.raw_result),
+                    is_error=pending.is_error,
+                )
+                for pending in input.pending_results
+            ]
+            return ReconcileToolResultsResult(results=results)
+
+        def mock_executor(input: AgentExecutorInput) -> AgentExecutorResult:
+            captured_inputs.append(input)
+            if len(captured_inputs) == 1:
+                return AgentExecutorResult(
+                    success=True,
+                    approval_requested=True,
+                    approval_items=[
+                        ToolCallContent(
+                            id="call_123",
+                            name="core__http_request",
+                            input={"url": "https://example.com", "method": "GET"},
+                        )
+                    ],
+                )
+
+            assert input.is_approval_continuation is True
+            assert input.sdk_session_id == "sdk-session"
+            assert input.sdk_session_data == sdk_history_without_tool_result
+            assert '"type":"tool_result"' not in input.sdk_session_data
+            assert "Continue." not in input.sdk_session_data
+            assert len(input.approval_tool_results) == 1
+            [tool_result] = input.approval_tool_results
+            assert tool_result.tool_call_id == "call_123"
+            assert tool_result.is_error is False
+            return AgentExecutorResult(
+                success=True,
+                approval_requested=False,
+                output={"status": "continued"},
+            )
+
+        agent_activities = AgentActivities()
+        activities: list[Callable[..., Any]] = [
+            *agent_activities.get_activities(),
+            mock_create_session_activity,
+            mock_load_session_activity,
+            mock_record_approval_requests,
+            mock_apply_approval_decisions,
+            mock_execute_action_activity,
+            mock_reconcile_tool_results_activity,
+            create_mock_run_agent_activity(mock_executor),
+        ]
+
+        workflow_args = AgentWorkflowArgs(
+            role=svc_role,
+            agent_args=RunAgentArgs(
+                session_id=session_id,
+                user_prompt="Run approved tool",
+                config=AgentConfig(
+                    model_name="claude-3-5-sonnet-20241022",
+                    model_provider="anthropic",
+                    actions=["core.http_request"],
+                    tool_approvals={"core.http_request": True},
+                ),
+            ),
+            entity_type=AgentSessionEntity.WORKFLOW,
+            entity_id=uuid.uuid4(),
+        )
+
+        async with agent_worker_factory(
+            temporal_client, task_queue=queue, custom_activities=activities
+        ):
+            wf_handle = await temporal_client.start_workflow(
+                DurableAgentWorkflow.run,
+                workflow_args,
+                id=AgentWorkflowID(session_id),
+                task_queue=queue,
+                retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+                execution_timeout=timedelta(seconds=30),
+            )
+
+            await asyncio.wait_for(approval_request_recorded.wait(), timeout=10)
+            await wf_handle.execute_update(
+                DurableAgentWorkflow.set_approvals,
+                WorkflowApprovalSubmission(
+                    approvals={"call_123": True},
+                    approved_by=svc_role.user_id,
+                ),
+            )
+
+            result = await wf_handle.result()
+
+        assert result.output == {"status": "continued"}
+        assert [input.is_approval_continuation for input in captured_inputs] == [
+            False,
+            True,
+        ]
 
 
 class TestAgentWorkerMultiTenant:

--- a/tests/integration/test_agent_worker.py
+++ b/tests/integration/test_agent_worker.py
@@ -400,13 +400,13 @@ class TestAgentWorkerSingleTenant:
 
     @pytest.mark.anyio
     @pytest.mark.integration
-    async def test_approval_continuation_sends_tool_result_as_next_input(
+    async def test_approval_continuation_resumes_with_seeded_tool_result(
         self,
         svc_role: Role,
         temporal_client: Client,
         agent_worker_factory: Callable[..., Worker],
     ) -> None:
-        """Approval continuation should resume before tool_result and pass it separately."""
+        """Approval continuation should resume after the reconciled tool_result row."""
         session_id = uuid.uuid4()
         queue = TEST_AGENT_QUEUE
         approval_request_recorded = asyncio.Event()
@@ -416,6 +416,12 @@ class TestAgentWorkerSingleTenant:
             '{"type":"assistant","message":{"content":[{"type":"tool_use",'
             '"id":"call_123","name":"core__http_request","input":{"url":'
             '"https://example.com","method":"GET"}}]}}\n'
+        )
+        sdk_history_with_tool_result = (
+            sdk_history_without_tool_result
+            + '{"type":"user","message":{"content":[{"type":"tool_result",'
+            '"tool_use_id":"call_123","content":"{\\"status\\":\\"success\\"}",'
+            '"is_error":false}]}}\n'
         )
 
         @activity.defn(name="create_session_activity")
@@ -438,7 +444,7 @@ class TestAgentWorkerSingleTenant:
             return LoadSessionResult(
                 found=True,
                 sdk_session_id="sdk-session",
-                sdk_session_data=sdk_history_without_tool_result,
+                sdk_session_data=sdk_history_with_tool_result,
             )
 
         @activity.defn(name="record_approval_requests")
@@ -490,8 +496,8 @@ class TestAgentWorkerSingleTenant:
 
             assert input.is_approval_continuation is True
             assert input.sdk_session_id == "sdk-session"
-            assert input.sdk_session_data == sdk_history_without_tool_result
-            assert '"type":"tool_result"' not in input.sdk_session_data
+            assert input.sdk_session_data == sdk_history_with_tool_result
+            assert '"type":"tool_result"' in input.sdk_session_data
             assert "Continue." not in input.sdk_session_data
             assert len(input.approval_tool_results) == 1
             [tool_result] = input.approval_tool_results

--- a/tests/integration/test_agent_worker.py
+++ b/tests/integration/test_agent_worker.py
@@ -499,10 +499,6 @@ class TestAgentWorkerSingleTenant:
             assert input.sdk_session_data == sdk_history_with_tool_result
             assert '"type":"tool_result"' in input.sdk_session_data
             assert "Continue." not in input.sdk_session_data
-            assert len(input.approval_tool_results) == 1
-            [tool_result] = input.approval_tool_results
-            assert tool_result.tool_call_id == "call_123"
-            assert tool_result.is_error is False
             return AgentExecutorResult(
                 success=True,
                 approval_requested=False,

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -643,7 +643,7 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
                                     {
                                         "type": "tool_result",
                                         "tool_use_id": "call_123",
-                                        "content": "interrupted",
+                                        "content": "The user doesn't want to take this action right now.",
                                         "is_error": True,
                                     }
                                 ],
@@ -689,7 +689,9 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
             for block in entry.get("message", {}).get("content", [])
             if isinstance(block, dict) and block.get("type") == "tool_result"
         ]
-        assert tool_result_blocks == []
+        assert len(tool_result_blocks) == 1
+        assert tool_result_blocks[0]["tool_use_id"] == "call_123"
+        assert tool_result_blocks[0]["is_error"] is False
 
         resumed_after_approval.set()
         run_agent_call_count += 1
@@ -811,9 +813,7 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
         for block in entry.content.get("message", {}).get("content", [])
         if isinstance(block, dict) and block.get("type") == "tool_result"
     ]
-    assert not any(
-        block.get("tool_use_id") == "call_123" for block in tool_result_blocks
-    )
+    assert any(block.get("tool_use_id") == "call_123" for block in tool_result_blocks)
 
 
 @pytest.mark.anyio
@@ -853,6 +853,10 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
         '"method":"GET"}},{"type":"tool_use","id":"call_risky",'
         '"name":"core__http_request","input":{"url":"https://risky.example.com",'
         '"method":"DELETE"}}]}}\n'
+        '{"type":"user","message":{"content":[{"type":"tool_result",'
+        '"tool_use_id":"call_safe","content":"{\\"status\\":\\"success\\"}",'
+        '"is_error":false},{"type":"tool_result","tool_use_id":"call_risky",'
+        '"content":"denied","is_error":true}]}}\n'
     )
 
     @activity.defn(name="create_session_activity")
@@ -949,7 +953,7 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
         assert input.sdk_session_data == continuation_sdk_session_data
         assert input.is_fork is False
         assert input.is_approval_continuation is True
-        assert '"type":"tool_result"' not in input.sdk_session_data
+        assert '"type":"tool_result"' in input.sdk_session_data
         assert [result.tool_call_id for result in input.approval_tool_results] == [
             "call_safe",
             "call_risky",
@@ -1253,7 +1257,7 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
                                     {
                                         "type": "tool_result",
                                         "tool_use_id": "call_123",
-                                        "content": "interrupted",
+                                        "content": "The user doesn't want to take this action right now.",
                                         "is_error": True,
                                     }
                                 ],
@@ -1296,7 +1300,9 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
             for block in entry.get("message", {}).get("content", [])
             if isinstance(block, dict) and block.get("type") == "tool_result"
         ]
-        assert tool_result_blocks == []
+        assert len(tool_result_blocks) == 1
+        assert tool_result_blocks[0]["tool_use_id"] == "call_123"
+        assert tool_result_blocks[0]["is_error"] is True
 
         resumed_after_approval.set()
         run_agent_call_count += 1
@@ -1402,9 +1408,7 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
         for block in entry.content.get("message", {}).get("content", [])
         if isinstance(block, dict) and block.get("type") == "tool_result"
     ]
-    assert not any(
-        block.get("tool_use_id") == "call_123" for block in tool_result_blocks
-    )
+    assert any(block.get("tool_use_id") == "call_123" for block in tool_result_blocks)
 
 
 # =============================================================================

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -643,7 +643,7 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
                                     {
                                         "type": "tool_result",
                                         "tool_use_id": "call_123",
-                                        "content": "The user doesn't want to take this action right now.",
+                                        "content": "interrupted",
                                         "is_error": True,
                                     }
                                 ],
@@ -1257,7 +1257,7 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
                                     {
                                         "type": "tool_result",
                                         "tool_use_id": "call_123",
-                                        "content": "The user doesn't want to take this action right now.",
+                                        "content": "interrupted",
                                         "is_error": True,
                                     }
                                 ],

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -669,14 +669,6 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
         assert input.is_approval_continuation is True
         assert input.sdk_session_id == "sdk-session"
         assert input.sdk_session_data is not None
-        assert len(input.approval_tool_results) == 1
-        [tool_result] = input.approval_tool_results
-        assert tool_result.tool_call_id == "call_123"
-        assert tool_result.is_error is False
-        assert tool_result.result == {
-            "status": "success",
-            "executor_queue": executor_queue,
-        }
 
         session_lines = [
             orjson.loads(line)
@@ -692,6 +684,10 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
         assert len(tool_result_blocks) == 1
         assert tool_result_blocks[0]["tool_use_id"] == "call_123"
         assert tool_result_blocks[0]["is_error"] is False
+        assert orjson.loads(tool_result_blocks[0]["content"]) == {
+            "status": "success",
+            "executor_queue": executor_queue,
+        }
 
         resumed_after_approval.set()
         run_agent_call_count += 1
@@ -968,12 +964,6 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
         assert input.is_fork is False
         assert input.is_approval_continuation is True
         assert '"type":"tool_result"' in input.sdk_session_data
-        assert [result.tool_call_id for result in input.approval_tool_results] == [
-            "call_safe",
-            "call_risky",
-        ]
-        assert input.approval_tool_results[0].is_error is False
-        assert input.approval_tool_results[1].is_error is True
         continuation_seen.set()
         return AgentExecutorResult(
             success=True,
@@ -1297,11 +1287,6 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
         assert input.is_approval_continuation is True
         assert input.sdk_session_id == "sdk-session"
         assert input.sdk_session_data is not None
-        assert len(input.approval_tool_results) == 1
-        [tool_result] = input.approval_tool_results
-        assert tool_result.tool_call_id == "call_123"
-        assert tool_result.is_error is True
-        assert "transient tool failure" in str(tool_result.result)
 
         session_lines = [
             orjson.loads(line)
@@ -1317,6 +1302,7 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
         assert len(tool_result_blocks) == 1
         assert tool_result_blocks[0]["tool_use_id"] == "call_123"
         assert tool_result_blocks[0]["is_error"] is True
+        assert "transient tool failure" in tool_result_blocks[0]["content"]
 
         resumed_after_approval.set()
         run_agent_call_count += 1

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -813,7 +813,21 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
         for block in entry.content.get("message", {}).get("content", [])
         if isinstance(block, dict) and block.get("type") == "tool_result"
     ]
-    assert any(block.get("tool_use_id") == "call_123" for block in tool_result_blocks)
+    assert any(
+        block.get("tool_use_id") == "call_123" and block.get("is_error") is False
+        for block in tool_result_blocks
+    )
+    assert not any(
+        block.get("tool_use_id") == "call_123" and block.get("is_error") is True
+        for block in tool_result_blocks
+    )
+    inserted_block = next(
+        block for block in tool_result_blocks if block.get("tool_use_id") == "call_123"
+    )
+    assert orjson.loads(inserted_block["content"]) == {
+        "status": "success",
+        "executor_queue": executor_queue,
+    }
 
 
 @pytest.mark.anyio
@@ -1408,7 +1422,11 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
         for block in entry.content.get("message", {}).get("content", [])
         if isinstance(block, dict) and block.get("type") == "tool_result"
     ]
-    assert any(block.get("tool_use_id") == "call_123" for block in tool_result_blocks)
+    inserted_block = next(
+        block for block in tool_result_blocks if block.get("tool_use_id") == "call_123"
+    )
+    assert inserted_block["is_error"] is True
+    assert "Tool execution failed:" in inserted_block["content"]
 
 
 # =============================================================================

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -669,6 +669,14 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
         assert input.is_approval_continuation is True
         assert input.sdk_session_id == "sdk-session"
         assert input.sdk_session_data is not None
+        assert len(input.approval_tool_results) == 1
+        [tool_result] = input.approval_tool_results
+        assert tool_result.tool_call_id == "call_123"
+        assert tool_result.is_error is False
+        assert tool_result.result == {
+            "status": "success",
+            "executor_queue": executor_queue,
+        }
 
         session_lines = [
             orjson.loads(line)
@@ -681,10 +689,8 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
             for block in entry.get("message", {}).get("content", [])
             if isinstance(block, dict) and block.get("type") == "tool_result"
         ]
-        assert any(
-            block.get("tool_use_id") == "call_123" and block.get("is_error") is False
-            for block in tool_result_blocks
-        )
+        assert tool_result_blocks == []
+
         resumed_after_approval.set()
         run_agent_call_count += 1
         return AgentExecutorResult(
@@ -805,21 +811,9 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
         for block in entry.content.get("message", {}).get("content", [])
         if isinstance(block, dict) and block.get("type") == "tool_result"
     ]
-    assert any(
-        block.get("tool_use_id") == "call_123" and block.get("is_error") is False
-        for block in tool_result_blocks
-    )
     assert not any(
-        block.get("tool_use_id") == "call_123" and block.get("is_error") is True
-        for block in tool_result_blocks
+        block.get("tool_use_id") == "call_123" for block in tool_result_blocks
     )
-    inserted_block = next(
-        block for block in tool_result_blocks if block.get("tool_use_id") == "call_123"
-    )
-    assert orjson.loads(inserted_block["content"]) == {
-        "status": "success",
-        "executor_queue": executor_queue,
-    }
 
 
 @pytest.mark.anyio
@@ -856,10 +850,9 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
         '{"type":"user","message":{"content":"parent prompt"}}\n'
         '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"call_safe",'
         '"name":"core__http_request","input":{"url":"https://safe.example.com",'
-        '"method":"GET"}}]}}\n'
-        '{"type":"user","message":{"content":[{"type":"tool_result",'
-        '"tool_use_id":"call_safe","content":"{\\"status\\":\\"success\\"}",'
-        '"is_error":false}]}}\n'
+        '"method":"GET"}},{"type":"tool_use","id":"call_risky",'
+        '"name":"core__http_request","input":{"url":"https://risky.example.com",'
+        '"method":"DELETE"}}]}}\n'
     )
 
     @activity.defn(name="create_session_activity")
@@ -956,6 +949,13 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
         assert input.sdk_session_data == continuation_sdk_session_data
         assert input.is_fork is False
         assert input.is_approval_continuation is True
+        assert '"type":"tool_result"' not in input.sdk_session_data
+        assert [result.tool_call_id for result in input.approval_tool_results] == [
+            "call_safe",
+            "call_risky",
+        ]
+        assert input.approval_tool_results[0].is_error is False
+        assert input.approval_tool_results[1].is_error is True
         continuation_seen.set()
         return AgentExecutorResult(
             success=True,
@@ -1279,6 +1279,11 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
         assert input.is_approval_continuation is True
         assert input.sdk_session_id == "sdk-session"
         assert input.sdk_session_data is not None
+        assert len(input.approval_tool_results) == 1
+        [tool_result] = input.approval_tool_results
+        assert tool_result.tool_call_id == "call_123"
+        assert tool_result.is_error is True
+        assert "transient tool failure" in str(tool_result.result)
 
         session_lines = [
             orjson.loads(line)
@@ -1291,10 +1296,8 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
             for block in entry.get("message", {}).get("content", [])
             if isinstance(block, dict) and block.get("type") == "tool_result"
         ]
-        assert any(
-            block.get("tool_use_id") == "call_123" and block.get("is_error") is True
-            for block in tool_result_blocks
-        )
+        assert tool_result_blocks == []
+
         resumed_after_approval.set()
         run_agent_call_count += 1
         return AgentExecutorResult(
@@ -1399,11 +1402,9 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
         for block in entry.content.get("message", {}).get("content", [])
         if isinstance(block, dict) and block.get("type") == "tool_result"
     ]
-    inserted_block = next(
-        block for block in tool_result_blocks if block.get("tool_use_id") == "call_123"
+    assert not any(
+        block.get("tool_use_id") == "call_123" for block in tool_result_blocks
     )
-    assert inserted_block["is_error"] is True
-    assert "Tool execution failed:" in inserted_block["content"]
 
 
 # =============================================================================

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import orjson
 import pytest
 from claude_agent_sdk.types import (
     HookContext,
@@ -24,7 +25,7 @@ from claude_agent_sdk.types import (
 )
 
 import tracecat.agent.runtime.claude_code.runtime as runtime_module
-from tracecat.agent.common.protocol import RuntimeInitPayload
+from tracecat.agent.common.protocol import RuntimeInitPayload, RuntimeToolResult
 from tracecat.agent.common.socket_io import SocketStreamWriter
 from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
 from tracecat.agent.common.types import (
@@ -632,7 +633,7 @@ class TestClaudeAgentRuntimeRun:
         ],
     )
     @pytest.mark.anyio
-    async def test_approval_continuation_uses_hidden_prompt_in_each_sandbox_mode(
+    async def test_approval_continuation_sends_tool_result_input_in_each_sandbox_mode(
         self,
         monkeypatch: pytest.MonkeyPatch,
         mock_socket_writer: MagicMock,
@@ -641,7 +642,7 @@ class TestClaudeAgentRuntimeRun:
         tmp_path: Path,
         disable_nsjail: bool,
     ) -> None:
-        """Approval continuations must resume with Tracecat's hidden prompt."""
+        """Approval continuations send tool_result blocks as SDK input."""
         monkeypatch.setattr(runtime_module, "TRACECAT__DISABLE_NSJAIL", disable_nsjail)
         captured_options: list[Any] = []
 
@@ -652,8 +653,18 @@ class TestClaudeAgentRuntimeRun:
         continued_payload = replace(
             sample_init_payload,
             sdk_session_id="eed8297f-26fb-4e00-905f-a10f0cf20704",
-            sdk_session_data='{"type":"user","message":{"content":"tool result"}}\n',
+            sdk_session_data=(
+                '{"type":"assistant","message":{"content":[{"type":"tool_use",'
+                '"id":"call_123","name":"core__http_request","input":{}}]}}\n'
+            ),
             is_approval_continuation=True,
+            approval_tool_results=[
+                RuntimeToolResult(
+                    tool_call_id="call_123",
+                    content='{"status":"success"}',
+                    is_error=False,
+                )
+            ],
         )
 
         with (
@@ -679,9 +690,28 @@ class TestClaudeAgentRuntimeRun:
         assert captured_options[0].resume == continued_payload.sdk_session_id
         assert captured_options[0].fork_session is False
         assert captured_options[0].sandbox["enabled"] is disable_nsjail
-        mock_claude_sdk_client.query.assert_awaited_once_with(
-            "[INTERNAL] End of Tool Call"
-        )
+        mock_claude_sdk_client.query.assert_awaited_once()
+        query_input = mock_claude_sdk_client.query.await_args.args[0]
+        assert not isinstance(query_input, str)
+        messages = [message async for message in query_input]
+        assert messages == [
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_123",
+                            "content": '{"status":"success"}',
+                            "is_error": False,
+                        }
+                    ],
+                },
+                "parent_tool_use_id": None,
+                "session_id": "default",
+            }
+        ]
 
     @pytest.mark.parametrize(
         "disable_nsjail",
@@ -1201,3 +1231,117 @@ class TestClaudeAgentRuntimeInternalSessionLines:
         }
 
         assert runtime._is_internal_session_line(line_data) is True
+
+    @pytest.mark.anyio
+    async def test_approval_continuation_hides_sdk_meta_prompt_and_reasoning(
+        self,
+        mock_socket_writer: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Approval continuation control rows should not show in chat or traces."""
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+        )
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        runtime._sdk_session_id = sdk_session_id
+        runtime._approval_continuation_active = True
+
+        tool_result_uuid = "tool-result-uuid"
+        meta_uuid = "meta-uuid"
+        synthetic_uuid = "synthetic-uuid"
+        prompt_uuid = "prompt-uuid"
+        thinking_uuid = "thinking-uuid"
+        answer_uuid = "answer-uuid"
+        lines = [
+            {
+                "type": "user",
+                "uuid": tool_result_uuid,
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "call_123"}],
+                },
+            },
+            {
+                "type": "user",
+                "uuid": meta_uuid,
+                "isMeta": True,
+                "parentUuid": tool_result_uuid,
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Continue from where you left off.",
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "assistant",
+                "uuid": synthetic_uuid,
+                "parentUuid": meta_uuid,
+                "message": {"model": "<synthetic>", "content": []},
+            },
+            {
+                "type": "user",
+                "uuid": prompt_uuid,
+                "parentUuid": synthetic_uuid,
+                "message": {
+                    "role": "user",
+                    "content": runtime_module.APPROVAL_CONTINUATION_PROMPT,
+                },
+            },
+            {
+                "type": "assistant",
+                "uuid": thinking_uuid,
+                "parentUuid": prompt_uuid,
+                "message": {
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "Saw hidden continuation prompts.",
+                        }
+                    ]
+                },
+            },
+            {
+                "type": "assistant",
+                "uuid": answer_uuid,
+                "parentUuid": thinking_uuid,
+                "message": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "There are no cases.",
+                        }
+                    ]
+                },
+            },
+        ]
+
+        session_file = runtime._get_session_file_path(sdk_session_id)
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_text(
+            "\n".join(orjson.dumps(line).decode("utf-8") for line in lines) + "\n"
+        )
+
+        await runtime._emit_new_session_lines()
+
+        persisted = [
+            (orjson.loads(call.args[1]), call.kwargs["internal"])
+            for call in mock_socket_writer.send_session_line.await_args_list
+        ]
+        internal_by_uuid = {
+            line["uuid"]: internal
+            for line, internal in persisted
+            if isinstance(line.get("uuid"), str)
+        }
+        assert internal_by_uuid[tool_result_uuid] is False
+        assert internal_by_uuid[meta_uuid] is True
+        assert internal_by_uuid[synthetic_uuid] is True
+        assert internal_by_uuid[prompt_uuid] is True
+        assert internal_by_uuid[thinking_uuid] is True
+        assert internal_by_uuid[answer_uuid] is False

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -711,6 +711,102 @@ class TestClaudeAgentRuntimeRun:
             }
         ]
 
+    @pytest.mark.anyio
+    async def test_approval_continuation_forwards_live_thinking_events(
+        self,
+        mock_socket_writer: MagicMock,
+        mock_claude_sdk_client: MagicMock,
+        sample_init_payload: RuntimeInitPayload,
+        tmp_path: Path,
+    ) -> None:
+        """Real resumed-turn thinking should stream during approval continuation."""
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        continued_payload = replace(
+            sample_init_payload,
+            sdk_session_id=sdk_session_id,
+            sdk_session_data=(
+                '{"type":"assistant","message":{"content":[{"type":"tool_use",'
+                '"id":"call_123","name":"core__http_request","input":{}}]}}\n'
+            ),
+            is_approval_continuation=True,
+            approval_tool_results=[
+                RuntimeToolResult(
+                    tool_call_id="call_123",
+                    content='{"status":"success"}',
+                    is_error=False,
+                )
+            ],
+        )
+
+        async def mock_receive() -> Any:
+            yield StreamEvent(
+                uuid="thinking-start",
+                session_id=sdk_session_id,
+                event={
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "thinking", "thinking": ""},
+                },
+            )
+            yield StreamEvent(
+                uuid="thinking-delta",
+                session_id=sdk_session_id,
+                event={
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {
+                        "type": "thinking_delta",
+                        "thinking": "Using the approved tool result.",
+                    },
+                },
+            )
+            yield StreamEvent(
+                uuid="thinking-stop",
+                session_id=sdk_session_id,
+                event={"type": "content_block_stop", "index": 0},
+            )
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id=sdk_session_id,
+                usage={},
+                result="done",
+            )
+
+        mock_claude_sdk_client.receive_response = mock_receive
+
+        with (
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKClient",
+                return_value=mock_claude_sdk_client,
+            ),
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.create_proxy_mcp_server",
+                AsyncMock(return_value={}),
+            ),
+        ):
+            runtime = ClaudeAgentRuntime(
+                mock_socket_writer,
+                transport_factory=lambda _options: MagicMock(),
+                session_home_dir=tmp_path / "claude-home",
+                cwd=tmp_path / "claude-project",
+                cwd_setup_path=tmp_path / "claude-project",
+            )
+            await runtime.run(continued_payload)
+
+        event_types = [
+            call.args[0].type
+            for call in mock_socket_writer.send_stream_event.await_args_list
+        ]
+        assert event_types == [
+            StreamEventType.THINKING_START,
+            StreamEventType.THINKING_DELTA,
+            StreamEventType.THINKING_STOP,
+        ]
+
     @pytest.mark.parametrize(
         "disable_nsjail",
         [
@@ -1231,12 +1327,12 @@ class TestClaudeAgentRuntimeInternalSessionLines:
         assert runtime._is_internal_session_line(line_data) is True
 
     @pytest.mark.anyio
-    async def test_approval_continuation_hides_sdk_meta_prompt_and_reasoning(
+    async def test_approval_continuation_hides_sdk_meta_prompt_only(
         self,
         mock_socket_writer: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Approval continuation control rows should not show in chat or traces."""
+        """Approval continuation control rows should not hide assistant output."""
         runtime = ClaudeAgentRuntime(
             mock_socket_writer,
             transport_factory=lambda _: MagicMock(),
@@ -1245,7 +1341,7 @@ class TestClaudeAgentRuntimeInternalSessionLines:
         )
         sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
         runtime._sdk_session_id = sdk_session_id
-        runtime._approval_continuation_active = True
+        runtime._hide_next_approval_continuation_prompt = True
 
         tool_result_uuid = "tool-result-uuid"
         meta_uuid = "meta-uuid"
@@ -1341,5 +1437,5 @@ class TestClaudeAgentRuntimeInternalSessionLines:
         assert internal_by_uuid[meta_uuid] is True
         assert internal_by_uuid[synthetic_uuid] is True
         assert internal_by_uuid[prompt_uuid] is True
-        assert internal_by_uuid[thinking_uuid] is True
+        assert internal_by_uuid[thinking_uuid] is False
         assert internal_by_uuid[answer_uuid] is False

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -639,7 +639,7 @@ class TestClaudeAgentRuntimeRun:
         ],
     )
     @pytest.mark.anyio
-    async def test_approval_continuation_sends_tool_result_input_in_each_sandbox_mode(
+    async def test_approval_continuation_sends_meta_prompt_in_each_sandbox_mode(
         self,
         monkeypatch: pytest.MonkeyPatch,
         mock_socket_writer: MagicMock,
@@ -648,7 +648,7 @@ class TestClaudeAgentRuntimeRun:
         tmp_path: Path,
         disable_nsjail: bool,
     ) -> None:
-        """Approval continuations send tool_result blocks as SDK input."""
+        """Approval continuations send a hidden tick after tool_result is seeded."""
         monkeypatch.setattr(runtime_module, "TRACECAT__DISABLE_NSJAIL", disable_nsjail)
         captured_options: list[Any] = []
 
@@ -696,27 +696,18 @@ class TestClaudeAgentRuntimeRun:
         assert captured_options[0].resume == continued_payload.sdk_session_id
         assert captured_options[0].fork_session is False
         assert captured_options[0].sandbox["enabled"] is disable_nsjail
-        mock_claude_sdk_client.connect.assert_awaited_once()
-        mock_claude_sdk_client.query.assert_not_awaited()
-        query_input = mock_claude_sdk_client.connect.await_args.args[0]
+        mock_claude_sdk_client.connect.assert_awaited_once_with(None)
+        mock_claude_sdk_client.query.assert_awaited_once()
+        query_input = mock_claude_sdk_client.query.await_args.args[0]
         assert not isinstance(query_input, str)
         messages = [message async for message in query_input]
         assert messages == [
             {
                 "type": "user",
-                "message": {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": "call_123",
-                            "content": '{"status":"success"}',
-                            "is_error": False,
-                        }
-                    ],
-                },
+                "message": {"role": "user", "content": "Continue."},
                 "parent_tool_use_id": None,
                 "session_id": "default",
+                "isMeta": True,
             }
         ]
 

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -25,7 +25,7 @@ from claude_agent_sdk.types import (
 )
 
 import tracecat.agent.runtime.claude_code.runtime as runtime_module
-from tracecat.agent.common.protocol import RuntimeInitPayload, RuntimeToolResult
+from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.socket_io import SocketStreamWriter
 from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
 from tracecat.agent.common.types import (
@@ -672,13 +672,6 @@ class TestClaudeAgentRuntimeRun:
                 '"id":"call_123","name":"core__http_request","input":{}}]}}\n'
             ),
             is_approval_continuation=True,
-            approval_tool_results=[
-                RuntimeToolResult(
-                    tool_call_id="call_123",
-                    content='{"status":"success"}',
-                    is_error=False,
-                )
-            ],
         )
 
         with (
@@ -737,13 +730,6 @@ class TestClaudeAgentRuntimeRun:
                 '"id":"call_123","name":"core__http_request","input":{}}]}}\n'
             ),
             is_approval_continuation=True,
-            approval_tool_results=[
-                RuntimeToolResult(
-                    tool_call_id="call_123",
-                    content='{"status":"success"}',
-                    is_error=False,
-                )
-            ],
         )
 
         async def mock_receive() -> Any:

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -135,6 +135,8 @@ def mock_claude_sdk_client() -> MagicMock:
     mock_client = MagicMock()
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.connect = AsyncMock()
+    mock_client.disconnect = AsyncMock()
     mock_client.query = AsyncMock()
     mock_client.interrupt = AsyncMock()
 
@@ -304,12 +306,13 @@ class TestClaudeAgentRuntimeRun:
         monkeypatch.delenv("CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK", raising=False)
         mock_client = MagicMock()
 
-        async def enter_client() -> MagicMock:
+        async def connect_client(_prompt: Any = None) -> None:
             assert os.environ["CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK"] == "1"
-            return mock_client
 
-        mock_client.__aenter__ = AsyncMock(side_effect=enter_client)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.connect = AsyncMock(side_effect=connect_client)
+        mock_client.disconnect = AsyncMock()
         mock_client.query = AsyncMock()
         mock_client.interrupt = AsyncMock()
 
@@ -347,12 +350,13 @@ class TestClaudeAgentRuntimeRun:
         monkeypatch.setenv("CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK", "existing")
         mock_client = MagicMock()
 
-        async def enter_client() -> MagicMock:
+        async def connect_client(_prompt: Any = None) -> None:
             assert os.environ["CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK"] == "existing"
-            return mock_client
 
-        mock_client.__aenter__ = AsyncMock(side_effect=enter_client)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.connect = AsyncMock(side_effect=connect_client)
+        mock_client.disconnect = AsyncMock()
         mock_client.query = AsyncMock()
         mock_client.interrupt = AsyncMock()
 
@@ -543,6 +547,8 @@ class TestClaudeAgentRuntimeRun:
         class ApprovalHookClient:
             def __init__(self, options: Any) -> None:
                 self.options = options
+                self.connect = AsyncMock()
+                self.disconnect = AsyncMock()
                 self.query = AsyncMock(side_effect=self._query)
                 self.interrupt = AsyncMock()
 
@@ -690,8 +696,9 @@ class TestClaudeAgentRuntimeRun:
         assert captured_options[0].resume == continued_payload.sdk_session_id
         assert captured_options[0].fork_session is False
         assert captured_options[0].sandbox["enabled"] is disable_nsjail
-        mock_claude_sdk_client.query.assert_awaited_once()
-        query_input = mock_claude_sdk_client.query.await_args.args[0]
+        mock_claude_sdk_client.connect.assert_awaited_once()
+        mock_claude_sdk_client.query.assert_not_awaited()
+        query_input = mock_claude_sdk_client.connect.await_args.args[0]
         assert not isinstance(query_input, str)
         messages = [message async for message in query_input]
         assert messages == [

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -133,12 +133,20 @@ def mock_socket_writer() -> MagicMock:
 def mock_claude_sdk_client() -> MagicMock:
     """Create a mock ClaudeSDKClient."""
     mock_client = MagicMock()
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
     mock_client.connect = AsyncMock()
     mock_client.disconnect = AsyncMock()
     mock_client.query = AsyncMock()
     mock_client.interrupt = AsyncMock()
+
+    async def enter_client() -> MagicMock:
+        await mock_client.connect()
+        return mock_client
+
+    async def exit_client(*_args: Any) -> None:
+        await mock_client.disconnect()
+
+    mock_client.__aenter__ = AsyncMock(side_effect=enter_client)
+    mock_client.__aexit__ = AsyncMock(side_effect=exit_client)
 
     # Default: return empty response
     async def empty_response() -> Any:
@@ -696,7 +704,7 @@ class TestClaudeAgentRuntimeRun:
         assert captured_options[0].resume == continued_payload.sdk_session_id
         assert captured_options[0].fork_session is False
         assert captured_options[0].sandbox["enabled"] is disable_nsjail
-        mock_claude_sdk_client.connect.assert_awaited_once_with(None)
+        mock_claude_sdk_client.connect.assert_awaited_once_with()
         mock_claude_sdk_client.query.assert_awaited_once()
         query_input = mock_claude_sdk_client.query.await_args.args[0]
         assert not isinstance(query_input, str)

--- a/tests/unit/test_agent_session_activities.py
+++ b/tests/unit/test_agent_session_activities.py
@@ -105,7 +105,7 @@ async def test_reconcile_tool_results_removes_interrupts_and_returns_tool_result
     assert result.results[0].tool_call_id == "toolu_123"
     assert result.results[0].result == {"status": "ok"}
     stream.append.assert_awaited_once()
-    service.remove_interrupt_entries_for_tool_results.assert_awaited_once_with(
+    service.replace_interrupt_with_tool_results.assert_awaited_once_with(
         input.session_id,
         result.results,
     )

--- a/tests/unit/test_agent_session_activities.py
+++ b/tests/unit/test_agent_session_activities.py
@@ -59,3 +59,53 @@ async def test_reconcile_tool_results_raises_on_materialization_failure(
         await reconcile_tool_results_activity(input)
 
     stream.append.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_reconcile_tool_results_removes_interrupts_and_returns_tool_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stream = MagicMock()
+    stream.append = AsyncMock()
+
+    service = AsyncMock()
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = service
+
+    monkeypatch.setattr(
+        "tracecat.agent.session.activities.AgentStream.new",
+        AsyncMock(return_value=stream),
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.session.activities.AgentSessionService.with_session",
+        MagicMock(return_value=ctx),
+    )
+
+    input = ReconcileToolResultsInput(
+        session_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        role=Role(
+            type="service",
+            user_id=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
+            service_id="tracecat-service",
+        ),
+        pending_results=[
+            PendingToolResult(
+                tool_call_id="toolu_123",
+                tool_name="core.http_request",
+                raw_result={"status": "ok"},
+            )
+        ],
+    )
+
+    result = await reconcile_tool_results_activity(input)
+
+    assert len(result.results) == 1
+    assert result.results[0].tool_call_id == "toolu_123"
+    assert result.results[0].result == {"status": "ok"}
+    stream.append.assert_awaited_once()
+    service.remove_interrupt_entries_for_tool_results.assert_awaited_once_with(
+        input.session_id,
+        result.results,
+    )

--- a/tests/unit/test_agent_session_approval_sink.py
+++ b/tests/unit/test_agent_session_approval_sink.py
@@ -282,6 +282,208 @@ async def test_replace_interrupt_with_tool_results_replaces_legacy_interrupted_r
 
 
 @pytest.mark.anyio
+async def test_replace_interrupt_with_tool_results_does_not_duplicate_existing_result(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """Do not append a duplicate tool_result when replacement is retried."""
+    # Arrange: create the session that owns the approval continuation history.
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Approval chat",
+        workspace_id=svc_role.workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        sdk_session_id="sdk-session",
+    )
+    assistant_uuid = str(uuid.uuid4())
+    session.add(agent_session)
+    # Arrange: persist the assistant tool_use that the replacement logic anchors
+    # on before looking for later tool_result rows.
+    session.add(
+        AgentSessionHistory(
+            session_id=agent_session.id,
+            workspace_id=svc_role.workspace_id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "uuid": assistant_uuid,
+                "sessionId": "sdk-session",
+                "type": "assistant",
+                "timestamp": "2026-03-18T00:00:00Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_123",
+                            "name": "core__http_request",
+                            "input": {"url": "https://example.com"},
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    # Arrange: simulate an activity retry after the replacement row was already
+    # committed. The existing real tool_result should make the replacement path
+    # a no-op.
+    session.add(
+        AgentSessionHistory(
+            session_id=agent_session.id,
+            workspace_id=svc_role.workspace_id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "uuid": str(uuid.uuid4()),
+                "parentUuid": assistant_uuid,
+                "sessionId": "sdk-session",
+                "type": "user",
+                "timestamp": "2026-03-18T00:00:01Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_123",
+                            "content": '{"status":"already-recorded"}',
+                            "is_error": False,
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    await service.replace_interrupt_with_tool_results(
+        agent_session.id,
+        [
+            ToolExecutionResult(
+                tool_call_id="call_123",
+                tool_name="core.http_request",
+                result={"status": "success"},
+                is_error=False,
+            )
+        ],
+    )
+
+    history = await service.get_session_history(agent_session.id)
+    # The SQL-backed existence check should prevent appending a second
+    # tool_result for the same tool call.
+    tool_result_blocks = [
+        block
+        for entry in history
+        for block in entry.content.get("message", {}).get("content", [])
+        if isinstance(block, dict) and block.get("type") == "tool_result"
+    ]
+
+    assert len(tool_result_blocks) == 1
+    assert tool_result_blocks[0]["content"] == '{"status":"already-recorded"}'
+
+
+@pytest.mark.anyio
+async def test_replace_interrupt_with_tool_results_ignores_existing_interrupt_result(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    # Arrange: create a session with the assistant tool_use that originally
+    # triggered human approval.
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Approval chat",
+        workspace_id=svc_role.workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        sdk_session_id="sdk-session",
+    )
+    assistant_uuid = str(uuid.uuid4())
+    session.add(agent_session)
+    session.add(
+        AgentSessionHistory(
+            session_id=agent_session.id,
+            workspace_id=svc_role.workspace_id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "uuid": assistant_uuid,
+                "sessionId": "sdk-session",
+                "type": "assistant",
+                "timestamp": "2026-03-18T00:00:00Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_123",
+                            "name": "core__http_request",
+                            "input": {"url": "https://example.com"},
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    # This row has the same tool_call_id as the approved result, but it is only
+    # the SDK's approval-interrupt placeholder. The idempotency check must
+    # ignore it, otherwise we would skip writing the real approved result.
+    session.add(
+        AgentSessionHistory(
+            session_id=agent_session.id,
+            workspace_id=svc_role.workspace_id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "uuid": str(uuid.uuid4()),
+                "parentUuid": assistant_uuid,
+                "sessionId": "sdk-session",
+                "type": "user",
+                "timestamp": "2026-03-18T00:00:01Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_123",
+                            "content": "interrupted",
+                            "is_error": True,
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    # Act: replace the interrupted approval artifact with the actual tool
+    # execution result produced after approval.
+    await service.replace_interrupt_with_tool_results(
+        agent_session.id,
+        [
+            ToolExecutionResult(
+                tool_call_id="call_123",
+                tool_name="core.http_request",
+                result={"status": "success"},
+                is_error=False,
+            )
+        ],
+    )
+
+    history = await service.get_session_history(agent_session.id)
+    # Assert: the placeholder was deleted and exactly one real, non-error
+    # tool_result was inserted for the approved tool call.
+    tool_result_blocks = [
+        block
+        for entry in history
+        for block in entry.content.get("message", {}).get("content", [])
+        if isinstance(block, dict) and block.get("type") == "tool_result"
+    ]
+
+    assert len(tool_result_blocks) == 1
+    assert tool_result_blocks[0]["tool_use_id"] == "call_123"
+    assert tool_result_blocks[0]["is_error"] is False
+    assert orjson.loads(tool_result_blocks[0]["content"]) == {"status": "success"}
+
+
+@pytest.mark.anyio
 async def test_run_turn_continue_with_inbox_source_for_non_external_session(
     session: AsyncSession,
     svc_role: Role,

--- a/tests/unit/test_agent_session_approval_sink.py
+++ b/tests/unit/test_agent_session_approval_sink.py
@@ -575,6 +575,158 @@ async def test_replace_interrupt_with_tool_results_ignores_existing_interrupt_re
 
 
 @pytest.mark.anyio
+async def test_replace_interrupt_with_tool_results_requires_same_assistant_turn(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Approval chat",
+        workspace_id=svc_role.workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        sdk_session_id="sdk-session",
+    )
+    older_assistant_uuid = str(uuid.uuid4())
+    newer_assistant_uuid = str(uuid.uuid4())
+    session.add(agent_session)
+    session.add(
+        AgentSessionHistory(
+            session_id=agent_session.id,
+            workspace_id=svc_role.workspace_id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "uuid": older_assistant_uuid,
+                "sessionId": "sdk-session",
+                "type": "assistant",
+                "timestamp": "2026-03-18T00:00:00Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_old",
+                            "name": "core__http_request",
+                            "input": {"url": "https://old.example.com"},
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    session.add(
+        AgentSessionHistory(
+            session_id=agent_session.id,
+            workspace_id=svc_role.workspace_id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "uuid": str(uuid.uuid4()),
+                "parentUuid": older_assistant_uuid,
+                "sessionId": "sdk-session",
+                "type": "user",
+                "timestamp": "2026-03-18T00:00:01Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_old",
+                            "content": "interrupted",
+                            "is_error": True,
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    session.add(
+        AgentSessionHistory(
+            session_id=agent_session.id,
+            workspace_id=svc_role.workspace_id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "uuid": newer_assistant_uuid,
+                "sessionId": "sdk-session",
+                "type": "assistant",
+                "timestamp": "2026-03-18T00:00:02Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_new",
+                            "name": "core__http_request",
+                            "input": {"url": "https://new.example.com"},
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    session.add(
+        AgentSessionHistory(
+            session_id=agent_session.id,
+            workspace_id=svc_role.workspace_id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "uuid": str(uuid.uuid4()),
+                "parentUuid": newer_assistant_uuid,
+                "sessionId": "sdk-session",
+                "type": "user",
+                "timestamp": "2026-03-18T00:00:03Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_new",
+                            "content": "interrupted",
+                            "is_error": True,
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    await service.replace_interrupt_with_tool_results(
+        agent_session.id,
+        [
+            ToolExecutionResult(
+                tool_call_id="call_old",
+                tool_name="core.http_request",
+                result={"status": "old"},
+                is_error=False,
+            ),
+            ToolExecutionResult(
+                tool_call_id="call_new",
+                tool_name="core.http_request",
+                result={"status": "new"},
+                is_error=False,
+            ),
+        ],
+    )
+
+    history = await service.get_session_history(agent_session.id)
+    tool_result_blocks = [
+        block
+        for entry in history
+        for block in entry.content.get("message", {}).get("content", [])
+        if isinstance(block, dict) and block.get("type") == "tool_result"
+    ]
+
+    assert len(tool_result_blocks) == 2
+    assert {block["tool_use_id"] for block in tool_result_blocks} == {
+        "call_old",
+        "call_new",
+    }
+    assert all(block["content"] == "interrupted" for block in tool_result_blocks)
+    assert all(block["is_error"] is True for block in tool_result_blocks)
+
+
+@pytest.mark.anyio
 async def test_run_turn_continue_with_inbox_source_for_non_external_session(
     session: AsyncSession,
     svc_role: Role,

--- a/tests/unit/test_agent_session_approval_sink.py
+++ b/tests/unit/test_agent_session_approval_sink.py
@@ -382,6 +382,97 @@ async def test_replace_interrupt_with_tool_results_does_not_duplicate_existing_r
 
 
 @pytest.mark.anyio
+async def test_replace_interrupt_with_tool_results_preserves_interrupt_without_assistant_uuid(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Approval chat",
+        workspace_id=svc_role.workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        sdk_session_id="sdk-session",
+    )
+    session.add(agent_session)
+    session.add(
+        AgentSessionHistory(
+            session_id=agent_session.id,
+            workspace_id=svc_role.workspace_id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "sessionId": "sdk-session",
+                "type": "assistant",
+                "timestamp": "2026-03-18T00:00:00Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_123",
+                            "name": "core__http_request",
+                            "input": {"url": "https://example.com"},
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    session.add(
+        AgentSessionHistory(
+            session_id=agent_session.id,
+            workspace_id=svc_role.workspace_id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "uuid": str(uuid.uuid4()),
+                "sessionId": "sdk-session",
+                "type": "user",
+                "timestamp": "2026-03-18T00:00:01Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_123",
+                            "content": "interrupted",
+                            "is_error": True,
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    await service.replace_interrupt_with_tool_results(
+        agent_session.id,
+        [
+            ToolExecutionResult(
+                tool_call_id="call_123",
+                tool_name="core.http_request",
+                result={"status": "success"},
+                is_error=False,
+            )
+        ],
+    )
+
+    history = await service.get_session_history(agent_session.id)
+    tool_result_blocks = [
+        block
+        for entry in history
+        for block in entry.content.get("message", {}).get("content", [])
+        if isinstance(block, dict) and block.get("type") == "tool_result"
+    ]
+
+    assert len(tool_result_blocks) == 1
+    [tool_result] = tool_result_blocks
+    assert tool_result["tool_use_id"] == "call_123"
+    assert tool_result["content"] == "interrupted"
+    assert tool_result["is_error"] is True
+
+
+@pytest.mark.anyio
 async def test_replace_interrupt_with_tool_results_ignores_existing_interrupt_result(
     session: AsyncSession,
     svc_role: Role,

--- a/tests/unit/test_agent_session_approval_sink.py
+++ b/tests/unit/test_agent_session_approval_sink.py
@@ -5,11 +5,13 @@ import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
+import orjson
 import pytest
 from pydantic_ai.tools import ToolApproved
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.approvals.enums import ApprovalStatus
+from tracecat.agent.executor.schemas import ToolExecutionResult
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import AgentConfig
@@ -179,6 +181,104 @@ async def test_list_messages_preserves_compaction_metadata(
         "phase": "completed",
         "pre_tokens": 128000,
     }
+
+
+@pytest.mark.anyio
+async def test_replace_interrupt_with_tool_results_replaces_legacy_interrupted_row(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Approval chat",
+        workspace_id=svc_role.workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        sdk_session_id="sdk-session",
+    )
+    assistant_uuid = str(uuid.uuid4())
+    session.add(agent_session)
+    session.add(
+        AgentSessionHistory(
+            session_id=agent_session.id,
+            workspace_id=svc_role.workspace_id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "uuid": assistant_uuid,
+                "sessionId": "sdk-session",
+                "type": "assistant",
+                "timestamp": "2026-03-18T00:00:00Z",
+                "cwd": "/home/agent",
+                "version": "2.0.72",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_123",
+                            "name": "core__http_request",
+                            "input": {"url": "https://example.com"},
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    session.add(
+        AgentSessionHistory(
+            session_id=agent_session.id,
+            workspace_id=svc_role.workspace_id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "uuid": str(uuid.uuid4()),
+                "parentUuid": assistant_uuid,
+                "sessionId": "sdk-session",
+                "type": "user",
+                "timestamp": "2026-03-18T00:00:01Z",
+                "cwd": "/home/agent",
+                "version": "2.0.72",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_123",
+                            "content": "interrupted",
+                            "is_error": True,
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    await service.replace_interrupt_with_tool_results(
+        agent_session.id,
+        [
+            ToolExecutionResult(
+                tool_call_id="call_123",
+                tool_name="core.http_request",
+                result={"status": "success"},
+                is_error=False,
+            )
+        ],
+    )
+
+    history = await service.get_session_history(agent_session.id)
+    tool_result_blocks = [
+        block
+        for entry in history
+        for block in entry.content.get("message", {}).get("content", [])
+        if isinstance(block, dict) and block.get("type") == "tool_result"
+    ]
+
+    assert len(tool_result_blocks) == 1
+    [tool_result] = tool_result_blocks
+    assert tool_result["tool_use_id"] == "call_123"
+    assert tool_result["is_error"] is False
+    assert orjson.loads(tool_result["content"]) == {"status": "success"}
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_session_messages.py
+++ b/tests/unit/test_agent_session_messages.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
 
+import orjson
 import pytest
 
 from tracecat.agent.session.service import AgentSessionService
@@ -74,3 +75,184 @@ async def test_list_messages_preserves_compaction_metadata() -> None:
         "phase": "completed",
         "pre_tokens": 128000,
     }
+
+
+@pytest.mark.anyio
+async def test_load_session_history_omits_internal_rows_and_repairs_parent_chain() -> (
+    None
+):
+    service, _ = _build_service()
+    session_id = uuid.uuid4()
+    sdk_session = SimpleNamespace(
+        id=session_id,
+        parent_session_id=None,
+        sdk_session_id="sdk-session-123",
+    )
+    tool_result_uuid = "tool-result-uuid"
+    thinking_uuid = "thinking-uuid"
+    answer_uuid = "answer-uuid"
+    entries = [
+        SimpleNamespace(
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "type": "user",
+                "uuid": tool_result_uuid,
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "call_123"}],
+                },
+            },
+        ),
+        SimpleNamespace(
+            kind=MessageKind.INTERNAL.value,
+            content={
+                "type": "user",
+                "uuid": "meta-uuid",
+                "isMeta": True,
+                "parentUuid": tool_result_uuid,
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Continue from where you left off.",
+                        }
+                    ],
+                },
+            },
+        ),
+        SimpleNamespace(
+            kind=MessageKind.INTERNAL.value,
+            content={
+                "type": "assistant",
+                "uuid": "synthetic-uuid",
+                "parentUuid": "meta-uuid",
+                "message": {"model": "<synthetic>", "content": []},
+            },
+        ),
+        SimpleNamespace(
+            kind=MessageKind.INTERNAL.value,
+            content={
+                "type": "user",
+                "uuid": "prompt-uuid",
+                "parentUuid": "synthetic-uuid",
+                "message": {"role": "user", "content": "Continue."},
+            },
+        ),
+        SimpleNamespace(
+            kind=MessageKind.INTERNAL.value,
+            content={
+                "type": "assistant",
+                "uuid": thinking_uuid,
+                "parentUuid": "prompt-uuid",
+                "message": {
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "Saw hidden continuation prompts.",
+                        }
+                    ]
+                },
+            },
+        ),
+        SimpleNamespace(
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "type": "assistant",
+                "uuid": answer_uuid,
+                "parentUuid": thinking_uuid,
+                "message": {
+                    "content": [{"type": "text", "text": "There are no cases."}]
+                },
+            },
+        ),
+    ]
+
+    service.get_session = AsyncMock(return_value=sdk_session)
+    service.session.execute = AsyncMock(return_value=_mock_scalar_result(entries))
+
+    history = await service.load_session_history(session_id)
+
+    assert history is not None
+    assert history.sdk_session_id == "sdk-session-123"
+    lines = [orjson.loads(line) for line in history.sdk_session_data.splitlines()]
+    assert [line["uuid"] for line in lines] == [tool_result_uuid, answer_uuid]
+    assert lines[1]["parentUuid"] == tool_result_uuid
+    assert "Continue" not in history.sdk_session_data
+
+
+@pytest.mark.anyio
+async def test_list_messages_skips_misclassified_continuation_artifacts() -> None:
+    service, _ = _build_service()
+    session_id = uuid.uuid4()
+    agent_session = SimpleNamespace(
+        id=session_id,
+        parent_session_id=None,
+    )
+    prompt_uuid = "prompt-uuid"
+    thinking_uuid = "thinking-uuid"
+    entries = [
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            kind=MessageKind.INTERNAL.value,
+            content={
+                "type": "assistant",
+                "uuid": "synthetic-uuid",
+                "message": {"model": "<synthetic>", "content": []},
+            },
+        ),
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "type": "user",
+                "uuid": prompt_uuid,
+                "parentUuid": "synthetic-uuid",
+                "message": {"role": "user", "content": "Continue."},
+            },
+        ),
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "type": "assistant",
+                "uuid": thinking_uuid,
+                "parentUuid": prompt_uuid,
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "Saw hidden continuation prompts.",
+                        }
+                    ],
+                },
+            },
+        ),
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "type": "assistant",
+                "uuid": "answer-uuid",
+                "parentUuid": thinking_uuid,
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "There are no cases."}],
+                },
+            },
+        ),
+    ]
+
+    service.get_session = AsyncMock(return_value=agent_session)
+    service.session.execute = AsyncMock(
+        side_effect=[
+            _mock_scalar_result(entries),
+            _mock_scalar_result([]),
+        ]
+    )
+
+    messages = await service.list_messages(session_id)
+
+    assert len(messages) == 1
+    assert messages[0].message is not None

--- a/tests/unit/test_agent_socket_io.py
+++ b/tests/unit/test_agent_socket_io.py
@@ -57,6 +57,8 @@ class TestRuntimeSocketCommunication:
         mock_client = MagicMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.connect = AsyncMock()
+        mock_client.disconnect = AsyncMock()
         mock_client.query = AsyncMock()
         mock_client.interrupt = AsyncMock()
 

--- a/tests/unit/test_vercel_adapter.py
+++ b/tests/unit/test_vercel_adapter.py
@@ -1,0 +1,36 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from tracecat.agent.adapter.vercel import convert_chat_messages_to_ui
+from tracecat.agent.approvals.enums import ApprovalStatus
+from tracecat.chat.enums import MessageKind
+from tracecat.chat.schemas import ApprovalRead, ChatMessage
+
+
+def _approval_message(status: ApprovalStatus) -> ChatMessage:
+    return ChatMessage(
+        id=str(uuid4()),
+        kind=MessageKind.APPROVAL_REQUEST,
+        approval=ApprovalRead(
+            id=uuid4(),
+            tool_call_id="toolu_123",
+            tool_name="core.cases.list_cases",
+            tool_call_args={"limit": 100},
+            status=status,
+            created_at=datetime.now(UTC),
+        ),
+    )
+
+
+def test_convert_chat_messages_to_ui_emits_pending_approval_request() -> None:
+    messages = convert_chat_messages_to_ui([_approval_message(ApprovalStatus.PENDING)])
+
+    assert len(messages) == 1
+    assert messages[0].role == "assistant"
+    assert messages[0].parts[0]["type"] == "data-approval-request"
+
+
+def test_convert_chat_messages_to_ui_skips_resolved_approval_request() -> None:
+    messages = convert_chat_messages_to_ui([_approval_message(ApprovalStatus.APPROVED)])
+
+    assert messages == []

--- a/tracecat/agent/adapter/vercel.py
+++ b/tracecat/agent/adapter/vercel.py
@@ -59,6 +59,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_core import to_json
 
+from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
 from tracecat.agent.mcp.metadata import strip_proxy_tool_metadata
 from tracecat.agent.mcp.utils import normalize_mcp_tool_name
@@ -1529,6 +1530,8 @@ def convert_chat_messages_to_ui(
         # These are inserted by list_messages() when loading session history
         if chat_message.kind == MessageKind.APPROVAL_REQUEST and chat_message.approval:
             approval = chat_message.approval
+            if approval.status != ApprovalStatus.PENDING:
+                continue
             # Create an assistant message with the approval data part
             # Normalize tool name for display
             tool_name = normalize_mcp_tool_name(approval.tool_name)

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -52,8 +52,9 @@ class RuntimeInitPayload:
     The orchestrator sends this after the runtime connects to the control socket.
     Contains everything the runtime needs to execute an agent turn.
 
-    On resume after approval, sdk_session_data ends at the assistant tool_use.
-    The approved or denied tool results are sent as the next Claude SDK input.
+    On resume after approval, sdk_session_data already includes the approved or
+    denied tool_result entry. approval_tool_results is runtime metadata, not a
+    second SDK input.
     """
 
     # Runtime selection

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -9,11 +9,40 @@ Uses pure dataclasses with orjson for minimal import footprint.
 from __future__ import annotations
 
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from tracecat.agent.common.stream_types import UnifiedStreamEvent
 from tracecat.agent.common.types import MCPToolDefinition, SandboxAgentConfig
+
+
+@dataclass(kw_only=True, slots=True)
+class RuntimeToolResult:
+    """Tool result block to send as the next Claude SDK input."""
+
+    tool_call_id: str
+    content: str | list[dict[str, Any]] | None = None
+    is_error: bool | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RuntimeToolResult:
+        """Construct from dict (orjson parsed)."""
+        return cls(
+            tool_call_id=data["tool_call_id"],
+            content=data.get("content"),
+            is_error=data.get("is_error"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dict for orjson serialization."""
+        result: dict[str, Any] = {
+            "tool_call_id": self.tool_call_id,
+        }
+        if self.content is not None:
+            result["content"] = self.content
+        if self.is_error is not None:
+            result["is_error"] = self.is_error
+        return result
 
 
 @dataclass(kw_only=True, slots=True)
@@ -23,9 +52,8 @@ class RuntimeInitPayload:
     The orchestrator sends this after the runtime connects to the control socket.
     Contains everything the runtime needs to execute an agent turn.
 
-    On resume after approval, the sdk_session_data contains the proper tool_result
-    entry (inserted by execute_approved_tools_activity before reload), so the
-    runtime just resumes normally.
+    On resume after approval, sdk_session_data ends at the assistant tool_use.
+    The approved or denied tool results are sent as the next Claude SDK input.
     """
 
     # Runtime selection
@@ -44,6 +72,7 @@ class RuntimeInitPayload:
     sdk_session_id: str | None = None
     sdk_session_data: str | None = None  # JSONL content for resume
     is_approval_continuation: bool = False  # True when resuming after approval decision
+    approval_tool_results: list[RuntimeToolResult] = field(default_factory=list)
     is_fork: bool = False
 
     @classmethod
@@ -76,6 +105,10 @@ class RuntimeInitPayload:
             sdk_session_id=data.get("sdk_session_id"),
             sdk_session_data=data.get("sdk_session_data"),
             is_approval_continuation=data.get("is_approval_continuation", False),
+            approval_tool_results=[
+                RuntimeToolResult.from_dict(result)
+                for result in data.get("approval_tool_results", [])
+            ],
             is_fork=data.get("is_fork", False),
         )
 
@@ -99,6 +132,10 @@ class RuntimeInitPayload:
             result["sdk_session_id"] = self.sdk_session_id
         if self.sdk_session_data is not None:
             result["sdk_session_data"] = self.sdk_session_data
+        if self.approval_tool_results:
+            result["approval_tool_results"] = [
+                tool_result.to_dict() for tool_result in self.approval_tool_results
+            ]
         return result
 
 

--- a/tracecat/agent/common/protocol.py
+++ b/tracecat/agent/common/protocol.py
@@ -9,40 +9,11 @@ Uses pure dataclasses with orjson for minimal import footprint.
 from __future__ import annotations
 
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Literal
 
 from tracecat.agent.common.stream_types import UnifiedStreamEvent
 from tracecat.agent.common.types import MCPToolDefinition, SandboxAgentConfig
-
-
-@dataclass(kw_only=True, slots=True)
-class RuntimeToolResult:
-    """Tool result block to send as the next Claude SDK input."""
-
-    tool_call_id: str
-    content: str | list[dict[str, Any]] | None = None
-    is_error: bool | None = None
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> RuntimeToolResult:
-        """Construct from dict (orjson parsed)."""
-        return cls(
-            tool_call_id=data["tool_call_id"],
-            content=data.get("content"),
-            is_error=data.get("is_error"),
-        )
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert to dict for orjson serialization."""
-        result: dict[str, Any] = {
-            "tool_call_id": self.tool_call_id,
-        }
-        if self.content is not None:
-            result["content"] = self.content
-        if self.is_error is not None:
-            result["is_error"] = self.is_error
-        return result
 
 
 @dataclass(kw_only=True, slots=True)
@@ -53,8 +24,7 @@ class RuntimeInitPayload:
     Contains everything the runtime needs to execute an agent turn.
 
     On resume after approval, sdk_session_data already includes the approved or
-    denied tool_result entry. approval_tool_results is runtime metadata, not a
-    second SDK input.
+    denied tool_result entry.
     """
 
     # Runtime selection
@@ -73,7 +43,6 @@ class RuntimeInitPayload:
     sdk_session_id: str | None = None
     sdk_session_data: str | None = None  # JSONL content for resume
     is_approval_continuation: bool = False  # True when resuming after approval decision
-    approval_tool_results: list[RuntimeToolResult] = field(default_factory=list)
     is_fork: bool = False
 
     @classmethod
@@ -106,10 +75,6 @@ class RuntimeInitPayload:
             sdk_session_id=data.get("sdk_session_id"),
             sdk_session_data=data.get("sdk_session_data"),
             is_approval_continuation=data.get("is_approval_continuation", False),
-            approval_tool_results=[
-                RuntimeToolResult.from_dict(result)
-                for result in data.get("approval_tool_results", [])
-            ],
             is_fork=data.get("is_fork", False),
         )
 
@@ -133,10 +98,6 @@ class RuntimeInitPayload:
             result["sdk_session_id"] = self.sdk_session_id
         if self.sdk_session_data is not None:
             result["sdk_session_data"] = self.sdk_session_data
-        if self.approval_tool_results:
-            result["approval_tool_results"] = [
-                tool_result.to_dict() for tool_result in self.approval_tool_results
-            ]
         return result
 
 

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -23,7 +23,7 @@ from tracecat.agent.common.config import (
     TRACECAT__DISABLE_NSJAIL,
 )
 from tracecat.agent.common.exceptions import AgentSandboxExecutionError
-from tracecat.agent.common.protocol import RuntimeInitPayload, RuntimeToolResult
+from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.stream_types import ToolCallContent
 from tracecat.agent.common.types import MCPToolDefinition, SandboxAgentConfig
 from tracecat.agent.executor.loopback import (
@@ -54,7 +54,6 @@ from .schemas import (
     ApprovedToolCall,
     DeniedToolCall,
     ToolExecutionResult,
-    serialize_tool_result_content,
 )
 
 
@@ -62,8 +61,8 @@ class AgentExecutorInput(BaseModel):
     """Input for the agent executor activity.
 
     On resume after approval, sdk_session_data already includes the reconciled
-    user tool_result entry. approval_tool_results is metadata for the runtime
-    turn, not input to stream back into Claude.
+    user tool_result entry. approval_tool_results remains on the executor input
+    as workflow-level reconciliation metadata, not runtime input.
     """
 
     # ``extra="ignore"`` keeps Temporal activity replay working after the
@@ -218,14 +217,6 @@ class SandboxedAgentExecutor:
             sdk_session_id=self.input.sdk_session_id,
             sdk_session_data=self.input.sdk_session_data,
             is_approval_continuation=self.input.is_approval_continuation,
-            approval_tool_results=[
-                RuntimeToolResult(
-                    tool_call_id=result.tool_call_id,
-                    content=serialize_tool_result_content(result.result),
-                    is_error=result.is_error,
-                )
-                for result in self.input.approval_tool_results
-            ],
             is_fork=self.input.is_fork,
         )
 

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -61,8 +61,7 @@ class AgentExecutorInput(BaseModel):
     """Input for the agent executor activity.
 
     On resume after approval, sdk_session_data already includes the reconciled
-    user tool_result entry. approval_tool_results remains on the executor input
-    as workflow-level reconciliation metadata, not runtime input.
+    user tool_result entry.
     """
 
     # ``extra="ignore"`` keeps Temporal activity replay working after the
@@ -89,8 +88,6 @@ class AgentExecutorInput(BaseModel):
     sdk_session_data: str | None = None
     # True when resuming after an approval decision.
     is_approval_continuation: bool = False
-    # Approved or denied tool results reconciled into sdk_session_data.
-    approval_tool_results: list[ToolExecutionResult] = Field(default_factory=list)
     # True when forking from parent session (SDK should use fork_session=True)
     is_fork: bool = False
 

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -61,8 +61,9 @@ from .schemas import (
 class AgentExecutorInput(BaseModel):
     """Input for the agent executor activity.
 
-    On resume after approval, sdk_session_data ends at the assistant tool_use
-    and approval_tool_results carries the user tool_result input.
+    On resume after approval, sdk_session_data already includes the reconciled
+    user tool_result entry. approval_tool_results is metadata for the runtime
+    turn, not input to stream back into Claude.
     """
 
     # ``extra="ignore"`` keeps Temporal activity replay working after the
@@ -89,7 +90,7 @@ class AgentExecutorInput(BaseModel):
     sdk_session_data: str | None = None
     # True when resuming after an approval decision.
     is_approval_continuation: bool = False
-    # Approved or denied tool results to send as the next Claude SDK input.
+    # Approved or denied tool results reconciled into sdk_session_data.
     approval_tool_results: list[ToolExecutionResult] = Field(default_factory=list)
     # True when forking from parent session (SDK should use fork_session=True)
     is_fork: bool = False

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -23,7 +23,7 @@ from tracecat.agent.common.config import (
     TRACECAT__DISABLE_NSJAIL,
 )
 from tracecat.agent.common.exceptions import AgentSandboxExecutionError
-from tracecat.agent.common.protocol import RuntimeInitPayload
+from tracecat.agent.common.protocol import RuntimeInitPayload, RuntimeToolResult
 from tracecat.agent.common.stream_types import ToolCallContent
 from tracecat.agent.common.types import MCPToolDefinition, SandboxAgentConfig
 from tracecat.agent.executor.loopback import (
@@ -50,15 +50,19 @@ from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage import blob
 
-from .schemas import ApprovedToolCall, DeniedToolCall, ToolExecutionResult
+from .schemas import (
+    ApprovedToolCall,
+    DeniedToolCall,
+    ToolExecutionResult,
+    serialize_tool_result_content,
+)
 
 
 class AgentExecutorInput(BaseModel):
     """Input for the agent executor activity.
 
-    On resume after approval, the sdk_session_data contains the proper tool_result
-    entry (inserted by the approval reconciliation activity before reload), so the
-    runtime just resumes normally.
+    On resume after approval, sdk_session_data ends at the assistant tool_use
+    and approval_tool_results carries the user tool_result input.
     """
 
     # ``extra="ignore"`` keeps Temporal activity replay working after the
@@ -80,11 +84,13 @@ class AgentExecutorInput(BaseModel):
     )
     # Resolved tool definitions
     allowed_actions: dict[str, MCPToolDefinition] | None = None
-    # Session resume data (from previous run, includes tool_result for approval flow)
+    # Session resume data from previous runs
     sdk_session_id: str | None = None
     sdk_session_data: str | None = None
-    # True when resuming after approval decision (continuation prompt should be internal)
+    # True when resuming after an approval decision.
     is_approval_continuation: bool = False
+    # Approved or denied tool results to send as the next Claude SDK input.
+    approval_tool_results: list[ToolExecutionResult] = Field(default_factory=list)
     # True when forking from parent session (SDK should use fork_session=True)
     is_fork: bool = False
 
@@ -211,6 +217,14 @@ class SandboxedAgentExecutor:
             sdk_session_id=self.input.sdk_session_id,
             sdk_session_data=self.input.sdk_session_data,
             is_approval_continuation=self.input.is_approval_continuation,
+            approval_tool_results=[
+                RuntimeToolResult(
+                    tool_call_id=result.tool_call_id,
+                    content=serialize_tool_result_content(result.result),
+                    is_error=result.is_error,
+                )
+                for result in self.input.approval_tool_results
+            ],
             is_fork=self.input.is_fork,
         )
 

--- a/tracecat/agent/executor/schemas.py
+++ b/tracecat/agent/executor/schemas.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import orjson
 from pydantic import BaseModel, Field
 
 from tracecat.storage.object import StoredObject
@@ -30,6 +31,16 @@ class ToolExecutionResult(BaseModel):
     tool_name: str
     result: Any
     is_error: bool = False
+
+
+def serialize_tool_result_content(result: Any) -> str:
+    """Serialize a tool result to the string content Claude SDK expects."""
+    if isinstance(result, str):
+        return result
+    try:
+        return orjson.dumps(result).decode("utf-8")
+    except (TypeError, ValueError):
+        return str(result)
 
 
 class ToolExecutionResultHandle(BaseModel):

--- a/tracecat/agent/executor/schemas.py
+++ b/tracecat/agent/executor/schemas.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import orjson
 from pydantic import BaseModel, Field
 
 from tracecat.storage.object import StoredObject
@@ -31,16 +30,6 @@ class ToolExecutionResult(BaseModel):
     tool_name: str
     result: Any
     is_error: bool = False
-
-
-def serialize_tool_result_content(result: Any) -> str:
-    """Serialize a tool result to the string content Claude SDK expects."""
-    if isinstance(result, str):
-        return result
-    try:
-        return orjson.dumps(result).decode("utf-8")
-    except (TypeError, ValueError):
-        return str(result)
 
 
 class ToolExecutionResultHandle(BaseModel):

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -15,7 +15,7 @@ import asyncio
 import os
 import tempfile
 import uuid
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Literal, Protocol, cast
@@ -57,6 +57,12 @@ from tracecat.agent.mcp.proxy_server import (
 )
 from tracecat.agent.mcp.utils import normalize_mcp_tool_name
 from tracecat.agent.runtime.claude_code.adapter import ClaudeSDKAdapter
+from tracecat.agent.runtime.claude_code.session_lines import (
+    APPROVAL_CONTINUATION_PROMPT,
+    is_approval_continuation_prompt_line,
+    is_meta_session_line,
+    is_synthetic_session_line,
+)
 from tracecat.logger import logger
 
 
@@ -99,8 +105,6 @@ _LITELLM_ROUTE_PREFIXES: dict[str, str] = {
     "azure_openai": "azure",
     "azure_ai": "azure_ai",
 }
-
-APPROVAL_CONTINUATION_PROMPT = "Continue."
 
 
 def get_litellm_route_model(
@@ -393,22 +397,6 @@ class ClaudeAgentRuntime:
         return any(marker in text for marker in compact_markers)
 
     @staticmethod
-    def _is_approval_continuation_prompt_line(
-        line_data: Mapping[str, object],
-    ) -> bool:
-        """Return True for the hidden approval continuation prompt JSONL row."""
-        match line_data:
-            case {"type": "user", "message": {"content": str(text)}}:
-                return text == APPROVAL_CONTINUATION_PROMPT
-            case {
-                "type": "user",
-                "message": {"content": [{"type": "text", "text": str(text)}]},
-            }:
-                return text == APPROVAL_CONTINUATION_PROMPT
-            case _:
-                return False
-
-    @staticmethod
     async def _tool_result_input_stream(
         tool_results: list[RuntimeToolResult],
     ) -> AsyncIterator[dict[str, Any]]:
@@ -467,7 +455,7 @@ class ClaudeAgentRuntime:
         # SDK compaction artifacts marked with structural flags
         # isCompactSummary messages are persisted as kind='compaction' for badge rendering
         # isMeta messages (like caveats) are internal
-        if line_data.get("isMeta") is True or line_data.get("isCompactSummary"):
+        if is_meta_session_line(line_data) or line_data.get("isCompactSummary"):
             return True
 
         msg_type = line_data.get("type", "")
@@ -483,7 +471,7 @@ class ClaudeAgentRuntime:
         message = line_data.get("message", {})
 
         # Synthetic messages are internal (placeholders during approval flow)
-        if message.get("model") == "<synthetic>":
+        if is_synthetic_session_line(line_data):
             return True
 
         # "(no content)" placeholder assistant message from the SDK's
@@ -589,7 +577,7 @@ class ClaudeAgentRuntime:
 
                 if (
                     self._hide_next_approval_continuation_prompt
-                    and self._is_approval_continuation_prompt_line(line_data)
+                    and is_approval_continuation_prompt_line(line_data)
                 ):
                     internal = True
                     self._hide_next_approval_continuation_prompt = False

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -435,6 +435,17 @@ class ClaudeAgentRuntime:
         }
 
     @staticmethod
+    async def _meta_text_input_stream(text: str) -> AsyncIterator[dict[str, Any]]:
+        """Yield a hidden Claude SDK stream-json user message."""
+        yield {
+            "type": "user",
+            "message": {"role": "user", "content": text},
+            "parent_tool_use_id": None,
+            "session_id": "default",
+            "isMeta": True,
+        }
+
+    @staticmethod
     def _is_thinking_only_assistant_line(line_data: dict[str, Any]) -> bool:
         """Return True for assistant JSONL rows that only contain thinking."""
         if line_data.get("type") != "assistant":
@@ -773,9 +784,9 @@ class ClaudeAgentRuntime:
         This is the main entry point for sandboxed execution.
         Called after receiving init payload from orchestrator via socket.
 
-        On resume after approval, session history ends at the assistant tool_use.
-        The runtime sends approved or denied tool_result blocks as the next SDK
-        input.
+        On resume after approval, session history already contains the
+        approved or denied tool_result. The runtime sends a hidden meta tick so
+        Claude Code consumes the completed history.
         """
         run_started_at = perf_counter()
 
@@ -942,28 +953,17 @@ class ClaudeAgentRuntime:
                 mcp_servers=list(mcp_servers.keys()),
             )
             _configure_claude_sdk_process_env()
-            if payload.approval_tool_results:
-                query_input = self._tool_result_input_stream(
-                    payload.approval_tool_results
-                )
-                self._pending_approval_tool_ids.update(
-                    result.tool_call_id for result in payload.approval_tool_results
-                )
-                query_log_extra = {
-                    "tool_result_count": len(payload.approval_tool_results)
-                }
-                connect_prompt = query_input
-                send_query_after_connect = False
-                logger.debug("Approval continuation with tool_result input")
-            # Legacy fallback for old callers that only pre-seed tool_result
-            # history and need a neutral query to advance the resumed session.
-            elif payload.is_approval_continuation:
-                query_input = APPROVAL_CONTINUATION_PROMPT
+            if payload.is_approval_continuation:
+                query_input = self._meta_text_input_stream(APPROVAL_CONTINUATION_PROMPT)
                 self._approval_continuation_active = True
-                query_log_extra = {"prompt_length": len(query_input)}
+                query_log_extra = {
+                    "prompt_length": len(APPROVAL_CONTINUATION_PROMPT),
+                    "preseeded_tool_result_count": len(payload.approval_tool_results),
+                    "is_meta": True,
+                }
                 connect_prompt = None
                 send_query_after_connect = True
-                logger.debug("Approval continuation with hidden prompt")
+                logger.debug("Approval continuation with meta prompt")
             else:
                 query_input = payload.user_prompt
                 query_log_extra = {"prompt_length": len(query_input)}

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -222,9 +222,9 @@ class ClaudeAgentRuntime:
         # For incremental JSONL line tracking
         self._sdk_session_id: str | None = None
         self._last_seen_line_index: int = 0
-        # True while an approval continuation turn is running. Claude Code emits
-        # resume metadata plus our neutral query; both are control-plane state.
-        self._approval_continuation_active: bool = False
+        # One-shot guard for hiding our neutral approval-continuation prompt.
+        # Other SDK metadata rows are hidden structurally by `_is_internal_session_line`.
+        self._hide_next_approval_continuation_prompt: bool = False
         # Adapter for converting Claude SDK events - must be reused to track state
         self._stream_adapter = ClaudeSDKAdapter()
         # Working directory for session file path resolution
@@ -445,25 +445,6 @@ class ClaudeAgentRuntime:
             "isMeta": True,
         }
 
-    @staticmethod
-    def _is_thinking_only_assistant_line(line_data: dict[str, Any]) -> bool:
-        """Return True for assistant JSONL rows that only contain thinking."""
-        if line_data.get("type") != "assistant":
-            return False
-
-        message = line_data.get("message", {})
-        if not isinstance(message, dict):
-            return False
-
-        content = message.get("content")
-        if not isinstance(content, list) or not content:
-            return False
-
-        return all(
-            isinstance(part, dict) and part.get("type") == "thinking"
-            for part in content
-        )
-
     def _is_internal_session_line(self, line_data: dict[str, Any]) -> bool:
         """Determine if a session line is internal (not shown in UI timeline).
 
@@ -609,18 +590,14 @@ class ClaudeAgentRuntime:
 
                 internal = self._is_internal_session_line(line_data)
 
-                if self._approval_continuation_active:
-                    # Claude Code emits an isMeta "Continue from where you left off."
-                    # row before the actual SDK query. Hide both that metadata and
-                    # our neutral query, plus the reasoning-only block they induce.
-                    if line_data.get("type") == "user" and (
-                        line_data.get("isMeta") is True
-                        or self._message_text_content(line_data)
-                        == APPROVAL_CONTINUATION_PROMPT
-                    ):
-                        internal = True
-                    elif self._is_thinking_only_assistant_line(line_data):
-                        internal = True
+                if (
+                    self._hide_next_approval_continuation_prompt
+                    and line_data.get("type") == "user"
+                    and self._message_text_content(line_data)
+                    == APPROVAL_CONTINUATION_PROMPT
+                ):
+                    internal = True
+                    self._hide_next_approval_continuation_prompt = False
 
                 await self._event_writer.send_session_line(
                     self._sdk_session_id, line, internal=internal
@@ -955,7 +932,7 @@ class ClaudeAgentRuntime:
             _configure_claude_sdk_process_env()
             if payload.is_approval_continuation:
                 query_input = self._meta_text_input_stream(APPROVAL_CONTINUATION_PROMPT)
-                self._approval_continuation_active = True
+                self._hide_next_approval_continuation_prompt = True
                 query_log_extra = {
                     "prompt_length": len(APPROVAL_CONTINUATION_PROMPT),
                     "preseeded_tool_result_count": len(payload.approval_tool_results),
@@ -1042,16 +1019,7 @@ class ClaudeAgentRuntime:
 
                             # Partial streaming delta - forward to UI
                             unified = self._stream_adapter.to_unified_event(message)
-                            if not (
-                                self._approval_continuation_active
-                                and unified.type
-                                in {
-                                    StreamEventType.THINKING_START,
-                                    StreamEventType.THINKING_DELTA,
-                                    StreamEventType.THINKING_STOP,
-                                }
-                            ):
-                                await self._event_writer.send_stream_event(unified)
+                            await self._event_writer.send_stream_event(unified)
 
                         elif isinstance(message, ResultMessage):
                             # Final result - emit any remaining lines
@@ -1079,7 +1047,7 @@ class ClaudeAgentRuntime:
                                 duration_ms=message.duration_ms,
                                 output=result_output,
                             )
-                            self._approval_continuation_active = False
+                            self._hide_next_approval_continuation_prompt = False
 
                         elif isinstance(message, SystemMessage):
                             await self._emit_new_session_lines()

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -43,7 +43,7 @@ from claude_agent_sdk.types import (
 from tracecat.agent.common.config import TRACECAT__DISABLE_NSJAIL
 from tracecat.agent.common.exceptions import AgentSandboxValidationError
 from tracecat.agent.common.output_format import build_sdk_output_format
-from tracecat.agent.common.protocol import RuntimeInitPayload, RuntimeToolResult
+from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.stream_types import (
     StreamEventType,
     ToolCallContent,
@@ -395,29 +395,6 @@ class ClaudeAgentRuntime:
             "<local-command-stdout>Compacted ",
         )
         return any(marker in text for marker in compact_markers)
-
-    @staticmethod
-    async def _tool_result_input_stream(
-        tool_results: list[RuntimeToolResult],
-    ) -> AsyncIterator[dict[str, Any]]:
-        """Yield the Claude SDK stream-json user message for tool results."""
-        yield {
-            "type": "user",
-            "message": {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": result.tool_call_id,
-                        "content": result.content,
-                        "is_error": result.is_error or False,
-                    }
-                    for result in tool_results
-                ],
-            },
-            "parent_tool_use_id": None,
-            "session_id": "default",
-        }
 
     @staticmethod
     async def _meta_text_input_stream(text: str) -> AsyncIterator[dict[str, Any]]:
@@ -918,7 +895,6 @@ class ClaudeAgentRuntime:
                 self._hide_next_approval_continuation_prompt = True
                 query_log_extra = {
                     "prompt_length": len(APPROVAL_CONTINUATION_PROMPT),
-                    "preseeded_tool_result_count": len(payload.approval_tool_results),
                     "is_meta": True,
                 }
                 logger.debug("Approval continuation with meta prompt")

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -393,15 +393,20 @@ class ClaudeAgentRuntime:
         return any(marker in text for marker in compact_markers)
 
     @staticmethod
-    def _message_text_content(line_data: Mapping[str, object]) -> str | None:
-        """Extract simple text content from a Claude session line."""
+    def _is_approval_continuation_prompt_line(
+        line_data: Mapping[str, object],
+    ) -> bool:
+        """Return True for the hidden approval continuation prompt JSONL row."""
         match line_data:
-            case {"message": {"content": str(text)}}:
-                return text
-            case {"message": {"content": [{"type": "text", "text": str(text)}]}}:
-                return text
+            case {"type": "user", "message": {"content": str(text)}}:
+                return text == APPROVAL_CONTINUATION_PROMPT
+            case {
+                "type": "user",
+                "message": {"content": [{"type": "text", "text": str(text)}]},
+            }:
+                return text == APPROVAL_CONTINUATION_PROMPT
             case _:
-                return None
+                return False
 
     @staticmethod
     async def _tool_result_input_stream(
@@ -584,9 +589,7 @@ class ClaudeAgentRuntime:
 
                 if (
                     self._hide_next_approval_continuation_prompt
-                    and line_data.get("type") == "user"
-                    and self._message_text_content(line_data)
-                    == APPROVAL_CONTINUATION_PROMPT
+                    and self._is_approval_continuation_prompt_line(line_data)
                 ):
                     internal = True
                     self._hide_next_approval_continuation_prompt = False

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -942,38 +942,44 @@ class ClaudeAgentRuntime:
                 mcp_servers=list(mcp_servers.keys()),
             )
             _configure_claude_sdk_process_env()
+            if payload.approval_tool_results:
+                query_input = self._tool_result_input_stream(
+                    payload.approval_tool_results
+                )
+                self._pending_approval_tool_ids.update(
+                    result.tool_call_id for result in payload.approval_tool_results
+                )
+                query_log_extra = {
+                    "tool_result_count": len(payload.approval_tool_results)
+                }
+                connect_prompt = query_input
+                send_query_after_connect = False
+                logger.debug("Approval continuation with tool_result input")
+            # Legacy fallback for old callers that only pre-seed tool_result
+            # history and need a neutral query to advance the resumed session.
+            elif payload.is_approval_continuation:
+                query_input = APPROVAL_CONTINUATION_PROMPT
+                self._approval_continuation_active = True
+                query_log_extra = {"prompt_length": len(query_input)}
+                connect_prompt = None
+                send_query_after_connect = True
+                logger.debug("Approval continuation with hidden prompt")
+            else:
+                query_input = payload.user_prompt
+                query_log_extra = {"prompt_length": len(query_input)}
+                connect_prompt = None
+                send_query_after_connect = True
+                logger.debug("Normal turn with user prompt")
+
             transport = self._transport_factory(options)
             client = ClaudeSDKClient(options=options, transport=transport)
-            logger.debug("Client created, entering context")
-            async with client:
+            logger.debug("Client created, connecting")
+            await client.connect(connect_prompt)
+            try:
                 self.client = client
                 log_benchmark_phase("runtime_client_connected")
                 stderr_task = asyncio.create_task(drain_stderr())
                 try:
-                    if payload.approval_tool_results:
-                        query_input = self._tool_result_input_stream(
-                            payload.approval_tool_results
-                        )
-                        self._pending_approval_tool_ids.update(
-                            result.tool_call_id
-                            for result in payload.approval_tool_results
-                        )
-                        query_log_extra = {
-                            "tool_result_count": len(payload.approval_tool_results)
-                        }
-                        logger.debug("Approval continuation with tool_result input")
-                    # Legacy fallback for old callers that only pre-seed tool_result
-                    # history and need a neutral query to advance the resumed session.
-                    elif payload.is_approval_continuation:
-                        query_input = APPROVAL_CONTINUATION_PROMPT
-                        self._approval_continuation_active = True
-                        query_log_extra = {"prompt_length": len(query_input)}
-                        logger.debug("Approval continuation with hidden prompt")
-                    else:
-                        query_input = payload.user_prompt
-                        query_log_extra = {"prompt_length": len(query_input)}
-                        logger.debug("Normal turn with user prompt")
-
                     await self._event_writer.send_log(
                         "info",
                         "Sending query to Claude SDK",
@@ -986,7 +992,8 @@ class ClaudeAgentRuntime:
                         await self._event_writer.send_stream_event(
                             self._build_compaction_status_event(phase="started")
                         )
-                    await client.query(query_input)
+                    if send_query_after_connect:
+                        await client.query(query_input)
                     log_benchmark_phase("runtime_query_sent")
 
                     await self._event_writer.send_log(
@@ -1122,6 +1129,8 @@ class ClaudeAgentRuntime:
                         await stderr_task
                     except asyncio.CancelledError:
                         pass
+            finally:
+                await client.disconnect()
 
             # CLI has exited — session file is fully flushed.
             await self._emit_new_session_lines()

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -15,7 +15,7 @@ import asyncio
 import os
 import tempfile
 import uuid
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Literal, Protocol, cast
@@ -43,7 +43,7 @@ from claude_agent_sdk.types import (
 from tracecat.agent.common.config import TRACECAT__DISABLE_NSJAIL
 from tracecat.agent.common.exceptions import AgentSandboxValidationError
 from tracecat.agent.common.output_format import build_sdk_output_format
-from tracecat.agent.common.protocol import RuntimeInitPayload
+from tracecat.agent.common.protocol import RuntimeInitPayload, RuntimeToolResult
 from tracecat.agent.common.stream_types import (
     StreamEventType,
     ToolCallContent,
@@ -99,6 +99,8 @@ _LITELLM_ROUTE_PREFIXES: dict[str, str] = {
     "azure_openai": "azure",
     "azure_ai": "azure_ai",
 }
+
+APPROVAL_CONTINUATION_PROMPT = "Continue."
 
 
 def get_litellm_route_model(
@@ -220,8 +222,9 @@ class ClaudeAgentRuntime:
         # For incremental JSONL line tracking
         self._sdk_session_id: str | None = None
         self._last_seen_line_index: int = 0
-        # Flag to mark continuation prompt as internal (consumed after first use)
-        self._is_continuation: bool = False
+        # True while an approval continuation turn is running. Claude Code emits
+        # resume metadata plus our neutral query; both are control-plane state.
+        self._approval_continuation_active: bool = False
         # Adapter for converting Claude SDK events - must be reused to track state
         self._stream_adapter = ClaudeSDKAdapter()
         # Working directory for session file path resolution
@@ -389,6 +392,67 @@ class ClaudeAgentRuntime:
         )
         return any(marker in text for marker in compact_markers)
 
+    @staticmethod
+    def _message_text_content(line_data: dict[str, Any]) -> str | None:
+        """Extract simple text content from a Claude session line."""
+        message = line_data.get("message", {})
+        if not isinstance(message, dict):
+            return None
+
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+
+        if isinstance(content, list) and len(content) == 1:
+            [part] = content
+            if isinstance(part, dict) and part.get("type") == "text":
+                text = part.get("text")
+                return text if isinstance(text, str) else None
+
+        return None
+
+    @staticmethod
+    async def _tool_result_input_stream(
+        tool_results: list[RuntimeToolResult],
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Yield the Claude SDK stream-json user message for tool results."""
+        yield {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": result.tool_call_id,
+                        "content": result.content,
+                        "is_error": result.is_error or False,
+                    }
+                    for result in tool_results
+                ],
+            },
+            "parent_tool_use_id": None,
+            "session_id": "default",
+        }
+
+    @staticmethod
+    def _is_thinking_only_assistant_line(line_data: dict[str, Any]) -> bool:
+        """Return True for assistant JSONL rows that only contain thinking."""
+        if line_data.get("type") != "assistant":
+            return False
+
+        message = line_data.get("message", {})
+        if not isinstance(message, dict):
+            return False
+
+        content = message.get("content")
+        if not isinstance(content, list) or not content:
+            return False
+
+        return all(
+            isinstance(part, dict) and part.get("type") == "thinking"
+            for part in content
+        )
+
     def _is_internal_session_line(self, line_data: dict[str, Any]) -> bool:
         """Determine if a session line is internal (not shown in UI timeline).
 
@@ -534,10 +598,18 @@ class ClaudeAgentRuntime:
 
                 internal = self._is_internal_session_line(line_data)
 
-                # On continuation, mark the continuation prompt (first user message) as internal
-                if self._is_continuation and line_data.get("type") == "user":
-                    internal = True
-                    self._is_continuation = False
+                if self._approval_continuation_active:
+                    # Claude Code emits an isMeta "Continue from where you left off."
+                    # row before the actual SDK query. Hide both that metadata and
+                    # our neutral query, plus the reasoning-only block they induce.
+                    if line_data.get("type") == "user" and (
+                        line_data.get("isMeta") is True
+                        or self._message_text_content(line_data)
+                        == APPROVAL_CONTINUATION_PROMPT
+                    ):
+                        internal = True
+                    elif self._is_thinking_only_assistant_line(line_data):
+                        internal = True
 
                 await self._event_writer.send_session_line(
                     self._sdk_session_id, line, internal=internal
@@ -701,9 +773,9 @@ class ClaudeAgentRuntime:
         This is the main entry point for sandboxed execution.
         Called after receiving init payload from orchestrator via socket.
 
-        On resume after approval, the session history already contains the proper
-        tool_result entry (inserted by execute_approved_tools_activity), so we just
-        resume the session normally and the agent will continue from there.
+        On resume after approval, session history ends at the assistant tool_use.
+        The runtime sends approved or denied tool_result blocks as the next SDK
+        input.
         """
         run_started_at = perf_counter()
 
@@ -878,27 +950,43 @@ class ClaudeAgentRuntime:
                 log_benchmark_phase("runtime_client_connected")
                 stderr_task = asyncio.create_task(drain_stderr())
                 try:
-                    # On approval continuation, send hidden continuation prompt
-                    # On normal turn (fresh or resume), send the user's prompt
-                    if payload.is_approval_continuation:
-                        query_prompt = "[INTERNAL] End of Tool Call"
-                        self._is_continuation = True
+                    if payload.approval_tool_results:
+                        query_input = self._tool_result_input_stream(
+                            payload.approval_tool_results
+                        )
+                        self._pending_approval_tool_ids.update(
+                            result.tool_call_id
+                            for result in payload.approval_tool_results
+                        )
+                        query_log_extra = {
+                            "tool_result_count": len(payload.approval_tool_results)
+                        }
+                        logger.debug("Approval continuation with tool_result input")
+                    # Legacy fallback for old callers that only pre-seed tool_result
+                    # history and need a neutral query to advance the resumed session.
+                    elif payload.is_approval_continuation:
+                        query_input = APPROVAL_CONTINUATION_PROMPT
+                        self._approval_continuation_active = True
+                        query_log_extra = {"prompt_length": len(query_input)}
                         logger.debug("Approval continuation with hidden prompt")
                     else:
-                        query_prompt = payload.user_prompt
+                        query_input = payload.user_prompt
+                        query_log_extra = {"prompt_length": len(query_input)}
                         logger.debug("Normal turn with user prompt")
 
                     await self._event_writer.send_log(
                         "info",
                         "Sending query to Claude SDK",
-                        prompt_length=len(query_prompt),
                         is_continuation=payload.is_approval_continuation,
+                        **query_log_extra,
                     )
-                    if self._is_manual_compaction_prompt(query_prompt):
+                    if isinstance(
+                        query_input, str
+                    ) and self._is_manual_compaction_prompt(query_input):
                         await self._event_writer.send_stream_event(
                             self._build_compaction_status_event(phase="started")
                         )
-                    await client.query(query_prompt)
+                    await client.query(query_input)
                     log_benchmark_phase("runtime_query_sent")
 
                     await self._event_writer.send_log(
@@ -947,7 +1035,16 @@ class ClaudeAgentRuntime:
 
                             # Partial streaming delta - forward to UI
                             unified = self._stream_adapter.to_unified_event(message)
-                            await self._event_writer.send_stream_event(unified)
+                            if not (
+                                self._approval_continuation_active
+                                and unified.type
+                                in {
+                                    StreamEventType.THINKING_START,
+                                    StreamEventType.THINKING_DELTA,
+                                    StreamEventType.THINKING_STOP,
+                                }
+                            ):
+                                await self._event_writer.send_stream_event(unified)
 
                         elif isinstance(message, ResultMessage):
                             # Final result - emit any remaining lines
@@ -975,6 +1072,7 @@ class ClaudeAgentRuntime:
                                 duration_ms=message.duration_ms,
                                 output=result_output,
                             )
+                            self._approval_continuation_active = False
 
                         elif isinstance(message, SystemMessage):
                             await self._emit_new_session_lines()

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -15,7 +15,7 @@ import asyncio
 import os
 import tempfile
 import uuid
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Callable, Mapping
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Literal, Protocol, cast
@@ -393,23 +393,15 @@ class ClaudeAgentRuntime:
         return any(marker in text for marker in compact_markers)
 
     @staticmethod
-    def _message_text_content(line_data: dict[str, Any]) -> str | None:
+    def _message_text_content(line_data: Mapping[str, object]) -> str | None:
         """Extract simple text content from a Claude session line."""
-        message = line_data.get("message", {})
-        if not isinstance(message, dict):
-            return None
-
-        content = message.get("content")
-        if isinstance(content, str):
-            return content
-
-        if isinstance(content, list) and len(content) == 1:
-            [part] = content
-            if isinstance(part, dict) and part.get("type") == "text":
-                text = part.get("text")
-                return text if isinstance(text, str) else None
-
-        return None
+        match line_data:
+            case {"message": {"content": str(text)}}:
+                return text
+            case {"message": {"content": [{"type": "text", "text": str(text)}]}}:
+                return text
+            case _:
+                return None
 
     @staticmethod
     async def _tool_result_input_stream(
@@ -938,21 +930,16 @@ class ClaudeAgentRuntime:
                     "preseeded_tool_result_count": len(payload.approval_tool_results),
                     "is_meta": True,
                 }
-                connect_prompt = None
-                send_query_after_connect = True
                 logger.debug("Approval continuation with meta prompt")
             else:
                 query_input = payload.user_prompt
                 query_log_extra = {"prompt_length": len(query_input)}
-                connect_prompt = None
-                send_query_after_connect = True
                 logger.debug("Normal turn with user prompt")
 
             transport = self._transport_factory(options)
             client = ClaudeSDKClient(options=options, transport=transport)
-            logger.debug("Client created, connecting")
-            await client.connect(connect_prompt)
-            try:
+            logger.debug("Client created, entering context")
+            async with client:
                 self.client = client
                 log_benchmark_phase("runtime_client_connected")
                 stderr_task = asyncio.create_task(drain_stderr())
@@ -969,8 +956,7 @@ class ClaudeAgentRuntime:
                         await self._event_writer.send_stream_event(
                             self._build_compaction_status_event(phase="started")
                         )
-                    if send_query_after_connect:
-                        await client.query(query_input)
+                    await client.query(query_input)
                     log_benchmark_phase("runtime_query_sent")
 
                     await self._event_writer.send_log(
@@ -1097,8 +1083,6 @@ class ClaudeAgentRuntime:
                         await stderr_task
                     except asyncio.CancelledError:
                         pass
-            finally:
-                await client.disconnect()
 
             # CLI has exited — session file is fully flushed.
             await self._emit_new_session_lines()

--- a/tracecat/agent/runtime/claude_code/session_lines.py
+++ b/tracecat/agent/runtime/claude_code/session_lines.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 APPROVAL_CONTINUATION_PROMPT = "Continue."
+APPROVAL_INTERRUPT_CONTENT_EXACT = "interrupted"
+APPROVAL_INTERRUPT_CONTENT_MARKERS = (
+    "doesn't want to take this action",
+    "stop what you are doing and wait for the user",
+    "request interrupted by user",
+    "[request interrupted",
+)
 
 
 def session_line_uuid(line_data: Mapping[str, object]) -> str | None:
@@ -79,3 +86,36 @@ def is_continuation_control_artifact(
             )
         case _:
             return False
+
+
+def is_approval_interrupt_tool_result(
+    block: Mapping[str, object],
+    tool_call_ids: set[str],
+) -> bool:
+    """Return True for SDK approval-interrupt placeholder tool results."""
+    if not is_error_tool_result_for_tool_calls(block, tool_call_ids):
+        return False
+
+    return is_approval_interrupt_content(block.get("content", ""))
+
+
+def is_error_tool_result_for_tool_calls(
+    block: Mapping[str, object],
+    tool_call_ids: set[str],
+) -> bool:
+    match block:
+        case {
+            "type": "tool_result",
+            "is_error": True,
+            "tool_use_id": str(tool_call_id),
+        }:
+            return tool_call_id in tool_call_ids
+        case _:
+            return False
+
+
+def is_approval_interrupt_content(content: object) -> bool:
+    content_text = str(content).strip().lower()
+    return content_text == APPROVAL_INTERRUPT_CONTENT_EXACT or any(
+        marker in content_text for marker in APPROVAL_INTERRUPT_CONTENT_MARKERS
+    )

--- a/tracecat/agent/runtime/claude_code/session_lines.py
+++ b/tracecat/agent/runtime/claude_code/session_lines.py
@@ -1,0 +1,81 @@
+"""Shared helpers for Claude Code JSONL session rows."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+APPROVAL_CONTINUATION_PROMPT = "Continue."
+
+
+def session_line_uuid(line_data: Mapping[str, object]) -> str | None:
+    """Return the Claude Code JSONL row UUID when present."""
+    match line_data:
+        case {"uuid": str(line_uuid)}:
+            return line_uuid
+        case _:
+            return None
+
+
+def is_meta_session_line(line_data: Mapping[str, object]) -> bool:
+    """Return True for Claude Code metadata rows."""
+    return line_data.get("isMeta") is True
+
+
+def is_synthetic_session_line(line_data: Mapping[str, object]) -> bool:
+    """Return True for Claude Code synthetic assistant placeholder rows."""
+    match line_data:
+        case {"message": {"model": "<synthetic>"}}:
+            return True
+        case _:
+            return False
+
+
+def is_approval_continuation_prompt_line(line_data: Mapping[str, object]) -> bool:
+    """Return True for the hidden approval continuation prompt JSONL row."""
+    match line_data:
+        case {"type": "user", "message": {"content": str(text)}}:
+            return text == APPROVAL_CONTINUATION_PROMPT
+        case {
+            "type": "user",
+            "message": {"content": [{"type": "text", "text": str(text)}]},
+        }:
+            return text == APPROVAL_CONTINUATION_PROMPT
+        case _:
+            return False
+
+
+def is_continuation_control_artifact(
+    line_data: Mapping[str, object],
+    internal_uuids: set[str],
+) -> bool:
+    """Return True for Claude Code continuation artifacts, even if mis-kind-ed.
+
+    Claude Code can persist a short hidden continuation chain after approval
+    resume: an `isMeta` user tick, a synthetic assistant row, the actual
+    "Continue." prompt, and sometimes a thinking-only assistant row. The first
+    two rows are intrinsically internal; later rows are internal only when they
+    descend from an internal row.
+    """
+    if is_meta_session_line(line_data) or is_synthetic_session_line(line_data):
+        return True
+
+    match line_data:
+        case {"parentUuid": str(parent_uuid)}:
+            parent_is_internal = parent_uuid in internal_uuids
+        case _:
+            parent_is_internal = False
+
+    if not parent_is_internal:
+        return False
+
+    if is_approval_continuation_prompt_line(line_data):
+        return True
+
+    match line_data:
+        case {"type": "assistant", "message": {"content": list(parts)}}:
+            return bool(parts) and all(
+                isinstance(part, dict) and part.get("type") == "thinking"
+                for part in parts
+            )
+        case _:
+            return False

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -257,7 +257,7 @@ async def reconcile_tool_results_activity(
 
     if results:
         async with AgentSessionService.with_session(role=input.role) as service:
-            await service.remove_interrupt_entries_for_tool_results(
+            await service.replace_interrupt_with_tool_results(
                 input.session_id,
                 results,
             )

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -214,7 +214,7 @@ async def load_session_activity(input: LoadSessionInput) -> LoadSessionResult:
 async def reconcile_tool_results_activity(
     input: ReconcileToolResultsInput,
 ) -> ReconcileToolResultsResult:
-    """Materialize executor results and persist tool_result continuation state."""
+    """Materialize executor results and clean interrupted approval state."""
     ctx_role.set(input.role)
     results: list[ToolExecutionResult] = []
     stream = await AgentStream.new(
@@ -257,7 +257,7 @@ async def reconcile_tool_results_activity(
 
     if results:
         async with AgentSessionService.with_session(role=input.role) as service:
-            await service.replace_interrupt_with_tool_results(
+            await service.remove_interrupt_entries_for_tool_results(
                 input.session_id,
                 results,
             )

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -39,6 +39,10 @@ from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.mcp.metadata import sanitize_message_tool_inputs
 from tracecat.agent.preset.prompts import AgentPresetBuilderPrompt
 from tracecat.agent.preset.service import AgentPresetService
+from tracecat.agent.runtime.claude_code.session_lines import (
+    is_continuation_control_artifact,
+    session_line_uuid,
+)
 from tracecat.agent.schemas import RunAgentArgs
 from tracecat.agent.service import AgentManagementService
 from tracecat.agent.session.schemas import (
@@ -98,7 +102,6 @@ if TYPE_CHECKING:
 
 AUTO_TITLE_SERVICE_ID = "tracecat-api"
 APPROVAL_CONTINUATION_DEDUP_TTL_SECONDS = 5 * 60
-APPROVAL_CONTINUATION_PROMPT = "Continue."
 
 
 @dataclass
@@ -549,75 +552,6 @@ class AgentSessionService(BaseWorkspaceService):
     # Session History Management (for Claude SDK session persistence)
     # =========================================================================
 
-    @staticmethod
-    def _session_line_uuid(content: dict[str, Any]) -> str | None:
-        line_uuid = content.get("uuid")
-        return line_uuid if isinstance(line_uuid, str) else None
-
-    @staticmethod
-    def _message_text_content(content: dict[str, Any]) -> str | None:
-        message = content.get("message")
-        if not isinstance(message, dict):
-            return None
-
-        message_content = message.get("content")
-        if isinstance(message_content, str):
-            return message_content
-
-        if isinstance(message_content, list) and len(message_content) == 1:
-            [part] = message_content
-            if isinstance(part, dict) and part.get("type") == "text":
-                text = part.get("text")
-                return text if isinstance(text, str) else None
-
-        return None
-
-    @staticmethod
-    def _is_thinking_only_assistant_content(content: dict[str, Any]) -> bool:
-        if content.get("type") != "assistant":
-            return False
-
-        message = content.get("message")
-        if not isinstance(message, dict):
-            return False
-
-        message_content = message.get("content")
-        if not isinstance(message_content, list) or not message_content:
-            return False
-
-        return all(
-            isinstance(part, dict) and part.get("type") == "thinking"
-            for part in message_content
-        )
-
-    @classmethod
-    def _is_continuation_control_artifact(
-        cls,
-        content: dict[str, Any],
-        internal_uuids: set[str],
-    ) -> bool:
-        """Return True for Claude Code continuation artifacts, even if mis-kind-ed."""
-        parent_uuid = content.get("parentUuid")
-        parent_is_internal = (
-            isinstance(parent_uuid, str) and parent_uuid in internal_uuids
-        )
-
-        if content.get("isMeta") is True:
-            return True
-
-        message = content.get("message")
-        if isinstance(message, dict) and message.get("model") == "<synthetic>":
-            return True
-
-        if (
-            content.get("type") == "user"
-            and parent_is_internal
-            and cls._message_text_content(content) == APPROVAL_CONTINUATION_PROMPT
-        ):
-            return True
-
-        return parent_is_internal and cls._is_thinking_only_assistant_content(content)
-
     async def load_session_history(
         self,
         session_id: uuid.UUID,
@@ -707,13 +641,13 @@ class AgentSessionService(BaseWorkspaceService):
             if not isinstance(content, dict):
                 continue
 
-            line_uuid = self._session_line_uuid(content)
+            line_uuid = session_line_uuid(content)
             if entry.kind == MessageKind.INTERNAL.value:
                 if line_uuid is not None:
                     internal_uuids.add(line_uuid)
                 continue
 
-            if self._is_continuation_control_artifact(content, internal_uuids):
+            if is_continuation_control_artifact(content, internal_uuids):
                 if line_uuid is not None:
                     internal_uuids.add(line_uuid)
                 continue
@@ -1627,12 +1561,12 @@ class AgentSessionService(BaseWorkspaceService):
 
             # Skip internal entries (e.g., continuation prompts)
             if entry.kind == MessageKind.INTERNAL.value:
-                if line_uuid := self._session_line_uuid(content):
+                if line_uuid := session_line_uuid(content):
                     internal_uuids.add(line_uuid)
                 continue
 
-            if self._is_continuation_control_artifact(content, internal_uuids):
-                if line_uuid := self._session_line_uuid(content):
+            if is_continuation_control_artifact(content, internal_uuids):
+                if line_uuid := session_line_uuid(content):
                     internal_uuids.add(line_uuid)
                 continue
 

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -17,7 +17,18 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.tools import ToolApproved, ToolDenied
-from sqlalchemy import delete, select, update
+from sqlalchemy import (
+    and_,
+    case,
+    column,
+    delete,
+    func,
+    literal,
+    or_,
+    select,
+    update,
+)
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import SQLAlchemyError
 from temporalio.common import TypedSearchAttributes
 from tracecat_registry._internal.exceptions import SecretNotFoundError
@@ -1851,34 +1862,56 @@ class AgentSessionService(BaseWorkspaceService):
         assistant_surrogate_id: int,
         tool_call_ids: set[str],
     ) -> bool:
-        stmt = (
-            select(AgentSessionHistory.content)
+        if not tool_call_ids:
+            return False
+
+        message_content = AgentSessionHistory.content["message"]["content"]
+        message_content_array = case(
+            (func.jsonb_typeof(message_content) == "array", message_content),
+            else_=literal([], type_=JSONB),
+        )
+        content_blocks = (
+            func.jsonb_array_elements(message_content_array)
+            .table_valued(column("value", JSONB))
+            .alias("content_block")
+        )
+        block = content_blocks.c.value
+        block_text = func.lower(func.btrim(block["content"].astext))
+        is_approval_interrupt = and_(
+            block["is_error"].astext == "true",
+            or_(
+                block_text == "interrupted",
+                block_text.contains("doesn't want to take this action"),
+                block_text.contains("stop what you are doing and wait for the user"),
+                block_text.contains("request interrupted by user"),
+                block_text.contains("[request interrupted"),
+            ),
+        )
+        matching_tool_result_count = (
+            select(func.count(func.distinct(block["tool_use_id"].astext)))
+            .select_from(content_blocks)
             .where(
+                block["type"].astext == "tool_result",
+                block["tool_use_id"].astext.in_(tool_call_ids),
+                ~is_approval_interrupt,
+            )
+            .correlate(AgentSessionHistory)
+            .scalar_subquery()
+        )
+
+        stmt = (
+            select(literal(True))
+            .where(
+                AgentSessionHistory.workspace_id == self.workspace_id,
                 AgentSessionHistory.session_id == session_id,
                 AgentSessionHistory.surrogate_id > assistant_surrogate_id,
+                AgentSessionHistory.content["type"].astext == "user",
+                matching_tool_result_count == len(tool_call_ids),
             )
-            .order_by(AgentSessionHistory.surrogate_id)
+            .limit(1)
         )
         result = await self.session.execute(stmt)
-        for content in result.scalars().all():
-            if content.get("type") != "user":
-                continue
-            message = content.get("message", {})
-            if not isinstance(message, dict):
-                continue
-            msg_content = message.get("content", [])
-            if not isinstance(msg_content, list):
-                continue
-            result_ids = {
-                block.get("tool_use_id")
-                for block in msg_content
-                if isinstance(block, dict)
-                and block.get("type") == "tool_result"
-                and not self._is_approval_interrupt_tool_result(block, tool_call_ids)
-            }
-            if tool_call_ids.issubset(result_ids):
-                return True
-        return False
+        return result.scalar_one_or_none() is True
 
     @staticmethod
     def _is_approval_interrupt_tool_result(

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -7,7 +7,7 @@ import hashlib
 import uuid
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass, replace
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal
 
 import orjson
@@ -1713,24 +1713,26 @@ class AgentSessionService(BaseWorkspaceService):
         ]
 
     # =========================================================================
-    # Approval Flow: Remove Interrupt Entries
+    # Approval Flow: Replace Interrupt Entries
     # =========================================================================
 
-    async def remove_interrupt_entries_for_tool_results(
+    async def replace_interrupt_with_tool_results(
         self,
         session_id: uuid.UUID,
         tool_results: Sequence[ToolExecutionResult],
     ) -> None:
-        """Remove interrupted approval artifacts before tool_result continuation.
+        """Replace interrupted approval artifacts with a real tool_result entry.
 
         After approval execution, the session history contains SDK-generated
         interrupt entries (error tool_result, interrupt text, synthetic message).
         This method:
         1. Finds the assistant message with tool_use blocks
         2. Deletes the interrupt entries
+        3. Inserts the approved/denied tool_result as the next user entry
 
-        The runtime sends the approved/denied tool_result blocks as the next SDK
-        input so Claude Code writes the canonical user tool_result row itself.
+        Claude Code must see tool_result immediately after the assistant tool_use
+        when it loads the resumed session. If we stream tool_result after the CLI
+        starts, the CLI may first append a synthetic no-op assistant entry.
 
         Args:
             session_id: The session UUID.
@@ -1751,7 +1753,6 @@ class AgentSessionService(BaseWorkspaceService):
         # interrupt artifacts that follow the pending tool call.
         history = await self.get_session_history(session_id)
         assistant_entry: AgentSessionHistory | None = None
-        assistant_surrogate_id = None
 
         for entry in reversed(history):
             if entry.content.get("type") == "assistant":
@@ -1760,10 +1761,9 @@ class AgentSessionService(BaseWorkspaceService):
                 )
                 if any(tu.get("id") in tool_call_ids for tu in tool_uses):
                     assistant_entry = entry
-                    assistant_surrogate_id = entry.surrogate_id
                     break
 
-        if assistant_entry is None or assistant_surrogate_id is None:
+        if assistant_entry is None:
             logger.warning(
                 "Could not find assistant message with tool_use for continuation",
                 session_id=session_id,
@@ -1773,16 +1773,110 @@ class AgentSessionService(BaseWorkspaceService):
 
         # Delete interrupt entries that follow the assistant message
         await self._delete_interrupt_entries_for_tool_calls(
-            session_id, assistant_surrogate_id, tool_call_ids
+            session_id, assistant_entry.surrogate_id, tool_call_ids
         )
 
+        # Avoid duplicate tool_result rows if the activity is retried after the
+        # replacement has already been committed.
+        if await self._has_tool_result_entry_after(
+            session_id, assistant_entry.surrogate_id, tool_call_ids
+        ):
+            await self.session.commit()
+            logger.info(
+                "Tool_result entry already exists for approval continuation",
+                session_id=session_id,
+                tool_call_ids=list(tool_call_ids),
+            )
+            return
+
+        assistant_content = assistant_entry.content
+        assistant_uuid = assistant_content.get("uuid")
+        if not isinstance(assistant_uuid, str):
+            logger.warning(
+                "Assistant tool_use entry is missing uuid for continuation",
+                session_id=session_id,
+                tool_call_ids=tool_call_ids,
+            )
+            await self.session.commit()
+            return
+
+        entry_content: dict[str, Any] = {
+            "uuid": str(uuid.uuid4()),
+            "parentUuid": assistant_uuid,
+            "sessionId": session.sdk_session_id,
+            "type": "user",
+            "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "cwd": assistant_content.get("cwd") or "/home/agent",
+            "version": assistant_content.get("version") or "2.1.85",
+            "userType": assistant_content.get("userType") or "external",
+            "gitBranch": assistant_content.get("gitBranch") or "",
+            "entrypoint": assistant_content.get("entrypoint") or "sdk-py",
+            "isSidechain": False,
+            "permissionMode": "default",
+            "promptId": str(uuid.uuid4()),
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": result.tool_call_id,
+                        "content": self._serialize_tool_result(result.result),
+                        "is_error": result.is_error,
+                    }
+                    for result in tool_results
+                ],
+            },
+        }
+
+        self.session.add(
+            AgentSessionHistory(
+                session_id=session_id,
+                workspace_id=self.workspace_id,
+                content=entry_content,
+                kind=MessageKind.CHAT_MESSAGE.value,
+            )
+        )
         await self.session.commit()
 
         logger.info(
-            "Removed interrupt entries before tool_result continuation",
+            "Replaced interrupt entries with tool_result",
             session_id=session_id,
             tool_call_ids=list(tool_call_ids),
+            parent_uuid=assistant_uuid,
         )
+
+    async def _has_tool_result_entry_after(
+        self,
+        session_id: uuid.UUID,
+        assistant_surrogate_id: int,
+        tool_call_ids: set[str],
+    ) -> bool:
+        stmt = (
+            select(AgentSessionHistory.content)
+            .where(
+                AgentSessionHistory.session_id == session_id,
+                AgentSessionHistory.surrogate_id > assistant_surrogate_id,
+            )
+            .order_by(AgentSessionHistory.surrogate_id)
+        )
+        result = await self.session.execute(stmt)
+        for content in result.scalars().all():
+            if content.get("type") != "user":
+                continue
+            message = content.get("message", {})
+            if not isinstance(message, dict):
+                continue
+            msg_content = message.get("content", [])
+            if not isinstance(msg_content, list):
+                continue
+            result_ids = {
+                block.get("tool_use_id")
+                for block in msg_content
+                if isinstance(block, dict) and block.get("type") == "tool_result"
+            }
+            if tool_call_ids.issubset(result_ids):
+                return True
+        return False
 
     async def _delete_interrupt_entries_for_tool_calls(
         self,
@@ -1835,6 +1929,8 @@ class AgentSessionService(BaseWorkspaceService):
                         block.get("type") == "tool_result"
                         and block.get("is_error") is True
                         and block.get("tool_use_id") in tool_call_ids
+                        and "doesn't want to take this action"
+                        in str(block.get("content", ""))
                     ):
                         entries_to_delete.append(entry)
                         break
@@ -1863,6 +1959,16 @@ class AgentSessionService(BaseWorkspaceService):
                 deleted_count=len(entries_to_delete),
                 deleted_ids=[str(id) for id in ids_to_delete],
             )
+
+    @staticmethod
+    def _serialize_tool_result(result: Any) -> str:
+        """Serialize a tool result to Claude's string tool_result content."""
+        if isinstance(result, str):
+            return result
+        try:
+            return orjson.dumps(result).decode("utf-8")
+        except (TypeError, ValueError):
+            return str(result)
 
     # =========================================================================
     # Session Forking (for post-decision agent interactions)

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -40,6 +40,9 @@ from tracecat.agent.mcp.metadata import sanitize_message_tool_inputs
 from tracecat.agent.preset.prompts import AgentPresetBuilderPrompt
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.runtime.claude_code.session_lines import (
+    APPROVAL_INTERRUPT_CONTENT_EXACT,
+    APPROVAL_INTERRUPT_CONTENT_MARKERS,
+    is_approval_interrupt_tool_result,
     is_continuation_control_artifact,
     session_line_uuid,
 )
@@ -88,14 +91,6 @@ from tracecat.workflow.executions.enums import (
     TriggerType,
 )
 from tracecat.workspaces.prompts import WorkspaceCopilotPrompts
-
-APPROVAL_INTERRUPT_CONTENT_EXACT = "interrupted"
-APPROVAL_INTERRUPT_CONTENT_MARKERS = (
-    "doesn't want to take this action",
-    "stop what you are doing and wait for the user",
-    "request interrupted by user",
-    "[request interrupted",
-)
 
 if TYPE_CHECKING:
     from tracecat.agent.executor.activity import ToolExecutionResult
@@ -1871,40 +1866,6 @@ class AgentSessionService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none() is True
 
-    @classmethod
-    def _is_approval_interrupt_tool_result(
-        cls,
-        block: dict[str, Any],
-        tool_call_ids: set[str],
-    ) -> bool:
-        """Return True for SDK approval-interrupt placeholder tool results."""
-        if not cls._is_error_tool_result_for_tool_calls(block, tool_call_ids):
-            return False
-
-        return cls._is_approval_interrupt_content(block.get("content", ""))
-
-    @staticmethod
-    def _is_error_tool_result_for_tool_calls(
-        block: dict[str, Any],
-        tool_call_ids: set[str],
-    ) -> bool:
-        match block:
-            case {
-                "type": "tool_result",
-                "is_error": True,
-                "tool_use_id": str(tool_call_id),
-            }:
-                return tool_call_id in tool_call_ids
-            case _:
-                return False
-
-    @staticmethod
-    def _is_approval_interrupt_content(content: object) -> bool:
-        content_text = str(content).strip().lower()
-        return content_text == APPROVAL_INTERRUPT_CONTENT_EXACT or any(
-            marker in content_text for marker in APPROVAL_INTERRUPT_CONTENT_MARKERS
-        )
-
     async def _delete_interrupt_entries_for_tool_calls(
         self,
         session_id: uuid.UUID,
@@ -1952,7 +1913,7 @@ class AgentSessionService(BaseWorkspaceService):
                     if not isinstance(block, dict):
                         continue
                     # Check for error tool_result matching our tool_call_ids
-                    if self._is_approval_interrupt_tool_result(block, tool_call_ids):
+                    if is_approval_interrupt_tool_result(block, tool_call_ids):
                         entries_to_delete.append(entry)
                         break
                     # Check for interrupt text

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -1872,11 +1872,38 @@ class AgentSessionService(BaseWorkspaceService):
             result_ids = {
                 block.get("tool_use_id")
                 for block in msg_content
-                if isinstance(block, dict) and block.get("type") == "tool_result"
+                if isinstance(block, dict)
+                and block.get("type") == "tool_result"
+                and not self._is_approval_interrupt_tool_result(block, tool_call_ids)
             }
             if tool_call_ids.issubset(result_ids):
                 return True
         return False
+
+    @staticmethod
+    def _is_approval_interrupt_tool_result(
+        block: dict[str, Any],
+        tool_call_ids: set[str],
+    ) -> bool:
+        """Return True for SDK approval-interrupt placeholder tool results."""
+        if (
+            block.get("type") != "tool_result"
+            or block.get("is_error") is not True
+            or block.get("tool_use_id") not in tool_call_ids
+        ):
+            return False
+
+        content = str(block.get("content", "")).strip().lower()
+        if content == "interrupted":
+            return True
+
+        markers = (
+            "doesn't want to take this action",
+            "stop what you are doing and wait for the user",
+            "request interrupted by user",
+            "[request interrupted",
+        )
+        return any(marker in content for marker in markers)
 
     async def _delete_interrupt_entries_for_tool_calls(
         self,
@@ -1925,13 +1952,7 @@ class AgentSessionService(BaseWorkspaceService):
                     if not isinstance(block, dict):
                         continue
                     # Check for error tool_result matching our tool_call_ids
-                    if (
-                        block.get("type") == "tool_result"
-                        and block.get("is_error") is True
-                        and block.get("tool_use_id") in tool_call_ids
-                        and "doesn't want to take this action"
-                        in str(block.get("content", ""))
-                    ):
+                    if self._is_approval_interrupt_tool_result(block, tool_call_ids):
                         entries_to_delete.append(entry)
                         break
                     # Check for interrupt text

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -85,6 +85,14 @@ from tracecat.workflow.executions.enums import (
 )
 from tracecat.workspaces.prompts import WorkspaceCopilotPrompts
 
+APPROVAL_INTERRUPT_CONTENT_EXACT = "interrupted"
+APPROVAL_INTERRUPT_CONTENT_MARKERS = (
+    "doesn't want to take this action",
+    "stop what you are doing and wait for the user",
+    "request interrupted by user",
+    "[request interrupted",
+)
+
 if TYPE_CHECKING:
     from tracecat.agent.executor.activity import ToolExecutionResult
 
@@ -1862,9 +1870,19 @@ class AgentSessionService(BaseWorkspaceService):
         assistant_surrogate_id: int,
         tool_call_ids: set[str],
     ) -> bool:
+        """Return True when all approval tool calls already have real results.
+
+        This is the idempotency guard for approval reconciliation retries. SDK
+        approval interrupts also write error `tool_result` blocks, so those
+        placeholder rows must be ignored here; otherwise a retry could mistake
+        stale interrupt state for the approved/denied tool execution result.
+        """
         if not tool_call_ids:
             return False
 
+        # Only user messages with list content can contain Anthropic
+        # `tool_result` blocks. Treat other content shapes as empty so malformed
+        # or text-only rows cannot satisfy the idempotency check.
         message_content = AgentSessionHistory.content["message"]["content"]
         message_content_array = case(
             (func.jsonb_typeof(message_content) == "array", message_content),
@@ -1876,17 +1894,23 @@ class AgentSessionService(BaseWorkspaceService):
             .alias("content_block")
         )
         block = content_blocks.c.value
+
+        # The SDK writes approval-interrupt placeholders as error tool_results
+        # for the same tool_use IDs. Those rows should be deleted/replaced, not
+        # treated as the real reconciled tool result.
         block_text = func.lower(func.btrim(block["content"].astext))
         is_approval_interrupt = and_(
             block["is_error"].astext == "true",
             or_(
-                block_text == "interrupted",
-                block_text.contains("doesn't want to take this action"),
-                block_text.contains("stop what you are doing and wait for the user"),
-                block_text.contains("request interrupted by user"),
-                block_text.contains("[request interrupted"),
+                block_text == APPROVAL_INTERRUPT_CONTENT_EXACT,
+                *(
+                    block_text.contains(marker)
+                    for marker in APPROVAL_INTERRUPT_CONTENT_MARKERS
+                ),
             ),
         )
+        # A multi-tool approval continuation is only reconciled once every
+        # pending tool_use has a non-placeholder result after the assistant row.
         matching_tool_result_count = (
             select(func.count(func.distinct(block["tool_use_id"].astext)))
             .select_from(content_blocks)
@@ -1913,30 +1937,39 @@ class AgentSessionService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none() is True
 
-    @staticmethod
+    @classmethod
     def _is_approval_interrupt_tool_result(
+        cls,
         block: dict[str, Any],
         tool_call_ids: set[str],
     ) -> bool:
         """Return True for SDK approval-interrupt placeholder tool results."""
-        if (
-            block.get("type") != "tool_result"
-            or block.get("is_error") is not True
-            or block.get("tool_use_id") not in tool_call_ids
-        ):
+        if not cls._is_error_tool_result_for_tool_calls(block, tool_call_ids):
             return False
 
-        content = str(block.get("content", "")).strip().lower()
-        if content == "interrupted":
-            return True
+        return cls._is_approval_interrupt_content(block.get("content", ""))
 
-        markers = (
-            "doesn't want to take this action",
-            "stop what you are doing and wait for the user",
-            "request interrupted by user",
-            "[request interrupted",
+    @staticmethod
+    def _is_error_tool_result_for_tool_calls(
+        block: dict[str, Any],
+        tool_call_ids: set[str],
+    ) -> bool:
+        match block:
+            case {
+                "type": "tool_result",
+                "is_error": True,
+                "tool_use_id": str(tool_call_id),
+            }:
+                return tool_call_id in tool_call_ids
+            case _:
+                return False
+
+    @staticmethod
+    def _is_approval_interrupt_content(content: object) -> bool:
+        content_text = str(content).strip().lower()
+        return content_text == APPROVAL_INTERRUPT_CONTENT_EXACT or any(
+            marker in content_text for marker in APPROVAL_INTERRUPT_CONTENT_MARKERS
         )
-        return any(marker in content for marker in markers)
 
     async def _delete_interrupt_entries_for_tool_calls(
         self,

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -7,7 +7,7 @@ import hashlib
 import uuid
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Literal
 
 import orjson
@@ -64,7 +64,8 @@ from tracecat.identifiers import UserID
 from tracecat.logger import logger
 from tracecat.redis.client import get_redis_client
 from tracecat.service import BaseWorkspaceService
-from tracecat.tiers.entitlements import Entitlement, check_entitlement
+from tracecat.tiers.entitlements import check_entitlement
+from tracecat.tiers.enums import Entitlement
 from tracecat.workflow.executions.correlation import build_agent_session_correlation_id
 from tracecat.workflow.executions.enums import (
     ExecutionType,
@@ -78,6 +79,7 @@ if TYPE_CHECKING:
 
 AUTO_TITLE_SERVICE_ID = "tracecat-api"
 APPROVAL_CONTINUATION_DEDUP_TTL_SECONDS = 5 * 60
+APPROVAL_CONTINUATION_PROMPT = "Continue."
 
 
 @dataclass
@@ -528,6 +530,75 @@ class AgentSessionService(BaseWorkspaceService):
     # Session History Management (for Claude SDK session persistence)
     # =========================================================================
 
+    @staticmethod
+    def _session_line_uuid(content: dict[str, Any]) -> str | None:
+        line_uuid = content.get("uuid")
+        return line_uuid if isinstance(line_uuid, str) else None
+
+    @staticmethod
+    def _message_text_content(content: dict[str, Any]) -> str | None:
+        message = content.get("message")
+        if not isinstance(message, dict):
+            return None
+
+        message_content = message.get("content")
+        if isinstance(message_content, str):
+            return message_content
+
+        if isinstance(message_content, list) and len(message_content) == 1:
+            [part] = message_content
+            if isinstance(part, dict) and part.get("type") == "text":
+                text = part.get("text")
+                return text if isinstance(text, str) else None
+
+        return None
+
+    @staticmethod
+    def _is_thinking_only_assistant_content(content: dict[str, Any]) -> bool:
+        if content.get("type") != "assistant":
+            return False
+
+        message = content.get("message")
+        if not isinstance(message, dict):
+            return False
+
+        message_content = message.get("content")
+        if not isinstance(message_content, list) or not message_content:
+            return False
+
+        return all(
+            isinstance(part, dict) and part.get("type") == "thinking"
+            for part in message_content
+        )
+
+    @classmethod
+    def _is_continuation_control_artifact(
+        cls,
+        content: dict[str, Any],
+        internal_uuids: set[str],
+    ) -> bool:
+        """Return True for Claude Code continuation artifacts, even if mis-kind-ed."""
+        parent_uuid = content.get("parentUuid")
+        parent_is_internal = (
+            isinstance(parent_uuid, str) and parent_uuid in internal_uuids
+        )
+
+        if content.get("isMeta") is True:
+            return True
+
+        message = content.get("message")
+        if isinstance(message, dict) and message.get("model") == "<synthetic>":
+            return True
+
+        if (
+            content.get("type") == "user"
+            and parent_is_internal
+            and cls._message_text_content(content) == APPROVAL_CONTINUATION_PROMPT
+        ):
+            return True
+
+        return parent_is_internal and cls._is_thinking_only_assistant_content(content)
+
     async def load_session_history(
         self,
         session_id: uuid.UUID,
@@ -605,11 +676,51 @@ class AgentSessionService(BaseWorkspaceService):
             )
             return None
 
-        # Reconstruct JSONL from history entries (content stored pristine)
+        # Reconstruct JSONL from model-visible history entries. Internal rows are
+        # stored for debugging/UI filtering but should not be fed back into Claude
+        # on later resumes.
         lines = []
+        included_uuids: set[str] = set()
+        internal_uuids: set[str] = set()
+        last_visible_uuid: str | None = None
         for entry in history_entries:
-            line = orjson.dumps(entry.content).decode("utf-8")
+            content = orjson.loads(orjson.dumps(entry.content))
+            if not isinstance(content, dict):
+                continue
+
+            line_uuid = self._session_line_uuid(content)
+            if entry.kind == MessageKind.INTERNAL.value:
+                if line_uuid is not None:
+                    internal_uuids.add(line_uuid)
+                continue
+
+            if self._is_continuation_control_artifact(content, internal_uuids):
+                if line_uuid is not None:
+                    internal_uuids.add(line_uuid)
+                continue
+
+            parent_uuid = content.get("parentUuid")
+            if (
+                isinstance(parent_uuid, str)
+                and parent_uuid not in included_uuids
+                and last_visible_uuid is not None
+            ):
+                content["parentUuid"] = last_visible_uuid
+
+            if line_uuid is not None:
+                included_uuids.add(line_uuid)
+                last_visible_uuid = line_uuid
+
+            line = orjson.dumps(content).decode("utf-8")
             lines.append(line)
+
+        if not lines:
+            logger.warning(
+                "sdk_session_id set but no model-visible history entries",
+                session_id=source_session_id,
+                sdk_session_id=sdk_session_id,
+            )
+            return None
 
         sdk_session_data = "\n".join(lines)
 
@@ -1489,6 +1600,7 @@ class AgentSessionService(BaseWorkspaceService):
         # Process both chat-message and internal entries in order
         # Internal entries contain tool results that the adapter will extract
         messages: list[ChatMessage] = []
+        internal_uuids: set[str] = set()
         for entry in all_entries:
             content = entry.content
             if not content:
@@ -1496,6 +1608,13 @@ class AgentSessionService(BaseWorkspaceService):
 
             # Skip internal entries (e.g., continuation prompts)
             if entry.kind == MessageKind.INTERNAL.value:
+                if line_uuid := self._session_line_uuid(content):
+                    internal_uuids.add(line_uuid)
+                continue
+
+            if self._is_continuation_control_artifact(content, internal_uuids):
+                if line_uuid := self._session_line_uuid(content):
+                    internal_uuids.add(line_uuid)
                 continue
 
             # Handle compaction entries: these are badges showing when compaction happened
@@ -1594,22 +1713,24 @@ class AgentSessionService(BaseWorkspaceService):
         ]
 
     # =========================================================================
-    # Approval Flow: Replace Interrupt Entries
+    # Approval Flow: Remove Interrupt Entries
     # =========================================================================
 
-    async def replace_interrupt_with_tool_results(
+    async def remove_interrupt_entries_for_tool_results(
         self,
         session_id: uuid.UUID,
         tool_results: Sequence[ToolExecutionResult],
     ) -> None:
-        """Replace interrupt entries with proper tool_result entry.
+        """Remove interrupted approval artifacts before tool_result continuation.
 
         After approval execution, the session history contains SDK-generated
         interrupt entries (error tool_result, interrupt text, synthetic message).
         This method:
-        1. Finds the assistant message with tool_use blocks (for parentUuid)
+        1. Finds the assistant message with tool_use blocks
         2. Deletes the interrupt entries
-        3. Inserts a proper tool_result JSONL entry
+
+        The runtime sends the approved/denied tool_result blocks as the next SDK
+        input so Claude Code writes the canonical user tool_result row itself.
 
         Args:
             session_id: The session UUID.
@@ -1626,9 +1747,10 @@ class AgentSessionService(BaseWorkspaceService):
 
         tool_call_ids = {tr.tool_call_id for tr in tool_results}
 
-        # Find the assistant message containing these tool_uses (for parentUuid)
+        # Find the assistant message containing these tool_uses so we only delete
+        # interrupt artifacts that follow the pending tool call.
         history = await self.get_session_history(session_id)
-        assistant_uuid = None
+        assistant_entry: AgentSessionHistory | None = None
         assistant_surrogate_id = None
 
         for entry in reversed(history):
@@ -1637,69 +1759,29 @@ class AgentSessionService(BaseWorkspaceService):
                     entry.content.get("message", {})
                 )
                 if any(tu.get("id") in tool_call_ids for tu in tool_uses):
-                    assistant_uuid = entry.content.get("uuid")
+                    assistant_entry = entry
                     assistant_surrogate_id = entry.surrogate_id
                     break
 
-        if assistant_uuid is None:
+        if assistant_entry is None or assistant_surrogate_id is None:
             logger.warning(
-                "Could not find assistant message with tool_use for replacement",
+                "Could not find assistant message with tool_use for continuation",
                 session_id=session_id,
                 tool_call_ids=tool_call_ids,
             )
             return
-        if assistant_surrogate_id is None:
-            logger.warning(
-                "Could not find assistant message with tool_use for replacement",
-                session_id=session_id,
-                tool_call_ids=tool_call_ids,
-            )
-            return
+
         # Delete interrupt entries that follow the assistant message
         await self._delete_interrupt_entries_for_tool_calls(
             session_id, assistant_surrogate_id, tool_call_ids
         )
 
-        # Build and insert proper tool_result entry
-        entry_content = {
-            "uuid": str(uuid.uuid4()),
-            "parentUuid": assistant_uuid,
-            "sessionId": session.sdk_session_id,
-            "type": "user",
-            "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
-            "cwd": "/home/agent",
-            "version": "2.0.72",
-            "userType": "external",
-            "gitBranch": "",
-            "isSidechain": False,
-            "message": {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": tr.tool_call_id,
-                        "content": self._serialize_tool_result(tr.result),
-                        "is_error": tr.is_error,
-                    }
-                    for tr in tool_results
-                ],
-            },
-        }
-
-        history_entry = AgentSessionHistory(
-            session_id=session_id,
-            workspace_id=self.workspace_id,
-            content=entry_content,
-            kind="chat-message",
-        )
-        self.session.add(history_entry)
         await self.session.commit()
 
         logger.info(
-            "Replaced interrupt entries with proper tool_result",
+            "Removed interrupt entries before tool_result continuation",
             session_id=session_id,
             tool_call_ids=list(tool_call_ids),
-            parent_uuid=assistant_uuid,
         )
 
     async def _delete_interrupt_entries_for_tool_calls(
@@ -1781,16 +1863,6 @@ class AgentSessionService(BaseWorkspaceService):
                 deleted_count=len(entries_to_delete),
                 deleted_ids=[str(id) for id in ids_to_delete],
             )
-
-    @staticmethod
-    def _serialize_tool_result(result: Any) -> str:
-        """Serialize a tool result to string for Claude SDK format."""
-        if isinstance(result, str):
-            return result
-        try:
-            return orjson.dumps(result).decode("utf-8")
-        except (TypeError, ValueError):
-            return str(result)
 
     # =========================================================================
     # Session Forking (for post-decision agent interactions)

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -1719,6 +1719,16 @@ class AgentSessionService(BaseWorkspaceService):
             )
             return
 
+        assistant_content = assistant_entry.content
+        assistant_uuid = assistant_content.get("uuid")
+        if not isinstance(assistant_uuid, str):
+            logger.warning(
+                "Assistant tool_use entry is missing uuid for continuation",
+                session_id=session_id,
+                tool_call_ids=tool_call_ids,
+            )
+            return
+
         # Delete interrupt entries that follow the assistant message
         await self._delete_interrupt_entries_for_tool_calls(
             session_id, assistant_entry.surrogate_id, tool_call_ids
@@ -1735,17 +1745,6 @@ class AgentSessionService(BaseWorkspaceService):
                 session_id=session_id,
                 tool_call_ids=list(tool_call_ids),
             )
-            return
-
-        assistant_content = assistant_entry.content
-        assistant_uuid = assistant_content.get("uuid")
-        if not isinstance(assistant_uuid, str):
-            logger.warning(
-                "Assistant tool_use entry is missing uuid for continuation",
-                session_id=session_id,
-                tool_call_ids=tool_call_ids,
-            )
-            await self.session.commit()
             return
 
         entry_content: dict[str, Any] = {

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -1707,7 +1707,12 @@ class AgentSessionService(BaseWorkspaceService):
                 tool_uses = self._extract_tool_uses_from_message(
                     entry.content.get("message", {})
                 )
-                if any(tu.get("id") in tool_call_ids for tu in tool_uses):
+                assistant_tool_call_ids = {
+                    tool_use_id
+                    for tool_use in tool_uses
+                    if isinstance(tool_use_id := tool_use.get("id"), str)
+                }
+                if tool_call_ids.issubset(assistant_tool_call_ids):
                     assistant_entry = entry
                     break
 


### PR DESCRIPTION
## Summary

- replace visible synthetic approval continuation prompts with a hidden Claude Code `isMeta` continuation tick
- preseed/reconcile Claude-format `user/tool_result` history rows so the model sees the real approved or denied tool result
- preserve legitimate thinking from the resumed assistant turn while hiding only SDK continuation metadata and synthetic artifacts
- replace legacy approval interrupt placeholders before duplicate detection so existing pending approvals can reconcile correctly
- update workflow, runtime, session activity, socket, adapter, unit, Temporal, and integration coverage for approval continuation ordering

## Existing Pending Approvals

This should be safe for workflows that are currently waiting on approval. Those workflows are paused before post-approval execution at `await self.approvals.wait()`. After the approval signal arrives, the new code runs the post-approval path: execute approved/denied tools, reconcile the session history by inserting the real `user/tool_result` row, reload the session history, then resume Claude Code with the hidden meta continuation tick.

Existing pending approvals should already have the assistant `tool_use` row and Claude Code interrupt artifacts in session history. The reconciliation step is designed for that state: find the matching assistant `tool_use`, remove interrupt artifacts including legacy `"interrupted"` placeholders, and insert the real tool result immediately after the tool use.

Caveats:

- Workflows that already received approval and are mid-continuation under the old behavior may still be in a bad/stuck state and are not guaranteed to self-heal.
- If session history is malformed or missing the matching assistant `tool_use`, reconciliation logs and returns without inserting a `tool_result`.
- The workflow worker and agent executor should both be running this version; mixed old/new workers are risky for this path.

## Attempted Alternative and Limitation

We also tried a cleaner continuation shape: keep session service as the canonical owner of the approved `user/tool_result` row, seed Claude Code with history only through the original assistant `tool_use`, then send that final `tool_result` as the first resumed SDK stdin message instead of using a hidden `Continue.` tick.

That does not work correctly with the current Claude Code SDK/CLI behavior. In live cluster testing, the DB showed the original approved tool result persisted correctly, but Claude Code inserted a synthetic assistant row (`<synthetic>` / `No response requested.`) before the replayed stdin `tool_result`. That broke the clean `assistant tool_use -> user tool_result` adjacency and the model requested the same tool again, creating a second pending approval for the same user request.

TODO: revisit this if Claude Code exposes a supported “resume and consume pending tool_result” API, or if the SDK/CLI allows passing a tool result without inserting the synthetic assistant placeholder. Until then, this PR keeps the more reliable design: preseed the reconciled `tool_result` into session history and use a hidden metadata continuation tick, while filtering those control-plane rows from normal chat history.

## Tests

- `uv run pytest tests/unit/test_agent_runtime.py tests/unit/test_agent_session_activities.py tests/unit/test_agent_session_approval_sink.py::test_replace_interrupt_with_tool_results_replaces_legacy_interrupted_row tests/temporal/test_durable_agent_workflow.py::test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_history tests/temporal/test_durable_agent_workflow.py::test_agent_workflow_does_not_retry_approved_tool_failures -q`
- `uv run ruff check packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py tests/integration/test_agent_worker.py tests/temporal/test_durable_agent_workflow.py tests/unit/test_agent_runtime.py tests/unit/test_agent_session_activities.py tests/unit/test_agent_session_approval_sink.py tests/unit/test_agent_session_messages.py tests/unit/test_agent_socket_io.py tests/unit/test_vercel_adapter.py tracecat/agent/adapter/vercel.py tracecat/agent/common/protocol.py tracecat/agent/executor/activity.py tracecat/agent/executor/schemas.py tracecat/agent/runtime/claude_code/runtime.py tracecat/agent/session/activities.py tracecat/agent/session/service.py`
- `uv run ruff format --check packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py tests/integration/test_agent_worker.py tests/temporal/test_durable_agent_workflow.py tests/unit/test_agent_runtime.py tests/unit/test_agent_session_activities.py tests/unit/test_agent_session_approval_sink.py tests/unit/test_agent_session_messages.py tests/unit/test_agent_socket_io.py tests/unit/test_vercel_adapter.py tracecat/agent/adapter/vercel.py tracecat/agent/common/protocol.py tracecat/agent/executor/activity.py tracecat/agent/executor/schemas.py tracecat/agent/runtime/claude_code/runtime.py tracecat/agent/session/activities.py tracecat/agent/session/service.py`
- `uv run basedpyright --warnings packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py tests/integration/test_agent_worker.py tests/temporal/test_durable_agent_workflow.py tests/unit/test_agent_runtime.py tests/unit/test_agent_session_activities.py tests/unit/test_agent_session_approval_sink.py tests/unit/test_agent_session_messages.py tests/unit/test_agent_socket_io.py tests/unit/test_vercel_adapter.py tracecat/agent/adapter/vercel.py tracecat/agent/common/protocol.py tracecat/agent/executor/activity.py tracecat/agent/executor/schemas.py tracecat/agent/runtime/claude_code/runtime.py tracecat/agent/session/activities.py tracecat/agent/session/service.py`
