### PR TITLE
feat(db): add agent folders and tags schema

### DIFF
--- a/alembic/versions/90dc4e29c691_add_agent_folders_and_tags.py
+++ b/alembic/versions/90dc4e29c691_add_agent_folders_and_tags.py
@@ -1,0 +1,172 @@
+"""add agent folders and tags
+
+Revision ID: 90dc4e29c691
+Revises: 8b2f6a9c4d10
+Create Date: 2026-05-05 00:00:00.000000
+
+Adds the agent_folder, agent_tag, and agent_tag_link tables, plus a nullable
+folder_id column on agent_preset. Schema mirrors workflow_folder /
+workflow_tag / workflow_tag_link 1:1 (materialized-path folders, slug-based
+tag refs, M2M link table). RLS is enabled on the workspace-scoped tables
+following the same pattern as the skill migration.
+
+This migration is purely additive: every change is a new table or a nullable
+column with no required backfill. Old application versions remain functional
+after upgrade.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from tracecat.db.tenant_rls import (
+    disable_workspace_table_rls,
+    enable_workspace_table_rls,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "90dc4e29c691"
+down_revision: str | None = "8b2f6a9c4d10"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_folder",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("path", sa.String(), nullable=False),
+        sa.Column("workspace_id", sa.UUID(), nullable=False),
+        sa.Column("surrogate_id", sa.Integer(), sa.Identity(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_agent_folder_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name=op.f("pk_agent_folder")),
+        sa.UniqueConstraint(
+            "path", "workspace_id", name="uq_agent_folder_path_workspace"
+        ),
+    )
+    op.create_index(op.f("ix_agent_folder_id"), "agent_folder", ["id"], unique=True)
+    op.create_index(
+        op.f("ix_agent_folder_path"), "agent_folder", ["path"], unique=False
+    )
+
+    op.create_table(
+        "agent_tag",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("ref", sa.String(), nullable=False),
+        sa.Column("color", sa.String(), nullable=True),
+        sa.Column("workspace_id", sa.UUID(), nullable=False),
+        sa.Column("surrogate_id", sa.Integer(), sa.Identity(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_agent_tag_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name=op.f("pk_agent_tag")),
+        sa.UniqueConstraint(
+            "name", "workspace_id", name="uq_agent_tag_name_workspace"
+        ),
+        sa.UniqueConstraint("ref", "workspace_id", name="uq_agent_tag_ref_workspace"),
+    )
+    op.create_index(op.f("ix_agent_tag_id"), "agent_tag", ["id"], unique=True)
+    op.create_index(op.f("ix_agent_tag_name"), "agent_tag", ["name"], unique=False)
+    op.create_index(op.f("ix_agent_tag_ref"), "agent_tag", ["ref"], unique=False)
+
+    op.create_table(
+        "agent_tag_link",
+        sa.Column("tag_id", sa.UUID(), nullable=False),
+        sa.Column("preset_id", sa.UUID(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["preset_id"],
+            ["agent_preset.id"],
+            name=op.f("fk_agent_tag_link_preset_id_agent_preset"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tag_id"],
+            ["agent_tag.id"],
+            name=op.f("fk_agent_tag_link_tag_id_agent_tag"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "tag_id", "preset_id", name=op.f("pk_agent_tag_link")
+        ),
+    )
+
+    op.add_column(
+        "agent_preset",
+        sa.Column("folder_id", sa.UUID(), nullable=True),
+    )
+    op.create_foreign_key(
+        op.f("fk_agent_preset_folder_id_agent_folder"),
+        "agent_preset",
+        "agent_folder",
+        ["folder_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        op.f("ix_agent_preset_folder_id"),
+        "agent_preset",
+        ["folder_id"],
+        unique=False,
+    )
+
+    for table in ("agent_folder", "agent_tag"):
+        op.execute(enable_workspace_table_rls(table))
+
+
+def downgrade() -> None:
+    for table in ("agent_tag", "agent_folder"):
+        op.execute(disable_workspace_table_rls(table))
+
+    op.drop_index(op.f("ix_agent_preset_folder_id"), table_name="agent_preset")
+    op.drop_constraint(
+        op.f("fk_agent_preset_folder_id_agent_folder"),
+        "agent_preset",
+        type_="foreignkey",
+    )
+    op.drop_column("agent_preset", "folder_id")
+
+    op.drop_table("agent_tag_link")
+
+    op.drop_index(op.f("ix_agent_tag_ref"), table_name="agent_tag")
+    op.drop_index(op.f("ix_agent_tag_name"), table_name="agent_tag")
+    op.drop_index(op.f("ix_agent_tag_id"), table_name="agent_tag")
+    op.drop_table("agent_tag")
+
+    op.drop_index(op.f("ix_agent_folder_path"), table_name="agent_folder")
+    op.drop_index(op.f("ix_agent_folder_id"), table_name="agent_folder")
+    op.drop_table("agent_folder")

--- a/alembic/versions/90dc4e29c691_add_agent_folders_and_tags.py
+++ b/alembic/versions/90dc4e29c691_add_agent_folders_and_tags.py
@@ -95,9 +95,7 @@ def upgrade() -> None:
             ondelete="CASCADE",
         ),
         sa.PrimaryKeyConstraint("surrogate_id", name=op.f("pk_agent_tag")),
-        sa.UniqueConstraint(
-            "name", "workspace_id", name="uq_agent_tag_name_workspace"
-        ),
+        sa.UniqueConstraint("name", "workspace_id", name="uq_agent_tag_name_workspace"),
         sa.UniqueConstraint("ref", "workspace_id", name="uq_agent_tag_ref_workspace"),
     )
     op.create_index(op.f("ix_agent_tag_id"), "agent_tag", ["id"], unique=True)
@@ -120,9 +118,7 @@ def upgrade() -> None:
             name=op.f("fk_agent_tag_link_tag_id_agent_tag"),
             ondelete="CASCADE",
         ),
-        sa.PrimaryKeyConstraint(
-            "tag_id", "preset_id", name=op.f("pk_agent_tag_link")
-        ),
+        sa.PrimaryKeyConstraint("tag_id", "preset_id", name=op.f("pk_agent_tag_link")),
     )
 
     op.add_column(

--- a/alembic/versions/90dc4e29c691_add_agent_folders_and_tags.py
+++ b/alembic/versions/90dc4e29c691_add_agent_folders_and_tags.py
@@ -7,12 +7,25 @@ Create Date: 2026-05-05 00:00:00.000000
 Adds the agent_folder, agent_tag, and agent_tag_link tables, plus a nullable
 folder_id column on agent_preset. Schema mirrors workflow_folder /
 workflow_tag / workflow_tag_link 1:1 (materialized-path folders, slug-based
-tag refs, M2M link table). RLS is enabled on the workspace-scoped tables
-following the same pattern as the skill migration.
+tag refs, M2M link table) with one extra layer of safety: cross-references
+between workspace-scoped tables use composite foreign keys that include
+workspace_id, so a row in workspace A can never reference a row in
+workspace B even if a stray UUID is supplied. This mirrors the pattern
+already used for agent_catalog -> agent_custom_provider at the org tier.
 
-This migration is purely additive: every change is a new table or a nullable
-column with no required backfill. Old application versions remain functional
-after upgrade.
+Concretely:
+- agent_folder, agent_tag, and agent_preset each carry a
+  UNIQUE (workspace_id, id) constraint so children can target it.
+- agent_preset.folder_id is enforced via a composite FK
+  (workspace_id, folder_id) -> agent_folder (workspace_id, id).
+- agent_tag_link carries its own NOT NULL workspace_id column with composite
+  FKs to both agent_tag and agent_preset, ensuring the linked tag and
+  preset always live in the same workspace.
+
+This migration is purely additive: every change is a new table, a new
+nullable column, or a new constraint that existing rows already satisfy
+(since `id` is unique table-wide, `(workspace_id, id)` is unique too). Old
+application versions remain functional after upgrade.
 """
 
 from collections.abc import Sequence
