### PR TITLE
fix(rbac): give org members scope to run agents

### DIFF
--- a/tests/unit/test_rbac_scopes.py
+++ b/tests/unit/test_rbac_scopes.py
@@ -294,8 +294,14 @@ class TestOrgRoleScopes:
                 "org:registry:read",
                 "agent:read",
                 "agent:execute",
+                "org:secret:read",
             }
         )
+
+    def test_member_can_execute_agents_with_org_secret_read(self):
+        required_scopes = {"agent:read", "agent:execute", "org:secret:read"}
+
+        assert required_scopes.issubset(PRESET_ROLE_SCOPES["organization-member"])
 
 
 class TestRequireScopeDecorator:

--- a/tracecat/authz/scopes.py
+++ b/tracecat/authz/scopes.py
@@ -321,6 +321,7 @@ ORG_MEMBER_SCOPES: frozenset[str] = frozenset(
         "org:registry:read",
         "agent:read",
         "agent:execute",
+        "org:secret:read",
     }
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow organization members to run agents by adding the missing `org:secret:read` scope to the `organization-member` preset. This unblocks agent execution that needs org secrets.

- **Bug Fixes**
  - Added `org:secret:read` to `organization-member` in `PRESET_ROLE_SCOPES`.
  - Added a unit test to verify members have `agent:read`, `agent:execute`, and `org:secret:read`.

<sup>Written for commit 87add39d413e573cb36fbb4d0b197e2193fe94a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

