### PR TITLE
fix: Sanitize and normalize skill name input inline

### DIFF
--- a/frontend/src/components/skills/create-skill-dialog.tsx
+++ b/frontend/src/components/skills/create-skill-dialog.tsx
@@ -12,7 +12,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { validateSkillName } from "@/lib/skills-studio"
-import { cn, slugify } from "@/lib/utils"
+import { cn } from "@/lib/utils"
 
 type CreateSkillDialogProps = {
   open: boolean
@@ -60,7 +60,14 @@ export function CreateSkillDialog({
               id="new-skill-name"
               value={name}
               onChange={(event) =>
-                onNameChange(slugify(event.target.value, "-"))
+                onNameChange(
+                  event.target.value
+                    .toLowerCase()
+                    .replace(/_/g, "-")
+                    .replace(/[^a-z0-9-\s]/g, "")
+                    .replace(/[\s-]+/g, "-")
+                    .replace(/^-+|-+$/g, "")
+                )
               }
               placeholder="threat-intel"
               aria-invalid={showNameError || undefined}

--- a/frontend/src/components/skills/create-skill-dialog.tsx
+++ b/frontend/src/components/skills/create-skill-dialog.tsx
@@ -62,6 +62,8 @@ export function CreateSkillDialog({
               onChange={(event) =>
                 onNameChange(
                   event.target.value
+                    .normalize("NFKD")
+                    .replace(/[\u0300-\u036f]/g, "")
                     .toLowerCase()
                     .replace(/_/g, "-")
                     .replace(/[^a-z0-9-\s]/g, "")

--- a/frontend/tests/create-skill-dialog.test.tsx
+++ b/frontend/tests/create-skill-dialog.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { CreateSkillDialog } from "@/components/skills/create-skill-dialog"
+
+jest.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: ReactNode }) => (
+    <p>{children}</p>
+  ),
+  DialogFooter: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}))
+
+describe("CreateSkillDialog", () => {
+  it("preserves accented Latin letters when sanitizing skill names", () => {
+    const onNameChange = jest.fn()
+
+    render(
+      <CreateSkillDialog
+        open={true}
+        onOpenChange={jest.fn()}
+        name=""
+        onNameChange={onNameChange}
+        description=""
+        onDescriptionChange={jest.fn()}
+        pending={false}
+        onCreate={jest.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Café Tools" },
+    })
+
+    expect(onNameChange).toHaveBeenCalledWith("cafe-tools")
+  })
+})


### PR DESCRIPTION
### Motivation

- Replace the external `slugify` usage with an inline normalization to ensure skill names are consistently formatted client-side before validation. 
- Enforce the allowed character set and hyphen rules early so the `validateSkillName` check receives normalized input.

### Description

- Removed the `slugify` import and updated the `onChange` for the name `Input` to perform inline normalization. 
- The new normalization lowercases the string, converts underscores to hyphens, removes invalid characters, collapses repeated spaces/hyphens into single hyphens, and trims leading/trailing hyphens. 
- Existing validation via `validateSkillName` and error UI are unchanged and still applied after normalization.

### Testing

- Ran the frontend type-check and build (`pnpm build`) to verify there are no TypeScript or bundling errors, and the build succeeded. 
- Ran the frontend unit tests (`pnpm test`) and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c5fabd3083209525928852f2826e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize skill name input inline with Unicode support to enforce kebab-case before validation. Strips diacritics so accented names like “Café Tools” become “cafe-tools”, ensuring `validateSkillName` always receives normalized input.

- **Bug Fixes**
  - Replaced `slugify` with inline normalization in the name input’s `onChange`.
  - Added Unicode NFKD normalization and diacritic stripping; rules: lowercase, `_`→`-`, remove invalid chars, collapse spaces/hyphens to `-`, trim edges.
  - Added test for accented input; validation via `validateSkillName` and error UI remain unchanged.

<sup>Written for commit 745409b93aac567a236a112628b4f7f0843e4139. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

