### PR TITLE
fix(approvals): hide legacy chats from approvals

### DIFF
--- a/frontend/src/components/inbox/inbox-chat.tsx
+++ b/frontend/src/components/inbox/inbox-chat.tsx
@@ -15,6 +15,7 @@ export function InboxChat({ session }: InboxChatProps) {
 
   // Track the forked session ID and pending message
   const [forkedState, setForkedState] = useState<{
+    parentSessionId: string
     sessionId: string
     pendingMessage?: string
   } | null>(null)
@@ -38,7 +39,10 @@ export function InboxChat({ session }: InboxChatProps) {
         if (!isCurrent) return
 
         if (childSessions.length > 0) {
-          setForkedState({ sessionId: childSessions[0].id })
+          setForkedState({
+            parentSessionId: session.id,
+            sessionId: childSessions[0].id,
+          })
         } else {
           setForkedState(null)
         }
@@ -58,10 +62,16 @@ export function InboxChat({ session }: InboxChatProps) {
     }
   }, [session?.id, workspaceId])
 
-  const activeSessionId = forkedState?.sessionId ?? session.id
+  const activeForkedState =
+    forkedState?.parentSessionId === session.id ? forkedState : null
+  const activeSessionId = activeForkedState?.sessionId ?? session.id
 
   const handleForked = (forkedId: string, pendingMessage: string) => {
-    setForkedState({ sessionId: forkedId, pendingMessage })
+    setForkedState({
+      parentSessionId: session.id,
+      sessionId: forkedId,
+      pendingMessage,
+    })
   }
 
   const handlePendingMessageSent = () => {
@@ -77,7 +87,7 @@ export function InboxChat({ session }: InboxChatProps) {
       parentSessionId={session.id}
       session={session}
       onForked={handleForked}
-      pendingMessage={forkedState?.pendingMessage}
+      pendingMessage={activeForkedState?.pendingMessage}
       onPendingMessageSent={handlePendingMessageSent}
     />
   )

--- a/tests/unit/test_agent_session_list_sessions.py
+++ b/tests/unit/test_agent_session_list_sessions.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from tracecat.agent.session.schemas import AgentSessionRead
+from tracecat.agent.session.service import AgentSessionService
+from tracecat.auth.types import Role
+
+
+def _mock_scalar_result(items: list[Any]) -> Mock:
+    scalars = Mock()
+    scalars.all.return_value = items
+    result = Mock()
+    result.scalars.return_value = scalars
+    return result
+
+
+def _build_service() -> tuple[AgentSessionService, SimpleNamespace, Role]:
+    workspace_id = uuid.uuid4()
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        user_id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+        scopes=frozenset({"agent:read"}),
+    )
+    session = SimpleNamespace(execute=AsyncMock())
+    return AgentSessionService(cast(Any, session), role), session, role
+
+
+def _agent_session_row(
+    *,
+    workspace_id: uuid.UUID,
+    user_id: uuid.UUID,
+    parent_session_id: uuid.UUID | None,
+) -> SimpleNamespace:
+    now = datetime.now(UTC)
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        title="Child approval chat",
+        created_by=user_id,
+        entity_type="approval",
+        entity_id=uuid.uuid4(),
+        channel_context=None,
+        tools=None,
+        agent_preset_id=None,
+        agent_preset_version_id=None,
+        harness_type=None,
+        last_stream_id=None,
+        parent_session_id=parent_session_id,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.anyio
+async def test_list_sessions_parent_session_filter_excludes_legacy_chats() -> None:
+    service, session, role = _build_service()
+    assert role.workspace_id is not None
+    assert role.user_id is not None
+    parent_session_id = uuid.uuid4()
+    child_session = _agent_session_row(
+        workspace_id=role.workspace_id,
+        user_id=role.user_id,
+        parent_session_id=parent_session_id,
+    )
+    session.execute.return_value = _mock_scalar_result([child_session])
+
+    results = await service.list_sessions(
+        created_by=role.user_id,
+        parent_session_id=parent_session_id,
+        limit=1,
+    )
+
+    session.execute.assert_awaited_once()
+    assert results == [
+        AgentSessionRead.model_validate(child_session, from_attributes=True)
+    ]

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -373,22 +373,24 @@ class AgentSessionService(BaseWorkspaceService):
         session_result = await self.session.execute(session_stmt)
         sessions = list(session_result.scalars().all())
 
-        # Query legacy Chat table
-        # Note: exclude_entity_types is not applied here because legacy Chat records
-        # predate entity types like WORKFLOW and APPROVAL that are typically excluded.
-        # Legacy chats only have entity types like "case" or "agent_preset".
-        chat_stmt = select(Chat).where(Chat.workspace_id == self.workspace_id)
-        if created_by is not None:
-            chat_stmt = chat_stmt.where(Chat.user_id == created_by)
-        if entity_type is not None:
-            chat_stmt = chat_stmt.where(Chat.entity_type == entity_type.value)
-        if entity_id is not None:
-            chat_stmt = chat_stmt.where(Chat.entity_id == entity_id)
-        # Bound query cost at the database layer; we still merge+sort below.
-        chat_stmt = chat_stmt.order_by(Chat.created_at.desc()).limit(limit)
+        legacy_chats: list[Chat] = []
+        if parent_session_id is None:
+            # Query legacy Chat table
+            # Note: exclude_entity_types is not applied here because legacy Chat records
+            # predate entity types like WORKFLOW and APPROVAL that are typically excluded.
+            # Legacy chats only have entity types like "case" or "agent_preset".
+            chat_stmt = select(Chat).where(Chat.workspace_id == self.workspace_id)
+            if created_by is not None:
+                chat_stmt = chat_stmt.where(Chat.user_id == created_by)
+            if entity_type is not None:
+                chat_stmt = chat_stmt.where(Chat.entity_type == entity_type.value)
+            if entity_id is not None:
+                chat_stmt = chat_stmt.where(Chat.entity_id == entity_id)
+            # Bound query cost at the database layer; we still merge+sort below.
+            chat_stmt = chat_stmt.order_by(Chat.created_at.desc()).limit(limit)
 
-        chat_result = await self.session.execute(chat_stmt)
-        legacy_chats = list(chat_result.scalars().all())
+            chat_result = await self.session.execute(chat_stmt)
+            legacy_chats = list(chat_result.scalars().all())
 
         # Convert and merge
         items: list[AgentSessionRead | ChatReadMinimal] = []


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide legacy chats in approvals by filtering them out when listing child sessions and scoping forked state to the current parent chat. This keeps approval threads clean and prevents stray pending messages.

- **Bug Fixes**
  - Backend: Skip merging legacy `Chat` rows when `parent_session_id` is provided in `AgentSessionService.list_sessions`, so approval children only include sessions.
  - Frontend: `InboxChat` now tracks `parentSessionId` and only uses `forkedState` when it matches the current chat; passes `pendingMessage` only for the active fork.
  - Tests: Added unit test to verify legacy chats are excluded when listing sessions with a `parent_session_id`.

<sup>Written for commit b5423ceb54340b8734d6278936e6389ba22a5f5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

