### PR TITLE
infra: separate migrations task

### DIFF
--- a/deployments/fargate/README.md
+++ b/deployments/fargate/README.md
@@ -76,19 +76,64 @@ terraform apply
 
 For Terraform Cloud direct OIDC runs, the target account and role come from `TFC_AWS_RUN_ROLE_ARN`. This stack now uses the ambient AWS credentials from the execution environment and no longer accepts `aws_account_id` / `aws_role_name` inputs for a second provider-side assume-role hop.
 
-## Self-contained migrations
+## Database migrations
 
-- API task startup includes an internal migrations init container.
-- API container starts only if migrations succeed (`dependsOn: SUCCESS`).
-- `worker`, `executor`, and `agent-executor` are ordered after API in Terraform, so service updates do not proceed past API if migrations fail.
+Fargate migrations run as a standalone one-shot ECS task. API tasks do not run
+migrations on startup or scale-out.
 
-By default, the migrations init container uses the same backend image repository
-and tag as the application. Set these optional variables to decouple it:
+By default, the migrations task uses the same backend image repository and tag
+as the application. Set these optional variables to decouple it:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `tracecat_migrations_image` | `tracecat_image` | Optional migrations image repository override |
 | `tracecat_migrations_image_tag` | `tracecat_image_tag` | Optional migrations image tag override |
+| `migrations_cpu` | `1024` | CPU units for the one-shot migrations task |
+| `migrations_memory` | `2048` | Memory for the one-shot migrations task |
+
+The runner script requires Terraform, AWS CLI, and `jq`.
+
+```bash
+cd deployments/fargate
+./scripts/run-migrations-task.sh
+```
+
+Production upgrades should use a two-phase apply so schema changes complete
+before app services move to the new image:
+
+```bash
+# Phase 1: register the migration task for the new release while app services
+# keep running the current application image.
+terraform apply \
+  -var 'tracecat_image_tag=<current-app-tag>' \
+  -var 'tracecat_migrations_image_tag=<new-release-tag>'
+
+./scripts/run-migrations-task.sh
+
+# Phase 2: update application services after migrations succeed.
+terraform apply \
+  -var 'tracecat_image_tag=<new-release-tag>' \
+  -var 'tracecat_migrations_image_tag=<new-release-tag>'
+```
+
+For fresh installs, create the infrastructure with DB-backed app services at
+zero desired count, run migrations, then apply again with the intended service
+counts:
+
+```bash
+terraform apply \
+  -var 'api_desired_count=0' \
+  -var 'worker_desired_count=0' \
+  -var 'agent_worker_desired_count=0' \
+  -var 'executor_desired_count=0' \
+  -var 'agent_executor_desired_count=0' \
+  -var 'litellm_desired_count=0' \
+  -var 'mcp_desired_count=0'
+
+./scripts/run-migrations-task.sh
+
+terraform apply
+```
 
 For app-only rollbacks, keep the migrations image on a version that understands
 the current Alembic database revision while rolling back the app images.
@@ -98,6 +143,9 @@ the current Alembic database revision while rolling back the app images.
 - `public_app_url`
 - `public_api_url`
 - `ecs_cluster_name`
+- `tracecat_migrations_task_definition_arn`
+- `tracecat_migrations_container_name`
+- `tracecat_migrations_security_group_ids`
 - `s3_attachments_bucket_name`
 - `s3_registry_bucket_name`
 - `s3_workflow_bucket_name`

