### PR TITLE
feat(mcp): PAT data models

### DIFF
--- a/alembic/versions/8b2f6a9c4d10_add_mcp_personal_access_token.py
+++ b/alembic/versions/8b2f6a9c4d10_add_mcp_personal_access_token.py
@@ -1,0 +1,146 @@
+"""add mcp personal access token table
+
+Revision ID: 8b2f6a9c4d10
+Revises: 96470fdcc686
+Create Date: 2026-05-04 16:45:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from tracecat.db.tenant_rls import (
+    disable_org_optional_workspace_table_rls,
+    enable_org_optional_workspace_table_rls,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "8b2f6a9c4d10"
+down_revision: str | None = "96470fdcc686"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mcp_personal_access_token",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("organization_id", sa.UUID(), nullable=False),
+        sa.Column("workspace_id", sa.UUID(), nullable=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("key_id", sa.String(length=32), nullable=False),
+        sa.Column("hashed", sa.String(length=128), nullable=False),
+        sa.Column("salt", sa.String(length=64), nullable=False),
+        sa.Column("preview", sa.String(length=32), nullable=False),
+        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("last_used_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_by", sa.UUID(), nullable=True),
+        sa.Column("revoked_by", sa.UUID(), nullable=True),
+        sa.Column("surrogate_id", sa.Integer(), sa.Identity(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by"],
+            ["user.id"],
+            name=op.f("fk_mcp_personal_access_token_created_by_user"),
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organization.id"],
+            name=op.f("fk_mcp_personal_access_token_organization_id_organization"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["revoked_by"],
+            ["user.id"],
+            name=op.f("fk_mcp_personal_access_token_revoked_by_user"),
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+            name=op.f("fk_mcp_personal_access_token_user_id_user"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_mcp_personal_access_token_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "surrogate_id", name=op.f("pk_mcp_personal_access_token")
+        ),
+    )
+    op.create_index(
+        op.f("ix_mcp_personal_access_token_id"),
+        "mcp_personal_access_token",
+        ["id"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_mcp_personal_access_token_key_id"),
+        "mcp_personal_access_token",
+        ["key_id"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_mcp_personal_access_token_organization_id"),
+        "mcp_personal_access_token",
+        ["organization_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_mcp_personal_access_token_user_id"),
+        "mcp_personal_access_token",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_mcp_personal_access_token_workspace_id"),
+        "mcp_personal_access_token",
+        ["workspace_id"],
+        unique=False,
+    )
+
+    op.execute(enable_org_optional_workspace_table_rls("mcp_personal_access_token"))
+
+
+def downgrade() -> None:
+    op.execute(disable_org_optional_workspace_table_rls("mcp_personal_access_token"))
+    op.drop_index(
+        op.f("ix_mcp_personal_access_token_workspace_id"),
+        table_name="mcp_personal_access_token",
+    )
+    op.drop_index(
+        op.f("ix_mcp_personal_access_token_user_id"),
+        table_name="mcp_personal_access_token",
+    )
+    op.drop_index(
+        op.f("ix_mcp_personal_access_token_organization_id"),
+        table_name="mcp_personal_access_token",
+    )
+    op.drop_index(
+        op.f("ix_mcp_personal_access_token_key_id"),
+        table_name="mcp_personal_access_token",
+    )
+    op.drop_index(
+        op.f("ix_mcp_personal_access_token_id"),
+        table_name="mcp_personal_access_token",
+    )
+    op.drop_table("mcp_personal_access_token")

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -1082,6 +1082,64 @@ class ServiceAccountApiKey(RecordModel):
     )
 
 
+class MCPPersonalAccessToken(RecordModel):
+    """Credential material for MCP-only personal access tokens."""
+
+    __tablename__ = "mcp_personal_access_token"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    organization_id: Mapped[OrganizationID] = mapped_column(
+        UUID,
+        ForeignKey("organization.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    workspace_id: Mapped[WorkspaceID | None] = mapped_column(
+        UUID,
+        ForeignKey("workspace.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    key_id: Mapped[str] = mapped_column(
+        String(32), nullable=False, unique=True, index=True
+    )
+    hashed: Mapped[str] = mapped_column(String(128), nullable=False)
+    salt: Mapped[str] = mapped_column(String(64), nullable=False)
+    preview: Mapped[str] = mapped_column(String(32), nullable=False)
+    expires_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID,
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    revoked_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID,
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+
 class Webhook(WorkspaceModel):
     __tablename__ = "webhook"
 

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -94,6 +94,7 @@ POST_RLS_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES = (
     "watchtower_agent_session",
     "watchtower_agent_tool_call",
     "service_account",
+    "mcp_personal_access_token",
     "agent_model_access",
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the `mcp_personal_access_token` table and `MCPPersonalAccessToken` ORM model to support MCP-only personal access tokens with org/workspace scoping and row-level security. This enables secure storage, lookup, and revocation of PATs.

- **New Features**
  - Alembic migration creates `mcp_personal_access_token` with `key_id` (unique), hash/salt/preview, `expires_at`, `last_used_at`, `revoked_at`, audit fields (`created_by`, `revoked_by`), and timestamps.
  - Enforces org/workspace relationships via FKs; cascades on delete where appropriate.
  - Adds indexes for `id` (unique), `key_id` (unique), `user_id`, `organization_id`, and `workspace_id`.
  - Enables RLS using `enable_org_optional_workspace_table_rls` and whitelists the table in `tenant_rls.py`.

- **Migration**
  - Run database migrations.

<sup>Written for commit 9029dec5de94b49f4fba57639850e43f43102e99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

