### PR TITLE
fix: admin sidebar back link to workspaces

### DIFF
--- a/frontend/src/components/sidebar/admin-sidebar.tsx
+++ b/frontend/src/components/sidebar/admin-sidebar.tsx
@@ -98,7 +98,7 @@ export function AdminSidebar({
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton asChild>
-              <Link href="/admin" className="text-muted-foreground">
+              <Link href="/workspaces" className="text-muted-foreground">
                 <ChevronLeftIcon />
                 <span>Admin console</span>
               </Link>


### PR DESCRIPTION
### Motivation
- The admin sidebar back button linked to `/admin`, which caused superusers with org membership to be redirected back into the admin console instead of returning to the workspace list when clicking `< Admin console`.

### Description
- Update the admin sidebar header back link to navigate to `/workspaces` by changing the `Link` `href` in `frontend/src/components/sidebar/admin-sidebar.tsx`.

### Testing
- Ran `pnpm -C frontend exec biome check src/components/sidebar/admin-sidebar.tsx`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa2150577c832093266ea8341b1150)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the admin sidebar back link to go to /workspaces instead of /admin. This returns superusers to the workspace list and avoids redirecting them back into the admin console.

<sup>Written for commit d9a1b29ac3bfdac4f67f87c473880517e4f6b837. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

