### PR TITLE
fix: sandbox DNS resolver

### DIFF
--- a/tests/unit/test_sandbox_networking.py
+++ b/tests/unit/test_sandbox_networking.py
@@ -12,7 +12,9 @@ from tracecat.sandbox.networking import (
 from tracecat.sandbox.types import SandboxConfig
 
 
-def test_build_pasta_resolv_conf_preserves_search_and_options(tmp_path: Path) -> None:
+def test_build_pasta_resolv_conf_preserves_host_resolver(
+    tmp_path: Path,
+) -> None:
     host_resolv = tmp_path / "host-resolv.conf"
     host_resolv.write_text(
         "\n".join(
@@ -29,10 +31,36 @@ def test_build_pasta_resolv_conf_preserves_search_and_options(tmp_path: Path) ->
     resolv_conf = build_pasta_resolv_conf(host_resolv)
 
     assert resolv_conf == (
-        f"nameserver {PASTA_GATEWAY_IP}\n"
+        "nameserver 10.0.0.10\n"
         "search default.svc.cluster.local svc.cluster.local\n"
         "options ndots:5 timeout:2 attempts:3\n"
     )
+
+
+def test_build_pasta_resolv_conf_falls_back_to_pasta_dns(
+    tmp_path: Path,
+) -> None:
+    host_resolv = tmp_path / "host-resolv.conf"
+    host_resolv.write_text("search svc.cluster.local\noptions ndots:5\n")
+
+    resolv_conf = build_pasta_resolv_conf(host_resolv)
+
+    assert resolv_conf == (
+        f"nameserver {PASTA_GATEWAY_IP}\nsearch svc.cluster.local\noptions ndots:5\n"
+    )
+
+
+def test_build_pasta_resolv_conf_ignores_loopback_nameservers(
+    tmp_path: Path,
+) -> None:
+    host_resolv = tmp_path / "host-resolv.conf"
+    host_resolv.write_text(
+        "nameserver 127.0.0.11\nnameserver ::1\nsearch svc.cluster.local\n"
+    )
+
+    resolv_conf = build_pasta_resolv_conf(host_resolv)
+
+    assert resolv_conf == f"nameserver {PASTA_GATEWAY_IP}\nsearch svc.cluster.local\n"
 
 
 def test_write_pasta_network_files_writes_hostname_resolution_files(
@@ -40,9 +68,7 @@ def test_write_pasta_network_files_writes_hostname_resolution_files(
 ) -> None:
     network_files = write_pasta_network_files(tmp_path)
 
-    assert network_files.resolv_conf.read_text().startswith(
-        f"nameserver {PASTA_GATEWAY_IP}\n"
-    )
+    assert "nameserver " in network_files.resolv_conf.read_text()
     assert "127.0.0.1\tlocalhost" in network_files.hosts.read_text()
     assert "hosts:          files dns" in network_files.nsswitch_conf.read_text()
 

--- a/tracecat/sandbox/networking.py
+++ b/tracecat/sandbox/networking.py
@@ -3,12 +3,24 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from ipaddress import ip_address
 from pathlib import Path
 
 PASTA_GUEST_IP = "10.255.255.2"
 PASTA_GATEWAY_IP = "10.255.255.1"
 PASTA_GUEST_IP6 = "fc00::2"
 PASTA_GATEWAY_IP6 = "fc00::1"
+
+
+def _is_loopback_nameserver(line: str) -> bool:
+    parts = line.split()
+    if len(parts) < 2:
+        return False
+    address = parts[1].split("%", maxsplit=1)[0]
+    try:
+        return ip_address(address).is_loopback
+    except ValueError:
+        return False
 
 
 @dataclass(frozen=True)
@@ -39,8 +51,14 @@ def pasta_user_net_config_lines() -> list[str]:
 def build_pasta_resolv_conf(
     host_resolv_path: Path = Path("/etc/resolv.conf"),
 ) -> str:
-    """Build resolv.conf for pasta DNS while preserving resolver search options."""
-    lines = [f"nameserver {PASTA_GATEWAY_IP}"]
+    """Build resolv.conf for a pasta-backed jail.
+
+    Preserve the host resolver so Kubernetes service discovery keeps working
+    inside the sandbox. Fall back to pasta's gateway resolver only when the
+    host does not expose nameservers.
+    """
+    nameservers: list[str] = []
+    options: list[str] = []
     try:
         host_resolv = host_resolv_path.read_text()
     except OSError:
@@ -48,8 +66,12 @@ def build_pasta_resolv_conf(
 
     for line in host_resolv.splitlines():
         stripped = line.strip()
-        if stripped.startswith("search ") or stripped.startswith("options "):
-            lines.append(stripped)
+        if stripped.startswith("nameserver ") and not _is_loopback_nameserver(stripped):
+            nameservers.append(stripped)
+        elif stripped.startswith("search ") or stripped.startswith("options "):
+            options.append(stripped)
+    lines = nameservers or [f"nameserver {PASTA_GATEWAY_IP}"]
+    lines.extend(options)
     return "\n".join(lines) + "\n"
 
 


### PR DESCRIPTION
## Summary

Fix sandbox DNS generation for pasta-backed nsjail actions by preserving the executor pod's real non-loopback nameservers instead of always pointing sandbox resolv.conf at pasta's gateway resolver.

## Root Cause

In EKS, the action sandbox had outbound connectivity through pasta, but DNS lookups went to `10.255.255.1` and failed with temporary name resolution errors. The executor pod itself could resolve Kubernetes service names through CoreDNS, and the same nsjail+pasta sandbox resolved successfully when pointed at the pod's CoreDNS resolver.

## Changes

- Preserve non-loopback `nameserver` entries from the host `/etc/resolv.conf` when generating sandbox DNS files.
- Keep `search` and `options` entries intact for Kubernetes service discovery.
- Fall back to pasta's gateway resolver when no usable host nameserver is present.
- Add focused unit coverage for CoreDNS preservation, fallback behavior, and loopback nameserver filtering.

## Validation

- `uv run pytest tests/unit/test_sandbox_networking.py`
- `uv run ruff check tracecat/sandbox/networking.py tests/unit/test_sandbox_networking.py`
- `uv run ruff format --check tracecat/sandbox/networking.py tests/unit/test_sandbox_networking.py`
- `uv run basedpyright tracecat/sandbox/networking.py tests/unit/test_sandbox_networking.py`
- Commit hooks also passed during `git commit`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix DNS in pasta-backed sandboxes by using the pod’s real non-loopback nameservers. Restores Kubernetes service resolution in EKS and similar setups.

- **Bug Fixes**
  - Preserve non-loopback nameservers from the host `/etc/resolv.conf`.
  - Keep `search` and `options` lines for Kubernetes discovery.
  - Fall back to the pasta gateway resolver only when no usable host nameserver exists.
  - Add unit tests for CoreDNS preservation, fallback behavior, and loopback filtering.

<sup>Written for commit 01882ca867d1398f3a6301a88850f15760a5422d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

