### PR TITLE
feat(engine+ui): label workflow reset points with their action

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -30797,6 +30797,51 @@ export const $WorkflowRunReadMinimal = {
       description:
         "Workflow alias from workspace metadata or execution search attributes.",
     },
+    has_been_reset: {
+      type: "boolean",
+      title: "Has Been Reset",
+      description:
+        "True when this run belongs to an execution that has reset runs.",
+      default: false,
+    },
+    is_reset_run: {
+      type: "boolean",
+      title: "Is Reset Run",
+      description: "True when this specific Temporal run was created by reset.",
+      default: false,
+    },
+    reset_original_run_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Reset Original Run Id",
+      description: "Temporal run ID of the original run in this reset lineage.",
+    },
+    reset_run_count: {
+      type: "integer",
+      minimum: 0,
+      title: "Reset Run Count",
+      description: "Number of reset-created runs in this execution lineage.",
+      default: 0,
+    },
+    reset_run_index: {
+      anyOf: [
+        {
+          type: "integer",
+          minimum: 1,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Reset Run Index",
+      description: "One-based index of this reset-created run in reset order.",
+    },
   },
   type: "object",
   required: [

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -30084,6 +30084,56 @@ export const $WorkflowExecutionResetPointRead = {
       type: "string",
       title: "Label",
     },
+    action_ref: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Action Ref",
+      description: "Workflow action ref used to describe this reset point.",
+    },
+    action_name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Action Name",
+      description: "Workflow action name used to describe this reset point.",
+    },
+    action_event_id: {
+      anyOf: [
+        {
+          type: "integer",
+          minimum: 1,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Action Event Id",
+      description: "Temporal source or close event id for the related action.",
+    },
+    action_relation: {
+      anyOf: [
+        {
+          type: "string",
+          enum: ["after", "after_scheduling", "before"],
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Action Relation",
+      description: "How the reset checkpoint relates to the related action.",
+    },
     is_start: {
       type: "boolean",
       title: "Is Start",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -9146,6 +9146,26 @@ export type WorkflowRunReadMinimal = {
    * Workflow alias from workspace metadata or execution search attributes.
    */
   workflow_alias?: string | null
+  /**
+   * True when this run belongs to an execution that has reset runs.
+   */
+  has_been_reset?: boolean
+  /**
+   * True when this specific Temporal run was created by reset.
+   */
+  is_reset_run?: boolean
+  /**
+   * Temporal run ID of the original run in this reset lineage.
+   */
+  reset_original_run_id?: string | null
+  /**
+   * Number of reset-created runs in this execution lineage.
+   */
+  reset_run_count?: number
+  /**
+   * One-based index of this reset-created run in reset order.
+   */
+  reset_run_index?: number | null
 }
 
 /**

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -8957,6 +8957,22 @@ export type WorkflowExecutionResetPointRead = {
   event_type: string
   label: string
   /**
+   * Workflow action ref used to describe this reset point.
+   */
+  action_ref?: string | null
+  /**
+   * Workflow action name used to describe this reset point.
+   */
+  action_name?: string | null
+  /**
+   * Temporal source or close event id for the related action.
+   */
+  action_event_id?: number | null
+  /**
+   * How the reset checkpoint relates to the related action.
+   */
+  action_relation?: "after" | "after_scheduling" | "before" | null
+  /**
    * True when this point maps to the earliest resettable point.
    */
   is_start?: boolean

--- a/frontend/src/components/workflow-runs/reset-workflow-run-dialog.tsx
+++ b/frontend/src/components/workflow-runs/reset-workflow-run-dialog.tsx
@@ -63,8 +63,9 @@ export function formatResetPointPrimaryLabel(
 
 export function formatResetPointSecondaryLabel(
   point: WorkflowExecutionResetPointRead
-): string {
-  return `Event ${point.event_id}`
+): string | null {
+  const eventLabel = `Event ${point.event_id}`
+  return formatResetPointPrimaryLabel(point) === eventLabel ? null : eventLabel
 }
 
 export function ResetWorkflowRunDialog({
@@ -168,20 +169,26 @@ export function ResetWorkflowRunDialog({
                   <SelectItem value="start" textValue="Workflow start">
                     Workflow start
                   </SelectItem>
-                  {visibleResettablePoints.map((point) => (
-                    <SelectItem
-                      key={point.event_id}
-                      value={String(point.event_id)}
-                      textValue={formatResetPointPrimaryLabel(point)}
-                    >
-                      <span className="truncate">
-                        {formatResetPointPrimaryLabel(point)}
-                        <span className="ml-2 text-muted-foreground">
-                          {formatResetPointSecondaryLabel(point)}
+                  {visibleResettablePoints.map((point) => {
+                    const primaryLabel = formatResetPointPrimaryLabel(point)
+                    const secondaryLabel = formatResetPointSecondaryLabel(point)
+                    return (
+                      <SelectItem
+                        key={point.event_id}
+                        value={String(point.event_id)}
+                        textValue={primaryLabel}
+                      >
+                        <span className="truncate">
+                          {primaryLabel}
+                          {secondaryLabel ? (
+                            <span className="ml-2 text-muted-foreground">
+                              {secondaryLabel}
+                            </span>
+                          ) : null}
                         </span>
-                      </span>
-                    </SelectItem>
-                  ))}
+                      </SelectItem>
+                    )
+                  })}
                 </SelectContent>
               </Select>
             ) : (

--- a/frontend/src/components/workflow-runs/reset-workflow-run-dialog.tsx
+++ b/frontend/src/components/workflow-runs/reset-workflow-run-dialog.tsx
@@ -19,7 +19,10 @@ import { Label } from "@/components/ui/label"
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
@@ -43,11 +46,15 @@ function formatResetActionRef(actionRef: string): string {
   return undoSlugify(actionRef, ACTION_REF_DELIMITER)
 }
 
+function hasActionContext(point: WorkflowExecutionResetPointRead): boolean {
+  return Boolean(point.action_ref && point.action_relation)
+}
+
 export function formatResetPointPrimaryLabel(
   point: WorkflowExecutionResetPointRead
 ): string {
   if (!point.action_ref || !point.action_relation) {
-    return point.label
+    return point.is_start ? point.label : "Workflow checkpoint"
   }
 
   const actionLabel = formatResetActionRef(point.action_ref)
@@ -65,6 +72,9 @@ export function formatResetPointSecondaryLabel(
   point: WorkflowExecutionResetPointRead
 ): string | null {
   const eventLabel = `Event ${point.event_id}`
+  if (!hasActionContext(point) && !point.is_start) {
+    return `${eventLabel} · system checkpoint`
+  }
   return formatResetPointPrimaryLabel(point) === eventLabel ? null : eventLabel
 }
 
@@ -100,6 +110,16 @@ export function ResetWorkflowRunDialog({
   const visibleResettablePoints = useMemo(
     () => resettablePoints.filter((point) => !point.is_start),
     [resettablePoints]
+  )
+
+  const recommendedResettablePoints = useMemo(
+    () => visibleResettablePoints.filter(hasActionContext),
+    [visibleResettablePoints]
+  )
+
+  const advancedResettablePoints = useMemo(
+    () => visibleResettablePoints.filter((point) => !hasActionContext(point)),
+    [visibleResettablePoints]
   )
 
   const useResetPointSelect =
@@ -169,26 +189,31 @@ export function ResetWorkflowRunDialog({
                   <SelectItem value="start" textValue="Workflow start">
                     Workflow start
                   </SelectItem>
-                  {visibleResettablePoints.map((point) => {
-                    const primaryLabel = formatResetPointPrimaryLabel(point)
-                    const secondaryLabel = formatResetPointSecondaryLabel(point)
-                    return (
-                      <SelectItem
-                        key={point.event_id}
-                        value={String(point.event_id)}
-                        textValue={primaryLabel}
-                      >
-                        <span className="truncate">
-                          {primaryLabel}
-                          {secondaryLabel ? (
-                            <span className="ml-2 text-muted-foreground">
-                              {secondaryLabel}
-                            </span>
-                          ) : null}
-                        </span>
-                      </SelectItem>
-                    )
-                  })}
+                  {recommendedResettablePoints.length > 0 ? (
+                    <SelectGroup>
+                      <SelectLabel>Recommended reset points</SelectLabel>
+                      {recommendedResettablePoints.map((point) => (
+                        <ResetPointSelectItem
+                          key={point.event_id}
+                          point={point}
+                        />
+                      ))}
+                    </SelectGroup>
+                  ) : null}
+                  {advancedResettablePoints.length > 0 ? (
+                    <>
+                      <SelectSeparator />
+                      <SelectGroup>
+                        <SelectLabel>Advanced checkpoints</SelectLabel>
+                        {advancedResettablePoints.map((point) => (
+                          <ResetPointSelectItem
+                            key={point.event_id}
+                            point={point}
+                          />
+                        ))}
+                      </SelectGroup>
+                    </>
+                  ) : null}
                 </SelectContent>
               </Select>
             ) : (
@@ -250,5 +275,27 @@ export function ResetWorkflowRunDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  )
+}
+
+function ResetPointSelectItem({
+  point,
+}: {
+  point: WorkflowExecutionResetPointRead
+}) {
+  const primaryLabel = formatResetPointPrimaryLabel(point)
+  const secondaryLabel = formatResetPointSecondaryLabel(point)
+  return (
+    <SelectItem
+      value={String(point.event_id)}
+      textValue={`${primaryLabel}${secondaryLabel ? ` ${secondaryLabel}` : ""}`}
+    >
+      <span className="truncate">
+        {primaryLabel}
+        {secondaryLabel ? (
+          <span className="ml-2 text-muted-foreground">{secondaryLabel}</span>
+        ) : null}
+      </span>
+    </SelectItem>
   )
 }

--- a/frontend/src/components/workflow-runs/reset-workflow-run-dialog.tsx
+++ b/frontend/src/components/workflow-runs/reset-workflow-run-dialog.tsx
@@ -23,6 +23,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { ACTION_REF_DELIMITER, undoSlugify } from "@/lib/utils"
 
 interface ResetWorkflowRunDialogProps {
   open: boolean
@@ -36,6 +37,34 @@ interface ResetWorkflowRunDialogProps {
     reason?: string | null
     reapplyType: WorkflowExecutionResetReapplyType
   }) => Promise<void>
+}
+
+function formatResetActionRef(actionRef: string): string {
+  return undoSlugify(actionRef, ACTION_REF_DELIMITER)
+}
+
+export function formatResetPointPrimaryLabel(
+  point: WorkflowExecutionResetPointRead
+): string {
+  if (!point.action_ref || !point.action_relation) {
+    return point.label
+  }
+
+  const actionLabel = formatResetActionRef(point.action_ref)
+  switch (point.action_relation) {
+    case "after":
+      return `After ${actionLabel}`
+    case "after_scheduling":
+      return `After scheduling ${actionLabel}`
+    case "before":
+      return `Before ${actionLabel}`
+  }
+}
+
+export function formatResetPointSecondaryLabel(
+  point: WorkflowExecutionResetPointRead
+): string {
+  return `Event ${point.event_id}`
 }
 
 export function ResetWorkflowRunDialog({
@@ -67,12 +96,17 @@ export function ResetWorkflowRunDialog({
     [resetPoints]
   )
 
+  const visibleResettablePoints = useMemo(
+    () => resettablePoints.filter((point) => !point.is_start),
+    [resettablePoints]
+  )
+
   const useResetPointSelect =
     executionCount === 1 && resettablePoints.length > 0
 
   const helperText = useMemo(() => {
     if (useResetPointSelect) {
-      return "Select start or a specific reset point from workflow history."
+      return "Select where the run should resume. Event IDs are shown for Temporal history reference."
     }
     if (!eventIdText.trim()) {
       return "Leave empty to reset from start."
@@ -116,7 +150,7 @@ export function ResetWorkflowRunDialog({
           <DialogTitle>Reset workflow run</DialogTitle>
           <DialogDescription>
             {executionCount === 1
-              ? "Reset the selected workflow run from start or a specific event."
+              ? "Reset the selected workflow run from workflow start or a history checkpoint."
               : `Reset ${executionCount} selected workflow runs from start or a specific event.`}
           </DialogDescription>
         </DialogHeader>
@@ -131,14 +165,21 @@ export function ResetWorkflowRunDialog({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="start">Start</SelectItem>
-                  {resettablePoints.map((point) => (
+                  <SelectItem value="start" textValue="Workflow start">
+                    Workflow start
+                  </SelectItem>
+                  {visibleResettablePoints.map((point) => (
                     <SelectItem
                       key={point.event_id}
                       value={String(point.event_id)}
+                      textValue={formatResetPointPrimaryLabel(point)}
                     >
-                      Event {point.event_id} -{" "}
-                      {point.event_type.replaceAll("_", " ").toLowerCase()}
+                      <span className="truncate">
+                        {formatResetPointPrimaryLabel(point)}
+                        <span className="ml-2 text-muted-foreground">
+                          {formatResetPointSecondaryLabel(point)}
+                        </span>
+                      </span>
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/components/workflow-runs/workflow-run-item.tsx
+++ b/frontend/src/components/workflow-runs/workflow-run-item.tsx
@@ -8,6 +8,7 @@ import {
   CircleDot,
   CircleHelpIcon,
   FlagTriangleRight,
+  RotateCcw,
 } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
@@ -70,6 +71,70 @@ function getRelativeDateLabel(dateValue: string): string {
     return "-"
   }
   return formatDistanceToNow(new Date(dateValue), { addSuffix: true })
+}
+
+function getShortRunId(runId: string | null | undefined): string | null {
+  if (!runId) {
+    return null
+  }
+  return runId.slice(0, 8)
+}
+
+function getResetRunCountLabel(count: number | undefined): string {
+  if (!count) {
+    return "reset history"
+  }
+  return `${count} ${count === 1 ? "reset" : "resets"}`
+}
+
+function ResetLineageBadge({ run }: { run: WorkflowRunReadMinimal }) {
+  if (!run.has_been_reset) {
+    return null
+  }
+
+  const originalRunShortId = getShortRunId(run.reset_original_run_id)
+  const resetIndexLabel = run.reset_run_index
+    ? `Reset #${run.reset_run_index}`
+    : "Reset run"
+  const resetCountLabel = getResetRunCountLabel(run.reset_run_count)
+  let label = `Original - ${resetCountLabel}`
+  if (run.is_reset_run) {
+    label = originalRunShortId
+      ? `${resetIndexLabel} from ${originalRunShortId}`
+      : resetIndexLabel
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge
+          variant="outline"
+          className="h-5 shrink-0 cursor-default gap-1 px-1.5 text-[10px] font-normal text-muted-foreground"
+        >
+          <RotateCcw className="size-3" />
+          <span className="max-w-[140px] truncate">{label}</span>
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-80 space-y-1">
+        <div className="font-medium">
+          {run.is_reset_run ? "Reset-created run" : "Original run"}
+        </div>
+        {run.is_reset_run ? (
+          <div>
+            Original run:{" "}
+            <span className="font-mono">
+              {run.reset_original_run_id ?? "Unavailable"}
+            </span>
+          </div>
+        ) : (
+          <div>Reset-created runs: {run.reset_run_count ?? 0}</div>
+        )}
+        <div>
+          Current run: <span className="font-mono">{run.run_id}</span>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
 }
 
 export function WorkflowRunItem({
@@ -148,36 +213,39 @@ export function WorkflowRunItem({
       <div className="flex min-w-0 flex-1 items-center gap-3">
         <div className="flex min-w-0 flex-1 items-center gap-2">
           {statusIcon}
-          {workflowId ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="flex min-w-0 items-center gap-2">
-                  <span className="truncate text-xs font-medium">
-                    {run.workflow_title ?? "Unknown workflow"}
-                  </span>
-                  {run.workflow_alias ? (
-                    <span className="truncate text-[10px] text-muted-foreground">
-                      @{run.workflow_alias}
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            {workflowId ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex min-w-0 flex-1 items-center gap-2">
+                    <span className="truncate text-xs font-medium">
+                      {run.workflow_title ?? "Unknown workflow"}
                     </span>
-                  ) : null}
-                </div>
-              </TooltipTrigger>
-              <TooltipContent>
-                <span>Workflow ID: {workflowId}</span>
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            <div className="flex min-w-0 items-center gap-2">
-              <span className="truncate text-xs font-medium">
-                {run.workflow_title ?? "Unknown workflow"}
-              </span>
-              {run.workflow_alias ? (
-                <span className="truncate text-[10px] text-muted-foreground">
-                  @{run.workflow_alias}
+                    {run.workflow_alias ? (
+                      <span className="truncate text-[10px] text-muted-foreground">
+                        @{run.workflow_alias}
+                      </span>
+                    ) : null}
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <span>Workflow ID: {workflowId}</span>
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <div className="flex min-w-0 flex-1 items-center gap-2">
+                <span className="truncate text-xs font-medium">
+                  {run.workflow_title ?? "Unknown workflow"}
                 </span>
-              ) : null}
-            </div>
-          )}
+                {run.workflow_alias ? (
+                  <span className="truncate text-[10px] text-muted-foreground">
+                    @{run.workflow_alias}
+                  </span>
+                ) : null}
+              </div>
+            )}
+            <ResetLineageBadge run={run} />
+          </div>
         </div>
 
         <div className="flex shrink-0 items-center gap-1">

--- a/frontend/tests/reset-workflow-run-dialog.test.tsx
+++ b/frontend/tests/reset-workflow-run-dialog.test.tsx
@@ -28,6 +28,14 @@ const RESET_POINTS: WorkflowExecutionResetPointRead[] = [
     is_start: false,
     is_resettable: true,
   },
+  {
+    event_id: 12,
+    event_time: "2026-01-01T00:00:04Z",
+    event_type: "WORKFLOW_TASK_COMPLETED",
+    label: "Event 12",
+    is_start: false,
+    is_resettable: true,
+  },
 ]
 
 beforeAll(() => {
@@ -43,7 +51,7 @@ describe("ResetWorkflowRunDialog", () => {
     expect(formatResetPointSecondaryLabel(RESET_POINTS[1])).toBe("Event 8")
   })
 
-  it("does not repeat fallback event labels", () => {
+  it("formats unattributed reset points as advanced checkpoints", () => {
     const fallbackPoint: WorkflowExecutionResetPointRead = {
       event_id: 12,
       event_time: "2026-01-01T00:00:04Z",
@@ -53,8 +61,12 @@ describe("ResetWorkflowRunDialog", () => {
       is_resettable: true,
     }
 
-    expect(formatResetPointPrimaryLabel(fallbackPoint)).toBe("Event 12")
-    expect(formatResetPointSecondaryLabel(fallbackPoint)).toBeNull()
+    expect(formatResetPointPrimaryLabel(fallbackPoint)).toBe(
+      "Workflow checkpoint"
+    )
+    expect(formatResetPointSecondaryLabel(fallbackPoint)).toBe(
+      "Event 12 · system checkpoint"
+    )
   })
 
   it("submits workflow start as an empty event ID", async () => {
@@ -109,5 +121,28 @@ describe("ResetWorkflowRunDialog", () => {
       reason: null,
       reapplyType: "all_eligible",
     })
+  })
+
+  it("groups unattributed reset points under advanced checkpoints", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ResetWorkflowRunDialog
+        open={true}
+        onOpenChange={() => {}}
+        executionCount={1}
+        resetPoints={RESET_POINTS}
+        resetPointsLoading={false}
+        isSubmitting={false}
+        onSubmit={jest.fn().mockResolvedValue(undefined)}
+      />
+    )
+
+    await user.click(screen.getByRole("combobox", { name: "Reset point" }))
+
+    expect(screen.getByText("Recommended reset points")).toBeInTheDocument()
+    expect(screen.getByText("Advanced checkpoints")).toBeInTheDocument()
+    expect(screen.getByText("Workflow checkpoint")).toBeInTheDocument()
+    expect(screen.getByText("Event 12 · system checkpoint")).toBeInTheDocument()
   })
 })

--- a/frontend/tests/reset-workflow-run-dialog.test.tsx
+++ b/frontend/tests/reset-workflow-run-dialog.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { WorkflowExecutionResetPointRead } from "@/client"
+import {
+  formatResetPointPrimaryLabel,
+  ResetWorkflowRunDialog,
+} from "@/components/workflow-runs/reset-workflow-run-dialog"
+
+const RESET_POINTS: WorkflowExecutionResetPointRead[] = [
+  {
+    event_id: 4,
+    event_time: "2026-01-01T00:00:00Z",
+    event_type: "WORKFLOW_TASK_COMPLETED",
+    label: "Workflow start",
+    is_start: true,
+    is_resettable: true,
+  },
+  {
+    event_id: 8,
+    event_time: "2026-01-01T00:00:02Z",
+    event_type: "WORKFLOW_TASK_COMPLETED",
+    label: "After Action A",
+    action_ref: "action_a",
+    action_name: "core.transform.reshape",
+    action_event_id: 7,
+    action_relation: "after",
+    is_start: false,
+    is_resettable: true,
+  },
+]
+
+beforeAll(() => {
+  HTMLElement.prototype.hasPointerCapture ??= () => false
+  HTMLElement.prototype.setPointerCapture ??= () => {}
+  HTMLElement.prototype.releasePointerCapture ??= () => {}
+  HTMLElement.prototype.scrollIntoView ??= () => {}
+})
+
+describe("ResetWorkflowRunDialog", () => {
+  it("formats action-aware reset labels", () => {
+    expect(formatResetPointPrimaryLabel(RESET_POINTS[1])).toBe("After Action A")
+  })
+
+  it("submits workflow start as an empty event ID", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined)
+
+    render(
+      <ResetWorkflowRunDialog
+        open={true}
+        onOpenChange={() => {}}
+        executionCount={1}
+        resetPoints={RESET_POINTS}
+        resetPointsLoading={false}
+        isSubmitting={false}
+        onSubmit={onSubmit}
+      />
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Reset" }))
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      eventId: null,
+      reason: null,
+      reapplyType: "all_eligible",
+    })
+  })
+
+  it("shows action-aware reset labels with temporal event IDs", async () => {
+    const user = userEvent.setup()
+    const onSubmit = jest.fn().mockResolvedValue(undefined)
+
+    render(
+      <ResetWorkflowRunDialog
+        open={true}
+        onOpenChange={() => {}}
+        executionCount={1}
+        resetPoints={RESET_POINTS}
+        resetPointsLoading={false}
+        isSubmitting={false}
+        onSubmit={onSubmit}
+      />
+    )
+
+    await user.click(screen.getByRole("combobox", { name: "Reset point" }))
+    const actionOption = await screen.findByText("After Action A")
+    expect(screen.getByText("Event 8")).toBeInTheDocument()
+    await user.click(actionOption)
+
+    await user.click(screen.getByRole("button", { name: "Reset" }))
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      eventId: 8,
+      reason: null,
+      reapplyType: "all_eligible",
+    })
+  })
+})

--- a/frontend/tests/reset-workflow-run-dialog.test.tsx
+++ b/frontend/tests/reset-workflow-run-dialog.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event"
 import type { WorkflowExecutionResetPointRead } from "@/client"
 import {
   formatResetPointPrimaryLabel,
+  formatResetPointSecondaryLabel,
   ResetWorkflowRunDialog,
 } from "@/components/workflow-runs/reset-workflow-run-dialog"
 
@@ -39,6 +40,21 @@ beforeAll(() => {
 describe("ResetWorkflowRunDialog", () => {
   it("formats action-aware reset labels", () => {
     expect(formatResetPointPrimaryLabel(RESET_POINTS[1])).toBe("After Action A")
+    expect(formatResetPointSecondaryLabel(RESET_POINTS[1])).toBe("Event 8")
+  })
+
+  it("does not repeat fallback event labels", () => {
+    const fallbackPoint: WorkflowExecutionResetPointRead = {
+      event_id: 12,
+      event_time: "2026-01-01T00:00:04Z",
+      event_type: "WORKFLOW_TASK_COMPLETED",
+      label: "Event 12",
+      is_start: false,
+      is_resettable: true,
+    }
+
+    expect(formatResetPointPrimaryLabel(fallbackPoint)).toBe("Event 12")
+    expect(formatResetPointSecondaryLabel(fallbackPoint)).toBeNull()
   })
 
   it("submits workflow start as an empty event ID", async () => {

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -14,6 +14,7 @@ Objectives
 import datetime
 import hashlib
 import uuid
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -23,7 +24,7 @@ from pydantic import BaseModel
 from temporalio.api.enums.v1 import EventType, ParentClosePolicy, PendingActivityState
 from temporalio.api.failure.v1 import Failure
 from temporalio.api.history.v1 import HistoryEvent
-from temporalio.client import Client, WorkflowHandle
+from temporalio.client import Client, WorkflowExecution, WorkflowHandle
 from temporalio.converter import DefaultPayloadConverter
 
 from tracecat.auth.types import Role
@@ -60,6 +61,7 @@ from tracecat.workflow.executions.service import (
     WF_TRIGGER_REF,
     WorkflowExecutionsService,
     _sanitize_action_result,
+    _WorkflowRunResetDescription,
 )
 from tracecat.workspaces.service import WorkspaceService
 
@@ -188,6 +190,23 @@ def create_mock_timestamp(event_time_seconds: int = 1640995200) -> Mock:
         event_time_seconds, tz=datetime.UTC
     )
     return mock_timestamp
+
+
+def create_reset_lineage_execution(
+    run_id: str, *, start_offset_seconds: int
+) -> WorkflowExecution:
+    """Create the minimal WorkflowExecution shape needed by reset lineage tests."""
+    return cast(
+        WorkflowExecution,
+        SimpleNamespace(
+            id="wf_test/exec_test",
+            run_id=run_id,
+            start_time=datetime.datetime.fromtimestamp(
+                1640995200 + start_offset_seconds,
+                tz=datetime.UTC,
+            ),
+        ),
+    )
 
 
 def create_mock_child_workflow_initiated_event(
@@ -2820,3 +2839,66 @@ async def test_list_executions_paginated_emits_prev_cursor_history(
     assert rewound_page.has_previous is False
     assert rewound_page.prev_cursor is None
     assert calls == [None, b"page-2", None]
+
+
+def test_build_reset_lineage_marks_original_and_reset_runs() -> None:
+    original = create_reset_lineage_execution("run-original", start_offset_seconds=0)
+    reset_1 = create_reset_lineage_execution("run-reset-1", start_offset_seconds=10)
+    reset_2 = create_reset_lineage_execution("run-reset-2", start_offset_seconds=20)
+
+    lineage = WorkflowExecutionsService._build_reset_lineage_from_descriptions(
+        [
+            _WorkflowRunResetDescription(
+                execution=reset_2,
+                first_run_id="run-original",
+                is_reset_run=True,
+            ),
+            _WorkflowRunResetDescription(
+                execution=original,
+                first_run_id="run-original",
+                is_reset_run=False,
+            ),
+            _WorkflowRunResetDescription(
+                execution=reset_1,
+                first_run_id="run-original",
+                is_reset_run=True,
+            ),
+        ]
+    )
+
+    original_lineage = lineage["run-original"]
+    assert original_lineage.has_been_reset is True
+    assert original_lineage.is_reset_run is False
+    assert original_lineage.original_run_id == "run-original"
+    assert original_lineage.reset_run_count == 2
+    assert original_lineage.reset_run_index is None
+
+    reset_1_lineage = lineage["run-reset-1"]
+    assert reset_1_lineage.has_been_reset is True
+    assert reset_1_lineage.is_reset_run is True
+    assert reset_1_lineage.original_run_id == "run-original"
+    assert reset_1_lineage.reset_run_count == 2
+    assert reset_1_lineage.reset_run_index == 1
+
+    reset_2_lineage = lineage["run-reset-2"]
+    assert reset_2_lineage.has_been_reset is True
+    assert reset_2_lineage.is_reset_run is True
+    assert reset_2_lineage.original_run_id == "run-original"
+    assert reset_2_lineage.reset_run_count == 2
+    assert reset_2_lineage.reset_run_index == 2
+
+
+def test_build_reset_lineage_returns_empty_without_reset_runs() -> None:
+    original = create_reset_lineage_execution("run-original", start_offset_seconds=0)
+
+    lineage = WorkflowExecutionsService._build_reset_lineage_from_descriptions(
+        [
+            _WorkflowRunResetDescription(
+                execution=original,
+                first_run_id="run-original",
+                is_reset_run=False,
+            )
+        ]
+    )
+
+    assert lineage == {}

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -2343,7 +2343,72 @@ class TestWorkflowExecutionEvents:
         assert resettable_points[0].label == "Workflow start"
         assert resettable_points[1].label == "Event 5"
         assert resettable_points[1].action_ref is None
-        assert resettable_points[1].action_relation is None
+
+    async def test_reset_points_do_not_reuse_stale_action_context(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        """Only the first reset checkpoint after an action uses that action label."""
+        first_checkpoint = create_mock_history_event(
+            event_id=2,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,  # type: ignore
+        )
+        scheduled = create_mock_history_event(
+            event_id=3,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,  # type: ignore
+        )
+        completed = create_mock_history_event(
+            event_id=4,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_COMPLETED,  # type: ignore
+            scheduled_event_id=3,
+        )
+        action_checkpoint = create_mock_history_event(
+            event_id=5,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,  # type: ignore
+        )
+        system_checkpoint = create_mock_history_event(
+            event_id=8,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,  # type: ignore
+        )
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**kwargs):
+            yield first_checkpoint
+            yield scheduled
+            yield completed
+            yield action_checkpoint
+            yield system_checkpoint
+
+        mock_handle.describe = AsyncMock(return_value=Mock())
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        action_event = WorkflowExecutionEventCompact(
+            source_event_id=3,
+            schedule_time=datetime.datetime.fromtimestamp(1640995200, tz=datetime.UTC),
+            curr_event_type=WorkflowEventType.ACTIVITY_TASK_SCHEDULED,
+            status=WorkflowExecutionEventStatus.SCHEDULED,
+            action_name="core.transform.reshape",
+            action_ref="action_a",
+        )
+
+        with patch(
+            "tracecat.workflow.executions.service.WorkflowExecutionEventCompact.from_source_event",
+            AsyncMock(return_value=action_event),
+        ):
+            points = await workflow_executions_service.list_reset_points(
+                workflow_exec_id
+            )
+
+        resettable_points = [point for point in points if point.is_resettable]
+        assert resettable_points[1].label == "After Action A"
+        assert resettable_points[2].label == "Event 8"
+        assert resettable_points[2].action_ref is None
+        assert resettable_points[2].action_relation is None
 
 
 # === Timeout Resolution Tests ===

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -2192,6 +2192,159 @@ class TestWorkflowExecutionEvents:
                 assert event.while_iteration is None
                 assert event.while_continue is None
 
+    async def test_reset_points_label_completed_action(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        """Reset checkpoints after a closed action use action-aware labels."""
+        first_checkpoint = create_mock_history_event(
+            event_id=2,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,  # type: ignore
+        )
+        scheduled = create_mock_history_event(
+            event_id=3,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,  # type: ignore
+        )
+        completed = create_mock_history_event(
+            event_id=4,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_COMPLETED,  # type: ignore
+            scheduled_event_id=3,
+        )
+        action_checkpoint = create_mock_history_event(
+            event_id=5,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,  # type: ignore
+        )
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**kwargs):
+            yield first_checkpoint
+            yield scheduled
+            yield completed
+            yield action_checkpoint
+
+        mock_handle.describe = AsyncMock(return_value=Mock())
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        action_event = WorkflowExecutionEventCompact(
+            source_event_id=3,
+            schedule_time=datetime.datetime.fromtimestamp(1640995200, tz=datetime.UTC),
+            curr_event_type=WorkflowEventType.ACTIVITY_TASK_SCHEDULED,
+            status=WorkflowExecutionEventStatus.SCHEDULED,
+            action_name="core.transform.reshape",
+            action_ref="action_a",
+        )
+
+        with patch(
+            "tracecat.workflow.executions.service.WorkflowExecutionEventCompact.from_source_event",
+            AsyncMock(return_value=action_event),
+        ):
+            points = await workflow_executions_service.list_reset_points(
+                workflow_exec_id
+            )
+
+        resettable_points = [point for point in points if point.is_resettable]
+        assert resettable_points[0].label == "Workflow start"
+        assert resettable_points[0].is_start is True
+        assert resettable_points[1].label == "After Action A"
+        assert resettable_points[1].action_ref == "action_a"
+        assert resettable_points[1].action_name == "core.transform.reshape"
+        assert resettable_points[1].action_event_id == 4
+        assert resettable_points[1].action_relation == "after"
+
+    async def test_reset_points_label_scheduled_action(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        """Reset checkpoints after a source event identify scheduled actions."""
+        first_checkpoint = create_mock_history_event(
+            event_id=2,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,  # type: ignore
+        )
+        scheduled = create_mock_history_event(
+            event_id=3,
+            event_type=EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,  # type: ignore
+        )
+        scheduled_checkpoint = create_mock_history_event(
+            event_id=4,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,  # type: ignore
+        )
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**kwargs):
+            yield first_checkpoint
+            yield scheduled
+            yield scheduled_checkpoint
+
+        mock_handle.describe = AsyncMock(return_value=Mock())
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        action_event = WorkflowExecutionEventCompact(
+            source_event_id=3,
+            schedule_time=datetime.datetime.fromtimestamp(1640995200, tz=datetime.UTC),
+            curr_event_type=WorkflowEventType.ACTIVITY_TASK_SCHEDULED,
+            status=WorkflowExecutionEventStatus.SCHEDULED,
+            action_name="core.transform.reshape",
+            action_ref="action_b",
+        )
+
+        with patch(
+            "tracecat.workflow.executions.service.WorkflowExecutionEventCompact.from_source_event",
+            AsyncMock(return_value=action_event),
+        ):
+            points = await workflow_executions_service.list_reset_points(
+                workflow_exec_id
+            )
+
+        resettable_points = [point for point in points if point.is_resettable]
+        assert resettable_points[1].label == "After scheduling Action B"
+        assert resettable_points[1].action_event_id == 3
+        assert resettable_points[1].action_relation == "after_scheduling"
+
+    async def test_reset_points_fallback_without_action_context(
+        self,
+        workflow_executions_service: WorkflowExecutionsService,
+        workflow_exec_id: WorkflowExecutionID,
+    ) -> None:
+        """Reset point labels fall back to event IDs when no action is available."""
+        first_checkpoint = create_mock_history_event(
+            event_id=2,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,  # type: ignore
+        )
+        later_checkpoint = create_mock_history_event(
+            event_id=5,
+            event_type=EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,  # type: ignore
+        )
+
+        mock_handle = Mock(spec=WorkflowHandle)
+
+        async def mock_fetch_history_events(**kwargs):
+            yield first_checkpoint
+            yield later_checkpoint
+
+        mock_handle.describe = AsyncMock(return_value=Mock())
+        mock_handle.fetch_history_events.return_value = mock_fetch_history_events()
+        workflow_executions_service._client.get_workflow_handle_for = Mock(
+            return_value=mock_handle
+        )
+
+        points = await workflow_executions_service.list_reset_points(workflow_exec_id)
+
+        resettable_points = [point for point in points if point.is_resettable]
+        assert resettable_points[0].label == "Workflow start"
+        assert resettable_points[1].label == "Event 5"
+        assert resettable_points[1].action_ref is None
+        assert resettable_points[1].action_relation is None
+
 
 # === Timeout Resolution Tests ===
 

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -2902,3 +2902,24 @@ def test_build_reset_lineage_returns_empty_without_reset_runs() -> None:
     )
 
     assert lineage == {}
+
+
+def test_build_reset_lineage_counts_unseen_reset_successors() -> None:
+    original = create_reset_lineage_execution("run-original", start_offset_seconds=0)
+
+    lineage = WorkflowExecutionsService._build_reset_lineage_from_descriptions(
+        [
+            _WorkflowRunResetDescription(
+                execution=original,
+                first_run_id="run-original",
+                reset_run_id="run-reset-1",
+            )
+        ]
+    )
+
+    original_lineage = lineage["run-original"]
+    assert original_lineage.has_been_reset is True
+    assert original_lineage.is_reset_run is False
+    assert original_lineage.original_run_id == "run-original"
+    assert original_lineage.reset_run_count == 1
+    assert original_lineage.reset_run_index is None

--- a/tests/unit/test_workflow_executions.py
+++ b/tests/unit/test_workflow_executions.py
@@ -2851,17 +2851,17 @@ def test_build_reset_lineage_marks_original_and_reset_runs() -> None:
             _WorkflowRunResetDescription(
                 execution=reset_2,
                 first_run_id="run-original",
-                is_reset_run=True,
+                reset_run_id=None,
             ),
             _WorkflowRunResetDescription(
                 execution=original,
                 first_run_id="run-original",
-                is_reset_run=False,
+                reset_run_id="run-reset-1",
             ),
             _WorkflowRunResetDescription(
                 execution=reset_1,
                 first_run_id="run-original",
-                is_reset_run=True,
+                reset_run_id="run-reset-2",
             ),
         ]
     )
@@ -2896,7 +2896,7 @@ def test_build_reset_lineage_returns_empty_without_reset_runs() -> None:
             _WorkflowRunResetDescription(
                 execution=original,
                 first_run_id="run-original",
-                is_reset_run=False,
+                reset_run_id=None,
             )
         ]
     )

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -89,6 +89,7 @@ from tracecat.workflow.executions.schemas import (
 )
 from tracecat.workflow.executions.service import (
     WorkflowExecutionNotFoundError,
+    WorkflowExecutionResetLineage,
     WorkflowExecutionResultMaskedError,
     WorkflowExecutionResultNotFoundError,
     WorkflowExecutionsService,
@@ -347,6 +348,7 @@ async def _load_workflow_metadata_map(
 def _to_workflow_run_read_minimal(
     execution: WorkflowExecution,
     workflow_metadata: dict[WorkflowIDShort, tuple[str, str | None]],
+    reset_lineage: WorkflowExecutionResetLineage | None = None,
 ) -> WorkflowRunReadMinimal:
     workflow_id: WorkflowIDShort | None = None
     workflow_title: str | None = None
@@ -367,6 +369,11 @@ def _to_workflow_run_read_minimal(
         workflow_id=workflow_id,
         workflow_title=workflow_title,
         workflow_alias=workflow_alias,
+        has_been_reset=reset_lineage.has_been_reset if reset_lineage else False,
+        is_reset_run=reset_lineage.is_reset_run if reset_lineage else False,
+        reset_original_run_id=reset_lineage.original_run_id if reset_lineage else None,
+        reset_run_count=reset_lineage.reset_run_count if reset_lineage else 0,
+        reset_run_index=reset_lineage.reset_run_index if reset_lineage else None,
     )
 
 
@@ -520,8 +527,13 @@ async def search_workflow_executions(
         role=role,
         workflow_ids=page_workflow_ids,
     )
+    reset_lineage_by_run_id = await service.get_reset_lineage_by_run_id(page.items)
     items = [
-        _to_workflow_run_read_minimal(execution, workflow_metadata)
+        _to_workflow_run_read_minimal(
+            execution,
+            workflow_metadata,
+            reset_lineage=reset_lineage_by_run_id.get(execution.run_id),
+        )
         for execution in page.items
     ]
     return CursorPaginatedResponse(

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -195,6 +195,28 @@ class WorkflowRunReadMinimal(WorkflowExecutionReadMinimal):
             "Workflow alias from workspace metadata or execution search attributes."
         ),
     )
+    has_been_reset: bool = Field(
+        default=False,
+        description="True when this run belongs to an execution that has reset runs.",
+    )
+    is_reset_run: bool = Field(
+        default=False,
+        description="True when this specific Temporal run was created by reset.",
+    )
+    reset_original_run_id: str | None = Field(
+        default=None,
+        description="Temporal run ID of the original run in this reset lineage.",
+    )
+    reset_run_count: int = Field(
+        default=0,
+        ge=0,
+        description="Number of reset-created runs in this execution lineage.",
+    )
+    reset_run_index: int | None = Field(
+        default=None,
+        ge=1,
+        description="One-based index of this reset-created run in reset order.",
+    )
 
     @staticmethod
     def from_dataclass(
@@ -203,6 +225,11 @@ class WorkflowRunReadMinimal(WorkflowExecutionReadMinimal):
         workflow_id: str | None = None,
         workflow_title: str | None = None,
         workflow_alias: str | None = None,
+        has_been_reset: bool = False,
+        is_reset_run: bool = False,
+        reset_original_run_id: str | None = None,
+        reset_run_count: int = 0,
+        reset_run_index: int | None = None,
     ) -> WorkflowRunReadMinimal:
         base = WorkflowExecutionReadMinimal.from_dataclass(execution)
         return WorkflowRunReadMinimal(
@@ -221,6 +248,11 @@ class WorkflowRunReadMinimal(WorkflowExecutionReadMinimal):
             workflow_id=workflow_id,
             workflow_title=workflow_title,
             workflow_alias=workflow_alias,
+            has_been_reset=has_been_reset,
+            is_reset_run=is_reset_run,
+            reset_original_run_id=reset_original_run_id,
+            reset_run_count=reset_run_count,
+            reset_run_index=reset_run_index,
         )
 
 

--- a/tracecat/workflow/executions/schemas.py
+++ b/tracecat/workflow/executions/schemas.py
@@ -1118,6 +1118,23 @@ class WorkflowExecutionResetPointRead(BaseModel):
     event_time: datetime
     event_type: str
     label: str
+    action_ref: str | None = Field(
+        default=None,
+        description="Workflow action ref used to describe this reset point.",
+    )
+    action_name: str | None = Field(
+        default=None,
+        description="Workflow action name used to describe this reset point.",
+    )
+    action_event_id: int | None = Field(
+        default=None,
+        ge=1,
+        description="Temporal source or close event id for the related action.",
+    )
+    action_relation: Literal["after", "after_scheduling", "before"] | None = Field(
+        default=None,
+        description="How the reset checkpoint relates to the related action.",
+    )
     is_start: bool = Field(
         default=False,
         description="True when this point maps to the earliest resettable point.",

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -1889,6 +1889,7 @@ class WorkflowExecutionsService:
         cls,
         point: WorkflowExecutionResetPointRead,
         action_contexts: Sequence[WorkflowResetActionContext],
+        resettable_event_ids: Sequence[int],
     ) -> WorkflowExecutionResetPointRead:
         if point.is_start:
             return point.model_copy(update={"label": "Workflow start"})
@@ -1900,6 +1901,10 @@ class WorkflowExecutionsService:
             for action in action_contexts
             if action.close_event_id is not None
             and action.close_event_id <= point.event_id
+            and cls._first_resettable_after_event(
+                resettable_event_ids, action.close_event_id
+            )
+            == point.event_id
         ]
         if closed_actions:
             action = max(
@@ -1917,6 +1922,13 @@ class WorkflowExecutionsService:
             action
             for action in action_contexts
             if action.source_event_id <= point.event_id
+            and (
+                action.close_event_id is None or action.close_event_id > point.event_id
+            )
+            and cls._first_resettable_after_event(
+                resettable_event_ids, action.source_event_id
+            )
+            == point.event_id
         ]
         if scheduled_actions:
             action = max(scheduled_actions, key=lambda item: item.source_event_id)
@@ -1931,6 +1943,10 @@ class WorkflowExecutionsService:
             action
             for action in action_contexts
             if action.source_event_id > point.event_id
+            and cls._last_resettable_before_event(
+                resettable_event_ids, action.source_event_id
+            )
+            == point.event_id
         ]
         if future_actions:
             action = min(future_actions, key=lambda item: item.source_event_id)
@@ -1941,6 +1957,32 @@ class WorkflowExecutionsService:
                 action_event_id=action.source_event_id,
             )
         return point
+
+    @staticmethod
+    def _first_resettable_after_event(
+        resettable_event_ids: Sequence[int], event_id: int
+    ) -> int | None:
+        return next(
+            (
+                resettable_event_id
+                for resettable_event_id in resettable_event_ids
+                if resettable_event_id > event_id
+            ),
+            None,
+        )
+
+    @staticmethod
+    def _last_resettable_before_event(
+        resettable_event_ids: Sequence[int], event_id: int
+    ) -> int | None:
+        return next(
+            (
+                resettable_event_id
+                for resettable_event_id in reversed(resettable_event_ids)
+                if resettable_event_id < event_id
+            ),
+            None,
+        )
 
     @staticmethod
     async def _build_reset_action_contexts(
@@ -2034,7 +2076,13 @@ class WorkflowExecutionsService:
                 point.is_start = point.event_id == first_resettable_event_id
 
         action_contexts = await self._build_reset_action_contexts(events)
-        return [self._annotate_reset_point(point, action_contexts) for point in points]
+        resettable_event_ids = [
+            point.event_id for point in points if point.is_resettable
+        ]
+        return [
+            self._annotate_reset_point(point, action_contexts, resettable_event_ids)
+            for point in points
+        ]
 
     async def _resolve_reset_event_id(
         self,

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -147,6 +147,22 @@ class WorkflowExecutionsPage:
     has_previous: bool
 
 
+@dataclass(frozen=True)
+class WorkflowExecutionResetLineage:
+    has_been_reset: bool
+    is_reset_run: bool
+    original_run_id: str | None = None
+    reset_run_count: int = 0
+    reset_run_index: int | None = None
+
+
+@dataclass(frozen=True)
+class _WorkflowRunResetDescription:
+    execution: WorkflowExecution
+    first_run_id: str | None
+    is_reset_run: bool
+
+
 def _unwrap_loop_control_result(value: Any) -> Any:
     """Unwrap loop control result payloads across known envelope shapes."""
     curr = value
@@ -434,6 +450,141 @@ class WorkflowExecutionsService:
         if not clauses:
             return None
         return f"({' OR '.join(clauses)})"
+
+    @staticmethod
+    def _quote_temporal_visibility_value(value: str) -> str:
+        return value.replace("\\", "\\\\").replace("'", "\\'")
+
+    @staticmethod
+    def _build_exact_execution_ids_clause(
+        execution_ids: Sequence[WorkflowExecutionID],
+    ) -> str | None:
+        unique_ids = sorted({str(execution_id) for execution_id in execution_ids})
+        if not unique_ids:
+            return None
+        clauses = [
+            (
+                "WorkflowId = "
+                f"'{WorkflowExecutionsService._quote_temporal_visibility_value(execution_id)}'"
+            )
+            for execution_id in unique_ids
+        ]
+        return f"({' OR '.join(clauses)})"
+
+    async def _describe_reset_lineage_run(
+        self, execution: WorkflowExecution
+    ) -> _WorkflowRunResetDescription:
+        handle = self._client.get_workflow_handle(execution.id, run_id=execution.run_id)
+        description = await handle.describe()
+        raw_description = description.raw_description
+        execution_info = raw_description.workflow_execution_info
+        extended_info = raw_description.workflow_extended_info
+        first_run_id = execution_info.first_run_id or None
+        return _WorkflowRunResetDescription(
+            execution=execution,
+            first_run_id=first_run_id,
+            is_reset_run=extended_info.HasField("last_reset_time"),
+        )
+
+    async def _describe_reset_lineage_runs(
+        self,
+        executions: Sequence[WorkflowExecution],
+        *,
+        concurrency_limit: int = 10,
+    ) -> list[_WorkflowRunResetDescription]:
+        semaphore = asyncio.Semaphore(max(1, concurrency_limit))
+
+        async def describe(
+            execution: WorkflowExecution,
+        ) -> _WorkflowRunResetDescription | None:
+            async with semaphore:
+                try:
+                    return await self._describe_reset_lineage_run(execution)
+                except RPCError as e:
+                    self.logger.warning(
+                        "Could not describe workflow run reset lineage",
+                        wf_exec_id=execution.id,
+                        run_id=execution.run_id,
+                        error=e,
+                    )
+                    return None
+
+        results = await asyncio.gather(
+            *(describe(execution) for execution in executions)
+        )
+        return [result for result in results if result is not None]
+
+    @staticmethod
+    def _build_reset_lineage_from_descriptions(
+        descriptions: Sequence[_WorkflowRunResetDescription],
+    ) -> dict[str, WorkflowExecutionResetLineage]:
+        if not descriptions:
+            return {}
+
+        sorted_descriptions = sorted(
+            descriptions, key=lambda item: item.execution.start_time
+        )
+        reset_descriptions = [
+            description
+            for description in sorted_descriptions
+            if description.is_reset_run
+        ]
+        reset_run_count = len(reset_descriptions)
+        if reset_run_count == 0:
+            return {}
+
+        original_run_id = next(
+            (
+                description.first_run_id
+                for description in sorted_descriptions
+                if description.first_run_id
+            ),
+            sorted_descriptions[0].execution.run_id,
+        )
+        reset_index_by_run_id = {
+            description.execution.run_id: index
+            for index, description in enumerate(reset_descriptions, start=1)
+        }
+        return {
+            description.execution.run_id: WorkflowExecutionResetLineage(
+                has_been_reset=True,
+                is_reset_run=description.is_reset_run,
+                original_run_id=original_run_id,
+                reset_run_count=reset_run_count,
+                reset_run_index=reset_index_by_run_id.get(description.execution.run_id),
+            )
+            for description in sorted_descriptions
+        }
+
+    async def get_reset_lineage_by_run_id(
+        self, executions: Sequence[WorkflowExecution]
+    ) -> dict[str, WorkflowExecutionResetLineage]:
+        """Return reset lineage metadata keyed by Temporal run ID."""
+        execution_ids_clause = self._build_exact_execution_ids_clause(
+            [cast(WorkflowExecutionID, execution.id) for execution in executions]
+        )
+        if execution_ids_clause is None:
+            return {}
+
+        query = (
+            f"{TemporalSearchAttr.WORKSPACE_ID.value} = '{self.workspace_id}' "
+            f"AND {execution_ids_clause}"
+        )
+        runs_by_execution_id: dict[str, list[WorkflowExecution]] = {}
+        async for execution in self._client.list_workflows(query=query):
+            if not self._is_execution_visible_in_workspace(execution):
+                continue
+            runs_by_execution_id.setdefault(execution.id, []).append(execution)
+
+        lineage_by_run_id: dict[str, WorkflowExecutionResetLineage] = {}
+        for runs in runs_by_execution_id.values():
+            if len(runs) <= 1:
+                continue
+            descriptions = await self._describe_reset_lineage_runs(runs)
+            lineage_by_run_id.update(
+                self._build_reset_lineage_from_descriptions(descriptions)
+            )
+        return lineage_by_run_id
 
     async def list_executions_paginated(
         self,

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -8,8 +8,8 @@ import json
 import uuid
 from collections import OrderedDict
 from collections.abc import AsyncGenerator, Sequence
-from dataclasses import dataclass
-from typing import Any, cast
+from dataclasses import dataclass, replace
+from typing import Any, Literal, cast
 
 import orjson
 import temporalio.api.enums.v1
@@ -128,6 +128,14 @@ class WorkflowExecutionStoredResult:
     event: HistoryEvent
     stored: StoredObject
     should_mask_output: bool
+
+
+@dataclass(frozen=True)
+class WorkflowResetActionContext:
+    source_event_id: int
+    action_ref: str
+    action_name: str
+    close_event_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -1843,6 +1851,140 @@ class WorkflowExecutionsService:
         return event.event_type == EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED
 
     @staticmethod
+    def _format_reset_action_ref(action_ref: str) -> str:
+        label = action_ref.replace("_", " ").replace("-", " ")
+        return " ".join(part.capitalize() for part in label.split()) or action_ref
+
+    @classmethod
+    def _reset_point_for_action(
+        cls,
+        *,
+        point: WorkflowExecutionResetPointRead,
+        action: WorkflowResetActionContext,
+        relation: Literal["after", "after_scheduling", "before"],
+        action_event_id: int,
+    ) -> WorkflowExecutionResetPointRead:
+        action_label = cls._format_reset_action_ref(action.action_ref)
+        match relation:
+            case "after":
+                label = f"After {action_label}"
+            case "after_scheduling":
+                label = f"After scheduling {action_label}"
+            case "before":
+                label = f"Before {action_label}"
+            case _:
+                label = point.label
+        return point.model_copy(
+            update={
+                "label": label,
+                "action_ref": action.action_ref,
+                "action_name": action.action_name,
+                "action_event_id": action_event_id,
+                "action_relation": relation,
+            }
+        )
+
+    @classmethod
+    def _annotate_reset_point(
+        cls,
+        point: WorkflowExecutionResetPointRead,
+        action_contexts: Sequence[WorkflowResetActionContext],
+    ) -> WorkflowExecutionResetPointRead:
+        if point.is_start:
+            return point.model_copy(update={"label": "Workflow start"})
+        if not point.is_resettable:
+            return point
+
+        closed_actions = [
+            action
+            for action in action_contexts
+            if action.close_event_id is not None
+            and action.close_event_id <= point.event_id
+        ]
+        if closed_actions:
+            action = max(
+                closed_actions,
+                key=lambda item: item.close_event_id or item.source_event_id,
+            )
+            return cls._reset_point_for_action(
+                point=point,
+                action=action,
+                relation="after",
+                action_event_id=action.close_event_id or action.source_event_id,
+            )
+
+        scheduled_actions = [
+            action
+            for action in action_contexts
+            if action.source_event_id <= point.event_id
+        ]
+        if scheduled_actions:
+            action = max(scheduled_actions, key=lambda item: item.source_event_id)
+            return cls._reset_point_for_action(
+                point=point,
+                action=action,
+                relation="after_scheduling",
+                action_event_id=action.source_event_id,
+            )
+
+        future_actions = [
+            action
+            for action in action_contexts
+            if action.source_event_id > point.event_id
+        ]
+        if future_actions:
+            action = min(future_actions, key=lambda item: item.source_event_id)
+            return cls._reset_point_for_action(
+                point=point,
+                action=action,
+                relation="before",
+                action_event_id=action.source_event_id,
+            )
+        return point
+
+    @staticmethod
+    async def _build_reset_action_contexts(
+        events: Sequence[HistoryEvent],
+    ) -> list[WorkflowResetActionContext]:
+        context_by_source_id: OrderedDict[int, WorkflowResetActionContext] = (
+            OrderedDict()
+        )
+        for event in events:
+            if is_scheduled_event(event):
+                try:
+                    source = await WorkflowExecutionEventCompact.from_source_event(
+                        event
+                    )
+                except (TypeError, ValueError, ValidationError) as e:
+                    logger.trace(
+                        "Skipping reset action context; source event could not be parsed",
+                        event_id=event.event_id,
+                        error=e,
+                    )
+                    continue
+                if source is None:
+                    continue
+                context_by_source_id[event.event_id] = WorkflowResetActionContext(
+                    source_event_id=event.event_id,
+                    action_ref=source.action_ref,
+                    action_name=source.action_name,
+                )
+                continue
+
+            if not (is_close_event(event) or is_error_event(event)):
+                continue
+            source_event_id = get_source_event_id(event)
+            if source_event_id is None:
+                continue
+            action_context = context_by_source_id.get(source_event_id)
+            if action_context is None:
+                continue
+            context_by_source_id[source_event_id] = replace(
+                action_context, close_event_id=event.event_id
+            )
+        return list(context_by_source_id.values())
+
+    @staticmethod
     def _to_temporal_reset_reapply_type(
         reapply_type: WorkflowExecutionResetReapplyType,
     ) -> ResetReapplyType.ValueType:
@@ -1864,11 +2006,13 @@ class WorkflowExecutionsService:
     ) -> list[WorkflowExecutionResetPointRead]:
         await self.require_execution(wf_exec_id)
         points: list[WorkflowExecutionResetPointRead] = []
+        events: list[HistoryEvent] = []
         first_resettable_event_id: int | None = None
         handle = self.handle(wf_exec_id)
         async for event in handle.fetch_history_events(
             event_filter_type=WorkflowHistoryEventFilterType.ALL_EVENT
         ):
+            events.append(event)
             resettable = self._is_resettable_event(event)
             if resettable and first_resettable_event_id is None:
                 first_resettable_event_id = event.event_id
@@ -1888,7 +2032,9 @@ class WorkflowExecutionsService:
         if first_resettable_event_id is not None:
             for point in points:
                 point.is_start = point.event_id == first_resettable_event_id
-        return points
+
+        action_contexts = await self._build_reset_action_contexts(events)
+        return [self._annotate_reset_point(point, action_contexts) for point in points]
 
     async def _resolve_reset_event_id(
         self,

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -527,17 +527,18 @@ class WorkflowExecutionsService:
         described_run_ids = {
             description.execution.run_id for description in sorted_descriptions
         }
-        reset_run_ids = {
+        reset_successor_run_ids = {
             description.reset_run_id
             for description in sorted_descriptions
-            if description.reset_run_id in described_run_ids
+            if description.reset_run_id is not None
         }
+        described_reset_run_ids = reset_successor_run_ids & described_run_ids
         reset_descriptions = [
             description
             for description in sorted_descriptions
-            if description.execution.run_id in reset_run_ids
+            if description.execution.run_id in described_reset_run_ids
         ]
-        reset_run_count = len(reset_descriptions)
+        reset_run_count = len(reset_successor_run_ids)
         if reset_run_count == 0:
             return {}
 
@@ -556,7 +557,7 @@ class WorkflowExecutionsService:
         return {
             description.execution.run_id: WorkflowExecutionResetLineage(
                 has_been_reset=True,
-                is_reset_run=description.execution.run_id in reset_run_ids,
+                is_reset_run=description.execution.run_id in described_reset_run_ids,
                 original_run_id=original_run_id,
                 reset_run_count=reset_run_count,
                 reset_run_index=reset_index_by_run_id.get(description.execution.run_id),

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -160,7 +160,7 @@ class WorkflowExecutionResetLineage:
 class _WorkflowRunResetDescription:
     execution: WorkflowExecution
     first_run_id: str | None
-    is_reset_run: bool
+    reset_run_id: str | None
 
 
 def _unwrap_loop_control_result(value: Any) -> Any:
@@ -483,7 +483,7 @@ class WorkflowExecutionsService:
         return _WorkflowRunResetDescription(
             execution=execution,
             first_run_id=first_run_id,
-            is_reset_run=extended_info.HasField("last_reset_time"),
+            reset_run_id=extended_info.reset_run_id or None,
         )
 
     async def _describe_reset_lineage_runs(
@@ -524,10 +524,18 @@ class WorkflowExecutionsService:
         sorted_descriptions = sorted(
             descriptions, key=lambda item: item.execution.start_time
         )
+        described_run_ids = {
+            description.execution.run_id for description in sorted_descriptions
+        }
+        reset_run_ids = {
+            description.reset_run_id
+            for description in sorted_descriptions
+            if description.reset_run_id in described_run_ids
+        }
         reset_descriptions = [
             description
             for description in sorted_descriptions
-            if description.is_reset_run
+            if description.execution.run_id in reset_run_ids
         ]
         reset_run_count = len(reset_descriptions)
         if reset_run_count == 0:
@@ -548,7 +556,7 @@ class WorkflowExecutionsService:
         return {
             description.execution.run_id: WorkflowExecutionResetLineage(
                 has_been_reset=True,
-                is_reset_run=description.is_reset_run,
+                is_reset_run=description.execution.run_id in reset_run_ids,
                 original_run_id=original_run_id,
                 reset_run_count=reset_run_count,
                 reset_run_index=reset_index_by_run_id.get(description.execution.run_id),


### PR DESCRIPTION
## Summary

- Add action-aware metadata to workflow execution reset points
- Label reset checkpoints with workflow context like `After Action A` while retaining Temporal event IDs
- Update the reset workflow dialog to show action labels first and event IDs as supporting context
- Group unattributed resettable events under `Advanced checkpoints` as neutral `Workflow checkpoint` entries
- Avoid stale action labels on later system-only reset checkpoints and avoid duplicate fallback event text
- Surface reset lineage in the Runs list so reset-created runs show their original run and original runs show reset history

## Testing

- [x] `PG_PORT=5632 REDIS_PORT=6579 MINIO_PORT=9200 TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/test_workflow_executions.py -k reset`
- [x] `uv run pytest tests/unit/test_workflow_executions.py -k "reset_lineage"`
- [x] `pnpm -C frontend test -- reset-workflow-run-dialog`
- [x] `uv run ruff check tracecat/workflow/executions/schemas.py tracecat/workflow/executions/service.py tracecat/workflow/executions/router.py tests/unit/test_workflow_executions.py`
- [x] `uv run ruff format --check tracecat/workflow/executions/schemas.py tracecat/workflow/executions/service.py tracecat/workflow/executions/router.py tests/unit/test_workflow_executions.py`
- [x] `uv run basedpyright tracecat/workflow/executions/schemas.py tracecat/workflow/executions/service.py tracecat/workflow/executions/router.py tests/unit/test_workflow_executions.py`
- [x] `pnpm -C frontend exec biome check src/components/workflow-runs/workflow-run-item.tsx src/components/workflow-runs/reset-workflow-run-dialog.tsx tests/reset-workflow-run-dialog.test.tsx src/client/types.gen.ts src/client/schemas.gen.ts`
- [x] `pnpm -C frontend run typecheck`

## Live QA

Cluster: `tracecat-feat-workflow-reset-clarity-3`
UI: `https://c3.feat-workflow-reset-clarity.tracecat.localhost`
API: `http://localhost:280/api`
Workspace: `87d04124-afa7-4e64-a1fa-8aa20e0cb6e2`
Workflow: `Reset clarity QA` / `wf_2TzvUs1tyGiJ7psYaxPjUR`
Execution: `wf_2TzvUs1tyGiJ7psYaxPjUR/exec_1nZkpmT7EKo6qt32iJtU5Y`

QA workflow topology:

```mermaid
flowchart LR
  Trigger([Manual API run]) --> A[action_a<br/>core.transform.reshape]
  A --> B[action_b<br/>core.transform.reshape]
  B --> C[action_c<br/>core.transform.reshape]
  C --> Return([returns ACTIONS.action_c.result])
```

- Uploaded and committed a three-action DSL directly through the cluster API.
- Ran the workflow, inspected `/reset-points`, and verified resettable labels: `Workflow start`, `Before Action A`, `After Action A`, `After Action B`, `After Action C`, plus an unattributed system checkpoint surfaced in the UI as `Workflow checkpoint`.
- Reset from `After Action A` through the API; Temporal returned new run ID `db78b996-09dc-469f-b1ef-616a8b8c5937`.
- Authenticated in Chrome DevTools, opened the Runs view, verified the reset dialog groups action-correlated points separately from `Advanced checkpoints`, selected `After Action A`, submitted the reset through the UI, and confirmed the Runs view showed the additional completed reset run.
- Restarted the API, verified the Runs search response includes reset lineage for the existing reset chain (`reset_run_count: 3`, reset-created runs #1-#3 all pointing to original run `019dfedc-c321-7486-8484-9a16d3289362`), and confirmed the Runs list renders `Reset #N from 019dfedc` plus `Original - 3 resets`.

### Screenshots

Runs list before UI reset:

![Runs list before UI reset](https://raw.githubusercontent.com/TracecatHQ/tracecat/codex-pr-2630-reset-qa/pr-qa/2630/runs-list.png?v=dfbc4e2a68db5e96ede98e5ae4c0abda39f800c5)

Dialog default reset point:

![Reset dialog default state](https://raw.githubusercontent.com/TracecatHQ/tracecat/codex-pr-2630-reset-qa/pr-qa/2630/dialog-default.png?v=dfbc4e2a68db5e96ede98e5ae4c0abda39f800c5)

Action-aware reset point options:

![Action-aware reset point options](https://raw.githubusercontent.com/TracecatHQ/tracecat/codex-pr-2630-reset-qa/pr-qa/2630/dialog-options.png?v=dfbc4e2a68db5e96ede98e5ae4c0abda39f800c5)

Selected action reset point before submit:

![Selected action reset point](https://raw.githubusercontent.com/TracecatHQ/tracecat/codex-pr-2630-reset-qa/pr-qa/2630/dialog-selected.png?v=dfbc4e2a68db5e96ede98e5ae4c0abda39f800c5)

UI reset submitted:

![UI reset submitted](https://raw.githubusercontent.com/TracecatHQ/tracecat/codex-pr-2630-reset-qa/pr-qa/2630/ui-reset-started.png?v=dfbc4e2a68db5e96ede98e5ae4c0abda39f800c5)

Runs list after UI reset:

![Runs list after UI reset](https://raw.githubusercontent.com/TracecatHQ/tracecat/codex-pr-2630-reset-qa/pr-qa/2630/after-ui-reset.png?v=dfbc4e2a68db5e96ede98e5ae4c0abda39f800c5)

Runs list with reset lineage badges:

![Runs list with reset lineage badges](https://raw.githubusercontent.com/TracecatHQ/tracecat/codex-pr-2630-reset-qa/pr-qa/2630/reset-lineage-runs-list.png?v=718d408386067cc775e8a3e70f16d03b264993f573924bfc6a294ce30a8df099)

## Summary by cubic

Make workflow reset points action-aware and easier to pick. Backend annotates reset points with related action context, and the reset dialog shows readable labels with supporting Temporal event IDs.

New Features

Backend annotates reset points with action context and readable labels:

Labels like “After Action A”, “After scheduling Action B”, or “Before Action C”.
Keeps “Workflow start” and includes Temporal event IDs for reference.
API extends `WorkflowExecutionResetPointRead` with `action_ref`, `action_name`, `action_event_id`, and `action_relation` (backward compatible).
Reset dialog shows action label first and event ID as secondary text; updated helper copy, hides the “start” checkpoint from the history list while keeping a dedicated “Workflow start” option, and groups unattributed checkpoints under an advanced section.
Added unit tests for reset point labeling and a frontend test for the dialog to verify label formatting and submission behavior.



