### PR TITLE
feat(mcp): pat service

### DIFF
--- a/tests/unit/api/test_api_mcp_personal_access_tokens.py
+++ b/tests/unit/api/test_api_mcp_personal_access_tokens.py
@@ -1,0 +1,160 @@
+"""Router tests for MCP personal access token endpoints."""
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import get_type_hints
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tracecat.auth.dependencies import OrgUserOnlyRole
+from tracecat.auth.types import Role
+from tracecat.mcp.personal_access_tokens import router as mcp_pat_router
+from tracecat.mcp.personal_access_tokens.schemas import MCPPersonalAccessTokenCreate
+from tracecat.pagination import CursorPaginatedResponse
+
+
+def _token_read(
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    workspace_id: uuid.UUID | None = None,
+):
+    now = datetime(2024, 1, 1, tzinfo=UTC)
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        organization_id=organization_id,
+        workspace_id=workspace_id,
+        name="Claude Desktop",
+        key_id="mcp_key_123",
+        preview="tc_mcp_pat_...abcd",
+        expires_at=None,
+        last_used_at=None,
+        revoked_at=None,
+        created_by=user_id,
+        revoked_by=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _with_org_read(role: Role) -> Role:
+    return role.model_copy(
+        update={"scopes": frozenset(set(role.scopes or frozenset()) | {"org:read"})}
+    )
+
+
+@pytest.mark.anyio
+async def test_list_mcp_personal_access_tokens_success(
+    test_admin_role: Role,
+) -> None:
+    role = _with_org_read(test_admin_role)
+    organization_id = role.organization_id
+    user_id = role.user_id
+    assert organization_id is not None
+    assert user_id is not None
+    token_read = _token_read(organization_id, user_id)
+    page = CursorPaginatedResponse(
+        items=[token_read],
+        next_cursor=None,
+        prev_cursor=None,
+        has_more=False,
+        has_previous=False,
+        total_estimate=1,
+    )
+
+    with patch.object(
+        mcp_pat_router, "MCPPersonalAccessTokenService"
+    ) as mock_service_cls:
+        mock_svc = AsyncMock()
+        mock_svc.list_tokens.return_value = page
+        mock_service_cls.return_value = mock_svc
+
+        response = await mcp_pat_router.list_mcp_personal_access_tokens(
+            role=role,
+            session=AsyncMock(),
+            limit=20,
+            cursor=None,
+            reverse=False,
+        )
+
+    payload = response.model_dump(mode="json")
+    assert payload["items"][0]["id"] == str(token_read.id)
+    assert payload["items"][0]["organization_id"] == str(organization_id)
+    assert payload["items"][0]["preview"] == "tc_mcp_pat_...abcd"
+    assert "raw_token" not in payload["items"][0]
+
+
+@pytest.mark.anyio
+async def test_create_mcp_personal_access_token_success(
+    test_admin_role: Role,
+) -> None:
+    role = _with_org_read(test_admin_role)
+    organization_id = role.organization_id
+    user_id = role.user_id
+    workspace_id = role.workspace_id
+    assert organization_id is not None
+    assert user_id is not None
+    token_read = _token_read(organization_id, user_id, workspace_id=workspace_id)
+
+    with patch.object(
+        mcp_pat_router, "MCPPersonalAccessTokenService"
+    ) as mock_service_cls:
+        mock_svc = AsyncMock()
+        mock_svc.create_token.return_value = (token_read, "tc_mcp_pat_raw-secret")
+        mock_service_cls.return_value = mock_svc
+
+        response = await mcp_pat_router.create_mcp_personal_access_token(
+            role=role,
+            session=AsyncMock(),
+            params=MCPPersonalAccessTokenCreate(
+                name="Claude Desktop",
+                workspace_id=workspace_id,
+            ),
+        )
+
+    payload = response.model_dump(mode="json")
+    assert payload["issued_token"]["raw_token"] == "tc_mcp_pat_raw-secret"
+    assert payload["issued_token"]["token"]["id"] == str(token_read.id)
+    mock_svc.create_token.assert_awaited_once_with(
+        name="Claude Desktop",
+        workspace_id=workspace_id,
+        expires_at=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_revoke_mcp_personal_access_token_success(
+    test_admin_role: Role,
+) -> None:
+    role = _with_org_read(test_admin_role)
+    token_id = uuid.uuid4()
+
+    with patch.object(
+        mcp_pat_router, "MCPPersonalAccessTokenService"
+    ) as mock_service_cls:
+        mock_svc = AsyncMock()
+        mock_service_cls.return_value = mock_svc
+
+        response = await mcp_pat_router.revoke_mcp_personal_access_token(
+            role=role,
+            session=AsyncMock(),
+            token_id=token_id,
+        )
+
+    assert response is None
+    mock_svc.revoke_token.assert_awaited_once_with(token_id)
+
+
+def test_mcp_personal_access_token_routes_remain_user_only() -> None:
+    endpoints = [
+        mcp_pat_router.list_mcp_personal_access_tokens,
+        mcp_pat_router.create_mcp_personal_access_token,
+        mcp_pat_router.revoke_mcp_personal_access_token,
+    ]
+
+    for endpoint in endpoints:
+        role = get_type_hints(endpoint, include_extras=True)["role"]
+        assert role == OrgUserOnlyRole

--- a/tests/unit/api/test_api_mcp_personal_access_tokens.py
+++ b/tests/unit/api/test_api_mcp_personal_access_tokens.py
@@ -7,8 +7,9 @@ from typing import get_type_hints
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi.routing import APIRoute
 
-from tracecat.auth.dependencies import OrgUserOnlyRole
+from tracecat.auth.dependencies import WorkspaceUserPathRole
 from tracecat.auth.types import Role
 from tracecat.mcp.personal_access_tokens import router as mcp_pat_router
 from tracecat.mcp.personal_access_tokens.schemas import MCPPersonalAccessTokenCreate
@@ -19,7 +20,7 @@ def _token_read(
     organization_id: uuid.UUID,
     user_id: uuid.UUID,
     *,
-    workspace_id: uuid.UUID | None = None,
+    workspace_id: uuid.UUID,
 ):
     now = datetime(2024, 1, 1, tzinfo=UTC)
     return SimpleNamespace(
@@ -40,9 +41,11 @@ def _token_read(
     )
 
 
-def _with_org_read(role: Role) -> Role:
+def _with_workspace_read(role: Role) -> Role:
     return role.model_copy(
-        update={"scopes": frozenset(set(role.scopes or frozenset()) | {"org:read"})}
+        update={
+            "scopes": frozenset(set(role.scopes or frozenset()) | {"workspace:read"})
+        }
     )
 
 
@@ -50,12 +53,14 @@ def _with_org_read(role: Role) -> Role:
 async def test_list_mcp_personal_access_tokens_success(
     test_admin_role: Role,
 ) -> None:
-    role = _with_org_read(test_admin_role)
+    role = _with_workspace_read(test_admin_role)
     organization_id = role.organization_id
     user_id = role.user_id
+    workspace_id = role.workspace_id
     assert organization_id is not None
     assert user_id is not None
-    token_read = _token_read(organization_id, user_id)
+    assert workspace_id is not None
+    token_read = _token_read(organization_id, user_id, workspace_id=workspace_id)
     page = CursorPaginatedResponse(
         items=[token_read],
         next_cursor=None,
@@ -91,12 +96,13 @@ async def test_list_mcp_personal_access_tokens_success(
 async def test_create_mcp_personal_access_token_success(
     test_admin_role: Role,
 ) -> None:
-    role = _with_org_read(test_admin_role)
+    role = _with_workspace_read(test_admin_role)
     organization_id = role.organization_id
     user_id = role.user_id
     workspace_id = role.workspace_id
     assert organization_id is not None
     assert user_id is not None
+    assert workspace_id is not None
     token_read = _token_read(organization_id, user_id, workspace_id=workspace_id)
 
     with patch.object(
@@ -111,7 +117,6 @@ async def test_create_mcp_personal_access_token_success(
             session=AsyncMock(),
             params=MCPPersonalAccessTokenCreate(
                 name="Claude Desktop",
-                workspace_id=workspace_id,
             ),
         )
 
@@ -120,7 +125,6 @@ async def test_create_mcp_personal_access_token_success(
     assert payload["issued_token"]["token"]["id"] == str(token_read.id)
     mock_svc.create_token.assert_awaited_once_with(
         name="Claude Desktop",
-        workspace_id=workspace_id,
         expires_at=None,
     )
 
@@ -129,7 +133,7 @@ async def test_create_mcp_personal_access_token_success(
 async def test_revoke_mcp_personal_access_token_success(
     test_admin_role: Role,
 ) -> None:
-    role = _with_org_read(test_admin_role)
+    role = _with_workspace_read(test_admin_role)
     token_id = uuid.uuid4()
 
     with patch.object(
@@ -148,7 +152,20 @@ async def test_revoke_mcp_personal_access_token_success(
     mock_svc.revoke_token.assert_awaited_once_with(token_id)
 
 
-def test_mcp_personal_access_token_routes_remain_user_only() -> None:
+def test_mcp_personal_access_token_routes_are_workspace_scoped() -> None:
+    routes = [
+        route for route in mcp_pat_router.router.routes if isinstance(route, APIRoute)
+    ]
+    route_paths = {route.path for route in routes}
+
+    assert route_paths == {
+        "/workspaces/{workspace_id}/mcp-personal-access-tokens",
+        "/workspaces/{workspace_id}/mcp-personal-access-tokens/{token_id}/revoke",
+    }
+    assert all("/organization/" not in route.path for route in routes)
+
+
+def test_mcp_personal_access_token_routes_remain_workspace_user_only() -> None:
     endpoints = [
         mcp_pat_router.list_mcp_personal_access_tokens,
         mcp_pat_router.create_mcp_personal_access_token,
@@ -157,4 +174,4 @@ def test_mcp_personal_access_token_routes_remain_user_only() -> None:
 
     for endpoint in endpoints:
         role = get_type_hints(endpoint, include_extras=True)["role"]
-        assert role == OrgUserOnlyRole
+        assert role == WorkspaceUserPathRole

--- a/tests/unit/test_mcp_personal_access_tokens_service.py
+++ b/tests/unit/test_mcp_personal_access_tokens_service.py
@@ -22,7 +22,7 @@ from tracecat.db.models import (
     User,
     Workspace,
 )
-from tracecat.exceptions import TracecatAuthorizationError
+from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
 from tracecat.mcp.personal_access_tokens.constants import MCP_PAT_PREFIX
 from tracecat.mcp.personal_access_tokens.service import (
     MCPPersonalAccessTokenService,
@@ -75,13 +75,14 @@ async def _create_user_org_workspace(
     return user, organization, workspace
 
 
-def _role_for(user: User, organization: Organization) -> Role:
+def _role_for(user: User, organization: Organization, workspace: Workspace) -> Role:
     return Role(
         type="user",
         user_id=user.id,
+        workspace_id=workspace.id,
         organization_id=organization.id,
         service_id="tracecat-api",
-        scopes=frozenset({"org:read", "org:workspace:read"}),
+        scopes=frozenset({"workspace:read"}),
     )
 
 
@@ -134,12 +135,11 @@ async def test_create_list_and_revoke_mcp_personal_access_token(
     user, organization, workspace = await _create_user_org_workspace(session)
     service = MCPPersonalAccessTokenService(
         session,
-        role=_role_for(user, organization),
+        role=_role_for(user, organization, workspace),
     )
 
     issued = await service.create_token(
         name="Claude Desktop",
-        workspace_id=workspace.id,
         expires_at=None,
     )
 
@@ -147,6 +147,20 @@ async def test_create_list_and_revoke_mcp_personal_access_token(
     assert issued.token.user_id == user.id
     assert issued.token.organization_id == organization.id
     assert issued.token.workspace_id == workspace.id
+
+    other_workspace = Workspace(
+        id=uuid.uuid4(),
+        organization_id=organization.id,
+        name="Other MCP PAT workspace",
+    )
+    session.add(other_workspace)
+    await session.commit()
+    await _store_token(
+        session,
+        user=user,
+        organization=organization,
+        workspace_id=other_workspace.id,
+    )
 
     page = await service.list_tokens(CursorPaginationParams(limit=10))
     assert [token.id for token in page.items] == [issued.token.id]
@@ -166,12 +180,11 @@ async def test_create_mcp_personal_access_token_allows_org_member_without_worksp
     )
     service = MCPPersonalAccessTokenService(
         session,
-        role=_role_for(user, organization),
+        role=_role_for(user, organization, workspace),
     )
 
     issued = await service.create_token(
         name="Claude Desktop",
-        workspace_id=workspace.id,
         expires_at=None,
     )
 
@@ -197,7 +210,7 @@ async def test_create_mcp_personal_access_token_rejects_workspace_in_other_org(
     await session.commit()
     service = MCPPersonalAccessTokenService(
         session,
-        role=_role_for(user, organization),
+        role=_role_for(user, organization, other_workspace),
     )
 
     with pytest.raises(
@@ -205,9 +218,36 @@ async def test_create_mcp_personal_access_token_rejects_workspace_in_other_org(
     ):
         await service.create_token(
             name="Claude Desktop",
-            workspace_id=other_workspace.id,
             expires_at=None,
         )
+
+
+async def test_revoke_mcp_personal_access_token_rejects_other_workspace_token(
+    session: AsyncSession,
+) -> None:
+    user, organization, workspace = await _create_user_org_workspace(session)
+    other_workspace = Workspace(
+        id=uuid.uuid4(),
+        organization_id=organization.id,
+        name="Other MCP PAT workspace",
+    )
+    session.add(other_workspace)
+    await session.commit()
+    token, _raw_token = await _store_token(
+        session,
+        user=user,
+        organization=organization,
+        workspace_id=other_workspace.id,
+    )
+    service = MCPPersonalAccessTokenService(
+        session,
+        role=_role_for(user, organization, workspace),
+    )
+
+    with pytest.raises(
+        TracecatNotFoundError, match="MCP personal access token not found"
+    ):
+        await service.revoke_token(token.id)
 
 
 async def test_verify_mcp_personal_access_token_updates_last_used(
@@ -305,6 +345,23 @@ async def test_verify_mcp_personal_access_token_requires_org_membership(
     )
 
     assert await mcp_pat_service.verify_mcp_personal_access_token(raw_token) is None
+
+
+async def test_verify_mcp_personal_access_token_rejects_missing_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+    session: AsyncSession,
+) -> None:
+    _use_verifier_session(monkeypatch, session)
+    user, organization, _workspace = await _create_user_org_workspace(session)
+    token, raw_token = await _store_token(
+        session,
+        user=user,
+        organization=organization,
+    )
+
+    assert await mcp_pat_service.verify_mcp_personal_access_token(raw_token) is None
+    await session.refresh(token)
+    assert token.last_used_at is None
 
 
 async def test_regular_api_key_auth_ignores_mcp_personal_access_tokens(

--- a/tests/unit/test_mcp_personal_access_tokens_service.py
+++ b/tests/unit/test_mcp_personal_access_tokens_service.py
@@ -278,6 +278,35 @@ async def test_verify_mcp_personal_access_token_updates_last_used(
     assert refreshed.last_used_at is not None
 
 
+async def test_verify_mcp_personal_access_token_allows_org_member_without_workspace_membership(
+    monkeypatch: pytest.MonkeyPatch,
+    session: AsyncSession,
+) -> None:
+    _use_verifier_session(monkeypatch, session)
+    user, organization, workspace = await _create_user_org_workspace(
+        session,
+        workspace_membership=False,
+    )
+    token, raw_token = await _store_token(
+        session,
+        user=user,
+        organization=organization,
+        workspace_id=workspace.id,
+    )
+
+    identity = await mcp_pat_service.verify_mcp_personal_access_token(raw_token)
+
+    assert identity is not None
+    assert identity.user_id == user.id
+    assert identity.workspace_id == workspace.id
+
+    refreshed = await session.scalar(
+        select(MCPPersonalAccessToken).where(MCPPersonalAccessToken.id == token.id)
+    )
+    assert refreshed is not None
+    assert refreshed.last_used_at is not None
+
+
 async def test_verify_mcp_personal_access_token_rejects_revoked_token(
     monkeypatch: pytest.MonkeyPatch,
     session: AsyncSession,

--- a/tests/unit/test_mcp_personal_access_tokens_service.py
+++ b/tests/unit/test_mcp_personal_access_tokens_service.py
@@ -1,0 +1,320 @@
+"""Tests for MCP personal access token service behavior."""
+
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import tracecat.mcp.personal_access_tokens.service as mcp_pat_service
+from tracecat.auth.api_keys import generate_managed_api_key
+from tracecat.auth.credentials import _authenticate_api_key
+from tracecat.auth.schemas import UserRole
+from tracecat.auth.types import Role
+from tracecat.db.models import (
+    MCPPersonalAccessToken,
+    Membership,
+    Organization,
+    OrganizationMembership,
+    User,
+    Workspace,
+)
+from tracecat.exceptions import TracecatAuthorizationError
+from tracecat.mcp.personal_access_tokens.constants import MCP_PAT_PREFIX
+from tracecat.mcp.personal_access_tokens.service import (
+    MCPPersonalAccessTokenService,
+)
+from tracecat.pagination import CursorPaginationParams
+
+pytestmark = pytest.mark.anyio
+
+
+async def _create_user_org_workspace(
+    session: AsyncSession,
+    *,
+    org_membership: bool = True,
+    workspace_membership: bool = True,
+) -> tuple[User, Organization, Workspace]:
+    test_id = uuid.uuid4()
+    user = User(
+        id=uuid.uuid4(),
+        email=f"mcp-pat-{test_id.hex}@example.com",
+        hashed_password="not-used",
+        role=UserRole.BASIC,
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    organization = Organization(
+        id=uuid.uuid4(),
+        name=f"MCP PAT test {test_id.hex}",
+        slug=f"mcp-pat-test-{test_id.hex}",
+        is_active=True,
+    )
+    workspace = Workspace(
+        id=uuid.uuid4(),
+        organization_id=organization.id,
+        name=f"MCP PAT workspace {test_id.hex}",
+    )
+    session.add_all([user, organization, workspace])
+    await session.flush()
+
+    if org_membership:
+        session.add(
+            OrganizationMembership(
+                user_id=user.id,
+                organization_id=organization.id,
+            )
+        )
+    if workspace_membership:
+        session.add(Membership(user_id=user.id, workspace_id=workspace.id))
+    await session.commit()
+    return user, organization, workspace
+
+
+def _role_for(user: User, organization: Organization) -> Role:
+    return Role(
+        type="user",
+        user_id=user.id,
+        organization_id=organization.id,
+        service_id="tracecat-api",
+        scopes=frozenset({"org:read", "org:workspace:read"}),
+    )
+
+
+async def _store_token(
+    session: AsyncSession,
+    *,
+    user: User,
+    organization: Organization,
+    workspace_id: uuid.UUID | None = None,
+    expires_at: datetime | None = None,
+) -> tuple[MCPPersonalAccessToken, str]:
+    generated = generate_managed_api_key(prefix=MCP_PAT_PREFIX)
+    token = MCPPersonalAccessToken(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        organization_id=organization.id,
+        workspace_id=workspace_id,
+        name="Claude Desktop",
+        key_id=generated.key_id,
+        hashed=generated.hashed,
+        salt=generated.salt_b64,
+        preview=generated.preview(),
+        expires_at=expires_at,
+        created_by=user.id,
+    )
+    session.add(token)
+    await session.commit()
+    await session.refresh(token)
+    return token, generated.raw
+
+
+def _use_verifier_session(
+    monkeypatch: pytest.MonkeyPatch,
+    session: AsyncSession,
+) -> None:
+    @asynccontextmanager
+    async def same_session() -> AsyncIterator[AsyncSession]:
+        yield session
+
+    monkeypatch.setattr(
+        mcp_pat_service,
+        "get_async_session_bypass_rls_context_manager",
+        same_session,
+    )
+
+
+async def test_create_list_and_revoke_mcp_personal_access_token(
+    session: AsyncSession,
+) -> None:
+    user, organization, workspace = await _create_user_org_workspace(session)
+    service = MCPPersonalAccessTokenService(
+        session,
+        role=_role_for(user, organization),
+    )
+
+    issued = await service.create_token(
+        name="Claude Desktop",
+        workspace_id=workspace.id,
+        expires_at=None,
+    )
+
+    assert issued.raw_token.startswith(MCP_PAT_PREFIX)
+    assert issued.token.user_id == user.id
+    assert issued.token.organization_id == organization.id
+    assert issued.token.workspace_id == workspace.id
+
+    page = await service.list_tokens(CursorPaginationParams(limit=10))
+    assert [token.id for token in page.items] == [issued.token.id]
+
+    await service.revoke_token(issued.token.id)
+    await session.refresh(issued.token)
+    assert issued.token.revoked_at is not None
+    assert issued.token.revoked_by == user.id
+
+
+async def test_create_mcp_personal_access_token_allows_org_member_without_workspace_membership(
+    session: AsyncSession,
+) -> None:
+    user, organization, workspace = await _create_user_org_workspace(
+        session,
+        workspace_membership=False,
+    )
+    service = MCPPersonalAccessTokenService(
+        session,
+        role=_role_for(user, organization),
+    )
+
+    issued = await service.create_token(
+        name="Claude Desktop",
+        workspace_id=workspace.id,
+        expires_at=None,
+    )
+
+    assert issued.token.workspace_id == workspace.id
+
+
+async def test_create_mcp_personal_access_token_rejects_workspace_in_other_org(
+    session: AsyncSession,
+) -> None:
+    user, organization, _workspace = await _create_user_org_workspace(session)
+    other_org = Organization(
+        id=uuid.uuid4(),
+        name="Other org",
+        slug=f"other-org-{uuid.uuid4().hex}",
+        is_active=True,
+    )
+    other_workspace = Workspace(
+        id=uuid.uuid4(),
+        organization_id=other_org.id,
+        name="Other workspace",
+    )
+    session.add_all([other_org, other_workspace])
+    await session.commit()
+    service = MCPPersonalAccessTokenService(
+        session,
+        role=_role_for(user, organization),
+    )
+
+    with pytest.raises(
+        TracecatAuthorizationError, match="User cannot access workspace"
+    ):
+        await service.create_token(
+            name="Claude Desktop",
+            workspace_id=other_workspace.id,
+            expires_at=None,
+        )
+
+
+async def test_verify_mcp_personal_access_token_updates_last_used(
+    monkeypatch: pytest.MonkeyPatch,
+    session: AsyncSession,
+) -> None:
+    _use_verifier_session(monkeypatch, session)
+    user, organization, workspace = await _create_user_org_workspace(session)
+    token, raw_token = await _store_token(
+        session,
+        user=user,
+        organization=organization,
+        workspace_id=workspace.id,
+    )
+
+    identity = await mcp_pat_service.verify_mcp_personal_access_token(raw_token)
+
+    assert identity is not None
+    assert identity.user_id == user.id
+    assert identity.email == user.email
+    assert identity.organization_id == organization.id
+    assert identity.workspace_id == workspace.id
+
+    refreshed = await session.scalar(
+        select(MCPPersonalAccessToken).where(MCPPersonalAccessToken.id == token.id)
+    )
+    assert refreshed is not None
+    assert refreshed.last_used_at is not None
+
+
+async def test_verify_mcp_personal_access_token_rejects_revoked_token(
+    monkeypatch: pytest.MonkeyPatch,
+    session: AsyncSession,
+) -> None:
+    _use_verifier_session(monkeypatch, session)
+    user, organization, _workspace = await _create_user_org_workspace(session)
+    token, raw_token = await _store_token(
+        session,
+        user=user,
+        organization=organization,
+    )
+    token.revoked_at = datetime.now(UTC)
+    await session.commit()
+
+    assert await mcp_pat_service.verify_mcp_personal_access_token(raw_token) is None
+
+
+async def test_verify_mcp_personal_access_token_rejects_expired_token(
+    monkeypatch: pytest.MonkeyPatch,
+    session: AsyncSession,
+) -> None:
+    _use_verifier_session(monkeypatch, session)
+    user, organization, _workspace = await _create_user_org_workspace(session)
+    _token, raw_token = await _store_token(
+        session,
+        user=user,
+        organization=organization,
+        expires_at=datetime.now(UTC) - timedelta(minutes=1),
+    )
+
+    assert await mcp_pat_service.verify_mcp_personal_access_token(raw_token) is None
+
+
+async def test_verify_mcp_personal_access_token_rejects_hash_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    session: AsyncSession,
+) -> None:
+    _use_verifier_session(monkeypatch, session)
+    user, organization, _workspace = await _create_user_org_workspace(session)
+    _token, raw_token = await _store_token(
+        session,
+        user=user,
+        organization=organization,
+    )
+
+    assert (
+        await mcp_pat_service.verify_mcp_personal_access_token(f"{raw_token}wrong")
+        is None
+    )
+
+
+async def test_verify_mcp_personal_access_token_requires_org_membership(
+    monkeypatch: pytest.MonkeyPatch,
+    session: AsyncSession,
+) -> None:
+    _use_verifier_session(monkeypatch, session)
+    user, organization, _workspace = await _create_user_org_workspace(
+        session,
+        org_membership=False,
+    )
+    _token, raw_token = await _store_token(
+        session,
+        user=user,
+        organization=organization,
+    )
+
+    assert await mcp_pat_service.verify_mcp_personal_access_token(raw_token) is None
+
+
+async def test_regular_api_key_auth_ignores_mcp_personal_access_tokens(
+    session: AsyncSession,
+) -> None:
+    user, organization, _workspace = await _create_user_org_workspace(session)
+    _token, raw_token = await _store_token(
+        session,
+        user=user,
+        organization=organization,
+    )
+
+    assert await _authenticate_api_key(api_key=raw_token, workspace_id=None) is None

--- a/tracecat/audit/types.py
+++ b/tracecat/audit/types.py
@@ -36,6 +36,7 @@ AuditResourceType = Literal[
     "workspace_invitation",
     "service_account",
     "service_account_api_key",
+    "mcp_personal_access_token",
     # RBAC resources
     "rbac_scope",
     "rbac_role",

--- a/tracecat/mcp/personal_access_tokens/__init__.py
+++ b/tracecat/mcp/personal_access_tokens/__init__.py
@@ -1,0 +1,1 @@
+"""MCP personal access token management."""

--- a/tracecat/mcp/personal_access_tokens/constants.py
+++ b/tracecat/mcp/personal_access_tokens/constants.py
@@ -1,0 +1,3 @@
+"""Constants for MCP personal access tokens."""
+
+MCP_PAT_PREFIX = "tc_mcp_pat_"

--- a/tracecat/mcp/personal_access_tokens/router.py
+++ b/tracecat/mcp/personal_access_tokens/router.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from tracecat.auth.dependencies import OrgUserOnlyRole
+from tracecat.authz.controls import require_scope
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import (
+    TracecatAuthorizationError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
+from tracecat.mcp.personal_access_tokens.schemas import (
+    IssuedMCPPersonalAccessToken,
+    MCPPersonalAccessTokenCreate,
+    MCPPersonalAccessTokenIssueResponse,
+    MCPPersonalAccessTokenRead,
+)
+from tracecat.mcp.personal_access_tokens.service import MCPPersonalAccessTokenService
+from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
+
+router = APIRouter(
+    prefix="/organization/mcp-personal-access-tokens",
+    tags=["mcp_personal_access_tokens"],
+)
+
+
+@router.get("", response_model=CursorPaginatedResponse[MCPPersonalAccessTokenRead])
+@require_scope("org:read")
+async def list_mcp_personal_access_tokens(
+    *,
+    role: OrgUserOnlyRole,
+    session: AsyncDBSession,
+    limit: int = Query(default=20, ge=1, le=100),
+    cursor: str | None = Query(default=None),
+    reverse: bool = Query(default=False),
+) -> CursorPaginatedResponse[MCPPersonalAccessTokenRead]:
+    service = MCPPersonalAccessTokenService(session, role=role)
+    try:
+        page = await service.list_tokens(
+            CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse)
+        )
+    except TracecatValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+    except TracecatAuthorizationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc
+
+    return CursorPaginatedResponse(
+        items=[
+            MCPPersonalAccessTokenRead.model_validate(item, from_attributes=True)
+            for item in page.items
+        ],
+        next_cursor=page.next_cursor,
+        prev_cursor=page.prev_cursor,
+        has_more=page.has_more,
+        has_previous=page.has_previous,
+        total_estimate=page.total_estimate,
+    )
+
+
+@router.post(
+    "",
+    response_model=MCPPersonalAccessTokenIssueResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+@require_scope("org:read")
+async def create_mcp_personal_access_token(
+    *,
+    role: OrgUserOnlyRole,
+    session: AsyncDBSession,
+    params: MCPPersonalAccessTokenCreate,
+) -> MCPPersonalAccessTokenIssueResponse:
+    service = MCPPersonalAccessTokenService(session, role=role)
+    try:
+        token, raw_token = await service.create_token(
+            name=params.name,
+            workspace_id=params.workspace_id,
+            expires_at=params.expires_at,
+        )
+    except TracecatAuthorizationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc
+
+    return MCPPersonalAccessTokenIssueResponse(
+        issued_token=IssuedMCPPersonalAccessToken(
+            raw_token=raw_token,
+            token=MCPPersonalAccessTokenRead.model_validate(
+                token,
+                from_attributes=True,
+            ),
+        )
+    )
+
+
+@router.post("/{token_id}/revoke", status_code=status.HTTP_204_NO_CONTENT)
+@require_scope("org:read")
+async def revoke_mcp_personal_access_token(
+    *,
+    role: OrgUserOnlyRole,
+    session: AsyncDBSession,
+    token_id: UUID,
+) -> None:
+    service = MCPPersonalAccessTokenService(session, role=role)
+    try:
+        await service.revoke_token(token_id)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    except TracecatAuthorizationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc

--- a/tracecat/mcp/personal_access_tokens/router.py
+++ b/tracecat/mcp/personal_access_tokens/router.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
 
-from tracecat.auth.dependencies import OrgUserOnlyRole
+from tracecat.auth.dependencies import WorkspaceUserPathRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import (
@@ -22,16 +22,16 @@ from tracecat.mcp.personal_access_tokens.service import MCPPersonalAccessTokenSe
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 
 router = APIRouter(
-    prefix="/organization/mcp-personal-access-tokens",
+    prefix="/workspaces/{workspace_id}/mcp-personal-access-tokens",
     tags=["mcp_personal_access_tokens"],
 )
 
 
 @router.get("", response_model=CursorPaginatedResponse[MCPPersonalAccessTokenRead])
-@require_scope("org:read")
+@require_scope("workspace:read")
 async def list_mcp_personal_access_tokens(
     *,
-    role: OrgUserOnlyRole,
+    role: WorkspaceUserPathRole,
     session: AsyncDBSession,
     limit: int = Query(default=20, ge=1, le=100),
     cursor: str | None = Query(default=None),
@@ -69,10 +69,10 @@ async def list_mcp_personal_access_tokens(
     response_model=MCPPersonalAccessTokenIssueResponse,
     status_code=status.HTTP_201_CREATED,
 )
-@require_scope("org:read")
+@require_scope("workspace:read")
 async def create_mcp_personal_access_token(
     *,
-    role: OrgUserOnlyRole,
+    role: WorkspaceUserPathRole,
     session: AsyncDBSession,
     params: MCPPersonalAccessTokenCreate,
 ) -> MCPPersonalAccessTokenIssueResponse:
@@ -80,7 +80,6 @@ async def create_mcp_personal_access_token(
     try:
         token, raw_token = await service.create_token(
             name=params.name,
-            workspace_id=params.workspace_id,
             expires_at=params.expires_at,
         )
     except TracecatAuthorizationError as exc:
@@ -100,10 +99,10 @@ async def create_mcp_personal_access_token(
 
 
 @router.post("/{token_id}/revoke", status_code=status.HTTP_204_NO_CONTENT)
-@require_scope("org:read")
+@require_scope("workspace:read")
 async def revoke_mcp_personal_access_token(
     *,
-    role: OrgUserOnlyRole,
+    role: WorkspaceUserPathRole,
     session: AsyncDBSession,
     token_id: UUID,
 ) -> None:

--- a/tracecat/mcp/personal_access_tokens/schemas.py
+++ b/tracecat/mcp/personal_access_tokens/schemas.py
@@ -1,0 +1,43 @@
+"""Schemas for MCP personal access token management."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import Field
+
+from tracecat.core.schemas import Schema
+from tracecat.identifiers import OrganizationID, UserID, WorkspaceID
+
+
+class MCPPersonalAccessTokenRead(Schema):
+    id: UUID
+    user_id: UserID
+    organization_id: OrganizationID
+    workspace_id: WorkspaceID | None = None
+    name: str
+    key_id: str
+    preview: str
+    expires_at: datetime | None = None
+    last_used_at: datetime | None = None
+    revoked_at: datetime | None = None
+    created_by: UserID | None = None
+    revoked_by: UserID | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class MCPPersonalAccessTokenCreate(Schema):
+    name: str = Field(default=..., min_length=1, max_length=255)
+    workspace_id: WorkspaceID | None = None
+    expires_at: datetime | None = None
+
+
+class IssuedMCPPersonalAccessToken(Schema):
+    raw_token: str
+    token: MCPPersonalAccessTokenRead
+
+
+class MCPPersonalAccessTokenIssueResponse(Schema):
+    issued_token: IssuedMCPPersonalAccessToken

--- a/tracecat/mcp/personal_access_tokens/schemas.py
+++ b/tracecat/mcp/personal_access_tokens/schemas.py
@@ -15,7 +15,7 @@ class MCPPersonalAccessTokenRead(Schema):
     id: UUID
     user_id: UserID
     organization_id: OrganizationID
-    workspace_id: WorkspaceID | None = None
+    workspace_id: WorkspaceID
     name: str
     key_id: str
     preview: str
@@ -30,7 +30,6 @@ class MCPPersonalAccessTokenRead(Schema):
 
 class MCPPersonalAccessTokenCreate(Schema):
     name: str = Field(default=..., min_length=1, max_length=255)
-    workspace_id: WorkspaceID | None = None
     expires_at: datetime | None = None
 
 

--- a/tracecat/mcp/personal_access_tokens/service.py
+++ b/tracecat/mcp/personal_access_tokens/service.py
@@ -10,6 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat.audit.logger import audit_log
 from tracecat.auth.api_keys import (
     generate_managed_api_key,
     parse_managed_api_key,
@@ -36,12 +37,16 @@ from tracecat.pagination import (
     CursorPaginatedResponse,
     CursorPaginationParams,
 )
-from tracecat.service import BaseOrgService
+from tracecat.service import BaseWorkspaceService
 
 
 class IssuedMCPPersonalAccessTokenResult(NamedTuple):
     token: MCPPersonalAccessToken
     raw_token: str
+
+    @property
+    def token_id(self) -> uuid.UUID:
+        return self.token.id
 
 
 async def _user_can_access_workspace(
@@ -80,10 +85,10 @@ async def _user_can_access_workspace(
     return result.scalar_one_or_none() is not None
 
 
-class MCPPersonalAccessTokenService(BaseOrgService):
+class MCPPersonalAccessTokenService(BaseWorkspaceService):
     service_name = "mcp_personal_access_tokens"
 
-    @require_scope("org:read")
+    @require_scope("workspace:read")
     async def list_tokens(
         self,
         params: CursorPaginationParams,
@@ -92,6 +97,7 @@ class MCPPersonalAccessTokenService(BaseOrgService):
         stmt = select(MCPPersonalAccessToken).where(
             MCPPersonalAccessToken.user_id == self.role.user_id,
             MCPPersonalAccessToken.organization_id == self.organization_id,
+            MCPPersonalAccessToken.workspace_id == self.workspace_id,
         )
 
         if params.cursor:
@@ -147,6 +153,7 @@ class MCPPersonalAccessTokenService(BaseOrgService):
             .where(
                 MCPPersonalAccessToken.user_id == self.role.user_id,
                 MCPPersonalAccessToken.organization_id == self.organization_id,
+                MCPPersonalAccessToken.workspace_id == self.workspace_id,
             )
         )
 
@@ -193,19 +200,23 @@ class MCPPersonalAccessTokenService(BaseOrgService):
             total_estimate=int(await self.session.scalar(count_stmt) or 0),
         )
 
-    @require_scope("org:read")
+    @require_scope("workspace:read")
+    @audit_log(
+        resource_type="mcp_personal_access_token",
+        action="create",
+        resource_id_attr="token_id",
+    )
     async def create_token(
         self,
         *,
         name: str,
-        workspace_id: uuid.UUID | None,
         expires_at: datetime | None,
     ) -> IssuedMCPPersonalAccessTokenResult:
-        if workspace_id is not None and not await _user_can_access_workspace(
+        if not await _user_can_access_workspace(
             self.session,
             user_id=self.role.user_id,
             organization_id=self.organization_id,
-            workspace_id=workspace_id,
+            workspace_id=self.workspace_id,
         ):
             raise TracecatAuthorizationError("User cannot access workspace")
 
@@ -214,7 +225,7 @@ class MCPPersonalAccessTokenService(BaseOrgService):
             id=uuid.uuid4(),
             user_id=self.role.user_id,
             organization_id=self.organization_id,
-            workspace_id=workspace_id,
+            workspace_id=self.workspace_id,
             name=name,
             key_id=generated.key_id,
             hashed=generated.hashed,
@@ -238,6 +249,7 @@ class MCPPersonalAccessTokenService(BaseOrgService):
             MCPPersonalAccessToken.id == token_id,
             MCPPersonalAccessToken.user_id == self.role.user_id,
             MCPPersonalAccessToken.organization_id == self.organization_id,
+            MCPPersonalAccessToken.workspace_id == self.workspace_id,
         )
         if for_update:
             stmt = stmt.with_for_update()
@@ -246,7 +258,12 @@ class MCPPersonalAccessTokenService(BaseOrgService):
             raise TracecatNotFoundError("MCP personal access token not found")
         return token
 
-    @require_scope("org:read")
+    @require_scope("workspace:read")
+    @audit_log(
+        resource_type="mcp_personal_access_token",
+        action="revoke",
+        resource_id_attr="token_id",
+    )
     async def revoke_token(self, token_id: uuid.UUID) -> None:
         token = await self.get_token(token_id, for_update=True)
         if token.revoked_at is not None:
@@ -288,6 +305,8 @@ async def verify_mcp_personal_access_token(raw_token: str) -> MCPPATIdentity | N
             return None
         if not verify_api_key(raw_token, record.salt, record.hashed):
             return None
+        if record.workspace_id is None:
+            return None
         if not user.is_superuser:
             result = await session.execute(
                 select(OrganizationMembership.user_id).where(
@@ -297,7 +316,7 @@ async def verify_mcp_personal_access_token(raw_token: str) -> MCPPATIdentity | N
             )
             if result.scalar_one_or_none() is None:
                 return None
-        if record.workspace_id is not None and not await _user_can_access_workspace(
+        if not await _user_can_access_workspace(
             session,
             user_id=user.id,
             organization_id=record.organization_id,

--- a/tracecat/mcp/personal_access_tokens/service.py
+++ b/tracecat/mcp/personal_access_tokens/service.py
@@ -56,33 +56,33 @@ async def _user_can_access_workspace(
     organization_id: uuid.UUID,
     workspace_id: uuid.UUID,
 ) -> bool:
-    stmt = (
-        select(Workspace.id)
-        .outerjoin(
-            Membership,
-            sa.and_(
-                Membership.workspace_id == Workspace.id,
-                Membership.user_id == user_id,
-            ),
-        )
-        .outerjoin(
-            OrganizationMembership,
-            sa.and_(
-                OrganizationMembership.organization_id == Workspace.organization_id,
-                OrganizationMembership.user_id == user_id,
-            ),
-        )
+    if user_id is None:
+        return False
+
+    membership_exists = (
+        select(1)
         .where(
+            Membership.workspace_id == workspace_id,
+            Membership.user_id == user_id,
+        )
+        .exists()
+    )
+    org_membership_exists = (
+        select(1)
+        .where(
+            OrganizationMembership.organization_id == organization_id,
+            OrganizationMembership.user_id == user_id,
+        )
+        .exists()
+    )
+    stmt = select(
+        sa.exists().where(
             Workspace.id == workspace_id,
             Workspace.organization_id == organization_id,
-            sa.or_(
-                Membership.user_id.is_not(None),
-                OrganizationMembership.user_id.is_not(None),
-            ),
+            sa.or_(membership_exists, org_membership_exists),
         )
     )
-    result = await session.execute(stmt)
-    return result.scalar_one_or_none() is not None
+    return bool(await session.scalar(stmt))
 
 
 class MCPPersonalAccessTokenService(BaseWorkspaceService):

--- a/tracecat/mcp/personal_access_tokens/service.py
+++ b/tracecat/mcp/personal_access_tokens/service.py
@@ -1,0 +1,317 @@
+"""Service layer for MCP personal access tokens."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import NamedTuple
+
+import sqlalchemy as sa
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.api_keys import (
+    generate_managed_api_key,
+    parse_managed_api_key,
+    verify_api_key,
+)
+from tracecat.authz.controls import require_scope
+from tracecat.db.engine import get_async_session_bypass_rls_context_manager
+from tracecat.db.models import (
+    MCPPersonalAccessToken,
+    Membership,
+    OrganizationMembership,
+    User,
+    Workspace,
+)
+from tracecat.exceptions import (
+    TracecatAuthorizationError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
+from tracecat.mcp.personal_access_tokens.constants import MCP_PAT_PREFIX
+from tracecat.mcp.personal_access_tokens.types import MCPPATIdentity
+from tracecat.pagination import (
+    BaseCursorPaginator,
+    CursorPaginatedResponse,
+    CursorPaginationParams,
+)
+from tracecat.service import BaseOrgService
+
+
+class IssuedMCPPersonalAccessTokenResult(NamedTuple):
+    token: MCPPersonalAccessToken
+    raw_token: str
+
+
+async def _user_can_access_workspace(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID | None,
+    organization_id: uuid.UUID,
+    workspace_id: uuid.UUID,
+) -> bool:
+    stmt = (
+        select(Workspace.id)
+        .outerjoin(
+            Membership,
+            sa.and_(
+                Membership.workspace_id == Workspace.id,
+                Membership.user_id == user_id,
+            ),
+        )
+        .outerjoin(
+            OrganizationMembership,
+            sa.and_(
+                OrganizationMembership.organization_id == Workspace.organization_id,
+                OrganizationMembership.user_id == user_id,
+            ),
+        )
+        .where(
+            Workspace.id == workspace_id,
+            Workspace.organization_id == organization_id,
+            sa.or_(
+                Membership.user_id.is_not(None),
+                OrganizationMembership.user_id.is_not(None),
+            ),
+        )
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none() is not None
+
+
+class MCPPersonalAccessTokenService(BaseOrgService):
+    service_name = "mcp_personal_access_tokens"
+
+    @require_scope("org:read")
+    async def list_tokens(
+        self,
+        params: CursorPaginationParams,
+    ) -> CursorPaginatedResponse[MCPPersonalAccessToken]:
+        paginator = BaseCursorPaginator(self.session)
+        stmt = select(MCPPersonalAccessToken).where(
+            MCPPersonalAccessToken.user_id == self.role.user_id,
+            MCPPersonalAccessToken.organization_id == self.organization_id,
+        )
+
+        if params.cursor:
+            try:
+                cursor_data = paginator.decode_cursor(params.cursor)
+                cursor_id = uuid.UUID(cursor_data.id)
+            except ValueError as exc:
+                raise TracecatValidationError(
+                    "Invalid cursor for MCP personal access tokens"
+                ) from exc
+
+            cursor_created_at = cursor_data.sort_value
+            if not isinstance(cursor_created_at, datetime):
+                raise TracecatValidationError(
+                    "Invalid cursor for MCP personal access tokens"
+                )
+
+            if params.reverse:
+                stmt = stmt.where(
+                    sa.or_(
+                        MCPPersonalAccessToken.created_at > cursor_created_at,
+                        sa.and_(
+                            MCPPersonalAccessToken.created_at == cursor_created_at,
+                            MCPPersonalAccessToken.id > cursor_id,
+                        ),
+                    )
+                )
+            else:
+                stmt = stmt.where(
+                    sa.or_(
+                        MCPPersonalAccessToken.created_at < cursor_created_at,
+                        sa.and_(
+                            MCPPersonalAccessToken.created_at == cursor_created_at,
+                            MCPPersonalAccessToken.id < cursor_id,
+                        ),
+                    )
+                )
+
+        if params.reverse:
+            stmt = stmt.order_by(
+                MCPPersonalAccessToken.created_at.asc(),
+                MCPPersonalAccessToken.id.asc(),
+            )
+        else:
+            stmt = stmt.order_by(
+                MCPPersonalAccessToken.created_at.desc(),
+                MCPPersonalAccessToken.id.desc(),
+            )
+
+        count_stmt = (
+            select(func.count())
+            .select_from(MCPPersonalAccessToken)
+            .where(
+                MCPPersonalAccessToken.user_id == self.role.user_id,
+                MCPPersonalAccessToken.organization_id == self.organization_id,
+            )
+        )
+
+        result = await self.session.execute(stmt.limit(params.limit + 1))
+        items = list(result.scalars().all())
+        has_more = len(items) > params.limit
+        if has_more:
+            items = items[: params.limit]
+
+        next_cursor = None
+        prev_cursor = None
+        if items:
+            last = items[-1]
+            next_cursor = (
+                paginator.encode_cursor(
+                    last.id,
+                    sort_column="created_at",
+                    sort_value=last.created_at,
+                )
+                if has_more
+                else None
+            )
+            if params.cursor:
+                first = items[0]
+                prev_cursor = paginator.encode_cursor(
+                    first.id,
+                    sort_column="created_at",
+                    sort_value=first.created_at,
+                )
+
+        if params.reverse:
+            items.reverse()
+            next_cursor, prev_cursor = prev_cursor, next_cursor
+            has_more, has_previous = params.cursor is not None, has_more
+        else:
+            has_previous = params.cursor is not None
+
+        return CursorPaginatedResponse(
+            items=items,
+            next_cursor=next_cursor,
+            prev_cursor=prev_cursor,
+            has_more=has_more,
+            has_previous=has_previous,
+            total_estimate=int(await self.session.scalar(count_stmt) or 0),
+        )
+
+    @require_scope("org:read")
+    async def create_token(
+        self,
+        *,
+        name: str,
+        workspace_id: uuid.UUID | None,
+        expires_at: datetime | None,
+    ) -> IssuedMCPPersonalAccessTokenResult:
+        if workspace_id is not None and not await _user_can_access_workspace(
+            self.session,
+            user_id=self.role.user_id,
+            organization_id=self.organization_id,
+            workspace_id=workspace_id,
+        ):
+            raise TracecatAuthorizationError("User cannot access workspace")
+
+        generated = generate_managed_api_key(prefix=MCP_PAT_PREFIX)
+        token = MCPPersonalAccessToken(
+            id=uuid.uuid4(),
+            user_id=self.role.user_id,
+            organization_id=self.organization_id,
+            workspace_id=workspace_id,
+            name=name,
+            key_id=generated.key_id,
+            hashed=generated.hashed,
+            salt=generated.salt_b64,
+            preview=generated.preview(),
+            expires_at=expires_at,
+            created_by=self.role.user_id,
+        )
+        self.session.add(token)
+        await self.session.commit()
+        await self.session.refresh(token)
+        return IssuedMCPPersonalAccessTokenResult(token=token, raw_token=generated.raw)
+
+    async def get_token(
+        self,
+        token_id: uuid.UUID,
+        *,
+        for_update: bool = False,
+    ) -> MCPPersonalAccessToken:
+        stmt = select(MCPPersonalAccessToken).where(
+            MCPPersonalAccessToken.id == token_id,
+            MCPPersonalAccessToken.user_id == self.role.user_id,
+            MCPPersonalAccessToken.organization_id == self.organization_id,
+        )
+        if for_update:
+            stmt = stmt.with_for_update()
+        result = await self.session.execute(stmt)
+        if (token := result.scalar_one_or_none()) is None:
+            raise TracecatNotFoundError("MCP personal access token not found")
+        return token
+
+    @require_scope("org:read")
+    async def revoke_token(self, token_id: uuid.UUID) -> None:
+        token = await self.get_token(token_id, for_update=True)
+        if token.revoked_at is not None:
+            return
+        token.revoked_at = datetime.now(UTC)
+        token.revoked_by = self.role.user_id
+        await self.session.commit()
+
+
+async def verify_mcp_personal_access_token(raw_token: str) -> MCPPATIdentity | None:
+    """Verify an MCP personal access token and return its resolved identity."""
+    parsed = parse_managed_api_key(raw_token, prefixes=(MCP_PAT_PREFIX,))
+    if parsed is None:
+        return None
+
+    async with get_async_session_bypass_rls_context_manager() as session:
+        stmt = (
+            select(MCPPersonalAccessToken, User)
+            .join(User, MCPPersonalAccessToken.user_id == User.id)
+            .where(MCPPersonalAccessToken.key_id == parsed.key_id)
+        )
+        result = await session.execute(stmt)
+        row = result.one_or_none()
+        if row is None:
+            return None
+
+        record, user = row
+        if record.revoked_at is not None:
+            return None
+        if record.expires_at is not None:
+            expires_at = record.expires_at
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=UTC)
+            else:
+                expires_at = expires_at.astimezone(UTC)
+            if expires_at <= datetime.now(UTC):
+                return None
+        if not user.is_active:
+            return None
+        if not verify_api_key(raw_token, record.salt, record.hashed):
+            return None
+        if not user.is_superuser:
+            result = await session.execute(
+                select(OrganizationMembership.user_id).where(
+                    OrganizationMembership.user_id == user.id,
+                    OrganizationMembership.organization_id == record.organization_id,
+                )
+            )
+            if result.scalar_one_or_none() is None:
+                return None
+        if record.workspace_id is not None and not await _user_can_access_workspace(
+            session,
+            user_id=user.id,
+            organization_id=record.organization_id,
+            workspace_id=record.workspace_id,
+        ):
+            return None
+
+        record.last_used_at = datetime.now(UTC)
+        await session.commit()
+        return MCPPATIdentity(
+            key_id=record.key_id,
+            user_id=record.user_id,
+            email=user.email,
+            organization_id=record.organization_id,
+            workspace_id=record.workspace_id,
+            expires_at=record.expires_at,
+        )

--- a/tracecat/mcp/personal_access_tokens/types.py
+++ b/tracecat/mcp/personal_access_tokens/types.py
@@ -16,5 +16,5 @@ class MCPPATIdentity:
     user_id: UserID
     email: str
     organization_id: OrganizationID
-    workspace_id: WorkspaceID | None
+    workspace_id: WorkspaceID
     expires_at: datetime | None

--- a/tracecat/mcp/personal_access_tokens/types.py
+++ b/tracecat/mcp/personal_access_tokens/types.py
@@ -1,0 +1,20 @@
+"""Internal types for MCP personal access tokens."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from tracecat.identifiers import OrganizationID, UserID, WorkspaceID
+
+
+@dataclass(frozen=True, slots=True)
+class MCPPATIdentity:
+    """Resolved identity for a verified MCP personal access token."""
+
+    key_id: str
+    user_id: UserID
+    email: str
+    organization_id: OrganizationID
+    workspace_id: WorkspaceID | None
+    expires_at: datetime | None


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds MCP-only Personal Access Tokens with a workspace-scoped API to issue, list, and revoke user-scoped tokens with optional expiry. Tokens use the `tc_mcp_pat_` prefix, are hashed/salted, verified separately from regular API keys, update last-used on verify, and emit audit logs.

- **New Features**
  - `MCPPersonalAccessTokenService` (list/create/revoke) and `verify_mcp_personal_access_token`; supports optional `expires_at`.
  - Workspace endpoints under /workspaces/{workspace_id}/mcp-personal-access-tokens:
    - GET list (cursor pagination with `reverse`), POST create (returns raw token once), POST /{token_id}/revoke.
  - Requires `workspace:read` with `WorkspaceUserPathRole`; access via org or workspace membership; cross-org blocked.
  - Verification enforces non-revoked, non-expired, active user, org membership, and bound workspace; updates `last_used_at`. Regular API key auth ignores MCP PATs.
  - Audit events for create and revoke with resource type `mcp_personal_access_token`.

- **Performance**
  - Workspace access checks now use SQL EXISTS probes to reduce database overhead across list/create/revoke and verification.

<sup>Written for commit f2b84fe5acf883038f6ee66c7d68792a50b49d1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



