### PR TITLE
feat(db): add agent folder and tag models

### DIFF
--- a/alembic/versions/d0b32dce7f81_add_agent_folders_and_tags.py
+++ b/alembic/versions/d0b32dce7f81_add_agent_folders_and_tags.py
@@ -1,0 +1,144 @@
+"""add_agent_folders_and_tags
+
+Revision ID: d0b32dce7f81
+Revises: b742858f7d69
+Create Date: 2026-04-13 10:21:23.858770
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from tracecat.db.tenant_rls import (
+    disable_workspace_table_rls,
+    enable_workspace_table_rls,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "d0b32dce7f81"
+down_revision: str | None = "8b2f6a9c4d10"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_folder",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("path", sa.String(), nullable=False),
+        sa.Column("workspace_id", sa.UUID(), nullable=False),
+        sa.Column("surrogate_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_agent_folder_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name=op.f("pk_agent_folder")),
+        sa.UniqueConstraint(
+            "path", "workspace_id", name="uq_agent_folder_path_workspace"
+        ),
+    )
+    op.create_index(op.f("ix_agent_folder_id"), "agent_folder", ["id"], unique=True)
+    op.create_index(
+        op.f("ix_agent_folder_path"), "agent_folder", ["path"], unique=False
+    )
+
+    op.create_table(
+        "agent_tag",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("ref", sa.String(), nullable=False),
+        sa.Column("color", sa.String(), nullable=True),
+        sa.Column("workspace_id", sa.UUID(), nullable=False),
+        sa.Column("surrogate_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_agent_tag_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("surrogate_id", name=op.f("pk_agent_tag")),
+        sa.UniqueConstraint("name", "workspace_id", name="uq_agent_tag_name_workspace"),
+        sa.UniqueConstraint("ref", "workspace_id", name="uq_agent_tag_ref_workspace"),
+    )
+    op.create_index(op.f("ix_agent_tag_id"), "agent_tag", ["id"], unique=True)
+    op.create_index(op.f("ix_agent_tag_name"), "agent_tag", ["name"], unique=False)
+    op.create_index(op.f("ix_agent_tag_ref"), "agent_tag", ["ref"], unique=False)
+
+    op.create_table(
+        "agent_tag_link",
+        sa.Column("tag_id", sa.UUID(), nullable=False),
+        sa.Column("preset_id", sa.UUID(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["preset_id"],
+            ["agent_preset.id"],
+            name=op.f("fk_agent_tag_link_preset_id_agent_preset"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tag_id"],
+            ["agent_tag.id"],
+            name=op.f("fk_agent_tag_link_tag_id_agent_tag"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("tag_id", "preset_id", name=op.f("pk_agent_tag_link")),
+    )
+
+    op.add_column("agent_preset", sa.Column("folder_id", sa.UUID(), nullable=True))
+    op.create_foreign_key(
+        op.f("fk_agent_preset_folder_id_agent_folder"),
+        "agent_preset",
+        "agent_folder",
+        ["folder_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.execute(enable_workspace_table_rls("agent_folder"))
+    op.execute(enable_workspace_table_rls("agent_tag"))
+
+
+def downgrade() -> None:
+    op.execute(disable_workspace_table_rls("agent_tag"))
+    op.execute(disable_workspace_table_rls("agent_folder"))
+    op.drop_constraint(
+        op.f("fk_agent_preset_folder_id_agent_folder"),
+        "agent_preset",
+        type_="foreignkey",
+    )
+    op.drop_column("agent_preset", "folder_id")
+    op.drop_table("agent_tag_link")
+    op.drop_index(op.f("ix_agent_tag_ref"), table_name="agent_tag")
+    op.drop_index(op.f("ix_agent_tag_name"), table_name="agent_tag")
+    op.drop_index(op.f("ix_agent_tag_id"), table_name="agent_tag")
+    op.drop_table("agent_tag")
+    op.drop_index(op.f("ix_agent_folder_path"), table_name="agent_folder")
+    op.drop_index(op.f("ix_agent_folder_id"), table_name="agent_folder")
+    op.drop_table("agent_folder")

--- a/alembic/versions/d0b32dce7f81_add_agent_folders_and_tags.py
+++ b/alembic/versions/d0b32dce7f81_add_agent_folders_and_tags.py
@@ -12,7 +12,9 @@ import sqlalchemy as sa
 
 from alembic import op
 from tracecat.db.tenant_rls import (
+    disable_agent_tag_link_table_rls,
     disable_workspace_table_rls,
+    enable_agent_tag_link_table_rls,
     enable_workspace_table_rls,
 )
 
@@ -123,9 +125,11 @@ def upgrade() -> None:
     )
     op.execute(enable_workspace_table_rls("agent_folder"))
     op.execute(enable_workspace_table_rls("agent_tag"))
+    op.execute(enable_agent_tag_link_table_rls())
 
 
 def downgrade() -> None:
+    op.execute(disable_agent_tag_link_table_rls())
     op.execute(disable_workspace_table_rls("agent_tag"))
     op.execute(disable_workspace_table_rls("agent_folder"))
     op.drop_constraint(

--- a/alembic/versions/d0b32dce7f81_add_agent_folders_and_tags.py
+++ b/alembic/versions/d0b32dce7f81_add_agent_folders_and_tags.py
@@ -1,7 +1,7 @@
 """add_agent_folders_and_tags
 
 Revision ID: d0b32dce7f81
