### PR TITLE
infra: decouple fargate migrations image

### DIFF
--- a/deployments/fargate/README.md
+++ b/deployments/fargate/README.md
@@ -82,6 +82,17 @@ For Terraform Cloud direct OIDC runs, the target account and role come from `TFC
 - API container starts only if migrations succeed (`dependsOn: SUCCESS`).
 - `worker`, `executor`, and `agent-executor` are ordered after API in Terraform, so service updates do not proceed past API if migrations fail.
 
+By default, the migrations init container uses the same backend image repository
+and tag as the application. Set these optional variables to decouple it:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `tracecat_migrations_image` | `tracecat_image` | Optional migrations image repository override |
+| `tracecat_migrations_image_tag` | `tracecat_image_tag` | Optional migrations image tag override |
+
+For app-only rollbacks, keep the migrations image on a version that understands
+the current Alembic database revision while rolling back the app images.
+
 ## Useful outputs
 
 - `public_app_url`

--- a/deployments/fargate/main.tf
+++ b/deployments/fargate/main.tf
@@ -50,14 +50,16 @@ module "ecs" {
   hosted_zone_id = var.hosted_zone_id
 
   # Tracecat version
-  tracecat_image            = var.tracecat_image
-  tracecat_ui_image         = var.tracecat_ui_image
-  tracecat_image_tag        = var.tracecat_image_tag
-  temporal_server_image     = var.temporal_server_image
-  temporal_server_image_tag = var.temporal_server_image_tag
-  temporal_ui_image         = var.temporal_ui_image
-  temporal_ui_image_tag     = var.temporal_ui_image_tag
-  force_new_deployment      = var.force_new_deployment
+  tracecat_image                = var.tracecat_image
+  tracecat_ui_image             = var.tracecat_ui_image
+  tracecat_image_tag            = var.tracecat_image_tag
+  tracecat_migrations_image     = var.tracecat_migrations_image
+  tracecat_migrations_image_tag = var.tracecat_migrations_image_tag
+  temporal_server_image         = var.temporal_server_image
+  temporal_server_image_tag     = var.temporal_server_image_tag
+  temporal_ui_image             = var.temporal_ui_image
+  temporal_ui_image_tag         = var.temporal_ui_image_tag
+  force_new_deployment          = var.force_new_deployment
 
   # Temporal configuration
   disable_temporal_ui        = var.disable_temporal_ui

--- a/deployments/fargate/modules/ecs/ecs-api.tf
+++ b/deployments/fargate/modules/ecs/ecs-api.tf
@@ -16,7 +16,7 @@ resource "aws_ecs_task_definition" "api_task_definition" {
   container_definitions = jsonencode([
     {
       name      = "TracecatApiMigrationsContainer"
-      image     = "${var.tracecat_image}:${local.tracecat_image_tag}"
+      image     = "${local.tracecat_migrations_image}:${local.tracecat_migrations_image_tag}"
       essential = false
       command   = ["python3", "-m", "alembic", "upgrade", "head"]
       logConfiguration = {

--- a/deployments/fargate/modules/ecs/locals.tf
+++ b/deployments/fargate/modules/ecs/locals.tf
@@ -2,7 +2,9 @@
 locals {
 
   # Tracecat version
-  tracecat_image_tag = var.tracecat_image_tag
+  tracecat_image_tag            = var.tracecat_image_tag
+  tracecat_migrations_image     = coalesce(var.tracecat_migrations_image, var.tracecat_image)
+  tracecat_migrations_image_tag = coalesce(var.tracecat_migrations_image_tag, local.tracecat_image_tag)
 
   # Tracecat common URLs
   public_app_url   = "https://${var.domain_name}"

--- a/deployments/fargate/modules/ecs/outputs.tf
+++ b/deployments/fargate/modules/ecs/outputs.tf
@@ -3,6 +3,16 @@ output "tracecat_image_tag" {
   value       = local.tracecat_image_tag
 }
 
+output "tracecat_migrations_image" {
+  description = "The Tracecat migrations init container image repository"
+  value       = local.tracecat_migrations_image
+}
+
+output "tracecat_migrations_image_tag" {
+  description = "The Tracecat migrations init container image tag"
+  value       = local.tracecat_migrations_image_tag
+}
+
 output "ecs_cluster_name" {
   description = "ECS cluster name"
   value       = aws_ecs_cluster.tracecat_cluster.name

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -170,6 +170,18 @@ variable "tracecat_image_tag" {
   default = "1.0.0-beta.47"
 }
 
+variable "tracecat_migrations_image" {
+  type        = string
+  description = "Docker image repository for the Tracecat migrations init container. Defaults to tracecat_image."
+  default     = null
+}
+
+variable "tracecat_migrations_image_tag" {
+  type        = string
+  description = "Docker image tag for the Tracecat migrations init container. Defaults to tracecat_image_tag."
+  default     = null
+}
+
 variable "temporal_server_image" {
   type    = string
   default = "temporalio/auto-setup"

--- a/deployments/fargate/outputs.tf
+++ b/deployments/fargate/outputs.tf
@@ -20,6 +20,16 @@ output "tracecat_image_tag" {
   value       = module.ecs.tracecat_image_tag
 }
 
+output "tracecat_migrations_image" {
+  description = "The Tracecat migrations init container image repository"
+  value       = module.ecs.tracecat_migrations_image
+}
+
+output "tracecat_migrations_image_tag" {
+  description = "The Tracecat migrations init container image tag"
+  value       = module.ecs.tracecat_migrations_image_tag
+}
+
 output "ecs_cluster_name" {
   description = "ECS cluster name"
   value       = module.ecs.ecs_cluster_name

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -138,6 +138,18 @@ variable "tracecat_image_tag" {
   default = "1.0.0-beta.47"
 }
 
+variable "tracecat_migrations_image" {
+  type        = string
+  description = "Docker image repository for the Tracecat migrations init container. Defaults to tracecat_image."
+  default     = null
+}
+
+variable "tracecat_migrations_image_tag" {
+  type        = string
+  description = "Docker image tag for the Tracecat migrations init container. Defaults to tracecat_image_tag."
+  default     = null
+}
+
 variable "temporal_server_image" {
   type    = string
   default = "temporalio/auto-setup"


### PR DESCRIPTION
## Summary

Decouple the Fargate migrations init container image from the application image. This adds optional `tracecat_migrations_image` and `tracecat_migrations_image_tag` variables at the root and ECS module layers, resolves them with fallbacks to the existing backend image settings, and wires the API migrations container to the resolved migration image.

The default behavior is unchanged: if the new variables are unset, migrations continue to use `tracecat_image:tracecat_image_tag`.

## Impact

This enables the same app-only rollback pattern used in the Helm chart: keep migrations on a version that understands the current Alembic database revision while rolling the app containers back to an older image tag.

## Validation

- `terraform fmt -check -recursive deployments/fargate`
- `terraform -chdir=deployments/fargate validate`
- `uv run ruff check deployments/fargate`
- `git diff --check`
- repo pre-commit hooks during commit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouple the Fargate migrations init container image from the app image to allow pinning migrations while rolling back app versions. Default behavior is unchanged if new variables are not set.

- New Features
  - Added optional `tracecat_migrations_image` and `tracecat_migrations_image_tag` at root and ECS module.
  - Fallbacks to `tracecat_image` and `tracecat_image_tag` when unset.
  - API migrations container now uses the resolved migrations image/tag.
  - Exported `tracecat_migrations_image` and `tracecat_migrations_image_tag` as outputs.
  - Updated README with usage and rollback guidance.

<sup>Written for commit 9cae3d02a85adba13ab455582694650dd5592f6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