@@ -62,6 +75,7 @@ def upgrade() -> None:
         sa.UniqueConstraint(
             "path", "workspace_id", name="uq_agent_folder_path_workspace"
         ),
+        sa.UniqueConstraint("workspace_id", "id", name="uq_agent_folder_workspace_id"),
     )
     op.create_index(op.f("ix_agent_folder_id"), "agent_folder", ["id"], unique=True)
     op.create_index(
@@ -97,25 +111,37 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("surrogate_id", name=op.f("pk_agent_tag")),
         sa.UniqueConstraint("name", "workspace_id", name="uq_agent_tag_name_workspace"),
         sa.UniqueConstraint("ref", "workspace_id", name="uq_agent_tag_ref_workspace"),
+        sa.UniqueConstraint("workspace_id", "id", name="uq_agent_tag_workspace_id"),
     )
     op.create_index(op.f("ix_agent_tag_id"), "agent_tag", ["id"], unique=True)
     op.create_index(op.f("ix_agent_tag_name"), "agent_tag", ["name"], unique=False)
     op.create_index(op.f("ix_agent_tag_ref"), "agent_tag", ["ref"], unique=False)
 
+    # agent_preset already exists; add a workspace-aware unique so children
+    # (agent_tag_link, agent_preset.folder_id) can target it via composite FK.
+    # Existing rows are unique on `id` alone, so this constraint is satisfied
+    # at creation time without backfill.
+    op.create_unique_constraint(
+        "uq_agent_preset_workspace_id",
+        "agent_preset",
+        ["workspace_id", "id"],
+    )
+
     op.create_table(
         "agent_tag_link",
         sa.Column("tag_id", sa.UUID(), nullable=False),
         sa.Column("preset_id", sa.UUID(), nullable=False),
+        sa.Column("workspace_id", sa.UUID(), nullable=False),
         sa.ForeignKeyConstraint(
-            ["preset_id"],
-            ["agent_preset.id"],
-            name=op.f("fk_agent_tag_link_preset_id_agent_preset"),
+            ["workspace_id", "preset_id"],
+            ["agent_preset.workspace_id", "agent_preset.id"],
+            name=op.f("fk_agent_tag_link_preset_workspace"),
             ondelete="CASCADE",
         ),
         sa.ForeignKeyConstraint(
-            ["tag_id"],
-            ["agent_tag.id"],
-            name=op.f("fk_agent_tag_link_tag_id_agent_tag"),
+            ["workspace_id", "tag_id"],
+            ["agent_tag.workspace_id", "agent_tag.id"],
+            name=op.f("fk_agent_tag_link_tag_workspace"),
             ondelete="CASCADE",
         ),
         sa.PrimaryKeyConstraint("tag_id", "preset_id", name=op.f("pk_agent_tag_link")),
@@ -125,13 +151,18 @@ def upgrade() -> None:
         "agent_preset",
         sa.Column("folder_id", sa.UUID(), nullable=True),
     )
