### PR TITLE
fix: handle single-tenant organization admin flow

### DIFF
--- a/frontend/src/app/admin/organizations/page.tsx
+++ b/frontend/src/app/admin/organizations/page.tsx
@@ -1,35 +1,15 @@
 "use client"
 
-import { useRouter } from "next/navigation"
-import { useEffect } from "react"
 import { AdminOrganizationsTable } from "@/components/admin/admin-organizations-table"
 import { CreateOrganizationDialog } from "@/components/admin/create-organization-dialog"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { useAdminOrganizations } from "@/hooks/use-admin"
-import { useAppInfo } from "@/lib/hooks"
 
 export default function AdminOrganizationsPage() {
-  const router = useRouter()
-  const { appInfo, appInfoIsLoading } = useAppInfo()
-  const shouldRedirectToRegistry =
-    !appInfoIsLoading && appInfo?.ee_multi_tenant === false
-  const shouldLoadOrganizations = !appInfoIsLoading && !shouldRedirectToRegistry
-  const { isLoading, error } = useAdminOrganizations({
-    enabled: shouldLoadOrganizations,
-  })
+  const { isLoading, error } = useAdminOrganizations()
 
-  useEffect(() => {
-    if (shouldRedirectToRegistry) {
-      router.replace("/admin/registry")
-    }
-  }, [router, shouldRedirectToRegistry])
-
-  if (appInfoIsLoading || isLoading) {
+  if (isLoading) {
     return <CenteredSpinner />
-  }
-
-  if (shouldRedirectToRegistry) {
-    return null
   }
 
   if (error) {

--- a/frontend/src/components/admin/create-organization-dialog.tsx
+++ b/frontend/src/components/admin/create-organization-dialog.tsx
@@ -27,6 +27,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { toast } from "@/components/ui/use-toast"
 import { useAdminOrganizations } from "@/hooks/use-admin"
+import { useAppInfo } from "@/lib/hooks"
 
 const formSchema = z.object({
   name: z.string().min(1, "Name is required").max(100, "Name is too long"),
@@ -44,7 +45,12 @@ type FormValues = z.infer<typeof formSchema>
 
 export function CreateOrganizationDialog() {
   const [open, setOpen] = useState(false)
-  const { createOrganization, createPending } = useAdminOrganizations()
+  const { appInfo, appInfoIsLoading } = useAppInfo()
+  const multiTenantEnabled = appInfo?.ee_multi_tenant === true
+  const createDisabled = appInfoIsLoading || !multiTenantEnabled
+  const { createOrganization, createPending } = useAdminOrganizations({
+    enabled: false,
+  })
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -55,6 +61,15 @@ export function CreateOrganizationDialog() {
   })
 
   const onSubmit = async (values: FormValues) => {
+    if (!multiTenantEnabled) {
+      toast({
+        title: "Organization creation is disabled",
+        description: "Enable multi-tenant mode to create new organizations.",
+        variant: "destructive",
+      })
+      return
+    }
+
     try {
       await createOrganization(values)
       toast({
@@ -85,7 +100,15 @@ export function CreateOrganizationDialog() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button size="sm">
+        <Button
+          size="sm"
+          disabled={createDisabled}
+          title={
+            createDisabled
+              ? "Enable multi-tenant mode to create new organizations."
+              : undefined
+          }
+        >
           <PlusIcon className="mr-2 size-4" />
           New organization
         </Button>
@@ -146,7 +169,7 @@ export function CreateOrganizationDialog() {
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={createPending}>
+              <Button type="submit" disabled={createPending || createDisabled}>
                 {createPending ? "Creating..." : "Create"}
               </Button>
             </DialogFooter>

--- a/frontend/src/components/sidebar/admin-sidebar.tsx
+++ b/frontend/src/components/sidebar/admin-sidebar.tsx
@@ -29,31 +29,23 @@ import {
   SidebarRail,
 } from "@/components/ui/sidebar"
 import { useAuthActions } from "@/hooks/use-auth"
-import { useAppInfo } from "@/lib/hooks"
 
 export function AdminSidebar({
   ...props
 }: React.ComponentProps<typeof Sidebar>) {
   const pathname = usePathname()
   const { logout } = useAuthActions()
-  const { appInfo } = useAppInfo()
-  const multiTenantEnabled = appInfo?.ee_multi_tenant ?? true
-
   const handleLogout = async () => {
     await logout()
   }
 
   const navPlatform = [
-    ...(multiTenantEnabled
-      ? [
-          {
-            title: "Organizations",
-            url: "/admin/organizations",
-            icon: BuildingIcon,
-            isActive: pathname?.includes("/admin/organizations"),
-          },
-        ]
-      : []),
+    {
+      title: "Organizations",
+      url: "/admin/organizations",
+      icon: BuildingIcon,
+      isActive: pathname?.includes("/admin/organizations"),
+    },
     {
       title: "Users",
       url: "/admin/users",

--- a/packages/tracecat-ee/tracecat_ee/admin/organizations/router.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/organizations/router.py
@@ -139,7 +139,6 @@ async def delete_organization(
     "/{org_id}/invitations",
     response_model=AdminOrgInvitationCreateResponse,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(_require_multi_tenant)],
 )
 async def create_organization_invitation(
     role: SuperuserRole,
@@ -163,7 +162,6 @@ async def create_organization_invitation(
 @router.get(
     "/{org_id}/invitations",
     response_model=CursorPaginatedResponse[AdminOrgInvitationRead],
-    dependencies=[Depends(_require_multi_tenant)],
 )
 async def list_organization_invitations(
     role: SuperuserRole,
@@ -201,7 +199,6 @@ async def list_organization_invitations(
 @router.get(
     "/{org_id}/invitations/{invitation_id}/token",
     response_model=AdminOrgInvitationTokenRead,
-    dependencies=[Depends(_require_multi_tenant)],
 )
 async def get_organization_invitation_token(
     role: SuperuserRole,
@@ -223,7 +220,6 @@ async def get_organization_invitation_token(
 @router.delete(
     "/{org_id}/invitations/{invitation_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(_require_multi_tenant)],
 )
 async def revoke_organization_invitation(
     role: SuperuserRole,

--- a/tests/unit/api/test_api_admin_organizations.py
+++ b/tests/unit/api/test_api_admin_organizations.py
@@ -252,6 +252,30 @@ async def test_create_organization_invitation_success(
 
 
 @pytest.mark.anyio
+async def test_create_organization_invitation_allowed_without_multi_tenant(
+    client: TestClient,
+    test_admin_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    invitation = _org_invitation_read(org_id, token="raw-token")
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", False)
+
+    with patch.object(organizations_router, "AdminOrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.create_organization_invitation.return_value = invitation
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            f"/admin/organizations/{org_id}/invitations",
+            json={"email": "owner@example.com"},
+        )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["token"] == "raw-token"
+
+
+@pytest.mark.anyio
 async def test_create_organization_invitation_rejects_invalid_role_slug(
     client: TestClient,
     test_admin_role: Role,
@@ -335,6 +359,29 @@ async def test_list_organization_invitations_success(
 
 
 @pytest.mark.anyio
+async def test_list_organization_invitations_allowed_without_multi_tenant(
+    client: TestClient,
+    test_admin_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    invitation = _org_invitation_read(org_id)
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", False)
+
+    with patch.object(organizations_router, "AdminOrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.list_organization_invitations.return_value = CursorPaginatedResponse[
+            AdminOrgInvitationRead
+        ](items=[invitation])
+        MockService.return_value = mock_svc
+
+        response = client.get(f"/admin/organizations/{org_id}/invitations")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["items"][0]["id"] == str(invitation.id)
+
+
+@pytest.mark.anyio
 async def test_list_organization_invitations_invalid_cursor(
     client: TestClient,
     test_admin_role: Role,
@@ -383,6 +430,31 @@ async def test_get_organization_invitation_token_success(
 
 
 @pytest.mark.anyio
+async def test_get_organization_invitation_token_allowed_without_multi_tenant(
+    client: TestClient,
+    test_admin_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    invitation_id = uuid.uuid4()
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", False)
+
+    with patch.object(organizations_router, "AdminOrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_organization_invitation_token.return_value = (
+            AdminOrgInvitationTokenRead(token="raw-token")
+        )
+        MockService.return_value = mock_svc
+
+        response = client.get(
+            f"/admin/organizations/{org_id}/invitations/{invitation_id}/token"
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"token": "raw-token"}
+
+
+@pytest.mark.anyio
 async def test_revoke_organization_invitation_success(
     client: TestClient,
     test_admin_role: Role,
@@ -406,6 +478,28 @@ async def test_revoke_organization_invitation_success(
         org_id,
         invitation_id,
     )
+
+
+@pytest.mark.anyio
+async def test_revoke_organization_invitation_allowed_without_multi_tenant(
+    client: TestClient,
+    test_admin_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    invitation_id = uuid.uuid4()
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", False)
+
+    with patch.object(organizations_router, "AdminOrgService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.revoke_organization_invitation.return_value = None
+        MockService.return_value = mock_svc
+
+        response = client.delete(
+            f"/admin/organizations/{org_id}/invitations/{invitation_id}"
+        )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation

- Simplify admin organizations page behavior by removing a redirect based on `ee_multi_tenant` and avoid coupling page load to `useAppInfo` state.  
- Prevent creating organizations when multi-tenant mode is disabled by making the create UI explicitly disabled and showing a descriptive tooltip.  
- Ensure the Organizations item is always present in the admin sidebar so navigation remains consistent regardless of tenant mode.

### Description

- Removed `useAppInfo` usage and redirect logic from `frontend/src/app/admin/organizations/page.tsx`, and always render the organizations page spinner based only on `useAdminOrganizations` loading state.  
- Updated `frontend/src/components/admin/create-organization-dialog.tsx` to use `useAppInfo` to detect `ee_multi_tenant`, disable the create button and dialog trigger when multi-tenant is not enabled, short-circuit `onSubmit` with a destructive toast when creation is not allowed, and initialize `useAdminOrganizations` with `enabled: false`.  
- Simplified `frontend/src/components/sidebar/admin-sidebar.tsx` by removing the `useAppInfo` check and always including the `Organizations` nav item.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb60e522988320abfc17f503cb7822)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes admin organizations across tenant modes. Removes redirect, disables org creation in single-tenant, allows admin invitations in single-tenant, and always shows the Organizations nav.

- **New Features**
  - Organizations page now loads via `useAdminOrganizations` only; no `useAppInfo` redirect; spinner shown while loading.
  - Create dialog checks `ee_multi_tenant` via `useAppInfo`; disables trigger and submit with tooltip; shows a destructive toast when creation isn’t allowed; initializes `useAdminOrganizations` with `enabled: false`.
  - Admin sidebar always shows Organizations; removed the `useAppInfo` gate.
  - Backend allows admin organization invitations in single-tenant; added tests for create/list/token/revoke.

<sup>Written for commit 1297d8626a571efafceadbcd4ccd3e29c708af08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

