### PR TITLE
fix(agents): bump claude shim buffer limit

### DIFF
--- a/tests/unit/test_agent_nsjail.py
+++ b/tests/unit/test_agent_nsjail.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import tracecat.agent.sandbox.nsjail as nsjail_module
+
+
+class _FakeProcess:
+    pass
+
+
+@pytest.mark.anyio
+async def test_spawned_claude_shim_uses_explicit_stdio_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(nsjail_module, "TRACECAT__DISABLE_NSJAIL", True)
+    captured: dict[str, Any] = {}
+
+    async def fake_create_subprocess_exec(
+        *_args: object,
+        **kwargs: object,
+    ) -> _FakeProcess:
+        captured["kwargs"] = kwargs
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        nsjail_module.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    socket_dir = tmp_path / "sockets"
+    socket_dir.mkdir()
+
+    await nsjail_module.spawn_jailed_runtime(
+        socket_dir=socket_dir,
+        init_payload_path=tmp_path / "init.json",
+        pipe_stdin=True,
+    )
+
+    assert captured["kwargs"]["limit"] == nsjail_module.CLAUDE_SHIM_STDIO_LIMIT_BYTES

--- a/tracecat/agent/runtime/claude_code/transport.py
+++ b/tracecat/agent/runtime/claude_code/transport.py
@@ -41,7 +41,7 @@ class SandboxedCLITransport(Transport):
     """Claude SDK transport that runs the Claude CLI inside the sandbox shim."""
 
     JAILED_SITE_PACKAGES_ROOT = Path("/site-packages")
-    _MAX_BUFFER_SIZE = 1024 * 1024
+    _MAX_BUFFER_SIZE = 5 * 1024 * 1024
 
     def __init__(
         self,

--- a/tracecat/agent/sandbox/nsjail.py
+++ b/tracecat/agent/sandbox/nsjail.py
@@ -55,6 +55,7 @@ from tracecat.logger import logger
 BROKER_SHIM_SCRIPT_NAME = Path(JAILED_SHIM_ENTRYPOINT_PATH).name
 SESSION_HOME_ENV_VAR = "TRACECAT__AGENT_SESSION_HOME_DIR"
 SESSION_PROJECT_ENV_VAR = "TRACECAT__AGENT_SESSION_PROJECT_DIR"
+CLAUDE_SHIM_STDIO_LIMIT_BYTES = 5 * 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -327,6 +328,7 @@ async def _spawn_direct_runtime(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         env=env,
+        limit=CLAUDE_SHIM_STDIO_LIMIT_BYTES,
     )
 
     return SpawnedRuntime(process=process, job_dir=None)
@@ -452,6 +454,7 @@ async def _spawn_nsjail_runtime(
             stderr=asyncio.subprocess.PIPE,
             cwd=str(job_dir),
             env=env_map,
+            limit=CLAUDE_SHIM_STDIO_LIMIT_BYTES,
         )
 
         # Return result with job_dir for caller to clean up after process completes


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase the Claude shim stdio buffer to 5 MB to prevent truncated output and crashes with large responses. Align the transport buffer with the shim for consistent behavior.

- **Bug Fixes**
  - Set a shared `CLAUDE_SHIM_STDIO_LIMIT_BYTES` (5 MB) and pass it as `limit` when spawning the runtime in both direct and nsjail paths.
  - Raise `SandboxedCLITransport._MAX_BUFFER_SIZE` to 5 MB.
  - Add unit test to verify the explicit stdio limit is applied when spawning the shim.

<sup>Written for commit a41a73b04c4c168835772daddbc723a4752c1c32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