+    # Composite FK enforces same-workspace folder reference. ON DELETE
+    # NO ACTION rather than SET NULL: a composite SET NULL would also null
+    # workspace_id, violating its NOT NULL constraint. The folder service
+    # is responsible for detaching presets before deleting a folder
+    # (delete_folder in tracecat/agent/folders/service.py).
     op.create_foreign_key(
-        op.f("fk_agent_preset_folder_id_agent_folder"),
+        op.f("fk_agent_preset_folder_workspace"),
         "agent_preset",
         "agent_folder",
-        ["folder_id"],
-        ["id"],
-        ondelete="SET NULL",
+        ["workspace_id", "folder_id"],
+        ["workspace_id", "id"],
+        ondelete="NO ACTION",
     )
     op.create_index(
         op.f("ix_agent_preset_folder_id"),
@@ -140,23 +171,25 @@ def upgrade() -> None:
         unique=False,
     )
 
-    for table in ("agent_folder", "agent_tag"):
+    for table in ("agent_folder", "agent_tag", "agent_tag_link"):
         op.execute(enable_workspace_table_rls(table))
 
 
 def downgrade() -> None:
-    for table in ("agent_tag", "agent_folder"):
+    for table in ("agent_tag_link", "agent_tag", "agent_folder"):
         op.execute(disable_workspace_table_rls(table))
 
     op.drop_index(op.f("ix_agent_preset_folder_id"), table_name="agent_preset")
     op.drop_constraint(
-        op.f("fk_agent_preset_folder_id_agent_folder"),
+        op.f("fk_agent_preset_folder_workspace"),
         "agent_preset",
         type_="foreignkey",
     )
     op.drop_column("agent_preset", "folder_id")
 
     op.drop_table("agent_tag_link")
