### PR TITLE
feat(agent): folders, tags, and minimal tags admin UI

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/agents/tags/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/agents/tags/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next"
+import { AgentTagsView } from "@/components/agents/agent-tags-view"
+
+export const metadata: Metadata = {
+  title: "Agent tags",
+}
+
+export default function AgentTagsPage() {
+  return <AgentTagsView />
+}

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1671,6 +1671,165 @@ export const $AgentCustomProviderUpdate = {
   description: "Update custom provider.",
 } as const
 
+export const $AgentFolderCreate = {
+  properties: {
+    name: {
+      type: "string",
+      maxLength: 120,
+      minLength: 1,
+      title: "Name",
+    },
+    parent_path: {
+      type: "string",
+      title: "Parent Path",
+      default: "/",
+    },
+  },
+  type: "object",
+  required: ["name"],
+  title: "AgentFolderCreate",
+} as const
+
+export const $AgentFolderDelete = {
+  properties: {
+    recursive: {
+      type: "boolean",
+      title: "Recursive",
+      default: false,
+    },
+  },
+  type: "object",
+  title: "AgentFolderDelete",
+} as const
+
+export const $AgentFolderDirectoryItem = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    name: {
+      type: "string",
+      title: "Name",
+    },
+    path: {
+      type: "string",
+      title: "Path",
+    },
+    workspace_id: {
+      type: "string",
+      format: "uuid",
+      title: "Workspace Id",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+    type: {
+      type: "string",
+      const: "folder",
+      title: "Type",
+    },
+    num_items: {
+      type: "integer",
+      title: "Num Items",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "name",
+    "path",
+    "workspace_id",
+    "created_at",
+    "updated_at",
+    "type",
+    "num_items",
+  ],
+  title: "AgentFolderDirectoryItem",
+} as const
+
+export const $AgentFolderMove = {
+  properties: {
+    new_parent_path: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "New Parent Path",
+    },
+  },
+  type: "object",
+  title: "AgentFolderMove",
+} as const
+
+export const $AgentFolderRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    name: {
+      type: "string",
+      title: "Name",
+    },
+    path: {
+      type: "string",
+      title: "Path",
+    },
+    workspace_id: {
+      type: "string",
+      format: "uuid",
+      title: "Workspace Id",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: ["id", "name", "path", "workspace_id", "created_at", "updated_at"],
+  title: "AgentFolderRead",
+} as const
+
+export const $AgentFolderUpdate = {
+  properties: {
+    name: {
+      anyOf: [
+        {
+          type: "string",
+          maxLength: 120,
+          minLength: 1,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Name",
+    },
+  },
+  type: "object",
+  title: "AgentFolderUpdate",
+} as const
+
 export const $AgentModel = {
   properties: {
     component_id: {
@@ -2011,6 +2170,89 @@ export const $AgentPresetCreate = {
   required: ["model_name", "model_provider", "name"],
   title: "AgentPresetCreate",
   description: "Payload for creating a new agent preset.",
+} as const
+
+export const $AgentPresetDirectoryItem = {
+  properties: {
+    type: {
+      type: "string",
+      const: "preset",
+      title: "Type",
+    },
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    name: {
+      type: "string",
+      title: "Name",
+    },
+    slug: {
+      type: "string",
+      title: "Slug",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    model_provider: {
+      type: "string",
+      title: "Model Provider",
+    },
+    model_name: {
+      type: "string",
+      title: "Model Name",
+    },
+    folder_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Folder Id",
+    },
+    tags: {
+      items: {
+        $ref: "#/components/schemas/TagRead",
+      },
+      type: "array",
+      title: "Tags",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: [
+    "type",
+    "id",
+    "name",
+    "slug",
+    "model_provider",
+    "model_name",
+    "created_at",
+    "updated_at",
+  ],
+  title: "AgentPresetDirectoryItem",
 } as const
 
 export const $AgentPresetRead = {
@@ -2393,6 +2635,20 @@ export const $AgentPresetSkillBindingRead = {
   required: ["skill_id", "skill_version_id", "skill_name", "skill_version"],
   title: "AgentPresetSkillBindingRead",
   description: "Resolved preset skill binding with metadata.",
+} as const
+
+export const $AgentPresetTagCreate = {
+  properties: {
+    tag_id: {
+      type: "string",
+      format: "uuid",
+      title: "Tag Id",
+    },
+  },
+  type: "object",
+  required: ["tag_id"],
+  title: "AgentPresetTagCreate",
+  description: "Payload for attaching a tag to a preset.",
 } as const
 
 export const $AgentPresetUpdate = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -107,6 +107,20 @@ import type {
   AgentCreateProviderCredentialsResponse,
   AgentDeleteProviderCredentialsData,
   AgentDeleteProviderCredentialsResponse,
+  AgentFoldersCreateFolderData,
+  AgentFoldersCreateFolderResponse,
+  AgentFoldersDeleteFolderData,
+  AgentFoldersDeleteFolderResponse,
+  AgentFoldersGetDirectoryData,
+  AgentFoldersGetDirectoryResponse,
+  AgentFoldersGetFolderData,
+  AgentFoldersGetFolderResponse,
+  AgentFoldersListFoldersData,
+  AgentFoldersListFoldersResponse,
+  AgentFoldersMoveFolderData,
+  AgentFoldersMoveFolderResponse,
+  AgentFoldersUpdateFolderData,
+  AgentFoldersUpdateFolderResponse,
   AgentGetDefaultModelResponse,
   AgentGetDefaultModelSelectionResponse,
   AgentGetProviderCredentialConfigData,
@@ -117,6 +131,8 @@ import type {
   AgentListModelsResponse,
   AgentListProviderCredentialConfigsResponse,
   AgentListProvidersResponse,
+  AgentPresetsAddPresetTagData,
+  AgentPresetsAddPresetTagResponse,
   AgentPresetsCompareAgentPresetVersionsData,
   AgentPresetsCompareAgentPresetVersionsResponse,
   AgentPresetsCreateAgentPresetData,
@@ -133,6 +149,10 @@ import type {
   AgentPresetsListAgentPresetsResponse,
   AgentPresetsListAgentPresetVersionsData,
   AgentPresetsListAgentPresetVersionsResponse,
+  AgentPresetsListPresetTagsData,
+  AgentPresetsListPresetTagsResponse,
+  AgentPresetsRemovePresetTagData,
+  AgentPresetsRemovePresetTagResponse,
   AgentPresetsRestoreAgentPresetVersionData,
   AgentPresetsRestoreAgentPresetVersionResponse,
   AgentPresetsUpdateAgentPresetData,
@@ -187,6 +207,16 @@ import type {
   AgentSkillsRestoreSkillVersionResponse,
   AgentSkillsUploadSkillData,
   AgentSkillsUploadSkillResponse,
+  AgentTagsCreateTagData,
+  AgentTagsCreateTagResponse,
+  AgentTagsDeleteTagData,
+  AgentTagsDeleteTagResponse,
+  AgentTagsGetTagData,
+  AgentTagsGetTagResponse,
+  AgentTagsListTagsData,
+  AgentTagsListTagsResponse,
+  AgentTagsUpdateTagData,
+  AgentTagsUpdateTagResponse,
   AgentUpdateProviderCredentialsData,
   AgentUpdateProviderCredentialsResponse,
   ApprovalsSubmitApprovalsData,
@@ -6139,6 +6169,406 @@ export const agentSessionsForkSession = (
     },
     body: data.requestBody,
     mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Directory
+ * List the directory items (folders and presets) at the given path.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.path Folder path
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersGetDirectory = (
+  data: AgentFoldersGetDirectoryData
+): CancelablePromise<AgentFoldersGetDirectoryResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/agent/folders/directory",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    query: {
+      path: data.path,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Folders
+ * List folders in the subtree under ``parent_path``.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.parentPath Parent folder path
+ * @returns AgentFolderRead Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersListFolders = (
+  data: AgentFoldersListFoldersData
+): CancelablePromise<AgentFoldersListFoldersResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/agent/folders",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    query: {
+      parent_path: data.parentPath,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create Folder
+ * Create a new agent folder.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns AgentFolderRead Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersCreateFolder = (
+  data: AgentFoldersCreateFolderData
+): CancelablePromise<AgentFoldersCreateFolderResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/agent/folders",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Folder
+ * Get folder details by ID.
+ * @param data The data for the request.
+ * @param data.folderId
+ * @param data.workspaceId
+ * @returns AgentFolderRead Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersGetFolder = (
+  data: AgentFoldersGetFolderData
+): CancelablePromise<AgentFoldersGetFolderResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/agent/folders/{folder_id}",
+    path: {
+      folder_id: data.folderId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Update Folder
+ * Update a folder (rename).
+ * @param data The data for the request.
+ * @param data.folderId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns AgentFolderRead Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersUpdateFolder = (
+  data: AgentFoldersUpdateFolderData
+): CancelablePromise<AgentFoldersUpdateFolderResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/workspaces/{workspace_id}/agent/folders/{folder_id}",
+    path: {
+      folder_id: data.folderId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete Folder
+ * Delete a folder.
+ *
+ * With ``recursive=True`` descendant folders are deleted and their presets
+ * are moved back to root. With ``recursive=False`` (default) the folder
+ * must be empty.
+ * @param data The data for the request.
+ * @param data.folderId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersDeleteFolder = (
+  data: AgentFoldersDeleteFolderData
+): CancelablePromise<AgentFoldersDeleteFolderResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/workspaces/{workspace_id}/agent/folders/{folder_id}",
+    path: {
+      folder_id: data.folderId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Move Folder
+ * Move a folder to a new parent.
+ * @param data The data for the request.
+ * @param data.folderId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns AgentFolderRead Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersMoveFolder = (
+  data: AgentFoldersMoveFolderData
+): CancelablePromise<AgentFoldersMoveFolderResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/agent/folders/{folder_id}/move",
+    path: {
+      folder_id: data.folderId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Tags
+ * List all agent tags in the workspace.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @returns TagRead Successful Response
+ * @throws ApiError
+ */
+export const agentTagsListTags = (
+  data: AgentTagsListTagsData
+): CancelablePromise<AgentTagsListTagsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/agent/tags",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create Tag
+ * Create a new agent tag definition.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns TagRead Successful Response
+ * @throws ApiError
+ */
+export const agentTagsCreateTag = (
+  data: AgentTagsCreateTagData
+): CancelablePromise<AgentTagsCreateTagResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/agent/tags",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Tag
+ * Get a single agent tag by ID.
+ * @param data The data for the request.
+ * @param data.tagId
+ * @param data.workspaceId
+ * @returns TagRead Successful Response
+ * @throws ApiError
+ */
+export const agentTagsGetTag = (
+  data: AgentTagsGetTagData
+): CancelablePromise<AgentTagsGetTagResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/agent/tags/{tag_id}",
+    path: {
+      tag_id: data.tagId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Update Tag
+ * Update an agent tag's name or color.
+ * @param data The data for the request.
+ * @param data.tagId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns TagRead Successful Response
+ * @throws ApiError
+ */
+export const agentTagsUpdateTag = (
+  data: AgentTagsUpdateTagData
+): CancelablePromise<AgentTagsUpdateTagResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/workspaces/{workspace_id}/agent/tags/{tag_id}",
+    path: {
+      tag_id: data.tagId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete Tag
+ * Delete an agent tag definition.
+ * @param data The data for the request.
+ * @param data.tagId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const agentTagsDeleteTag = (
+  data: AgentTagsDeleteTagData
+): CancelablePromise<AgentTagsDeleteTagResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/workspaces/{workspace_id}/agent/tags/{tag_id}",
+    path: {
+      tag_id: data.tagId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Preset Tags
+ * List tags attached to a preset.
+ * @param data The data for the request.
+ * @param data.presetId
+ * @param data.workspaceId
+ * @returns TagRead Successful Response
+ * @throws ApiError
+ */
+export const agentPresetsListPresetTags = (
+  data: AgentPresetsListPresetTagsData
+): CancelablePromise<AgentPresetsListPresetTagsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}/tags",
+    path: {
+      preset_id: data.presetId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Add Preset Tag
+ * Attach a tag to a preset (idempotent).
+ * @param data The data for the request.
+ * @param data.presetId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const agentPresetsAddPresetTag = (
+  data: AgentPresetsAddPresetTagData
+): CancelablePromise<AgentPresetsAddPresetTagResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}/tags",
+    path: {
+      preset_id: data.presetId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Remove Preset Tag
+ * Detach a tag from a preset.
+ * @param data The data for the request.
+ * @param data.presetId
+ * @param data.tagId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const agentPresetsRemovePresetTag = (
+  data: AgentPresetsRemovePresetTagData
+): CancelablePromise<AgentPresetsRemovePresetTagResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}/tags/{tag_id}",
+    path: {
+      preset_id: data.presetId,
+      tag_id: data.tagId,
+      workspace_id: data.workspaceId,
+    },
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -442,6 +442,43 @@ export type AgentCustomProviderUpdate = {
   } | null
 }
 
+export type AgentFolderCreate = {
+  name: string
+  parent_path?: string
+}
+
+export type AgentFolderDelete = {
+  recursive?: boolean
+}
+
+export type AgentFolderDirectoryItem = {
+  id: string
+  name: string
+  path: string
+  workspace_id: string
+  created_at: string
+  updated_at: string
+  type: "folder"
+  num_items: number
+}
+
+export type AgentFolderMove = {
+  new_parent_path?: string | null
+}
+
+export type AgentFolderRead = {
+  id: string
+  name: string
+  path: string
+  workspace_id: string
+  created_at: string
+  updated_at: string
+}
+
+export type AgentFolderUpdate = {
+  name?: string | null
+}
+
 export type AgentModel = {
   component_id?: "agent-model"
 }
@@ -507,6 +544,20 @@ export type AgentPresetCreate = {
   skills?: Array<AgentPresetSkillBindingBase> | null
   name: string
   slug?: string | null
+}
+
+export type AgentPresetDirectoryItem = {
+  type: "preset"
+  id: string
+  name: string
+  slug: string
+  description?: string | null
+  model_provider: string
+  model_name: string
+  folder_id?: string | null
+  tags?: Array<TagRead>
+  created_at: string
+  updated_at: string
 }
 
 /**
@@ -581,6 +632,13 @@ export type AgentPresetSkillBindingRead = {
   skill_version_id: string
   skill_name: string
   skill_version: number
+}
+
+/**
+ * Payload for attaching a tag to a preset.
+ */
+export type AgentPresetTagCreate = {
+  tag_id: string
 }
 
 /**
@@ -10289,6 +10347,124 @@ export type AgentSessionsForkSessionData = {
 
 export type AgentSessionsForkSessionResponse = AgentSessionRead
 
+export type AgentFoldersGetDirectoryData = {
+  /**
+   * Folder path
+   */
+  path?: string
+  workspaceId: string
+}
+
+export type AgentFoldersGetDirectoryResponse = Array<
+  AgentFolderDirectoryItem | AgentPresetDirectoryItem
+>
+
+export type AgentFoldersListFoldersData = {
+  /**
+   * Parent folder path
+   */
+  parentPath?: string
+  workspaceId: string
+}
+
+export type AgentFoldersListFoldersResponse = Array<AgentFolderRead>
+
+export type AgentFoldersCreateFolderData = {
+  requestBody: AgentFolderCreate
+  workspaceId: string
+}
+
+export type AgentFoldersCreateFolderResponse = AgentFolderRead
+
+export type AgentFoldersGetFolderData = {
+  folderId: string
+  workspaceId: string
+}
+
+export type AgentFoldersGetFolderResponse = AgentFolderRead
+
+export type AgentFoldersUpdateFolderData = {
+  folderId: string
+  requestBody: AgentFolderUpdate
+  workspaceId: string
+}
+
+export type AgentFoldersUpdateFolderResponse = AgentFolderRead
+
+export type AgentFoldersDeleteFolderData = {
+  folderId: string
+  requestBody: AgentFolderDelete
+  workspaceId: string
+}
+
+export type AgentFoldersDeleteFolderResponse = void
+
+export type AgentFoldersMoveFolderData = {
+  folderId: string
+  requestBody: AgentFolderMove
+  workspaceId: string
+}
+
+export type AgentFoldersMoveFolderResponse = AgentFolderRead
+
+export type AgentTagsListTagsData = {
+  workspaceId: string
+}
+
+export type AgentTagsListTagsResponse = Array<TagRead>
+
+export type AgentTagsCreateTagData = {
+  requestBody: TagCreate
+  workspaceId: string
+}
+
+export type AgentTagsCreateTagResponse = TagRead
+
+export type AgentTagsGetTagData = {
+  tagId: string
+  workspaceId: string
+}
+
+export type AgentTagsGetTagResponse = TagRead
+
+export type AgentTagsUpdateTagData = {
+  requestBody: TagUpdate
+  tagId: string
+  workspaceId: string
+}
+
+export type AgentTagsUpdateTagResponse = TagRead
+
+export type AgentTagsDeleteTagData = {
+  tagId: string
+  workspaceId: string
+}
+
+export type AgentTagsDeleteTagResponse = void
+
+export type AgentPresetsListPresetTagsData = {
+  presetId: string
+  workspaceId: string
+}
+
+export type AgentPresetsListPresetTagsResponse = Array<TagRead>
+
+export type AgentPresetsAddPresetTagData = {
+  presetId: string
+  requestBody: AgentPresetTagCreate
+  workspaceId: string
+}
+
+export type AgentPresetsAddPresetTagResponse = unknown
+
+export type AgentPresetsRemovePresetTagData = {
+  presetId: string
+  tagId: string
+  workspaceId: string
+}
+
+export type AgentPresetsRemovePresetTagResponse = void
+
 export type ApprovalsSubmitApprovalsData = {
   requestBody: ApprovalSubmission
   sessionId: string
@@ -14998,6 +15174,217 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: AgentSessionRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/folders/directory": {
+    get: {
+      req: AgentFoldersGetDirectoryData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<AgentFolderDirectoryItem | AgentPresetDirectoryItem>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/folders": {
+    get: {
+      req: AgentFoldersListFoldersData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<AgentFolderRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    post: {
+      req: AgentFoldersCreateFolderData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: AgentFolderRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/folders/{folder_id}": {
+    get: {
+      req: AgentFoldersGetFolderData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AgentFolderRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    patch: {
+      req: AgentFoldersUpdateFolderData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AgentFolderRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: AgentFoldersDeleteFolderData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/folders/{folder_id}/move": {
+    post: {
+      req: AgentFoldersMoveFolderData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AgentFolderRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/tags": {
+    get: {
+      req: AgentTagsListTagsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<TagRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    post: {
+      req: AgentTagsCreateTagData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: TagRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/tags/{tag_id}": {
+    get: {
+      req: AgentTagsGetTagData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: TagRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    patch: {
+      req: AgentTagsUpdateTagData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: TagRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: AgentTagsDeleteTagData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/presets/{preset_id}/tags": {
+    get: {
+      req: AgentPresetsListPresetTagsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<TagRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    post: {
+      req: AgentPresetsAddPresetTagData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: unknown
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/presets/{preset_id}/tags/{tag_id}": {
+    delete: {
+      req: AgentPresetsRemovePresetTagData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
         /**
          * Validation Error
          */

--- a/frontend/src/components/agents/add-agent-tag-dialog.tsx
+++ b/frontend/src/components/agents/add-agent-tag-dialog.tsx
@@ -1,0 +1,155 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import z from "zod"
+import type { TagCreate } from "@/client"
+import { ColorPicker } from "@/components/color-picker"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { useAgentTags } from "@/hooks/use-agent-tags"
+import { useWorkspaceId } from "@/providers/workspace-id"
+
+const createTagSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Tag name cannot be empty")
+    .max(50, "Tag name cannot be longer than 50 characters")
+    .trim()
+    .refine(
+      (name) => name.trim().length > 0,
+      "Tag name cannot be only whitespace"
+    ),
+  color: z
+    .string()
+    .regex(/^#[0-9A-Fa-f]{6}$/, "Color must be a valid hex color code"),
+})
+
+interface AddAgentTagDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Modal for creating a new agent tag definition.
+ *
+ * Mirrors AddWorkflowTagDialog so the UX is consistent across catalogs.
+ */
+export function AddAgentTagDialog({
+  open,
+  onOpenChange,
+}: AddAgentTagDialogProps) {
+  const workspaceId = useWorkspaceId()
+  const { tags, createTag } = useAgentTags(workspaceId, { enabled: open })
+
+  const methods = useForm<TagCreate>({
+    resolver: zodResolver(createTagSchema),
+    defaultValues: {
+      name: "",
+      color: "#aabbcc",
+    },
+  })
+
+  async function handleCreate(params: TagCreate) {
+    try {
+      const collision = tags?.some(
+        (tag) => tag.name.toLowerCase() === params.name.trim().toLowerCase()
+      )
+      if (collision) {
+        methods.setError("name", {
+          type: "manual",
+          message: "A tag with this name already exists",
+        })
+        return
+      }
+      await createTag(params)
+      methods.reset({ name: "", color: "#aabbcc" })
+      onOpenChange(false)
+    } catch (error) {
+      console.error("Error creating agent tag", error)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create new agent tag</DialogTitle>
+          <DialogDescription>
+            Enter a name and color for your new agent tag.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...methods}>
+          <form onSubmit={methods.handleSubmit(handleCreate)}>
+            <div className="space-y-4">
+              <FormField
+                key="name"
+                control={methods.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-sm">Name</FormLabel>
+                    <FormControl>
+                      <Input
+                        className="text-sm"
+                        placeholder="Name"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                key="color"
+                control={methods.control}
+                name="color"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-sm">Color</FormLabel>
+                    <div className="flex gap-2">
+                      <FormControl>
+                        <Input
+                          className="max-w-24 font-mono text-sm"
+                          placeholder="#000000"
+                          value={field.value ?? "#000000"}
+                          onChange={(e) => field.onChange(e.target.value)}
+                        />
+                      </FormControl>
+                      <ColorPicker
+                        value={field.value ?? "#000000"}
+                        onChange={(color) => field.onChange(color)}
+                      />
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <DialogFooter>
+                <Button className="ml-auto" type="submit">
+                  Create tag
+                </Button>
+              </DialogFooter>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/agents/agent-tags-view.tsx
+++ b/frontend/src/components/agents/agent-tags-view.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { PlusIcon, TagIcon } from "lucide-react"
+import { useState } from "react"
+import type { TagUpdate } from "@/client"
+import { AddAgentTagDialog } from "@/components/agents/add-agent-tag-dialog"
+import { WorkflowTagsTable } from "@/components/dashboard/workflow-tags-table"
+import { CenteredSpinner } from "@/components/loading/spinner"
+import { AlertNotification } from "@/components/notifications"
+import { Button } from "@/components/ui/button"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
+import { useAgentTags } from "@/hooks/use-agent-tags"
+import { useWorkspaceDetails } from "@/hooks/use-workspace"
+import { useWorkspaceId } from "@/providers/workspace-id"
+
+/**
+ * Workspace-level admin view for agent tag definitions.
+ *
+ * Reuses WorkflowTagsTable since the underlying tag shape (name, ref, color)
+ * is identical to WorkflowTag. Only the data source and CRUD callbacks change.
+ */
+export function AgentTagsView() {
+  const workspaceId = useWorkspaceId()
+  const { workspace, workspaceLoading, workspaceError } = useWorkspaceDetails()
+  const [createOpen, setCreateOpen] = useState(false)
+
+  const {
+    tags,
+    tagsIsLoading,
+    tagsError,
+    deleteTag,
+    deleteTagIsPending,
+    updateTag,
+    updateTagIsPending,
+  } = useAgentTags(workspaceId)
+
+  async function handleDelete(tagId: string) {
+    await deleteTag(tagId)
+  }
+
+  async function handleUpdate(tagId: string, params: TagUpdate) {
+    await updateTag({ tagId, params })
+  }
+
+  if (workspaceLoading || tagsIsLoading) {
+    return <CenteredSpinner />
+  }
+
+  if (workspaceError) {
+    return (
+      <AlertNotification
+        level="error"
+        message="Error loading workspace info."
+      />
+    )
+  }
+
+  if (!workspace) {
+    return <AlertNotification level="error" message="Workspace not found." />
+  }
+
+  if (tagsError) {
+    return (
+      <AlertNotification
+        level="error"
+        message={`Error loading tags: ${tagsError.message}`}
+      />
+    )
+  }
+
+  return (
+    <div className="size-full overflow-auto">
+      <div className="container flex h-full max-w-[1000px] flex-col space-y-8 py-8">
+        <div className="flex items-center justify-between">
+          <div className="space-y-3">
+            <h2 className="text-2xl font-semibold tracking-tight">
+              Agent tags
+            </h2>
+            <p className="text-base text-muted-foreground">
+              Organize agents with tags. Tags are scoped to this workspace.
+            </p>
+          </div>
+          <Button
+            size="sm"
+            className="flex items-center gap-2"
+            onClick={() => setCreateOpen(true)}
+          >
+            <PlusIcon className="size-4" />
+            New tag
+          </Button>
+        </div>
+
+        {!tags || tags.length === 0 ? (
+          <Empty className="h-full">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <TagIcon className="size-6" />
+              </EmptyMedia>
+              <EmptyTitle>No tags defined yet</EmptyTitle>
+              <EmptyDescription>
+                Create your first agent tag using the button above.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <div className="space-y-4">
+            <WorkflowTagsTable
+              tags={tags}
+              onDeleteTag={handleDelete}
+              onUpdateTag={handleUpdate}
+              isDeleting={deleteTagIsPending}
+              isUpdating={updateTagIsPending}
+            />
+          </div>
+        )}
+
+        <AddAgentTagDialog open={createOpen} onOpenChange={setCreateOpen} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/use-agent-folders.ts
+++ b/frontend/src/hooks/use-agent-folders.ts
@@ -1,0 +1,226 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  type AgentFolderCreate,
+  type AgentFolderDirectoryItem,
+  type AgentFolderRead,
+  type AgentPresetDirectoryItem,
+  agentFoldersCreateFolder,
+  agentFoldersDeleteFolder,
+  agentFoldersGetDirectory,
+  agentFoldersListFolders,
+  agentFoldersMoveFolder,
+  agentFoldersUpdateFolder,
+} from "@/client"
+import { toast } from "@/components/ui/use-toast"
+import type { TracecatApiError } from "@/lib/errors"
+
+export type AgentDirectoryItem =
+  | AgentFolderDirectoryItem
+  | AgentPresetDirectoryItem
+
+const FOLDERS_KEY = "agent-folders"
+const DIRECTORY_KEY = "agent-directory-items"
+
+/**
+ * Manage agent preset folders for a workspace.
+ *
+ * Mirrors the workflow folder hook so the agents catalog feels identical to
+ * users coming from /workflows.
+ */
+export function useAgentFolders(
+  workspaceId: string,
+  options: { enabled?: boolean } = {}
+) {
+  const enabled = options.enabled ?? true
+  const queryClient = useQueryClient()
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: [FOLDERS_KEY, workspaceId] })
+    queryClient.invalidateQueries({ queryKey: [DIRECTORY_KEY, workspaceId] })
+  }
+
+  const {
+    data: folders,
+    isLoading: foldersIsLoading,
+    error: foldersError,
+  } = useQuery<AgentFolderRead[]>({
+    queryKey: [FOLDERS_KEY, workspaceId],
+    queryFn: async () => await agentFoldersListFolders({ workspaceId }),
+    enabled: enabled && !!workspaceId,
+  })
+
+  const { mutateAsync: createFolder, isPending: createFolderIsPending } =
+    useMutation({
+      mutationFn: async (params: AgentFolderCreate) =>
+        await agentFoldersCreateFolder({ workspaceId, requestBody: params }),
+      onSuccess: () => {
+        invalidate()
+        toast({ title: "Created folder" })
+      },
+      onError: (error: TracecatApiError) => {
+        if (error.status === 409) {
+          toast({
+            title: "Folder already exists",
+            description: "Pick a different name and try again.",
+          })
+        } else if (error.status === 403) {
+          toast({
+            title: "Forbidden",
+            description: "You cannot perform this action",
+          })
+        } else {
+          toast({
+            title: "Failed to create folder",
+            description: String(error.body.detail ?? error.message),
+          })
+        }
+      },
+    })
+
+  const { mutateAsync: updateFolder, isPending: updateFolderIsPending } =
+    useMutation({
+      mutationFn: async ({
+        folderId,
+        name,
+      }: {
+        folderId: string
+        name: string
+      }) =>
+        await agentFoldersUpdateFolder({
+          folderId,
+          workspaceId,
+          requestBody: { name },
+        }),
+      onSuccess: () => {
+        invalidate()
+        toast({ title: "Renamed folder" })
+      },
+      onError: (error: TracecatApiError) => {
+        if (error.status === 409) {
+          toast({
+            title: "Folder already exists",
+            description: "Pick a different name and try again.",
+          })
+        } else {
+          toast({
+            title: "Failed to rename folder",
+            description: String(error.body.detail ?? error.message),
+          })
+        }
+      },
+    })
+
+  const { mutateAsync: moveFolder, isPending: moveFolderIsPending } =
+    useMutation({
+      mutationFn: async ({
+        folderId,
+        newParentPath,
+      }: {
+        folderId: string
+        newParentPath: string | null
+      }) =>
+        await agentFoldersMoveFolder({
+          folderId,
+          workspaceId,
+          requestBody: { new_parent_path: newParentPath },
+        }),
+      onSuccess: () => {
+        invalidate()
+        toast({ title: "Moved folder" })
+      },
+      onError: (error: TracecatApiError) => {
+        toast({
+          title: "Failed to move folder",
+          description: String(error.body.detail ?? error.message),
+        })
+      },
+    })
+
+  const { mutateAsync: deleteFolder, isPending: deleteFolderIsPending } =
+    useMutation({
+      mutationFn: async ({
+        folderId,
+        recursive = false,
+      }: {
+        folderId: string
+        recursive?: boolean
+      }) =>
+        await agentFoldersDeleteFolder({
+          folderId,
+          workspaceId,
+          requestBody: { recursive },
+        }),
+      onSuccess: () => {
+        invalidate()
+        toast({ title: "Deleted folder" })
+      },
+      onError: (error: TracecatApiError) => {
+        if (error.status === 400) {
+          toast({
+            title: "Cannot delete folder",
+            description: String(error.body.detail),
+          })
+        } else {
+          toast({
+            title: "Failed to delete folder",
+            description: String(error.body.detail ?? error.message),
+          })
+        }
+      },
+    })
+
+  return {
+    folders,
+    foldersIsLoading,
+    foldersError,
+    createFolder,
+    createFolderIsPending,
+    updateFolder,
+    updateFolderIsPending,
+    moveFolder,
+    moveFolderIsPending,
+    deleteFolder,
+    deleteFolderIsPending,
+  }
+}
+
+/**
+ * Fetch directory items (folders and presets) at a given path.
+ */
+export function useAgentDirectory(
+  path: string,
+  workspaceId?: string,
+  options: { enabled?: boolean } = {}
+) {
+  const enabled = options.enabled ?? true
+  const {
+    data: items,
+    isLoading,
+    error,
+  } = useQuery<AgentDirectoryItem[]>({
+    enabled: enabled && !!workspaceId,
+    queryKey: [DIRECTORY_KEY, workspaceId, path],
+    queryFn: async () =>
+      await agentFoldersGetDirectory({ path, workspaceId: workspaceId ?? "" }),
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  })
+
+  return { items, isLoading, error }
+}
+
+/** Predicate for narrowing AgentDirectoryItem to folder. */
+export function isAgentFolderItem(
+  item: AgentDirectoryItem
+): item is AgentFolderDirectoryItem {
+  return item.type === "folder"
+}
+
+/** Predicate for narrowing AgentDirectoryItem to preset. */
+export function isAgentPresetItem(
+  item: AgentDirectoryItem
+): item is AgentPresetDirectoryItem {
+  return item.type === "preset"
+}

--- a/frontend/src/hooks/use-agent-tags.ts
+++ b/frontend/src/hooks/use-agent-tags.ts
@@ -1,0 +1,210 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  agentPresetsAddPresetTag,
+  agentPresetsListPresetTags,
+  agentPresetsRemovePresetTag,
+  agentTagsCreateTag,
+  agentTagsDeleteTag,
+  agentTagsListTags,
+  agentTagsUpdateTag,
+  type TagCreate,
+  type TagRead,
+  type TagUpdate,
+} from "@/client"
+import { toast } from "@/components/ui/use-toast"
+import type { TracecatApiError } from "@/lib/errors"
+
+const TAGS_KEY = "agent-tags"
+const PRESET_TAGS_KEY = "agent-preset-tags"
+const DIRECTORY_KEY = "agent-directory-items"
+
+/**
+ * Manage agent tag definitions for a workspace.
+ */
+export function useAgentTags(
+  workspaceId: string,
+  options: { enabled?: boolean } = {}
+) {
+  const enabled = options.enabled ?? true
+  const queryClient = useQueryClient()
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: [TAGS_KEY, workspaceId] })
+    queryClient.invalidateQueries({ queryKey: [PRESET_TAGS_KEY] })
+    queryClient.invalidateQueries({ queryKey: [DIRECTORY_KEY, workspaceId] })
+  }
+
+  const {
+    data: tags,
+    isLoading: tagsIsLoading,
+    error: tagsError,
+  } = useQuery<TagRead[]>({
+    queryKey: [TAGS_KEY, workspaceId],
+    queryFn: async () => await agentTagsListTags({ workspaceId }),
+    enabled: enabled && !!workspaceId,
+  })
+
+  const { mutateAsync: createTag, isPending: createTagIsPending } = useMutation(
+    {
+      mutationFn: async (params: TagCreate) =>
+        await agentTagsCreateTag({ workspaceId, requestBody: params }),
+      onSuccess: () => {
+        invalidate()
+        toast({ title: "Created tag" })
+      },
+      onError: (error: TracecatApiError) => {
+        if (error.status === 409) {
+          toast({
+            title: "Tag already exists",
+            description:
+              "A tag with this name already exists in this workspace.",
+          })
+        } else {
+          toast({
+            title: "Failed to create tag",
+            description: String(error.body.detail ?? error.message),
+          })
+        }
+      },
+    }
+  )
+
+  const { mutateAsync: updateTag, isPending: updateTagIsPending } = useMutation(
+    {
+      mutationFn: async ({
+        tagId,
+        params,
+      }: {
+        tagId: string
+        params: TagUpdate
+      }) =>
+        await agentTagsUpdateTag({
+          tagId,
+          workspaceId,
+          requestBody: params,
+        }),
+      onSuccess: () => {
+        invalidate()
+        toast({ title: "Updated tag" })
+      },
+      onError: (error: TracecatApiError) => {
+        if (error.status === 409) {
+          toast({
+            title: "Tag already exists",
+            description: "Another tag with this name already exists.",
+          })
+        } else {
+          toast({
+            title: "Failed to update tag",
+            description: String(error.body.detail ?? error.message),
+          })
+        }
+      },
+    }
+  )
+
+  const { mutateAsync: deleteTag, isPending: deleteTagIsPending } = useMutation(
+    {
+      mutationFn: async (tagId: string) =>
+        await agentTagsDeleteTag({ tagId, workspaceId }),
+      onSuccess: () => {
+        invalidate()
+        toast({ title: "Deleted tag" })
+      },
+      onError: (error: TracecatApiError) => {
+        toast({
+          title: "Failed to delete tag",
+          description: String(error.body.detail ?? error.message),
+        })
+      },
+    }
+  )
+
+  return {
+    tags,
+    tagsIsLoading,
+    tagsError,
+    createTag,
+    createTagIsPending,
+    updateTag,
+    updateTagIsPending,
+    deleteTag,
+    deleteTagIsPending,
+  }
+}
+
+/**
+ * Manage tags attached to a single agent preset.
+ */
+export function usePresetTags(
+  presetId: string,
+  workspaceId: string,
+  options: { enabled?: boolean } = {}
+) {
+  const enabled = options.enabled ?? true
+  const queryClient = useQueryClient()
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({
+      queryKey: [PRESET_TAGS_KEY, workspaceId, presetId],
+    })
+    queryClient.invalidateQueries({ queryKey: [DIRECTORY_KEY, workspaceId] })
+  }
+
+  const {
+    data: presetTags,
+    isLoading: presetTagsIsLoading,
+    error: presetTagsError,
+  } = useQuery<TagRead[]>({
+    queryKey: [PRESET_TAGS_KEY, workspaceId, presetId],
+    queryFn: async () =>
+      await agentPresetsListPresetTags({ presetId, workspaceId }),
+    enabled: enabled && !!workspaceId && !!presetId,
+  })
+
+  const { mutateAsync: addPresetTag, isPending: addPresetTagIsPending } =
+    useMutation({
+      mutationFn: async (tagId: string) =>
+        await agentPresetsAddPresetTag({
+          presetId,
+          workspaceId,
+          requestBody: { tag_id: tagId },
+        }),
+      onSuccess: () => {
+        invalidate()
+      },
+      onError: (error: TracecatApiError) => {
+        toast({
+          title: "Failed to attach tag",
+          description: String(error.body.detail ?? error.message),
+        })
+      },
+    })
+
+  const { mutateAsync: removePresetTag, isPending: removePresetTagIsPending } =
+    useMutation({
+      mutationFn: async (tagId: string) =>
+        await agentPresetsRemovePresetTag({ presetId, tagId, workspaceId }),
+      onSuccess: () => {
+        invalidate()
+      },
+      onError: (error: TracecatApiError) => {
+        toast({
+          title: "Failed to detach tag",
+          description: String(error.body.detail ?? error.message),
+        })
+      },
+    })
+
+  return {
+    presetTags,
+    presetTagsIsLoading,
+    presetTagsError,
+    addPresetTag,
+    addPresetTagIsPending,
+    removePresetTag,
+    removePresetTagIsPending,
+  }
+}

--- a/tests/unit/test_agent_folders_service.py
+++ b/tests/unit/test_agent_folders_service.py
@@ -1,0 +1,178 @@
+"""Unit tests for AgentFolderService."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.agent.folders.service import AgentFolderService
+from tracecat.auth.types import Role
+from tracecat.db.models import AgentPreset, Workspace
+from tracecat.exceptions import (
+    TracecatConflictError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+async def folder_service(session: AsyncSession, svc_role: Role) -> AgentFolderService:
+    return AgentFolderService(session=session, role=svc_role)
+
+
+@pytest.fixture
+async def preset(
+    session: AsyncSession, svc_workspace: Workspace
+) -> AsyncGenerator[AgentPreset, None]:
+    p = AgentPreset(
+        name="test preset",
+        slug="test-preset",
+        workspace_id=svc_workspace.id,
+        model_name="claude-3-5-sonnet",
+        model_provider="anthropic",
+    )
+    session.add(p)
+    await session.commit()
+    try:
+        yield p
+    finally:
+        await session.delete(p)
+        await session.commit()
+
+
+@pytest.mark.anyio
+class TestAgentFolderService:
+    async def test_create_and_get(self, folder_service: AgentFolderService) -> None:
+        folder = await folder_service.create_folder(name="alpha")
+        assert folder.path == "/alpha/"
+
+        by_id = await folder_service.get_folder(folder.id)
+        assert by_id is not None and by_id.id == folder.id
+
+        by_path = await folder_service.get_folder_by_path("/alpha/")
+        assert by_path is not None and by_path.id == folder.id
+
+    async def test_nested_create(self, folder_service: AgentFolderService) -> None:
+        await folder_service.create_folder(name="parent")
+        child = await folder_service.create_folder(name="child", parent_path="/parent/")
+        assert child.path == "/parent/child/"
+
+    async def test_blank_name_rejected(
+        self, folder_service: AgentFolderService
+    ) -> None:
+        with pytest.raises(TracecatValidationError):
+            await folder_service.create_folder(name="   ")
+
+    async def test_slash_in_name_rejected(
+        self, folder_service: AgentFolderService
+    ) -> None:
+        with pytest.raises(TracecatValidationError):
+            await folder_service.create_folder(name="bad/name")
+
+    async def test_duplicate_path_raises_conflict(
+        self, folder_service: AgentFolderService
+    ) -> None:
+        await folder_service.create_folder(name="dup")
+        with pytest.raises(TracecatConflictError):
+            await folder_service.create_folder(name="dup")
+
+    async def test_missing_parent_rejected(
+        self, folder_service: AgentFolderService
+    ) -> None:
+        with pytest.raises(TracecatValidationError):
+            await folder_service.create_folder(name="x", parent_path="/nope/")
+
+    async def test_rename_updates_descendants(
+        self, folder_service: AgentFolderService
+    ) -> None:
+        await folder_service.create_folder(name="parent")
+        await folder_service.create_folder(name="child", parent_path="/parent/")
+        await folder_service.create_folder(
+            name="grandchild", parent_path="/parent/child/"
+        )
+
+        parent = await folder_service.get_folder_by_path("/parent/")
+        assert parent is not None
+        await folder_service.rename_folder(parent.id, "renamed")
+
+        grandchild = await folder_service.get_folder_by_path(
+            "/renamed/child/grandchild/"
+        )
+        assert grandchild is not None
+
+    async def test_move_folder_prevents_cycles(
+        self, folder_service: AgentFolderService
+    ) -> None:
+        a = await folder_service.create_folder(name="a")
+        b = await folder_service.create_folder(name="b", parent_path="/a/")
+        with pytest.raises(TracecatValidationError):
+            await folder_service.move_folder(a.id, b.id)
+
+    async def test_delete_non_empty_blocks_without_recursive(
+        self, folder_service: AgentFolderService
+    ) -> None:
+        parent = await folder_service.create_folder(name="parent")
+        await folder_service.create_folder(name="child", parent_path="/parent/")
+        with pytest.raises(TracecatValidationError):
+            await folder_service.delete_folder(parent.id, recursive=False)
+
+    async def test_delete_recursive_detaches_presets(
+        self,
+        folder_service: AgentFolderService,
+        preset: AgentPreset,
+        session: AsyncSession,
+    ) -> None:
+        folder = await folder_service.create_folder(name="bucket")
+        await folder_service.move_preset(preset.id, folder)
+
+        await folder_service.delete_folder(folder.id, recursive=True)
+
+        await session.refresh(preset)
+        assert preset.folder_id is None
+
+    async def test_move_preset_to_root(
+        self,
+        folder_service: AgentFolderService,
+        preset: AgentPreset,
+        session: AsyncSession,
+    ) -> None:
+        folder = await folder_service.create_folder(name="bucket")
+        await folder_service.move_preset(preset.id, folder)
+        await session.refresh(preset)
+        assert preset.folder_id == folder.id
+
+        await folder_service.move_preset(preset.id, None)
+        await session.refresh(preset)
+        assert preset.folder_id is None
+
+    async def test_move_missing_preset_raises_not_found(
+        self, folder_service: AgentFolderService
+    ) -> None:
+        import uuid
+
+        with pytest.raises(TracecatNotFoundError):
+            await folder_service.move_preset(uuid.uuid4(), None)
+
+    async def test_get_directory_items_root(
+        self,
+        folder_service: AgentFolderService,
+        preset: AgentPreset,
+    ) -> None:
+        await folder_service.create_folder(name="alpha")
+        await folder_service.create_folder(name="beta")
+
+        items = await folder_service.get_directory_items("/")
+        types = {i.type for i in items}
+        assert "folder" in types and "preset" in types
+        names = {getattr(i, "name", None) for i in items}
+        assert {"alpha", "beta"}.issubset(names)
+
+    async def test_get_directory_items_unknown_path_raises(
+        self, folder_service: AgentFolderService
+    ) -> None:
+        with pytest.raises(TracecatNotFoundError):
+            await folder_service.get_directory_items("/does-not-exist/")

--- a/tests/unit/test_agent_tags_service.py
+++ b/tests/unit/test_agent_tags_service.py
@@ -1,0 +1,138 @@
+"""Unit tests for AgentTagsService."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.agent.tags.schemas import AgentTagCreate, AgentTagUpdate
+from tracecat.agent.tags.service import AgentTagsService
+from tracecat.auth.types import Role
+from tracecat.db.models import AgentPreset, AgentTagLink, Workspace
+from tracecat.exceptions import TracecatConflictError, TracecatNotFoundError
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+async def tags_service(session: AsyncSession, svc_role: Role) -> AgentTagsService:
+    return AgentTagsService(session=session, role=svc_role)
+
+
+@pytest.fixture
+async def preset(
+    session: AsyncSession, svc_workspace: Workspace
+) -> AsyncGenerator[AgentPreset, None]:
+    p = AgentPreset(
+        name="test preset",
+        slug="test-preset-tags",
+        workspace_id=svc_workspace.id,
+        model_name="claude-3-5-sonnet",
+        model_provider="anthropic",
+    )
+    session.add(p)
+    await session.commit()
+    try:
+        yield p
+    finally:
+        await session.delete(p)
+        await session.commit()
+
+
+@pytest.mark.anyio
+class TestAgentTagsService:
+    async def test_create_and_list(self, tags_service: AgentTagsService) -> None:
+        tag = await tags_service.create_tag(
+            AgentTagCreate(name="Sec Ops", color="#FF0000")
+        )
+        assert tag.name == "Sec Ops"
+        assert tag.ref == "sec-ops"
+        assert tag.color == "#FF0000"
+
+        tags = await tags_service.list_tags()
+        assert any(t.id == tag.id for t in tags)
+
+    async def test_duplicate_slug_raises_conflict(
+        self, tags_service: AgentTagsService
+    ) -> None:
+        await tags_service.create_tag(AgentTagCreate(name="Triage"))
+        with pytest.raises(TracecatConflictError):
+            await tags_service.create_tag(AgentTagCreate(name="triage"))
+
+    async def test_blank_slug_rejected(self, tags_service: AgentTagsService) -> None:
+        with pytest.raises(TracecatConflictError):
+            # Pure punctuation slugifies to empty.
+            await tags_service.create_tag(AgentTagCreate(name="---"))
+
+    async def test_update_regenerates_ref(self, tags_service: AgentTagsService) -> None:
+        tag = await tags_service.create_tag(AgentTagCreate(name="Old Name"))
+        updated = await tags_service.update_tag(tag, AgentTagUpdate(name="New Name"))
+        assert updated.name == "New Name"
+        assert updated.ref == "new-name"
+
+    async def test_update_to_existing_slug_raises_conflict(
+        self, tags_service: AgentTagsService
+    ) -> None:
+        await tags_service.create_tag(AgentTagCreate(name="One"))
+        two = await tags_service.create_tag(AgentTagCreate(name="Two"))
+        with pytest.raises(TracecatConflictError):
+            await tags_service.update_tag(two, AgentTagUpdate(name="One"))
+
+    async def test_get_by_ref(self, tags_service: AgentTagsService) -> None:
+        tag = await tags_service.create_tag(AgentTagCreate(name="Find Me"))
+        found = await tags_service.get_tag_by_ref(tag.ref)
+        assert found.id == tag.id
+
+    async def test_get_unknown_id_raises_not_found(
+        self, tags_service: AgentTagsService
+    ) -> None:
+        with pytest.raises(TracecatNotFoundError):
+            await tags_service.get_tag(uuid.uuid4())
+
+    async def test_add_preset_tag_idempotent(
+        self,
+        tags_service: AgentTagsService,
+        preset: AgentPreset,
+    ) -> None:
+        tag = await tags_service.create_tag(AgentTagCreate(name="Attach"))
+        link1 = await tags_service.add_preset_tag(preset.id, tag.id)
+        link2 = await tags_service.add_preset_tag(preset.id, tag.id)
+        assert isinstance(link1, AgentTagLink)
+        assert isinstance(link2, AgentTagLink)
+        assert link1.preset_id == link2.preset_id == preset.id
+        assert link1.tag_id == link2.tag_id == tag.id
+
+    async def test_remove_preset_tag(
+        self,
+        tags_service: AgentTagsService,
+        preset: AgentPreset,
+    ) -> None:
+        tag = await tags_service.create_tag(AgentTagCreate(name="Remove me"))
+        link = await tags_service.add_preset_tag(preset.id, tag.id)
+        await tags_service.remove_preset_tag(link)
+        with pytest.raises(TracecatNotFoundError):
+            await tags_service.get_preset_tag_link(preset.id, tag.id)
+
+    async def test_add_tag_for_unknown_preset_raises_not_found(
+        self,
+        tags_service: AgentTagsService,
+    ) -> None:
+        tag = await tags_service.create_tag(AgentTagCreate(name="Stray"))
+        with pytest.raises(TracecatNotFoundError):
+            await tags_service.add_preset_tag(uuid.uuid4(), tag.id)
+
+    async def test_list_tags_for_preset_returns_only_attached(
+        self,
+        tags_service: AgentTagsService,
+        preset: AgentPreset,
+    ) -> None:
+        attached = await tags_service.create_tag(AgentTagCreate(name="In"))
+        await tags_service.create_tag(AgentTagCreate(name="Out"))
+        await tags_service.add_preset_tag(preset.id, attached.id)
+
+        result = await tags_service.list_tags_for_preset(preset.id)
+        ids = {t.id for t in result}
+        assert ids == {attached.id}

--- a/tracecat/agent/folders/router.py
+++ b/tracecat/agent/folders/router.py
@@ -1,0 +1,184 @@
+"""HTTP routes for agent preset folders."""
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from tracecat.agent.folders.schemas import (
+    AgentFolderCreate,
+    AgentFolderDelete,
+    AgentFolderMove,
+    AgentFolderRead,
+    AgentFolderUpdate,
+    DirectoryItem,
+)
+from tracecat.agent.folders.service import AgentFolderService
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
+from tracecat.authz.controls import require_scope
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import (
+    TracecatConflictError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
+from tracecat.identifiers import AgentFolderID
+
+router = APIRouter(prefix="/agent/folders", tags=["agent-folders"])
+
+
+@router.get("/directory")
+@require_scope("agent:read")
+async def get_directory(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    path: str = Query(default="/", description="Folder path"),
+) -> list[DirectoryItem]:
+    """List the directory items (folders and presets) at the given path."""
+    service = AgentFolderService(session, role=role)
+    try:
+        result = await service.get_directory_items(path, order_by="desc")
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return list(result)
+
+
+@router.get("")
+@require_scope("agent:read")
+async def list_folders(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    parent_path: str = Query(default="/", description="Parent folder path"),
+) -> list[AgentFolderRead]:
+    """List folders in the subtree under ``parent_path``."""
+    service = AgentFolderService(session, role=role)
+    folders = await service.list_folders(parent_path=parent_path)
+    folders = [f for f in folders if f.path != parent_path]
+    return [
+        AgentFolderRead.model_validate(folder, from_attributes=True)
+        for folder in folders
+    ]
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+@require_scope("agent:create")
+async def create_folder(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    params: AgentFolderCreate,
+) -> AgentFolderRead:
+    """Create a new agent folder."""
+    service = AgentFolderService(session, role=role)
+    try:
+        folder = await service.create_folder(
+            name=params.name, parent_path=params.parent_path
+        )
+    except TracecatConflictError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from e
+    return AgentFolderRead.model_validate(folder, from_attributes=True)
+
+
+@router.get("/{folder_id}")
+@require_scope("agent:read")
+async def get_folder(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    folder_id: AgentFolderID,
+) -> AgentFolderRead:
+    """Get folder details by ID."""
+    service = AgentFolderService(session, role=role)
+    folder = await service.get_folder(folder_id)
+    if not folder:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found"
+        )
+    return AgentFolderRead.model_validate(folder, from_attributes=True)
+
+
+@router.patch("/{folder_id}")
+@require_scope("agent:update")
+async def update_folder(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    folder_id: AgentFolderID,
+    params: AgentFolderUpdate,
+) -> AgentFolderRead:
+    """Update a folder (rename)."""
+    service = AgentFolderService(session, role=role)
+    if params.name is None:
+        folder = await service.get_folder(folder_id)
+        if not folder:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found"
+            )
+        return AgentFolderRead.model_validate(folder, from_attributes=True)
+    try:
+        folder = await service.rename_folder(folder_id, params.name)
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except TracecatConflictError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from e
+    return AgentFolderRead.model_validate(folder, from_attributes=True)
+
+
+@router.delete("/{folder_id}", status_code=status.HTTP_204_NO_CONTENT)
+@require_scope("agent:delete")
+async def delete_folder(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    folder_id: AgentFolderID,
+    params: AgentFolderDelete,
+) -> None:
+    """Delete a folder.
+
+    With ``recursive=True`` descendant folders are deleted and their presets
+    are moved back to root. With ``recursive=False`` (default) the folder
+    must be empty.
+    """
+    service = AgentFolderService(session, role=role)
+    try:
+        await service.delete_folder(folder_id, recursive=params.recursive)
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from e
+
+
+@router.post("/{folder_id}/move")
+@require_scope("agent:update")
+async def move_folder(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    folder_id: AgentFolderID,
+    params: AgentFolderMove,
+) -> AgentFolderRead:
+    """Move a folder to a new parent."""
+    service = AgentFolderService(session, role=role)
+    new_parent_id: AgentFolderID | None = None
+    if params.new_parent_path and params.new_parent_path != "/":
+        parent_folder = await service.get_folder_by_path(params.new_parent_path)
+        if not parent_folder:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Parent folder with path {params.new_parent_path} not found",
+            )
+        new_parent_id = parent_folder.id
+
+    try:
+        folder = await service.move_folder(folder_id, new_parent_id)
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except TracecatConflictError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from e
+    return AgentFolderRead.model_validate(folder, from_attributes=True)

--- a/tracecat/agent/folders/schemas.py
+++ b/tracecat/agent/folders/schemas.py
@@ -1,0 +1,63 @@
+"""Pydantic schemas for agent folders and the directory listing."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field, TypeAdapter
+
+from tracecat.tags.schemas import TagRead
+
+
+class AgentFolderRead(BaseModel):
+    id: uuid.UUID
+    name: str
+    path: str
+    workspace_id: uuid.UUID
+    created_at: datetime
+    updated_at: datetime
+
+
+class AgentFolderCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    parent_path: str = "/"
+
+
+class AgentFolderUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+
+
+class AgentFolderMove(BaseModel):
+    new_parent_path: str | None = None
+
+
+class AgentFolderDelete(BaseModel):
+    recursive: bool = False
+
+
+class AgentFolderDirectoryItem(AgentFolderRead):
+    type: Literal["folder"]
+    num_items: int
+
+
+class AgentPresetDirectoryItem(BaseModel):
+    type: Literal["preset"]
+    id: uuid.UUID
+    name: str
+    slug: str
+    description: str | None = None
+    model_provider: str
+    model_name: str
+    folder_id: uuid.UUID | None = None
+    tags: list[TagRead] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+
+DirectoryItem = Annotated[
+    AgentFolderDirectoryItem | AgentPresetDirectoryItem,
+    Field(discriminator="type"),
+]
+DirectoryItemAdapter: TypeAdapter[DirectoryItem] = TypeAdapter(DirectoryItem)

--- a/tracecat/agent/folders/service.py
+++ b/tracecat/agent/folders/service.py
@@ -1,0 +1,504 @@
+"""Service for agent preset folders using the materialized-path pattern."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from typing import Literal
+
+from sqlalchemy import case, func, or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import selectinload
+
+from tracecat.agent.folders.schemas import (
+    AgentFolderDirectoryItem,
+    AgentPresetDirectoryItem,
+    DirectoryItem,
+)
+from tracecat.authz.controls import require_scope
+from tracecat.db.models import AgentFolder, AgentPreset
+from tracecat.exceptions import (
+    TracecatConflictError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
+from tracecat.identifiers import AgentFolderID
+from tracecat.service import BaseWorkspaceService
+from tracecat.tags.schemas import TagRead
+
+
+class AgentFolderService(BaseWorkspaceService):
+    """Manages agent preset folders using the materialized path pattern.
+
+    Path format: ``/parent/child/`` with each segment being a folder name.
+    Root folders have path ``/foldername/``.
+    """
+
+    service_name = "agent_folders"
+
+    @staticmethod
+    def _normalize_folder_path(path: str) -> str:
+        """Normalize a folder path to materialized-path format."""
+        if path == "/":
+            return path
+        return path if path.endswith("/") else f"{path}/"
+
+    @require_scope("agent:create")
+    async def create_folder(
+        self, name: str, parent_path: str = "/", *, commit: bool = True
+    ) -> AgentFolder:
+        """Create a new agent folder.
+
+        Concurrent creates of the same path are caught by the unique
+        ``(path, workspace_id)`` constraint and surfaced as a validation
+        error rather than an unhandled IntegrityError.
+        """
+        name = name.strip()
+        if not name:
+            raise TracecatValidationError("Folder name cannot be blank")
+        if "/" in name:
+            raise TracecatValidationError("Folder name cannot contain slashes")
+
+        parent_path = self._normalize_folder_path(parent_path)
+        if parent_path != "/" and not await self._folder_path_exists(parent_path):
+            raise TracecatValidationError(f"Parent path {parent_path} not found")
+
+        full_path = f"{parent_path}{name}/" if parent_path != "/" else f"/{name}/"
+        if await self._folder_path_exists(full_path):
+            raise TracecatConflictError(f"Folder {full_path} already exists")
+
+        folder = AgentFolder(
+            name=name,
+            path=full_path,
+            workspace_id=self.workspace_id,
+        )
+        self.session.add(folder)
+        try:
+            if commit:
+                await self.session.commit()
+            else:
+                await self.session.flush()
+        except IntegrityError as e:
+            await self.session.rollback()
+            raise TracecatConflictError(f"Folder {full_path} already exists") from e
+        await self.session.refresh(folder)
+        return folder
+
+    async def get_folder(self, folder_id: AgentFolderID) -> AgentFolder | None:
+        """Get a folder by ID."""
+        statement = select(AgentFolder).where(
+            AgentFolder.workspace_id == self.workspace_id,
+            AgentFolder.id == folder_id,
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one_or_none()
+
+    async def get_folder_by_path(self, path: str) -> AgentFolder | None:
+        """Get a folder by its path."""
+        path = self._normalize_folder_path(path)
+        statement = select(AgentFolder).where(
+            AgentFolder.workspace_id == self.workspace_id,
+            AgentFolder.path == path,
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one_or_none()
+
+    async def list_folders(self, parent_path: str = "/") -> Sequence[AgentFolder]:
+        """List all folders in the subtree under ``parent_path``."""
+        statement = select(AgentFolder).where(
+            AgentFolder.workspace_id == self.workspace_id,
+            AgentFolder.path.like(f"{parent_path}%"),
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().all()
+
+    async def get_presets_in_folder(
+        self, folder_id: AgentFolderID | None = None
+    ) -> Sequence[AgentPreset]:
+        """Get presets in the specified folder, or root-level presets if ``None``."""
+        statement = select(AgentPreset).where(
+            AgentPreset.workspace_id == self.workspace_id,
+            AgentPreset.folder_id == folder_id,
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().all()
+
+    @require_scope("agent:update")
+    async def move_preset(
+        self, preset_id: uuid.UUID, folder: AgentFolder | None = None
+    ) -> AgentPreset:
+        """Move a preset to a different folder (or to root when ``folder`` is None)."""
+        statement = select(AgentPreset).where(
+            AgentPreset.workspace_id == self.workspace_id,
+            AgentPreset.id == preset_id,
+        )
+        result = await self.session.execute(statement)
+        preset = result.scalar_one_or_none()
+        if not preset:
+            raise TracecatNotFoundError(f"Agent preset {preset_id} not found")
+
+        preset.folder_id = folder.id if folder else None
+        self.session.add(preset)
+        await self.session.commit()
+        await self.session.refresh(preset)
+        return preset
+
+    @require_scope("agent:update")
+    async def rename_folder(
+        self, folder_id: AgentFolderID, new_name: str
+    ) -> AgentFolder:
+        """Rename a folder, updating its path and all descendant paths."""
+        new_name = new_name.strip()
+        if not new_name:
+            raise TracecatValidationError("Folder name cannot be blank")
+        if "/" in new_name:
+            raise TracecatValidationError("Folder name cannot contain slashes")
+
+        folder = await self.get_folder(folder_id)
+        if not folder:
+            raise TracecatNotFoundError(f"Folder {folder_id} not found")
+
+        old_path = folder.path
+        parent_path = folder.parent_path
+        new_path = (
+            f"{parent_path}{new_name}/" if parent_path != "/" else f"/{new_name}/"
+        )
+
+        if new_path != old_path and await self._folder_path_exists(new_path):
+            raise TracecatConflictError(f"Folder {new_path} already exists")
+
+        descendants = await self._get_descendants(old_path)
+
+        folder.name = new_name
+        folder.path = new_path
+        self.session.add(folder)
+
+        for descendant in descendants:
+            descendant.path = descendant.path.replace(old_path, new_path, 1)
+            self.session.add(descendant)
+
+        try:
+            await self.session.commit()
+        except IntegrityError as e:
+            await self.session.rollback()
+            raise TracecatConflictError(f"Folder {new_path} already exists") from e
+        await self.session.refresh(folder)
+        return folder
+
+    @require_scope("agent:update")
+    async def move_folder(
+        self,
+        folder_id: AgentFolderID,
+        new_parent_id: AgentFolderID | None,
+    ) -> AgentFolder:
+        """Move a folder to a different parent (or to root when ``new_parent_id`` is None)."""
+        folder = await self.get_folder(folder_id)
+        if not folder:
+            raise TracecatNotFoundError(f"Folder {folder_id} not found")
+
+        new_parent_path = "/"
+        if new_parent_id is not None:
+            new_parent = await self.get_folder(new_parent_id)
+            if not new_parent:
+                raise TracecatNotFoundError(f"Parent folder {new_parent_id} not found")
+            new_parent_path = new_parent.path
+
+            if folder.path == new_parent_path:
+                raise TracecatValidationError("Cannot make a folder its own child")
+            if new_parent.path.startswith(folder.path):
+                raise TracecatValidationError("Cannot create cyclic folder structure")
+
+        old_path = folder.path
+        old_name = folder.name
+        new_path = (
+            f"{new_parent_path}{old_name}/"
+            if new_parent_path != "/"
+            else f"/{old_name}/"
+        )
+
+        if new_path != old_path and await self._folder_path_exists(new_path):
+            raise TracecatConflictError(f"Folder {new_path} already exists")
+
+        descendants = await self._get_descendants(old_path)
+
+        folder.path = new_path
+        self.session.add(folder)
+
+        for descendant in descendants:
+            descendant.path = descendant.path.replace(old_path, new_path, 1)
+            self.session.add(descendant)
+
+        try:
+            await self.session.commit()
+        except IntegrityError as e:
+            await self.session.rollback()
+            raise TracecatConflictError(f"Folder {new_path} already exists") from e
+        await self.session.refresh(folder)
+        return folder
+
+    @require_scope("agent:delete")
+    async def delete_folder(
+        self, folder_id: AgentFolderID, *, recursive: bool = False
+    ) -> None:
+        """Delete a folder.
+
+        With ``recursive=False`` the folder must be empty (no subfolders, no
+        presets). With ``recursive=True``, descendant folders are deleted and
+        contained presets are detached (folder_id set to NULL via FK ON
+        DELETE SET NULL — handled here explicitly so the operation is atomic
+        and predictable).
+        """
+        folder = await self.get_folder(folder_id)
+        if not folder:
+            raise TracecatNotFoundError(f"Folder {folder_id} not found")
+
+        if folder.path == "/":
+            raise TracecatValidationError("Cannot delete root folder")
+
+        if not recursive:
+            has_children = await self._has_children(folder.path)
+            has_presets = await self._has_presets(folder_id)
+            if has_children or has_presets:
+                raise TracecatValidationError(
+                    "Folder is not empty. Move or delete its contents first."
+                )
+        else:
+            descendants = await self._get_descendants(folder.path)
+            descendant_ids = [d.id for d in descendants] + [folder.id]
+            await self._detach_presets_from_folders(descendant_ids)
+            for descendant in descendants:
+                await self.session.delete(descendant)
+
+        await self.session.delete(folder)
+        await self.session.commit()
+
+    async def get_directory_items(
+        self,
+        path: str = "/",
+        *,
+        order_by: Literal["asc", "desc"] = "desc",
+    ) -> Sequence[DirectoryItem]:
+        """Return folders and presets at the given path.
+
+        Folder counts are computed in a single grouped query rather than
+        per-folder ``has_children`` / ``has_presets`` round-trips, fixing the
+        N+1 issue from the first attempt at this feature.
+        """
+        path = self._normalize_folder_path(path)
+
+        if path != "/":
+            folder = await self.get_folder_by_path(path)
+            if not folder:
+                raise TracecatNotFoundError(f"Folder {path} not found")
+            folder_id = folder.id
+        else:
+            folder_id = None
+
+        # Presets at this level
+        preset_statement = (
+            select(AgentPreset)
+            .where(
+                AgentPreset.workspace_id == self.workspace_id,
+                AgentPreset.folder_id == folder_id,
+            )
+            .order_by(
+                AgentPreset.created_at.desc()
+                if order_by == "desc"
+                else AgentPreset.created_at.asc()
+            )
+            .options(selectinload(AgentPreset.tags))
+        )
+        preset_result = await self.session.execute(preset_statement)
+        presets = preset_result.scalars().all()
+
+        # Direct child folders at this level
+        if path == "/":
+            folder_statement = select(AgentFolder).where(
+                AgentFolder.workspace_id == self.workspace_id,
+                func.length(AgentFolder.path)
+                - func.length(func.replace(AgentFolder.path, "/", ""))
+                == 2,
+            )
+        else:
+            folder_statement = select(AgentFolder).where(
+                AgentFolder.workspace_id == self.workspace_id,
+                AgentFolder.path.startswith(path),
+                AgentFolder.path != path,
+                ~AgentFolder.path.like(f"{path}%/%/"),
+            )
+        folder_result = await self.session.execute(folder_statement)
+        folders = folder_result.scalars().all()
+
+        # Per-folder counts in a single grouped query (fixes N+1)
+        child_counts = await self._child_folder_counts([f.path for f in folders])
+        preset_counts = await self._preset_counts([f.id for f in folders])
+
+        directory_items: list[DirectoryItem] = []
+
+        for f in folders:
+            num_items = (1 if child_counts.get(f.path, 0) > 0 else 0) + (
+                1 if preset_counts.get(f.id, 0) > 0 else 0
+            )
+            directory_items.append(
+                AgentFolderDirectoryItem(
+                    type="folder",
+                    num_items=num_items,
+                    id=f.id,
+                    name=f.name,
+                    path=f.path,
+                    workspace_id=f.workspace_id,
+                    created_at=f.created_at,
+                    updated_at=f.updated_at,
+                )
+            )
+
+        for preset in presets:
+            directory_items.append(
+                AgentPresetDirectoryItem(
+                    type="preset",
+                    id=preset.id,
+                    name=preset.name,
+                    slug=preset.slug,
+                    description=preset.description,
+                    model_provider=preset.model_provider,
+                    model_name=preset.model_name,
+                    folder_id=preset.folder_id,
+                    tags=[
+                        TagRead.model_validate(tag, from_attributes=True)
+                        for tag in preset.tags
+                    ],
+                    created_at=preset.created_at,
+                    updated_at=preset.updated_at,
+                )
+            )
+
+        return directory_items
+
+    async def get_folder_tree(self, root_path: str = "/") -> Sequence[AgentFolder]:
+        """Return the full folder subtree starting from ``root_path``."""
+        root_path = self._normalize_folder_path(root_path)
+        statement = (
+            select(AgentFolder)
+            .where(
+                AgentFolder.workspace_id == self.workspace_id,
+                or_(
+                    AgentFolder.path.startswith(root_path),
+                    AgentFolder.path == root_path,
+                ),
+            )
+            .order_by(AgentFolder.path)
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().all()
+
+    # --- Private helpers ---
+
+    async def _folder_path_exists(self, path: str) -> bool:
+        path = self._normalize_folder_path(path)
+        statement = (
+            select(func.count())
+            .select_from(AgentFolder)
+            .where(
+                AgentFolder.workspace_id == self.workspace_id,
+                AgentFolder.path == path,
+            )
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one() > 0
+
+    async def _has_children(self, path: str) -> bool:
+        path = self._normalize_folder_path(path)
+        statement = (
+            select(func.count())
+            .select_from(AgentFolder)
+            .where(
+                AgentFolder.workspace_id == self.workspace_id,
+                AgentFolder.path.startswith(path),
+                AgentFolder.path != path,
+            )
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one() > 0
+
+    async def _has_presets(self, folder_id: AgentFolderID) -> bool:
+        statement = (
+            select(func.count())
+            .select_from(AgentPreset)
+            .where(
+                AgentPreset.workspace_id == self.workspace_id,
+                AgentPreset.folder_id == folder_id,
+            )
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one() > 0
+
+    async def _get_descendants(self, path: str) -> Sequence[AgentFolder]:
+        path = self._normalize_folder_path(path)
+        statement = select(AgentFolder).where(
+            AgentFolder.workspace_id == self.workspace_id,
+            AgentFolder.path.startswith(path),
+            AgentFolder.path != path,
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().all()
+
+    async def _child_folder_counts(self, paths: Sequence[str]) -> dict[str, int]:
+        """Count direct child folders for each input path in one query."""
+        if not paths:
+            return {}
+
+        # For each parent_path, count folders whose path starts with parent_path,
+        # is not equal to parent_path, and contains no further nested separator.
+        # We use a CASE expression keyed by each parent path.
+        cases = []
+        for p in paths:
+            cases.append(
+                (
+                    AgentFolder.path.startswith(p)
+                    & (AgentFolder.path != p)
+                    & ~AgentFolder.path.like(f"{p}%/%/"),
+                    p,
+                )
+            )
+        parent_label = case(*cases, else_=None).label("parent_path")
+        statement = (
+            select(parent_label, func.count())
+            .where(AgentFolder.workspace_id == self.workspace_id)
+            .group_by(parent_label)
+        )
+        result = await self.session.execute(statement)
+        return {
+            row.parent_path: row[1] for row in result if row.parent_path is not None
+        }
+
+    async def _preset_counts(
+        self, folder_ids: Sequence[AgentFolderID]
+    ) -> dict[uuid.UUID, int]:
+        """Count presets in each folder in one grouped query."""
+        if not folder_ids:
+            return {}
+        statement = (
+            select(AgentPreset.folder_id, func.count())
+            .where(
+                AgentPreset.workspace_id == self.workspace_id,
+                AgentPreset.folder_id.in_(folder_ids),
+            )
+            .group_by(AgentPreset.folder_id)
+        )
+        result = await self.session.execute(statement)
+        return {row[0]: row[1] for row in result if row[0] is not None}
+
+    async def _detach_presets_from_folders(
+        self, folder_ids: Sequence[AgentFolderID]
+    ) -> None:
+        """Set folder_id to NULL for all presets in the given folders."""
+        if not folder_ids:
+            return
+        statement = select(AgentPreset).where(
+            AgentPreset.workspace_id == self.workspace_id,
+            AgentPreset.folder_id.in_(folder_ids),
+        )
+        result = await self.session.execute(statement)
+        for preset in result.scalars().all():
+            preset.folder_id = None
+            self.session.add(preset)

--- a/tracecat/agent/tags/router.py
+++ b/tracecat/agent/tags/router.py
@@ -1,0 +1,153 @@
+"""HTTP routes for agent tag definitions and preset-tag links."""
+
+from fastapi import APIRouter, HTTPException, status
+
+from tracecat.agent.tags.schemas import (
+    AgentPresetTagCreate,
+    AgentTagCreate,
+    AgentTagRead,
+    AgentTagUpdate,
+)
+from tracecat.agent.tags.service import AgentTagsService
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
+from tracecat.authz.controls import require_scope
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import TracecatConflictError, TracecatNotFoundError
+from tracecat.identifiers import AgentTagID
+
+router = APIRouter(prefix="/agent/tags", tags=["agent-tags"])
+preset_tags_router = APIRouter(prefix="/agent/presets", tags=["agent-presets"])
+
+
+# --- Tag definition CRUD ---
+
+
+@router.get("")
+@require_scope("agent:read")
+async def list_tags(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+) -> list[AgentTagRead]:
+    """List all agent tags in the workspace."""
+    service = AgentTagsService(session, role=role)
+    tags = await service.list_tags()
+    return [AgentTagRead.model_validate(tag, from_attributes=True) for tag in tags]
+
+
+@router.get("/{tag_id}")
+@require_scope("agent:read")
+async def get_tag(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    tag_id: AgentTagID,
+) -> AgentTagRead:
+    """Get a single agent tag by ID."""
+    service = AgentTagsService(session, role=role)
+    try:
+        tag = await service.get_tag(tag_id)
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return AgentTagRead.model_validate(tag, from_attributes=True)
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+@require_scope("agent:create")
+async def create_tag(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    params: AgentTagCreate,
+) -> AgentTagRead:
+    """Create a new agent tag definition."""
+    service = AgentTagsService(session, role=role)
+    try:
+        tag = await service.create_tag(params)
+    except TracecatConflictError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    return AgentTagRead.model_validate(tag, from_attributes=True)
+
+
+@router.patch("/{tag_id}")
+@require_scope("agent:update")
+async def update_tag(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    tag_id: AgentTagID,
+    params: AgentTagUpdate,
+) -> AgentTagRead:
+    """Update an agent tag's name or color."""
+    service = AgentTagsService(session, role=role)
+    try:
+        tag = await service.get_tag(tag_id)
+        tag = await service.update_tag(tag, params)
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except TracecatConflictError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    return AgentTagRead.model_validate(tag, from_attributes=True)
+
+
+@router.delete("/{tag_id}", status_code=status.HTTP_204_NO_CONTENT)
+@require_scope("agent:delete")
+async def delete_tag(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    tag_id: AgentTagID,
+) -> None:
+    """Delete an agent tag definition."""
+    service = AgentTagsService(session, role=role)
+    try:
+        tag = await service.get_tag(tag_id)
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    await service.delete_tag(tag)
+
+
+# --- Preset-tag link operations (mounted under /agent/presets) ---
+
+
+@preset_tags_router.get("/{preset_id}/tags", response_model=list[AgentTagRead])
+@require_scope("agent:read")
+async def list_preset_tags(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    preset_id: AgentTagID,
+) -> list[AgentTagRead]:
+    """List tags attached to a preset."""
+    service = AgentTagsService(session, role=role)
+    tags = await service.list_tags_for_preset(preset_id)
+    return [AgentTagRead.model_validate(tag, from_attributes=True) for tag in tags]
+
+
+@preset_tags_router.post("/{preset_id}/tags", status_code=status.HTTP_201_CREATED)
+@require_scope("agent:update")
+async def add_preset_tag(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    preset_id: AgentTagID,
+    params: AgentPresetTagCreate,
+) -> None:
+    """Attach a tag to a preset (idempotent)."""
+    service = AgentTagsService(session, role=role)
+    try:
+        await service.add_preset_tag(preset_id, params.tag_id)
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@preset_tags_router.delete(
+    "/{preset_id}/tags/{tag_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+@require_scope("agent:update")
+async def remove_preset_tag(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    preset_id: AgentTagID,
+    tag_id: AgentTagID,
+) -> None:
+    """Detach a tag from a preset."""
+    service = AgentTagsService(session, role=role)
+    try:
+        link = await service.get_preset_tag_link(preset_id, tag_id)
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    await service.remove_preset_tag(link)

--- a/tracecat/agent/tags/schemas.py
+++ b/tracecat/agent/tags/schemas.py
@@ -1,0 +1,22 @@
+"""Schemas for agent tags. Reuses the generic Tag* shapes."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from tracecat.identifiers import AgentTagID
+from tracecat.tags.schemas import TagCreate, TagRead, TagUpdate
+
+# Re-export under agent-namespaced names for client clarity, while reusing
+# the validated shapes from the generic tags module. Tag schemas are
+# entity-agnostic (name, ref, color), so duplicating the definitions adds
+# no value.
+AgentTagRead = TagRead
+AgentTagCreate = TagCreate
+AgentTagUpdate = TagUpdate
+
+
+class AgentPresetTagCreate(BaseModel):
+    """Payload for attaching a tag to a preset."""
+
+    tag_id: AgentTagID

--- a/tracecat/agent/tags/service.py
+++ b/tracecat/agent/tags/service.py
@@ -1,0 +1,204 @@
+"""Service for agent tag definitions and preset-tag links."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+
+from slugify import slugify
+from sqlalchemy import exists, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
+
+from tracecat.agent.tags.schemas import AgentTagCreate, AgentTagUpdate
+from tracecat.authz.controls import require_scope
+from tracecat.db.models import AgentPreset, AgentTag, AgentTagLink
+from tracecat.exceptions import TracecatConflictError, TracecatNotFoundError
+from tracecat.identifiers import AgentTagID
+from tracecat.service import BaseWorkspaceService
+
+
+class AgentTagsService(BaseWorkspaceService):
+    """Manages both agent tag definitions and preset-tag link rows."""
+
+    service_name = "agent_tags"
+
+    # --- Tag definitions ---
+
+    async def list_tags(self) -> Sequence[AgentTag]:
+        statement = select(AgentTag).where(AgentTag.workspace_id == self.workspace_id)
+        result = await self.session.execute(statement)
+        return result.scalars().all()
+
+    async def get_tag(self, tag_id: AgentTagID) -> AgentTag:
+        statement = select(AgentTag).where(
+            AgentTag.workspace_id == self.workspace_id,
+            AgentTag.id == tag_id,
+        )
+        result = await self.session.execute(statement)
+        tag = result.scalar_one_or_none()
+        if tag is None:
+            raise TracecatNotFoundError(f"Agent tag {tag_id} not found")
+        return tag
+
+    async def get_tag_by_ref(self, ref: str) -> AgentTag:
+        statement = select(AgentTag).where(
+            AgentTag.workspace_id == self.workspace_id,
+            AgentTag.ref == ref,
+        )
+        result = await self.session.execute(statement)
+        tag = result.scalar_one_or_none()
+        if tag is None:
+            raise TracecatNotFoundError(f"Agent tag with ref '{ref}' not found")
+        return tag
+
+    @require_scope("agent:create")
+    async def create_tag(self, params: AgentTagCreate) -> AgentTag:
+        ref = slugify(params.name)
+        if not ref:
+            raise TracecatConflictError(
+                "Tag name must contain at least one alphanumeric character"
+            )
+
+        existing = await self.session.execute(
+            select(AgentTag).where(
+                AgentTag.ref == ref,
+                AgentTag.workspace_id == self.workspace_id,
+            )
+        )
+        if existing.scalar_one_or_none():
+            raise TracecatConflictError(f"Agent tag with slug '{ref}' already exists")
+
+        tag = AgentTag(
+            name=params.name,
+            ref=ref,
+            workspace_id=self.workspace_id,
+            color=params.color,
+        )
+        self.session.add(tag)
+        try:
+            await self.session.commit()
+        except IntegrityError as e:
+            await self.session.rollback()
+            raise TracecatConflictError(
+                f"Agent tag '{params.name}' already exists"
+            ) from e
+        await self.session.refresh(tag)
+        return tag
+
+    @require_scope("agent:update")
+    async def update_tag(self, tag: AgentTag, params: AgentTagUpdate) -> AgentTag:
+        if params.name and params.name != tag.name:
+            new_ref = slugify(params.name)
+            if not new_ref:
+                raise TracecatConflictError(
+                    "Tag name must contain at least one alphanumeric character"
+                )
+            if new_ref != tag.ref:
+                existing = await self.session.execute(
+                    select(AgentTag).where(
+                        AgentTag.workspace_id == self.workspace_id,
+                        AgentTag.ref == new_ref,
+                        AgentTag.id != tag.id,
+                    )
+                )
+                if existing.scalar_one_or_none():
+                    raise TracecatConflictError(
+                        f"Agent tag with slug '{new_ref}' already exists"
+                    )
+                tag.ref = new_ref
+
+        for key, value in params.model_dump(exclude_unset=True).items():
+            setattr(tag, key, value)
+
+        try:
+            await self.session.commit()
+        except IntegrityError as e:
+            await self.session.rollback()
+            raise TracecatConflictError("Agent tag conflict on update") from e
+        await self.session.refresh(tag)
+        return tag
+
+    @require_scope("agent:delete")
+    async def delete_tag(self, tag: AgentTag) -> None:
+        await self.session.delete(tag)
+        await self.session.commit()
+
+    # --- Preset-tag links ---
+
+    async def _require_preset_and_tag_in_workspace(
+        self, preset_id: uuid.UUID, tag_id: AgentTagID
+    ) -> None:
+        preset_exists = exists(
+            select(AgentPreset.id).where(
+                AgentPreset.id == preset_id,
+                AgentPreset.workspace_id == self.workspace_id,
+            )
+        )
+        tag_exists = exists(
+            select(AgentTag.id).where(
+                AgentTag.id == tag_id,
+                AgentTag.workspace_id == self.workspace_id,
+            )
+        )
+        is_allowed = await self.session.scalar(select(preset_exists & tag_exists))
+        if not is_allowed:
+            raise TracecatNotFoundError("Agent preset or tag not found")
+
+    async def list_tags_for_preset(self, preset_id: uuid.UUID) -> Sequence[AgentTag]:
+        statement = (
+            select(AgentTag)
+            .join(AgentTagLink, AgentTag.id == AgentTagLink.tag_id)
+            .join(AgentPreset, AgentPreset.id == AgentTagLink.preset_id)
+            .where(
+                AgentTagLink.preset_id == preset_id,
+                AgentPreset.workspace_id == self.workspace_id,
+                AgentTag.workspace_id == self.workspace_id,
+            )
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().all()
+
+    async def get_preset_tag_link(
+        self, preset_id: uuid.UUID, tag_id: AgentTagID
+    ) -> AgentTagLink:
+        statement = (
+            select(AgentTagLink)
+            .join(AgentPreset, AgentPreset.id == AgentTagLink.preset_id)
+            .join(AgentTag, AgentTag.id == AgentTagLink.tag_id)
+            .where(
+                AgentTagLink.preset_id == preset_id,
+                AgentTagLink.tag_id == tag_id,
+                AgentPreset.workspace_id == self.workspace_id,
+                AgentTag.workspace_id == self.workspace_id,
+            )
+        )
+        result = await self.session.execute(statement)
+        link = result.scalar_one_or_none()
+        if link is None:
+            raise TracecatNotFoundError("Tag is not attached to this preset")
+        return link
+
+    @require_scope("agent:update")
+    async def add_preset_tag(
+        self, preset_id: uuid.UUID, tag_id: AgentTagID
+    ) -> AgentTagLink:
+        """Attach a tag to a preset. Idempotent — re-adding is a no-op."""
+        await self._require_preset_and_tag_in_workspace(preset_id, tag_id)
+        statement = (
+            pg_insert(AgentTagLink)
+            .values(preset_id=preset_id, tag_id=tag_id)
+            .on_conflict_do_nothing(index_elements=["tag_id", "preset_id"])
+            .returning(AgentTagLink)
+        )
+        result = await self.session.execute(statement)
+        link = result.scalar_one_or_none()
+        await self.session.commit()
+        if link is None:
+            link = await self.get_preset_tag_link(preset_id, tag_id)
+        return link
+
+    @require_scope("agent:update")
+    async def remove_preset_tag(self, link: AgentTagLink) -> None:
+        await self.session.delete(link)
+        await self.session.commit()

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -34,6 +34,7 @@ from tracecat.agent.channels.management_router import (
     router as agent_channels_management_router,
 )
 from tracecat.agent.channels.router import router as agent_channels_router
+from tracecat.agent.folders.router import router as agent_folders_router
 from tracecat.agent.internal_router import router as internal_agent_router
 from tracecat.agent.preset.internal_router import (
     router as internal_agent_preset_router,
@@ -44,6 +45,8 @@ from tracecat.agent.router import router as agent_router
 from tracecat.agent.router import workspace_router as agent_workspace_router
 from tracecat.agent.session.router import router as agent_session_router
 from tracecat.agent.skill.router import router as agent_skill_router
+from tracecat.agent.tags.router import preset_tags_router as agent_preset_tags_router
+from tracecat.agent.tags.router import router as agent_tags_router
 from tracecat.api.common import (
     add_temporal_search_attributes,
     bootstrap_role,
@@ -521,6 +524,9 @@ def create_app(**kwargs) -> FastAPI:
     _include_workspace_scoped_router(app, agent_preset_router)
     _include_workspace_scoped_router(app, agent_skill_router)
     _include_workspace_scoped_router(app, agent_session_router)
+    _include_workspace_scoped_router(app, agent_folders_router)
+    _include_workspace_scoped_router(app, agent_tags_router)
+    _include_workspace_scoped_router(app, agent_preset_tags_router)
     _include_workspace_scoped_router(app, approvals_router)
     app.include_router(watchtower_router)
     app.include_router(admin_router)

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -490,6 +490,16 @@ class Workspace(OrganizationModel):
         back_populates="workspace",
         cascade="all, delete",
     )
+    agent_folders: Mapped[list[AgentFolder]] = relationship(
+        "AgentFolder",
+        back_populates="workspace",
+        cascade="all, delete",
+    )
+    agent_tags: Mapped[list[AgentTag]] = relationship(
+        "AgentTag",
+        back_populates="workspace",
+        cascade="all, delete",
+    )
     integrations: Mapped[list[OAuthIntegration]] = relationship(
         "OAuthIntegration",
         back_populates="workspace",
@@ -3311,6 +3321,74 @@ class AgentChannelToken(WorkspaceModel):
     )
 
 
+class AgentFolder(WorkspaceModel):
+    """Folder for organizing agent presets.
+
+    Uses materialized path pattern for hierarchical structure.
+    Path format: "/parent/child/" where each segment is the folder name.
+    Root folders have path "/foldername/".
+    """
+
+    __tablename__ = "agent_folder"
+    __table_args__ = (
+        UniqueConstraint(
+            "path", "workspace_id", name="uq_agent_folder_path_workspace"
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    path: Mapped[str] = mapped_column(
+        String, index=True, nullable=False, doc="Full materialized path: /parent/child/"
+    )
+
+    workspace: Mapped[Workspace] = relationship(back_populates="agent_folders")
+    presets: Mapped[list[AgentPreset]] = relationship(
+        "AgentPreset", back_populates="folder"
+    )
+
+    @property
+    def parent_path(self) -> str:
+        """Get the parent path of this folder."""
+        if self.path == "/":
+            return "/"
+
+        path_parts = self.path.rstrip("/").split("/")
+        if len(path_parts) <= 2:
+            return "/"
+
+        return "/".join(path_parts[:-1]) + "/"
+
+    @property
+    def is_root(self) -> bool:
+        """Check if this is a root-level folder."""
+        return self.path.count("/") <= 2
+
+
+class AgentTagLink(Base):
+    """Link table for agent presets and agent tags."""
+
+    __tablename__ = "agent_tag_link"
+    __table_args__ = (PrimaryKeyConstraint("tag_id", "preset_id"),)
+
+    tag_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("agent_tag.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    preset_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("agent_preset.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+
 class AgentPreset(WorkspaceModel):
     """Database model for storing reusable agent preset configurations."""
 
@@ -3412,6 +3490,13 @@ class AgentPreset(WorkspaceModel):
         nullable=False,
         doc="Whether to enable direct internet access in the agent sandbox",
     )
+    folder_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID,
+        ForeignKey("agent_folder.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+        doc="Optional folder this preset is organized under",
+    )
 
     workspace: Mapped[Workspace] = relationship(back_populates="agent_presets")
     versions: Mapped[list[AgentPresetVersion]] = relationship(
@@ -3435,6 +3520,14 @@ class AgentPreset(WorkspaceModel):
         "Chat",
         back_populates="agent_preset",
         cascade="save-update",
+    )
+    folder: Mapped[AgentFolder | None] = relationship(
+        "AgentFolder", back_populates="presets"
+    )
+    tags: Mapped[list[AgentTag]] = relationship(
+        "AgentTag",
+        secondary=AgentTagLink.__table__,
+        back_populates="presets",
     )
 
 
@@ -4649,6 +4742,39 @@ class WorkflowTag(WorkspaceModel):
     workflows: Mapped[list[Workflow]] = relationship(
         "Workflow",
         secondary=WorkflowTagLink.__table__,
+        back_populates="tags",
+    )
+
+
+class AgentTag(WorkspaceModel):
+    """A tag for organizing and filtering agent presets."""
+
+    __tablename__ = "agent_tag"
+    __table_args__ = (
+        UniqueConstraint("name", "workspace_id", name="uq_agent_tag_name_workspace"),
+        UniqueConstraint("ref", "workspace_id", name="uq_agent_tag_ref_workspace"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    ref: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        index=True,
+        doc="Slug-like identifier derived from the name, used for API lookups alongside uuid.UUID",
+    )
+    color: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    workspace: Mapped[Workspace] = relationship(back_populates="agent_tags")
+    presets: Mapped[list[AgentPreset]] = relationship(
+        "AgentPreset",
+        secondary=AgentTagLink.__table__,
         back_populates="tags",
     )
 

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3331,9 +3331,7 @@ class AgentFolder(WorkspaceModel):
 
     __tablename__ = "agent_folder"
     __table_args__ = (
-        UniqueConstraint(
-            "path", "workspace_id", name="uq_agent_folder_path_workspace"
-        ),
+        UniqueConstraint("path", "workspace_id", name="uq_agent_folder_path_workspace"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/tracecat/exceptions.py
+++ b/tracecat/exceptions.py
@@ -115,6 +115,14 @@ class TracecatNotFoundError(TracecatException):
     """Raised when a resource is not found in the Tracecat database."""
 
 
+class TracecatConflictError(TracecatException):
+    """Raised when a request conflicts with current resource state.
+
+    Maps to HTTP 409 at the router layer. Use for unique-constraint-style
+    violations (e.g., duplicate names, paths, or slugs within a workspace).
+    """
+
+
 class TracecatServiceError(TracecatException):
     """Tracecat generic user-facing service error"""
 

--- a/tracecat/identifiers/__init__.py
+++ b/tracecat/identifiers/__init__.py
@@ -78,6 +78,8 @@ SessionID = uuid.UUID
 WorkflowTagID = uuid.UUID
 TagID = WorkflowTagID
 CaseTagID = uuid.UUID
+AgentFolderID = uuid.UUID
+AgentTagID = uuid.UUID
 TableID = uuid.UUID
 TableColumnID = uuid.UUID
 TableRowID = uuid.UUID
@@ -121,6 +123,8 @@ __all__ = [
     "TagID",
     "WorkflowTagID",
     "CaseTagID",
+    "AgentFolderID",
+    "AgentTagID",
     "SessionID",
     "VariableID",
     "InvitationID",


### PR DESCRIPTION
## Summary

Application code for the schema introduced in #2615, plus a minimal first-cut UI for managing agent tags. This is the second attempt at agent folders and tags — the first attempt (#2523) was closed without merge after drifting from main.

**Backend** (`786a64524`)

- `AgentFolder`, `AgentTag`, `AgentTagLink` SQLAlchemy models, plus `folder_id` / `folder` / `tags` on `AgentPreset` and matching back-populates on `Workspace` (`tracecat/db/models.py`).
- `AgentFolderService` at `tracecat/agent/folders/service.py`: CRUD, rename, move (with cycle prevention), recursive delete with preset detachment, mixed folder+preset directory listing.
- `AgentTagsService` at `tracecat/agent/tags/service.py`: tag definition CRUD with slugified `ref`, plus idempotent preset-tag link operations using `ON CONFLICT DO NOTHING`.
- HTTP routers at `/agent/folders`, `/agent/tags`, and `/agent/presets/{id}/tags`, mounted as workspace-scoped. All mutations guarded by `agent:*` scopes.
- New `TracecatConflictError` in `tracecat/exceptions.py` so duplicate paths/slugs surface as `409` instead of `400`. `AgentFolderID` and `AgentTagID` identifier aliases.
- 25 new unit tests (14 folder + 11 tag) covering hierarchy, blank-name and slash rejection, conflict mapping, cycle prevention, recursive delete preset detachment, idempotent tag attachment, slug regeneration, and cross-resource not-found cases.

**Reviewer-flagged fixes from #2523 baked in**

1. **N+1 in `get_directory_items`**: per-folder `_has_children` / `_has_presets` calls collapsed into two grouped queries.
2. **Concurrent folder creation race**: `create_folder` wraps the insert in `try/except IntegrityError` on the unique `(path, workspace_id)` constraint and surfaces it as `TracecatConflictError`.
3. **Error type consistency**: services raise typed exceptions (`TracecatValidationError`, `TracecatConflictError`, `TracecatNotFoundError`) instead of bare `ValueError` / SQLAlchemy `NoResultFound`. Routers map them to `400` / `409` / `404`.
4. **Blank folder/tag names rejected** at the service layer.
5. **DTO ownership**: directory listing assembles `AgentPresetDirectoryItem` from typed schemas rather than ad-hoc dicts.

**Frontend** (`bcef458d5`)

- `useAgentFolders` / `useAgentDirectory` hooks at `frontend/src/hooks/use-agent-folders.ts` mirroring `useFolders`.
- `useAgentTags` / `usePresetTags` hooks at `frontend/src/hooks/use-agent-tags.ts`.
- `AgentTagsView` at `frontend/src/components/agents/agent-tags-view.tsx` — workspace-level tag management page reusing `WorkflowTagsTable` since the underlying tag shape is identical.
- `AddAgentTagDialog` mirroring `AddWorkflowTagDialog`.
- `/workspaces/[workspaceId]/agents/tags` route page.
- Regenerated TS client to pick up the new endpoints (~1.1k adds after biome).

## Out of scope (intentional)

The catalog UI overhaul on `/agents` — dual-view toggle, `CreateAgentDialog` replacement, sidebar nav entry, folder breadcrumbs on the agents list — is deferred to a follow-up. The first attempt bundled all of this and the noisy reviewer churn buried the correctness fixes. Existing `/agents/new` builder flow is unchanged. Tags admin page is the only new UI surface.

## Test plan

- [ ] Apply PR 1's migration first: `TRACECAT__DB_URI=... .venv/bin/python -m alembic upgrade head`
- [ ] Backend: `uv run pytest tests/unit/test_agent_folders_service.py tests/unit/test_agent_tags_service.py -x` (25 tests)
- [ ] Lint/types: `uv run ruff check . && uv run ruff format --check . && uv run basedpyright --warnings --threads 4`
- [ ] Frontend: `pnpm -C frontend run typecheck && pnpm -C frontend exec biome check src/hooks/use-agent-folders.ts src/hooks/use-agent-tags.ts src/components/agents/`
- [ ] Smoke: visit `/workspaces/<id>/agents/tags`, create a tag with a color, edit it, delete it
- [ ] API: `curl POST /api/agent/folders {"name":"ops","parent_path":"/"}`, `GET /api/agent/folders/directory?path=/`, attach/detach a tag from a preset

## Depends on

#2615 (`feat/agent-folders-migration`) — schema must apply before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds agent folders and tags with a minimal tags admin UI. Includes a ruff formatting fix with no functional changes.

- New Features
  - Backend models: Agent folders and tags (`AgentFolder`, `AgentTag`, `AgentTagLink`) with `folder_id` and `tags` on `AgentPreset`.
  - Services: Folder CRUD, rename/move with cycle prevention, recursive delete that detaches presets, and mixed directory listing; tag CRUD with slug refs; idempotent preset-tag attach/detach.
  - APIs: `/agent/folders`, `/agent/tags`, `/agent/presets/{id}/tags` (workspace-scoped; mutations require `agent:*` scopes). Adds `TracecatConflictError` to return 409 on duplicates.
  - Frontend: `useAgentFolders`, `useAgentDirectory`, `useAgentTags`, `usePresetTags`; `AgentTagsView` and `AddAgentTagDialog`; route `/workspaces/[workspaceId]/agents/tags`.
  - Tests: 25 unit tests cover hierarchy, conflicts, cycle prevention, recursive deletes, slug regeneration, and idempotent links.

- Migration
  - Apply the schema from #2615 before merging.

<sup>Written for commit 6cd6153101e9562acf09c027f98bc3338e7f2aa2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

