### PR TITLE
ci: increase temporal test Postgres connections

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -107,7 +107,19 @@ jobs:
         env:
           COMPOSE_BAKE: "true"
           TRACECAT__UNSAFE_DISABLE_SM_MASKING: "true"
-        run: docker compose -f docker-compose.dev.yml up -d temporal api postgres_db caddy minio
+        run: |
+          compose_files=(-f docker-compose.dev.yml)
+
+          if [ "${{ matrix.test_group }}" = "temporal" ]; then
+            cat > /tmp/tracecat-ci-postgres.yml <<'YAML'
+          services:
+            postgres_db:
+              command: ["postgres", "-c", "max_connections=500"]
+          YAML
+            compose_files+=(-f /tmp/tracecat-ci-postgres.yml)
+          fi
+
+          docker compose "${compose_files[@]}" up -d temporal api postgres_db caddy minio
 
       - name: Install dependencies
         run: uv sync --frozen


### PR DESCRIPTION
## Summary

- Adds a CI-only Docker Compose override for the `temporal` Python test matrix leg.
- Starts `postgres_db` with `max_connections=500` for that leg to absorb xdist and workflow activity connection bursts.
- Leaves local compose defaults and the non-temporal test matrix legs unchanged.

## Root Cause

The failing job hit Postgres `FATAL: sorry, too many clients already` while the temporal suite was running under pytest-xdist. The default Postgres connection limit is too low for that CI leg's bursty concurrency.

## Validation

- `uv run ruff check .`
- Parsed `.github/workflows/test-python.yml` as YAML with Ruby
- Verified the temporary Compose override with `docker compose config`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise Postgres max_connections to 500 for the `temporal` test matrix in CI to prevent “too many clients already” errors under `pytest-xdist`. Implemented via a CI-only Docker Compose override in `.github/workflows/test-python.yml`; local dev and other matrix legs are unchanged.

<sup>Written for commit 1cb0b51203c63cab45b02e6f57979345716a3e23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

