### PR TITLE
feat(mcp): PAT Management

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/mcp/layout.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/mcp/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "MCP access | Workspace",
+}
+
+export default function WorkspaceMcpAccessLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/frontend/src/app/workspaces/[workspaceId]/mcp/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/mcp/page.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import { notFound } from "next/navigation"
+import { useScopeCheck } from "@/components/auth/scope-guard"
+import { WorkspaceMcpAccess } from "@/components/organization/workspace-mcp-access"
+
+export default function WorkspaceMcpAccessPage() {
+  const canReadWorkspace = useScopeCheck("workspace:read")
+
+  if (canReadWorkspace === false) {
+    notFound()
+  }
+  if (canReadWorkspace === undefined) {
+    return null
+  }
+
+  return <WorkspaceMcpAccess />
+}

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -9628,6 +9628,69 @@ export const $CursorPaginatedResponse_InboxItemRead_ = {
   title: "CursorPaginatedResponse[InboxItemRead]",
 } as const
 
+export const $CursorPaginatedResponse_MCPPersonalAccessTokenRead_ = {
+  properties: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/MCPPersonalAccessTokenRead",
+      },
+      type: "array",
+      title: "Items",
+    },
+    next_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Cursor",
+      description: "Cursor for next page",
+    },
+    prev_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Prev Cursor",
+      description: "Cursor for previous page",
+    },
+    has_more: {
+      type: "boolean",
+      title: "Has More",
+      description: "Whether more items exist",
+      default: false,
+    },
+    has_previous: {
+      type: "boolean",
+      title: "Has Previous",
+      description: "Whether previous items exist",
+      default: false,
+    },
+    total_estimate: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Estimate",
+      description: "Estimated total count from table statistics",
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "CursorPaginatedResponse[MCPPersonalAccessTokenRead]",
+} as const
+
 export const $CursorPaginatedResponse_ServiceAccountApiKeyRead_ = {
   properties: {
     items: {
@@ -13662,6 +13725,21 @@ export const $InvitationStatus = {
   description: "Invitation lifecycle status.",
 } as const
 
+export const $IssuedMCPPersonalAccessToken = {
+  properties: {
+    raw_token: {
+      type: "string",
+      title: "Raw Token",
+    },
+    token: {
+      $ref: "#/components/schemas/MCPPersonalAccessTokenRead",
+    },
+  },
+  type: "object",
+  required: ["raw_token", "token"],
+  title: "IssuedMCPPersonalAccessToken",
+} as const
+
 export const $IssuedServiceAccountApiKey = {
   properties: {
     raw_key: {
@@ -14108,6 +14186,163 @@ export const $MCPIntegrationUpdate = {
   type: "object",
   title: "MCPIntegrationUpdate",
   description: "Request model for updating an MCP integration.",
+} as const
+
+export const $MCPPersonalAccessTokenCreate = {
+  properties: {
+    name: {
+      type: "string",
+      maxLength: 255,
+      minLength: 1,
+      title: "Name",
+    },
+    expires_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Expires At",
+    },
+  },
+  type: "object",
+  required: ["name"],
+  title: "MCPPersonalAccessTokenCreate",
+} as const
+
+export const $MCPPersonalAccessTokenIssueResponse = {
+  properties: {
+    issued_token: {
+      $ref: "#/components/schemas/IssuedMCPPersonalAccessToken",
+    },
+  },
+  type: "object",
+  required: ["issued_token"],
+  title: "MCPPersonalAccessTokenIssueResponse",
+} as const
+
+export const $MCPPersonalAccessTokenRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    user_id: {
+      type: "string",
+      format: "uuid",
+      title: "User Id",
+    },
+    organization_id: {
+      type: "string",
+      format: "uuid",
+      title: "Organization Id",
+    },
+    workspace_id: {
+      type: "string",
+      format: "uuid",
+      title: "Workspace Id",
+    },
+    name: {
+      type: "string",
+      title: "Name",
+    },
+    key_id: {
+      type: "string",
+      title: "Key Id",
+    },
+    preview: {
+      type: "string",
+      title: "Preview",
+    },
+    expires_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Expires At",
+    },
+    last_used_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Used At",
+    },
+    revoked_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Revoked At",
+    },
+    created_by: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Created By",
+    },
+    revoked_by: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Revoked By",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "user_id",
+    "organization_id",
+    "workspace_id",
+    "name",
+    "key_id",
+    "preview",
+    "created_at",
+    "updated_at",
+  ],
+  title: "MCPPersonalAccessTokenRead",
 } as const
 
 export const $MCPServerType = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -408,6 +408,12 @@ import type {
   McpIntegrationsListMcpIntegrationsResponse,
   McpIntegrationsUpdateMcpIntegrationData,
   McpIntegrationsUpdateMcpIntegrationResponse,
+  McpPersonalAccessTokensCreateMcpPersonalAccessTokenData,
+  McpPersonalAccessTokensCreateMcpPersonalAccessTokenResponse,
+  McpPersonalAccessTokensListMcpPersonalAccessTokensData,
+  McpPersonalAccessTokensListMcpPersonalAccessTokensResponse,
+  McpPersonalAccessTokensRevokeMcpPersonalAccessTokenData,
+  McpPersonalAccessTokensRevokeMcpPersonalAccessTokenResponse,
   OrganizationAcceptInvitationData,
   OrganizationAcceptInvitationResponse,
   OrganizationCreateInvitationData,
@@ -1695,6 +1701,85 @@ export const serviceAccountsRevokeWorkspaceServiceAccountApiKey = (
     path: {
       service_account_id: data.serviceAccountId,
       api_key_id: data.apiKeyId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Mcp Personal Access Tokens
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.limit
+ * @param data.cursor
+ * @param data.reverse
+ * @returns CursorPaginatedResponse_MCPPersonalAccessTokenRead_ Successful Response
+ * @throws ApiError
+ */
+export const mcpPersonalAccessTokensListMcpPersonalAccessTokens = (
+  data: McpPersonalAccessTokensListMcpPersonalAccessTokensData
+): CancelablePromise<McpPersonalAccessTokensListMcpPersonalAccessTokensResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/mcp-personal-access-tokens",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    query: {
+      limit: data.limit,
+      cursor: data.cursor,
+      reverse: data.reverse,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create Mcp Personal Access Token
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns MCPPersonalAccessTokenIssueResponse Successful Response
+ * @throws ApiError
+ */
+export const mcpPersonalAccessTokensCreateMcpPersonalAccessToken = (
+  data: McpPersonalAccessTokensCreateMcpPersonalAccessTokenData
+): CancelablePromise<McpPersonalAccessTokensCreateMcpPersonalAccessTokenResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/mcp-personal-access-tokens",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Revoke Mcp Personal Access Token
+ * @param data The data for the request.
+ * @param data.tokenId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const mcpPersonalAccessTokensRevokeMcpPersonalAccessToken = (
+  data: McpPersonalAccessTokensRevokeMcpPersonalAccessTokenData
+): CancelablePromise<McpPersonalAccessTokensRevokeMcpPersonalAccessTokenResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/mcp-personal-access-tokens/{token_id}/revoke",
+    path: {
+      token_id: data.tokenId,
       workspace_id: data.workspaceId,
     },
     errors: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2750,6 +2750,30 @@ export type CursorPaginatedResponse_InboxItemRead_ = {
   total_estimate?: number | null
 }
 
+export type CursorPaginatedResponse_MCPPersonalAccessTokenRead_ = {
+  items: Array<MCPPersonalAccessTokenRead>
+  /**
+   * Cursor for next page
+   */
+  next_cursor?: string | null
+  /**
+   * Cursor for previous page
+   */
+  prev_cursor?: string | null
+  /**
+   * Whether more items exist
+   */
+  has_more?: boolean
+  /**
+   * Whether previous items exist
+   */
+  has_previous?: boolean
+  /**
+   * Estimated total count from table statistics
+   */
+  total_estimate?: number | null
+}
+
 export type CursorPaginatedResponse_ServiceAccountApiKeyRead_ = {
   items: Array<ServiceAccountApiKeyRead>
   /**
@@ -4235,6 +4259,11 @@ export type InteractionType = "approval" | "response"
  */
 export type InvitationStatus = "pending" | "accepted" | "revoked"
 
+export type IssuedMCPPersonalAccessToken = {
+  raw_token: string
+  token: MCPPersonalAccessTokenRead
+}
+
 export type IssuedServiceAccountApiKey = {
   raw_key: string
   api_key: ServiceAccountApiKeyRead
@@ -4366,6 +4395,32 @@ export type MCPIntegrationUpdate = {
    * Timeout in seconds
    */
   timeout?: number | null
+}
+
+export type MCPPersonalAccessTokenCreate = {
+  name: string
+  expires_at?: string | null
+}
+
+export type MCPPersonalAccessTokenIssueResponse = {
+  issued_token: IssuedMCPPersonalAccessToken
+}
+
+export type MCPPersonalAccessTokenRead = {
+  id: string
+  user_id: string
+  organization_id: string
+  workspace_id: string
+  name: string
+  key_id: string
+  preview: string
+  expires_at?: string | null
+  last_used_at?: string | null
+  revoked_at?: string | null
+  created_by?: string | null
+  revoked_by?: string | null
+  created_at: string
+  updated_at: string
 }
 
 export type MCPServerType = "http" | "stdio"
@@ -8941,6 +8996,31 @@ export type ServiceAccountsRevokeWorkspaceServiceAccountApiKeyData = {
 
 export type ServiceAccountsRevokeWorkspaceServiceAccountApiKeyResponse = void
 
+export type McpPersonalAccessTokensListMcpPersonalAccessTokensData = {
+  cursor?: string | null
+  limit?: number
+  reverse?: boolean
+  workspaceId: string
+}
+
+export type McpPersonalAccessTokensListMcpPersonalAccessTokensResponse =
+  CursorPaginatedResponse_MCPPersonalAccessTokenRead_
+
+export type McpPersonalAccessTokensCreateMcpPersonalAccessTokenData = {
+  requestBody: MCPPersonalAccessTokenCreate
+  workspaceId: string
+}
+
+export type McpPersonalAccessTokensCreateMcpPersonalAccessTokenResponse =
+  MCPPersonalAccessTokenIssueResponse
+
+export type McpPersonalAccessTokensRevokeMcpPersonalAccessTokenData = {
+  tokenId: string
+  workspaceId: string
+}
+
+export type McpPersonalAccessTokensRevokeMcpPersonalAccessTokenResponse = void
+
 export type WorkflowsListWorkflowsData = {
   cursor?: string | null
   limit?: number
@@ -12554,6 +12634,49 @@ export type $OpenApiTs = {
   "/workspaces/{workspace_id}/service-accounts/{service_account_id}/api-keys/{api_key_id}/revoke": {
     post: {
       req: ServiceAccountsRevokeWorkspaceServiceAccountApiKeyData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/mcp-personal-access-tokens": {
+    get: {
+      req: McpPersonalAccessTokensListMcpPersonalAccessTokensData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CursorPaginatedResponse_MCPPersonalAccessTokenRead_
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    post: {
+      req: McpPersonalAccessTokensCreateMcpPersonalAccessTokenData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: MCPPersonalAccessTokenIssueResponse
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/mcp-personal-access-tokens/{token_id}/revoke": {
+    post: {
+      req: McpPersonalAccessTokensRevokeMcpPersonalAccessTokenData
       res: {
         /**
          * Successful Response

--- a/frontend/src/components/nav/controls-header.tsx
+++ b/frontend/src/components/nav/controls-header.tsx
@@ -1437,6 +1437,35 @@ function ServiceAccountsActions() {
   )
 }
 
+function McpAccessActions() {
+  const canReadWorkspace = useScopeCheck("workspace:read")
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const router = useRouter()
+
+  if (canReadWorkspace !== true || !pathname) {
+    return null
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="h-7 bg-white"
+      onClick={() => {
+        const params = new URLSearchParams(searchParams?.toString())
+        params.set("createMcpToken", Date.now().toString())
+        router.replace(`${pathname}?${params.toString()}`, {
+          scroll: false,
+        })
+      }}
+    >
+      <Plus className="mr-1 h-3.5 w-3.5" />
+      Create token
+    </Button>
+  )
+}
+
 function VariablesActions() {
   return (
     <NewVariableDialog>
@@ -1789,6 +1818,13 @@ function getPageConfig(
     return {
       title: "Service accounts",
       actions: <ServiceAccountsActions />,
+    }
+  }
+
+  if (pagePath.startsWith("/mcp")) {
+    return {
+      title: "MCP access",
+      actions: <McpAccessActions />,
     }
   }
 

--- a/frontend/src/components/organization/workspace-mcp-access.tsx
+++ b/frontend/src/components/organization/workspace-mcp-access.tsx
@@ -1,0 +1,738 @@
+"use client"
+
+import { format, formatDistanceToNow } from "date-fns"
+import {
+  KeyRoundIcon,
+  SearchIcon,
+  TerminalIcon,
+  Trash2Icon,
+} from "lucide-react"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import type {
+  MCPPersonalAccessTokenCreate,
+  MCPPersonalAccessTokenIssueResponse,
+  MCPPersonalAccessTokenRead,
+} from "@/client"
+import { CopyButton } from "@/components/copy-button"
+import { AlertNotification } from "@/components/notifications"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { toast } from "@/components/ui/use-toast"
+import { useWorkspaceMcpPersonalAccessTokens } from "@/hooks/use-mcp-personal-access-tokens"
+import { getApiErrorDetail } from "@/lib/errors"
+import { useAppInfo } from "@/lib/hooks"
+import { cn } from "@/lib/utils"
+import { useWorkspaceId } from "@/providers/workspace-id"
+
+type ExpirationPreset = "never" | "7d" | "30d" | "90d" | "custom"
+type TokenStatus = "active" | "expired" | "revoked"
+type TokenStatusFilter = "all" | TokenStatus
+
+const CREATE_MCP_TOKEN_PARAM = "createMcpToken"
+
+const STATUS_FILTERS: { value: TokenStatusFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "active", label: "Active" },
+  { value: "expired", label: "Expired" },
+  { value: "revoked", label: "Revoked" },
+]
+
+const EXPIRATION_PRESETS: { value: ExpirationPreset; label: string }[] = [
+  { value: "never", label: "Never" },
+  { value: "7d", label: "7 days" },
+  { value: "30d", label: "30 days" },
+  { value: "90d", label: "90 days" },
+  { value: "custom", label: "Custom" },
+]
+
+function addDaysIso(days: number): string {
+  const date = new Date()
+  date.setDate(date.getDate() + days)
+  return date.toISOString()
+}
+
+function getPresetExpiresAt(preset: ExpirationPreset): string | null {
+  switch (preset) {
+    case "never":
+      return null
+    case "7d":
+      return addDaysIso(7)
+    case "30d":
+      return addDaysIso(30)
+    case "90d":
+      return addDaysIso(90)
+    case "custom":
+      return null
+  }
+}
+
+function getDefaultCustomExpiration(): string {
+  const date = new Date()
+  date.setDate(date.getDate() + 30)
+  const offsetMs = date.getTimezoneOffset() * 60 * 1000
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16)
+}
+
+function formatRelativeTimestamp(value?: string | null): string {
+  if (!value) {
+    return "Never"
+  }
+  return formatDistanceToNow(new Date(value), { addSuffix: true })
+}
+
+function formatFullTimestamp(value?: string | null): string {
+  if (!value) {
+    return "Never"
+  }
+  return format(new Date(value), "PPpp")
+}
+
+function getTokenStatus(token: MCPPersonalAccessTokenRead): TokenStatus {
+  if (token.revoked_at) {
+    return "revoked"
+  }
+  if (token.expires_at && new Date(token.expires_at).getTime() <= Date.now()) {
+    return "expired"
+  }
+  return "active"
+}
+
+function getStatusConfig(status: TokenStatus): {
+  label: string
+  dotClassName: string
+  textClassName: string
+} {
+  switch (status) {
+    case "active":
+      return {
+        label: "Active",
+        dotClassName: "bg-green-500",
+        textClassName: "text-green-700 dark:text-green-400",
+      }
+    case "expired":
+      return {
+        label: "Expired",
+        dotClassName: "bg-muted-foreground",
+        textClassName: "text-muted-foreground",
+      }
+    case "revoked":
+      return {
+        label: "Revoked",
+        dotClassName: "bg-muted-foreground",
+        textClassName: "text-muted-foreground",
+      }
+  }
+}
+
+function tokenMatchesSearch(
+  token: MCPPersonalAccessTokenRead,
+  query: string
+): boolean {
+  const normalizedQuery = query.trim().toLowerCase()
+  if (!normalizedQuery) {
+    return true
+  }
+  return [token.name, token.preview, token.key_id]
+    .filter(Boolean)
+    .some((value) => value.toLowerCase().includes(normalizedQuery))
+}
+
+function buildMcpUrl(publicAppUrl?: string): string {
+  if (publicAppUrl) {
+    return `${publicAppUrl.replace(/\/$/, "")}/mcp`
+  }
+  if (typeof window !== "undefined") {
+    return `${window.location.origin}/mcp`
+  }
+  return "https://<tracecat-app-url>/mcp"
+}
+
+function buildClaudeCommand(rawToken: string, mcpUrl: string): string {
+  return [
+    `claude mcp add --transport http tracecat ${mcpUrl} \\`,
+    "  --header 'Authorization: Bearer ${TRACECAT_MCP_PAT}'",
+  ].join("\n")
+}
+
+function CreateTokenDialog({
+  open,
+  pending,
+  onOpenChange,
+  onCreate,
+}: {
+  open: boolean
+  pending: boolean
+  onOpenChange: (open: boolean) => void
+  onCreate: (requestBody: MCPPersonalAccessTokenCreate) => Promise<void>
+}) {
+  const [name, setName] = useState("Claude Code")
+  const [expirationPreset, setExpirationPreset] =
+    useState<ExpirationPreset>("30d")
+  const [customExpiration, setCustomExpiration] = useState(
+    getDefaultCustomExpiration()
+  )
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const trimmedName = name.trim()
+    if (!trimmedName) {
+      toast({
+        title: "Name required",
+        description: "MCP tokens must have a name.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    let expiresAt = getPresetExpiresAt(expirationPreset)
+    if (expirationPreset === "custom") {
+      if (!customExpiration) {
+        toast({
+          title: "Expiration required",
+          description: "Choose a custom expiration time or use another preset.",
+          variant: "destructive",
+        })
+        return
+      }
+      expiresAt = new Date(customExpiration).toISOString()
+    }
+
+    await onCreate({
+      name: trimmedName,
+      expires_at: expiresAt,
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <DialogHeader>
+            <DialogTitle>Create MCP token</DialogTitle>
+            <DialogDescription>
+              Create a workspace-scoped bearer secret for MCP clients that
+              cannot use OIDC.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="mcp-token-name">Name</Label>
+              <Input
+                id="mcp-token-name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Claude Code"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Expiration</Label>
+              <Select
+                value={expirationPreset}
+                onValueChange={(value) =>
+                  setExpirationPreset(value as ExpirationPreset)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {EXPIRATION_PRESETS.map((preset) => (
+                    <SelectItem key={preset.value} value={preset.value}>
+                      {preset.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {expirationPreset === "custom" ? (
+              <div className="space-y-2">
+                <Label htmlFor="mcp-token-custom-expiration">
+                  Custom expiration
+                </Label>
+                <Input
+                  id="mcp-token-custom-expiration"
+                  type="datetime-local"
+                  value={customExpiration}
+                  onChange={(event) => setCustomExpiration(event.target.value)}
+                />
+              </div>
+            ) : null}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending}>
+              {pending ? "Creating..." : "Create token"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function IssuedTokenDialog({
+  issuedCredential,
+  mcpUrl,
+  onClose,
+}: {
+  issuedCredential: MCPPersonalAccessTokenIssueResponse | null
+  mcpUrl: string
+  onClose: () => void
+}) {
+  const rawToken = issuedCredential?.issued_token.raw_token ?? ""
+  const envVar = rawToken ? `TRACECAT_MCP_PAT=${rawToken}` : ""
+  const command = rawToken ? buildClaudeCommand(rawToken, mcpUrl) : ""
+
+  return (
+    <Dialog
+      open={issuedCredential !== null}
+      onOpenChange={(open) => !open && onClose()}
+    >
+      <DialogContent className="w-[calc(100vw-2rem)] max-w-2xl overflow-hidden">
+        <DialogHeader>
+          <DialogTitle>Set up an MCP PAT</DialogTitle>
+          <DialogDescription>
+            This token is shown once. Save it as a long-lived secret for MCP
+            clients that cannot use OAuth.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="min-w-0 space-y-4">
+          <div className="min-w-0 space-y-2">
+            <Label>1. Save the token</Label>
+            <p className="text-xs text-muted-foreground">
+              Add this to your shell profile, project env file, direnv, or
+              whichever environment launches your MCP client. A one-time export
+              only works for that terminal session.
+            </p>
+            <div className="flex min-w-0 max-w-full items-center gap-2 rounded-md border bg-muted/30 px-3 py-2">
+              <code className="min-w-0 flex-1 truncate font-mono text-xs">
+                {envVar}
+              </code>
+              <CopyButton
+                value={envVar}
+                toastMessage="MCP token environment variable copied."
+                tooltipMessage="Copy env var"
+              />
+            </div>
+          </div>
+
+          <div className="min-w-0 space-y-2">
+            <Label>2. Add the MCP</Label>
+            <p className="text-xs text-muted-foreground">
+              Configure your MCP client to send this token as a bearer header.
+              If you move or change the environment variable later, re-add the
+              server so the client uses the updated value.
+            </p>
+            <div className="min-w-0 max-w-full rounded-md border bg-muted/30">
+              <div className="flex min-w-0 items-center justify-between gap-2 border-b px-3 py-2">
+                <div className="min-w-0 text-xs font-medium">Setup command</div>
+                <CopyButton
+                  value={command}
+                  toastMessage="MCP setup command copied."
+                  tooltipMessage="Copy command"
+                />
+              </div>
+              <pre className="max-w-full overflow-x-auto p-3 text-xs leading-5">
+                <code className="block min-w-0">{command}</code>
+              </pre>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" onClick={onClose}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function TokenStatusBadge({ token }: { token: MCPPersonalAccessTokenRead }) {
+  const status = getTokenStatus(token)
+  const config = getStatusConfig(status)
+
+  return (
+    <Badge
+      variant="secondary"
+      className={cn(
+        "h-5 shrink-0 gap-1.5 bg-secondary px-1.5 py-0 text-[10px] font-normal",
+        config.textClassName
+      )}
+    >
+      <span
+        className={cn("size-1.5 shrink-0 rounded-full", config.dotClassName)}
+      />
+      <span>{config.label}</span>
+    </Badge>
+  )
+}
+
+function TokenRow({
+  token,
+  canManage,
+  onRevoke,
+}: {
+  token: MCPPersonalAccessTokenRead
+  canManage: boolean
+  onRevoke: (token: MCPPersonalAccessTokenRead) => void
+}) {
+  const status = getTokenStatus(token)
+
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-4 px-4 py-3">
+      <div className="flex min-w-0 gap-3">
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-md border bg-muted/30">
+          <KeyRoundIcon className="size-4 text-muted-foreground" />
+        </div>
+        <div className="min-w-0 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="truncate text-sm font-medium">{token.name}</div>
+            <TokenStatusBadge token={token} />
+          </div>
+          <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
+            <span>
+              Preview{" "}
+              <code className="font-mono text-foreground/80">
+                {token.preview}
+              </code>
+            </span>
+            <span title={formatFullTimestamp(token.created_at)}>
+              Created {formatRelativeTimestamp(token.created_at)}
+            </span>
+            <span title={formatFullTimestamp(token.expires_at)}>
+              Expires {formatRelativeTimestamp(token.expires_at)}
+            </span>
+            <span title={formatFullTimestamp(token.last_used_at)}>
+              Last used {formatRelativeTimestamp(token.last_used_at)}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-start">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={!canManage || status === "revoked"}
+          onClick={() => onRevoke(token)}
+          className="gap-2 text-muted-foreground hover:text-destructive"
+        >
+          <Trash2Icon className="size-3.5" />
+          Revoke
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Workspace MCP token management screen.
+ */
+export function WorkspaceMcpAccess() {
+  const workspaceId = useWorkspaceId()
+  const pathname = usePathname()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { appInfo } = useAppInfo()
+  const mcpUrl = buildMcpUrl(appInfo?.public_app_url)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [issuedCredential, setIssuedCredential] =
+    useState<MCPPersonalAccessTokenIssueResponse | null>(null)
+  const [revokeTarget, setRevokeTarget] =
+    useState<MCPPersonalAccessTokenRead | null>(null)
+  const [searchQuery, setSearchQuery] = useState("")
+  const [statusFilter, setStatusFilter] = useState<TokenStatusFilter>("all")
+
+  const {
+    tokens,
+    nextCursor,
+    isLoading,
+    error,
+    createToken,
+    createPending,
+    revokeToken,
+    revokePending,
+  } = useWorkspaceMcpPersonalAccessTokens(workspaceId)
+
+  const filteredTokens = useMemo(
+    () =>
+      tokens.filter((token) => {
+        const status = getTokenStatus(token)
+        return (
+          (statusFilter === "all" || status === statusFilter) &&
+          tokenMatchesSearch(token, searchQuery)
+        )
+      }),
+    [searchQuery, statusFilter, tokens]
+  )
+
+  const hasActiveFilters =
+    searchQuery.trim().length > 0 || statusFilter !== "all"
+
+  const handleCreateSignalConsumed = useCallback(() => {
+    if (!pathname || !searchParams?.get(CREATE_MCP_TOKEN_PARAM)) {
+      return
+    }
+    const params = new URLSearchParams(searchParams.toString())
+    params.delete(CREATE_MCP_TOKEN_PARAM)
+    const next = params.toString()
+    router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false })
+  }, [pathname, router, searchParams])
+
+  useEffect(() => {
+    if (!searchParams?.get(CREATE_MCP_TOKEN_PARAM)) {
+      return
+    }
+    setCreateOpen(true)
+    handleCreateSignalConsumed()
+  }, [handleCreateSignalConsumed, searchParams])
+
+  async function handleCreate(requestBody: MCPPersonalAccessTokenCreate) {
+    try {
+      const response = await createToken(requestBody)
+      setIssuedCredential(response)
+      setCreateOpen(false)
+      toast({
+        title: "MCP token created",
+        description: "Copy the token now. It will not be shown again.",
+      })
+    } catch (createError) {
+      toast({
+        title: "Failed to create MCP token",
+        description: getApiErrorDetail(createError) ?? "Please try again.",
+        variant: "destructive",
+      })
+    }
+  }
+
+  async function handleRevoke() {
+    if (!revokeTarget) {
+      return
+    }
+    try {
+      await revokeToken(revokeTarget.id)
+      toast({
+        title: "MCP token revoked",
+        description: `${revokeTarget.name} can no longer authenticate.`,
+      })
+      setRevokeTarget(null)
+    } catch (revokeError) {
+      toast({
+        title: "Failed to revoke MCP token",
+        description: getApiErrorDetail(revokeError) ?? "Please try again.",
+        variant: "destructive",
+      })
+    }
+  }
+
+  if (error) {
+    return (
+      <AlertNotification
+        level="error"
+        message={`Error loading MCP tokens: ${error.message}`}
+      />
+    )
+  }
+
+  return (
+    <div className="flex size-full flex-col">
+      <div className="shrink-0">
+        <header className="flex h-10 items-center gap-3 border-b pl-3 pr-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="flex size-7 shrink-0 items-center justify-center">
+              <SearchIcon className="size-4 text-muted-foreground" />
+            </div>
+            <Input
+              type="text"
+              placeholder="Search MCP tokens..."
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              className={cn(
+                "h-7 w-64 border-none bg-transparent p-0 text-sm shadow-none outline-none",
+                "placeholder:text-muted-foreground focus-visible:ring-0 focus-visible:ring-offset-0"
+              )}
+            />
+          </div>
+
+          <div className="ml-auto flex items-center gap-3">
+            <span className="text-xs text-muted-foreground">
+              {filteredTokens.length} tokens
+            </span>
+          </div>
+        </header>
+
+        <div className="flex flex-wrap items-center gap-2 border-b px-4 py-2">
+          {STATUS_FILTERS.map((filterOption) => (
+            <button
+              key={filterOption.value}
+              type="button"
+              onClick={() => setStatusFilter(filterOption.value)}
+              className={cn(
+                "flex h-6 items-center rounded-md border border-input bg-transparent px-2 text-xs font-medium transition-colors",
+                "hover:bg-muted/50",
+                statusFilter === filterOption.value
+                  ? "border-primary/50 bg-primary/5 text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {filterOption.label}
+            </button>
+          ))}
+
+          {hasActiveFilters ? (
+            <button
+              type="button"
+              onClick={() => {
+                setSearchQuery("")
+                setStatusFilter("all")
+              }}
+              className="flex h-6 items-center gap-1.5 rounded-md px-2 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              Reset
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        {isLoading ? (
+          <div className="px-4 py-3 text-sm text-muted-foreground">
+            Loading MCP tokens...
+          </div>
+        ) : tokens.length === 0 ? (
+          <Empty className="rounded-none border-0">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <TerminalIcon />
+              </EmptyMedia>
+              <EmptyTitle>No MCP tokens</EmptyTitle>
+              <EmptyDescription>
+                Create a workspace-scoped token for MCP clients that cannot use
+                OIDC.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : filteredTokens.length === 0 ? (
+          <Empty className="rounded-none border-0">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <SearchIcon />
+              </EmptyMedia>
+              <EmptyTitle>No matching MCP tokens</EmptyTitle>
+              <EmptyDescription>
+                Adjust the search query or filters to find a token.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <div className="divide-y divide-border/50">
+            {filteredTokens.map((token) => (
+              <TokenRow
+                key={token.id}
+                token={token}
+                canManage
+                onRevoke={setRevokeTarget}
+              />
+            ))}
+          </div>
+        )}
+
+        {nextCursor ? (
+          <p className="px-4 py-3 text-xs text-muted-foreground">
+            Only the first page of MCP tokens is shown in this view.
+          </p>
+        ) : null}
+      </div>
+
+      <CreateTokenDialog
+        open={createOpen}
+        pending={createPending}
+        onOpenChange={setCreateOpen}
+        onCreate={handleCreate}
+      />
+      <IssuedTokenDialog
+        issuedCredential={issuedCredential}
+        mcpUrl={mcpUrl}
+        onClose={() => setIssuedCredential(null)}
+      />
+      <AlertDialog
+        open={revokeTarget !== null}
+        onOpenChange={(open) => !open && setRevokeTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke MCP token?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This immediately prevents {revokeTarget?.name ?? "this token"}{" "}
+              from authenticating to the MCP server.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={revokePending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={revokePending}
+              onClick={(event) => {
+                event.preventDefault()
+                void handleRevoke()
+              }}
+            >
+              {revokePending ? "Revoking..." : "Revoke token"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Plus,
   Pyramid,
   Table2Icon,
+  TerminalIcon,
   UsersIcon,
   VariableIcon,
   WorkflowIcon,
@@ -117,6 +118,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const canViewInbox = useScopeCheck("inbox:read")
   const canViewMembers = useScopeCheck("workspace:member:read")
   const canViewServiceAccounts = useScopeCheck("workspace:service_account:read")
+  const canViewMcpAccess = useScopeCheck("workspace:read")
   const canViewCases = useScopeCheck("case:read")
   const shouldLoadEntitlements =
     canViewAgents === true || canViewServiceAccounts === true
@@ -463,6 +465,14 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   isActive: pathname?.startsWith(
                     `${basePath}/service-accounts`
                   ),
+                }
+              : null,
+            canViewMcpAccess === true
+              ? {
+                  title: "MCP access",
+                  href: `${basePath}/mcp`,
+                  icon: TerminalIcon,
+                  isActive: pathname?.startsWith(`${basePath}/mcp`),
                 }
               : null,
           ].filter((item) => item !== null)}

--- a/frontend/src/hooks/use-mcp-personal-access-tokens.ts
+++ b/frontend/src/hooks/use-mcp-personal-access-tokens.ts
@@ -1,0 +1,75 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  type MCPPersonalAccessTokenCreate,
+  type MCPPersonalAccessTokenIssueResponse,
+  mcpPersonalAccessTokensCreateMcpPersonalAccessToken,
+  mcpPersonalAccessTokensListMcpPersonalAccessTokens,
+  mcpPersonalAccessTokensRevokeMcpPersonalAccessToken,
+} from "@/client"
+
+function workspaceMcpTokensQueryKey(workspaceId: string) {
+  return ["workspace-mcp-personal-access-tokens", workspaceId] as const
+}
+
+/**
+ * Manage workspace-scoped MCP personal access tokens.
+ */
+export function useWorkspaceMcpPersonalAccessTokens(
+  workspaceId: string,
+  { enabled = true }: { enabled?: boolean } = {}
+) {
+  const queryClient = useQueryClient()
+
+  const {
+    data: response,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: workspaceMcpTokensQueryKey(workspaceId),
+    queryFn: async () =>
+      await mcpPersonalAccessTokensListMcpPersonalAccessTokens({
+        workspaceId,
+        limit: 100,
+      }),
+    enabled: enabled && Boolean(workspaceId),
+  })
+
+  function invalidate() {
+    return queryClient.invalidateQueries({
+      queryKey: workspaceMcpTokensQueryKey(workspaceId),
+    })
+  }
+
+  const { mutateAsync: createToken, isPending: createPending } = useMutation({
+    mutationFn: async (
+      requestBody: MCPPersonalAccessTokenCreate
+    ): Promise<MCPPersonalAccessTokenIssueResponse> =>
+      await mcpPersonalAccessTokensCreateMcpPersonalAccessToken({
+        workspaceId,
+        requestBody,
+      }),
+    onSuccess: invalidate,
+  })
+
+  const { mutateAsync: revokeToken, isPending: revokePending } = useMutation({
+    mutationFn: async (tokenId: string) =>
+      await mcpPersonalAccessTokensRevokeMcpPersonalAccessToken({
+        workspaceId,
+        tokenId,
+      }),
+    onSuccess: invalidate,
+  })
+
+  return {
+    tokens: response?.items ?? [],
+    nextCursor: response?.next_cursor ?? null,
+    isLoading,
+    error,
+    createToken,
+    createPending,
+    revokeToken,
+    revokePending,
+  }
+}

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -9,17 +9,24 @@ from unittest.mock import MagicMock, patch
 import pytest
 from cryptography.fernet import Fernet
 from fastmcp import FastMCP
-from fastmcp.server.auth import AccessToken
+from fastmcp.server.auth import AccessToken, MultiAuth
 from fastmcp.server.auth.cimd import CIMDDocument
+from fastmcp.server.auth.middleware import RequireAuthMiddleware
 from fastmcp.server.auth.oauth_proxy.models import ProxyDCRClient
 from key_value.aio.stores.memory import MemoryStore
 from mcp.server.auth.provider import AuthorizationParams
 from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import AnyHttpUrl, AnyUrl
 from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
 from starlette.testclient import TestClient
+from starlette.types import Receive, Scope, Send
 
+from tracecat.auth.types import Role
 from tracecat.mcp import auth as mcp_auth
+from tracecat.mcp.personal_access_tokens.constants import MCP_PAT_PREFIX
+from tracecat.mcp.personal_access_tokens.types import MCPPATIdentity
 
 type AsyncLookup = Callable[..., Awaitable[object]]
 
@@ -127,6 +134,22 @@ def test_create_mcp_auth_uses_oidc_mode(
 
     assert isinstance(auth, mcp_auth.OIDCProxy)
     assert getattr(auth, "_fallback_access_token_expiry_seconds", None) == 24 * 60 * 60
+
+
+def test_create_mcp_auth_wraps_oidc_with_mcp_pat_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    oidc_auth = _build_test_auth(monkeypatch)
+    monkeypatch.setattr(mcp_auth, "_create_oidc_auth", lambda: oidc_auth)
+
+    auth = mcp_auth.create_mcp_auth()
+
+    assert isinstance(auth, MultiAuth)
+    assert auth.server is oidc_auth
+    assert any(
+        isinstance(verifier, mcp_auth.MCPPATTokenVerifier)
+        for verifier in auth.verifiers
+    )
 
 
 def test_create_mcp_auth_metadata_advertises_public_client_auth(
@@ -781,6 +804,122 @@ async def test_load_access_token_preserves_fastmcp_upstream_claims(
     assert merged.claims["upstream_claims"] == {"email": " user@example.com "}
 
 
+@pytest.mark.anyio
+async def test_mcp_pat_token_verifier_returns_fastmcp_access_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    raw_token = f"{MCP_PAT_PREFIX}raw-secret"
+
+    async def _verify_mcp_personal_access_token(token: str) -> MCPPATIdentity | None:
+        assert token == raw_token
+        return MCPPATIdentity(
+            key_id="pat_key_123",
+            user_id=user_id,
+            email="user@example.com",
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+            expires_at=None,
+        )
+
+    monkeypatch.setattr(
+        mcp_auth,
+        "verify_mcp_personal_access_token",
+        _verify_mcp_personal_access_token,
+    )
+
+    access_token = await mcp_auth.MCPPATTokenVerifier().verify_token(raw_token)
+
+    assert access_token is not None
+    assert access_token.token == raw_token
+    assert access_token.client_id == "mcp_pat:pat_key_123"
+    assert access_token.claims == {
+        "sub": str(user_id),
+        "email": "user@example.com",
+        "organization_id": str(organization_id),
+        "organization_ids": [str(organization_id)],
+        "client_id": "mcp_pat:pat_key_123",
+        "workspace_id": str(workspace_id),
+        "workspace_ids": [str(workspace_id)],
+    }
+
+
+@pytest.mark.anyio
+async def test_mcp_pat_token_verifier_ignores_other_bearer_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _verify_mcp_personal_access_token(_token: str) -> MCPPATIdentity | None:
+        raise AssertionError("non-MCP PAT tokens should not hit the PAT verifier")
+
+    monkeypatch.setattr(
+        mcp_auth,
+        "verify_mcp_personal_access_token",
+        _verify_mcp_personal_access_token,
+    )
+
+    assert await mcp_auth.MCPPATTokenVerifier().verify_token("oauth-token") is None
+
+
+@pytest.mark.anyio
+async def test_mcp_pat_bearer_header_reaches_auth_middleware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    organization_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    raw_token = f"{MCP_PAT_PREFIX}raw-secret"
+
+    async def _verify_mcp_personal_access_token(token: str) -> MCPPATIdentity | None:
+        assert token == raw_token
+        return MCPPATIdentity(
+            key_id="pat_key_123",
+            user_id=uuid.uuid4(),
+            email="user@example.com",
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+            expires_at=None,
+        )
+
+    async def _protected_app(scope: Scope, receive: Receive, send: Send) -> None:
+        access_token = scope["user"].access_token
+        response = JSONResponse(
+            {
+                "client_id": access_token.client_id,
+                "workspace_id": access_token.claims["workspace_id"],
+            }
+        )
+        await response(scope, receive, send)
+
+    monkeypatch.setattr(
+        mcp_auth,
+        "verify_mcp_personal_access_token",
+        _verify_mcp_personal_access_token,
+    )
+    auth = mcp_auth.MCPPATTokenVerifier()
+    app = Starlette(
+        routes=[
+            Route(
+                "/mcp",
+                endpoint=RequireAuthMiddleware(_protected_app, auth.required_scopes),
+                methods=["POST"],
+            )
+        ],
+        middleware=auth.get_middleware(),
+    )
+
+    response = TestClient(app).post(
+        "/mcp",
+        headers={"Authorization": f"Bearer {raw_token}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "client_id": "mcp_pat:pat_key_123",
+        "workspace_id": str(workspace_id),
+    }
+
+
 def test_get_token_identity_extracts_ids_from_claims_and_scopes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -998,6 +1137,89 @@ async def test_list_workspaces_for_request_reads_email_from_upstream_claims(
 
     assert captured["email"] == "user@example.com"
     assert captured["organization_ids"] is None
+
+
+@pytest.mark.anyio
+async def test_list_workspaces_for_request_filters_claimed_workspace_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    other_workspace_id = uuid.uuid4()
+    identity = mcp_auth.MCPTokenIdentity(
+        client_id="mcp_pat:pat_key_123",
+        email="user@example.com",
+        workspace_ids=frozenset({workspace_id}),
+    )
+
+    async def _list_user_workspaces(
+        _email: str,
+        organization_ids: frozenset[uuid.UUID] | None = None,
+    ) -> list[dict[str, str]]:
+        assert organization_ids is None
+        return [
+            {"id": str(workspace_id), "name": "Allowed"},
+            {"id": str(other_workspace_id), "name": "Other"},
+        ]
+
+    monkeypatch.setattr(mcp_auth, "get_token_identity", lambda: identity)
+    monkeypatch.setattr(mcp_auth, "list_user_workspaces", _list_user_workspaces)
+
+    assert await mcp_auth.list_workspaces_for_request() == [
+        {"id": str(workspace_id), "name": "Allowed"}
+    ]
+
+
+@pytest.mark.anyio
+async def test_resolve_role_for_request_rejects_unscoped_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    requested_workspace_id = uuid.uuid4()
+    identity = mcp_auth.MCPTokenIdentity(
+        client_id="mcp_pat:pat_key_123",
+        email="user@example.com",
+        workspace_ids=frozenset({workspace_id}),
+    )
+
+    async def _resolve_role(_email: str, _workspace_id: uuid.UUID) -> Role:
+        raise AssertionError("workspace scope should be checked before role resolution")
+
+    monkeypatch.setattr(mcp_auth, "get_token_identity", lambda: identity)
+    monkeypatch.setattr(mcp_auth, "resolve_role", _resolve_role)
+
+    with pytest.raises(ValueError, match="not scoped to the requested workspace"):
+        await mcp_auth.resolve_role_for_request(requested_workspace_id)
+
+
+@pytest.mark.anyio
+async def test_resolve_role_for_request_allows_claimed_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    identity = mcp_auth.MCPTokenIdentity(
+        client_id="mcp_pat:pat_key_123",
+        email="user@example.com",
+        workspace_ids=frozenset({workspace_id}),
+    )
+    expected_role = Role(
+        type="user",
+        user_id=user_id,
+        workspace_id=workspace_id,
+        organization_id=organization_id,
+        service_id="tracecat-mcp",
+    )
+
+    async def _resolve_role(email: str, workspace_id_arg: uuid.UUID) -> Role:
+        assert email == "user@example.com"
+        assert workspace_id_arg == workspace_id
+        return expected_role
+
+    monkeypatch.setattr(mcp_auth, "get_token_identity", lambda: identity)
+    monkeypatch.setattr(mcp_auth, "resolve_role", _resolve_role)
+
+    assert await mcp_auth.resolve_role_for_request(workspace_id) == expected_role
 
 
 @pytest.mark.anyio
@@ -1351,6 +1573,7 @@ def _patch_resolve_org_role_deps(
     monkeypatch: pytest.MonkeyPatch,
     *,
     identity_org_ids: frozenset[uuid.UUID] = frozenset(),
+    identity_workspace_ids: frozenset[uuid.UUID] = frozenset(),
     membership_org_ids: list[uuid.UUID],
     user_id: uuid.UUID | None = None,
     is_superuser: bool = False,
@@ -1384,7 +1607,7 @@ def _patch_resolve_org_role_deps(
         client_id="tracecat-client",
         email="user@example.com",
         organization_ids=identity_org_ids,
-        workspace_ids=frozenset(),
+        workspace_ids=identity_workspace_ids,
     )
 
     async def _resolve_user_by_email(_email: str) -> SimpleNamespace:
@@ -1421,6 +1644,22 @@ async def test_resolve_org_role_intersects_token_scoping_with_memberships(
 
     assert role.organization_id == scoped_org
     assert role.workspace_id is None
+
+
+@pytest.mark.anyio
+async def test_resolve_org_role_rejects_workspace_scoped_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    _patch_resolve_org_role_deps(
+        monkeypatch,
+        identity_org_ids=frozenset({uuid.uuid4()}),
+        identity_workspace_ids=frozenset({workspace_id}),
+        membership_org_ids=[uuid.uuid4()],
+    )
+
+    with pytest.raises(ValueError, match="organization-level tools"):
+        await mcp_auth.resolve_org_role_for_request()
 
 
 @pytest.mark.anyio

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -129,6 +129,9 @@ from tracecat.integrations.router import (
 )
 from tracecat.logger import logger
 from tracecat.mcp.oidc import router as mcp_oidc_router
+from tracecat.mcp.personal_access_tokens.router import (
+    router as mcp_personal_access_tokens_router,
+)
 from tracecat.middleware import (
     AuthorizationCacheMiddleware,
     RequestLoggingMiddleware,
@@ -498,6 +501,7 @@ def create_app(**kwargs) -> FastAPI:
     app.include_router(agent_channels_router)
     app.include_router(workspaces_router)
     app.include_router(workspace_service_accounts_router)
+    app.include_router(mcp_personal_access_tokens_router)
     _include_workspace_scoped_router(app, workflow_management_router)
     _include_workspace_scoped_router(app, workflow_executions_workflow_router)
     _include_workspace_scoped_router(app, workflow_graph_router)

--- a/tracecat/mcp/auth.py
+++ b/tracecat/mcp/auth.py
@@ -9,12 +9,13 @@ import time
 import uuid
 from base64 import urlsafe_b64decode
 from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
 from typing import Any, cast
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 from cryptography.fernet import Fernet
-from fastmcp.server.auth import AccessToken, AuthProvider
+from fastmcp.server.auth import AccessToken, AuthProvider, MultiAuth, TokenVerifier
 from fastmcp.server.auth.cimd import CIMDDocument
 from fastmcp.server.auth.oauth_proxy.models import ProxyDCRClient
 from fastmcp.server.auth.oidc_proxy import OIDCProxy
@@ -69,6 +70,8 @@ from tracecat.mcp.oidc.features import (
     OFFLINE_ACCESS_SCOPE,
     get_supported_scopes,
 )
+from tracecat.mcp.personal_access_tokens.constants import MCP_PAT_PREFIX
+from tracecat.mcp.personal_access_tokens.service import verify_mcp_personal_access_token
 
 
 class MCPTokenIdentity(BaseModel):
@@ -363,6 +366,46 @@ def _extract_fastmcp_scopes(fastmcp_claims: Mapping[str, object]) -> list[str] |
     ):
         return [scope for scope in raw_scope if scope]
     return None
+
+
+def _expires_at_timestamp(expires_at: datetime | None) -> int | None:
+    if expires_at is None:
+        return None
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=UTC)
+    else:
+        expires_at = expires_at.astimezone(UTC)
+    return int(expires_at.timestamp())
+
+
+class MCPPATTokenVerifier(TokenVerifier):
+    """FastMCP token verifier for workspace-scoped MCP personal access tokens."""
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if not token.startswith(MCP_PAT_PREFIX):
+            return None
+
+        identity = await verify_mcp_personal_access_token(token)
+        if identity is None:
+            return None
+
+        client_id = f"mcp_pat:{identity.key_id}"
+        claims: dict[str, object] = {
+            "sub": str(identity.user_id),
+            "email": identity.email,
+            "organization_id": str(identity.organization_id),
+            "organization_ids": [str(identity.organization_id)],
+            "client_id": client_id,
+            "workspace_id": str(identity.workspace_id),
+            "workspace_ids": [str(identity.workspace_id)],
+        }
+        return AccessToken(
+            token=token,
+            client_id=client_id,
+            scopes=[],
+            expires_at=_expires_at_timestamp(identity.expires_at),
+            claims=claims,
+        )
 
 
 async def _fetch_userinfo_claims(
@@ -1057,7 +1100,7 @@ def _create_oidc_auth() -> OIDCProxy:
 
 def create_mcp_auth() -> AuthProvider:
     """Build the auth provider for external MCP."""
-    return _create_oidc_auth()
+    return MultiAuth(server=_create_oidc_auth(), verifiers=[MCPPATTokenVerifier()])
 
 
 async def resolve_user_by_email(email: str) -> User:
@@ -1280,8 +1323,12 @@ async def list_user_workspaces(
 
 async def resolve_role_for_request(workspace_id: WorkspaceID) -> Role:
     """Resolve caller role for a workspace."""
-    email = get_email_from_token()
-    return await resolve_role(email, workspace_id)
+    identity = get_token_identity()
+    if identity.email is None:
+        raise ValueError("Token does not contain an email claim")
+    if identity.workspace_ids and workspace_id not in identity.workspace_ids:
+        raise ValueError("Token is not scoped to the requested workspace")
+    return await resolve_role(identity.email, workspace_id)
 
 
 async def resolve_org_role_for_request() -> Role:
@@ -1298,6 +1345,10 @@ async def resolve_org_role_for_request() -> Role:
     identity = get_token_identity()
     if identity.email is None:
         raise ValueError("Token does not contain an email claim")
+    if identity.workspace_ids:
+        raise ValueError(
+            "Workspace-scoped tokens cannot access organization-level tools"
+        )
 
     user = await resolve_user_by_email(identity.email)
 
@@ -1346,10 +1397,17 @@ async def list_workspaces_for_request() -> list[dict[str, str]]:
     if identity.email is None:
         raise ValueError("Token does not contain an email claim")
     scoped_org_ids = identity.organization_ids or None
-    return await list_user_workspaces(
+    workspaces = await list_user_workspaces(
         identity.email,
         organization_ids=scoped_org_ids,
     )
+    if not identity.workspace_ids:
+        return workspaces
+    return [
+        workspace
+        for workspace in workspaces
+        if _coerce_uuid(workspace["id"]) in identity.workspace_ids
+    ]
 
 
 def get_email_from_token() -> str:


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add workspace-scoped MCP Personal Access Token (PAT) management and enable PAT auth on the MCP server so clients like Claude Code can connect with a bearer token instead of OIDC.

- **New Features**
  - UI: New “MCP access” workspace page with list/search/status filters, token details (preview/created/expires/last used), create dialog (expiry presets: never/7/30/90/custom), copy-once token with env var and Claude setup command, and revoke with confirm; added sidebar nav and a “Create token” header action.
  - Auth: Added `MCPPATTokenVerifier` and wrapped OIDC in `MultiAuth` to accept PATs; propagate org/workspace claims; enforce workspace scoping in role resolution and workspace listing; block org-level tools for workspace-scoped tokens; tests cover verifier, middleware path, and scoping rules.
  - Server: Mounted the MCP PAT router in the API app.

<sup>Written for commit fbe4082e48c85fbc4648a3c227247a9dae411526. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<img width="1719" height="958" alt="image" src="https://github.com/user-attachments/assets/257e3f01-22a8-4e0a-b98c-99faeb24da0f" />