--- a/deployments/fargate/main.tf
+++ b/deployments/fargate/main.tf
@@ -137,6 +137,8 @@ module "ecs" {
   api_cpu                                  = var.api_cpu
   api_memory                               = var.api_memory
   api_desired_count                        = var.api_desired_count
+  migrations_cpu                           = var.migrations_cpu
+  migrations_memory                        = var.migrations_memory
   worker_cpu                               = var.worker_cpu
   worker_memory                            = var.worker_memory
   worker_desired_count                     = var.worker_desired_count

--- a/deployments/fargate/modules/ecs/ecs-api.tf
+++ b/deployments/fargate/modules/ecs/ecs-api.tf
@@ -15,30 +15,9 @@ resource "aws_ecs_task_definition" "api_task_definition" {
 
   container_definitions = jsonencode([
     {
-      name      = "TracecatApiMigrationsContainer"
-      image     = "${local.tracecat_migrations_image}:${local.tracecat_migrations_image_tag}"
-      essential = false
-      command   = ["python3", "-m", "alembic", "upgrade", "head"]
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          awslogs-group         = aws_cloudwatch_log_group.tracecat_log_group.name
-          awslogs-region        = var.aws_region
-          awslogs-stream-prefix = "api-migrations"
-        }
-      }
-      environment = local.migrations_env
-    },
-    {
       name      = "TracecatApiContainer"
       image     = "${var.tracecat_image}:${local.tracecat_image_tag}"
       essential = true
-      dependsOn = [
-        {
-          containerName = "TracecatApiMigrationsContainer"
-          condition     = "SUCCESS"
-        }
-      ]
       portMappings = [
         {
           containerPort = 8000

--- a/deployments/fargate/modules/ecs/ecs-migrations.tf
+++ b/deployments/fargate/modules/ecs/ecs-migrations.tf
@@ -1,0 +1,33 @@
+# ECS Task Definition for one-shot database migrations
+resource "aws_ecs_task_definition" "migrations_task_definition" {
+  family                   = "${var.iam_name_prefix}MigrationsTaskDefinition"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.migrations_cpu
+  memory                   = var.migrations_memory
+  execution_role_arn       = aws_iam_role.migrations_execution.arn
+  task_role_arn            = aws_iam_role.migrations_task.arn
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "ARM64"
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = local.tracecat_migrations_container_name
+      image     = "${local.tracecat_migrations_image}:${local.tracecat_migrations_image_tag}"
+      essential = true
+      command   = ["python3", "-m", "alembic", "upgrade", "head"]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.tracecat_log_group.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "migrations"
+        }
+      }
+      environment = local.migrations_env
+    }
+  ])
+}

--- a/deployments/fargate/modules/ecs/iam.tf
+++ b/deployments/fargate/modules/ecs/iam.tf
@@ -269,6 +269,50 @@ resource "aws_iam_role_policy_attachment" "worker_execution_secrets" {
   role       = aws_iam_role.worker_execution.name
 }
 
