### PR TITLE
feat(agents): mcp support for ai agents

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -11084,6 +11084,9 @@ export const $EditorComponent = {
     {
       $ref: "#/components/schemas/AgentModel",
     },
+    {
+      $ref: "#/components/schemas/MCPIntegration",
+    },
   ],
   title: "EditorComponent",
   discriminator: {
@@ -11095,6 +11098,7 @@ export const $EditorComponent = {
       code: "#/components/schemas/Code",
       float: "#/components/schemas/Float",
       integer: "#/components/schemas/Integer",
+      "mcp-integration": "#/components/schemas/MCPIntegration",
       select: "#/components/schemas/Select",
       "tag-input": "#/components/schemas/TagInput",
       text: "#/components/schemas/Text",
@@ -13899,6 +13903,10 @@ export const $MCPHttpServerConfig = {
       type: "integer",
       title: "Timeout",
     },
+    id: {
+      type: "string",
+      title: "Id",
+    },
   },
   type: "object",
   required: ["name", "url"],
@@ -13916,6 +13924,24 @@ Example:
         "transport": "http",
         "headers": {"Authorization": "Bearer \${{ SECRETS.internal.API_KEY }}"}
     }`,
+} as const
+
+export const $MCPIntegration = {
+  properties: {
+    component_id: {
+      type: "string",
+      const: "mcp-integration",
+      title: "Component Id",
+      default: "mcp-integration",
+    },
+    multiple: {
+      type: "boolean",
+      title: "Multiple",
+      default: true,
+    },
+  },
+  type: "object",
+  title: "MCPIntegration",
 } as const
 
 export const $MCPIntegrationCreate = {
@@ -14482,6 +14508,10 @@ export const $MCPStdioServerConfig = {
     timeout: {
       type: "integer",
       title: "Timeout",
+    },
+    id: {
+      type: "string",
+      title: "Id",
     },
   },
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3273,6 +3273,7 @@ export type EditorComponent =
   | WorkflowAlias
   | AgentPreset
   | AgentModel
+  | MCPIntegration
 
 export type EditorFunctionRead = {
   name: string
@@ -4337,9 +4338,15 @@ export type MCPHttpServerConfig = {
   }
   transport?: "http" | "sse"
   timeout?: number
+  id?: string
 }
 
 export type transport = "http" | "sse"
+
+export type MCPIntegration = {
+  component_id?: "mcp-integration"
+  multiple?: boolean
+}
 
 export type MCPIntegrationCreate =
   | MCPHttpIntegrationCreate
@@ -4472,6 +4479,7 @@ export type MCPStdioServerConfig = {
     [key: string]: string
   }
   timeout?: number
+  id?: string
 }
 
 /**

--- a/frontend/src/components/builder/panel/action-panel-fields.tsx
+++ b/frontend/src/components/builder/panel/action-panel-fields.tsx
@@ -69,7 +69,11 @@ import {
   useAgentPresetVersions,
 } from "@/hooks/use-agent-presets"
 import { isExpression } from "@/lib/expressions"
-import { useBuilderRegistryActions, useWorkspaceAgentModels } from "@/lib/hooks"
+import {
+  useBuilderRegistryActions,
+  useListMcpIntegrations,
+  useWorkspaceAgentModels,
+} from "@/lib/hooks"
 import { getType } from "@/lib/jsonschema"
 import {
   type ExpressionComponent,
@@ -337,6 +341,25 @@ export function PolymorphicField({
             )}
           />
         )
+      case "mcp-integration":
+        return (
+          <Controller
+            name={fieldName}
+            control={methods.control}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabelComponent
+                  label={label}
+                  description={formattedDescription}
+                  deprecated={deprecated}
+                  type={type}
+                />
+                <FormMessage className="whitespace-pre-line" />
+                <MCPIntegrationField field={field} />
+              </FormItem>
+            )}
+          />
+        )
     }
   }
 
@@ -594,6 +617,8 @@ function ComponentContent({
           component={component}
         />
       )
+    case "mcp-integration":
+      return <MCPIntegrationField field={field} />
     // Expression, workflow alias, and other fields fallback to expression
     case "workflow-alias":
     case "expression":
@@ -867,6 +892,7 @@ const COMPONENT_LABELS: Record<TracecatComponentId, string> = {
   "workflow-alias": "Workflow Alias",
   "agent-preset": "Agent Preset",
   "agent-model": "Agent Model",
+  "mcp-integration": "MCP Integrations",
 }
 
 const COMPONENT_ICONS: Record<TracecatComponentId, LucideIcon> = {
@@ -884,6 +910,7 @@ const COMPONENT_ICONS: Record<TracecatComponentId, LucideIcon> = {
   "workflow-alias": WorkflowIcon,
   "agent-preset": WorkflowIcon,
   "agent-model": WorkflowIcon,
+  "mcp-integration": ListIcon,
 }
 
 function AgentPresetSelect({
@@ -1213,6 +1240,86 @@ function AgentModelSelect({
         ))}
       </SelectContent>
     </Select>
+  )
+}
+
+/**
+ * Maps an MCP integration slug to its provider icon ID, mirroring the
+ * mapping used by the agent presets builder. Falls back to "custom".
+ */
+function getMcpProviderId(slug: string): string | undefined {
+  const slugMap: Record<string, string> = {
+    "github-copilot": "github_mcp",
+    github: "github_mcp",
+    sentry: "sentry_mcp",
+    notion: "notion_mcp",
+    linear: "linear_mcp",
+    jira: "jira_mcp",
+    runreveal: "runreveal_mcp",
+    "secure-annex": "secureannex_mcp",
+    secureannex: "secureannex_mcp",
+    wiz: "wiz_mcp",
+  }
+  const normalized = slug.toLowerCase()
+  if (slugMap[normalized]) {
+    return slugMap[normalized]
+  }
+  const match = normalized.match(/^([a-z0-9-]+?)[-_]?mcp$/)
+  if (match) {
+    return `${match[1].replace(/-/g, "")}_mcp`
+  }
+  return undefined
+}
+
+/**
+ * Multi-select picker for saved MCP integrations. Stores selected
+ * integration UUIDs on the field; integration metadata is fetched via
+ * `useListMcpIntegrations`.
+ */
+function MCPIntegrationField({
+  field,
+}: {
+  field: ControllerRenderProps<FieldValues>
+}) {
+  const workspaceId = useWorkspaceId()
+  const { mcpIntegrations, mcpIntegrationsIsLoading } = useListMcpIntegrations(
+    workspaceId ?? ""
+  )
+
+  const suggestions: Suggestion[] = useMemo(() => {
+    if (!mcpIntegrations) {
+      return []
+    }
+    return mcpIntegrations
+      .map((integration) => ({
+        id: integration.id,
+        label: integration.name,
+        value: integration.id,
+        description: integration.description || "MCP integration",
+        icon: (
+          <ProviderIcon
+            providerId={getMcpProviderId(integration.slug) ?? "custom"}
+            className="size-3 bg-transparent p-0 mx-1"
+          />
+        ),
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  }, [mcpIntegrations])
+
+  const value = Array.isArray(field.value) ? (field.value as string[]) : []
+
+  return (
+    <MultiTagCommandInput
+      value={value}
+      onChange={(next) => field.onChange(next)}
+      suggestions={suggestions}
+      searchKeys={["label", "value"]}
+      placeholder={
+        mcpIntegrationsIsLoading
+          ? "Loading integrations..."
+          : "Select MCP integrations"
+      }
+    />
   )
 }
 

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -204,16 +204,35 @@ class AgentActivities:
                 for tool_name, tool_def in user_mcp_tools.items():
                     defs[tool_name] = tool_def
 
-                # JWT claims carry only refs — name + source integration id.
-                # Trusted MCP server re-resolves headers per call.
-                user_mcp_claims = [
-                    UserMCPServerClaim(
-                        name=cfg["name"],
-                        id=uuid.UUID(integration_id_str),
+                # JWT claims carry the source integration id when available so
+                # the trusted MCP server can re-resolve headers per call. For
+                # legacy in-flight payloads that don't carry ``id`` (recorded
+                # before the refs-only cutover), fall back to the pre-rollout
+                # inline shape — otherwise discovery would add ``mcp__*`` tools
+                # that the trusted server can't authorize at call time.
+                user_mcp_claims = []
+                for cfg in http_servers:
+                    integration_id_str = cfg.get("id")
+                    if integration_id_str:
+                        user_mcp_claims.append(
+                            UserMCPServerClaim(
+                                name=cfg["name"],
+                                id=uuid.UUID(integration_id_str),
+                            )
+                        )
+                        continue
+                    # Legacy replay path: no id → trusted server uses inline
+                    # url/headers from the claim itself. ``execute_user_mcp_tool``
+                    # has the matching read-side branch.
+                    user_mcp_claims.append(
+                        UserMCPServerClaim(
+                            name=cfg["name"],
+                            url=cfg["url"],
+                            transport=cfg.get("transport", "http"),
+                            headers=cfg.get("headers", {}),
+                            timeout=cfg.get("timeout"),
+                        )
                     )
-                    for cfg in http_servers
-                    if (integration_id_str := cfg.get("id"))
-                ]
 
                 logger.info(
                     "Discovered user MCP tools",

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Callable
-from typing import Any, TypeGuard
+from typing import Any
 
 from pydantic import (
     UUID4,
@@ -15,6 +15,7 @@ from tracecat.agent.common.types import (
     MCPHttpServerConfig,
     MCPServerConfig,
     MCPToolDefinition,
+    is_http_mcp_server,
 )
 from tracecat.agent.mcp.internal_tools import (
     BUILDER_BUNDLED_ACTIONS,
@@ -90,10 +91,6 @@ class EmitSessionErrorInputs(BaseModel):
 
 class AgentActivities:
     """Activities for agent execution."""
-
-    @staticmethod
-    def _is_http_server(config: MCPServerConfig) -> TypeGuard[MCPHttpServerConfig]:
-        return config.get("type", "http") == "http"
 
     def get_activities(self) -> list[Callable[..., Any]]:
         return all_activities(self)
@@ -172,44 +169,69 @@ class AgentActivities:
         user_mcp_claims: list[UserMCPServerClaim] | None = None
         if args.mcp_servers:
             from tracecat.agent.mcp.user_client import discover_user_mcp_tools
+            from tracecat.agent.preset.service import AgentPresetService
 
-            http_servers = [
-                cfg for cfg in args.mcp_servers if self._is_http_server(cfg)
-            ]
+            http_servers = [cfg for cfg in args.mcp_servers if is_http_mcp_server(cfg)]
             if not http_servers:
                 logger.info("No HTTP MCP servers configured for discovery")
                 http_servers = []
 
+            # Hydrate headers from the DB for the duration of this activity.
+            # Configs that arrive here carry ``id`` but no ``headers`` (the
+            # boundary-safe shape produced by ``resolve_mcp_integration_refs``).
+            # Fetch secrets per server, attach for ``tools/list``, and drop
+            # them before returning so they never enter ``BuildToolDefsResult``
+            # or leak across the Temporal boundary.
+            hydrated_servers: list[MCPHttpServerConfig] = []
+            async with AgentPresetService.with_session(role=args.role) as svc:
+                for cfg in http_servers:
+                    hydrated: MCPHttpServerConfig = {**cfg}
+                    integration_id_str = cfg.get("id")
+                    if integration_id_str:
+                        try:
+                            secrets = await svc.resolve_mcp_integration_secrets(
+                                uuid.UUID(integration_id_str)
+                            )
+                        except ValueError:
+                            secrets = None
+                        if secrets:
+                            hydrated["headers"] = secrets
+                    hydrated_servers.append(hydrated)
+
             try:
-                user_mcp_tools = await discover_user_mcp_tools(http_servers)
+                user_mcp_tools = await discover_user_mcp_tools(hydrated_servers)
                 # Add user MCP tools to definitions
                 for tool_name, tool_def in user_mcp_tools.items():
                     defs[tool_name] = tool_def
 
-                # Build claims for JWT (headers NOT resolved here - done by caller)
+                # JWT claims carry only refs — name + source integration id.
+                # Trusted MCP server re-resolves headers per call.
                 user_mcp_claims = [
                     UserMCPServerClaim(
                         name=cfg["name"],
-                        url=cfg["url"],
-                        transport=cfg.get("transport", "http"),
-                        headers=cfg.get("headers", {}),
-                        timeout=cfg.get("timeout"),
+                        id=uuid.UUID(integration_id_str),
                     )
                     for cfg in http_servers
+                    if (integration_id_str := cfg.get("id"))
                 ]
 
                 logger.info(
                     "Discovered user MCP tools",
                     tool_count=len(user_mcp_tools),
-                    server_count=len(http_servers),
+                    server_count=len(hydrated_servers),
                 )
             except Exception as e:
                 logger.error(
                     "Failed to discover user MCP tools",
                     error_type=type(e).__name__,
-                    server_count=len(http_servers),
+                    server_count=len(hydrated_servers),
                 )
                 # Continue without user MCP tools - don't fail the whole operation
+            finally:
+                # Defensive: ensure hydrated configs (with headers) drop out
+                # of scope before this activity returns. Local variable; this
+                # is documentation more than enforcement.
+                hydrated_servers = []
 
         # Resolve registry lock for these actions
         # This provides origin→version mappings needed for action execution

--- a/packages/tracecat-ee/tracecat_ee/agent/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/schemas.py
@@ -4,6 +4,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from tracecat import config
+from tracecat.agent.common.types import MCPServerConfig
 from tracecat.agent.types import OutputType
 
 # ``extra="ignore"`` keeps Temporal activity replay working after the legacy
@@ -45,7 +46,7 @@ class AgentActionArgs(BaseModel):
         return values
 
     actions: list[str] | None = None
-    mcp_integrations: list[str] | None = None
+    mcp_servers: list[MCPServerConfig] | None = None
     instructions: str | None = None
     output_type: OutputType | None = None
     session_id: uuid.UUID | None = None

--- a/packages/tracecat-ee/tracecat_ee/agent/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/schemas.py
@@ -45,6 +45,7 @@ class AgentActionArgs(BaseModel):
         return values
 
     actions: list[str] | None = None
+    mcp_integrations: list[str] | None = None
     instructions: str | None = None
     output_type: OutputType | None = None
     session_id: uuid.UUID | None = None

--- a/packages/tracecat-registry/tracecat_registry/core/agent.py
+++ b/packages/tracecat-registry/tracecat_registry/core/agent.py
@@ -15,6 +15,7 @@ from tracecat_registry.fields import (
     ActionType,
     AgentModel,
     AgentPreset,
+    MCPIntegration,
     ModelSelection,
     TextArea,
 )
@@ -255,6 +256,11 @@ async def agent(
         list[str] | None,
         Doc("Actions (e.g. 'tools.slack.post_message') to include in the agent."),
         ActionType(multiple=True),
+    ] = None,
+    mcp_integrations: Annotated[
+        list[str] | None,
+        Doc("Saved MCP integrations to include in the agent."),
+        MCPIntegration(multiple=True),
     ] = None,
     instructions: Annotated[
         str | None, Doc("Instructions for the agent."), TextArea()

--- a/packages/tracecat-registry/tracecat_registry/fields.py
+++ b/packages/tracecat-registry/tracecat_registry/fields.py
@@ -38,6 +38,12 @@ class ActionType:
     multiple: bool = False
 
 
+@dataclass(slots=True)
+class MCPIntegration:
+    component_id: Literal["mcp-integration"] = "mcp-integration"
+    multiple: bool = True
+
+
 class ModelSelection(BaseModel):
     """Model dropdown selection passed into registry actions.
 
@@ -59,6 +65,7 @@ __all__ = [
     "AgentModel",
     "AgentPreset",
     "Code",
+    "MCPIntegration",
     "ModelSelection",
     "TextArea",
 ]

--- a/tests/temporal/test_agent_config_workflow_boundary.py
+++ b/tests/temporal/test_agent_config_workflow_boundary.py
@@ -212,3 +212,248 @@ async def test_legacy_agent_config_payload_replays_as_agent_config_payload(
             execution_timeout=timedelta(seconds=15),
         )
         assert result == "gpt-5.2"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the MCP-ref shape rollout.
+#
+# These pin that:
+#   * the legacy MCP server shape (no ``id``, inline ``headers``) recorded in
+#     pre-rollout workflow history still decodes,
+#   * the new ref shape (carrying ``id``, no ``headers``) round-trips through
+#     the workflow boundary so trusted callers can re-resolve secrets,
+#   * a payload containing a mix of the two shapes (and a stdio server)
+#     decodes intact.
+# ---------------------------------------------------------------------------
+
+
+def _legacy_mcp_agent_config() -> TracecatAgentConfig:
+    """Pre-rollout config: inline ``headers``, no ``id`` on the MCP server."""
+    return TracecatAgentConfig(
+        model_name="gpt-5.2",
+        model_provider="openai",
+        mcp_servers=[
+            {
+                "type": "http",
+                "name": "internal-tools",
+                "url": "http://host.docker.internal:8080",
+                "transport": "http",
+                "headers": {"Authorization": "Bearer legacy-secret"},
+            }
+        ],
+        retries=3,
+    )
+
+
+def _ref_mcp_agent_config() -> TracecatAgentConfig:
+    """Post-rollout config: ``id`` set, no ``headers``."""
+    return TracecatAgentConfig(
+        model_name="gpt-5.2",
+        model_provider="openai",
+        mcp_servers=[
+            {
+                "type": "http",
+                "name": "internal-tools",
+                "url": "http://host.docker.internal:8080",
+                "transport": "http",
+                "id": "11111111-1111-1111-1111-111111111111",
+            }
+        ],
+        retries=3,
+    )
+
+
+def _mixed_mcp_agent_config() -> TracecatAgentConfig:
+    """Heterogeneous payload exercising every supported shape."""
+    return TracecatAgentConfig(
+        model_name="gpt-5.2",
+        model_provider="openai",
+        mcp_servers=[
+            # Legacy http with headers, no id
+            {
+                "type": "http",
+                "name": "legacy",
+                "url": "http://legacy.local",
+                "transport": "http",
+                "headers": {"Authorization": "Bearer legacy"},
+            },
+            # New http with id, no headers
+            {
+                "type": "http",
+                "name": "modern",
+                "url": "http://modern.local",
+                "transport": "http",
+                "id": "22222222-2222-2222-2222-222222222222",
+            },
+            # Stdio with id
+            {
+                "type": "stdio",
+                "name": "local-stdio",
+                "command": "/usr/bin/echo",
+                "args": ["hello"],
+                "id": "33333333-3333-3333-3333-333333333333",
+            },
+        ],
+        retries=3,
+    )
+
+
+@activity.defn(name="return_legacy_mcp_payload")
+async def return_legacy_mcp_payload() -> AgentConfigPayload:
+    return agent_config_to_payload(_legacy_mcp_agent_config())
+
+
+@activity.defn(name="return_ref_mcp_payload")
+async def return_ref_mcp_payload() -> AgentConfigPayload:
+    return agent_config_to_payload(_ref_mcp_agent_config())
+
+
+@activity.defn(name="return_mixed_mcp_payload")
+async def return_mixed_mcp_payload() -> AgentConfigPayload:
+    return agent_config_to_payload(_mixed_mcp_agent_config())
+
+
+@workflow.defn
+class LegacyMcpPayloadWorkflow:
+    @workflow.run
+    async def run(self, _: str) -> list[dict]:
+        payload = await workflow.execute_activity(
+            return_legacy_mcp_payload,
+            start_to_close_timeout=timedelta(seconds=10),
+        )
+        config = agent_config_from_payload(payload)
+        assert config.mcp_servers is not None
+        return [dict(server) for server in config.mcp_servers]
+
+
+@workflow.defn
+class RefMcpPayloadWorkflow:
+    @workflow.run
+    async def run(self, _: str) -> list[dict]:
+        payload = await workflow.execute_activity(
+            return_ref_mcp_payload,
+            start_to_close_timeout=timedelta(seconds=10),
+        )
+        config = agent_config_from_payload(payload)
+        assert config.mcp_servers is not None
+        return [dict(server) for server in config.mcp_servers]
+
+
+@workflow.defn
+class MixedMcpPayloadWorkflow:
+    @workflow.run
+    async def run(self, _: str) -> list[dict]:
+        payload = await workflow.execute_activity(
+            return_mixed_mcp_payload,
+            start_to_close_timeout=timedelta(seconds=10),
+        )
+        config = agent_config_from_payload(payload)
+        assert config.mcp_servers is not None
+        return [dict(server) for server in config.mcp_servers]
+
+
+@pytest.mark.anyio
+async def test_legacy_mcp_payload_decodes_without_id(
+    env: WorkflowEnvironment,
+) -> None:
+    """Pre-rollout MCP server shape (inline headers, no ``id``) must still decode."""
+    task_queue = "test-legacy-mcp-payload-decode"
+    async with Worker(
+        env.client,
+        task_queue=task_queue,
+        activities=[return_legacy_mcp_payload],
+        workflows=[LegacyMcpPayloadWorkflow],
+        workflow_runner=new_sandbox_runner(),
+    ):
+        servers = await env.client.execute_workflow(
+            LegacyMcpPayloadWorkflow.run,
+            "x",
+            id="test-legacy-mcp-payload-decode-1",
+            task_queue=task_queue,
+            execution_timeout=timedelta(seconds=15),
+        )
+    assert servers == [
+        {
+            "type": "http",
+            "name": "internal-tools",
+            "url": "http://host.docker.internal:8080",
+            "transport": "http",
+            "headers": {"Authorization": "Bearer legacy-secret"},
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_ref_mcp_payload_preserves_id_across_boundary(
+    env: WorkflowEnvironment,
+) -> None:
+    """New ref shape must round-trip with ``id`` intact and no headers added."""
+    task_queue = "test-ref-mcp-payload-decode"
+    async with Worker(
+        env.client,
+        task_queue=task_queue,
+        activities=[return_ref_mcp_payload],
+        workflows=[RefMcpPayloadWorkflow],
+        workflow_runner=new_sandbox_runner(),
+    ):
+        servers = await env.client.execute_workflow(
+            RefMcpPayloadWorkflow.run,
+            "x",
+            id="test-ref-mcp-payload-decode-1",
+            task_queue=task_queue,
+            execution_timeout=timedelta(seconds=15),
+        )
+    assert servers == [
+        {
+            "type": "http",
+            "name": "internal-tools",
+            "url": "http://host.docker.internal:8080",
+            "transport": "http",
+            "id": "11111111-1111-1111-1111-111111111111",
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_mixed_mcp_payload_decodes_intact(
+    env: WorkflowEnvironment,
+) -> None:
+    """Mixed legacy + ref + stdio payloads must all decode without loss."""
+    task_queue = "test-mixed-mcp-payload-decode"
+    async with Worker(
+        env.client,
+        task_queue=task_queue,
+        activities=[return_mixed_mcp_payload],
+        workflows=[MixedMcpPayloadWorkflow],
+        workflow_runner=new_sandbox_runner(),
+    ):
+        servers = await env.client.execute_workflow(
+            MixedMcpPayloadWorkflow.run,
+            "x",
+            id="test-mixed-mcp-payload-decode-1",
+            task_queue=task_queue,
+            execution_timeout=timedelta(seconds=15),
+        )
+    assert servers == [
+        {
+            "type": "http",
+            "name": "legacy",
+            "url": "http://legacy.local",
+            "transport": "http",
+            "headers": {"Authorization": "Bearer legacy"},
+        },
+        {
+            "type": "http",
+            "name": "modern",
+            "url": "http://modern.local",
+            "transport": "http",
+            "id": "22222222-2222-2222-2222-222222222222",
+        },
+        {
+            "type": "stdio",
+            "name": "local-stdio",
+            "command": "/usr/bin/echo",
+            "args": ["hello"],
+            "id": "33333333-3333-3333-3333-333333333333",
+        },
+    ]

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -7,6 +7,7 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 from tracecat.agent.mcp import trusted_server
+from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.tokens import MCPTokenClaims, UserMCPServerClaim
 from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
 
@@ -86,6 +87,97 @@ async def test_execute_user_mcp_tool_returns_descriptive_error_on_execution_erro
             {},
             "token",
         )
+
+
+@pytest.mark.anyio
+async def test_execute_user_mcp_tool_uses_claimed_name_for_resolved_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    integration_id = uuid.UUID("00000000-0000-0000-0000-000000000004")
+    monkeypatch.setattr(
+        trusted_server,
+        "verify_mcp_token",
+        lambda _: _build_claims(
+            user_mcp_servers=[
+                UserMCPServerClaim(
+                    name="Jira",
+                    id=integration_id,
+                )
+            ]
+        ),
+    )
+
+    class _PresetServiceContext:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def resolve_mcp_integration_refs(self, integration_ids):
+            assert integration_ids == [str(integration_id)]
+            return [
+                {
+                    "type": "http",
+                    "name": "Renamed Jira",
+                    "url": "https://mcp.atlassian.com/v1/mcp",
+                    "transport": "http",
+                    "id": str(integration_id),
+                }
+            ]
+
+        async def resolve_mcp_integration_secrets(self, resolved_integration_id):
+            assert resolved_integration_id == integration_id
+            return {"Authorization": "Bearer secret"}
+
+    monkeypatch.setattr(
+        AgentPresetService,
+        "with_session",
+        lambda role=None: _PresetServiceContext(),
+    )
+
+    created_configs: list[dict[str, object]] = []
+    call_args: dict[str, object] = {}
+
+    class _UserMCPClient:
+        def __init__(self, configs):
+            created_configs.extend(configs)
+
+        async def call_tool(self, server_name, tool_name, args):
+            call_args.update(
+                server_name=server_name,
+                tool_name=tool_name,
+                args=args,
+            )
+            return {"ok": True}
+
+    monkeypatch.setattr(trusted_server, "UserMCPClient", _UserMCPClient)
+    execute_user_mcp_tool = cast(
+        ExecuteUserMCPTool, trusted_server.execute_user_mcp_tool
+    )
+
+    result = await execute_user_mcp_tool(
+        "Jira",
+        "getIssue",
+        {"key": "SEC-1"},
+        "token",
+    )
+
+    assert result == '{"ok": true}'
+    assert created_configs == [
+        {
+            "type": "http",
+            "name": "Jira",
+            "url": "https://mcp.atlassian.com/v1/mcp",
+            "transport": "http",
+            "headers": {"Authorization": "Bearer secret"},
+        }
+    ]
+    assert call_args == {
+        "server_name": "Jira",
+        "tool_name": "getIssue",
+        "args": {"key": "SEC-1"},
+    }
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_tokens.py
+++ b/tests/unit/test_agent_tokens.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import uuid
 
 from tracecat import config
-from tracecat.agent.tokens import mint_mcp_token, verify_mcp_token
+from tracecat.agent.tokens import (
+    UserMCPServerClaim,
+    mint_mcp_token,
+    verify_mcp_token,
+)
 
 
 def test_mcp_token_round_trips_parent_agent_workflow_metadata(
@@ -33,3 +37,96 @@ def test_mcp_token_round_trips_parent_agent_workflow_metadata(
     assert claims.user_id == user_id
     assert claims.parent_agent_workflow_id == f"agent/{session_id}"
     assert claims.parent_agent_run_id == "run-123"
+
+
+def _setup_service_key(monkeypatch) -> tuple[uuid.UUID, uuid.UUID, uuid.UUID]:
+    monkeypatch.setattr(config, "TRACECAT__SERVICE_KEY", "test-service-key")
+    return uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+
+def test_mcp_token_accepts_legacy_user_mcp_server_claim_shape(monkeypatch) -> None:
+    """Tokens minted with the pre-rollout claim shape (no ``id``, inline ``url``
+    and ``headers``) must still verify. This locks in replay compatibility for
+    JWTs minted before the refs-only cutover.
+    """
+    workspace_id, organization_id, session_id = _setup_service_key(monkeypatch)
+
+    token = mint_mcp_token(
+        workspace_id=workspace_id,
+        organization_id=organization_id,
+        allowed_actions=["core.http_request"],
+        session_id=session_id,
+        user_mcp_servers=[
+            UserMCPServerClaim(
+                name="legacy-mcp",
+                url="https://legacy.example.com/mcp",
+                transport="http",
+                headers={"Authorization": "Bearer legacy-secret"},
+                timeout=30,
+            )
+        ],
+    )
+
+    claims = verify_mcp_token(token)
+    assert len(claims.user_mcp_servers) == 1
+    ref = claims.user_mcp_servers[0]
+    assert ref.name == "legacy-mcp"
+    assert ref.id is None
+    assert ref.url == "https://legacy.example.com/mcp"
+    assert ref.transport == "http"
+    assert ref.headers == {"Authorization": "Bearer legacy-secret"}
+    assert ref.timeout == 30
+
+
+def test_mcp_token_round_trips_refs_only_user_mcp_server_claim(monkeypatch) -> None:
+    """New-shape claims (``name`` + ``id`` only) must round-trip cleanly so the
+    trusted server has the integration id it needs to re-resolve secrets.
+    """
+    workspace_id, organization_id, session_id = _setup_service_key(monkeypatch)
+    integration_id = uuid.uuid4()
+
+    token = mint_mcp_token(
+        workspace_id=workspace_id,
+        organization_id=organization_id,
+        allowed_actions=["core.http_request"],
+        session_id=session_id,
+        user_mcp_servers=[UserMCPServerClaim(name="modern-mcp", id=integration_id)],
+    )
+
+    claims = verify_mcp_token(token)
+    assert len(claims.user_mcp_servers) == 1
+    ref = claims.user_mcp_servers[0]
+    assert ref.name == "modern-mcp"
+    assert ref.id == integration_id
+    # New-shape claims should not carry secret material.
+    assert ref.url is None
+    assert ref.headers == {}
+    assert ref.timeout is None
+
+
+def test_mcp_token_accepts_mixed_legacy_and_refs_user_mcp_servers(monkeypatch) -> None:
+    """A token carrying both shapes in the same claim list must decode without loss."""
+    workspace_id, organization_id, session_id = _setup_service_key(monkeypatch)
+    integration_id = uuid.uuid4()
+
+    token = mint_mcp_token(
+        workspace_id=workspace_id,
+        organization_id=organization_id,
+        allowed_actions=["core.http_request"],
+        session_id=session_id,
+        user_mcp_servers=[
+            UserMCPServerClaim(
+                name="legacy",
+                url="https://legacy.example.com/mcp",
+                transport="http",
+                headers={"Authorization": "Bearer legacy"},
+            ),
+            UserMCPServerClaim(name="modern", id=integration_id),
+        ],
+    )
+
+    claims = verify_mcp_token(token)
+    assert [(ref.name, ref.id, ref.url) for ref in claims.user_mcp_servers] == [
+        ("legacy", None, "https://legacy.example.com/mcp"),
+        ("modern", integration_id, None),
+    ]

--- a/tests/unit/test_build_agent_args.py
+++ b/tests/unit/test_build_agent_args.py
@@ -361,7 +361,7 @@ class TestBuildAgentArgsMcpResolution:
         )
 
         with patch(
-            "tracecat.dsl.action._resolve_mcp_integration_ids",
+            "tracecat.dsl.action._resolve_mcp_integrations",
             new_callable=AsyncMock,
             return_value=[resolved],
         ) as mock_resolve:
@@ -395,7 +395,7 @@ class TestBuildAgentArgsMcpResolution:
         )
 
         with patch(
-            "tracecat.dsl.action._resolve_mcp_integration_ids",
+            "tracecat.dsl.action._resolve_mcp_integrations",
             new_callable=AsyncMock,
             return_value=[resolved],
         ):
@@ -421,7 +421,7 @@ class TestBuildAgentArgsMcpResolution:
         )
 
         with patch(
-            "tracecat.dsl.action._resolve_mcp_integration_ids",
+            "tracecat.dsl.action._resolve_mcp_integrations",
             new_callable=AsyncMock,
         ) as mock_resolve:
             result = await DSLActivities.build_agent_args_activity(input)
@@ -451,7 +451,7 @@ class TestBuildAgentArgsMcpResolution:
             "user_prompt": "Hello",
             "model_name": "claude-sonnet-4-5-20250929",
             "model_provider": "anthropic",
-            "mcp_integration_ids": [id1, id2],
+            "mcp_integrations": [id1, id2],
         }
         input = BuildAgentArgsActivityInput(
             args=args,
@@ -462,7 +462,7 @@ class TestBuildAgentArgsMcpResolution:
         )
 
         with patch(
-            "tracecat.dsl.action._resolve_mcp_integration_ids",
+            "tracecat.dsl.action._resolve_mcp_integrations",
             new_callable=AsyncMock,
             return_value=resolved,
         ) as mock_resolve:
@@ -498,7 +498,7 @@ class TestBuildAgentArgsMcpResolution:
         )
 
         with patch(
-            "tracecat.dsl.action._resolve_mcp_integration_ids",
+            "tracecat.dsl.action._resolve_mcp_integrations",
             new_callable=AsyncMock,
             return_value=[resolved],
         ):
@@ -534,7 +534,7 @@ class TestBuildAgentArgsMcpResolution:
         )
 
         with patch(
-            "tracecat.dsl.action._resolve_mcp_integration_ids",
+            "tracecat.dsl.action._resolve_mcp_integrations",
             new_callable=AsyncMock,
             return_value=[resolved],
         ):

--- a/tests/unit/test_build_agent_args.py
+++ b/tests/unit/test_build_agent_args.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from tracecat_ee.agent.schemas import AgentActionArgs, PresetAgentActionArgs
 
+from tracecat.agent.common.types import MCPHttpServerConfig, MCPStdioServerConfig
 from tracecat.auth.types import Role
 from tracecat.dsl.action import (
     BuildAgentArgsActivityInput,
@@ -329,6 +330,218 @@ class TestBuildAgentArgsActivity:
         result = await DSLActivities.build_agent_args_activity(input)
 
         assert result.model_settings == {"reasoning_effort": "medium"}
+
+
+class TestBuildAgentArgsMcpResolution:
+    """Tests for mcp_integration_ids → mcp_servers resolution inside build_agent_args_activity."""
+
+    @pytest.mark.anyio
+    async def test_mcp_integration_ids_resolve_to_mcp_servers(self, role: Role):
+        """mcp_integration_ids in args are resolved to partial MCPServerConfigs
+        and surfaced as mcp_servers on the result; the raw IDs are not present."""
+        integration_id = str(uuid.uuid4())
+        resolved: MCPHttpServerConfig = {
+            "type": "http",
+            "name": "my-server",
+            "url": "https://mcp.example.com",
+            "id": integration_id,
+        }
+        args = {
+            "user_prompt": "Hello",
+            "model_name": "claude-sonnet-4-5-20250929",
+            "model_provider": "anthropic",
+            "mcp_integrations": [integration_id],
+        }
+        input = BuildAgentArgsActivityInput(
+            args=args,
+            operand=_make_context(),
+            role=role,
+            task_environment=None,
+            default_environment="default",
+        )
+
+        with patch(
+            "tracecat.dsl.action._resolve_mcp_integration_ids",
+            new_callable=AsyncMock,
+            return_value=[resolved],
+        ) as mock_resolve:
+            result = await DSLActivities.build_agent_args_activity(input)
+
+        mock_resolve.assert_awaited_once_with([integration_id], role=role)
+        assert result.mcp_servers == [resolved]
+
+    @pytest.mark.anyio
+    async def test_mcp_integration_ids_not_present_on_result(self, role: Role):
+        """mcp_integration_ids must not appear as a field on AgentActionArgs."""
+        integration_id = str(uuid.uuid4())
+        resolved: MCPHttpServerConfig = {
+            "type": "http",
+            "name": "my-server",
+            "url": "https://mcp.example.com",
+            "id": integration_id,
+        }
+        args = {
+            "user_prompt": "Hello",
+            "model_name": "claude-sonnet-4-5-20250929",
+            "model_provider": "anthropic",
+            "mcp_integrations": [integration_id],
+        }
+        input = BuildAgentArgsActivityInput(
+            args=args,
+            operand=_make_context(),
+            role=role,
+            task_environment=None,
+            default_environment="default",
+        )
+
+        with patch(
+            "tracecat.dsl.action._resolve_mcp_integration_ids",
+            new_callable=AsyncMock,
+            return_value=[resolved],
+        ):
+            result = await DSLActivities.build_agent_args_activity(input)
+
+        assert not hasattr(result, "mcp_integration_ids")
+
+    @pytest.mark.anyio
+    async def test_no_mcp_integration_ids_skips_resolution(self, role: Role):
+        """When mcp_integration_ids is absent, resolution is never called and
+        mcp_servers is None."""
+        args = {
+            "user_prompt": "Hello",
+            "model_name": "claude-sonnet-4-5-20250929",
+            "model_provider": "anthropic",
+        }
+        input = BuildAgentArgsActivityInput(
+            args=args,
+            operand=_make_context(),
+            role=role,
+            task_environment=None,
+            default_environment="default",
+        )
+
+        with patch(
+            "tracecat.dsl.action._resolve_mcp_integration_ids",
+            new_callable=AsyncMock,
+        ) as mock_resolve:
+            result = await DSLActivities.build_agent_args_activity(input)
+
+        mock_resolve.assert_not_called()
+        assert result.mcp_servers is None
+
+    @pytest.mark.anyio
+    async def test_multiple_mcp_integration_ids_resolve(self, role: Role):
+        """All IDs in the list are forwarded to the resolver as a batch."""
+        id1, id2 = str(uuid.uuid4()), str(uuid.uuid4())
+        resolved: list[MCPHttpServerConfig] = [
+            {
+                "type": "http",
+                "name": "server-a",
+                "url": "https://a.example.com",
+                "id": id1,
+            },
+            {
+                "type": "http",
+                "name": "server-b",
+                "url": "https://b.example.com",
+                "id": id2,
+            },
+        ]
+        args = {
+            "user_prompt": "Hello",
+            "model_name": "claude-sonnet-4-5-20250929",
+            "model_provider": "anthropic",
+            "mcp_integration_ids": [id1, id2],
+        }
+        input = BuildAgentArgsActivityInput(
+            args=args,
+            operand=_make_context(),
+            role=role,
+            task_environment=None,
+            default_environment="default",
+        )
+
+        with patch(
+            "tracecat.dsl.action._resolve_mcp_integration_ids",
+            new_callable=AsyncMock,
+            return_value=resolved,
+        ) as mock_resolve:
+            result = await DSLActivities.build_agent_args_activity(input)
+
+        mock_resolve.assert_awaited_once_with([id1, id2], role=role)
+        assert result.mcp_servers == resolved
+        assert len(result.mcp_servers) == 2  # type: ignore[arg-type]
+
+    @pytest.mark.anyio
+    async def test_stdio_mcp_integration_resolves(self, role: Role):
+        """Stdio server configs are resolved the same way as HTTP ones."""
+        integration_id = str(uuid.uuid4())
+        resolved: MCPStdioServerConfig = {
+            "type": "stdio",
+            "name": "local-tools",
+            "command": "python",
+            "args": ["-m", "my_mcp_server"],
+            "id": integration_id,
+        }
+        args = {
+            "user_prompt": "Hello",
+            "model_name": "claude-sonnet-4-5-20250929",
+            "model_provider": "anthropic",
+            "mcp_integrations": [integration_id],
+        }
+        input = BuildAgentArgsActivityInput(
+            args=args,
+            operand=_make_context(),
+            role=role,
+            task_environment=None,
+            default_environment="default",
+        )
+
+        with patch(
+            "tracecat.dsl.action._resolve_mcp_integration_ids",
+            new_callable=AsyncMock,
+            return_value=[resolved],
+        ):
+            result = await DSLActivities.build_agent_args_activity(input)
+
+        assert result.mcp_servers == [resolved]
+        assert result.mcp_servers[0]["type"] == "stdio"  # type: ignore[index]
+
+    @pytest.mark.anyio
+    async def test_resolved_configs_carry_no_secrets(self, role: Role):
+        """Resolved HTTP configs must not contain headers (secrets are omitted
+        on the partial config that crosses Temporal boundaries)."""
+        integration_id = str(uuid.uuid4())
+        resolved: MCPHttpServerConfig = {
+            "type": "http",
+            "name": "secure-server",
+            "url": "https://secure.example.com",
+            "id": integration_id,
+            # no 'headers' key — intentionally absent
+        }
+        args = {
+            "user_prompt": "Hello",
+            "model_name": "claude-sonnet-4-5-20250929",
+            "model_provider": "anthropic",
+            "mcp_integrations": [integration_id],
+        }
+        input = BuildAgentArgsActivityInput(
+            args=args,
+            operand=_make_context(),
+            role=role,
+            task_environment=None,
+            default_environment="default",
+        )
+
+        with patch(
+            "tracecat.dsl.action._resolve_mcp_integration_ids",
+            new_callable=AsyncMock,
+            return_value=[resolved],
+        ):
+            result = await DSLActivities.build_agent_args_activity(input)
+
+        assert result.mcp_servers is not None
+        assert "headers" not in result.mcp_servers[0]
 
 
 class TestBuildPresetAgentArgsActivity:

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -1030,6 +1030,42 @@ class TestMCPIntegrationValidation:
         )
         assert result is None
 
+    async def test_resolve_mcp_integration_refs_rejects_now_disallowed_stdio_command(
+        self,
+        integration_service: IntegrationService,
+    ) -> None:
+        """Regression: resolve_mcp_integration_refs must re-validate stdio command
+        policy so rows persisted before rules tightened are rejected at resolution
+        time rather than passed through to the agent runtime."""
+        created = await integration_service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name="Npx MCP",
+                stdio_command="npx",
+                stdio_args=["@modelcontextprotocol/server-github"],
+            )
+        )
+
+        preset_service = AgentPresetService(
+            session=integration_service.session,
+            role=integration_service.role,
+        )
+
+        # Simulate tightened policy: remove 'npx' from the allowed set after the
+        # row was already persisted.
+        from tracecat.exceptions import TracecatValidationError
+        from tracecat.integrations import mcp_validation
+
+        original = mcp_validation.ALLOWED_MCP_COMMANDS
+        mcp_validation.ALLOWED_MCP_COMMANDS = frozenset(original - {"npx"})
+        try:
+            # The integration should be skipped; with no remaining refs the
+            # method raises TracecatValidationError rather than returning an
+            # empty list.
+            with pytest.raises(TracecatValidationError):
+                await preset_service.resolve_mcp_integration_refs([str(created.id)])
+        finally:
+            mcp_validation.ALLOWED_MCP_COMMANDS = original
+
 
 @pytest.mark.anyio
 class TestMCPIntegrationWorkspaceIsolation:

--- a/tracecat/agent/common/types.py
+++ b/tracecat/agent/common/types.py
@@ -6,7 +6,7 @@ Pure dataclasses with no Pydantic dependencies for minimal import footprint.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Literal, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict, TypeGuard
 
 
 class MCPHttpServerConfig(TypedDict):
@@ -35,13 +35,23 @@ class MCPHttpServerConfig(TypedDict):
     """Required: HTTP/SSE endpoint URL for the MCP server."""
 
     headers: NotRequired[dict[str, str]]
-    """Optional: Auth headers (can reference Tracecat secrets)."""
+    """Optional: Auth headers (can reference Tracecat secrets).
+
+    Only populated when the config has been resolved at the trusted edge for
+    immediate use. Boundary-crossing configs omit this field; the trusted
+    caller re-resolves secrets per use via the source ``id``.
+    """
 
     transport: NotRequired[Literal["http", "sse"]]
     """Optional: Transport type. Defaults to 'http'."""
 
     timeout: NotRequired[int]
     """Optional: Request timeout in seconds."""
+
+    id: NotRequired[str]
+    """Optional: UUID of the source ``mcp_integrations`` row this config was
+    resolved from. Set when produced by ``AgentPresetService`` resolvers so
+    callers can re-resolve secrets per use without re-listing integrations."""
 
 
 class MCPStdioServerConfig(TypedDict):
@@ -52,10 +62,25 @@ class MCPStdioServerConfig(TypedDict):
     command: str
     args: NotRequired[list[str]]
     env: NotRequired[dict[str, str]]
+    """Optional: Process env vars. Treated as secrets; omitted at
+    boundary-crossing producers — re-resolved at the trusted edge."""
     timeout: NotRequired[int]
+    id: NotRequired[str]
+    """Optional: UUID of the source ``mcp_integrations`` row this config was
+    resolved from. See :class:`MCPHttpServerConfig.id`."""
 
 
 MCPServerConfig = MCPHttpServerConfig | MCPStdioServerConfig
+
+
+def is_http_mcp_server(config: MCPServerConfig) -> TypeGuard[MCPHttpServerConfig]:
+    """Narrow a generic ``MCPServerConfig`` to its HTTP variant.
+
+    HTTP is the default discriminator (the ``type`` key is optional on
+    ``MCPHttpServerConfig`` and defaults to ``"http"``), so configs without
+    an explicit ``type`` are treated as HTTP for backwards compatibility.
+    """
+    return config.get("type", "http") == "http"
 
 
 @dataclass(kw_only=True, slots=True)

--- a/tracecat/agent/common/types.py
+++ b/tracecat/agent/common/types.py
@@ -73,6 +73,11 @@ class MCPStdioServerConfig(TypedDict):
 MCPServerConfig = MCPHttpServerConfig | MCPStdioServerConfig
 
 
+def is_stdio_mcp_server(config: MCPServerConfig) -> TypeGuard[MCPStdioServerConfig]:
+    """Narrow a generic ``MCPServerConfig`` to its stdio variant."""
+    return config.get("type") == "stdio"
+
+
 def is_http_mcp_server(config: MCPServerConfig) -> TypeGuard[MCPHttpServerConfig]:
     """Narrow a generic ``MCPServerConfig`` to its HTTP variant.
 

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -25,7 +25,12 @@ from tracecat.agent.common.config import (
 from tracecat.agent.common.exceptions import AgentSandboxExecutionError
 from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.stream_types import ToolCallContent
-from tracecat.agent.common.types import MCPToolDefinition, SandboxAgentConfig
+from tracecat.agent.common.types import (
+    MCPServerConfig,
+    MCPToolDefinition,
+    SandboxAgentConfig,
+    is_stdio_mcp_server,
+)
 from tracecat.agent.executor.loopback import (
     LoopbackHandler,
     LoopbackInput,
@@ -520,8 +525,10 @@ class SandboxedAgentExecutor:
                 )
 
 
-async def _hydrate_stdio_env(mcp_servers: list[Any] | None, *, role: Role) -> None:
-    """Resolve stdio ``env`` secrets in-place before the runtime starts.
+async def _hydrate_stdio_env(
+    mcp_servers: list[MCPServerConfig] | None, *, role: Role
+) -> list[MCPServerConfig] | None:
+    """Resolve stdio ``env`` secrets and return a new list before the runtime starts.
 
     HTTP MCP servers route through the trusted MCP server, which re-resolves
     secrets per call. Stdio servers are spawned directly by the Claude
@@ -529,28 +536,30 @@ async def _hydrate_stdio_env(mcp_servers: list[Any] | None, *, role: Role) -> No
     rehydration hook — env secrets must be present on the config dict when
     the runtime reads it.
 
-    ``mcp_servers`` is mutated in place. Secret data lives only for the
-    lifetime of this activity frame.
+    Returns a new list with hydrated stdio configs; HTTP configs are passed
+    through unchanged. Secret data lives only for the lifetime of this
+    activity frame.
     """
     if not mcp_servers:
-        return
+        return mcp_servers
 
-    stdio_targets = [
-        cfg
-        for cfg in mcp_servers
-        if cfg.get("type") == "stdio" and cfg.get("id") and not cfg.get("env")
-    ]
-    if not stdio_targets:
-        return
-
+    result: list[MCPServerConfig] = []
     async with AgentPresetService.with_session(role=role) as svc:
-        for cfg in stdio_targets:
-            try:
-                env = await svc.resolve_mcp_integration_secrets(uuid.UUID(cfg["id"]))
-            except ValueError:
-                env = None
-            if env:
-                cfg["env"] = env
+        for cfg in mcp_servers:
+            if not is_stdio_mcp_server(cfg):
+                result.append(cfg)
+            else:
+                cfg_id = cfg.get("id")
+                if not cfg_id:
+                    raise ValueError(
+                        f"Stdio MCP server {cfg.get('name')!r} is missing a source integration id"
+                    )
+                try:
+                    env = await svc.resolve_mcp_integration_secrets(uuid.UUID(cfg_id))
+                except ValueError:
+                    env = None
+                result.append({**cfg, "env": env} if env else cfg)
+    return result
 
 
 @activity.defn
@@ -587,7 +596,9 @@ async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
     # configs in ``input.config.mcp_servers`` arrive in refs-only shape
     # (no ``env``) — hydrate from the DB here so the spawned process gets
     # its credentials.
-    await _hydrate_stdio_env(input.config.mcp_servers, role=input.role)
+    input.config.mcp_servers = await _hydrate_stdio_env(
+        input.config.mcp_servers, role=input.role
+    )
 
     executor = SandboxedAgentExecutor(input=input)
     result = await executor.run()

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -31,6 +31,7 @@ from tracecat.agent.executor.loopback import (
     LoopbackInput,
     LoopbackResult,
 )
+from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.runtime.claude_code.broker import (
     ClaudeTurnRequest,
     ConcurrentSessionTurnError,
@@ -519,6 +520,39 @@ class SandboxedAgentExecutor:
                 )
 
 
+async def _hydrate_stdio_env(mcp_servers: list[Any] | None, *, role: Role) -> None:
+    """Resolve stdio ``env`` secrets in-place before the runtime starts.
+
+    HTTP MCP servers route through the trusted MCP server, which re-resolves
+    secrets per call. Stdio servers are spawned directly by the Claude
+    runtime from ``payload.config.mcp_servers``, so there's no later
+    rehydration hook — env secrets must be present on the config dict when
+    the runtime reads it.
+
+    ``mcp_servers`` is mutated in place. Secret data lives only for the
+    lifetime of this activity frame.
+    """
+    if not mcp_servers:
+        return
+
+    stdio_targets = [
+        cfg
+        for cfg in mcp_servers
+        if cfg.get("type") == "stdio" and cfg.get("id") and not cfg.get("env")
+    ]
+    if not stdio_targets:
+        return
+
+    async with AgentPresetService.with_session(role=role) as svc:
+        for cfg in stdio_targets:
+            try:
+                env = await svc.resolve_mcp_integration_secrets(uuid.UUID(cfg["id"]))
+            except ValueError:
+                env = None
+            if env:
+                cfg["env"] = env
+
+
 @activity.defn
 async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
     """Temporal activity that runs one brokered agent turn.
@@ -547,6 +581,14 @@ async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
     )
 
     input = await _hydrate_sdk_session_history(input)
+   
+    # Stdio MCP servers are spawned directly by the runtime; unlike HTTP
+    # servers they have no per-call secret resolution hook downstream. The
+    # configs in ``input.config.mcp_servers`` arrive in refs-only shape
+    # (no ``env``) — hydrate from the DB here so the spawned process gets
+    # its credentials.
+    await _hydrate_stdio_env(input.config.mcp_servers, role=input.role)
+
     executor = SandboxedAgentExecutor(input=input)
     result = await executor.run()
 

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -581,7 +581,7 @@ async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
     )
 
     input = await _hydrate_sdk_session_history(input)
-   
+
     # Stdio MCP servers are spawned directly by the runtime; unlike HTTP
     # servers they have no per-call secret resolution hook downstream. The
     # configs in ``input.config.mcp_servers`` arrive in refs-only shape

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -22,7 +22,7 @@ from typing import Any
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 
-from tracecat.agent.common.types import MCPHttpServerConfig
+from tracecat.agent.common.types import MCPHttpServerConfig, is_http_mcp_server
 from tracecat.agent.mcp.executor import ActionExecutionError, execute_action
 from tracecat.agent.mcp.internal_tools import (
     INTERNAL_TOOL_HANDLERS,
@@ -151,18 +151,10 @@ async def execute_user_mcp_tool(
 ) -> str:
     """Execute a tool on a user-defined MCP server.
 
-    User MCP servers are configured in the agent config and their credentials
-    are stored in the JWT claims. This tool proxies calls from the sandboxed
-    runtime to the user's MCP server.
-
-    Args:
-        server_name: Name of the user MCP server (from config).
-        tool_name: Original tool name (without mcp__ prefix).
-        args: Arguments to pass to the tool.
-        auth_token: JWT token containing user MCP server configs.
-
-    Returns:
-        JSON-encoded result from the tool.
+    User MCP servers are authorized via the JWT claims (only ``name`` + source
+    integration ``id`` cross the boundary). Secrets (OAuth bearers, custom
+    auth headers, stdio env) are re-resolved here per call so they never
+    enter Temporal history or JWT payloads.
     """
     try:
         claims = verify_mcp_token(auth_token)
@@ -170,15 +162,13 @@ async def execute_user_mcp_tool(
         logger.warning("MCP token verification failed", error_type=_safe_error_type(e))
         raise ToolError("Authentication failed") from None
 
-    _set_role_context(claims)
-    # Find the server config in claims
-    server_config = None
-    for cfg in claims.user_mcp_servers:
-        if cfg.name == server_name:
-            server_config = cfg
-            break
+    role = _set_role_context(claims)
 
-    if server_config is None:
+    ref = next(
+        (s for s in claims.user_mcp_servers if s.name == server_name),
+        None,
+    )
+    if ref is None:
         logger.warning(
             "User MCP server not found in claims",
             server_name=server_name,
@@ -186,17 +176,48 @@ async def execute_user_mcp_tool(
         )
         raise ToolError(f"User MCP server '{server_name}' not authorized") from None
 
-    try:
+    # Resolve metadata + secrets per call. Both come from the DB; no
+    # secrets are carried through the claim itself.
+    from tracecat.agent.preset.service import AgentPresetService
+
+    if ref.id is None:
+        # Legacy replay path: in-flight tokens minted before the refs-only
+        # cutover. Use the inline url/headers from the claim. New tokens
+        # always carry ``id`` and never hit this branch.
+        if not ref.url:
+            raise ToolError(f"User MCP server '{server_name}' missing url")
         config_dict: MCPHttpServerConfig = {
             "type": "http",
-            "name": server_config.name,
-            "url": server_config.url,
-            "transport": server_config.transport,
-            "headers": server_config.headers,
+            "name": ref.name,
+            "url": ref.url,
+            "transport": ref.transport,
+            "headers": ref.headers,
         }
-        if server_config.timeout is not None:
-            config_dict["timeout"] = server_config.timeout
+        if ref.timeout is not None:
+            config_dict["timeout"] = ref.timeout
+    else:
+        async with AgentPresetService.with_session(role=role) as svc:
+            refs = await svc.resolve_mcp_integration_refs([str(ref.id)])
+            if not refs:
+                raise ToolError(f"MCP integration {ref.id} not found")
+            metadata = refs[0]
+            if not is_http_mcp_server(metadata):
+                raise ToolError(
+                    f"User MCP server '{server_name}' is not an HTTP server"
+                )
+            secrets = await svc.resolve_mcp_integration_secrets(ref.id)
+        config_dict = {
+            "type": "http",
+            "name": metadata["name"],
+            "url": metadata["url"],
+            "transport": metadata.get("transport", "http"),
+            "headers": secrets or {},
+        }
+        timeout = metadata.get("timeout")
+        if timeout is not None:
+            config_dict["timeout"] = timeout
 
+    try:
         client = UserMCPClient([config_dict])
         result = await client.call_tool(server_name, tool_name, args)
 

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -38,6 +38,8 @@ from tracecat.exceptions import (
     BuiltinRegistryHasNoSelectionError,
     EntitlementRequired,
     ExecutionError,
+    TracecatNotFoundError,
+    TracecatValidationError,
 )
 from tracecat.logger import logger
 from tracecat.registry.lock.service import RegistryLockService
@@ -196,16 +198,28 @@ async def execute_user_mcp_tool(
         if ref.timeout is not None:
             config_dict["timeout"] = ref.timeout
     else:
-        async with AgentPresetService.with_session(role=role) as svc:
-            refs = await svc.resolve_mcp_integration_refs([str(ref.id)])
-            if not refs:
-                raise ToolError(f"MCP integration {ref.id} not found")
-            metadata = refs[0]
-            if not is_http_mcp_server(metadata):
-                raise ToolError(
-                    f"User MCP server '{server_name}' is not an HTTP server"
-                )
-            secrets = await svc.resolve_mcp_integration_secrets(ref.id)
+        try:
+            async with AgentPresetService.with_session(role=role) as svc:
+                refs = await svc.resolve_mcp_integration_refs([str(ref.id)])
+                if not refs:
+                    raise ToolError(f"MCP integration {ref.id} not found")
+                metadata = refs[0]
+                if not is_http_mcp_server(metadata):
+                    raise ToolError(
+                        f"User MCP server '{server_name}' is not an HTTP server"
+                    )
+                secrets = await svc.resolve_mcp_integration_secrets(ref.id)
+        except ToolError:
+            raise
+        except (TracecatValidationError, TracecatNotFoundError) as e:
+            raise ToolError(f"MCP integration {ref.id} is unavailable: {e}") from None
+        except Exception:
+            logger.exception(
+                "Unexpected error resolving MCP integration",
+                mcp_integration_id=str(ref.id),
+                server_name=server_name,
+            )
+            raise ToolError(f"MCP integration {ref.id} could not be resolved") from None
         config_dict = {
             "type": "http",
             # Keep the call-time routing key stable. The DB row's display name

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -208,7 +208,10 @@ async def execute_user_mcp_tool(
             secrets = await svc.resolve_mcp_integration_secrets(ref.id)
         config_dict = {
             "type": "http",
-            "name": metadata["name"],
+            # Keep the call-time routing key stable. The DB row's display name
+            # may have changed after tools were discovered or while a run was
+            # paused, but the runtime still calls the claimed server name.
+            "name": ref.name,
             "url": metadata["url"],
             "transport": metadata.get("transport", "http"),
             "headers": secrets or {},

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -30,6 +30,7 @@ from tracecat.agent.mcp.internal_tools import (
 )
 from tracecat.agent.mcp.user_client import UserMCPClient
 from tracecat.agent.mcp.utils import normalize_mcp_tool_name
+from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.tokens import MCPTokenClaims, verify_mcp_token
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
@@ -180,8 +181,6 @@ async def execute_user_mcp_tool(
 
     # Resolve metadata + secrets per call. Both come from the DB; no
     # secrets are carried through the claim itself.
-    from tracecat.agent.preset.service import AgentPresetService
-
     if ref.id is None:
         # Legacy replay path: in-flight tokens minted before the refs-only
         # cutover. Use the inline url/headers from the claim. New tokens

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import uuid
 
 import sqlalchemy as sa
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 from sqlalchemy import select
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
+from tracecat.agent.common.types import MCPServerConfig
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.service import AgentManagementService
 from tracecat.agent.workflow_config import agent_config_to_payload
@@ -59,6 +60,36 @@ async def resolve_agent_preset_config_activity(
             preset_version=args.preset_version,
         ) as config:
             return agent_config_to_payload(config)
+
+
+class ResolveAiAgentMcpIntegrationsActivityInput(BaseModel):
+    role: Role
+    mcp_integration_ids: list[str]
+
+
+class ResolveAiAgentMcpIntegrationsActivityResult(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    mcp_servers: list[MCPServerConfig] | None = None
+    """Partial MCP server configs (no secrets). Each carries its source ``id``
+    so trusted callers can re-resolve secrets per use."""
+
+
+@activity.defn
+async def resolve_ai_agent_mcp_integrations_activity(
+    args: ResolveAiAgentMcpIntegrationsActivityInput,
+) -> ResolveAiAgentMcpIntegrationsActivityResult:
+    """Resolve ``core.ai.agent`` MCP integration IDs into partial server configs.
+
+    Activity-scope sibling of preset resolution. Returns metadata only —
+    no headers, no stdio env. The trusted MCP server fetches secrets per
+    call via :meth:`AgentPresetService.resolve_mcp_integration_secrets`.
+    """
+    async with AgentPresetService.with_session(role=args.role) as service:
+        # Validates IDs exist in the workspace before resolving.
+        await service.validate_mcp_integrations(args.mcp_integration_ids)
+        servers = await service.resolve_mcp_integration_refs(args.mcp_integration_ids)
+    return ResolveAiAgentMcpIntegrationsActivityResult(mcp_servers=servers)
 
 
 @activity.defn

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import uuid
 
 import sqlalchemy as sa
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, model_validator
 from sqlalchemy import select
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
-from tracecat.agent.common.types import MCPServerConfig
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.service import AgentManagementService
 from tracecat.agent.workflow_config import agent_config_to_payload
@@ -60,36 +59,6 @@ async def resolve_agent_preset_config_activity(
             preset_version=args.preset_version,
         ) as config:
             return agent_config_to_payload(config)
-
-
-class ResolveAiAgentMcpIntegrationsActivityInput(BaseModel):
-    role: Role
-    mcp_integration_ids: list[str]
-
-
-class ResolveAiAgentMcpIntegrationsActivityResult(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    mcp_servers: list[MCPServerConfig] | None = None
-    """Partial MCP server configs (no secrets). Each carries its source ``id``
-    so trusted callers can re-resolve secrets per use."""
-
-
-@activity.defn
-async def resolve_ai_agent_mcp_integrations_activity(
-    args: ResolveAiAgentMcpIntegrationsActivityInput,
-) -> ResolveAiAgentMcpIntegrationsActivityResult:
-    """Resolve ``core.ai.agent`` MCP integration IDs into partial server configs.
-
-    Activity-scope sibling of preset resolution. Returns metadata only —
-    no headers, no stdio env. The trusted MCP server fetches secrets per
-    call via :meth:`AgentPresetService.resolve_mcp_integration_secrets`.
-    """
-    async with AgentPresetService.with_session(role=args.role) as service:
-        # Validates IDs exist in the workspace before resolving.
-        await service.validate_mcp_integrations(args.mcp_integration_ids)
-        servers = await service.resolve_mcp_integration_refs(args.mcp_integration_ids)
-    return ResolveAiAgentMcpIntegrationsActivityResult(mcp_servers=servers)
 
 
 @activity.defn

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -679,6 +679,7 @@ class AgentPresetService(BaseWorkspaceService):
                     "type": "stdio",
                     "name": mcp_integration.slug,
                     "command": mcp_integration.stdio_command,
+                    "id": str(mcp_integration.id),
                 }
                 if mcp_integration.stdio_args:
                     command_config["args"] = mcp_integration.stdio_args
@@ -837,6 +838,7 @@ class AgentPresetService(BaseWorkspaceService):
                 "name": mcp_integration.name,
                 "url": mcp_integration.server_uri,
                 "headers": headers,
+                "id": str(mcp_integration.id),
             }
             if mcp_integration.timeout is not None:
                 http_config["timeout"] = mcp_integration.timeout
@@ -848,6 +850,216 @@ class AgentPresetService(BaseWorkspaceService):
             )
 
         return mcp_servers
+
+    async def resolve_mcp_integration_refs(
+        self, mcp_integrations: list[str] | None
+    ) -> list[MCPServerConfig] | None:
+        """Resolve MCP integration IDs into ``MCPServerConfig``s without secrets.
+
+        Returns metadata only — ``headers`` and stdio ``env`` are intentionally
+        omitted. Each config carries its source ``id`` so trusted callers can
+        re-resolve secrets per use via :meth:`resolve_mcp_integration_secrets`.
+
+        Safe to serialize across Temporal boundaries.
+
+        Returns ``None`` when ``mcp_integrations`` is empty. Raises
+        ``TracecatValidationError`` when at least one integration was
+        requested but none could be resolved — mirrors the behavior of
+        :meth:`resolve_mcp_integrations`.
+        """
+        if not mcp_integrations:
+            return None
+
+        integrations_service = IntegrationService(self.session, role=self.role)
+        available = await integrations_service.list_mcp_integrations()
+        by_id = {integration.id: integration for integration in available}
+
+        refs: list[MCPServerConfig] = []
+        for mcp_id_str in mcp_integrations:
+            try:
+                mcp_integration_id = uuid.UUID(mcp_id_str)
+            except ValueError:
+                logger.warning(
+                    "Invalid MCP integration ID format, skipping: %r",
+                    mcp_id_str,
+                    extra={
+                        "workspace_id": str(self.workspace_id),
+                        "mcp_id": mcp_id_str,
+                    },
+                )
+                continue
+
+            mcp_integration = by_id.get(mcp_integration_id)
+            if mcp_integration is None:
+                logger.warning(
+                    "MCP integration not found, skipping: %r",
+                    mcp_integration_id,
+                    extra={
+                        "workspace_id": str(self.workspace_id),
+                        "mcp_integration_id": str(mcp_integration_id),
+                    },
+                )
+                continue
+
+            if mcp_integration.server_type == "stdio":
+                if not mcp_integration.stdio_command:
+                    logger.warning(
+                        "Stdio MCP integration %r has no stdio_command, skipping",
+                        mcp_integration.name,
+                        extra={
+                            "workspace_id": str(self.workspace_id),
+                            "mcp_integration_id": str(mcp_integration.id),
+                        },
+                    )
+                    continue
+                stdio_ref: MCPServerConfig = {
+                    "type": "stdio",
+                    "name": mcp_integration.slug,
+                    "command": mcp_integration.stdio_command,
+                    "id": str(mcp_integration.id),
+                }
+                if mcp_integration.stdio_args:
+                    stdio_ref["args"] = mcp_integration.stdio_args
+                if mcp_integration.timeout is not None:
+                    stdio_ref["timeout"] = mcp_integration.timeout
+                refs.append(stdio_ref)
+                continue
+
+            if not mcp_integration.server_uri:
+                logger.warning(
+                    "HTTP MCP integration %r has no server_uri, skipping",
+                    mcp_integration.name,
+                    extra={
+                        "workspace_id": str(self.workspace_id),
+                        "mcp_integration_id": str(mcp_integration.id),
+                    },
+                )
+                continue
+            http_ref: MCPHttpServerConfig = {
+                "type": "http",
+                "name": mcp_integration.name,
+                "url": mcp_integration.server_uri,
+                "id": str(mcp_integration.id),
+            }
+            if mcp_integration.timeout is not None:
+                http_ref["timeout"] = mcp_integration.timeout
+            refs.append(http_ref)
+
+        if not refs:
+            raise TracecatValidationError(
+                "No matching MCP integrations found in the workspace"
+            )
+
+        return refs
+
+    async def resolve_mcp_integration_secrets(
+        self, mcp_integration_id: uuid.UUID
+    ) -> dict[str, str] | None:
+        """Resolve the secret material for a single MCP integration.
+
+        Returns the headers/env dict (depending on server type) freshly
+        decrypted, with OAuth tokens refreshed if applicable. Returns
+        ``None`` if the integration cannot be authenticated or is not found.
+
+        Call this at the trusted edge per use — never propagate the result
+        across a Temporal boundary.
+        """
+        integrations_service = IntegrationService(self.session, role=self.role)
+        available = await integrations_service.list_mcp_integrations()
+        mcp_integration = next(
+            (i for i in available if i.id == mcp_integration_id), None
+        )
+        if mcp_integration is None:
+            logger.warning(
+                "MCP integration not found",
+                extra={
+                    "workspace_id": str(self.workspace_id),
+                    "mcp_integration_id": str(mcp_integration_id),
+                },
+            )
+            return None
+
+        if mcp_integration.server_type == "stdio":
+            stdio_env = integrations_service.decrypt_stdio_env(mcp_integration)
+            if not stdio_env:
+                return None
+            try:
+                return await self._resolve_stdio_env(
+                    stdio_env=stdio_env,
+                    mcp_integration_id=mcp_integration.id,
+                    mcp_integration_slug=mcp_integration.slug,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Stdio env resolution failed for MCP integration %r: %s",
+                    mcp_integration.name,
+                    str(e),
+                    extra={
+                        "workspace_id": str(self.workspace_id),
+                        "mcp_integration_id": str(mcp_integration.id),
+                    },
+                )
+                return None
+
+        # HTTP server — resolve headers per auth type.
+        encryption_key = get_db_encryption_key()
+        headers: dict[str, str] = {}
+
+        if mcp_integration.auth_type == MCPAuthType.OAUTH2:
+            if not mcp_integration.oauth_integration_id:
+                return None
+            stmt = select(OAuthIntegration).where(
+                OAuthIntegration.id == mcp_integration.oauth_integration_id,
+                OAuthIntegration.workspace_id == self.workspace_id,
+            )
+            result = await self.session.execute(stmt)
+            oauth_integration = result.scalars().first()
+            if not oauth_integration:
+                return None
+            await integrations_service.refresh_token_if_needed(oauth_integration)
+            access_token = await integrations_service.get_access_token(
+                oauth_integration
+            )
+            if not access_token:
+                return None
+            token_type = oauth_integration.token_type or "Bearer"
+            headers["Authorization"] = f"{token_type} {access_token.get_secret_value()}"
+
+            if mcp_integration.encrypted_headers:
+                custom_headers = self._decrypt_mcp_headers(
+                    encrypted_headers=mcp_integration.encrypted_headers,
+                    encryption_key=encryption_key,
+                    mcp_integration_id=mcp_integration.id,
+                    mcp_integration_name=mcp_integration.name,
+                )
+                if custom_headers:
+                    # Drop any user-supplied Authorization header — the OAuth
+                    # one wins.
+                    for key in list(custom_headers):
+                        if key.strip().casefold() == "authorization":
+                            custom_headers.pop(key, None)
+                    headers.update(custom_headers)
+
+        elif mcp_integration.auth_type == MCPAuthType.CUSTOM:
+            if not mcp_integration.encrypted_headers:
+                return None
+            custom_headers = self._decrypt_mcp_headers(
+                encrypted_headers=mcp_integration.encrypted_headers,
+                encryption_key=encryption_key,
+                mcp_integration_id=mcp_integration.id,
+                mcp_integration_name=mcp_integration.name,
+            )
+            if not custom_headers:
+                return None
+            headers.update(custom_headers)
+
+        elif mcp_integration.auth_type == MCPAuthType.NONE:
+            pass
+
+        else:
+            return None
+
+        return headers
 
     async def _resolve_stdio_env(
         self,
@@ -1405,7 +1617,11 @@ class AgentPresetService(BaseWorkspaceService):
     async def _version_to_agent_config(
         self, version: AgentPresetVersion
     ) -> AgentConfig:
-        mcp_servers = await self.resolve_mcp_integrations(version.mcp_integrations)
+        # Resolve refs only — no headers / stdio env. The resulting
+        # AgentConfig is safe to cross Temporal boundaries. Trusted callers
+        # (build_tool_definitions, trusted MCP server) re-resolve secrets
+        # per use via resolve_mcp_integration_secrets.
+        mcp_servers = await self.resolve_mcp_integration_refs(version.mcp_integrations)
         model_settings: dict[str, Any] = {}
         resolved_skills = await self.skills.get_resolved_skill_refs_for_preset_version(
             version.id

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -912,6 +912,26 @@ class AgentPresetService(BaseWorkspaceService):
                         },
                     )
                     continue
+                # Re-validate command policy at resolution time so rows that
+                # predate tighter rules are rejected here rather than at spawn.
+                try:
+                    validate_mcp_command_config(
+                        command=mcp_integration.stdio_command,
+                        args=mcp_integration.stdio_args,
+                        env=None,
+                        name=mcp_integration.slug,
+                    )
+                except MCPValidationError as e:
+                    logger.warning(
+                        "Stdio MCP integration %r failed command validation, skipping: %s",
+                        mcp_integration.name,
+                        str(e),
+                        extra={
+                            "workspace_id": str(self.workspace_id),
+                            "mcp_integration_id": str(mcp_integration.id),
+                        },
+                    )
+                    continue
                 stdio_ref: MCPServerConfig = {
                     "type": "stdio",
                     "name": mcp_integration.slug,

--- a/tracecat/agent/tokens.py
+++ b/tracecat/agent/tokens.py
@@ -70,9 +70,13 @@ class UserMCPServerClaim(BaseModel):
     # --- Legacy fields kept for replay of in-flight tokens. ---
     # New mint paths leave these unset. Trusted server reads only (name, id).
     url: str | None = None
+    """HTTP/SSE endpoint URL."""
     transport: Literal["http", "sse"] = "http"
+    """Transport type: 'http' or 'sse'."""
     headers: dict[str, str] = Field(default_factory=dict)
+    """Auth headers."""
     timeout: int | None = None
+    """Optional request timeout in seconds."""
 
 
 class InternalToolContext(BaseModel):

--- a/tracecat/agent/tokens.py
+++ b/tracecat/agent/tokens.py
@@ -47,18 +47,32 @@ MCP_REQUIRED_CLAIMS = (
 
 
 class UserMCPServerClaim(BaseModel):
-    """User MCP server configuration in JWT claims."""
+    """User MCP server reference in JWT claims.
+
+    Carries only non-secret identifiers. Headers (OAuth bearers, custom
+    auth) are resolved fresh by the trusted MCP server at call time via the
+    source ``id``.
+
+    The legacy ``url``/``transport``/``headers``/``timeout`` fields are
+    kept here so in-flight JWTs and Temporal activity outputs serialized
+    before this change still validate on replay. New mint paths set only
+    ``(name, id)``; trusted-server code paths use ``id``.
+    """
+
+    model_config = ConfigDict(extra="ignore")
 
     name: str
     """Unique identifier for the server."""
-    url: str
-    """HTTP/SSE endpoint URL."""
+    id: uuid.UUID | None = None
+    """UUID of the source ``mcp_integrations`` row. Required on new tokens;
+    optional only to support replay of pre-rollout tokens that lack it."""
+
+    # --- Legacy fields kept for replay of in-flight tokens. ---
+    # New mint paths leave these unset. Trusted server reads only (name, id).
+    url: str | None = None
     transport: Literal["http", "sse"] = "http"
-    """Transport type: 'http' or 'sse'."""
     headers: dict[str, str] = Field(default_factory=dict)
-    """Auth headers."""
     timeout: int | None = None
-    """Optional request timeout in seconds."""
 
 
 class InternalToolContext(BaseModel):
@@ -165,7 +179,9 @@ def mint_mcp_token(
         payload["parent_agent_run_id"] = parent_agent_run_id
 
     if user_mcp_servers:
-        payload["user_mcp_servers"] = [s.model_dump() for s in user_mcp_servers]
+        payload["user_mcp_servers"] = [
+            s.model_dump(mode="json") for s in user_mcp_servers
+        ]
 
     if allowed_internal_tools:
         payload["allowed_internal_tools"] = allowed_internal_tools

--- a/tracecat/agent/workflow_config.py
+++ b/tracecat/agent/workflow_config.py
@@ -34,6 +34,7 @@ def _mcp_server_to_payload(
                 args=server.get("args"),
                 env=server.get("env"),
                 timeout=server.get("timeout"),
+                id=server.get("id"),
             )
         case {
             "name": str(name),
@@ -46,6 +47,7 @@ def _mcp_server_to_payload(
                 headers=server.get("headers"),
                 transport=server.get("transport"),
                 timeout=server.get("timeout"),
+                id=server.get("id"),
             )
         case _:
             raise ValueError(f"Unsupported MCP server config: {server!r}")
@@ -65,6 +67,8 @@ def _mcp_server_from_payload(server: MCPServerConfigPayload) -> MCPServerConfig:
                 stdio_server["env"] = server.env
             if server.timeout is not None:
                 stdio_server["timeout"] = server.timeout
+            if server.id is not None:
+                stdio_server["id"] = server.id
             return stdio_server
         case MCPHttpServerConfigPayload():
             http_server: MCPHttpServerConfig = {
@@ -78,6 +82,8 @@ def _mcp_server_from_payload(server: MCPServerConfigPayload) -> MCPServerConfig:
                 http_server["transport"] = server.transport
             if server.timeout is not None:
                 http_server["timeout"] = server.timeout
+            if server.id is not None:
+                http_server["id"] = server.id
             return http_server
 
 

--- a/tracecat/agent/workflow_schemas.py
+++ b/tracecat/agent/workflow_schemas.py
@@ -39,6 +39,10 @@ class MCPHttpServerConfigPayload(BaseModel):
     headers: dict[str, str] | None = Field(default=None)
     transport: Literal["http", "sse"] | None = Field(default=None)
     timeout: int | None = Field(default=None)
+    id: str | None = Field(default=None)
+    """UUID of the source ``mcp_integrations`` row. Lets trusted callers
+    re-resolve secrets per use without carrying them through workflow
+    history."""
 
 
 class MCPStdioServerConfigPayload(BaseModel):
@@ -52,6 +56,9 @@ class MCPStdioServerConfigPayload(BaseModel):
     args: list[str] | None = Field(default=None)
     env: dict[str, str] | None = Field(default=None)
     timeout: int | None = Field(default=None)
+    id: str | None = Field(default=None)
+    """UUID of the source ``mcp_integrations`` row. See
+    :class:`MCPHttpServerConfigPayload.id`."""
 
 
 type MCPServerConfigPayload = Annotated[

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -37,7 +37,7 @@ from tracecat.dsl.schemas import (
 )
 from tracecat.dsl.types import ActionErrorInfo, ActionErrorInfoAdapter
 from tracecat.dsl.validation import normalize_trigger_inputs
-from tracecat.exceptions import TracecatExpressionError
+from tracecat.exceptions import TracecatExpressionError, TracecatValidationError
 from tracecat.executor.service import get_workspace_variables
 from tracecat.expressions.common import ExprContext
 from tracecat.expressions.core import TemplateExpression
@@ -49,6 +49,7 @@ from tracecat.expressions.eval import (
 )
 from tracecat.expressions.schemas import ExpectedField
 from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.integrations.mcp_validation import MCPValidationError
 from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage.collection import (
@@ -71,12 +72,15 @@ from tracecat.validation.schemas import ValidationDetail
 _thread_local = threading.local()
 
 
-async def _resolve_mcp_integration_ids(
+async def _resolve_mcp_integrations(
     mcp_integration_ids: list[str], *, role: Role
 ) -> list[MCPServerConfig]:
-    async with AgentPresetService.with_session(role=role) as svc:
-        await svc.validate_mcp_integrations(mcp_integration_ids)
-        servers = await svc.resolve_mcp_integration_refs(mcp_integration_ids)
+    try:
+        async with AgentPresetService.with_session(role=role) as svc:
+            await svc.validate_mcp_integrations(mcp_integration_ids)
+            servers = await svc.resolve_mcp_integration_refs(mcp_integration_ids)
+    except (MCPValidationError, TracecatValidationError) as e:
+        raise ApplicationError(str(e), non_retryable=True) from e
     return servers or []
 
 
@@ -669,7 +673,7 @@ class DSLActivities:
         )
         mcp_integration_ids = evaled_args.pop("mcp_integrations", None)
         if mcp_integration_ids:
-            evaled_args["mcp_servers"] = await _resolve_mcp_integration_ids(
+            evaled_args["mcp_servers"] = await _resolve_mcp_integrations(
                 mcp_integration_ids, role=input.role
             )
         return AgentActionArgs(**evaled_args)

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -12,6 +12,8 @@ from temporalio.exceptions import ApplicationError
 from tracecat_ee.agent.schemas import AgentActionArgs, PresetAgentActionArgs
 
 from tracecat import config
+from tracecat.agent.common.types import MCPServerConfig
+from tracecat.agent.preset.service import AgentPresetService
 from tracecat.auth.types import Role
 from tracecat.common import is_iterable
 from tracecat.dsl.common import (
@@ -67,6 +69,15 @@ from tracecat.temporal.exceptions import UserError
 from tracecat.validation.schemas import ValidationDetail
 
 _thread_local = threading.local()
+
+
+async def _resolve_mcp_integration_ids(
+    mcp_integration_ids: list[str], *, role: Role
+) -> list[MCPServerConfig]:
+    async with AgentPresetService.with_session(role=role) as svc:
+        await svc.validate_mcp_integrations(mcp_integration_ids)
+        servers = await svc.resolve_mcp_integration_refs(mcp_integration_ids)
+    return servers or []
 
 
 def _strip_string_values(args: dict[str, Any]) -> dict[str, Any]:
@@ -656,6 +667,11 @@ class DSLActivities:
         evaled_args = await asyncio.to_thread(
             eval_templated_object, args, operand=materialized
         )
+        mcp_integration_ids = evaled_args.pop("mcp_integrations", None)
+        if mcp_integration_ids:
+            evaled_args["mcp_servers"] = await _resolve_mcp_integration_ids(
+                mcp_integration_ids, role=input.role
+            )
         return AgentActionArgs(**evaled_args)
 
     @staticmethod

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -21,7 +21,6 @@ with workflow.unsafe.imports_passed_through():
     from tracecat import config
     from tracecat.agent.preset.activities import (
         resolve_agent_preset_version_ref_activity,
-        resolve_ai_agent_mcp_integrations_activity,
     )
     from tracecat.dsl.action import DSLActivities
     from tracecat.dsl.client import get_temporal_client
@@ -92,7 +91,6 @@ def get_activities() -> list[Callable]:
         *DSLActivities.load(),
         *CollectionActivities.get_activities(),
         resolve_agent_preset_version_ref_activity,
-        resolve_ai_agent_mcp_integrations_activity,
         get_workflow_definition_activity,
         resolve_registry_lock_activity,
         get_workspace_organization_id_activity,

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -21,6 +21,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat import config
     from tracecat.agent.preset.activities import (
         resolve_agent_preset_version_ref_activity,
+        resolve_ai_agent_mcp_integrations_activity,
     )
     from tracecat.dsl.action import DSLActivities
     from tracecat.dsl.client import get_temporal_client
@@ -91,6 +92,7 @@ def get_activities() -> list[Callable]:
         *DSLActivities.load(),
         *CollectionActivities.get_activities(),
         resolve_agent_preset_version_ref_activity,
+        resolve_ai_agent_mcp_integrations_activity,
         get_workflow_definition_activity,
         resolve_registry_lock_activity,
         get_workspace_organization_id_activity,

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -38,7 +38,9 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.aliases import build_agent_alias
     from tracecat.agent.preset.activities import (
         ResolveAgentPresetVersionRefActivityInput,
+        ResolveAiAgentMcpIntegrationsActivityInput,
         resolve_agent_preset_version_ref_activity,
+        resolve_ai_agent_mcp_integrations_activity,
     )
     from tracecat.agent.schemas import RunAgentArgs
     from tracecat.agent.session.types import AgentSessionEntity
@@ -963,6 +965,18 @@ class DSLWorkflow:
                         start_to_close_timeout=timedelta(seconds=60),
                         retry_policy=RETRY_POLICIES["activity:fail_fast"],
                     )
+                    mcp_servers = None
+                    if action_args.mcp_integrations:
+                        mcp_result = await workflow.execute_activity(
+                            resolve_ai_agent_mcp_integrations_activity,
+                            arg=ResolveAiAgentMcpIntegrationsActivityInput(
+                                role=self.role,
+                                mcp_integration_ids=list(action_args.mcp_integrations),
+                            ),
+                            start_to_close_timeout=timedelta(seconds=30),
+                            retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                        )
+                        mcp_servers = mcp_result.mcp_servers
                     wf_info = workflow.info()
                     child_search_attributes = _build_agent_child_search_attributes(
                         wf_info, task.ref
@@ -985,6 +999,7 @@ class DSLWorkflow:
                                 base_url=action_args.base_url,
                                 actions=action_args.actions,
                                 tool_approvals=action_args.tool_approvals,
+                                mcp_servers=mcp_servers,
                             ),
                             max_requests=action_args.max_requests,
                             max_tool_calls=action_args.max_tool_calls,

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -38,9 +38,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.aliases import build_agent_alias
     from tracecat.agent.preset.activities import (
         ResolveAgentPresetVersionRefActivityInput,
-        ResolveAiAgentMcpIntegrationsActivityInput,
         resolve_agent_preset_version_ref_activity,
-        resolve_ai_agent_mcp_integrations_activity,
     )
     from tracecat.agent.schemas import RunAgentArgs
     from tracecat.agent.session.types import AgentSessionEntity
@@ -965,18 +963,6 @@ class DSLWorkflow:
                         start_to_close_timeout=timedelta(seconds=60),
                         retry_policy=RETRY_POLICIES["activity:fail_fast"],
                     )
-                    mcp_servers = None
-                    if action_args.mcp_integrations:
-                        mcp_result = await workflow.execute_activity(
-                            resolve_ai_agent_mcp_integrations_activity,
-                            arg=ResolveAiAgentMcpIntegrationsActivityInput(
-                                role=self.role,
-                                mcp_integration_ids=list(action_args.mcp_integrations),
-                            ),
-                            start_to_close_timeout=timedelta(seconds=30),
-                            retry_policy=RETRY_POLICIES["activity:fail_fast"],
-                        )
-                        mcp_servers = mcp_result.mcp_servers
                     wf_info = workflow.info()
                     child_search_attributes = _build_agent_child_search_attributes(
                         wf_info, task.ref
@@ -999,7 +985,7 @@ class DSLWorkflow:
                                 base_url=action_args.base_url,
                                 actions=action_args.actions,
                                 tool_approvals=action_args.tool_approvals,
-                                mcp_servers=mcp_servers,
+                                mcp_servers=action_args.mcp_servers,
                             ),
                             max_requests=action_args.max_requests,
                             max_tool_calls=action_args.max_tool_calls,

--- a/tracecat/registry/fields.py
+++ b/tracecat/registry/fields.py
@@ -26,6 +26,7 @@ class ComponentID(StrEnum):
     YAML = "yaml"
     ACTION_TYPE = "action-type"
     WORKFLOW_ALIAS = "workflow-alias"
+    MCP_INTEGRATION = "mcp-integration"
 
 
 @dataclass(slots=True)
@@ -135,6 +136,14 @@ class WorkflowAlias(Component):
     """Render field as workflow alias dropdown in UI"""
 
     component_id: Literal[ComponentID.WORKFLOW_ALIAS] = ComponentID.WORKFLOW_ALIAS
+
+
+@dataclass(slots=True)
+class MCPIntegration(Component):
+    """Render field as saved MCP integration picker in UI"""
+
+    component_id: Literal[ComponentID.MCP_INTEGRATION] = ComponentID.MCP_INTEGRATION
+    multiple: bool = True
 
 
 def _safe_issubclass(cls: type, base: type) -> bool:
@@ -300,6 +309,7 @@ class EditorComponent(RootModel):
         | ActionType
         | WorkflowAlias
         | AgentPreset
-        | AgentModel,
+        | AgentModel
+        | MCPIntegration,
         Field(discriminator="component_id"),
     ]


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds secure MCP support to `ai.agent` with saved `mcp_integrations`, refs‑only `mcp_servers` (carry `id`, no secrets) across workflow/JWT boundaries, and per‑call secret resolution at the trusted edge. Hydrates stdio envs at runtime, keeps routing stable on integration rename, re‑validates stdio commands at resolution, and returns clear ToolErrors when an integration is missing or unavailable.

- **New Features**
  - UI: added `mcp-integrations` to agents and presets with a `mcp-integration` builder field (multi‑select, provider icons, workspace‑scoped).
  - Flow: `build_agent_args_activity` resolves `mcp_integrations` to refs‑only `mcp_servers` (with `id`, no secrets) and workflow payloads now carry `id`; HTTP headers are hydrated only for `tools/list` and then dropped; stdio `env` is hydrated just before runtime; JWT claims now use `(name, id)` with legacy claim shapes still accepted; the trusted MCP server re‑resolves metadata and secrets per call, routes by the claimed server name, and converts lookup/validation failures to ToolError. (The separate MCP‑resolve activity was removed.)

- **Migration**
  - Configure MCP integrations in the workspace; invalid or missing IDs will error.
  - Requires the `agent_addons` entitlement for `mcp_integrations` (and `tool_approvals`).
  - Stdio MCP command policy is enforced at resolution time; previously saved disallowed commands will now be rejected.

<sup>Written for commit 8defaa607622187592da727702ddbb932f987442. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<img width="233" height="407" alt="image" src="https://github.com/user-attachments/assets/2a7ed967-b80e-4de4-a2c9-eb5961c8e951" />

