### PR TITLE
fix(auth): treat superusers as tenant users

### DIFF
--- a/frontend/src/app/workspaces/layout.tsx
+++ b/frontend/src/app/workspaces/layout.tsx
@@ -47,6 +47,7 @@ export default function WorkspaceLayout({
   children: React.ReactNode
 }) {
   const router = useRouter()
+  const { user, userIsLoading } = useAuth()
   const {
     workspaces,
     workspacesLoading,
@@ -90,6 +91,8 @@ export default function WorkspaceLayout({
     }
     return lastViewedWorkspaceId ?? workspaces[0]?.id
   }, [lastViewedWorkspaceId, workspaces])
+  const hasNoOrgMemberships =
+    workspacesError && isNoOrgMembershipsError(workspacesError)
 
   useEffect(() => {
     if (
@@ -111,10 +114,20 @@ export default function WorkspaceLayout({
     workspacesLoading,
   ])
 
+  useEffect(() => {
+    if (!hasNoOrgMemberships || userIsLoading || !user?.isSuperuser) {
+      return
+    }
+    router.replace("/admin")
+  }, [hasNoOrgMemberships, router, user?.isSuperuser, userIsLoading])
+
   if (workspacesLoading) {
     return <CenteredSpinner />
   }
-  if (workspacesError && isNoOrgMembershipsError(workspacesError)) {
+  if (hasNoOrgMemberships) {
+    if (userIsLoading || user?.isSuperuser) {
+      return <CenteredSpinner />
+    }
     return <NoOrganizationAccess />
   }
   if (workspacesError || !workspaces) {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -3904,7 +3904,7 @@ export const organizationGetOrganization =
  * Delete Organization
  * Delete the current organization.
  *
- * Restricted to organization owners and platform superusers.
+ * Restricted to organization owners/admins through tenant RBAC.
  * @param data The data for the request.
  * @param data.confirm Must exactly match the organization name.
  * @returns void Successful Response

--- a/frontend/src/lib/auth-redirect.test.ts
+++ b/frontend/src/lib/auth-redirect.test.ts
@@ -4,14 +4,14 @@ import {
 } from "@/lib/auth-redirect"
 
 describe("getPostAuthRedirectPath", () => {
-  it("forces multi-tenant superusers into admin", () => {
+  it("keeps multi-tenant superusers on normal app routes", () => {
     expect(
       getPostAuthRedirectPath({
         isSuperuser: true,
         eeMultiTenant: true,
         returnUrl: "/workspaces/tenant-path",
       })
-    ).toBe("/admin")
+    ).toBe("/workspaces/tenant-path")
   })
 
   it("honors MCP OAuth continuation paths for multi-tenant superusers", () => {
@@ -41,7 +41,7 @@ describe("getPostAuthRedirectPath", () => {
         eeMultiTenant: true,
         returnUrl: "/oauth/mcp/continue-later?txn=abc123",
       })
-    ).toBe("/admin")
+    ).toBe("/oauth/mcp/continue-later?txn=abc123")
   })
 
   it("keeps single-tenant superusers on normal app routes", () => {

--- a/frontend/src/lib/auth-redirect.ts
+++ b/frontend/src/lib/auth-redirect.ts
@@ -13,16 +13,11 @@ type PostAuthRedirectPathParams = {
  * Resolve the app route an authenticated user should land on after auth.
  */
 export function getPostAuthRedirectPath({
-  isSuperuser,
-  eeMultiTenant,
   returnUrl,
 }: PostAuthRedirectPathParams): string {
   const mcpAuthReturnUrl = normalizeMcpAuthReturnUrl(returnUrl)
   if (mcpAuthReturnUrl) {
     return mcpAuthReturnUrl
-  }
-  if (isSuperuser && eeMultiTenant) {
-    return "/admin"
   }
   return returnUrl ?? "/workspaces"
 }

--- a/frontend/tests/auth-ui-matrix.test.tsx
+++ b/frontend/tests/auth-ui-matrix.test.tsx
@@ -5,7 +5,8 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import HomePage from "@/app/page"
 import SignInPage from "@/app/sign-in/[[...sign-in]]/page"
-import { authDiscoverAuthMethod } from "@/client"
+import WorkspaceLayout from "@/app/workspaces/layout"
+import { ApiError, authDiscoverAuthMethod } from "@/client"
 import { SignIn } from "@/components/auth/sign-in"
 import { SignUp } from "@/components/auth/sign-up"
 import { startOidcLogin } from "@/lib/auth-login"
@@ -25,6 +26,8 @@ const mockLogin = jest.fn()
 const mockLogout = jest.fn()
 const mockRegister = jest.fn()
 let mockSearchParams = new URLSearchParams()
+let mockParams: Record<string, string | undefined> = {}
+let mockPathname = "/workspaces"
 
 let mockUser: { email: string; isSuperuser: boolean } | null = null
 let mockAppInfo: MockAppInfo | undefined = {
@@ -37,10 +40,15 @@ let mockAppInfo: MockAppInfo | undefined = {
 }
 let mockAppInfoIsLoading = false
 let mockAppInfoError: Error | null = null
+let mockWorkspaces: { id: string; name: string }[] | undefined = undefined
+let mockWorkspacesLoading = false
+let mockWorkspacesError: Error | null = null
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockRouterPush, replace: mockRouterReplace }),
   useSearchParams: () => mockSearchParams,
+  useParams: () => mockParams,
+  usePathname: () => mockPathname,
 }))
 
 jest.mock("next/image", () => ({
@@ -70,6 +78,72 @@ jest.mock("@/lib/hooks", () => ({
     appInfoIsLoading: mockAppInfoIsLoading,
     appInfoError: mockAppInfoError,
   }),
+  useWorkspaceManager: () => ({
+    workspaces: mockWorkspaces,
+    workspacesLoading: mockWorkspacesLoading,
+    workspacesError: mockWorkspacesError,
+    setLastWorkspaceId: jest.fn(),
+    getLastWorkspaceId: jest.fn(),
+    createWorkspace: jest.fn(),
+  }),
+}))
+
+jest.mock("@/components/auth/scope-guard", () => ({
+  useScopeCheck: () => true,
+}))
+
+jest.mock("@/hooks/use-pending-org-invitations", () => ({
+  usePendingOrgInvitations: () => ({
+    pendingInvitations: [],
+    pendingInvitationsIsLoading: false,
+    pendingInvitationsError: null,
+  }),
+}))
+
+jest.mock("@xyflow/react", () => ({
+  ReactFlowProvider: ({ children }: { children: JSX.Element }) => children,
+}))
+
+jest.mock("@/components/cases/case-selection-context", () => ({
+  CaseSelectionProvider: ({ children }: { children: JSX.Element }) => children,
+}))
+
+jest.mock("@/components/nav/controls-header", () => ({
+  ControlsHeader: () => null,
+}))
+
+jest.mock("@/components/nav/dynamic-nav", () => ({
+  DynamicNavbar: () => null,
+}))
+
+jest.mock("@/components/settings/settings-modal", () => ({
+  SettingsModal: () => null,
+}))
+
+jest.mock("@/components/sidebar/app-sidebar", () => ({
+  AppSidebar: () => null,
+}))
+
+jest.mock("@/components/ui/sidebar", () => ({
+  SidebarInset: ({ children }: { children: JSX.Element }) => children,
+  SidebarProvider: ({ children }: { children: JSX.Element }) => children,
+}))
+
+jest.mock("@/providers/builder", () => ({
+  WorkflowBuilderProvider: ({ children }: { children: JSX.Element }) =>
+    children,
+}))
+
+jest.mock("@/providers/scopes", () => ({
+  ScopeProvider: ({ children }: { children: JSX.Element }) => children,
+}))
+
+jest.mock("@/providers/workflow", () => ({
+  WorkflowProvider: ({ children }: { children: JSX.Element }) => children,
+}))
+
+jest.mock("@/providers/workspace-id", () => ({
+  WorkspaceIdProvider: ({ children }: { children: JSX.Element }) => children,
 }))
 
 jest.mock("@/lib/auth-login", () => ({
@@ -79,11 +153,15 @@ jest.mock("@/lib/auth-login", () => ({
 
 jest.mock("@/client", () => {
   class MockApiError extends Error {
-    body: { detail: unknown }
+    body: unknown
 
-    constructor(detail: unknown = "") {
-      super("ApiError")
-      this.body = { detail }
+    constructor(
+      _request: unknown,
+      response: { body?: unknown } = {},
+      message = "ApiError"
+    ) {
+      super(message)
+      this.body = response.body
     }
   }
 
@@ -119,6 +197,16 @@ function getDefaultAppInfo(): MockAppInfo {
   }
 }
 
+function getNoOrgMembershipsError(): ApiError {
+  return new ApiError(
+    {} as never,
+    {
+      body: { detail: "User has no organization memberships" },
+    } as never,
+    "ApiError"
+  )
+}
+
 describe("Auth UI matrix", () => {
   const mockDiscoverAuthMethod = authDiscoverAuthMethod as jest.MockedFunction<
     typeof authDiscoverAuthMethod
@@ -136,6 +224,11 @@ describe("Auth UI matrix", () => {
     mockAppInfo = getDefaultAppInfo()
     mockAppInfoIsLoading = false
     mockAppInfoError = null
+    mockParams = {}
+    mockPathname = "/workspaces"
+    mockWorkspaces = undefined
+    mockWorkspacesLoading = false
+    mockWorkspacesError = null
     setAuthTypes(["basic"])
     setMultiTenant(false)
   })
@@ -328,14 +421,46 @@ describe("Auth UI matrix", () => {
     })
   })
 
-  it("redirects authenticated multi-tenant superusers to admin from sign-up", async () => {
+  it("redirects authenticated multi-tenant superusers to workspaces from sign-up", async () => {
     setMultiTenant(true)
     mockUser = { email: "admin@example.com", isSuperuser: true }
 
     render(<SignUp />)
 
     await waitFor(() => {
-      expect(mockRouterPush).toHaveBeenCalledWith("/admin")
+      expect(mockRouterPush).toHaveBeenCalledWith("/workspaces")
     })
+  })
+
+  it("redirects superusers with no organization memberships to admin", async () => {
+    mockUser = { email: "admin@example.com", isSuperuser: true }
+    mockWorkspacesError = getNoOrgMembershipsError()
+
+    render(
+      <WorkspaceLayout>
+        <div>Workspace content</div>
+      </WorkspaceLayout>
+    )
+
+    await waitFor(() => {
+      expect(mockRouterReplace).toHaveBeenCalledWith("/admin")
+    })
+    expect(
+      screen.queryByText("No organization access yet")
+    ).not.toBeInTheDocument()
+  })
+
+  it("keeps regular users with no organization memberships on the help screen", () => {
+    mockUser = { email: "user@example.com", isSuperuser: false }
+    mockWorkspacesError = getNoOrgMembershipsError()
+
+    render(
+      <WorkspaceLayout>
+        <div>Workspace content</div>
+      </WorkspaceLayout>
+    )
+
+    expect(screen.getByText("No organization access yet")).toBeInTheDocument()
+    expect(mockRouterReplace).not.toHaveBeenCalledWith("/admin")
   })
 })

--- a/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
+++ b/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
@@ -421,7 +421,7 @@ async def create_dev_user(
     """Create local development SU and tenant user accounts.
 
     This bypasses public first-user registration on purpose. It is intended for
-    dev clusters where platform superusers cannot enter tenant context.
+    dev clusters that want separate platform-admin and tenant-user accounts.
     """
     if email.lower() == superuser_email.lower():
         raise ValueError("Dev user email must be different from superuser email")

--- a/packages/tracecat-ee/tracecat_ee/admin/organizations/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/organizations/service.py
@@ -6,12 +6,11 @@ import secrets
 import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
-from typing import cast
 
 import sqlalchemy as sa
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError, NoResultFound
-from sqlalchemy.orm import Mapped, selectinload
+from sqlalchemy.orm import selectinload
 
 from tracecat.audit.enums import AuditEventStatus
 from tracecat.audit.service import AuditService
@@ -158,15 +157,6 @@ class AdminOrgService(BasePlatformService):
         """Create a platform-scoped invitation for an organization."""
         await self._require_organization(org_id)
         role_obj = await self._get_org_invitation_role(org_id, params.role_slug)
-
-        existing_superuser = await self.session.scalar(
-            select(User).where(
-                func.lower(User.email) == params.email.lower(),
-                cast(Mapped[bool], User.is_superuser).is_(True),
-            )
-        )
-        if existing_superuser is not None:
-            raise TracecatValidationError("Invitation cannot be created for this email")
 
         existing_member_stmt = (
             select(OrganizationMembership)

--- a/tests/integration/test_install_and_run_custom_remote_registry_flow.py
+++ b/tests/integration/test_install_and_run_custom_remote_registry_flow.py
@@ -19,6 +19,7 @@ from datetime import timedelta
 import pytest
 import requests
 from pydantic import SecretStr, ValidationError
+from sqlalchemy import select
 from temporalio.client import WorkflowFailureError
 from temporalio.common import RetryPolicy
 
@@ -26,6 +27,9 @@ from tests.shared import generate_test_exec_id, to_data
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.contexts import ctx_role
+from tracecat.db.engine import get_async_session_bypass_rls_context_manager
+from tracecat.db.models import OrganizationMembership, User, UserRoleAssignment
+from tracecat.db.models import Role as DBRole
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
 from tracecat.dsl.schemas import ActionStatement
@@ -40,12 +44,68 @@ from tracecat.settings.schemas import GitSettingsUpdate
 GIT_SSH_URL = "git+ssh://git@github.com/TracecatHQ/internal-registry.git"
 KNOWN_GOOD_REMOTE_COMMIT_SHA = "e2bfd94c35c93f8052c2b97ff542961596ddd3f8"
 PLACEHOLDER_TARBALL_URI = "s3://test/test.tar.gz"
+TEST_USER_EMAIL = "test@tracecat.com"
 
 
 def _assert_response_ok(response: requests.Response, action: str) -> None:
     assert response.status_code == 200, (
         f"{action} failed: {response.status_code} - {response.text}"
     )
+
+
+async def _ensure_org_owner_membership(
+    *,
+    email: str,
+    organization_id: uuid.UUID,
+) -> None:
+    async with get_async_session_bypass_rls_context_manager() as db_session:
+        user = await db_session.scalar(
+            select(User).where(User.email == email)  # pyright: ignore[reportArgumentType]
+        )
+        assert user is not None, f"Test user {email} was not found"
+
+        membership = await db_session.scalar(
+            select(OrganizationMembership).where(
+                OrganizationMembership.user_id == user.id,
+                OrganizationMembership.organization_id == organization_id,
+            )
+        )
+        if membership is None:
+            db_session.add(
+                OrganizationMembership(
+                    user_id=user.id,
+                    organization_id=organization_id,
+                )
+            )
+
+        owner_role = await db_session.scalar(
+            select(DBRole).where(
+                DBRole.organization_id == organization_id,
+                DBRole.slug == "organization-owner",
+            )
+        )
+        assert owner_role is not None, "organization-owner role is not seeded"
+
+        assignment = await db_session.scalar(
+            select(UserRoleAssignment).where(
+                UserRoleAssignment.user_id == user.id,
+                UserRoleAssignment.organization_id == organization_id,
+                UserRoleAssignment.workspace_id.is_(None),
+            )
+        )
+        if assignment is None:
+            db_session.add(
+                UserRoleAssignment(
+                    organization_id=organization_id,
+                    user_id=user.id,
+                    workspace_id=None,
+                    role_id=owner_role.id,
+                )
+            )
+        else:
+            assignment.role_id = owner_role.id
+
+        await db_session.commit()
 
 
 def _builtin_versions(
@@ -215,7 +275,7 @@ async def test_remote_custom_registry_repo() -> None:
     # First, try to register the test user (in case it doesn't exist)
     register_response = session.post(
         f"{base_url}/auth/register",
-        json={"email": "test@tracecat.com", "password": "password1234"},
+        json={"email": TEST_USER_EMAIL, "password": "password1234"},
     )
     if register_response.status_code == 201:
         logger.info("Successfully registered test user")
@@ -229,7 +289,7 @@ async def test_remote_custom_registry_repo() -> None:
     # Login with test credentials
     login_response = session.post(
         f"{base_url}/auth/login",
-        data={"username": "test@tracecat.com", "password": "password1234"},
+        data={"username": TEST_USER_EMAIL, "password": "password1234"},
     )
     assert login_response.status_code == 204, f"Login failed: {login_response.text}"
     logger.info("Successfully logged in with test credentials")
@@ -245,6 +305,11 @@ async def test_remote_custom_registry_repo() -> None:
     org_id = orgs_list[0]["id"]
     session.cookies.set("tracecat-org-id", org_id)
     logger.info("Set organization context", organization_id=org_id)
+    await _ensure_org_owner_membership(
+        email=TEST_USER_EMAIL,
+        organization_id=uuid.UUID(org_id),
+    )
+    logger.info("Ensured tenant membership for test user", organization_id=org_id)
 
     logger.info("Ensuring builtin platform registry tarball is synced")
     _sync_builtin_platform_registry(session, base_url)

--- a/tests/integration/test_install_and_run_custom_remote_registry_flow.py
+++ b/tests/integration/test_install_and_run_custom_remote_registry_flow.py
@@ -24,11 +24,18 @@ from temporalio.client import WorkflowFailureError
 from temporalio.common import RetryPolicy
 
 from tests.shared import generate_test_exec_id, to_data
+from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import Role
+from tracecat.auth.users import get_user_db_context, get_user_manager_context
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
-from tracecat.db.models import OrganizationMembership, User, UserRoleAssignment
+from tracecat.db.models import (
+    Organization,
+    OrganizationMembership,
+    User,
+    UserRoleAssignment,
+)
 from tracecat.db.models import Role as DBRole
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import DSLEntrypoint, DSLInput, DSLRunArgs
@@ -45,6 +52,7 @@ GIT_SSH_URL = "git+ssh://git@github.com/TracecatHQ/internal-registry.git"
 KNOWN_GOOD_REMOTE_COMMIT_SHA = "e2bfd94c35c93f8052c2b97ff542961596ddd3f8"
 PLACEHOLDER_TARBALL_URI = "s3://test/test.tar.gz"
 TEST_USER_EMAIL = "test@tracecat.com"
+TEST_USER_PASSWORD = "password1234"
 
 
 def _assert_response_ok(response: requests.Response, action: str) -> None:
@@ -53,16 +61,35 @@ def _assert_response_ok(response: requests.Response, action: str) -> None:
     )
 
 
-async def _ensure_org_owner_membership(
+async def _hash_test_password(*, db_session, password: str) -> str:
+    async with get_user_db_context(db_session) as user_db:
+        async with get_user_manager_context(user_db) as user_manager:
+            return user_manager.password_helper.hash(password)
+
+
+async def _ensure_test_user_access(
     *,
     email: str,
-    organization_id: uuid.UUID,
-) -> None:
+    password: str,
+) -> uuid.UUID:
     async with get_async_session_bypass_rls_context_manager() as db_session:
+        organization_id = await db_session.scalar(
+            select(Organization.id).order_by(Organization.created_at.asc()).limit(1)
+        )
+        assert organization_id is not None, "Default organization was not seeded"
+
         user = await db_session.scalar(
             select(User).where(User.email == email)  # pyright: ignore[reportArgumentType]
         )
         assert user is not None, f"Test user {email} was not found"
+        user.hashed_password = await _hash_test_password(
+            db_session=db_session,
+            password=password,
+        )
+        user.role = UserRole.ADMIN
+        user.is_active = True
+        user.is_verified = True
+        user.is_superuser = True
 
         membership = await db_session.scalar(
             select(OrganizationMembership).where(
@@ -106,6 +133,7 @@ async def _ensure_org_owner_membership(
             assignment.role_id = owner_role.id
 
         await db_session.commit()
+        return organization_id
 
 
 def _builtin_versions(
@@ -275,7 +303,7 @@ async def test_remote_custom_registry_repo() -> None:
     # First, try to register the test user (in case it doesn't exist)
     register_response = session.post(
         f"{base_url}/auth/register",
-        json={"email": TEST_USER_EMAIL, "password": "password1234"},
+        json={"email": TEST_USER_EMAIL, "password": TEST_USER_PASSWORD},
     )
     if register_response.status_code == 201:
         logger.info("Successfully registered test user")
@@ -286,30 +314,27 @@ async def test_remote_custom_registry_repo() -> None:
             f"Registration returned unexpected status: {register_response.status_code} - {register_response.text}"
         )
 
+    org_id = await _ensure_test_user_access(
+        email=TEST_USER_EMAIL,
+        password=TEST_USER_PASSWORD,
+    )
+    logger.info(
+        "Ensured test user has platform and tenant access",
+        organization_id=str(org_id),
+    )
+
     # Login with test credentials
     login_response = session.post(
         f"{base_url}/auth/login",
-        data={"username": TEST_USER_EMAIL, "password": "password1234"},
+        data={"username": TEST_USER_EMAIL, "password": TEST_USER_PASSWORD},
     )
     assert login_response.status_code == 204, f"Login failed: {login_response.text}"
     logger.info("Successfully logged in with test credentials")
 
-    # Set organization context (required for superusers and org-scoped endpoints)
-    # Use the admin endpoint which doesn't require org context
-    orgs_resp = session.get(f"{base_url}/admin/organizations")
-    assert orgs_resp.status_code == 200, (
-        f"Failed to get organizations: {orgs_resp.text}"
-    )
-    orgs_list = orgs_resp.json()
-    assert len(orgs_list) > 0, "No organizations found"
-    org_id = orgs_list[0]["id"]
-    session.cookies.set("tracecat-org-id", org_id)
-    logger.info("Set organization context", organization_id=org_id)
-    await _ensure_org_owner_membership(
-        email=TEST_USER_EMAIL,
-        organization_id=uuid.UUID(org_id),
-    )
-    logger.info("Ensured tenant membership for test user", organization_id=org_id)
+    # Set organization context for org-scoped endpoints. Superuser only grants
+    # /admin access; tenant access is provided by the explicit owner assignment.
+    session.cookies.set("tracecat-org-id", str(org_id))
+    logger.info("Set organization context", organization_id=str(org_id))
 
     logger.info("Ensuring builtin platform registry tarball is synced")
     _sync_builtin_platform_registry(session, base_url)

--- a/tests/unit/test_admin_org_invitations_service.py
+++ b/tests/unit/test_admin_org_invitations_service.py
@@ -183,7 +183,7 @@ async def test_create_organization_invitation_rejects_existing_member(
 
 
 @pytest.mark.anyio
-async def test_create_organization_invitation_rejects_existing_superuser(
+async def test_create_organization_invitation_allows_existing_superuser(
     session: AsyncSession,
     org: Organization,
     org_roles: dict[str, DBRole],
@@ -202,24 +202,20 @@ async def test_create_organization_invitation_rejects_existing_superuser(
     await session.commit()
 
     service = AdminOrgService(session, platform_role)
-    with pytest.raises(
-        TracecatValidationError,
-        match="Invitation cannot be created for this email",
-    ):
-        await service.create_organization_invitation(
-            org.id,
-            AdminOrgInvitationCreate(
-                email=superuser.email,
-                role_slug="organization-member",
-            ),
-        )
+    invitation = await service.create_organization_invitation(
+        org.id,
+        AdminOrgInvitationCreate(
+            email=superuser.email,
+            role_slug="organization-member",
+        ),
+    )
 
     invitation_id = await session.scalar(
         select(OrganizationInvitation.id).where(
             OrganizationInvitation.email == superuser.email
         )
     )
-    assert invitation_id is None
+    assert invitation_id == invitation.id
     assert org_roles["organization-member"].organization_id == org.id
 
 

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -11,12 +11,13 @@ from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
-from tracecat.auth.credentials import RoleACL, _role_dependency
+from tracecat.auth.credentials import RoleACL, _role_dependency, authenticated_user_only
 from tracecat.auth.org_context import resolve_auth_organization_id
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import Role
 from tracecat.authz.enums import WorkspaceRole
 from tracecat.authz.service import MembershipWithOrg
+from tracecat.contexts import ctx_role
 from tracecat.db.models import (
     Membership,
     Organization,
@@ -50,6 +51,36 @@ def test_app():
 def client(test_app):
     """Create a test client."""
     return TestClient(test_app)
+
+
+@pytest.mark.anyio
+async def test_authenticated_user_only_does_not_activate_superuser_privileges() -> None:
+    """User.is_superuser is eligibility; generic auth must not activate it."""
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.is_superuser = True
+
+    async def _compute_effective_scopes(role: Role) -> frozenset[str]:
+        assert role.is_platform_superuser is False
+        return frozenset()
+
+    token = ctx_role.set(None)
+    try:
+        with patch(
+            "tracecat.auth.credentials.compute_effective_scopes",
+            new=AsyncMock(side_effect=_compute_effective_scopes),
+        ) as mock_compute_scopes:
+            role = await authenticated_user_only(user=user)
+
+        assert role.user_id == user.id
+        assert role.organization_id is None
+        assert role.workspace_id is None
+        assert role.is_platform_superuser is False
+        assert role.scopes == frozenset()
+        assert ctx_role.get() == role
+        mock_compute_scopes.assert_awaited_once()
+    finally:
+        ctx_role.reset(token)
 
 
 @pytest.mark.anyio
@@ -154,20 +185,10 @@ async def test_role_dependency_preserves_auth_exception_when_cleanup_fails():
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize(
-    ("require_workspace", "workspace_id"),
-    [
-        ("no", None),
-        ("optional", None),
-        ("yes", uuid.uuid4()),
-    ],
-)
-async def test_role_dependency_denies_multi_tenant_superuser_tenant_context(
-    require_workspace: str,
-    workspace_id: uuid.UUID | None,
+async def test_role_dependency_resolves_multi_tenant_superuser_as_regular_org_user(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Multi-tenant platform superusers cannot resolve tenant RoleACL context."""
+    """A superuser flag alone must not grant platform privileges in tenant context."""
     monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
 
     request = MagicMock(spec=Request)
@@ -178,52 +199,17 @@ async def test_role_dependency_denies_multi_tenant_superuser_tenant_context(
     user = MagicMock(spec=User)
     user.id = uuid.uuid4()
     user.is_superuser = True
-
-    with (
-        patch("tracecat.auth.credentials.set_rls_context", new=AsyncMock()),
-        patch(
-            "tracecat.auth.credentials.set_rls_context_from_role",
-            new=AsyncMock(),
-        ),
-    ):
-        with pytest.raises(HTTPException) as excinfo:
-            await _role_dependency(
-                request=request,
-                session=session,
-                workspace_id=workspace_id,
-                user=user,
-                api_key=None,
-                allow_user=True,
-                allow_service=False,
-                allow_executor=False,
-                require_workspace=require_workspace,  # pyright: ignore[reportArgumentType]
-            )
-
-    assert excinfo.value.status_code == status.HTTP_403_FORBIDDEN
-    assert excinfo.value.detail == "Platform superusers cannot access tenant context"
-
-
-@pytest.mark.anyio
-async def test_role_dependency_allows_single_tenant_superuser_default_org(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Single-tenant superuser RoleACL behavior still resolves the default org."""
-    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", False)
-
-    request = MagicMock(spec=Request)
-    request.state = MagicMock()
-    request.state.auth_cache = None
-    request.cookies = {}
-    session = AsyncMock()
-    user = MagicMock(spec=User)
-    user.id = uuid.uuid4()
-    user.is_superuser = True
     org_id = uuid.uuid4()
+    scopes = frozenset({"org:read"})
 
     with (
         patch(
-            "tracecat.auth.credentials.get_default_organization_id",
+            "tracecat.auth.credentials._resolve_org_for_regular_user",
             new=AsyncMock(return_value=org_id),
+        ) as mock_resolve_org,
+        patch(
+            "tracecat.auth.credentials.compute_effective_scopes",
+            new=AsyncMock(return_value=scopes),
         ),
         patch("tracecat.auth.credentials.set_rls_context", new=AsyncMock()),
         patch(
@@ -245,7 +231,80 @@ async def test_role_dependency_allows_single_tenant_superuser_default_org(
 
     assert role.organization_id == org_id
     assert role.user_id == user.id
-    assert role.is_platform_superuser is True
+    assert role.is_platform_superuser is False
+    assert role.scopes == scopes
+    mock_resolve_org.assert_awaited_once_with(session, user)
+
+
+@pytest.mark.anyio
+async def test_role_dependency_resolves_superuser_workspace_membership_without_platform_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Workspace access for superuser accounts still depends on membership/RBAC."""
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
+
+    request = MagicMock(spec=Request)
+    request.state = MagicMock()
+    request.state.auth_cache = None
+    request.cookies = {}
+    session = AsyncMock()
+    workspace_id = uuid.uuid4()
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.is_superuser = True
+    org_id = uuid.uuid4()
+    scopes = frozenset({"workspace:read"})
+    membership = MembershipWithOrg(
+        membership=MagicMock(spec=Membership),
+        org_id=org_id,
+    )
+
+    with (
+        patch(
+            "tracecat.auth.credentials._get_workspace_org_id",
+            new=AsyncMock(return_value=org_id),
+        ),
+        patch(
+            "tracecat.auth.credentials._is_org_admin_via_rbac",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "tracecat.auth.credentials._get_membership_with_cache",
+            new=AsyncMock(return_value=membership),
+        ) as mock_get_membership,
+        patch(
+            "tracecat.auth.credentials.compute_effective_scopes",
+            new=AsyncMock(return_value=scopes),
+        ),
+        patch("tracecat.auth.credentials.set_rls_context", new=AsyncMock()),
+        patch(
+            "tracecat.auth.credentials.set_rls_context_from_role",
+            new=AsyncMock(),
+        ),
+    ):
+        role = await _role_dependency(
+            request=request,
+            session=session,
+            workspace_id=workspace_id,
+            user=user,
+            api_key=None,
+            allow_user=True,
+            allow_service=False,
+            allow_executor=False,
+            require_workspace="yes",
+        )
+
+    assert role.organization_id == org_id
+    assert role.workspace_id == workspace_id
+    assert role.user_id == user.id
+    assert role.is_platform_superuser is False
+    assert role.scopes == scopes
+    mock_get_membership.assert_awaited_once_with(
+        request=request,
+        session=session,
+        workspace_id=workspace_id,
+        user=user,
+    )
 
 
 @pytest.mark.anyio
@@ -349,9 +408,6 @@ async def test_auth_cache_reduces_database_queries(mocker):
     mocker.patch(
         "tracecat.auth.credentials.MembershipService", return_value=mock_service
     )
-
-    # Mock is_unprivileged to return True for basic users
-    mocker.patch("tracecat.auth.credentials.is_unprivileged", return_value=True)
 
     # Mock _get_workspace_org_id to return org_id for any workspace
     mocker.patch(
@@ -605,7 +661,6 @@ async def test_cache_user_id_validation():
     # Set up mocks
     with (
         patch("tracecat.auth.credentials.MembershipService", return_value=mock_service),
-        patch("tracecat.auth.credentials.is_unprivileged", return_value=True),
         patch("tracecat.auth.credentials._get_workspace_org_id", return_value=org_id),
         patch("tracecat.auth.credentials._is_org_admin_via_rbac", return_value=False),
     ):
@@ -692,7 +747,6 @@ async def test_cache_size_limit():
     # Set up mocks
     with (
         patch("tracecat.auth.credentials.MembershipService", return_value=mock_service),
-        patch("tracecat.auth.credentials.is_unprivileged", return_value=True),
         patch("tracecat.auth.credentials._get_workspace_org_id", return_value=org_id),
         patch("tracecat.auth.credentials._is_org_admin_via_rbac", return_value=False),
     ):
@@ -756,9 +810,6 @@ async def test_organization_id_populated_when_require_workspace_no(mocker):
     scopes_result.scalars.return_value.all.return_value = []
 
     mock_session.execute.side_effect = [org_result, org_role_result, scopes_result]
-
-    # Mock is_unprivileged to return False for admin users
-    mocker.patch("tracecat.auth.credentials.is_unprivileged", return_value=False)
 
     mocker.patch(
         "tracecat.auth.credentials.set_rls_context",

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -1001,7 +1001,7 @@ async def test_list_workspaces_for_request_reads_email_from_upstream_claims(
 
 
 @pytest.mark.anyio
-async def test_resolve_role_allows_single_tenant_superuser_without_org_membership(
+async def test_resolve_role_superuser_uses_rbac_for_workspace_access(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     user_id = uuid.uuid4()
@@ -1016,7 +1016,8 @@ async def test_resolve_role_allows_single_tenant_superuser_without_org_membershi
         return organization_id
 
     async def _compute_effective_scopes(_role) -> frozenset[str]:
-        return frozenset({"*"})
+        assert _role.is_platform_superuser is False
+        return frozenset({"org:workspace:read"})
 
     async def _resolve_workspace_membership(
         _user_id: uuid.UUID, _workspace_id: uuid.UUID
@@ -1038,29 +1039,44 @@ async def test_resolve_role_allows_single_tenant_superuser_without_org_membershi
     assert role.user_id == user_id
     assert role.workspace_id == workspace_id
     assert role.organization_id == organization_id
-    assert role.scopes == frozenset({"*"})
+    assert role.is_platform_superuser is False
+    assert role.scopes == frozenset({"org:workspace:read"})
 
 
 @pytest.mark.anyio
-async def test_resolve_role_rejects_multi_tenant_superuser(
+async def test_resolve_role_requires_superuser_workspace_membership_without_org_admin(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workspace_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
 
     async def _resolve_user_by_email(_email: str) -> SimpleNamespace:
         return SimpleNamespace(id=uuid.uuid4(), is_superuser=True)
 
     async def _resolve_workspace_org(_workspace_id: uuid.UUID) -> uuid.UUID:
-        raise AssertionError("superusers should be blocked before workspace lookup")
+        assert _workspace_id == workspace_id
+        return organization_id
+
+    async def _compute_effective_scopes(_role) -> frozenset[str]:
+        assert _role.is_platform_superuser is False
+        return frozenset()
+
+    async def _resolve_workspace_membership(
+        _user_id: uuid.UUID, _workspace_id: uuid.UUID
+    ) -> None:
+        raise ValueError("no access")
 
     monkeypatch.setattr(mcp_auth, "resolve_user_by_email", _resolve_user_by_email)
     monkeypatch.setattr(mcp_auth, "resolve_workspace_org", _resolve_workspace_org)
+    monkeypatch.setattr(mcp_auth, "compute_effective_scopes", _compute_effective_scopes)
+    monkeypatch.setattr(
+        mcp_auth,
+        "resolve_workspace_membership",
+        _resolve_workspace_membership,
+    )
     monkeypatch.setattr(mcp_auth.config, "TRACECAT__EE_MULTI_TENANT", True)
 
-    with pytest.raises(
-        ValueError,
-        match="Platform superusers cannot access tenant MCP context",
-    ):
+    with pytest.raises(ValueError, match="no access"):
         await mcp_auth.resolve_role("admin@example.com", workspace_id)
 
 
@@ -1180,28 +1196,78 @@ async def test_list_user_workspaces_includes_direct_memberships_without_org_memb
 
 
 @pytest.mark.anyio
-async def test_list_user_workspaces_rejects_multi_tenant_superuser(
+async def test_list_user_workspaces_for_superuser_uses_membership_rows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _resolve_user_by_email(_email: str) -> SimpleNamespace:
-        return SimpleNamespace(id=uuid.uuid4(), is_superuser=True)
+    user_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
 
-    def _bypass_session_manager():
-        raise AssertionError("superusers should be blocked before workspace listing")
+    class _ScalarResult:
+        def __init__(self, values: list[uuid.UUID]) -> None:
+            self._values = values
+
+        def all(self) -> list[uuid.UUID]:
+            return self._values
+
+    class _TupleResult:
+        def __init__(self, values: list[tuple[uuid.UUID, str]]) -> None:
+            self._values = values
+
+        def all(self) -> list[tuple[uuid.UUID, str]]:
+            return self._values
+
+    class _Result:
+        def __init__(
+            self,
+            *,
+            scalars: list[uuid.UUID] | None = None,
+            tuples: list[tuple[uuid.UUID, str]] | None = None,
+        ) -> None:
+            self._scalars = scalars or []
+            self._tuples = tuples or []
+
+        def scalars(self) -> _ScalarResult:
+            return _ScalarResult(self._scalars)
+
+        def tuples(self) -> _TupleResult:
+            return _TupleResult(self._tuples)
+
+    class _Session:
+        def __init__(self) -> None:
+            self._calls = 0
+
+        async def execute(self, _stmt):
+            self._calls += 1
+            if self._calls == 1:
+                return _Result(scalars=[])
+            if self._calls == 2:
+                return _Result(tuples=[(workspace_id, "Workspace A")])
+            raise AssertionError("unexpected extra query")
+
+    class _AsyncContext:
+        def __init__(self, session: _Session) -> None:
+            self._session = session
+
+        async def __aenter__(self) -> _Session:
+            return self._session
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    async def _resolve_user_by_email(_email: str) -> SimpleNamespace:
+        return SimpleNamespace(id=user_id, is_superuser=True)
 
     monkeypatch.setattr(mcp_auth, "resolve_user_by_email", _resolve_user_by_email)
     monkeypatch.setattr(
         mcp_auth,
         "get_async_session_bypass_rls_context_manager",
-        _bypass_session_manager,
+        lambda: _AsyncContext(_Session()),
     )
     monkeypatch.setattr(mcp_auth.config, "TRACECAT__EE_MULTI_TENANT", True)
 
-    with pytest.raises(
-        ValueError,
-        match="Platform superusers cannot access tenant MCP context",
-    ):
-        await mcp_auth.list_user_workspaces("admin@example.com")
+    workspaces = await mcp_auth.list_user_workspaces("admin@example.com")
+
+    assert workspaces == [{"id": str(workspace_id), "name": "Workspace A"}]
 
 
 @pytest.mark.anyio
@@ -1406,26 +1472,19 @@ async def test_resolve_org_role_token_scoped_to_unowned_org_errors(
 
 
 @pytest.mark.anyio
-async def test_resolve_org_role_single_tenant_superuser_uses_default_org(
+async def test_resolve_org_role_superuser_uses_membership_org(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Single-tenant superusers without memberships fall back to default org."""
-    default_org = uuid.uuid4()
+    """Superuser accounts resolve org-scoped MCP roles from memberships."""
+    org_id = uuid.uuid4()
     _patch_resolve_org_role_deps(
         monkeypatch,
         identity_org_ids=frozenset(),
-        membership_org_ids=[],  # superuser with no memberships
+        membership_org_ids=[org_id],
         is_superuser=True,
-    )
-
-    async def _get_default_organization_id(_session) -> uuid.UUID:
-        return default_org
-
-    monkeypatch.setattr(
-        mcp_auth, "get_default_organization_id", _get_default_organization_id
     )
 
     role = await mcp_auth.resolve_org_role_for_request()
 
-    assert role.organization_id == default_org
-    assert role.is_platform_superuser is True
+    assert role.organization_id == org_id
+    assert role.is_platform_superuser is False

--- a/tests/unit/test_mcp_oidc_session.py
+++ b/tests/unit/test_mcp_oidc_session.py
@@ -1,26 +1,77 @@
+import uuid
 from types import SimpleNamespace
 from typing import cast
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
-from starlette.requests import Request
 
 from tracecat.db.models import User
 from tracecat.mcp.oidc import session as oidc_session
 
 
+class _Result:
+    def __init__(self, org_ids: list[uuid.UUID]) -> None:
+        self._org_ids = org_ids
+
+    def all(self) -> list[tuple[uuid.UUID]]:
+        return [(org_id,) for org_id in self._org_ids]
+
+
+class _Session:
+    def __init__(self, org_ids: list[uuid.UUID]) -> None:
+        self._org_ids = org_ids
+
+    async def execute(self, _stmt) -> _Result:
+        return _Result(self._org_ids)
+
+
+class _AsyncContext:
+    def __init__(self, session: _Session) -> None:
+        self._session = session
+
+    async def __aenter__(self) -> _Session:
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
 @pytest.mark.anyio
-async def test_resolve_superuser_org_rejects_multi_tenant_superuser(
+async def test_resolve_authorize_session_superuser_uses_membership_org(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(oidc_session.config, "TRACECAT__EE_MULTI_TENANT", True)
+    org_id = uuid.uuid4()
+    user = cast(
+        User,
+        SimpleNamespace(id=uuid.uuid4(), email="admin@example.com", is_superuser=True),
+    )
 
-    with pytest.raises(
-        ValueError,
-        match="Platform superusers cannot authorize tenant MCP sessions",
-    ):
-        await oidc_session._resolve_superuser_org(
-            cast(Request, object()),
-            cast(AsyncSession, object()),
-            cast(User, SimpleNamespace(id="user-id")),
-        )
+    monkeypatch.setattr(
+        oidc_session,
+        "get_async_session_bypass_rls_context_manager",
+        lambda: _AsyncContext(_Session([org_id])),
+    )
+
+    result = await oidc_session.resolve_authorize_session(user)
+
+    assert isinstance(result, oidc_session.SessionResult)
+    assert result.user is user
+    assert result.organization_id == org_id
+
+
+@pytest.mark.anyio
+async def test_resolve_authorize_session_superuser_without_membership_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = cast(
+        User,
+        SimpleNamespace(id=uuid.uuid4(), email="admin@example.com", is_superuser=True),
+    )
+
+    monkeypatch.setattr(
+        oidc_session,
+        "get_async_session_bypass_rls_context_manager",
+        lambda: _AsyncContext(_Session([])),
+    )
+
+    with pytest.raises(ValueError, match="expected exactly 1 organization membership"):
+        await oidc_session.resolve_authorize_session(user)

--- a/tests/unit/test_organization_membership.py
+++ b/tests/unit/test_organization_membership.py
@@ -323,7 +323,7 @@ class TestGetRoleFromUser:
 
     @pytest.mark.anyio
     async def test_get_role_from_superuser(self, session: AsyncSession):
-        """Test get_role_from_user for superuser sets is_platform_superuser."""
+        """Test tenant roles do not inherit platform superuser privileges."""
         user = User(
             id=uuid.uuid4(),
             email=f"superuser-{uuid.uuid4().hex[:8]}@example.com",
@@ -341,7 +341,7 @@ class TestGetRoleFromUser:
             organization_id=uuid.uuid4(),
         )
 
-        assert role.is_platform_superuser is True
+        assert role.is_platform_superuser is False
 
 
 class TestOrganizationMembershipRelationships:

--- a/tests/unit/test_organization_service.py
+++ b/tests/unit/test_organization_service.py
@@ -934,7 +934,7 @@ class TestOrganizationServiceInvitations:
             )
 
     @pytest.mark.anyio
-    async def test_create_invitation_rejects_existing_superuser_account_in_multi_tenant(
+    async def test_create_invitation_allows_existing_superuser_account_in_multi_tenant(
         self,
         session: AsyncSession,
         org1: Organization,
@@ -942,7 +942,7 @@ class TestOrganizationServiceInvitations:
         org1_member_role: DBRole,
         monkeypatch: pytest.MonkeyPatch,
     ):
-        """Test create_invitation rejects platform superuser targets in multi-tenant mode."""
+        """Test superuser accounts can be invited as regular org members."""
         monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
         superuser = User(
             id=uuid.uuid4(),
@@ -959,21 +959,17 @@ class TestOrganizationServiceInvitations:
         role = create_admin_role(org1.id, admin_in_org1.id)
         service = OrgService(session, role=role)
 
-        with pytest.raises(
-            TracecatValidationError,
-            match="Invitation cannot be created for this email",
-        ):
-            await service.create_invitation(
-                email=superuser.email,
-                role_id=org1_member_role.id,
-            )
+        invitation = await service.create_invitation(
+            email=superuser.email,
+            role_id=org1_member_role.id,
+        )
 
         invitation_id = await session.scalar(
             select(OrganizationInvitation.id).where(
                 OrganizationInvitation.email == superuser.email
             )
         )
-        assert invitation_id is None
+        assert invitation_id == invitation.id
 
     @pytest.mark.anyio
     async def test_list_invitations_returns_org_invitations(
@@ -1261,7 +1257,7 @@ class TestOrganizationServiceInvitations:
         assert invitation.accepted_at is not None
 
     @pytest.mark.anyio
-    async def test_accept_invitation_rejects_superuser_account_in_multi_tenant(
+    async def test_accept_invitation_allows_superuser_account_in_multi_tenant(
         self,
         session: AsyncSession,
         org1: Organization,
@@ -1270,56 +1266,61 @@ class TestOrganizationServiceInvitations:
         org1_member_role: DBRole,
         monkeypatch: pytest.MonkeyPatch,
     ):
-        """Test multi-tenant superuser accounts cannot accept org invitations."""
+        """Test multi-tenant superuser accounts accept org invitations as users."""
         monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
-        superuser = User(
+        standalone_superuser = User(
             id=uuid.uuid4(),
-            email=f"superuser-{uuid.uuid4().hex[:8]}@example.com",
+            email=f"standalone-superuser-{uuid.uuid4().hex[:8]}@example.com",
             hashed_password="hashed",
             role=UserRole.ADMIN,
             is_active=True,
             is_superuser=True,
             is_verified=True,
         )
-        session.add(superuser)
-        await session.commit()
-
-        invitation = OrganizationInvitation(
-            organization_id=org1.id,
-            email=superuser.email,
-            role_id=org1_member_role.id,
-            invited_by=admin_in_org1.id,
-            token=secrets.token_urlsafe(32),
-            expires_at=datetime.now(UTC) + timedelta(days=7),
-            status=InvitationStatus.PENDING,
+        service_superuser = User(
+            id=uuid.uuid4(),
+            email=f"service-superuser-{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="hashed",
+            role=UserRole.ADMIN,
+            is_active=True,
+            is_superuser=True,
+            is_verified=True,
         )
-        session.add(invitation)
+        session.add_all([standalone_superuser, service_superuser])
         await session.commit()
 
-        with pytest.raises(
-            TracecatAuthorizationError,
-            match="Platform superusers cannot accept organization invitations",
-        ):
-            await accept_invitation_for_user(
-                session,
-                user_id=superuser.id,
-                token=invitation.token,
-            )
+        admin_role = create_admin_role(org1.id, admin_in_org1.id)
+        admin_service = OrgService(session, role=admin_role)
+        standalone_invitation = await admin_service.create_invitation(
+            email=standalone_superuser.email,
+            role_id=org1_member_role.id,
+        )
+        service_invitation = await admin_service.create_invitation(
+            email=service_superuser.email,
+            role_id=org1_member_role.id,
+        )
+
+        standalone_membership = await accept_invitation_for_user(
+            session,
+            user_id=standalone_superuser.id,
+            token=standalone_invitation.token,
+        )
+        assert standalone_membership.user_id == standalone_superuser.id
+        assert standalone_membership.organization_id == org1.id
 
         user_role = Role(
             type="user",
-            user_id=superuser.id,
+            user_id=service_superuser.id,
             organization_id=org2.id,
             service_id="tracecat-api",
-            is_platform_superuser=True,
             scopes=ORG_MEMBER_SCOPES,
         )
         user_service = OrgService(session, role=user_role)
-        with pytest.raises(
-            TracecatAuthorizationError,
-            match="Platform superusers cannot accept organization invitations",
-        ):
-            await user_service.accept_invitation(invitation.token)
+        service_membership = await user_service.accept_invitation(
+            service_invitation.token
+        )
+        assert service_membership.user_id == service_superuser.id
+        assert service_membership.organization_id == org1.id
 
     @pytest.mark.anyio
     async def test_accept_invitation_allows_superuser_account_in_single_tenant(
@@ -1378,7 +1379,6 @@ class TestOrganizationServiceInvitations:
             user_id=service_superuser.id,
             organization_id=org2.id,
             service_id="tracecat-api",
-            is_platform_superuser=True,
             scopes=ORG_MEMBER_SCOPES,
         )
         user_service = OrgService(session, role=user_role)

--- a/tests/unit/test_saml_client_config.py
+++ b/tests/unit/test_saml_client_config.py
@@ -490,7 +490,7 @@ async def test_is_superadmin_saml_bootstrap_allowed_for_org_false_for_non_defaul
         (True, False, False, False, True),
         (False, True, False, False, True),
         (False, False, True, False, True),
-        (False, False, False, True, True),
+        (False, False, False, True, False),
         (True, True, False, False, True),
         (True, False, True, False, True),
         (False, True, True, False, True),

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -41,7 +41,6 @@ from tracecat.auth.secrets import get_service_key
 from tracecat.auth.types import PlatformRole, Role
 from tracecat.auth.users import (
     current_active_user,
-    is_unprivileged,
     optional_current_active_user,
 )
 from tracecat.authz.controls import has_scope
@@ -68,7 +67,6 @@ from tracecat.db.models import (
 from tracecat.db.rls import set_rls_context, set_rls_context_from_role
 from tracecat.identifiers import InternalServiceID
 from tracecat.logger import logger
-from tracecat.organization.management import get_default_organization_id
 from tracecat.tiers.access import is_org_entitled
 from tracecat.tiers.enums import Entitlement
 
@@ -125,7 +123,7 @@ async def compute_effective_scopes(role: Role) -> frozenset[str]:
     scopes through Role → RoleScope → Scope.
 
     Scope computation follows this hierarchy:
-    1. Platform superusers get "*" (all scopes)
+    1. Roles explicitly executing with platform-superuser privileges get "*"
     2. Service principals (non-user flows) use static allowlist scopes
     3. Direct user role assignments (org-wide and workspace-specific)
     4. Group role assignments (org-wide and workspace-specific)
@@ -232,6 +230,7 @@ def get_role_from_user(
     organization_id: uuid.UUID,
     workspace_id: uuid.UUID | None = None,
     service_id: InternalServiceID = "tracecat-api",
+    is_platform_superuser: bool = False,
 ) -> Role:
     return Role(
         type="user",
@@ -239,7 +238,7 @@ def get_role_from_user(
         organization_id=organization_id,
         user_id=user.id,
         service_id=service_id,
-        is_platform_superuser=user.is_superuser,
+        is_platform_superuser=is_platform_superuser,
     )
 
 
@@ -581,33 +580,6 @@ async def _get_membership_with_cache(
     return membership_with_org
 
 
-async def _resolve_org_for_superuser(
-    request: Request,
-    session: AsyncSession,
-) -> uuid.UUID:
-    """Resolve organization context for a superuser.
-
-    Multi-tenant superusers are platform-only operators and cannot resolve
-    tenant organization context through RoleACL. Single-tenant deployments keep
-    the historical default organization behavior.
-
-    Raises:
-        HTTPException(403): If a multi-tenant superuser tries to enter tenant context.
-    """
-    if not config.TRACECAT__EE_MULTI_TENANT:
-        default_org_id = await get_default_organization_id(session)
-        logger.debug(
-            "Multi-tenant disabled; using default organization",
-            organization_id=str(default_org_id),
-        )
-        return default_org_id
-
-    raise HTTPException(
-        status_code=status.HTTP_403_FORBIDDEN,
-        detail="Platform superusers cannot access tenant context",
-    )
-
-
 async def _resolve_org_for_regular_user(
     session: AsyncSession,
     user: User,
@@ -666,14 +638,12 @@ async def _authenticate_user(
 
     Handles:
     1. Workspace membership validation (if workspace_id provided)
-    2. Organization context resolution (superuser vs regular user)
+    2. Organization context resolution from tenant memberships
     3. Role construction (authorization is enforced via scopes, not enum roles)
     """
     organization_id: uuid.UUID
 
-    if user.is_superuser:
-        organization_id = await _resolve_org_for_superuser(request, session)
-    elif is_unprivileged(user) and workspace_id is not None:
+    if workspace_id is not None:
         resolved_org_id = await _get_workspace_org_id(workspace_id)
         if resolved_org_id is None:
             raise HTTPException(
@@ -696,7 +666,7 @@ async def _authenticate_user(
                 workspace_id=workspace_id,
             )
         else:
-            # Regular user - validate workspace membership
+            # Workspace member - validate direct workspace membership.
             await _get_membership_with_cache(
                 request=request,
                 session=session,
@@ -1313,12 +1283,13 @@ async def authenticated_user_only(
     - User profile operations that don't require org context
 
     Sets ctx_role for consistency but organization_id will be None.
+    This intentionally does not activate platform-superuser privileges; use
+    SuperuserRole for routes that need platform admin access.
     """
     role = Role(
         type="user",
         user_id=user.id,
         service_id="tracecat-api",
-        is_platform_superuser=user.is_superuser,
         # organization_id intentionally None - user may not belong to any org
     )
     scopes = await compute_effective_scopes(role)

--- a/tracecat/auth/saml.py
+++ b/tracecat/auth/saml.py
@@ -516,11 +516,11 @@ def should_allow_saml_org_access(
     is_platform_superuser: bool,
 ) -> bool:
     """Allow org access after SAML auth when at least one trusted path exists."""
+    _ = is_platform_superuser
     return (
         has_existing_membership
         or pending_invitation is not None
         or is_first_superadmin_bootstrap
-        or is_platform_superuser
     )
 
 

--- a/tracecat/auth/types.py
+++ b/tracecat/auth/types.py
@@ -39,7 +39,7 @@ class Role(BaseModel):
     service_id: InternalServiceID = Field(frozen=True)
     """The service's role name, or None if the role is a user."""
     is_platform_superuser: bool = Field(default=False, frozen=True)
-    """Whether this role belongs to a platform superuser (User.is_superuser=True)."""
+    """Whether this role is currently executing platform-superuser privileges."""
     scopes: frozenset[str] | None = Field(default=None, frozen=True)
     """Effective scopes for this role. None means unresolved/unset."""
 
@@ -70,7 +70,7 @@ class Role(BaseModel):
     def is_privileged(self) -> bool:
         """Check if this role has elevated privileges (platform admin).
 
-        Platform superusers and organization owners/admins are considered
+        Explicit platform-superuser roles and organization owners/admins are considered
         privileged for organization-level operations.
         All other authorization is scope-based via RBAC.
         """

--- a/tracecat/auth/users.py
+++ b/tracecat/auth/users.py
@@ -379,7 +379,8 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             await self._accept_invitation_atomically(user)
 
         # NOTE: We do NOT add users to any organization/workspace here unless invited.
-        # - Superusers have implicit access to all orgs (via is_platform_superuser)
+        # - Superusers get platform admin eligibility via User.is_superuser
+        # - Tenant access still comes from org/workspace membership and RBAC
         # - Regular users get org membership via invitation acceptance flow
         # - Workspace membership is managed separately by workspace admins
 
@@ -635,11 +636,6 @@ fastapi_users = FastAPIUserWithLogoutRouter[User, uuid.UUID](
 
 current_active_user = fastapi_users.current_user(active=True)
 optional_current_active_user = fastapi_users.current_user(active=True, optional=True)
-
-
-def is_unprivileged(user: User) -> bool:
-    """Check if a user is not privileged (i.e. not a superuser)."""
-    return not user.is_superuser
 
 
 async def get_or_create_user(params: UserCreate, exist_ok: bool = True) -> User:

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -69,7 +69,6 @@ from tracecat.mcp.oidc.features import (
     OFFLINE_ACCESS_SCOPE,
     get_supported_scopes,
 )
-from tracecat.organization.management import get_default_organization_id
 
 
 class MCPTokenIdentity(BaseModel):
@@ -1145,14 +1144,6 @@ async def resolve_workspace_membership(
         return WorkspaceRole.EDITOR
 
 
-def _raise_if_multi_tenant_superuser(user: User) -> None:
-    """Block platform superusers from tenant MCP context in multi-tenant mode."""
-    if config.TRACECAT__EE_MULTI_TENANT and user.is_superuser:
-        raise ValueError(
-            "Platform superusers cannot access tenant MCP context in multi-tenant mode"
-        )
-
-
 async def resolve_role(email: str, workspace_id: WorkspaceID) -> Role:
     """Resolve a user's Role for a given workspace from their OAuth email.
 
@@ -1160,10 +1151,8 @@ async def resolve_role(email: str, workspace_id: WorkspaceID) -> Role:
 
     Org admins/owners (users with ``org:workspace:read`` scope) bypass the
     workspace-level membership check, matching the behaviour of the main API.
-    Single-tenant platform superusers also bypass direct membership checks.
     """
     user = await resolve_user_by_email(email)
-    _raise_if_multi_tenant_superuser(user)
 
     org_id = await resolve_workspace_org(workspace_id)
 
@@ -1174,12 +1163,11 @@ async def resolve_role(email: str, workspace_id: WorkspaceID) -> Role:
         workspace_id=workspace_id,
         organization_id=org_id,
         service_id="tracecat-mcp",
-        is_platform_superuser=user.is_superuser,
     )
     scopes = await compute_effective_scopes(role)
 
-    # Platform superusers and org admins/owners can access any workspace.
-    if not user.is_superuser and not has_scope(scopes, "org:workspace:read"):
+    # Org admins/owners can access any workspace in their org.
+    if not has_scope(scopes, "org:workspace:read"):
         await resolve_workspace_membership(user.id, workspace_id)
 
     role = role.model_copy(update={"scopes": scopes})
@@ -1195,13 +1183,11 @@ async def list_user_workspaces(
 ) -> list[dict[str, str]]:
     """List workspaces accessible to the user.
 
-    Users with ``org:workspace:read`` scope (org admins/owners) or platform
-    superusers in single-tenant mode see every workspace in their
-    organization(s). Other users see only workspaces where they have an explicit
-    Membership row.
+    Users with ``org:workspace:read`` scope (org admins/owners) see every
+    workspace in their organization(s). Other users see only workspaces where
+    they have an explicit Membership row.
     """
     user = await resolve_user_by_email(email)
-    _raise_if_multi_tenant_superuser(user)
 
     async with get_async_session_bypass_rls_context_manager() as session:
 
@@ -1222,17 +1208,6 @@ async def list_user_workspaces(
                 member_result.tuples().all(),
                 key=lambda item: (item[1], str(item[0])),
             )
-
-        if user.is_superuser:
-            stmt = select(Workspace.id, Workspace.name)
-            if organization_ids:
-                stmt = stmt.where(Workspace.organization_id.in_(organization_ids))
-            stmt = stmt.order_by(Workspace.name.asc(), Workspace.id.asc())
-            result = await session.execute(stmt)
-            return [
-                {"id": str(workspace_id), "name": workspace_name}
-                for workspace_id, workspace_name in result.tuples().all()
-            ]
 
         # Resolve the user's organization(s)
         org_stmt = select(OrganizationMembership.organization_id).where(
@@ -1260,7 +1235,6 @@ async def list_user_workspaces(
                 organization_id=oid,
                 workspace_id=None,
                 service_id="tracecat-mcp",
-                is_platform_superuser=user.is_superuser,
             )
             scopes = await compute_effective_scopes(role)
             if has_scope(scopes, "org:workspace:read"):
@@ -1319,27 +1293,21 @@ async def resolve_org_role_for_request() -> Role:
     an ``organization_id`` claim or ``org:<uuid>`` scope, that scoping is
     intersected with the user's memberships before the ambiguity check, so a
     single-org-scoped token resolves cleanly even when the user belongs to
-    multiple orgs overall. Single-tenant platform superusers fall back to
-    the default organization (matching ``_resolve_org_for_superuser``) so
-    they can use org-scoped tools without an explicit OrganizationMembership.
+    multiple orgs overall.
     """
     identity = get_token_identity()
     if identity.email is None:
         raise ValueError("Token does not contain an email claim")
 
     user = await resolve_user_by_email(identity.email)
-    _raise_if_multi_tenant_superuser(user)
 
     async with get_async_session_bypass_rls_context_manager() as session:
-        if user.is_superuser and not config.TRACECAT__EE_MULTI_TENANT:
-            org_ids = {await get_default_organization_id(session)}
-        else:
-            result = await session.execute(
-                select(OrganizationMembership.organization_id).where(
-                    OrganizationMembership.user_id == user.id
-                )
+        result = await session.execute(
+            select(OrganizationMembership.organization_id).where(
+                OrganizationMembership.user_id == user.id
             )
-            org_ids = {row[0] for row in result.all()}
+        )
+        org_ids = {row[0] for row in result.all()}
 
     if identity.organization_ids:
         org_ids &= identity.organization_ids
@@ -1365,7 +1333,6 @@ async def resolve_org_role_for_request() -> Role:
         workspace_id=None,
         organization_id=organization_id,
         service_id="tracecat-mcp",
-        is_platform_superuser=user.is_superuser,
     )
     scopes = await compute_effective_scopes(role)
     role = role.model_copy(update={"scopes": scopes})

--- a/tracecat/mcp/oidc/endpoints.py
+++ b/tracecat/mcp/oidc/endpoints.py
@@ -310,7 +310,7 @@ async def _handle_authorize(
 
     # --- Session resolution ---
     try:
-        session_result = await resolve_authorize_session(request, user)
+        session_result = await resolve_authorize_session(user)
     except ValueError as exc:
         # The OAuth client callback has already been validated at this point.
         logger.warning(
@@ -368,7 +368,7 @@ async def _handle_authorize(
         user_id=resolved_user.id,
         email=resolved_user.email,
         organization_id=org_id,
-        is_platform_superuser=resolved_user.is_superuser,
+        is_platform_superuser=False,
         client_id=client_id,
         redirect_uri=redirect_uri,
         code_challenge=code_challenge,

--- a/tracecat/mcp/oidc/session.py
+++ b/tracecat/mcp/oidc/session.py
@@ -11,14 +11,11 @@ from enum import StrEnum, auto
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from starlette.requests import Request
 
-from tracecat import config
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import OrganizationMembership, User
 from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
-from tracecat.organization.management import get_default_organization_id
 
 
 class NeedsAction(StrEnum):
@@ -44,13 +41,11 @@ class SessionNeedsAction:
 
 
 async def resolve_authorize_session(
-    request: Request,
     user: User | None,
 ) -> SessionResult | SessionNeedsAction:
     """Resolve a Tracecat user and their single organization from the session.
 
     Args:
-        request: The incoming HTTP request (for cookie access).
         user: The ``optional_current_active_user`` dependency result.
 
     Returns:
@@ -61,34 +56,7 @@ async def resolve_authorize_session(
         return SessionNeedsAction(action=NeedsAction.LOGIN)
 
     async with get_async_session_bypass_rls_context_manager() as session:
-        if user.is_superuser:
-            return await _resolve_superuser_org(request, session, user)
         return await _resolve_regular_user_org(session, user)
-
-
-async def _resolve_superuser_org(
-    request: Request,
-    session: AsyncSession,
-    user: User,
-) -> SessionResult:
-    """Resolve org for a platform superadmin.
-
-    In single-tenant mode, uses the default org.
-    In multi-tenant mode, platform superusers cannot authorize tenant MCP
-    sessions because they are not tenant users.
-    """
-    if not config.TRACECAT__EE_MULTI_TENANT:
-        org_id = await get_default_organization_id(session)
-        logger.debug(
-            "MCP OIDC: superuser resolved to default org (single-tenant)",
-            user_id=str(user.id),
-            organization_id=str(org_id),
-        )
-        return SessionResult(user=user, organization_id=org_id)
-
-    raise ValueError(
-        "Platform superusers cannot authorize tenant MCP sessions in multi-tenant mode"
-    )
 
 
 async def _resolve_regular_user_org(

--- a/tracecat/organization/router.py
+++ b/tracecat/organization/router.py
@@ -152,7 +152,7 @@ async def delete_organization(
 ) -> None:
     """Delete the current organization.
 
-    Restricted to organization owners and platform superusers.
+    Restricted to organization owners/admins through tenant RBAC.
     """
     service = OrgService(session, role=role)
     try:

--- a/tracecat/organization/service.py
+++ b/tracecat/organization/service.py
@@ -5,14 +5,12 @@ import uuid
 from collections.abc import AsyncGenerator, Sequence
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
-from typing import cast as type_cast
 
 from sqlalchemy import and_, cast, func, select, update
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Mapped, contains_eager, selectinload
+from sqlalchemy.orm import contains_eager, selectinload
 
-from tracecat import config
 from tracecat.audit.enums import AuditEventStatus
 from tracecat.audit.logger import audit_log
 from tracecat.audit.service import AuditService
@@ -92,11 +90,6 @@ async def accept_invitation_for_user(
     user = user_result.scalar_one_or_none()
     if user is None:
         raise TracecatAuthorizationError("User not found")
-    if config.TRACECAT__EE_MULTI_TENANT and user.is_superuser:
-        raise TracecatAuthorizationError(
-            "Platform superusers cannot accept organization invitations"
-        )
-
     # Verify email match (case-insensitive)
     if user.email.lower() != invitation.email.lower():
         raise TracecatAuthorizationError(
@@ -451,18 +444,6 @@ class OrgService(BaseOrgService):
                     "Only organization owners can create owner invitations"
                 )
 
-        if config.TRACECAT__EE_MULTI_TENANT:
-            existing_superuser = await self.session.scalar(
-                select(User).where(
-                    func.lower(User.email) == email.lower(),
-                    type_cast(Mapped[bool], User.is_superuser).is_(True),
-                )
-            )
-            if existing_superuser is not None:
-                raise TracecatValidationError(
-                    "Invitation cannot be created for this email"
-                )
-
         # Check if user with this email is already a member (case-insensitive)
         existing_member_stmt = (
             select(OrganizationMembership)
@@ -624,10 +605,6 @@ class OrgService(BaseOrgService):
         user = user_result.scalar_one_or_none()
         if user is None:
             raise TracecatAuthorizationError("User not found")
-        if config.TRACECAT__EE_MULTI_TENANT and user.is_superuser:
-            raise TracecatAuthorizationError(
-                "Platform superusers cannot accept organization invitations"
-            )
         if user.email.lower() != invitation.email.lower():
             raise TracecatAuthorizationError(
                 "This invitation was sent to a different email address"


### PR DESCRIPTION
## Summary

- Treat `User.is_superuser` as platform-admin eligibility instead of implicit tenant-context privilege.
- Resolve superuser tenant access through normal org/workspace membership and RBAC paths across HTTP auth, MCP, OIDC, SAML, and invitation flows.
- Keep explicit superadmin routes on `SuperuserRole`, and prevent `AuthenticatedUserOnly` from activating platform privileges.
- Update frontend post-auth routing so superusers land in the workspace app when they have tenant memberships, with `/admin` as the fallback when they have no org access.

## Validation

- `uv run pytest tests/unit/test_admin_org_invitations_service.py tests/unit/test_auth_middleware.py tests/unit/test_mcp_auth.py tests/unit/test_mcp_oidc_session.py tests/unit/test_organization_membership.py tests/unit/test_organization_service.py tests/unit/test_saml_client_config.py -q`
- `uv run pytest tests/unit/api/test_api_users_router.py -q`
- `uv run ruff check <changed Python files>`
- `uv run ruff format --check tracecat/auth/credentials.py tests/unit/test_auth_middleware.py`
- `uv run basedpyright <changed Python files>`
- `pnpm -C frontend test -- src/lib/auth-redirect.test.ts tests/auth-ui-matrix.test.tsx --runInBand`
- `pnpm -C frontend exec biome check src/app/workspaces/layout.tsx src/lib/auth-redirect.ts src/lib/auth-redirect.test.ts tests/auth-ui-matrix.test.tsx`
- `pnpm -C frontend run typecheck`

Pre-commit also ran during commit and passed after regenerating the frontend client.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat superusers as tenant users: platform admin is opt-in and tenant access comes only from org/workspace membership and RBAC. Frontend keeps superusers on normal routes; only redirect to `/admin` when they have no org memberships.

- **Refactors**
  - Unify tenant auth paths: remove superuser-only tenant shortcuts across HTTP auth, MCP, OIDC, and SAML; all tenant access resolves via memberships and scopes.
  - Redefine `Role.is_platform_superuser` to mean explicit platform-admin execution; `authenticated_user_only` no longer enables it; scope computation updated.
  - MCP: `resolve_role`, `list_user_workspaces`, and org-role resolution use memberships/RBAC; superusers no longer bypass checks; issued tokens set `is_platform_superuser=false`.
  - OIDC (MCP): session resolution derives org from the user’s memberships; API updated to `resolve_authorize_session(user)`; tokens no longer carry platform-superuser execution.
  - Invitations: allow inviting and accepting superuser accounts as regular members; remove multi-tenant blocks in org services.
  - SAML: drop automatic org access for superusers; allow only via membership, pending invite, or first superadmin bootstrap.
  - Org deletion: restricted to org owners/admins through tenant RBAC.
  - Tests: make the registry integration auth setup deterministic by seeding a membership and owner role, hashing the test password, and setting the org cookie.

- **Frontend**
  - Post-auth redirect: remove superuser special-casing; honor `returnUrl`; use `/admin` only when a superuser has no org memberships.
  - Workspace layout: detect “no memberships”; redirect superusers to `/admin`; regular users see the help screen. Updated tests and generated client docs.

<sup>Written for commit 6d3557d6d0d26f127ad056960e0b2381d1e97ef1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

