### PR TITLE
ENG-1388 fix(agents): strip /vN from passthrough upstream_url to prevent /v1/v…

### DIFF
--- a/tests/unit/test_agent_llm_proxy.py
+++ b/tests/unit/test_agent_llm_proxy.py
@@ -278,14 +278,75 @@ async def test_forward_request_strips_authorization_for_passthrough_upstream(
     assert response_text.startswith("HTTP/1.1 200 OK")
 
 
-def test_passthrough_upstream_url_preserves_version_suffix(tmp_path: Path) -> None:
+def test_passthrough_upstream_url_strips_version_suffix(tmp_path: Path) -> None:
+    """Passthrough strips a trailing /vN from the stored base_url so it does
+    not collide with the /v1/... path the SDK clients emit."""
     socket_proxy = LLMSocketProxy(
         socket_path=tmp_path / "llm.sock",
         upstream_url="https://customer-litellm.example/v1/",
         passthrough=True,
     )
 
-    assert socket_proxy.upstream_url == "https://customer-litellm.example/v1"
+    assert socket_proxy.upstream_url == "https://customer-litellm.example"
+
+
+def test_non_passthrough_upstream_url_preserves_path(tmp_path: Path) -> None:
+    """Non-passthrough talks to internal LiteLLM at a known host root and must
+    not have any path segment trimmed."""
+    socket_proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        upstream_url="http://litellm:4000/v1",
+        passthrough=False,
+    )
+
+    assert socket_proxy.upstream_url == "http://litellm:4000/v1"
+
+
+@pytest.mark.anyio
+async def test_passthrough_does_not_double_prefix_version_in_request_url(
+    tmp_path: Path,
+) -> None:
+    """Customer base_url ending in /v1 + client path /v1/messages must not
+    produce /v1/v1/messages, which the upstream rejects with 404."""
+    received_urls: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        received_urls.append(str(request.url))
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "application/json"},
+            json={"ok": True},
+        )
+
+    socket_proxy = LLMSocketProxy(
+        socket_path=tmp_path / "llm.sock",
+        upstream_url="https://customer-litellm.example/v1",
+        passthrough=True,
+    )
+    socket_proxy._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    writer = _FakeWriter()
+
+    try:
+        await socket_proxy._forward_request(
+            {
+                "method": "POST",
+                "path": "/v1/messages",
+                "headers": {
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer llm-token",
+                },
+                "body": b'{"messages":[{"role":"user","content":"hello"}]}',
+            },
+            cast(asyncio.StreamWriter, writer),
+        )
+    finally:
+        if socket_proxy._client is not None:
+            await socket_proxy._client.aclose()
+
+    assert received_urls == ["https://customer-litellm.example/v1/messages"], (
+        f"expected single /v1 prefix, got {received_urls[0]!r} — "
+        "double-prefix causes upstream 404 'model not found'"
+    )
 
 
 @pytest.mark.anyio

--- a/tracecat/agent/sandbox/llm_proxy.py
+++ b/tracecat/agent/sandbox/llm_proxy.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import time
 import uuid
 from collections.abc import AsyncIterable, Callable
@@ -26,6 +27,16 @@ from tracecat.agent.observability import get_load_tracker
 from tracecat.agent.service import AgentManagementService
 from tracecat.auth.types import Role
 from tracecat.logger import logger
+
+# Strip a trailing "/vN" segment (with optional trailing slash) from a
+# passthrough upstream URL. The contract for stored ``base_url`` is the
+# OpenAI-compatible "/v1" form (so catalog discovery can hit
+# ``{base_url}/models`` → ``/v1/models``). In passthrough mode the SDK
+# clients (Claude Code SDK, pydantic-ai) emit fully-qualified paths like
+# ``/v1/messages``, so we strip the version suffix from ``upstream_url``
+# to avoid producing ``/v1/v1/messages``, which the upstream rejects with
+# a 404 "model not found".
+_PASSTHROUGH_VERSION_SUFFIX_RE = re.compile(r"/v\d+/?$")
 
 # Socket filename (created in job's socket directory)
 LLM_SOCKET_NAME = "llm.sock"
@@ -178,11 +189,13 @@ class LLMSocketProxy:
                 the legacy ``agent-custom-model-provider-credentials`` secret.
         """
         self.socket_path = socket_path
-        self.upstream_url = (
-            upstream_url.rstrip("/")
-            if upstream_url is not None
-            else app_config.TRACECAT__LITELLM_BASE_URL.rstrip("/")
-        )
+        if upstream_url is not None:
+            trimmed = upstream_url.rstrip("/")
+            if passthrough:
+                trimmed = _PASSTHROUGH_VERSION_SUFFIX_RE.sub("", trimmed)
+            self.upstream_url = trimmed
+        else:
+            self.upstream_url = app_config.TRACECAT__LITELLM_BASE_URL.rstrip("/")
         self._server: asyncio.Server | None = None
         self._client: httpx.AsyncClient | None = None
         self._on_error = on_error


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix passthrough LLM proxy URL handling by stripping a trailing /vN from the configured upstream_url to avoid /v1/v1 paths. Prevents upstream 404s; non-passthrough URLs are preserved.

- Bug Fixes
  - Normalize passthrough upstream_url by removing a trailing /vN (optional slash) so client paths like /v1/messages are not double-prefixed.
  - Add tests for passthrough normalization, non-passthrough preservation, and forwarding with a single /v1 prefix.

<sup>Written for commit 635a1ecc49ea9f5c93b4b933343cc9337c2d1059. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