+
+    op.drop_constraint("uq_agent_preset_workspace_id", "agent_preset", type_="unique")
 
     op.drop_index(op.f("ix_agent_tag_ref"), table_name="agent_tag")
     op.drop_index(op.f("ix_agent_tag_name"), table_name="agent_tag")


### PR DESCRIPTION
## Summary

- Adds the `agent_folder`, `agent_tag`, and `agent_tag_link` tables, plus a nullable `folder_id` column on `agent_preset`.
- Schema mirrors `workflow_folder` / `workflow_tag` / `workflow_tag_link` 1:1 (materialized paths for folders, slug-based tag refs, M2M link table with composite PK on `(tag_id, preset_id)`).
- RLS is enabled on the two workspace-scoped tables (`agent_folder`, `agent_tag`) via the existing `enable_workspace_table_rls` helper, matching the pattern used in the skill migration.
- Purely additive — every change is a new table or a nullable column with no required backfill. Old application versions remain functional after upgrade.

This is the schema-only PR. The application code (SQLAlchemy models, services, routers, UI) lands in a follow-up PR (`feat/agent-folders-attempt-2`) so that the schema can roll out independently.

This is the second attempt at agent folders + tags; the first attempt was #2523 (closed without merge). The schema here matches #2523's design where it was sound; a follow-up PR will pick up the reviewer-flagged correctness issues from that attempt (N+1 in directory listing, IntegrityError handling on concurrent folder creation, error type consistency, blank-name validation).

## Test plan

- [ ] `TRACECAT__DB_URI=... .venv/bin/python -m alembic upgrade head` applies cleanly against a dev DB at the previous head (`8b2f6a9c4d10`)
- [ ] `\d agent_folder`, `\d agent_tag`, `\d agent_tag_link`, `\d+ agent_preset` show the expected columns, indexes, FKs, and unique constraints
- [ ] `SELECT polname FROM pg_policy WHERE polrelid = 'agent_folder'::regclass;` shows `rls_policy_agent_folder` (and same for `agent_tag`)
- [ ] `alembic downgrade -1` cleanly drops everything and restores the prior head
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add schema for agent folders and tags, mirroring the workflow folder/tag design, and harden relations to be workspace-safe. Creates `agent_folder`, `agent_tag`, `agent_tag_link`, and a nullable `folder_id` on `agent_preset`, with RLS enabled and no breaking changes.

- **New Features**
  - Enforce same-workspace relations via composite FKs: `agent_preset` (workspace_id, folder_id) -> `agent_folder`; `agent_tag_link` (workspace_id, tag_id/preset_id) -> `agent_tag`/`agent_preset` (folder FK uses ON DELETE NO ACTION).
  - Add UNIQUE (workspace_id, id) to `agent_folder`, `agent_tag`, and `agent_preset`; enable RLS on `agent_tag_link`.

- **Refactors**
  - Reformatted the migration with `ruff` to satisfy CI; no functional changes.

<sup>Written for commit 43f90973f3e60c2e4ad9b470ba31be9811c4b0f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