+# Migrations execution role
+resource "aws_iam_role" "migrations_execution" {
+  name               = "${var.iam_name_prefix}MigrationsExecutionRole"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "migrations_execution_ecs_poll" {
+  policy_arn = aws_iam_policy.ecs_poll.arn
+  role       = aws_iam_role.migrations_execution.name
+}
+
+resource "aws_iam_role_policy_attachment" "migrations_execution_cloudwatch_logs" {
+  policy_arn = aws_iam_policy.cloudwatch_logs.arn
+  role       = aws_iam_role.migrations_execution.name
+}
+
+# Migrations task role
+resource "aws_iam_role" "migrations_task" {
+  name               = "${var.iam_name_prefix}MigrationsTaskRole"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy" "migrations_task_db_access" {
+  name = "${var.iam_name_prefix}MigrationsDBAccessPolicy"
+  role = aws_iam_role.migrations_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "rds-db:connect",
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = [
+          "${aws_db_instance.core_database.arn}/postgres",
+          aws_db_instance.core_database.master_user_secret[0].secret_arn,
+        ]
+      }
+    ]
+  })
+}
+
 # API and Worker task role
 resource "aws_iam_role" "api_worker_task" {
   name               = "${var.iam_name_prefix}APIWorkerTaskRole"

--- a/deployments/fargate/modules/ecs/locals.tf
+++ b/deployments/fargate/modules/ecs/locals.tf
@@ -2,9 +2,14 @@
 locals {
 
   # Tracecat version
-  tracecat_image_tag            = var.tracecat_image_tag
-  tracecat_migrations_image     = coalesce(var.tracecat_migrations_image, var.tracecat_image)
-  tracecat_migrations_image_tag = coalesce(var.tracecat_migrations_image_tag, local.tracecat_image_tag)
+  tracecat_image_tag                 = var.tracecat_image_tag
+  tracecat_migrations_image          = coalesce(var.tracecat_migrations_image, var.tracecat_image)
+  tracecat_migrations_image_tag      = coalesce(var.tracecat_migrations_image_tag, local.tracecat_image_tag)
+  tracecat_migrations_container_name = "TracecatMigrationsContainer"
+  tracecat_migrations_security_group_ids = [
+    aws_security_group.core.id,
+    aws_security_group.core_db.id,
+  ]
 
   # WAF regex pattern set names. Default to "${name_prefix}-..." so each stack
   # gets uniquely-named pattern sets within a shared AWS account; explicit

--- a/deployments/fargate/modules/ecs/outputs.tf
+++ b/deployments/fargate/modules/ecs/outputs.tf
@@ -4,13 +4,28 @@ output "tracecat_image_tag" {
 }
 
 output "tracecat_migrations_image" {
-  description = "The Tracecat migrations init container image repository"
+  description = "The Tracecat migrations task image repository"
   value       = local.tracecat_migrations_image
 }
 
 output "tracecat_migrations_image_tag" {
-  description = "The Tracecat migrations init container image tag"
+  description = "The Tracecat migrations task image tag"
   value       = local.tracecat_migrations_image_tag
+}
+
+output "tracecat_migrations_task_definition_arn" {
+  description = "The ECS task definition ARN for the one-shot Tracecat migrations task"
+  value       = aws_ecs_task_definition.migrations_task_definition.arn
+}
+
+output "tracecat_migrations_container_name" {
+  description = "The container name used by the one-shot Tracecat migrations task"
+  value       = local.tracecat_migrations_container_name
+}
+
+output "tracecat_migrations_security_group_ids" {
+  description = "Security group IDs to use when running the one-shot Tracecat migrations task"
+  value       = local.tracecat_migrations_security_group_ids
 }
 
 output "ecs_cluster_name" {

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -172,13 +172,13 @@ variable "tracecat_image_tag" {
 
 variable "tracecat_migrations_image" {
   type        = string
-  description = "Docker image repository for the Tracecat migrations init container. Defaults to tracecat_image."
+  description = "Docker image repository for the Tracecat migrations task. Defaults to tracecat_image."
   default     = null
 }
 
 variable "tracecat_migrations_image_tag" {
   type        = string
-  description = "Docker image tag for the Tracecat migrations init container. Defaults to tracecat_image_tag."
+  description = "Docker image tag for the Tracecat migrations task. Defaults to tracecat_image_tag."
   default     = null
 }
 
@@ -499,6 +499,18 @@ variable "api_desired_count" {
   type        = number
   description = "Desired number of API instances to run"
   default     = 2
+}
+
+variable "migrations_cpu" {
+  type        = string
+  description = "CPU units for the one-shot database migrations task"
+  default     = "1024"
+}
+
+variable "migrations_memory" {
+  type        = string
+  description = "Memory for the one-shot database migrations task"
+  default     = "2048"
 }
 
 variable "worker_cpu" {

--- a/deployments/fargate/outputs.tf
+++ b/deployments/fargate/outputs.tf
@@ -21,13 +21,28 @@ output "tracecat_image_tag" {
 }
 
 output "tracecat_migrations_image" {
-  description = "The Tracecat migrations init container image repository"
+  description = "The Tracecat migrations task image repository"
   value       = module.ecs.tracecat_migrations_image
 }
 
 output "tracecat_migrations_image_tag" {
-  description = "The Tracecat migrations init container image tag"
+  description = "The Tracecat migrations task image tag"
   value       = module.ecs.tracecat_migrations_image_tag
+}
+
+output "tracecat_migrations_task_definition_arn" {
+  description = "The ECS task definition ARN for the one-shot Tracecat migrations task"
+  value       = module.ecs.tracecat_migrations_task_definition_arn
+}
+
+output "tracecat_migrations_container_name" {
+  description = "The container name used by the one-shot Tracecat migrations task"
+  value       = module.ecs.tracecat_migrations_container_name
+}
+
+output "tracecat_migrations_security_group_ids" {
+  description = "Security group IDs to use when running the one-shot Tracecat migrations task"
+  value       = module.ecs.tracecat_migrations_security_group_ids
 }
 
 output "ecs_cluster_name" {

--- a/deployments/fargate/scripts/run-migrations-task.sh
+++ b/deployments/fargate/scripts/run-migrations-task.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export AWS_PAGER=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FARGATE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Error: required command not found: ${command_name}" >&2
+    exit 1
+  fi
+}
+
+terraform_output_raw() {
+  local output_name="$1"
+  terraform output -raw "$output_name"
+}
+
+terraform_output_json() {
+  local output_name="$1"
+  terraform output -json "$output_name"
+}
+
+require_command aws
+require_command jq
+require_command terraform
+
+cd "$FARGATE_DIR"
+
+cluster_name="$(terraform_output_raw ecs_cluster_name)"
+task_definition_arn="$(terraform_output_raw tracecat_migrations_task_definition_arn)"
+container_name="$(terraform_output_raw tracecat_migrations_container_name)"
+private_subnet_ids="$(terraform_output_json private_subnet_ids)"
+security_group_ids="$(terraform_output_json tracecat_migrations_security_group_ids)"
+
+network_configuration="$(
+  jq -cn \
+    --argjson subnets "$private_subnet_ids" \
+    --argjson securityGroups "$security_group_ids" \
+    '{
+      awsvpcConfiguration: {
+        subnets: $subnets,
+        securityGroups: $securityGroups,
+        assignPublicIp: "DISABLED"
+      }
+    }'
+)"
+
+echo "Starting Tracecat migrations task ${task_definition_arn} on cluster ${cluster_name}"
+
+run_task_response="$(
+  aws ecs run-task \
+    --cluster "$cluster_name" \
+    --task-definition "$task_definition_arn" \
+    --launch-type FARGATE \
+    --network-configuration "$network_configuration" \
+    --started-by "tracecat-migrations-$(date +%s)" \
+    --count 1 \
+    --output json
+)"
+
+run_task_failures="$(jq -r '.failures | length' <<<"$run_task_response")"
+if [[ "$run_task_failures" != "0" ]]; then
+  echo "Error: failed to start migrations task:" >&2
+  jq -r '.failures[] | "- " + (.arn // "unknown") + ": " + (.reason // "unknown") + " " + (.detail // "")' \
+    <<<"$run_task_response" >&2
+  exit 1
+fi
+
+task_arn="$(jq -r '.tasks[0].taskArn // empty' <<<"$run_task_response")"
+if [[ -z "$task_arn" ]]; then
+  echo "Error: ECS did not return a task ARN for the migrations task" >&2
+  exit 1
+fi
+
+echo "Waiting for migrations task to stop: ${task_arn}"
+aws ecs wait tasks-stopped --cluster "$cluster_name" --tasks "$task_arn"
+
+describe_response="$(
+  aws ecs describe-tasks \
+    --cluster "$cluster_name" \
+    --tasks "$task_arn" \
+    --output json
+)"
+
+describe_failures="$(jq -r '.failures | length' <<<"$describe_response")"
+if [[ "$describe_failures" != "0" ]]; then
+  echo "Error: failed to describe migrations task:" >&2
+  jq -r '.failures[] | "- " + (.arn // "unknown") + ": " + (.reason // "unknown") + " " + (.detail // "")' \
+    <<<"$describe_response" >&2
+  exit 1
+fi
+
+exit_code="$(
+  jq -r \
+    --arg container_name "$container_name" \
+    '.tasks[0].containers[]? | select(.name == $container_name) | .exitCode // empty' \
+    <<<"$describe_response"
+)"
+stopped_reason="$(jq -r '.tasks[0].stoppedReason // "unknown"' <<<"$describe_response")"
+container_reason="$(
+  jq -r \
+    --arg container_name "$container_name" \
+    '.tasks[0].containers[]? | select(.name == $container_name) | .reason // empty' \
+    <<<"$describe_response"
+)"
+
+if [[ -z "$exit_code" ]]; then
+  echo "Error: migrations container did not report an exit code" >&2
+  echo "Task stopped reason: ${stopped_reason}" >&2
+  if [[ -n "$container_reason" ]]; then
+    echo "Container reason: ${container_reason}" >&2
+  fi
+  exit 1
+fi
+
+if [[ "$exit_code" != "0" ]]; then
+  echo "Error: migrations task failed with exit code ${exit_code}" >&2
+  echo "Task stopped reason: ${stopped_reason}" >&2
+  if [[ -n "$container_reason" ]]; then
+    echo "Container reason: ${container_reason}" >&2
+  fi
+  exit "$exit_code"
+fi
+
+echo "Tracecat migrations completed successfully"

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -140,13 +140,13 @@ variable "tracecat_image_tag" {
 
 variable "tracecat_migrations_image" {
   type        = string
-  description = "Docker image repository for the Tracecat migrations init container. Defaults to tracecat_image."
+  description = "Docker image repository for the Tracecat migrations task. Defaults to tracecat_image."
   default     = null
 }
 
 variable "tracecat_migrations_image_tag" {
   type        = string
-  description = "Docker image tag for the Tracecat migrations init container. Defaults to tracecat_image_tag."
+  description = "Docker image tag for the Tracecat migrations task. Defaults to tracecat_image_tag."
   default     = null
 }
 
@@ -467,6 +467,18 @@ variable "api_desired_count" {
   type        = number
   description = "Desired number of API instances to run"
   default     = 2
+}
+
+variable "migrations_cpu" {
+  type        = string
+  description = "CPU units for the one-shot database migrations task"
+  default     = "1024"
+}
+
+variable "migrations_memory" {
+  type        = string
+  description = "Memory for the one-shot database migrations task"
+  default     = "2048"
 }
 
 variable "worker_cpu" {


### PR DESCRIPTION
## Summary

- replace the API-task migration sidecar with a standalone one-shot Fargate task definition
- add dedicated migration IAM roles, task sizing variables, and Terraform outputs for orchestration
- add a migration runner script that starts the ECS task, waits for completion, and fails on nonzero/missing container exit codes
- update the Fargate README with two-phase upgrade and fresh-install migration runbooks

## Why

This materially improves Fargate deployment safety. Previously, migrations were coupled to API task startup, so Alembic could run on API restarts, replacements, or scale-out, and the `dependsOn` gate only coordinated containers inside one API task. That was not a true deploy-phase migration job.

With this change, migrations run as an explicit one-shot ECS task that CI/operators can use as a hard gate before app services move to a new image tag. API restarts and scale-outs no longer rerun migrations, the migration image tag can advance independently from the app image tag, and the migration task uses narrower DB-oriented IAM permissions.

## Deploy flow

Production upgrades should be two-phase:

1. Apply Terraform with `tracecat_image_tag` still set to the current app tag and `tracecat_migrations_image_tag` set to the new release tag.
2. Run `./scripts/run-migrations-task.sh` and require it to exit successfully.
3. Apply Terraform again with `tracecat_image_tag` set to the new release tag.

For fresh installs, first apply with DB-backed services at desired count `0`, run the migration task, then apply again with the intended service counts.

## Validation

- `terraform -chdir=deployments/fargate fmt -check -recursive`
- `terraform -chdir=deployments/fargate init -backend=false`
- `terraform -chdir=deployments/fargate validate`
- `bash -n deployments/fargate/scripts/run-migrations-task.sh`
- `shellcheck -x deployments/fargate/scripts/run-migrations-task.sh`
- `git diff --check`
- `uv run ruff check .`

No Python files changed, so focused pyright was not applicable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split database migrations from the API into a standalone, one-shot Fargate task. This adds a hard deploy-time gate and prevents migrations from running on API restarts or scale-outs.

- **New Features**
  - Added ECS one-shot migrations task with sizing vars `migrations_cpu` and `migrations_memory`, plus image overrides `tracecat_migrations_image` and `tracecat_migrations_image_tag`.
  - Added dedicated IAM roles with scoped DB/Secrets access for the migrations task.
  - Added runner script `deployments/fargate/scripts/run-migrations-task.sh` that starts the task, waits for completion, and fails on bad/missing exit codes; exposed new Terraform outputs for orchestration (`tracecat_migrations_task_definition_arn`, `tracecat_migrations_container_name`, `tracecat_migrations_security_group_ids`).
  - Removed API migrations init container and `dependsOn`; updated README with two-phase upgrade and fresh-install runbooks.

- **Migration**
  - Upgrades: apply with current app image and new migrations image, run `./scripts/run-migrations-task.sh`, then apply again with the new app image.
  - Fresh installs: apply with DB-backed services at desired count 0, run `./scripts/run-migrations-task.sh`, then apply again with target counts.

<sup>Written for commit 64e4149306bc943acb236182970dc85b0e47a99f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