-Revises: b742858f7d69
+Revises: 8b2f6a9c4d10
 Create Date: 2026-04-13 10:21:23.858770
 
 """
@@ -113,6 +113,12 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("tag_id", "preset_id", name=op.f("pk_agent_tag_link")),
     )
+    op.create_index(
+        op.f("ix_agent_tag_link_preset_id"),
+        "agent_tag_link",
+        ["preset_id"],
+        unique=False,
+    )
 
     op.add_column("agent_preset", sa.Column("folder_id", sa.UUID(), nullable=True))
     op.create_foreign_key(
@@ -138,6 +144,7 @@ def downgrade() -> None:
         type_="foreignkey",
     )
     op.drop_column("agent_preset", "folder_id")
+    op.drop_index(op.f("ix_agent_tag_link_preset_id"), table_name="agent_tag_link")
     op.drop_table("agent_tag_link")
     op.drop_index(op.f("ix_agent_tag_ref"), table_name="agent_tag")
     op.drop_index(op.f("ix_agent_tag_name"), table_name="agent_tag")

--- a/tests/unit/test_tenant_rls_registry.py
+++ b/tests/unit/test_tenant_rls_registry.py
@@ -14,8 +14,10 @@ from tracecat.db.tenant_rls import (
     ORG_OPTIONAL_WORKSPACE_POLICY_TABLES,
     ORG_POLICY_TABLES,
     SPECIAL_ORG_POLICY_TABLES,
+    SPECIAL_TENANT_POLICY_TABLES,
     SPECIAL_WORKSPACE_POLICY_TABLES,
     WORKSPACE_POLICY_TABLES,
+    enable_agent_tag_link_table_rls,
 )
 from tracecat.tables.service import TablesService
 
@@ -85,6 +87,24 @@ def test_tenant_rls_registry_contains_only_mapped_tables() -> None:
         "Tenant RLS registry contains tables that are not mapped in SQLAlchemy: "
         f"{sorted(stale_registry_entries)}"
     )
+
+
+def test_agent_tag_link_is_registered_for_tenant_rls() -> None:
+    assert "agent_tag_link" in SPECIAL_TENANT_POLICY_TABLES
+
+
+def test_agent_tag_link_rls_policy_uses_parent_workspace_scopes() -> None:
+    policy_sql = enable_agent_tag_link_table_rls()
+
+    assert 'ALTER TABLE "agent_tag_link" ENABLE ROW LEVEL SECURITY' in policy_sql
+    assert "CREATE POLICY rls_policy_agent_tag_link" in policy_sql
+    assert "FROM agent_tag" in policy_sql
+    assert "agent_tag.id = agent_tag_link.tag_id" in policy_sql
+    assert "agent_tag.workspace_id = NULLIF(current_setting" in policy_sql
+    assert "FROM agent_preset" in policy_sql
+    assert "agent_preset.id = agent_tag_link.preset_id" in policy_sql
+    assert "agent_preset.workspace_id = NULLIF(current_setting" in policy_sql
+    assert "WITH CHECK" in policy_sql
 
 
 def test_dynamic_workspace_rls_targets_workspace_scoped_schemas() -> None:

--- a/tests/unit/test_workspace_service.py
+++ b/tests/unit/test_workspace_service.py
@@ -196,20 +196,26 @@ class TestWorkspaceService:
     async def test_list_accessible_workspaces_returns_all_for_org_service_account(
         self,
         session: AsyncSession,
-        svc_organization: Organization,
     ) -> None:
+        organization = Organization(
+            id=uuid.uuid4(),
+            name="Workspace access org",
+            slug=f"workspace-access-{uuid.uuid4().hex}",
+            is_active=True,
+        )
         workspace_ids = [uuid.uuid4(), uuid.uuid4()]
         session.add_all(
             [
+                organization,
                 Workspace(
                     id=workspace_ids[0],
                     name="alpha",
-                    organization_id=svc_organization.id,
+                    organization_id=organization.id,
                 ),
                 Workspace(
                     id=workspace_ids[1],
                     name="beta",
-                    organization_id=svc_organization.id,
+                    organization_id=organization.id,
                 ),
             ]
         )
@@ -219,7 +225,7 @@ class TestWorkspaceService:
             session=session,
             role=Role(
                 type="service_account",
-                organization_id=svc_organization.id,
+                organization_id=organization.id,
                 service_account_id=uuid.uuid4(),
                 service_id="tracecat-api",
                 scopes=frozenset({"org:workspace:read"}),

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -465,6 +465,16 @@ class Workspace(OrganizationModel):
         back_populates="workspace",
         cascade="all, delete",
     )
+    agent_folders: Mapped[list[AgentFolder]] = relationship(
+        "AgentFolder",
+        back_populates="workspace",
+        cascade="all, delete",
+    )
+    agent_tags: Mapped[list[AgentTag]] = relationship(
+        "AgentTag",
+        back_populates="workspace",
+        cascade="all, delete",
+    )
     skills: Mapped[list[Skill]] = relationship(
         "Skill",
         back_populates="workspace",
@@ -3311,6 +3321,59 @@ class AgentChannelToken(WorkspaceModel):
     )
 
 
+class AgentFolder(WorkspaceModel):
+    """Folder for organizing agent presets.
+
+    Uses materialized path pattern for hierarchical structure.
+    Path format: "/parent/child/" where each segment is the folder name.
+    Root folders have path "/foldername/".
+    """
+
+    __tablename__ = "agent_folder"
+    __table_args__ = (
+        UniqueConstraint("path", "workspace_id", name="uq_agent_folder_path_workspace"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    path: Mapped[str] = mapped_column(
+        String,
+        index=True,
+        nullable=False,
+        doc="Full materialized path: /parent/child/",
+    )
+
+    workspace: Mapped[Workspace] = relationship(back_populates="agent_folders")
+    presets: Mapped[list[AgentPreset]] = relationship(
+        "AgentPreset",
+        back_populates="folder",
+    )
+
+
+class AgentTagLink(Base):
+    """Link table for agent presets and agent tags."""
+
+    __tablename__ = "agent_tag_link"
+    __table_args__ = (PrimaryKeyConstraint("tag_id", "preset_id"),)
+
+    tag_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("agent_tag.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    preset_id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        ForeignKey("agent_preset.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+
 class AgentPreset(WorkspaceModel):
     """Database model for storing reusable agent preset configurations."""
 
@@ -3412,8 +3475,19 @@ class AgentPreset(WorkspaceModel):
         nullable=False,
         doc="Whether to enable direct internet access in the agent sandbox",
     )
+    folder_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID,
+        ForeignKey("agent_folder.id", ondelete="SET NULL"),
+        nullable=True,
+    )
 
     workspace: Mapped[Workspace] = relationship(back_populates="agent_presets")
+    folder: Mapped[AgentFolder | None] = relationship(back_populates="presets")
+    tags: Mapped[list[AgentTag]] = relationship(
+        "AgentTag",
+        secondary=AgentTagLink.__table__,
+        back_populates="presets",
+    )
     versions: Mapped[list[AgentPresetVersion]] = relationship(
         "AgentPresetVersion",
         back_populates="preset",
@@ -4010,6 +4084,39 @@ class AgentPresetVersionSkill(WorkspaceModel):
     skill_version: Mapped[SkillVersion] = relationship(
         back_populates="preset_version_refs",
         foreign_keys=[skill_version_id],
+    )
+
+
+class AgentTag(WorkspaceModel):
+    """A tag for organizing and filtering agent presets."""
+
+    __tablename__ = "agent_tag"
+    __table_args__ = (
+        UniqueConstraint("name", "workspace_id", name="uq_agent_tag_name_workspace"),
+        UniqueConstraint("ref", "workspace_id", name="uq_agent_tag_ref_workspace"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    ref: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        index=True,
+        doc="Slug-like identifier derived from the name, used for API lookups alongside uuid.UUID",
+    )
+    color: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    workspace: Mapped[Workspace] = relationship(back_populates="agent_tags")
+    presets: Mapped[list[AgentPreset]] = relationship(
+        "AgentPreset",
+        secondary=AgentTagLink.__table__,
+        back_populates="tags",
     )
 
 

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -74,6 +74,8 @@ POST_RLS_WORKSPACE_SCOPED_TABLES = (
     "case_table_row",
     "agent_channel_token",
     "agent_preset_version",
+    "agent_folder",
+    "agent_tag",
     "skill",
     "skill_blob",
     "skill_upload",

--- a/tracecat/db/tenant_rls.py
+++ b/tracecat/db/tenant_rls.py
@@ -101,7 +101,7 @@ POST_RLS_ORG_OPTIONAL_WORKSPACE_SCOPED_TABLES = (
 )
 
 SPECIAL_TENANT_POLICY_TABLES = frozenset(
-    {"service_account_api_key", "service_account_scope"}
+    {"agent_tag_link", "service_account_api_key", "service_account_scope"}
 )
 
 # Workspace and oauth_state carry custom policy SQL. scope and agent_catalog
@@ -350,6 +350,52 @@ def disable_service_account_child_table_rls(table: str) -> str:
     return f"""
         DROP POLICY IF EXISTS {policy_name(table)} ON "{table}";
         ALTER TABLE "{table}" DISABLE ROW LEVEL SECURITY;
+    """
+
+
+def _agent_tag_link_workspace_condition() -> str:
+    return """
+                EXISTS (
+                    SELECT 1
+                    FROM agent_tag
+                    WHERE agent_tag.id = agent_tag_link.tag_id
+                      AND agent_tag.workspace_id = NULLIF(current_setting('app.current_workspace_id', true), '')::uuid
+                )
+                AND EXISTS (
+                    SELECT 1
+                    FROM agent_preset
+                    WHERE agent_preset.id = agent_tag_link.preset_id
+                      AND agent_preset.workspace_id = NULLIF(current_setting('app.current_workspace_id', true), '')::uuid
+                )
+    """
+
+
+def enable_agent_tag_link_table_rls() -> str:
+    workspace_condition = _agent_tag_link_workspace_condition()
+    return f"""
+        ALTER TABLE "agent_tag_link" ENABLE ROW LEVEL SECURITY;
+
+        CREATE POLICY {policy_name("agent_tag_link")} ON "agent_tag_link"
+            FOR ALL
+            USING (
+                current_setting('{RLS_BYPASS_VAR}', true) = '{RLS_BYPASS_ON}'
+                OR (
+{workspace_condition}
+                )
+            )
+            WITH CHECK (
+                current_setting('{RLS_BYPASS_VAR}', true) = '{RLS_BYPASS_ON}'
+                OR (
+{workspace_condition}
+                )
+            );
+    """
+
+
+def disable_agent_tag_link_table_rls() -> str:
+    return f"""
+        DROP POLICY IF EXISTS {policy_name("agent_tag_link")} ON "agent_tag_link";
+        ALTER TABLE "agent_tag_link" DISABLE ROW LEVEL SECURITY;
     """
 
 

--- a/tracecat/identifiers/__init__.py
+++ b/tracecat/identifiers/__init__.py
@@ -78,6 +78,7 @@ SessionID = uuid.UUID
 WorkflowTagID = uuid.UUID
 TagID = WorkflowTagID
 CaseTagID = uuid.UUID
+AgentTagID = uuid.UUID
 TableID = uuid.UUID
 TableColumnID = uuid.UUID
 TableRowID = uuid.UUID
@@ -121,6 +122,7 @@ __all__ = [
     "TagID",
     "WorkflowTagID",
     "CaseTagID",
+    "AgentTagID",
     "SessionID",
     "VariableID",
     "InvitationID",


### PR DESCRIPTION
## Summary

- Add the Alembic migration for agent folders, agent tags, and preset folder links.
- Add the SQLAlchemy models and workspace relationships for agent folders/tags.
- Register the new workspace-scoped tables with the tenant RLS table registry.

## Testing

- Commit hooks ran: Ruff check/format, generated client check, Python type check, secret scan.
