### PR TITLE
feat(agent): add folder and tag APIs

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1671,6 +1671,161 @@ export const $AgentCustomProviderUpdate = {
   description: "Update custom provider.",
 } as const
 
+export const $AgentFolderCreate = {
+  properties: {
+    name: {
+      type: "string",
+      title: "Name",
+    },
+    parent_path: {
+      type: "string",
+      title: "Parent Path",
+      default: "/",
+    },
+  },
+  type: "object",
+  required: ["name"],
+  title: "AgentFolderCreate",
+} as const
+
+export const $AgentFolderDelete = {
+  properties: {
+    recursive: {
+      type: "boolean",
+      title: "Recursive",
+      default: false,
+    },
+  },
+  type: "object",
+  title: "AgentFolderDelete",
+} as const
+
+export const $AgentFolderDirectoryItem = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    name: {
+      type: "string",
+      title: "Name",
+    },
+    path: {
+      type: "string",
+      title: "Path",
+    },
+    workspace_id: {
+      type: "string",
+      format: "uuid",
+      title: "Workspace Id",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+    type: {
+      type: "string",
+      const: "folder",
+      title: "Type",
+    },
+    num_items: {
+      type: "integer",
+      title: "Num Items",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "name",
+    "path",
+    "workspace_id",
+    "created_at",
+    "updated_at",
+    "type",
+    "num_items",
+  ],
+  title: "AgentFolderDirectoryItem",
+} as const
+
+export const $AgentFolderMove = {
+  properties: {
+    new_parent_path: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "New Parent Path",
+    },
+  },
+  type: "object",
+  title: "AgentFolderMove",
+} as const
+
+export const $AgentFolderRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    name: {
+      type: "string",
+      title: "Name",
+    },
+    path: {
+      type: "string",
+      title: "Path",
+    },
+    workspace_id: {
+      type: "string",
+      format: "uuid",
+      title: "Workspace Id",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: ["id", "name", "path", "workspace_id", "created_at", "updated_at"],
+  title: "AgentFolderRead",
+} as const
+
+export const $AgentFolderUpdate = {
+  properties: {
+    name: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Name",
+    },
+  },
+  type: "object",
+  title: "AgentFolderUpdate",
+} as const
+
 export const $AgentModel = {
   properties: {
     component_id: {
@@ -2013,6 +2168,112 @@ export const $AgentPresetCreate = {
   description: "Payload for creating a new agent preset.",
 } as const
 
+export const $AgentPresetDirectoryItem = {
+  properties: {
+    type: {
+      type: "string",
+      const: "preset",
+      title: "Type",
+    },
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    name: {
+      type: "string",
+      title: "Name",
+    },
+    slug: {
+      type: "string",
+      title: "Slug",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    model_provider: {
+      type: "string",
+      title: "Model Provider",
+    },
+    model_name: {
+      type: "string",
+      title: "Model Name",
+    },
+    folder_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Folder Id",
+    },
+    tags: {
+      items: {
+        $ref: "#/components/schemas/TagRead",
+      },
+      type: "array",
+      title: "Tags",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: [
+    "type",
+    "id",
+    "name",
+    "slug",
+    "description",
+    "model_provider",
+    "model_name",
+    "folder_id",
+    "tags",
+    "created_at",
+    "updated_at",
+  ],
+  title: "AgentPresetDirectoryItem",
+  description: "Agent preset as a directory item.",
+} as const
+
+export const $AgentPresetMoveToFolder = {
+  properties: {
+    folder_path: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Folder Path",
+    },
+  },
+  type: "object",
+  title: "AgentPresetMoveToFolder",
+  description: "Payload for moving an agent preset to a folder.",
+} as const
+
 export const $AgentPresetRead = {
   properties: {
     instructions: {
@@ -2248,6 +2509,33 @@ export const $AgentPresetReadMinimal = {
       ],
       title: "Description",
     },
+    model_provider: {
+      type: "string",
+      title: "Model Provider",
+    },
+    model_name: {
+      type: "string",
+      title: "Model Name",
+    },
+    folder_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Folder Id",
+    },
+    tags: {
+      items: {
+        $ref: "#/components/schemas/TagRead",
+      },
+      type: "array",
+      title: "Tags",
+    },
     current_version_id: {
       anyOf: [
         {
@@ -2278,6 +2566,8 @@ export const $AgentPresetReadMinimal = {
     "name",
     "slug",
     "description",
+    "model_provider",
+    "model_name",
     "created_at",
     "updated_at",
   ],
@@ -2393,6 +2683,20 @@ export const $AgentPresetSkillBindingRead = {
   required: ["skill_id", "skill_version_id", "skill_name", "skill_version"],
   title: "AgentPresetSkillBindingRead",
   description: "Resolved preset skill binding with metadata.",
+} as const
+
+export const $AgentPresetTagCreate = {
+  properties: {
+    tag_id: {
+      type: "string",
+      format: "uuid",
+      title: "Tag Id",
+    },
+  },
+  type: "object",
+  required: ["tag_id"],
+  title: "AgentPresetTagCreate",
+  description: "Payload for adding a tag to an agent preset.",
 } as const
 
 export const $AgentPresetUpdate = {
@@ -3714,6 +4018,39 @@ export const $AgentSettingsUpdate = {
   },
   type: "object",
   title: "AgentSettingsUpdate",
+} as const
+
+export const $AgentTagRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    name: {
+      type: "string",
+      title: "Name",
+    },
+    ref: {
+      type: "string",
+      title: "Ref",
+    },
+    color: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Color",
+    },
+  },
+  type: "object",
+  required: ["id", "name", "ref", "color"],
+  title: "AgentTagRead",
+  description: "Tag data.",
 } as const
 
 export const $AppSettingsRead = {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1671,6 +1671,84 @@ export const $AgentCustomProviderUpdate = {
   description: "Update custom provider.",
 } as const
 
+export const $AgentDirectoryResponse = {
+  properties: {
+    items: {
+      items: {
+        oneOf: [
+          {
+            $ref: "#/components/schemas/AgentPresetDirectoryItem",
+          },
+          {
+            $ref: "#/components/schemas/AgentFolderDirectoryItem",
+          },
+        ],
+        discriminator: {
+          propertyName: "type",
+          mapping: {
+            folder: "#/components/schemas/AgentFolderDirectoryItem",
+            preset: "#/components/schemas/AgentPresetDirectoryItem",
+          },
+        },
+      },
+      type: "array",
+      title: "Items",
+    },
+    next_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Cursor",
+      description: "Cursor for next page",
+    },
+    prev_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Prev Cursor",
+      description: "Cursor for previous page",
+    },
+    has_more: {
+      type: "boolean",
+      title: "Has More",
+      description: "Whether more items exist",
+      default: false,
+    },
+    has_previous: {
+      type: "boolean",
+      title: "Has Previous",
+      description: "Whether previous items exist",
+      default: false,
+    },
+    total_estimate: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Estimate",
+      description: "Estimated total count from table statistics",
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "AgentDirectoryResponse",
+  description: "Paginated response for agent folder directory items.",
+} as const
+
 export const $AgentFolderCreate = {
   properties: {
     name: {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -9788,6 +9788,69 @@ export const $CursorPaginatedResponse_AgentPresetVersionReadMinimal_ = {
   title: "CursorPaginatedResponse[AgentPresetVersionReadMinimal]",
 } as const
 
+export const $CursorPaginatedResponse_AgentTagRead_ = {
+  properties: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/AgentTagRead",
+      },
+      type: "array",
+      title: "Items",
+    },
+    next_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Cursor",
+      description: "Cursor for next page",
+    },
+    prev_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Prev Cursor",
+      description: "Cursor for previous page",
+    },
+    has_more: {
+      type: "boolean",
+      title: "Has More",
+      description: "Whether more items exist",
+      default: false,
+    },
+    has_previous: {
+      type: "boolean",
+      title: "Has Previous",
+      description: "Whether previous items exist",
+      default: false,
+    },
+    total_estimate: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Estimate",
+      description: "Estimated total count from table statistics",
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "CursorPaginatedResponse[AgentTagRead]",
+} as const
+
 export const $CursorPaginatedResponse_CaseReadMinimal_ = {
   properties: {
     items: {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -9725,6 +9725,69 @@ export const $CursorPaginatedResponse_AdminOrgInvitationRead_ = {
   title: "CursorPaginatedResponse[AdminOrgInvitationRead]",
 } as const
 
+export const $CursorPaginatedResponse_AgentFolderRead_ = {
+  properties: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/AgentFolderRead",
+      },
+      type: "array",
+      title: "Items",
+    },
+    next_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Cursor",
+      description: "Cursor for next page",
+    },
+    prev_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Prev Cursor",
+      description: "Cursor for previous page",
+    },
+    has_more: {
+      type: "boolean",
+      title: "Has More",
+      description: "Whether more items exist",
+      default: false,
+    },
+    has_previous: {
+      type: "boolean",
+      title: "Has Previous",
+      description: "Whether previous items exist",
+      default: false,
+    },
+    total_estimate: {
+      anyOf: [
+        {
+          type: "integer",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Total Estimate",
+      description: "Estimated total count from table statistics",
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "CursorPaginatedResponse[AgentFolderRead]",
+} as const
+
 export const $CursorPaginatedResponse_AgentPresetVersionReadMinimal_ = {
   properties: {
     items: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -5638,7 +5638,10 @@ export const agentPresetsMoveAgentPresetToFolder = (
  * @param data The data for the request.
  * @param data.presetId
  * @param data.workspaceId
- * @returns AgentTagRead Successful Response
+ * @param data.limit
+ * @param data.cursor
+ * @param data.reverse
+ * @returns CursorPaginatedResponse_AgentTagRead_ Successful Response
  * @throws ApiError
  */
 export const agentPresetsListPresetTags = (
@@ -5650,6 +5653,11 @@ export const agentPresetsListPresetTags = (
     path: {
       preset_id: data.presetId,
       workspace_id: data.workspaceId,
+    },
+    query: {
+      limit: data.limit,
+      cursor: data.cursor,
+      reverse: data.reverse,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -5745,7 +5745,10 @@ export const agentFoldersGetDirectory = (
  * @param data The data for the request.
  * @param data.workspaceId
  * @param data.parentPath Parent folder path
- * @returns AgentFolderRead Successful Response
+ * @param data.limit
+ * @param data.cursor
+ * @param data.reverse
+ * @returns CursorPaginatedResponse_AgentFolderRead_ Successful Response
  * @throws ApiError
  */
 export const agentFoldersListFolders = (
@@ -5759,6 +5762,9 @@ export const agentFoldersListFolders = (
     },
     query: {
       parent_path: data.parentPath,
+      limit: data.limit,
+      cursor: data.cursor,
+      reverse: data.reverse,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -5906,7 +5906,10 @@ export const agentFoldersMoveFolder = (
  * List all agent tags in the workspace.
  * @param data The data for the request.
  * @param data.workspaceId
- * @returns AgentTagRead Successful Response
+ * @param data.limit
+ * @param data.cursor
+ * @param data.reverse
+ * @returns CursorPaginatedResponse_AgentTagRead_ Successful Response
  * @throws ApiError
  */
 export const agentTagsListAgentTags = (
@@ -5917,6 +5920,11 @@ export const agentTagsListAgentTags = (
     url: "/workspaces/{workspace_id}/agent-tags",
     path: {
       workspace_id: data.workspaceId,
+    },
+    query: {
+      limit: data.limit,
+      cursor: data.cursor,
+      reverse: data.reverse,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -107,6 +107,20 @@ import type {
   AgentCreateProviderCredentialsResponse,
   AgentDeleteProviderCredentialsData,
   AgentDeleteProviderCredentialsResponse,
+  AgentFoldersCreateFolderData,
+  AgentFoldersCreateFolderResponse,
+  AgentFoldersDeleteFolderData,
+  AgentFoldersDeleteFolderResponse,
+  AgentFoldersGetDirectoryData,
+  AgentFoldersGetDirectoryResponse,
+  AgentFoldersGetFolderData,
+  AgentFoldersGetFolderResponse,
+  AgentFoldersListFoldersData,
+  AgentFoldersListFoldersResponse,
+  AgentFoldersMoveFolderData,
+  AgentFoldersMoveFolderResponse,
+  AgentFoldersUpdateFolderData,
+  AgentFoldersUpdateFolderResponse,
   AgentGetDefaultModelResponse,
   AgentGetDefaultModelSelectionResponse,
   AgentGetProviderCredentialConfigData,
@@ -117,6 +131,8 @@ import type {
   AgentListModelsResponse,
   AgentListProviderCredentialConfigsResponse,
   AgentListProvidersResponse,
+  AgentPresetsAddPresetTagData,
+  AgentPresetsAddPresetTagResponse,
   AgentPresetsCompareAgentPresetVersionsData,
   AgentPresetsCompareAgentPresetVersionsResponse,
   AgentPresetsCreateAgentPresetData,
@@ -133,6 +149,12 @@ import type {
   AgentPresetsListAgentPresetsResponse,
   AgentPresetsListAgentPresetVersionsData,
   AgentPresetsListAgentPresetVersionsResponse,
+  AgentPresetsListPresetTagsData,
+  AgentPresetsListPresetTagsResponse,
+  AgentPresetsMoveAgentPresetToFolderData,
+  AgentPresetsMoveAgentPresetToFolderResponse,
+  AgentPresetsRemovePresetTagData,
+  AgentPresetsRemovePresetTagResponse,
   AgentPresetsRestoreAgentPresetVersionData,
   AgentPresetsRestoreAgentPresetVersionResponse,
   AgentPresetsUpdateAgentPresetData,
@@ -187,6 +209,16 @@ import type {
   AgentSkillsRestoreSkillVersionResponse,
   AgentSkillsUploadSkillData,
   AgentSkillsUploadSkillResponse,
+  AgentTagsCreateAgentTagData,
+  AgentTagsCreateAgentTagResponse,
+  AgentTagsDeleteAgentTagData,
+  AgentTagsDeleteAgentTagResponse,
+  AgentTagsGetAgentTagData,
+  AgentTagsGetAgentTagResponse,
+  AgentTagsListAgentTagsData,
+  AgentTagsListAgentTagsResponse,
+  AgentTagsUpdateAgentTagData,
+  AgentTagsUpdateAgentTagResponse,
   AgentUpdateProviderCredentialsData,
   AgentUpdateProviderCredentialsResponse,
   ApprovalsSubmitApprovalsData,
@@ -5564,6 +5596,430 @@ export const agentPresetsRestoreAgentPresetVersion = (
     path: {
       preset_id: data.presetId,
       version_id: data.versionId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Move Agent Preset To Folder
+ * Move an agent preset to a folder.
+ * @param data The data for the request.
+ * @param data.presetId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const agentPresetsMoveAgentPresetToFolder = (
+  data: AgentPresetsMoveAgentPresetToFolderData
+): CancelablePromise<AgentPresetsMoveAgentPresetToFolderResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}/move",
+    path: {
+      preset_id: data.presetId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Preset Tags
+ * List all tags for an agent preset.
+ * @param data The data for the request.
+ * @param data.presetId
+ * @param data.workspaceId
+ * @returns AgentTagRead Successful Response
+ * @throws ApiError
+ */
+export const agentPresetsListPresetTags = (
+  data: AgentPresetsListPresetTagsData
+): CancelablePromise<AgentPresetsListPresetTagsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}/tags",
+    path: {
+      preset_id: data.presetId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Add Preset Tag
+ * Add a tag to an agent preset.
+ * @param data The data for the request.
+ * @param data.presetId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const agentPresetsAddPresetTag = (
+  data: AgentPresetsAddPresetTagData
+): CancelablePromise<AgentPresetsAddPresetTagResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}/tags",
+    path: {
+      preset_id: data.presetId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Remove Preset Tag
+ * Remove a tag from an agent preset.
+ * @param data The data for the request.
+ * @param data.presetId
+ * @param data.tagId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const agentPresetsRemovePresetTag = (
+  data: AgentPresetsRemovePresetTagData
+): CancelablePromise<AgentPresetsRemovePresetTagResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/workspaces/{workspace_id}/agent/presets/{preset_id}/tags/{tag_id}",
+    path: {
+      preset_id: data.presetId,
+      tag_id: data.tagId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Directory
+ * Get directory items (presets and folders) in the given path.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.path Folder path
+ * @returns unknown Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersGetDirectory = (
+  data: AgentFoldersGetDirectoryData
+): CancelablePromise<AgentFoldersGetDirectoryResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/agent-folders/directory",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    query: {
+      path: data.path,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Folders
+ * List folders under the specified parent path.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.parentPath Parent folder path
+ * @returns AgentFolderRead Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersListFolders = (
+  data: AgentFoldersListFoldersData
+): CancelablePromise<AgentFoldersListFoldersResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/agent-folders",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    query: {
+      parent_path: data.parentPath,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create Folder
+ * Create a new agent folder.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns AgentFolderRead Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersCreateFolder = (
+  data: AgentFoldersCreateFolderData
+): CancelablePromise<AgentFoldersCreateFolderResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/agent-folders",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Folder
+ * Get folder details by ID.
+ * @param data The data for the request.
+ * @param data.folderId
+ * @param data.workspaceId
+ * @returns AgentFolderRead Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersGetFolder = (
+  data: AgentFoldersGetFolderData
+): CancelablePromise<AgentFoldersGetFolderResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/agent-folders/{folder_id}",
+    path: {
+      folder_id: data.folderId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Update Folder
+ * Update a folder (rename).
+ * @param data The data for the request.
+ * @param data.folderId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns AgentFolderRead Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersUpdateFolder = (
+  data: AgentFoldersUpdateFolderData
+): CancelablePromise<AgentFoldersUpdateFolderResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/workspaces/{workspace_id}/agent-folders/{folder_id}",
+    path: {
+      folder_id: data.folderId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete Folder
+ * Delete an agent folder.
+ * @param data The data for the request.
+ * @param data.folderId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersDeleteFolder = (
+  data: AgentFoldersDeleteFolderData
+): CancelablePromise<AgentFoldersDeleteFolderResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/workspaces/{workspace_id}/agent-folders/{folder_id}",
+    path: {
+      folder_id: data.folderId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Move Folder
+ * Move a folder to a new parent folder.
+ * @param data The data for the request.
+ * @param data.folderId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns AgentFolderRead Successful Response
+ * @throws ApiError
+ */
+export const agentFoldersMoveFolder = (
+  data: AgentFoldersMoveFolderData
+): CancelablePromise<AgentFoldersMoveFolderResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/agent-folders/{folder_id}/move",
+    path: {
+      folder_id: data.folderId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Agent Tags
+ * List all agent tags in the workspace.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @returns AgentTagRead Successful Response
+ * @throws ApiError
+ */
+export const agentTagsListAgentTags = (
+  data: AgentTagsListAgentTagsData
+): CancelablePromise<AgentTagsListAgentTagsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/agent-tags",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create Agent Tag
+ * Create a new agent tag definition.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns AgentTagRead Successful Response
+ * @throws ApiError
+ */
+export const agentTagsCreateAgentTag = (
+  data: AgentTagsCreateAgentTagData
+): CancelablePromise<AgentTagsCreateAgentTagResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/agent-tags",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Agent Tag
+ * Get an agent tag by ID.
+ * @param data The data for the request.
+ * @param data.tagId
+ * @param data.workspaceId
+ * @returns AgentTagRead Successful Response
+ * @throws ApiError
+ */
+export const agentTagsGetAgentTag = (
+  data: AgentTagsGetAgentTagData
+): CancelablePromise<AgentTagsGetAgentTagResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/agent-tags/{tag_id}",
+    path: {
+      tag_id: data.tagId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Update Agent Tag
+ * Update an agent tag definition.
+ * @param data The data for the request.
+ * @param data.tagId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns AgentTagRead Successful Response
+ * @throws ApiError
+ */
+export const agentTagsUpdateAgentTag = (
+  data: AgentTagsUpdateAgentTagData
+): CancelablePromise<AgentTagsUpdateAgentTagResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/workspaces/{workspace_id}/agent-tags/{tag_id}",
+    path: {
+      tag_id: data.tagId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete Agent Tag
+ * Delete an agent tag definition.
+ * @param data The data for the request.
+ * @param data.tagId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const agentTagsDeleteAgentTag = (
+  data: AgentTagsDeleteAgentTagData
+): CancelablePromise<AgentTagsDeleteAgentTagResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/workspaces/{workspace_id}/agent-tags/{tag_id}",
+    path: {
+      tag_id: data.tagId,
       workspace_id: data.workspaceId,
     },
     errors: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -5718,7 +5718,10 @@ export const agentPresetsRemovePresetTag = (
  * @param data The data for the request.
  * @param data.workspaceId
  * @param data.path Folder path
- * @returns unknown Successful Response
+ * @param data.limit
+ * @param data.cursor
+ * @param data.reverse
+ * @returns AgentDirectoryResponse Successful Response
  * @throws ApiError
  */
 export const agentFoldersGetDirectory = (
@@ -5732,6 +5735,9 @@ export const agentFoldersGetDirectory = (
     },
     query: {
       path: data.path,
+      limit: data.limit,
+      cursor: data.cursor,
+      reverse: data.reverse,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -442,6 +442,33 @@ export type AgentCustomProviderUpdate = {
   } | null
 }
 
+/**
+ * Paginated response for agent folder directory items.
+ */
+export type AgentDirectoryResponse = {
+  items: Array<AgentPresetDirectoryItem | AgentFolderDirectoryItem>
+  /**
+   * Cursor for next page
+   */
+  next_cursor?: string | null
+  /**
+   * Cursor for previous page
+   */
+  prev_cursor?: string | null
+  /**
+   * Whether more items exist
+   */
+  has_more?: boolean
+  /**
+   * Whether previous items exist
+   */
+  has_previous?: boolean
+  /**
+   * Estimated total count from table statistics
+   */
+  total_estimate?: number | null
+}
+
 export type AgentFolderCreate = {
   name: string
   parent_path?: string
@@ -10344,16 +10371,17 @@ export type AgentPresetsRemovePresetTagData = {
 export type AgentPresetsRemovePresetTagResponse = void
 
 export type AgentFoldersGetDirectoryData = {
+  cursor?: string | null
+  limit?: number
   /**
    * Folder path
    */
   path?: string
+  reverse?: boolean
   workspaceId: string
 }
 
-export type AgentFoldersGetDirectoryResponse = Array<
-  AgentPresetDirectoryItem | AgentFolderDirectoryItem
->
+export type AgentFoldersGetDirectoryResponse = AgentDirectoryResponse
 
 export type AgentFoldersListFoldersData = {
   cursor?: string | null
@@ -15150,7 +15178,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: Array<AgentPresetDirectoryItem | AgentFolderDirectoryItem>
+        200: AgentDirectoryResponse
         /**
          * Validation Error
          */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -442,6 +442,43 @@ export type AgentCustomProviderUpdate = {
   } | null
 }
 
+export type AgentFolderCreate = {
+  name: string
+  parent_path?: string
+}
+
+export type AgentFolderDelete = {
+  recursive?: boolean
+}
+
+export type AgentFolderDirectoryItem = {
+  id: string
+  name: string
+  path: string
+  workspace_id: string
+  created_at: string
+  updated_at: string
+  type: "folder"
+  num_items: number
+}
+
+export type AgentFolderMove = {
+  new_parent_path?: string | null
+}
+
+export type AgentFolderRead = {
+  id: string
+  name: string
+  path: string
+  workspace_id: string
+  created_at: string
+  updated_at: string
+}
+
+export type AgentFolderUpdate = {
+  name?: string | null
+}
+
 export type AgentModel = {
   component_id?: "agent-model"
 }
@@ -510,6 +547,30 @@ export type AgentPresetCreate = {
 }
 
 /**
+ * Agent preset as a directory item.
+ */
+export type AgentPresetDirectoryItem = {
+  type: "preset"
+  id: string
+  name: string
+  slug: string
+  description: string | null
+  model_provider: string
+  model_name: string
+  folder_id: string | null
+  tags: Array<TagRead>
+  created_at: string
+  updated_at: string
+}
+
+/**
+ * Payload for moving an agent preset to a folder.
+ */
+export type AgentPresetMoveToFolder = {
+  folder_path?: string | null
+}
+
+/**
  * API model for reading agent presets.
  */
 export type AgentPresetRead = {
@@ -548,6 +609,10 @@ export type AgentPresetReadMinimal = {
   name: string
   slug: string
   description: string | null
+  model_provider: string
+  model_name: string
+  folder_id?: string | null
+  tags?: Array<TagRead>
   current_version_id?: string | null
   created_at: string
   updated_at: string
@@ -581,6 +646,13 @@ export type AgentPresetSkillBindingRead = {
   skill_version_id: string
   skill_name: string
   skill_version: number
+}
+
+/**
+ * Payload for adding a tag to an agent preset.
+ */
+export type AgentPresetTagCreate = {
+  tag_id: string
 }
 
 /**
@@ -866,6 +938,16 @@ export type AgentSettingsUpdate = {
    * Whether to automatically inject case content into agent prompts when a case_id is available.
    */
   agent_case_chat_inject_content?: boolean
+}
+
+/**
+ * Tag data.
+ */
+export type AgentTagRead = {
+  id: string
+  name: string
+  ref: string
+  color: string | null
 }
 
 /**
@@ -10182,6 +10264,132 @@ export type AgentPresetsRestoreAgentPresetVersionData = {
 
 export type AgentPresetsRestoreAgentPresetVersionResponse = AgentPresetRead
 
+export type AgentPresetsMoveAgentPresetToFolderData = {
+  presetId: string
+  requestBody: AgentPresetMoveToFolder
+  workspaceId: string
+}
+
+export type AgentPresetsMoveAgentPresetToFolderResponse = void
+
+export type AgentPresetsListPresetTagsData = {
+  presetId: string
+  workspaceId: string
+}
+
+export type AgentPresetsListPresetTagsResponse = Array<AgentTagRead>
+
+export type AgentPresetsAddPresetTagData = {
+  presetId: string
+  requestBody: AgentPresetTagCreate
+  workspaceId: string
+}
+
+export type AgentPresetsAddPresetTagResponse = unknown
+
+export type AgentPresetsRemovePresetTagData = {
+  presetId: string
+  tagId: string
+  workspaceId: string
+}
+
+export type AgentPresetsRemovePresetTagResponse = void
+
+export type AgentFoldersGetDirectoryData = {
+  /**
+   * Folder path
+   */
+  path?: string
+  workspaceId: string
+}
+
+export type AgentFoldersGetDirectoryResponse = Array<
+  AgentPresetDirectoryItem | AgentFolderDirectoryItem
+>
+
+export type AgentFoldersListFoldersData = {
+  /**
+   * Parent folder path
+   */
+  parentPath?: string
+  workspaceId: string
+}
+
+export type AgentFoldersListFoldersResponse = Array<AgentFolderRead>
+
+export type AgentFoldersCreateFolderData = {
+  requestBody: AgentFolderCreate
+  workspaceId: string
+}
+
+export type AgentFoldersCreateFolderResponse = AgentFolderRead
+
+export type AgentFoldersGetFolderData = {
+  folderId: string
+  workspaceId: string
+}
+
+export type AgentFoldersGetFolderResponse = AgentFolderRead
+
+export type AgentFoldersUpdateFolderData = {
+  folderId: string
+  requestBody: AgentFolderUpdate
+  workspaceId: string
+}
+
+export type AgentFoldersUpdateFolderResponse = AgentFolderRead
+
+export type AgentFoldersDeleteFolderData = {
+  folderId: string
+  requestBody: AgentFolderDelete
+  workspaceId: string
+}
+
+export type AgentFoldersDeleteFolderResponse = void
+
+export type AgentFoldersMoveFolderData = {
+  folderId: string
+  requestBody: AgentFolderMove
+  workspaceId: string
+}
+
+export type AgentFoldersMoveFolderResponse = AgentFolderRead
+
+export type AgentTagsListAgentTagsData = {
+  workspaceId: string
+}
+
+export type AgentTagsListAgentTagsResponse = Array<AgentTagRead>
+
+export type AgentTagsCreateAgentTagData = {
+  requestBody: TagCreate
+  workspaceId: string
+}
+
+export type AgentTagsCreateAgentTagResponse = AgentTagRead
+
+export type AgentTagsGetAgentTagData = {
+  tagId: string
+  workspaceId: string
+}
+
+export type AgentTagsGetAgentTagResponse = AgentTagRead
+
+export type AgentTagsUpdateAgentTagData = {
+  requestBody: TagUpdate
+  tagId: string
+  workspaceId: string
+}
+
+export type AgentTagsUpdateAgentTagResponse = AgentTagRead
+
+export type AgentTagsDeleteAgentTagData = {
+  tagId: string
+  workspaceId: string
+}
+
+export type AgentTagsDeleteAgentTagResponse = void
+
 export type AgentSkillsListSkillsData = {
   cursor?: string | null
   limit?: number
@@ -14814,6 +15022,232 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: AgentPresetRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/presets/{preset_id}/move": {
+    post: {
+      req: AgentPresetsMoveAgentPresetToFolderData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/presets/{preset_id}/tags": {
+    get: {
+      req: AgentPresetsListPresetTagsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<AgentTagRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    post: {
+      req: AgentPresetsAddPresetTagData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: unknown
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/presets/{preset_id}/tags/{tag_id}": {
+    delete: {
+      req: AgentPresetsRemovePresetTagData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent-folders/directory": {
+    get: {
+      req: AgentFoldersGetDirectoryData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<AgentPresetDirectoryItem | AgentFolderDirectoryItem>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent-folders": {
+    get: {
+      req: AgentFoldersListFoldersData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<AgentFolderRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    post: {
+      req: AgentFoldersCreateFolderData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: AgentFolderRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent-folders/{folder_id}": {
+    get: {
+      req: AgentFoldersGetFolderData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AgentFolderRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    patch: {
+      req: AgentFoldersUpdateFolderData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AgentFolderRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: AgentFoldersDeleteFolderData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent-folders/{folder_id}/move": {
+    post: {
+      req: AgentFoldersMoveFolderData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AgentFolderRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent-tags": {
+    get: {
+      req: AgentTagsListAgentTagsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<AgentTagRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    post: {
+      req: AgentTagsCreateAgentTagData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: AgentTagRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent-tags/{tag_id}": {
+    get: {
+      req: AgentTagsGetAgentTagData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AgentTagRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    patch: {
+      req: AgentTagsUpdateAgentTagData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AgentTagRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: AgentTagsDeleteAgentTagData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
         /**
          * Validation Error
          */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -10348,11 +10348,15 @@ export type AgentPresetsMoveAgentPresetToFolderData = {
 export type AgentPresetsMoveAgentPresetToFolderResponse = void
 
 export type AgentPresetsListPresetTagsData = {
+  cursor?: string | null
+  limit?: number
   presetId: string
+  reverse?: boolean
   workspaceId: string
 }
 
-export type AgentPresetsListPresetTagsResponse = Array<AgentTagRead>
+export type AgentPresetsListPresetTagsResponse =
+  CursorPaginatedResponse_AgentTagRead_
 
 export type AgentPresetsAddPresetTagData = {
   presetId: string
@@ -15135,7 +15139,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: Array<AgentTagRead>
+        200: CursorPaginatedResponse_AgentTagRead_
         /**
          * Validation Error
          */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -10365,7 +10365,7 @@ export type AgentFoldersUpdateFolderResponse = AgentFolderRead
 
 export type AgentFoldersDeleteFolderData = {
   folderId: string
-  requestBody: AgentFolderDelete
+  requestBody?: AgentFolderDelete | null
   workspaceId: string
 }
 

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2738,6 +2738,30 @@ export type CursorPaginatedResponse_AdminOrgInvitationRead_ = {
   total_estimate?: number | null
 }
 
+export type CursorPaginatedResponse_AgentFolderRead_ = {
+  items: Array<AgentFolderRead>
+  /**
+   * Cursor for next page
+   */
+  next_cursor?: string | null
+  /**
+   * Cursor for previous page
+   */
+  prev_cursor?: string | null
+  /**
+   * Whether more items exist
+   */
+  has_more?: boolean
+  /**
+   * Whether previous items exist
+   */
+  has_previous?: boolean
+  /**
+   * Estimated total count from table statistics
+   */
+  total_estimate?: number | null
+}
+
 export type CursorPaginatedResponse_AgentPresetVersionReadMinimal_ = {
   items: Array<AgentPresetVersionReadMinimal>
   /**
@@ -10332,14 +10356,18 @@ export type AgentFoldersGetDirectoryResponse = Array<
 >
 
 export type AgentFoldersListFoldersData = {
+  cursor?: string | null
+  limit?: number
   /**
    * Parent folder path
    */
   parentPath?: string
+  reverse?: boolean
   workspaceId: string
 }
 
-export type AgentFoldersListFoldersResponse = Array<AgentFolderRead>
+export type AgentFoldersListFoldersResponse =
+  CursorPaginatedResponse_AgentFolderRead_
 
 export type AgentFoldersCreateFolderData = {
   requestBody: AgentFolderCreate
@@ -15137,7 +15165,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: Array<AgentFolderRead>
+        200: CursorPaginatedResponse_AgentFolderRead_
         /**
          * Validation Error
          */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2762,6 +2762,30 @@ export type CursorPaginatedResponse_AgentPresetVersionReadMinimal_ = {
   total_estimate?: number | null
 }
 
+export type CursorPaginatedResponse_AgentTagRead_ = {
+  items: Array<AgentTagRead>
+  /**
+   * Cursor for next page
+   */
+  next_cursor?: string | null
+  /**
+   * Cursor for previous page
+   */
+  prev_cursor?: string | null
+  /**
+   * Whether more items exist
+   */
+  has_more?: boolean
+  /**
+   * Whether previous items exist
+   */
+  has_previous?: boolean
+  /**
+   * Estimated total count from table statistics
+   */
+  total_estimate?: number | null
+}
+
 export type CursorPaginatedResponse_CaseReadMinimal_ = {
   items: Array<CaseReadMinimal>
   /**
@@ -10356,10 +10380,14 @@ export type AgentFoldersMoveFolderData = {
 export type AgentFoldersMoveFolderResponse = AgentFolderRead
 
 export type AgentTagsListAgentTagsData = {
+  cursor?: string | null
+  limit?: number
+  reverse?: boolean
   workspaceId: string
 }
 
-export type AgentTagsListAgentTagsResponse = Array<AgentTagRead>
+export type AgentTagsListAgentTagsResponse =
+  CursorPaginatedResponse_AgentTagRead_
 
 export type AgentTagsCreateAgentTagData = {
   requestBody: TagCreate
@@ -15193,7 +15221,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: Array<AgentTagRead>
+        200: CursorPaginatedResponse_AgentTagRead_
         /**
          * Validation Error
          */

--- a/tests/unit/api/test_api_agent_folders.py
+++ b/tests/unit/api/test_api_agent_folders.py
@@ -1,0 +1,319 @@
+"""HTTP-level tests for agent folder API endpoints."""
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.agent.folders import router as agent_folder_router
+from tracecat.agent.folders.service import (
+    AGENT_FOLDER_CONFLICT_CODE,
+    AGENT_FOLDER_INVALID_CODE,
+    AGENT_FOLDER_PARENT_NOT_FOUND_CODE,
+)
+from tracecat.agent.preset import router as agent_preset_router
+from tracecat.agent.preset.schemas import AgentPresetMoveToFolder
+from tracecat.auth.types import Role
+from tracecat.exceptions import EntitlementRequired, TracecatValidationError
+
+# Fixed UUID for parametrized test IDs — uuid.uuid4() at module level causes
+# pytest-xdist collection mismatches because each worker generates a different value.
+_FIXED_FOLDER_ID = "00000000-0000-4000-8000-000000000001"
+
+
+def _mock_service_with_async_method(
+    method_name: str,
+    *,
+    side_effect: Exception | None = None,
+    return_value: object = None,
+) -> MagicMock:
+    service = MagicMock()
+    service_method = AsyncMock()
+    if side_effect is not None:
+        service_method.side_effect = side_effect
+    else:
+        service_method.return_value = return_value
+    setattr(service, method_name, service_method)
+    return service
+
+
+@pytest.mark.anyio
+async def test_create_folder_conflict_returns_409(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Duplicate folder paths should surface as conflicts."""
+    with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "create_folder",
+            side_effect=TracecatValidationError(
+                "Folder /agents/ already exists",
+                detail={"code": AGENT_FOLDER_CONFLICT_CODE},
+            ),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.post(
+            "/agent-folders",
+            json={"name": "agents", "parent_path": "/"},
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert response.json()["detail"] == "Folder /agents/ already exists"
+
+
+@pytest.mark.anyio
+async def test_create_folder_missing_parent_returns_404(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Missing parent paths should not be misreported as conflicts."""
+    with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "create_folder",
+            side_effect=TracecatValidationError(
+                "Parent path /missing/ not found",
+                detail={"code": AGENT_FOLDER_PARENT_NOT_FOUND_CODE},
+            ),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.post(
+            "/agent-folders",
+            json={"name": "child", "parent_path": "/missing/"},
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json()["detail"] == "Parent path /missing/ not found"
+
+
+@pytest.mark.anyio
+async def test_create_folder_blank_name_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Blank folder names should be rejected before path construction."""
+    with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "create_folder",
+            side_effect=TracecatValidationError(
+                "Folder name cannot be empty",
+                detail={"code": AGENT_FOLDER_INVALID_CODE},
+            ),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.post(
+            "/agent-folders",
+            json={"name": "   ", "parent_path": "/"},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "Folder name cannot be empty"
+
+
+@pytest.mark.anyio
+async def test_update_folder_validation_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Invalid rename requests should stay in the 4xx range."""
+    with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "rename_folder",
+            side_effect=TracecatValidationError(
+                "Folder name cannot contain slashes",
+                detail={"code": AGENT_FOLDER_INVALID_CODE},
+            ),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.patch(
+            f"/agent-folders/{uuid.uuid4()}",
+            json={"name": "bad/name"},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "Folder name cannot contain slashes"
+
+
+@pytest.mark.anyio
+async def test_update_folder_blank_name_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Blank folder renames should stay in the 4xx range."""
+    with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "rename_folder",
+            side_effect=TracecatValidationError(
+                "Folder name cannot be empty",
+                detail={"code": AGENT_FOLDER_INVALID_CODE},
+            ),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.patch(
+            f"/agent-folders/{uuid.uuid4()}",
+            json={"name": "   "},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "Folder name cannot be empty"
+
+
+@pytest.mark.anyio
+async def test_move_folder_validation_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Cyclic folder moves should not fall through as 500s."""
+    with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "move_folder",
+            side_effect=TracecatValidationError(
+                "Cannot create cyclic folder structure",
+                detail={"code": AGENT_FOLDER_INVALID_CODE},
+            ),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.post(
+            f"/agent-folders/{uuid.uuid4()}/move",
+            json={"new_parent_path": "/"},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "Cannot create cyclic folder structure"
+
+
+@pytest.mark.anyio
+async def test_move_agent_preset_to_root_skips_folder_lookup(
+    test_admin_role: Role,
+) -> None:
+    """Moving to '/' should clear the folder instead of trying to resolve a root row."""
+    preset_id = uuid.uuid4()
+    session = AsyncMock()
+
+    with patch.object(agent_preset_router, "AgentFolderService") as mock_service_cls:
+        mock_service = MagicMock()
+        mock_service.move_preset = AsyncMock(return_value=None)
+        mock_service.get_folder_by_path = AsyncMock()
+        mock_service_cls.return_value = mock_service
+
+        await agent_preset_router.move_agent_preset_to_folder(
+            role=test_admin_role,
+            session=session,
+            preset_id=preset_id,
+            params=AgentPresetMoveToFolder(folder_path="/"),
+        )
+
+        mock_service.get_folder_by_path.assert_not_called()
+        mock_service.move_preset.assert_awaited_once_with(preset_id, None)
+
+
+@pytest.mark.anyio
+async def test_move_agent_preset_requires_agent_addons_entitlement(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Preset moves should surface AGENT_ADDONS entitlement failures as 403s."""
+    preset_id = uuid.uuid4()
+
+    with patch.object(agent_preset_router, "AgentFolderService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "move_preset",
+            side_effect=EntitlementRequired("agent_addons"),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.post(
+            f"/agent/presets/{preset_id}/move",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"folder_path": "/"},
+        )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    payload = response.json()
+    assert payload["type"] == "EntitlementRequired"
+    assert payload["detail"]["entitlement"] == "agent_addons"
+
+
+@pytest.mark.anyio
+async def test_get_directory_requires_agent_addons_entitlement(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Folder directory reads should preserve the AGENT_ADDONS gate at HTTP level."""
+    with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "get_directory_items",
+            side_effect=EntitlementRequired("agent_addons"),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.get("/agent-folders/directory", params={"path": "/"})
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    payload = response.json()
+    assert payload["type"] == "EntitlementRequired"
+    assert payload["detail"]["entitlement"] == "agent_addons"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("method", "path", "kwargs", "service_method"),
+    [
+        ("get", "/agent-folders", {"params": {"parent_path": "/"}}, "list_folders"),
+        (
+            "post",
+            "/agent-folders",
+            {"json": {"name": "agents", "parent_path": "/"}},
+            "create_folder",
+        ),
+        ("get", f"/agent-folders/{_FIXED_FOLDER_ID}", {}, "get_folder"),
+        (
+            "patch",
+            f"/agent-folders/{_FIXED_FOLDER_ID}",
+            {"json": {"name": "renamed"}},
+            "rename_folder",
+        ),
+        (
+            "delete",
+            f"/agent-folders/{_FIXED_FOLDER_ID}",
+            {"json": {"recursive": False}},
+            "delete_folder",
+        ),
+        (
+            "post",
+            f"/agent-folders/{_FIXED_FOLDER_ID}/move",
+            {"json": {"new_parent_path": "/"}},
+            "move_folder",
+        ),
+    ],
+)
+async def test_folder_management_routes_require_agent_addons_entitlement(
+    client: TestClient,
+    test_admin_role: Role,
+    method: str,
+    path: str,
+    kwargs: dict[str, Any],
+    service_method: str,
+) -> None:
+    """Folder management routes should surface AGENT_ADDONS failures as 403s."""
+    with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            service_method,
+            side_effect=EntitlementRequired("agent_addons"),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.request(method.upper(), path, **kwargs)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    payload = response.json()
+    assert payload["type"] == "EntitlementRequired"
+    assert payload["detail"]["entitlement"] == "agent_addons"

--- a/tests/unit/api/test_api_agent_folders.py
+++ b/tests/unit/api/test_api_agent_folders.py
@@ -157,6 +157,48 @@ async def test_list_folders_returns_paginated_response(
 
 
 @pytest.mark.anyio
+async def test_get_directory_returns_paginated_response(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Directory listing should use the cursor-paginated API shape."""
+    with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "get_directory_items_paginated",
+            return_value=CursorPaginatedResponse(items=[], has_more=True),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.get(
+            "/agent-folders/directory",
+            params={
+                "path": "/agents/",
+                "limit": 2,
+                "cursor": "encoded-cursor",
+                "reverse": True,
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "items": [],
+        "next_cursor": None,
+        "prev_cursor": None,
+        "has_more": True,
+        "has_previous": False,
+        "total_estimate": None,
+    }
+    mock_service.get_directory_items_paginated.assert_awaited_once_with(
+        "/agents/",
+        CursorPaginationParams(
+            limit=2,
+            cursor="encoded-cursor",
+            reverse=True,
+        ),
+    )
+
+
+@pytest.mark.anyio
 async def test_create_folder_blank_name_returns_400(
     client: TestClient,
     test_admin_role: Role,
@@ -316,7 +358,7 @@ async def test_get_directory_requires_agent_addons_entitlement(
     """Folder directory reads should preserve the AGENT_ADDONS gate at HTTP level."""
     with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
         mock_service = _mock_service_with_async_method(
-            "get_directory_items",
+            "get_directory_items_paginated",
             side_effect=EntitlementRequired("agent_addons"),
         )
         mock_service_cls.return_value = mock_service

--- a/tests/unit/api/test_api_agent_folders.py
+++ b/tests/unit/api/test_api_agent_folders.py
@@ -10,9 +10,7 @@ from fastapi.testclient import TestClient
 
 from tracecat.agent.folders import router as agent_folder_router
 from tracecat.agent.folders.service import (
-    AGENT_FOLDER_CONFLICT_CODE,
-    AGENT_FOLDER_INVALID_CODE,
-    AGENT_FOLDER_PARENT_NOT_FOUND_CODE,
+    AgentFolderErrorCode,
 )
 from tracecat.agent.preset import router as agent_preset_router
 from tracecat.agent.preset.schemas import AgentPresetMoveToFolder
@@ -52,7 +50,7 @@ async def test_create_folder_conflict_returns_409(
             "create_folder",
             side_effect=TracecatValidationError(
                 "Folder /agents/ already exists",
-                detail={"code": AGENT_FOLDER_CONFLICT_CODE},
+                detail={"code": AgentFolderErrorCode.CONFLICT.value},
             ),
         )
         mock_service_cls.return_value = mock_service
@@ -77,7 +75,7 @@ async def test_create_folder_missing_parent_returns_404(
             "create_folder",
             side_effect=TracecatValidationError(
                 "Parent path /missing/ not found",
-                detail={"code": AGENT_FOLDER_PARENT_NOT_FOUND_CODE},
+                detail={"code": AgentFolderErrorCode.PARENT_NOT_FOUND.value},
             ),
         )
         mock_service_cls.return_value = mock_service
@@ -102,7 +100,7 @@ async def test_list_folders_missing_parent_returns_404(
             "list_folders_paginated",
             side_effect=TracecatValidationError(
                 "Parent path /missing/ not found",
-                detail={"code": AGENT_FOLDER_PARENT_NOT_FOUND_CODE},
+                detail={"code": AgentFolderErrorCode.PARENT_NOT_FOUND.value},
             ),
         )
         mock_service_cls.return_value = mock_service
@@ -169,7 +167,7 @@ async def test_create_folder_blank_name_returns_400(
             "create_folder",
             side_effect=TracecatValidationError(
                 "Folder name cannot be empty",
-                detail={"code": AGENT_FOLDER_INVALID_CODE},
+                detail={"code": AgentFolderErrorCode.INVALID.value},
             ),
         )
         mock_service_cls.return_value = mock_service
@@ -194,7 +192,7 @@ async def test_update_folder_validation_returns_400(
             "rename_folder",
             side_effect=TracecatValidationError(
                 "Folder name cannot contain slashes",
-                detail={"code": AGENT_FOLDER_INVALID_CODE},
+                detail={"code": AgentFolderErrorCode.INVALID.value},
             ),
         )
         mock_service_cls.return_value = mock_service
@@ -219,7 +217,7 @@ async def test_update_folder_blank_name_returns_400(
             "rename_folder",
             side_effect=TracecatValidationError(
                 "Folder name cannot be empty",
-                detail={"code": AGENT_FOLDER_INVALID_CODE},
+                detail={"code": AgentFolderErrorCode.INVALID.value},
             ),
         )
         mock_service_cls.return_value = mock_service
@@ -244,7 +242,7 @@ async def test_move_folder_validation_returns_400(
             "move_folder",
             side_effect=TracecatValidationError(
                 "Cannot create cyclic folder structure",
-                detail={"code": AGENT_FOLDER_INVALID_CODE},
+                detail={"code": AgentFolderErrorCode.INVALID.value},
             ),
         )
         mock_service_cls.return_value = mock_service

--- a/tests/unit/api/test_api_agent_folders.py
+++ b/tests/unit/api/test_api_agent_folders.py
@@ -91,6 +91,32 @@ async def test_create_folder_missing_parent_returns_404(
 
 
 @pytest.mark.anyio
+async def test_list_folders_missing_parent_returns_404(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Listing a missing folder path should not look like an empty folder."""
+    with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "list_folders",
+            side_effect=TracecatValidationError(
+                "Parent path /missing/ not found",
+                detail={"code": AGENT_FOLDER_PARENT_NOT_FOUND_CODE},
+            ),
+        )
+        mock_service._normalize_folder_path.return_value = "/missing/"
+        mock_service_cls.return_value = mock_service
+
+        response = client.get(
+            "/agent-folders",
+            params={"parent_path": "/missing/"},
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json()["detail"] == "Parent path /missing/ not found"
+
+
+@pytest.mark.anyio
 async def test_create_folder_blank_name_returns_400(
     client: TestClient,
     test_admin_role: Role,

--- a/tests/unit/api/test_api_agent_folders.py
+++ b/tests/unit/api/test_api_agent_folders.py
@@ -18,6 +18,7 @@ from tracecat.agent.preset import router as agent_preset_router
 from tracecat.agent.preset.schemas import AgentPresetMoveToFolder
 from tracecat.auth.types import Role
 from tracecat.exceptions import EntitlementRequired, TracecatValidationError
+from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 
 # Fixed UUID for parametrized test IDs — uuid.uuid4() at module level causes
 # pytest-xdist collection mismatches because each worker generates a different value.
@@ -98,13 +99,12 @@ async def test_list_folders_missing_parent_returns_404(
     """Listing a missing folder path should not look like an empty folder."""
     with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
         mock_service = _mock_service_with_async_method(
-            "list_folders",
+            "list_folders_paginated",
             side_effect=TracecatValidationError(
                 "Parent path /missing/ not found",
                 detail={"code": AGENT_FOLDER_PARENT_NOT_FOUND_CODE},
             ),
         )
-        mock_service._normalize_folder_path.return_value = "/missing/"
         mock_service_cls.return_value = mock_service
 
         response = client.get(
@@ -114,6 +114,48 @@ async def test_list_folders_missing_parent_returns_404(
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json()["detail"] == "Parent path /missing/ not found"
+
+
+@pytest.mark.anyio
+async def test_list_folders_returns_paginated_response(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Folder listing should use the cursor-paginated API shape."""
+    with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "list_folders_paginated",
+            return_value=CursorPaginatedResponse(items=[], has_more=True),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.get(
+            "/agent-folders",
+            params={
+                "parent_path": "/agents/",
+                "limit": 2,
+                "cursor": "encoded-cursor",
+                "reverse": True,
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "items": [],
+        "next_cursor": None,
+        "prev_cursor": None,
+        "has_more": True,
+        "has_previous": False,
+        "total_estimate": None,
+    }
+    mock_service.list_folders_paginated.assert_awaited_once_with(
+        parent_path="/agents/",
+        params=CursorPaginationParams(
+            limit=2,
+            cursor="encoded-cursor",
+            reverse=True,
+        ),
+    )
 
 
 @pytest.mark.anyio
@@ -311,7 +353,12 @@ async def test_delete_folder_without_body_defaults_to_non_recursive(
 @pytest.mark.parametrize(
     ("method", "path", "kwargs", "service_method"),
     [
-        ("get", "/agent-folders", {"params": {"parent_path": "/"}}, "list_folders"),
+        (
+            "get",
+            "/agent-folders",
+            {"params": {"parent_path": "/"}},
+            "list_folders_paginated",
+        ),
         (
             "post",
             "/agent-folders",

--- a/tests/unit/api/test_api_agent_folders.py
+++ b/tests/unit/api/test_api_agent_folders.py
@@ -264,6 +264,24 @@ async def test_get_directory_requires_agent_addons_entitlement(
 
 
 @pytest.mark.anyio
+async def test_delete_folder_without_body_defaults_to_non_recursive(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Non-recursive folder deletes should not require a request body."""
+    folder_id = uuid.uuid4()
+
+    with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method("delete_folder")
+        mock_service_cls.return_value = mock_service
+
+        response = client.delete(f"/agent-folders/{folder_id}")
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    mock_service.delete_folder.assert_awaited_once_with(folder_id, recursive=False)
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     ("method", "path", "kwargs", "service_method"),
     [

--- a/tests/unit/api/test_api_agent_tags.py
+++ b/tests/unit/api/test_api_agent_tags.py
@@ -1,0 +1,152 @@
+"""HTTP-level tests for agent preset tag entitlement gating."""
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.agent.tags import definitions_router as agent_tag_definitions_router
+from tracecat.agent.tags import router as agent_tags_router
+from tracecat.auth.types import Role
+from tracecat.exceptions import EntitlementRequired
+
+# Fixed UUID for parametrized test IDs — uuid.uuid4() at module level causes
+# pytest-xdist collection mismatches because each worker generates a different value.
+_FIXED_TAG_ID = "00000000-0000-4000-8000-000000000002"
+
+
+def _mock_service_with_async_method(
+    method_name: str,
+    *,
+    side_effect: Exception | None = None,
+) -> MagicMock:
+    service = MagicMock()
+    service_method = AsyncMock()
+    if side_effect is not None:
+        service_method.side_effect = side_effect
+    setattr(service, method_name, service_method)
+    return service
+
+
+@pytest.mark.anyio
+async def test_list_preset_tags_requires_agent_addons_entitlement(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Preset tag reads should surface AGENT_ADDONS entitlement failures as 403s."""
+    preset_id = uuid.uuid4()
+
+    with patch.object(agent_tags_router, "AgentTagsService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "list_tags_for_preset",
+            side_effect=EntitlementRequired("agent_addons"),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.get(f"/agent/presets/{preset_id}/tags")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    payload = response.json()
+    assert payload["type"] == "EntitlementRequired"
+    assert payload["detail"]["entitlement"] == "agent_addons"
+
+
+@pytest.mark.anyio
+async def test_add_preset_tag_requires_agent_addons_entitlement(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Preset tag writes should surface AGENT_ADDONS entitlement failures as 403s."""
+    preset_id = uuid.uuid4()
+    tag_id = uuid.uuid4()
+
+    with patch.object(agent_tags_router, "AgentTagsService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "add_preset_tag",
+            side_effect=EntitlementRequired("agent_addons"),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.post(
+            f"/agent/presets/{preset_id}/tags",
+            json={"tag_id": str(tag_id)},
+        )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    payload = response.json()
+    assert payload["type"] == "EntitlementRequired"
+    assert payload["detail"]["entitlement"] == "agent_addons"
+
+
+@pytest.mark.anyio
+async def test_remove_preset_tag_requires_agent_addons_entitlement(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Preset tag deletes should surface AGENT_ADDONS entitlement failures as 403s."""
+    preset_id = uuid.uuid4()
+    tag_id = uuid.uuid4()
+
+    with patch.object(agent_tags_router, "AgentTagsService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "get_preset_tag",
+            side_effect=EntitlementRequired("agent_addons"),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.delete(f"/agent/presets/{preset_id}/tags/{tag_id}")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    payload = response.json()
+    assert payload["type"] == "EntitlementRequired"
+    assert payload["detail"]["entitlement"] == "agent_addons"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("method", "path", "kwargs", "service_method"),
+    [
+        ("get", "/agent-tags", {}, "list_tags"),
+        ("get", f"/agent-tags/{_FIXED_TAG_ID}", {}, "get_tag"),
+        (
+            "post",
+            "/agent-tags",
+            {"json": {"name": "Urgent", "color": "#000000"}},
+            "create_tag",
+        ),
+        (
+            "patch",
+            f"/agent-tags/{_FIXED_TAG_ID}",
+            {"json": {"name": "Updated"}},
+            "get_tag",
+        ),
+        ("delete", f"/agent-tags/{_FIXED_TAG_ID}", {}, "get_tag"),
+    ],
+)
+async def test_agent_tag_definition_routes_require_agent_addons_entitlement(
+    client: TestClient,
+    test_admin_role: Role,
+    method: str,
+    path: str,
+    kwargs: dict[str, Any],
+    service_method: str,
+) -> None:
+    """Agent tag definition CRUD should surface AGENT_ADDONS failures as 403s."""
+    with patch.object(
+        agent_tag_definitions_router, "AgentTagsService"
+    ) as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            service_method,
+            side_effect=EntitlementRequired("agent_addons"),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = getattr(client, method)(path, **kwargs)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    payload = response.json()
+    assert payload["type"] == "EntitlementRequired"
+    assert payload["detail"]["entitlement"] == "agent_addons"

--- a/tests/unit/api/test_api_agent_tags.py
+++ b/tests/unit/api/test_api_agent_tags.py
@@ -108,6 +108,31 @@ async def test_add_preset_tag_requires_agent_addons_entitlement(
 
 
 @pytest.mark.anyio
+async def test_add_preset_tag_duplicate_returns_409(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Duplicate preset-tag assignments should return a conflict."""
+    preset_id = uuid.uuid4()
+    tag_id = uuid.uuid4()
+
+    with patch.object(agent_tags_router, "AgentTagsService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "add_preset_tag",
+            side_effect=ValueError("Agent preset tag already exists"),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.post(
+            f"/agent/presets/{preset_id}/tags",
+            json={"tag_id": str(tag_id)},
+        )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json()["detail"] == "Agent preset tag already exists"
+
+
+@pytest.mark.anyio
 async def test_remove_preset_tag_requires_agent_addons_entitlement(
     client: TestClient,
     test_admin_role: Role,

--- a/tests/unit/api/test_api_agent_tags.py
+++ b/tests/unit/api/test_api_agent_tags.py
@@ -108,19 +108,16 @@ async def test_add_preset_tag_requires_agent_addons_entitlement(
 
 
 @pytest.mark.anyio
-async def test_add_preset_tag_duplicate_returns_409(
+async def test_add_preset_tag_success_returns_201(
     client: TestClient,
     test_admin_role: Role,
 ) -> None:
-    """Duplicate preset-tag assignments should return a conflict."""
+    """Preset tag writes should return 201 when the service accepts the request."""
     preset_id = uuid.uuid4()
     tag_id = uuid.uuid4()
 
     with patch.object(agent_tags_router, "AgentTagsService") as mock_service_cls:
-        mock_service = _mock_service_with_async_method(
-            "add_preset_tag",
-            side_effect=ValueError("Agent preset tag already exists"),
-        )
+        mock_service = _mock_service_with_async_method("add_preset_tag")
         mock_service_cls.return_value = mock_service
 
         response = client.post(
@@ -128,8 +125,7 @@ async def test_add_preset_tag_duplicate_returns_409(
             json={"tag_id": str(tag_id)},
         )
 
-    assert response.status_code == status.HTTP_409_CONFLICT
-    assert response.json()["detail"] == "Agent preset tag already exists"
+    assert response.status_code == status.HTTP_201_CREATED
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_agent_tags.py
+++ b/tests/unit/api/test_api_agent_tags.py
@@ -12,7 +12,7 @@ from sqlalchemy.exc import NoResultFound
 from tracecat.agent.tags import definitions_router as agent_tag_definitions_router
 from tracecat.agent.tags import router as agent_tags_router
 from tracecat.auth.types import Role
-from tracecat.exceptions import EntitlementRequired
+from tracecat.exceptions import EntitlementRequired, TracecatConflictError
 from tracecat.pagination import CursorPaginatedResponse
 
 # Fixed UUID for parametrized test IDs — uuid.uuid4() at module level causes
@@ -178,6 +178,33 @@ async def test_list_agent_tags_returns_paginated_response(
         "has_previous": False,
         "total_estimate": None,
     }
+
+
+@pytest.mark.anyio
+async def test_update_agent_tag_conflict_returns_409(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Agent tag definition conflicts should be reported as 409s."""
+    tag_id = uuid.uuid4()
+
+    with patch.object(
+        agent_tag_definitions_router, "AgentTagsService"
+    ) as mock_service_cls:
+        mock_service = MagicMock()
+        mock_service.get_tag = AsyncMock(return_value=object())
+        mock_service.update_tag = AsyncMock(
+            side_effect=TracecatConflictError("Agent tag already exists")
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.patch(
+            f"/agent-tags/{tag_id}",
+            json={"name": "Updated"},
+        )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json()["detail"] == "Agent tag already exists"
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_agent_tags.py
+++ b/tests/unit/api/test_api_agent_tags.py
@@ -16,7 +16,7 @@ from tracecat.exceptions import (
     TracecatConflictError,
     TracecatNotFoundError,
 )
-from tracecat.pagination import CursorPaginatedResponse
+from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 
 # Fixed UUID for parametrized test IDs — uuid.uuid4() at module level causes
 # pytest-xdist collection mismatches because each worker generates a different value.
@@ -49,7 +49,7 @@ async def test_list_preset_tags_requires_agent_addons_entitlement(
 
     with patch.object(agent_tags_router, "AgentTagsService") as mock_service_cls:
         mock_service = _mock_service_with_async_method(
-            "list_tags_for_preset",
+            "list_tags_for_preset_paginated",
             side_effect=EntitlementRequired("agent_addons"),
         )
         mock_service_cls.return_value = mock_service
@@ -72,7 +72,7 @@ async def test_list_preset_tags_missing_preset_returns_404(
 
     with patch.object(agent_tags_router, "AgentTagsService") as mock_service_cls:
         mock_service = _mock_service_with_async_method(
-            "list_tags_for_preset",
+            "list_tags_for_preset_paginated",
             side_effect=TracecatNotFoundError("Agent preset not found"),
         )
         mock_service_cls.return_value = mock_service
@@ -81,6 +81,49 @@ async def test_list_preset_tags_missing_preset_returns_404(
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["detail"] == "Agent preset not found"
+
+
+@pytest.mark.anyio
+async def test_list_preset_tags_returns_paginated_response(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Preset tag listing should use the cursor-paginated API shape."""
+    preset_id = uuid.uuid4()
+
+    with patch.object(agent_tags_router, "AgentTagsService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "list_tags_for_preset_paginated",
+            return_value=CursorPaginatedResponse(items=[], has_more=True),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.get(
+            f"/agent/presets/{preset_id}/tags",
+            params={
+                "limit": 2,
+                "cursor": "encoded-cursor",
+                "reverse": True,
+            },
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "items": [],
+        "next_cursor": None,
+        "prev_cursor": None,
+        "has_more": True,
+        "has_previous": False,
+        "total_estimate": None,
+    }
+    mock_service.list_tags_for_preset_paginated.assert_awaited_once_with(
+        preset_id,
+        CursorPaginationParams(
+            limit=2,
+            cursor="encoded-cursor",
+            reverse=True,
+        ),
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_agent_tags.py
+++ b/tests/unit/api/test_api_agent_tags.py
@@ -123,7 +123,7 @@ async def test_remove_preset_tag_requires_agent_addons_entitlement(
             {"json": {"name": "Updated"}},
             "get_tag",
         ),
-        ("delete", f"/agent-tags/{_FIXED_TAG_ID}", {}, "get_tag"),
+        ("delete", f"/agent-tags/{_FIXED_TAG_ID}", {}, "delete_tag_by_id"),
     ],
 )
 async def test_agent_tag_definition_routes_require_agent_addons_entitlement(

--- a/tests/unit/api/test_api_agent_tags.py
+++ b/tests/unit/api/test_api_agent_tags.py
@@ -13,6 +13,7 @@ from tracecat.agent.tags import definitions_router as agent_tag_definitions_rout
 from tracecat.agent.tags import router as agent_tags_router
 from tracecat.auth.types import Role
 from tracecat.exceptions import EntitlementRequired
+from tracecat.pagination import CursorPaginatedResponse
 
 # Fixed UUID for parametrized test IDs — uuid.uuid4() at module level causes
 # pytest-xdist collection mismatches because each worker generates a different value.
@@ -23,11 +24,14 @@ def _mock_service_with_async_method(
     method_name: str,
     *,
     side_effect: Exception | None = None,
+    return_value: object = None,
 ) -> MagicMock:
     service = MagicMock()
     service_method = AsyncMock()
     if side_effect is not None:
         service_method.side_effect = side_effect
+    else:
+        service_method.return_value = return_value
     setattr(service, method_name, service_method)
     return service
 
@@ -128,10 +132,38 @@ async def test_remove_preset_tag_requires_agent_addons_entitlement(
 
 
 @pytest.mark.anyio
+async def test_list_agent_tags_returns_paginated_response(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Agent tag listing should use the cursor-paginated API shape."""
+    with patch.object(
+        agent_tag_definitions_router, "AgentTagsService"
+    ) as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "list_tags_paginated",
+            return_value=CursorPaginatedResponse(items=[]),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.get("/agent-tags")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "items": [],
+        "next_cursor": None,
+        "prev_cursor": None,
+        "has_more": False,
+        "has_previous": False,
+        "total_estimate": None,
+    }
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     ("method", "path", "kwargs", "service_method"),
     [
-        ("get", "/agent-tags", {}, "list_tags"),
+        ("get", "/agent-tags", {}, "list_tags_paginated"),
         ("get", f"/agent-tags/{_FIXED_TAG_ID}", {}, "get_tag"),
         (
             "post",

--- a/tests/unit/api/test_api_agent_tags.py
+++ b/tests/unit/api/test_api_agent_tags.py
@@ -7,12 +7,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
-from sqlalchemy.exc import NoResultFound
 
 from tracecat.agent.tags import definitions_router as agent_tag_definitions_router
 from tracecat.agent.tags import router as agent_tags_router
 from tracecat.auth.types import Role
-from tracecat.exceptions import EntitlementRequired, TracecatConflictError
+from tracecat.exceptions import (
+    EntitlementRequired,
+    TracecatConflictError,
+    TracecatNotFoundError,
+)
 from tracecat.pagination import CursorPaginatedResponse
 
 # Fixed UUID for parametrized test IDs — uuid.uuid4() at module level causes
@@ -70,7 +73,7 @@ async def test_list_preset_tags_missing_preset_returns_404(
     with patch.object(agent_tags_router, "AgentTagsService") as mock_service_cls:
         mock_service = _mock_service_with_async_method(
             "list_tags_for_preset",
-            side_effect=NoResultFound("Agent preset not found"),
+            side_effect=TracecatNotFoundError("Agent preset not found"),
         )
         mock_service_cls.return_value = mock_service
 

--- a/tests/unit/api/test_api_agent_tags.py
+++ b/tests/unit/api/test_api_agent_tags.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import NoResultFound
 
 from tracecat.agent.tags import definitions_router as agent_tag_definitions_router
 from tracecat.agent.tags import router as agent_tags_router
@@ -52,6 +53,27 @@ async def test_list_preset_tags_requires_agent_addons_entitlement(
     payload = response.json()
     assert payload["type"] == "EntitlementRequired"
     assert payload["detail"]["entitlement"] == "agent_addons"
+
+
+@pytest.mark.anyio
+async def test_list_preset_tags_missing_preset_returns_404(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Missing presets should not be reported as empty tag lists."""
+    preset_id = uuid.uuid4()
+
+    with patch.object(agent_tags_router, "AgentTagsService") as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "list_tags_for_preset",
+            side_effect=NoResultFound("Agent preset not found"),
+        )
+        mock_service_cls.return_value = mock_service
+
+        response = client.get(f"/agent/presets/{preset_id}/tags")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "Agent preset not found"
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_folders_service.py
+++ b/tests/unit/test_agent_folders_service.py
@@ -1,0 +1,205 @@
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.agent.folders.schemas import AgentFolderDirectoryItem
+from tracecat.agent.folders.service import AgentFolderService
+from tracecat.auth.types import Role
+from tracecat.db.models import AgentPreset
+from tracecat.exceptions import EntitlementRequired, TracecatValidationError
+from tracecat.tiers.enums import Entitlement
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+async def folder_service(
+    session: AsyncSession, svc_role: Role
+) -> AsyncGenerator[AgentFolderService, None]:
+    """Create an agent folder service instance for testing."""
+    yield AgentFolderService(session=session, role=svc_role)
+
+
+@pytest.mark.anyio
+async def test_list_folders_escapes_like_wildcards(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Listing a subtree should treat percent signs in folder names literally."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+    await folder_service.create_folder(name="foo%", parent_path="/")
+    await folder_service.create_folder(name="child", parent_path="/foo%/")
+    await folder_service.create_folder(name="fooz", parent_path="/")
+
+    folders = await folder_service.list_folders("/foo%")
+
+    assert {folder.path for folder in folders} == {"/foo%/", "/foo%/child/"}
+
+
+@pytest.mark.anyio
+async def test_get_directory_items_escapes_like_wildcards(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Directory queries should not leak sibling folders via LIKE wildcards."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+    await folder_service.create_folder(name="foo%", parent_path="/")
+    await folder_service.create_folder(name="child", parent_path="/foo%/")
+    await folder_service.create_folder(name="fooz", parent_path="/")
+    await folder_service.create_folder(name="intruder", parent_path="/fooz/")
+
+    directory_items = await folder_service.get_directory_items("/foo%")
+    folder_paths = {
+        item.path
+        for item in directory_items
+        if isinstance(item, AgentFolderDirectoryItem)
+    }
+
+    assert folder_paths == {"/foo%/child/"}
+
+
+@pytest.mark.anyio
+async def test_get_directory_items_requires_agent_addons_entitlement(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Directory reads should preserve the AGENT_ADDONS entitlement gate."""
+    mock_has_entitlement = AsyncMock(return_value=False)
+    monkeypatch.setattr(folder_service, "has_entitlement", mock_has_entitlement)
+
+    with pytest.raises(EntitlementRequired, match=Entitlement.AGENT_ADDONS.value):
+        await folder_service.get_directory_items("/")
+
+    mock_has_entitlement.assert_awaited_once_with(Entitlement.AGENT_ADDONS)
+
+
+@pytest.mark.anyio
+async def test_move_preset_requires_agent_addons_entitlement(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preset folder moves should preserve the AGENT_ADDONS entitlement gate."""
+    mock_has_entitlement = AsyncMock(return_value=False)
+    monkeypatch.setattr(folder_service, "has_entitlement", mock_has_entitlement)
+
+    with pytest.raises(EntitlementRequired, match=Entitlement.AGENT_ADDONS.value):
+        await folder_service.move_preset(uuid4(), None)
+
+    mock_has_entitlement.assert_awaited_once_with(Entitlement.AGENT_ADDONS)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "invoker",
+    [
+        lambda service: service.get_folder(uuid4()),
+        lambda service: service.get_folder_by_path("/parent/"),
+        lambda service: service.list_folders("/"),
+        lambda service: service.create_folder(name="parent", parent_path="/"),
+        lambda service: service.get_folder_tree("/"),
+    ],
+)
+async def test_folder_management_methods_require_agent_addons_entitlement(
+    folder_service: AgentFolderService,
+    invoker,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Folder management methods should preserve the AGENT_ADDONS gate."""
+    mock_has_entitlement = AsyncMock(return_value=False)
+    monkeypatch.setattr(folder_service, "has_entitlement", mock_has_entitlement)
+
+    with pytest.raises(EntitlementRequired, match=Entitlement.AGENT_ADDONS.value):
+        await invoker(folder_service)
+
+    mock_has_entitlement.assert_awaited_once_with(Entitlement.AGENT_ADDONS)
+
+
+@pytest.mark.anyio
+async def test_get_directory_items_returns_real_direct_item_counts(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Folder rows should report direct child counts, not just boolean presence."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+
+    parent = await folder_service.create_folder(name="parent", parent_path="/")
+    await folder_service.create_folder(name="child-a", parent_path="/parent/")
+    await folder_service.create_folder(name="child-b", parent_path="/parent/")
+    await folder_service.create_folder(
+        name="grandchild", parent_path="/parent/child-a/"
+    )
+
+    folder_service.session.add_all(
+        [
+            AgentPreset(
+                workspace_id=folder_service.workspace_id,
+                name="alpha",
+                slug="alpha",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                retries=3,
+                enable_internet_access=False,
+                folder_id=parent.id,
+            ),
+            AgentPreset(
+                workspace_id=folder_service.workspace_id,
+                name="beta",
+                slug="beta",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                retries=3,
+                enable_internet_access=False,
+                folder_id=parent.id,
+            ),
+        ]
+    )
+    await folder_service.session.commit()
+
+    directory_items = await folder_service.get_directory_items("/")
+    parent_item = next(
+        item
+        for item in directory_items
+        if isinstance(item, AgentFolderDirectoryItem) and item.id == parent.id
+    )
+
+    assert parent_item.num_items == 4
+
+
+@pytest.mark.anyio
+async def test_create_folder_rejects_blank_name(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Folder creation should reject empty or whitespace-only names."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+    with pytest.raises(TracecatValidationError, match="Folder name cannot be empty"):
+        await folder_service.create_folder(name="   ", parent_path="/")
+
+
+@pytest.mark.anyio
+async def test_create_folder_trims_name_before_persisting(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Folder creation should store trimmed names and normalized paths."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+    folder = await folder_service.create_folder(name="  parent  ", parent_path="/")
+
+    assert folder.name == "parent"
+    assert folder.path == "/parent/"
+
+
+@pytest.mark.anyio
+async def test_rename_folder_rejects_blank_name(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Folder renames should reject empty or whitespace-only names."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+    folder = await folder_service.create_folder(name="parent", parent_path="/")
+
+    with pytest.raises(TracecatValidationError, match="Folder name cannot be empty"):
+        await folder_service.rename_folder(folder.id, "  ")

--- a/tests/unit/test_agent_folders_service.py
+++ b/tests/unit/test_agent_folders_service.py
@@ -18,6 +18,7 @@ from tracecat.exceptions import (
     ScopeDeniedError,
     TracecatValidationError,
 )
+from tracecat.pagination import CursorPaginationParams
 from tracecat.tiers.enums import Entitlement
 
 pytestmark = pytest.mark.usefixtures("db")
@@ -38,6 +39,7 @@ async def folder_service(
         lambda service: service.get_folder(uuid4()),
         lambda service: service.get_folder_by_path("/parent/"),
         lambda service: service.list_folders("/"),
+        lambda service: service.list_folders_paginated("/", CursorPaginationParams()),
         lambda service: service.get_directory_items("/"),
         lambda service: service.get_folder_tree("/"),
     ],
@@ -108,6 +110,75 @@ async def test_list_folders_escapes_like_wildcards(
     folders = await folder_service.list_folders("/foo%")
 
     assert {folder.path for folder in folders} == {"/foo%/", "/foo%/child/"}
+
+
+@pytest.mark.anyio
+async def test_list_folders_paginated_excludes_parent_and_escapes_like_wildcards(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Paginated subtree listing should exclude the parent and escape LIKE wildcards."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+    await folder_service.create_folder(name="foo%", parent_path="/")
+    await folder_service.create_folder(name="child", parent_path="/foo%/")
+    await folder_service.create_folder(name="fooz", parent_path="/")
+
+    page = await folder_service.list_folders_paginated(
+        "/foo%", CursorPaginationParams(limit=10)
+    )
+
+    assert [folder.path for folder in page.items] == ["/foo%/child/"]
+    assert page.has_more is False
+
+
+@pytest.mark.anyio
+async def test_list_folders_paginated_uses_cursor_pages(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Paginated folder listing should return stable cursor pages."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+    created_paths = {
+        (await folder_service.create_folder(name="alpha", parent_path="/")).path,
+        (await folder_service.create_folder(name="beta", parent_path="/")).path,
+        (await folder_service.create_folder(name="gamma", parent_path="/")).path,
+    }
+
+    first_page = await folder_service.list_folders_paginated(
+        "/", CursorPaginationParams(limit=2)
+    )
+
+    assert len(first_page.items) == 2
+    assert first_page.has_more is True
+    assert first_page.has_previous is False
+    assert first_page.next_cursor is not None
+
+    second_page = await folder_service.list_folders_paginated(
+        "/", CursorPaginationParams(limit=2, cursor=first_page.next_cursor)
+    )
+
+    assert len(second_page.items) == 1
+    assert second_page.has_more is False
+    assert second_page.has_previous is True
+    assert {folder.path for folder in first_page.items + second_page.items} == (
+        created_paths
+    )
+
+
+@pytest.mark.anyio
+async def test_list_folders_paginated_invalid_cursor_raises_tracecat_validation(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid folder cursors should surface app-level validation errors."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+
+    with pytest.raises(
+        TracecatValidationError, match="Invalid cursor for agent folders"
+    ):
+        await folder_service.list_folders_paginated(
+            "/", CursorPaginationParams(cursor="invalid")
+        )
 
 
 @pytest.mark.anyio
@@ -183,6 +254,7 @@ async def test_move_preset_requires_agent_addons_entitlement(
         lambda service: service.get_folder(uuid4()),
         lambda service: service.get_folder_by_path("/parent/"),
         lambda service: service.list_folders("/"),
+        lambda service: service.list_folders_paginated("/", CursorPaginationParams()),
         lambda service: service.create_folder(name="parent", parent_path="/"),
         lambda service: service.get_folder_tree("/"),
         lambda service: service.rename_folder(uuid4(), "renamed"),

--- a/tests/unit/test_agent_folders_service.py
+++ b/tests/unit/test_agent_folders_service.py
@@ -42,6 +42,9 @@ async def folder_service(
         lambda service: service.list_folders("/"),
         lambda service: service.list_folders_paginated("/", CursorPaginationParams()),
         lambda service: service.get_directory_items("/"),
+        lambda service: service.get_directory_items_paginated(
+            "/", CursorPaginationParams()
+        ),
         lambda service: service.get_folder_tree("/"),
     ],
 )
@@ -87,6 +90,7 @@ async def test_delete_folder_allows_delete_scope_without_read(
         ),
     )
     folder = SimpleNamespace(id=uuid4(), path="/folder/")
+    monkeypatch.setattr(service, "has_entitlement", AsyncMock(return_value=True))
     monkeypatch.setattr(service, "_get_folder", AsyncMock(return_value=folder))
     monkeypatch.setattr(service, "_has_children", AsyncMock(return_value=False))
     monkeypatch.setattr(service, "_has_presets", AsyncMock(return_value=False))
@@ -221,6 +225,67 @@ async def test_get_directory_items_escapes_like_wildcards(
 
 
 @pytest.mark.anyio
+async def test_get_directory_items_paginated_uses_cursor_pages(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Paginated directory listing should return stable bounded pages."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+    alpha = await folder_service.create_folder(name="alpha", parent_path="/")
+    preset = AgentPreset(
+        workspace_id=folder_service.workspace_id,
+        name="Root preset",
+        slug="root-preset",
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        retries=3,
+        enable_internet_access=False,
+        folder_id=None,
+    )
+    folder_service.session.add(preset)
+    beta = await folder_service.create_folder(name="beta", parent_path="/")
+    await folder_service.session.commit()
+
+    first_page = await folder_service.get_directory_items_paginated(
+        "/", CursorPaginationParams(limit=2)
+    )
+
+    assert len(first_page.items) == 2
+    assert first_page.has_more is True
+    assert first_page.has_previous is False
+    assert first_page.next_cursor is not None
+
+    second_page = await folder_service.get_directory_items_paginated(
+        "/", CursorPaginationParams(limit=2, cursor=first_page.next_cursor)
+    )
+
+    assert len(second_page.items) == 1
+    assert second_page.has_more is False
+    assert second_page.has_previous is True
+    assert {item.id for item in first_page.items + second_page.items} == {
+        alpha.id,
+        beta.id,
+        preset.id,
+    }
+
+
+@pytest.mark.anyio
+async def test_get_directory_items_paginated_invalid_cursor_raises_validation(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid directory cursors should surface app-level validation errors."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+
+    with pytest.raises(
+        TracecatValidationError, match="Invalid cursor for agent folder directory"
+    ):
+        await folder_service.get_directory_items_paginated(
+            "/", CursorPaginationParams(cursor="invalid")
+        )
+
+
+@pytest.mark.anyio
 async def test_get_directory_items_requires_agent_addons_entitlement(
     folder_service: AgentFolderService,
     monkeypatch: pytest.MonkeyPatch,
@@ -258,6 +323,9 @@ async def test_move_preset_requires_agent_addons_entitlement(
         lambda service: service.get_folder_by_path("/parent/"),
         lambda service: service.list_folders("/"),
         lambda service: service.list_folders_paginated("/", CursorPaginationParams()),
+        lambda service: service.get_directory_items_paginated(
+            "/", CursorPaginationParams()
+        ),
         lambda service: service.create_folder(name="parent", parent_path="/"),
         lambda service: service.get_folder_tree("/"),
         lambda service: service.rename_folder(uuid4(), "renamed"),

--- a/tests/unit/test_agent_folders_service.py
+++ b/tests/unit/test_agent_folders_service.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.folders.schemas import AgentFolderDirectoryItem
@@ -12,7 +13,7 @@ from tracecat.agent.folders.service import (
     AgentFolderService,
 )
 from tracecat.auth.types import Role
-from tracecat.db.models import AgentPreset
+from tracecat.db.models import AgentFolder, AgentPreset
 from tracecat.exceptions import (
     EntitlementRequired,
     ScopeDeniedError,
@@ -328,6 +329,118 @@ async def test_get_directory_items_returns_real_direct_item_counts(
     )
 
     assert parent_item.num_items == 4
+
+
+@pytest.mark.anyio
+async def test_rename_folder_updates_descendant_paths(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Folder renames should rewrite descendant materialized paths."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+    parent = await folder_service.create_folder(name="parent", parent_path="/")
+    await folder_service.create_folder(name="child", parent_path="/parent/")
+    await folder_service.create_folder(name="grandchild", parent_path="/parent/child/")
+
+    renamed = await folder_service.rename_folder(parent.id, "renamed")
+    result = await folder_service.session.execute(
+        select(AgentFolder.path).where(
+            AgentFolder.workspace_id == folder_service.workspace_id,
+            AgentFolder.path.startswith("/renamed/", autoescape=True),
+        )
+    )
+
+    assert renamed.path == "/renamed/"
+    assert set(result.scalars().all()) == {
+        "/renamed/",
+        "/renamed/child/",
+        "/renamed/child/grandchild/",
+    }
+
+
+@pytest.mark.anyio
+async def test_move_folder_updates_descendant_paths(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Folder moves should rewrite descendant materialized paths."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+    source = await folder_service.create_folder(name="source", parent_path="/")
+    target = await folder_service.create_folder(name="target", parent_path="/")
+    child = await folder_service.create_folder(name="child", parent_path="/source/")
+    await folder_service.create_folder(name="grandchild", parent_path="/source/child/")
+
+    moved = await folder_service.move_folder(child.id, target.id)
+    result = await folder_service.session.execute(
+        select(AgentFolder.path).where(
+            AgentFolder.workspace_id == folder_service.workspace_id,
+            AgentFolder.path.startswith("/target/child/", autoescape=True),
+        )
+    )
+
+    assert moved.path == "/target/child/"
+    assert set(result.scalars().all()) == {
+        "/target/child/",
+        "/target/child/grandchild/",
+    }
+    assert await folder_service.get_folder_by_path(source.path) is not None
+
+
+@pytest.mark.anyio
+async def test_delete_folder_recursive_clears_presets_and_deletes_descendants(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recursive folder deletes should batch-clear preset links and remove descendants."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+    parent = await folder_service.create_folder(name="parent", parent_path="/")
+    child = await folder_service.create_folder(name="child", parent_path="/parent/")
+    folder_service.session.add_all(
+        [
+            AgentPreset(
+                workspace_id=folder_service.workspace_id,
+                name="Parent preset",
+                slug="parent-preset",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                retries=3,
+                enable_internet_access=False,
+                folder_id=parent.id,
+            ),
+            AgentPreset(
+                workspace_id=folder_service.workspace_id,
+                name="Child preset",
+                slug="child-preset",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                retries=3,
+                enable_internet_access=False,
+                folder_id=child.id,
+            ),
+        ]
+    )
+    await folder_service.session.commit()
+
+    await folder_service.delete_folder(parent.id, recursive=True)
+
+    folder_result = await folder_service.session.execute(
+        select(AgentFolder.path).where(
+            AgentFolder.workspace_id == folder_service.workspace_id,
+            AgentFolder.path.startswith("/parent/", autoescape=True),
+        )
+    )
+    preset_result = await folder_service.session.execute(
+        select(AgentPreset.slug, AgentPreset.folder_id).where(
+            AgentPreset.workspace_id == folder_service.workspace_id,
+            AgentPreset.slug.in_(["parent-preset", "child-preset"]),
+        )
+    )
+
+    assert folder_result.scalars().all() == []
+    assert dict(preset_result.tuples().all()) == {
+        "parent-preset": None,
+        "child-preset": None,
+    }
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_folders_service.py
+++ b/tests/unit/test_agent_folders_service.py
@@ -168,6 +168,9 @@ async def test_move_preset_requires_agent_addons_entitlement(
         lambda service: service.list_folders("/"),
         lambda service: service.create_folder(name="parent", parent_path="/"),
         lambda service: service.get_folder_tree("/"),
+        lambda service: service.rename_folder(uuid4(), "renamed"),
+        lambda service: service.move_folder(uuid4(), None),
+        lambda service: service.delete_folder(uuid4()),
     ],
 )
 async def test_folder_management_methods_require_agent_addons_entitlement(

--- a/tests/unit/test_agent_folders_service.py
+++ b/tests/unit/test_agent_folders_service.py
@@ -7,7 +7,10 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.folders.schemas import AgentFolderDirectoryItem
-from tracecat.agent.folders.service import AgentFolderService
+from tracecat.agent.folders.service import (
+    AGENT_FOLDER_PARENT_NOT_FOUND_CODE,
+    AgentFolderService,
+)
 from tracecat.auth.types import Role
 from tracecat.db.models import AgentPreset
 from tracecat.exceptions import (
@@ -105,6 +108,20 @@ async def test_list_folders_escapes_like_wildcards(
     folders = await folder_service.list_folders("/foo%")
 
     assert {folder.path for folder in folders} == {"/foo%/", "/foo%/child/"}
+
+
+@pytest.mark.anyio
+async def test_list_folders_rejects_missing_parent_path(
+    folder_service: AgentFolderService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing parent paths should not look like empty folders."""
+    monkeypatch.setattr(folder_service, "has_entitlement", AsyncMock(return_value=True))
+
+    with pytest.raises(TracecatValidationError) as exc_info:
+        await folder_service.list_folders("/missing/")
+
+    assert exc_info.value.detail == {"code": AGENT_FOLDER_PARENT_NOT_FOUND_CODE}
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_folders_service.py
+++ b/tests/unit/test_agent_folders_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.folders.schemas import AgentFolderDirectoryItem
 from tracecat.agent.folders.service import (
-    AGENT_FOLDER_PARENT_NOT_FOUND_CODE,
+    AgentFolderErrorCode,
     AgentFolderService,
 )
 from tracecat.auth.types import Role
@@ -192,7 +192,9 @@ async def test_list_folders_rejects_missing_parent_path(
     with pytest.raises(TracecatValidationError) as exc_info:
         await folder_service.list_folders("/missing/")
 
-    assert exc_info.value.detail == {"code": AGENT_FOLDER_PARENT_NOT_FOUND_CODE}
+    assert exc_info.value.detail == {
+        "code": AgentFolderErrorCode.PARENT_NOT_FOUND.value
+    }
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_folders_service.py
+++ b/tests/unit/test_agent_folders_service.py
@@ -1,4 +1,5 @@
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -9,7 +10,11 @@ from tracecat.agent.folders.schemas import AgentFolderDirectoryItem
 from tracecat.agent.folders.service import AgentFolderService
 from tracecat.auth.types import Role
 from tracecat.db.models import AgentPreset
-from tracecat.exceptions import EntitlementRequired, TracecatValidationError
+from tracecat.exceptions import (
+    EntitlementRequired,
+    ScopeDeniedError,
+    TracecatValidationError,
+)
 from tracecat.tiers.enums import Entitlement
 
 pytestmark = pytest.mark.usefixtures("db")
@@ -21,6 +26,69 @@ async def folder_service(
 ) -> AsyncGenerator[AgentFolderService, None]:
     """Create an agent folder service instance for testing."""
     yield AgentFolderService(session=session, role=svc_role)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "invoker",
+    [
+        lambda service: service.get_folder(uuid4()),
+        lambda service: service.get_folder_by_path("/parent/"),
+        lambda service: service.list_folders("/"),
+        lambda service: service.get_directory_items("/"),
+        lambda service: service.get_folder_tree("/"),
+    ],
+)
+async def test_folder_read_methods_require_agent_read_scope(
+    invoker: Callable[[AgentFolderService], Awaitable[object]],
+) -> None:
+    """Folder read methods should reject callers without agent:read before querying."""
+    session = AsyncMock()
+    service = AgentFolderService(
+        session=session,
+        role=Role(
+            type="user",
+            user_id=uuid4(),
+            organization_id=uuid4(),
+            workspace_id=uuid4(),
+            service_id="tracecat-api",
+            scopes=frozenset(),
+        ),
+    )
+
+    with pytest.raises(ScopeDeniedError) as exc_info:
+        await invoker(service)
+
+    assert exc_info.value.missing_scopes == ["agent:read"]
+    session.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_delete_folder_allows_delete_scope_without_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Folder deletes should not require agent:read for the internal lookup."""
+    session = AsyncMock()
+    service = AgentFolderService(
+        session=session,
+        role=Role(
+            type="user",
+            user_id=uuid4(),
+            organization_id=uuid4(),
+            workspace_id=uuid4(),
+            service_id="tracecat-api",
+            scopes=frozenset({"agent:delete"}),
+        ),
+    )
+    folder = SimpleNamespace(id=uuid4(), path="/folder/")
+    monkeypatch.setattr(service, "_get_folder", AsyncMock(return_value=folder))
+    monkeypatch.setattr(service, "_has_children", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_has_presets", AsyncMock(return_value=False))
+
+    await service.delete_folder(folder.id)
+
+    session.delete.assert_awaited_once_with(folder)
+    session.commit.assert_awaited_once()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_tags_service.py
+++ b/tests/unit/test_agent_tags_service.py
@@ -1,0 +1,121 @@
+from collections.abc import Awaitable, Callable
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from tracecat.agent.tags.service import AgentTagsService
+from tracecat.auth.types import Role
+from tracecat.exceptions import EntitlementRequired, ScopeDeniedError
+from tracecat.tags.schemas import TagCreate, TagUpdate
+from tracecat.tiers.enums import Entitlement
+
+
+def _role_with_scopes(scopes: frozenset[str] | None) -> Role:
+    return Role(
+        type="user",
+        user_id=uuid4(),
+        organization_id=uuid4(),
+        workspace_id=uuid4(),
+        service_id="tracecat-api",
+        scopes=scopes,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "invoker",
+    [
+        lambda service: service.list_tags(),
+        lambda service: service.get_tag(uuid4()),
+    ],
+)
+async def test_agent_tag_read_methods_require_agent_read_scope(
+    invoker: Callable[[AgentTagsService], Awaitable[object]],
+) -> None:
+    """Read methods should reject callers without agent:read before querying."""
+    session = AsyncMock()
+    service = AgentTagsService(session=session, role=_role_with_scopes(frozenset()))
+
+    with pytest.raises(ScopeDeniedError) as exc_info:
+        await invoker(service)
+
+    assert exc_info.value.missing_scopes == ["agent:read"]
+    session.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("invoker", "role_scopes"),
+    [
+        (
+            lambda service: service.list_tags_for_preset(uuid4()),
+            frozenset({"agent:read"}),
+        ),
+        (
+            lambda service: service.get_preset_tag(uuid4(), uuid4()),
+            frozenset({"agent:update"}),
+        ),
+        (
+            lambda service: service.add_preset_tag(uuid4(), uuid4()),
+            frozenset({"agent:update"}),
+        ),
+        (
+            lambda service: service.remove_preset_tag(object()),
+            frozenset({"agent:update"}),
+        ),
+    ],
+)
+async def test_preset_tag_methods_require_agent_addons_entitlement(
+    invoker: Callable[[AgentTagsService], Awaitable[object]],
+    role_scopes: frozenset[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preset-tag association methods should preserve the AGENT_ADDONS gate."""
+    session = AsyncMock()
+    service = AgentTagsService(session=session, role=_role_with_scopes(role_scopes))
+    mock_has_entitlement = AsyncMock(return_value=False)
+    monkeypatch.setattr(service, "has_entitlement", mock_has_entitlement)
+
+    with pytest.raises(EntitlementRequired, match=Entitlement.AGENT_ADDONS.value):
+        await invoker(service)
+
+    mock_has_entitlement.assert_awaited_once_with(Entitlement.AGENT_ADDONS)
+    session.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("invoker", "role_scopes"),
+    [
+        (lambda service: service.list_tags(), frozenset({"agent:read"})),
+        (lambda service: service.get_tag(uuid4()), frozenset({"agent:read"})),
+        (
+            lambda service: service.create_tag(
+                TagCreate(name="alpha", color="#000000")
+            ),
+            frozenset({"agent:create"}),
+        ),
+        (
+            lambda service: service.update_tag(object(), TagUpdate(name="beta")),
+            frozenset({"agent:update"}),
+        ),
+        (lambda service: service.delete_tag(object()), frozenset({"agent:delete"})),
+    ],
+)
+async def test_agent_tag_definition_methods_require_agent_addons_entitlement(
+    invoker: Callable[[AgentTagsService], Awaitable[object]],
+    role_scopes: frozenset[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agent tag definition CRUD should preserve the AGENT_ADDONS gate."""
+    session = AsyncMock()
+    service = AgentTagsService(session=session, role=_role_with_scopes(role_scopes))
+    mock_has_entitlement = AsyncMock(return_value=False)
+    monkeypatch.setattr(service, "has_entitlement", mock_has_entitlement)
+
+    with pytest.raises(EntitlementRequired, match=Entitlement.AGENT_ADDONS.value):
+        await invoker(service)
+
+    mock_has_entitlement.assert_awaited_once_with(Entitlement.AGENT_ADDONS)
+    session.execute.assert_not_awaited()

--- a/tests/unit/test_agent_tags_service.py
+++ b/tests/unit/test_agent_tags_service.py
@@ -4,12 +4,16 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
-from sqlalchemy.exc import NoResultFound
 
 from tracecat.agent.tags.service import AgentTagsService
 from tracecat.auth.types import Role
 from tracecat.db.models import AgentTag, AgentTagLink
-from tracecat.exceptions import EntitlementRequired, ScopeDeniedError
+from tracecat.exceptions import (
+    EntitlementRequired,
+    ScopeDeniedError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
 from tracecat.pagination import BaseCursorPaginator, CursorPaginationParams
 from tracecat.tags.schemas import TagCreate, TagUpdate
 from tracecat.tiers.enums import Entitlement
@@ -202,7 +206,7 @@ async def test_delete_tag_by_id_allows_delete_scope_without_read(
     """Deleting by ID should not require agent:read."""
     tag = object()
     result = MagicMock()
-    result.scalar_one.return_value = tag
+    result.scalar_one_or_none.return_value = tag
     session = AsyncMock()
     session.execute.return_value = result
     service = AgentTagsService(
@@ -218,6 +222,40 @@ async def test_delete_tag_by_id_allows_delete_scope_without_read(
 
 
 @pytest.mark.anyio
+async def test_get_tag_missing_raises_tracecat_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing tag definitions should surface app-level not-found errors."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    session = AsyncMock()
+    session.execute.return_value = result
+    service = AgentTagsService(
+        session=session,
+        role=_role_with_scopes(frozenset({"agent:read"})),
+    )
+    monkeypatch.setattr(service, "has_entitlement", AsyncMock(return_value=True))
+
+    with pytest.raises(TracecatNotFoundError, match="Agent tag not found"):
+        await service.get_tag(uuid4())
+
+
+@pytest.mark.anyio
+async def test_list_tags_paginated_invalid_cursor_raises_tracecat_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid tag cursors should surface app-level validation errors."""
+    service = AgentTagsService(
+        session=AsyncMock(),
+        role=_role_with_scopes(frozenset({"agent:read"})),
+    )
+    monkeypatch.setattr(service, "has_entitlement", AsyncMock(return_value=True))
+
+    with pytest.raises(TracecatValidationError, match="Invalid cursor for agent tags"):
+        await service.list_tags_paginated(CursorPaginationParams(cursor="invalid"))
+
+
+@pytest.mark.anyio
 async def test_list_tags_for_preset_requires_existing_preset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -230,7 +268,7 @@ async def test_list_tags_for_preset_requires_existing_preset(
     )
     monkeypatch.setattr(service, "has_entitlement", AsyncMock(return_value=True))
 
-    with pytest.raises(NoResultFound, match="Agent preset not found"):
+    with pytest.raises(TracecatNotFoundError, match="Agent preset not found"):
         await service.list_tags_for_preset(uuid4())
 
     session.execute.assert_not_awaited()
@@ -245,7 +283,7 @@ async def test_add_preset_tag_returns_existing_link_for_duplicate_assignment(
     insert_result = MagicMock()
     insert_result.scalar_one_or_none.return_value = None
     existing_result = MagicMock()
-    existing_result.scalar_one.return_value = existing_link
+    existing_result.scalar_one_or_none.return_value = existing_link
     session = AsyncMock()
     session.scalar.return_value = True
     session.execute.side_effect = [insert_result, existing_result]

--- a/tests/unit/test_agent_tags_service.py
+++ b/tests/unit/test_agent_tags_service.py
@@ -1,5 +1,5 @@
 from collections.abc import Awaitable, Callable
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -101,6 +101,10 @@ async def test_preset_tag_methods_require_agent_addons_entitlement(
             frozenset({"agent:update"}),
         ),
         (lambda service: service.delete_tag(object()), frozenset({"agent:delete"})),
+        (
+            lambda service: service.delete_tag_by_id(uuid4()),
+            frozenset({"agent:delete"}),
+        ),
     ],
 )
 async def test_agent_tag_definition_methods_require_agent_addons_entitlement(
@@ -119,3 +123,25 @@ async def test_agent_tag_definition_methods_require_agent_addons_entitlement(
 
     mock_has_entitlement.assert_awaited_once_with(Entitlement.AGENT_ADDONS)
     session.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_delete_tag_by_id_allows_delete_scope_without_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deleting by ID should not require agent:read."""
+    tag = object()
+    result = MagicMock()
+    result.scalar_one.return_value = tag
+    session = AsyncMock()
+    session.execute.return_value = result
+    service = AgentTagsService(
+        session=session,
+        role=_role_with_scopes(frozenset({"agent:delete"})),
+    )
+    monkeypatch.setattr(service, "has_entitlement", AsyncMock(return_value=True))
+
+    await service.delete_tag_by_id(uuid4())
+
+    session.delete.assert_awaited_once_with(tag)
+    session.commit.assert_awaited_once()

--- a/tests/unit/test_agent_tags_service.py
+++ b/tests/unit/test_agent_tags_service.py
@@ -171,3 +171,26 @@ async def test_list_tags_for_preset_requires_existing_preset(
         await service.list_tags_for_preset(uuid4())
 
     session.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_add_preset_tag_rejects_duplicate_assignment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Duplicate preset-tag assignments should surface as conflicts."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    session = AsyncMock()
+    session.scalar.return_value = True
+    session.execute.return_value = result
+    service = AgentTagsService(
+        session=session,
+        role=_role_with_scopes(frozenset({"agent:update"})),
+    )
+    monkeypatch.setattr(service, "has_entitlement", AsyncMock(return_value=True))
+
+    with pytest.raises(ValueError, match="Agent preset tag already exists"):
+        await service.add_preset_tag(uuid4(), uuid4())
+
+    session.rollback.assert_awaited_once()
+    session.commit.assert_not_awaited()

--- a/tests/unit/test_agent_tags_service.py
+++ b/tests/unit/test_agent_tags_service.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from tracecat.agent.tags.service import AgentTagsService
 from tracecat.auth.types import Role
@@ -11,6 +12,7 @@ from tracecat.db.models import AgentTag, AgentTagLink
 from tracecat.exceptions import (
     EntitlementRequired,
     ScopeDeniedError,
+    TracecatConflictError,
     TracecatNotFoundError,
     TracecatValidationError,
 )
@@ -253,6 +255,37 @@ async def test_list_tags_paginated_invalid_cursor_raises_tracecat_validation(
 
     with pytest.raises(TracecatValidationError, match="Invalid cursor for agent tags"):
         await service.list_tags_paginated(CursorPaginationParams(cursor="invalid"))
+
+
+@pytest.mark.anyio
+async def test_update_tag_commit_conflict_raises_tracecat_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Commit-time uniqueness races should be translated by the service."""
+    workspace_id = uuid4()
+    tag = _agent_tag("alpha", datetime(2026, 1, 1, tzinfo=UTC), workspace_id)
+    result = MagicMock()
+    result.one_or_none.return_value = None
+    session = AsyncMock()
+    session.execute.return_value = result
+    session.commit.side_effect = IntegrityError(
+        statement="UPDATE agent_tag",
+        params={},
+        orig=Exception("duplicate key"),
+    )
+    service = AgentTagsService(
+        session=session,
+        role=_role_with_scopes(frozenset({"agent:update"})),
+    )
+    monkeypatch.setattr(service, "has_entitlement", AsyncMock(return_value=True))
+
+    with pytest.raises(
+        TracecatConflictError, match="Agent tag with slug 'beta' already exists"
+    ):
+        await service.update_tag(tag, TagUpdate(name="beta"))
+
+    session.rollback.assert_awaited_once()
+    session.refresh.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_tags_service.py
+++ b/tests/unit/test_agent_tags_service.py
@@ -50,6 +50,9 @@ def _agent_tag(name: str, created_at: datetime, workspace_id: object) -> AgentTa
     [
         lambda service: service.list_tags(),
         lambda service: service.list_tags_paginated(CursorPaginationParams()),
+        lambda service: service.list_tags_for_preset_paginated(
+            uuid4(), CursorPaginationParams()
+        ),
         lambda service: service.get_tag(uuid4()),
     ],
 )
@@ -73,6 +76,12 @@ async def test_agent_tag_read_methods_require_agent_read_scope(
     [
         (
             lambda service: service.list_tags_for_preset(uuid4()),
+            frozenset({"agent:read"}),
+        ),
+        (
+            lambda service: service.list_tags_for_preset_paginated(
+                uuid4(), CursorPaginationParams()
+            ),
             frozenset({"agent:read"}),
         ),
         (
@@ -199,6 +208,64 @@ async def test_list_tags_paginated_reverse_pages_use_canonical_order(
     )
     assert page.has_more is True
     assert page.has_previous is True
+
+
+@pytest.mark.anyio
+async def test_list_tags_for_preset_paginated_uses_cursor_pages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Paginated preset tag listing should return stable bounded pages."""
+    workspace_id = uuid4()
+    preset_id = uuid4()
+    base_time = datetime(2026, 1, 1, tzinfo=UTC)
+    rows = [
+        _agent_tag("newer", base_time + timedelta(minutes=3), workspace_id),
+        _agent_tag("middle", base_time + timedelta(minutes=2), workspace_id),
+        _agent_tag("older", base_time + timedelta(minutes=1), workspace_id),
+    ]
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = rows
+    session = AsyncMock()
+    session.scalar.return_value = True
+    session.execute.return_value = result
+    service = AgentTagsService(
+        session=session,
+        role=_role_with_scopes(frozenset({"agent:read"})),
+    )
+    monkeypatch.setattr(service, "has_entitlement", AsyncMock(return_value=True))
+
+    page = await service.list_tags_for_preset_paginated(
+        preset_id, CursorPaginationParams(limit=2)
+    )
+
+    assert [tag.id for tag in page.items] == [rows[0].id, rows[1].id]
+    assert page.next_cursor == BaseCursorPaginator.encode_cursor(
+        rows[1].id,
+        sort_column="created_at",
+        sort_value=rows[1].created_at,
+    )
+    assert page.has_more is True
+    assert page.has_previous is False
+
+
+@pytest.mark.anyio
+async def test_list_tags_for_preset_paginated_invalid_cursor_raises_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid preset tag cursors should surface app-level validation errors."""
+    service = AgentTagsService(
+        session=AsyncMock(),
+        role=_role_with_scopes(frozenset({"agent:read"})),
+    )
+    monkeypatch.setattr(service, "has_entitlement", AsyncMock(return_value=True))
+    monkeypatch.setattr(service, "_require_preset_in_workspace", AsyncMock())
+
+    with pytest.raises(
+        TracecatValidationError, match="Invalid cursor for agent preset tags"
+    ):
+        await service.list_tags_for_preset_paginated(
+            uuid4(), CursorPaginationParams(cursor="invalid")
+        )
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_tags_service.py
+++ b/tests/unit/test_agent_tags_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import NoResultFound
 
 from tracecat.agent.tags.service import AgentTagsService
 from tracecat.auth.types import Role
-from tracecat.db.models import AgentTag
+from tracecat.db.models import AgentTag, AgentTagLink
 from tracecat.exceptions import EntitlementRequired, ScopeDeniedError
 from tracecat.pagination import BaseCursorPaginator, CursorPaginationParams
 from tracecat.tags.schemas import TagCreate, TagUpdate
@@ -237,23 +237,26 @@ async def test_list_tags_for_preset_requires_existing_preset(
 
 
 @pytest.mark.anyio
-async def test_add_preset_tag_rejects_duplicate_assignment(
+async def test_add_preset_tag_returns_existing_link_for_duplicate_assignment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Duplicate preset-tag assignments should surface as conflicts."""
-    result = MagicMock()
-    result.scalar_one_or_none.return_value = None
+    """Duplicate preset-tag assignments should return the existing link."""
+    existing_link = AgentTagLink(tag_id=uuid4(), preset_id=uuid4())
+    insert_result = MagicMock()
+    insert_result.scalar_one_or_none.return_value = None
+    existing_result = MagicMock()
+    existing_result.scalar_one.return_value = existing_link
     session = AsyncMock()
     session.scalar.return_value = True
-    session.execute.return_value = result
+    session.execute.side_effect = [insert_result, existing_result]
     service = AgentTagsService(
         session=session,
         role=_role_with_scopes(frozenset({"agent:update"})),
     )
     monkeypatch.setattr(service, "has_entitlement", AsyncMock(return_value=True))
 
-    with pytest.raises(ValueError, match="Agent preset tag already exists"):
-        await service.add_preset_tag(uuid4(), uuid4())
+    link = await service.add_preset_tag(existing_link.preset_id, existing_link.tag_id)
 
-    session.rollback.assert_awaited_once()
-    session.commit.assert_not_awaited()
+    assert link is existing_link
+    session.rollback.assert_not_awaited()
+    session.commit.assert_awaited_once()

--- a/tests/unit/test_agent_tags_service.py
+++ b/tests/unit/test_agent_tags_service.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.exc import NoResultFound
 
 from tracecat.agent.tags.service import AgentTagsService
 from tracecat.auth.types import Role
@@ -145,3 +146,22 @@ async def test_delete_tag_by_id_allows_delete_scope_without_read(
 
     session.delete.assert_awaited_once_with(tag)
     session.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_list_tags_for_preset_requires_existing_preset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preset tag listing should fail when the preset is missing."""
+    session = AsyncMock()
+    session.scalar.return_value = False
+    service = AgentTagsService(
+        session=session,
+        role=_role_with_scopes(frozenset({"agent:read"})),
+    )
+    monkeypatch.setattr(service, "has_entitlement", AsyncMock(return_value=True))
+
+    with pytest.raises(NoResultFound, match="Agent preset not found"):
+        await service.list_tags_for_preset(uuid4())
+
+    session.execute.assert_not_awaited()

--- a/tests/unit/test_agent_tags_service.py
+++ b/tests/unit/test_agent_tags_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import NoResultFound
 from tracecat.agent.tags.service import AgentTagsService
 from tracecat.auth.types import Role
 from tracecat.exceptions import EntitlementRequired, ScopeDeniedError
+from tracecat.pagination import CursorPaginationParams
 from tracecat.tags.schemas import TagCreate, TagUpdate
 from tracecat.tiers.enums import Entitlement
 
@@ -28,6 +29,7 @@ def _role_with_scopes(scopes: frozenset[str] | None) -> Role:
     "invoker",
     [
         lambda service: service.list_tags(),
+        lambda service: service.list_tags_paginated(CursorPaginationParams()),
         lambda service: service.get_tag(uuid4()),
     ],
 )
@@ -90,6 +92,10 @@ async def test_preset_tag_methods_require_agent_addons_entitlement(
     ("invoker", "role_scopes"),
     [
         (lambda service: service.list_tags(), frozenset({"agent:read"})),
+        (
+            lambda service: service.list_tags_paginated(CursorPaginationParams()),
+            frozenset({"agent:read"}),
+        ),
         (lambda service: service.get_tag(uuid4()), frozenset({"agent:read"})),
         (
             lambda service: service.create_tag(

--- a/tests/unit/test_agent_tags_service.py
+++ b/tests/unit/test_agent_tags_service.py
@@ -1,4 +1,5 @@
 from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -7,8 +8,9 @@ from sqlalchemy.exc import NoResultFound
 
 from tracecat.agent.tags.service import AgentTagsService
 from tracecat.auth.types import Role
+from tracecat.db.models import AgentTag
 from tracecat.exceptions import EntitlementRequired, ScopeDeniedError
-from tracecat.pagination import CursorPaginationParams
+from tracecat.pagination import BaseCursorPaginator, CursorPaginationParams
 from tracecat.tags.schemas import TagCreate, TagUpdate
 from tracecat.tiers.enums import Entitlement
 
@@ -21,6 +23,18 @@ def _role_with_scopes(scopes: frozenset[str] | None) -> Role:
         workspace_id=uuid4(),
         service_id="tracecat-api",
         scopes=scopes,
+    )
+
+
+def _agent_tag(name: str, created_at: datetime, workspace_id: object) -> AgentTag:
+    return AgentTag(
+        id=uuid4(),
+        workspace_id=workspace_id,
+        name=name,
+        ref=name,
+        color=None,
+        created_at=created_at,
+        updated_at=created_at,
     )
 
 
@@ -130,6 +144,55 @@ async def test_agent_tag_definition_methods_require_agent_addons_entitlement(
 
     mock_has_entitlement.assert_awaited_once_with(Entitlement.AGENT_ADDONS)
     session.execute.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_list_tags_paginated_reverse_pages_use_canonical_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reverse tag pages should return newest-first items with swapped cursors."""
+    workspace_id = uuid4()
+    base_time = datetime(2026, 1, 1, tzinfo=UTC)
+    raw_reverse_rows = [
+        _agent_tag("older", base_time + timedelta(minutes=1), workspace_id),
+        _agent_tag("middle", base_time + timedelta(minutes=2), workspace_id),
+        _agent_tag("newer", base_time + timedelta(minutes=3), workspace_id),
+    ]
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = raw_reverse_rows
+    session = AsyncMock()
+    session.execute.return_value = result
+    service = AgentTagsService(
+        session=session,
+        role=_role_with_scopes(frozenset({"agent:read"})),
+    )
+    monkeypatch.setattr(service, "has_entitlement", AsyncMock(return_value=True))
+    cursor = BaseCursorPaginator.encode_cursor(
+        uuid4(),
+        sort_column="created_at",
+        sort_value=base_time,
+    )
+
+    page = await service.list_tags_paginated(
+        CursorPaginationParams(limit=2, cursor=cursor, reverse=True)
+    )
+
+    assert [tag.id for tag in page.items] == [
+        raw_reverse_rows[1].id,
+        raw_reverse_rows[0].id,
+    ]
+    assert page.next_cursor == BaseCursorPaginator.encode_cursor(
+        raw_reverse_rows[0].id,
+        sort_column="created_at",
+        sort_value=raw_reverse_rows[0].created_at,
+    )
+    assert page.prev_cursor == BaseCursorPaginator.encode_cursor(
+        raw_reverse_rows[1].id,
+        sort_column="created_at",
+        sort_value=raw_reverse_rows[1].created_at,
+    )
+    assert page.has_more is True
+    assert page.has_previous is True
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_route_scope_guards.py
+++ b/tests/unit/test_route_scope_guards.py
@@ -186,6 +186,9 @@ async def test_agent_folder_scope_guards(
     [
         (agent_tag_definitions_router.list_agent_tags, "agent:read"),
         (agent_tag_definitions_router.get_agent_tag, "agent:read"),
+        (agent_tag_definitions_router.create_agent_tag, "agent:create"),
+        (agent_tag_definitions_router.update_agent_tag, "agent:update"),
+        (agent_tag_definitions_router.delete_agent_tag, "agent:delete"),
     ],
 )
 async def test_agent_tag_definition_scope_guards(

--- a/tests/unit/test_route_scope_guards.py
+++ b/tests/unit/test_route_scope_guards.py
@@ -4,7 +4,9 @@ from collections.abc import Awaitable, Callable, Sequence
 
 import pytest
 
+from tracecat.agent.folders import router as agent_folder_router
 from tracecat.agent.preset import router as agent_preset_router
+from tracecat.agent.tags import definitions_router as agent_tag_definitions_router
 from tracecat.auth.types import Role
 from tracecat.cases.dropdowns import router as case_dropdowns_router
 from tracecat.cases.durations import router as case_durations_router
@@ -160,6 +162,33 @@ async def test_registry_action_scope_guards(
     ],
 )
 async def test_agent_preset_scope_guards(
+    endpoint: AsyncEndpoint, required_scope: str
+) -> None:
+    await _assert_endpoint_requires_scope(endpoint, required_scope)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("endpoint", "required_scope"),
+    [
+        (agent_folder_router.get_directory, "agent:read"),
+    ],
+)
+async def test_agent_folder_scope_guards(
+    endpoint: AsyncEndpoint, required_scope: str
+) -> None:
+    await _assert_endpoint_requires_scope(endpoint, required_scope)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("endpoint", "required_scope"),
+    [
+        (agent_tag_definitions_router.list_agent_tags, "agent:read"),
+        (agent_tag_definitions_router.get_agent_tag, "agent:read"),
+    ],
+)
+async def test_agent_tag_definition_scope_guards(
     endpoint: AsyncEndpoint, required_scope: str
 ) -> None:
     await _assert_endpoint_requires_scope(endpoint, required_scope)

--- a/tracecat/agent/folders/router.py
+++ b/tracecat/agent/folders/router.py
@@ -138,12 +138,13 @@ async def delete_folder(
     role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     folder_id: UUID,
-    params: AgentFolderDelete,
+    params: AgentFolderDelete | None = None,
 ) -> None:
     """Delete an agent folder."""
     service = AgentFolderService(session, role=role)
     try:
-        await service.delete_folder(folder_id, recursive=params.recursive)
+        recursive = params.recursive if params is not None else False
+        await service.delete_folder(folder_id, recursive=recursive)
     except TracecatValidationError as e:
         raise _folder_http_exception(e) from e
 

--- a/tracecat/agent/folders/router.py
+++ b/tracecat/agent/folders/router.py
@@ -85,10 +85,7 @@ async def list_folders(
     except TracecatValidationError as e:
         raise _folder_http_exception(e) from e
     return CursorPaginatedResponse(
-        items=[
-            AgentFolderRead.model_validate(folder, from_attributes=True)
-            for folder in page.items
-        ],
+        items=AgentFolderRead.list_adapter().validate_python(page.items),
         next_cursor=page.next_cursor,
         prev_cursor=page.prev_cursor,
         has_more=page.has_more,

--- a/tracecat/agent/folders/router.py
+++ b/tracecat/agent/folders/router.py
@@ -63,7 +63,10 @@ async def list_folders(
     """List folders under the specified parent path."""
     service = AgentFolderService(session, role=role)
     normalized_parent_path = service._normalize_folder_path(parent_path)
-    folders = await service.list_folders(parent_path=parent_path)
+    try:
+        folders = await service.list_folders(parent_path=parent_path)
+    except TracecatValidationError as e:
+        raise _folder_http_exception(e) from e
     folders = [f for f in folders if f.path != normalized_parent_path]
     return [
         AgentFolderRead.model_validate(folder, from_attributes=True)

--- a/tracecat/agent/folders/router.py
+++ b/tracecat/agent/folders/router.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
 
+from tracecat import config
 from tracecat.agent.folders.schemas import (
     AgentFolderCreate,
     AgentFolderDelete,
@@ -22,6 +23,7 @@ from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 
 router = APIRouter(prefix="/agent-folders", tags=["agent-folders"])
 
@@ -53,25 +55,44 @@ async def get_directory(
     return list(result)
 
 
-@router.get("")
+@router.get("", response_model=CursorPaginatedResponse[AgentFolderRead])
 @require_scope("agent:read")
 async def list_folders(
     role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     parent_path: str = Query(default="/", description="Parent folder path"),
-) -> list[AgentFolderRead]:
+    limit: int = Query(
+        default=config.TRACECAT__LIMIT_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+    ),
+    cursor: str | None = Query(default=None),
+    reverse: bool = Query(default=False),
+) -> CursorPaginatedResponse[AgentFolderRead]:
     """List folders under the specified parent path."""
     service = AgentFolderService(session, role=role)
-    normalized_parent_path = service._normalize_folder_path(parent_path)
     try:
-        folders = await service.list_folders(parent_path=parent_path)
+        page = await service.list_folders_paginated(
+            parent_path=parent_path,
+            params=CursorPaginationParams(
+                limit=limit,
+                cursor=cursor,
+                reverse=reverse,
+            ),
+        )
     except TracecatValidationError as e:
         raise _folder_http_exception(e) from e
-    folders = [f for f in folders if f.path != normalized_parent_path]
-    return [
-        AgentFolderRead.model_validate(folder, from_attributes=True)
-        for folder in folders
-    ]
+    return CursorPaginatedResponse(
+        items=[
+            AgentFolderRead.model_validate(folder, from_attributes=True)
+            for folder in page.items
+        ],
+        next_cursor=page.next_cursor,
+        prev_cursor=page.prev_cursor,
+        has_more=page.has_more,
+        has_previous=page.has_previous,
+        total_estimate=page.total_estimate,
+    )
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)

--- a/tracecat/agent/folders/router.py
+++ b/tracecat/agent/folders/router.py
@@ -6,12 +6,12 @@ from fastapi import APIRouter, HTTPException, Query, status
 
 from tracecat import config
 from tracecat.agent.folders.schemas import (
+    AgentDirectoryResponse,
     AgentFolderCreate,
     AgentFolderDelete,
     AgentFolderMove,
     AgentFolderRead,
     AgentFolderUpdate,
-    DirectoryItem,
 )
 from tracecat.agent.folders.service import (
     AgentFolderErrorCode,
@@ -41,20 +41,43 @@ def _folder_http_exception(err: TracecatValidationError) -> HTTPException:
     return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(err))
 
 
-@router.get("/directory")
+@router.get("/directory", response_model=AgentDirectoryResponse)
 @require_scope("agent:read")
 async def get_directory(
     role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     path: str = Query(default="/", description="Folder path"),
-) -> list[DirectoryItem]:
+    limit: int = Query(
+        default=config.TRACECAT__LIMIT_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+    ),
+    cursor: str | None = Query(default=None),
+    reverse: bool = Query(default=False),
+) -> AgentDirectoryResponse:
     """Get directory items (presets and folders) in the given path."""
     service = AgentFolderService(session, role=role)
     try:
-        result = await service.get_directory_items(path, order_by="desc")
+        page = await service.get_directory_items_paginated(
+            path,
+            CursorPaginationParams(
+                limit=limit,
+                cursor=cursor,
+                reverse=reverse,
+            ),
+        )
     except TracecatNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
-    return list(result)
+    except TracecatValidationError as e:
+        raise _folder_http_exception(e) from e
+    return AgentDirectoryResponse(
+        items=page.items,
+        next_cursor=page.next_cursor,
+        prev_cursor=page.prev_cursor,
+        has_more=page.has_more,
+        has_previous=page.has_previous,
+        total_estimate=page.total_estimate,
+    )
 
 
 @router.get("", response_model=CursorPaginatedResponse[AgentFolderRead])

--- a/tracecat/agent/folders/router.py
+++ b/tracecat/agent/folders/router.py
@@ -1,0 +1,177 @@
+"""HTTP routes for agent folder management."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from tracecat.agent.folders.schemas import (
+    AgentFolderCreate,
+    AgentFolderDelete,
+    AgentFolderMove,
+    AgentFolderRead,
+    AgentFolderUpdate,
+    DirectoryItem,
+)
+from tracecat.agent.folders.service import (
+    AGENT_FOLDER_CONFLICT_CODE,
+    AGENT_FOLDER_NOT_FOUND_CODE,
+    AGENT_FOLDER_PARENT_NOT_FOUND_CODE,
+    AgentFolderService,
+)
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
+from tracecat.authz.controls import require_scope
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+
+router = APIRouter(prefix="/agent-folders", tags=["agent-folders"])
+
+
+def _folder_http_exception(err: TracecatValidationError) -> HTTPException:
+    detail = err.detail if isinstance(err.detail, dict) else {}
+    code = detail.get("code") if isinstance(detail, dict) else None
+
+    if code in {AGENT_FOLDER_NOT_FOUND_CODE, AGENT_FOLDER_PARENT_NOT_FOUND_CODE}:
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(err))
+    if code == AGENT_FOLDER_CONFLICT_CODE:
+        return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(err))
+    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(err))
+
+
+@router.get("/directory")
+@require_scope("agent:read")
+async def get_directory(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    path: str = Query(default="/", description="Folder path"),
+) -> list[DirectoryItem]:
+    """Get directory items (presets and folders) in the given path."""
+    service = AgentFolderService(session, role=role)
+    try:
+        result = await service.get_directory_items(path, order_by="desc")
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return list(result)
+
+
+@router.get("")
+@require_scope("agent:read")
+async def list_folders(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    parent_path: str = Query(default="/", description="Parent folder path"),
+) -> list[AgentFolderRead]:
+    """List folders under the specified parent path."""
+    service = AgentFolderService(session, role=role)
+    normalized_parent_path = service._normalize_folder_path(parent_path)
+    folders = await service.list_folders(parent_path=parent_path)
+    folders = [f for f in folders if f.path != normalized_parent_path]
+    return [
+        AgentFolderRead.model_validate(folder, from_attributes=True)
+        for folder in folders
+    ]
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+@require_scope("agent:create")
+async def create_folder(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    params: AgentFolderCreate,
+) -> AgentFolderRead:
+    """Create a new agent folder."""
+    service = AgentFolderService(session, role=role)
+    try:
+        folder = await service.create_folder(
+            name=params.name, parent_path=params.parent_path
+        )
+        return AgentFolderRead.model_validate(folder, from_attributes=True)
+    except TracecatValidationError as e:
+        raise _folder_http_exception(e) from e
+
+
+@router.get("/{folder_id}")
+@require_scope("agent:read")
+async def get_folder(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    folder_id: UUID,
+) -> AgentFolderRead:
+    """Get folder details by ID."""
+    service = AgentFolderService(session, role=role)
+    folder = await service.get_folder(folder_id)
+    if not folder:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found"
+        )
+    return AgentFolderRead.model_validate(folder, from_attributes=True)
+
+
+@router.patch("/{folder_id}")
+@require_scope("agent:update")
+async def update_folder(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    folder_id: UUID,
+    params: AgentFolderUpdate,
+) -> AgentFolderRead:
+    """Update a folder (rename)."""
+    service = AgentFolderService(session, role=role)
+    if params.name is None:
+        folder = await service.get_folder(folder_id)
+        if not folder:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found"
+            )
+        return AgentFolderRead.model_validate(folder, from_attributes=True)
+
+    try:
+        folder = await service.rename_folder(folder_id, params.name)
+    except TracecatValidationError as e:
+        raise _folder_http_exception(e) from e
+    else:
+        return AgentFolderRead.model_validate(folder, from_attributes=True)
+
+
+@router.delete("/{folder_id}", status_code=status.HTTP_204_NO_CONTENT)
+@require_scope("agent:delete")
+async def delete_folder(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    folder_id: UUID,
+    params: AgentFolderDelete,
+) -> None:
+    """Delete an agent folder."""
+    service = AgentFolderService(session, role=role)
+    try:
+        await service.delete_folder(folder_id, recursive=params.recursive)
+    except TracecatValidationError as e:
+        raise _folder_http_exception(e) from e
+
+
+@router.post("/{folder_id}/move")
+@require_scope("agent:update")
+async def move_folder(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    folder_id: UUID,
+    params: AgentFolderMove,
+) -> AgentFolderRead:
+    """Move a folder to a new parent folder."""
+    service = AgentFolderService(session, role=role)
+    new_parent_id: UUID | None = None
+
+    if params.new_parent_path and params.new_parent_path != "/":
+        parent_folder = await service.get_folder_by_path(params.new_parent_path)
+        if not parent_folder:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Parent folder with path {params.new_parent_path} not found",
+            )
+        new_parent_id = parent_folder.id
+
+    try:
+        folder = await service.move_folder(folder_id, new_parent_id)
+    except TracecatValidationError as e:
+        raise _folder_http_exception(e) from e
+    else:
+        return AgentFolderRead.model_validate(folder, from_attributes=True)

--- a/tracecat/agent/folders/router.py
+++ b/tracecat/agent/folders/router.py
@@ -14,9 +14,7 @@ from tracecat.agent.folders.schemas import (
     DirectoryItem,
 )
 from tracecat.agent.folders.service import (
-    AGENT_FOLDER_CONFLICT_CODE,
-    AGENT_FOLDER_NOT_FOUND_CODE,
-    AGENT_FOLDER_PARENT_NOT_FOUND_CODE,
+    AgentFolderErrorCode,
     AgentFolderService,
 )
 from tracecat.auth.dependencies import WorkspaceUserRouteRole
@@ -30,11 +28,15 @@ router = APIRouter(prefix="/agent-folders", tags=["agent-folders"])
 
 def _folder_http_exception(err: TracecatValidationError) -> HTTPException:
     detail = err.detail if isinstance(err.detail, dict) else {}
-    code = detail.get("code") if isinstance(detail, dict) else None
+    raw_code = detail.get("code") if isinstance(detail, dict) else None
+    try:
+        code = AgentFolderErrorCode(raw_code)
+    except (TypeError, ValueError):
+        code = None
 
-    if code in {AGENT_FOLDER_NOT_FOUND_CODE, AGENT_FOLDER_PARENT_NOT_FOUND_CODE}:
+    if code in {AgentFolderErrorCode.NOT_FOUND, AgentFolderErrorCode.PARENT_NOT_FOUND}:
         return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(err))
-    if code == AGENT_FOLDER_CONFLICT_CODE:
+    if code == AgentFolderErrorCode.CONFLICT:
         return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(err))
     return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(err))
 

--- a/tracecat/agent/folders/schemas.py
+++ b/tracecat/agent/folders/schemas.py
@@ -1,0 +1,63 @@
+"""Pydantic schemas for agent folder resources."""
+
+import uuid
+from datetime import datetime
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field, TypeAdapter
+
+from tracecat.tags.schemas import TagRead
+
+
+class AgentFolderRead(BaseModel):
+    id: uuid.UUID
+    name: str
+    path: str
+    workspace_id: uuid.UUID
+    created_at: datetime
+    updated_at: datetime
+
+
+class AgentFolderCreate(BaseModel):
+    name: str
+    parent_path: str = "/"
+
+
+class AgentFolderUpdate(BaseModel):
+    name: str | None = None
+
+
+class AgentFolderMove(BaseModel):
+    new_parent_path: str | None = None
+
+
+class AgentFolderDelete(BaseModel):
+    recursive: bool = False
+
+
+class AgentFolderDirectoryItem(AgentFolderRead):
+    type: Literal["folder"]
+    num_items: int
+
+
+class AgentPresetDirectoryItem(BaseModel):
+    """Agent preset as a directory item."""
+
+    type: Literal["preset"]
+    id: uuid.UUID
+    name: str
+    slug: str
+    description: str | None
+    model_provider: str
+    model_name: str
+    folder_id: uuid.UUID | None
+    tags: list[TagRead]
+    created_at: datetime
+    updated_at: datetime
+
+
+DirectoryItem = Annotated[
+    AgentPresetDirectoryItem | AgentFolderDirectoryItem,
+    Field(discriminator="type"),
+]
+DirectoryItemAdapter: TypeAdapter[DirectoryItem] = TypeAdapter(DirectoryItem)

--- a/tracecat/agent/folders/schemas.py
+++ b/tracecat/agent/folders/schemas.py
@@ -7,6 +7,7 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, Field, TypeAdapter
 
 from tracecat.core.schemas import Schema
+from tracecat.pagination import CursorPaginatedResponse
 from tracecat.tags.schemas import TagRead
 
 
@@ -62,3 +63,7 @@ DirectoryItem = Annotated[
     Field(discriminator="type"),
 ]
 DirectoryItemAdapter: TypeAdapter[DirectoryItem] = TypeAdapter(DirectoryItem)
+
+
+class AgentDirectoryResponse(CursorPaginatedResponse[DirectoryItem]):
+    """Paginated response for agent folder directory items."""

--- a/tracecat/agent/folders/schemas.py
+++ b/tracecat/agent/folders/schemas.py
@@ -6,10 +6,11 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, TypeAdapter
 
+from tracecat.core.schemas import Schema
 from tracecat.tags.schemas import TagRead
 
 
-class AgentFolderRead(BaseModel):
+class AgentFolderRead(Schema):
     id: uuid.UUID
     name: str
     path: str

--- a/tracecat/agent/folders/service.py
+++ b/tracecat/agent/folders/service.py
@@ -1,0 +1,531 @@
+"""Service for managing agent preset folders using materialized path pattern."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from typing import Literal
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import selectinload
+
+from tracecat.agent.folders.schemas import (
+    AgentFolderDirectoryItem,
+    AgentPresetDirectoryItem,
+    DirectoryItem,
+)
+from tracecat.authz.controls import require_scope
+from tracecat.db.models import AgentFolder, AgentPreset
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.service import BaseWorkspaceService, requires_entitlement
+from tracecat.tags.schemas import TagRead
+from tracecat.tiers.enums import Entitlement
+
+AGENT_FOLDER_CONFLICT_CODE = "agent_folder_conflict"
+AGENT_FOLDER_NOT_FOUND_CODE = "agent_folder_not_found"
+AGENT_FOLDER_PARENT_NOT_FOUND_CODE = "agent_folder_parent_not_found"
+AGENT_FOLDER_INVALID_CODE = "agent_folder_invalid"
+
+
+class AgentFolderService(BaseWorkspaceService):
+    """Service for managing agent preset folders using materialized path pattern."""
+
+    service_name = "agent_folders"
+
+    @staticmethod
+    def _normalize_folder_path(path: str) -> str:
+        """Normalize folder paths to materialized-path format."""
+        if not path or path == "/":
+            return "/"
+        return path if path.endswith("/") else f"{path}/"
+
+    @staticmethod
+    def _folder_validation_error(
+        message: str,
+        *,
+        code: str,
+    ) -> TracecatValidationError:
+        return TracecatValidationError(message, detail={"code": code})
+
+    @staticmethod
+    def _normalize_folder_name(name: str) -> str:
+        """Trim folder names and reject blank values."""
+        normalized_name = name.strip()
+        if not normalized_name:
+            raise AgentFolderService._folder_validation_error(
+                "Folder name cannot be empty",
+                code=AGENT_FOLDER_INVALID_CODE,
+            )
+        if "/" in normalized_name:
+            raise AgentFolderService._folder_validation_error(
+                "Folder name cannot contain slashes",
+                code=AGENT_FOLDER_INVALID_CODE,
+            )
+        return normalized_name
+
+    @classmethod
+    def _get_parent_path(cls, path: str) -> str:
+        """Return the immediate parent path for a normalized folder path."""
+        path = cls._normalize_folder_path(path)
+        if path == "/":
+            return "/"
+
+        parent_path, _, _ = path.rstrip("/").rpartition("/")
+        return f"{parent_path}/" if parent_path else "/"
+
+    async def _write_folder_change(
+        self,
+        *,
+        conflict_path: str,
+        commit: bool,
+    ) -> None:
+        """Persist a folder write and translate unique conflicts cleanly."""
+        try:
+            if commit:
+                await self.session.commit()
+            else:
+                await self.session.flush()
+        except IntegrityError as exc:
+            await self.session.rollback()
+            raise self._folder_validation_error(
+                f"Folder {conflict_path} already exists",
+                code=AGENT_FOLDER_CONFLICT_CODE,
+            ) from exc
+
+    @require_scope("agent:create")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def create_folder(
+        self, name: str, parent_path: str = "/", commit: bool = True
+    ) -> AgentFolder:
+        """Create a new agent folder."""
+        normalized_name = self._normalize_folder_name(name)
+
+        parent_path = self._normalize_folder_path(parent_path)
+
+        if parent_path != "/":
+            parent_exists = await self._folder_path_exists(parent_path)
+            if not parent_exists:
+                raise self._folder_validation_error(
+                    f"Parent path {parent_path} not found",
+                    code=AGENT_FOLDER_PARENT_NOT_FOUND_CODE,
+                )
+
+        full_path = (
+            f"{parent_path}{normalized_name}/"
+            if parent_path != "/"
+            else f"/{normalized_name}/"
+        )
+
+        path_exists = await self._folder_path_exists(full_path)
+        if path_exists:
+            raise self._folder_validation_error(
+                f"Folder {full_path} already exists",
+                code=AGENT_FOLDER_CONFLICT_CODE,
+            )
+
+        folder = AgentFolder(
+            name=normalized_name,
+            path=full_path,
+            workspace_id=self.workspace_id,
+        )
+        self.session.add(folder)
+        await self._write_folder_change(conflict_path=full_path, commit=commit)
+        await self.session.refresh(folder)
+        return folder
+
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def get_folder(self, folder_id: uuid.UUID) -> AgentFolder | None:
+        """Get a folder by ID."""
+        statement = select(AgentFolder).where(
+            AgentFolder.workspace_id == self.workspace_id,
+            AgentFolder.id == folder_id,
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one_or_none()
+
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def get_folder_by_path(self, path: str) -> AgentFolder | None:
+        """Get a folder by its path."""
+        path = self._normalize_folder_path(path)
+
+        statement = select(AgentFolder).where(
+            AgentFolder.workspace_id == self.workspace_id,
+            AgentFolder.path == path,
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one_or_none()
+
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def list_folders(self, parent_path: str = "/") -> Sequence[AgentFolder]:
+        """List all folders within the specified parent path subtree."""
+        parent_path = self._normalize_folder_path(parent_path)
+        statement = select(AgentFolder).where(
+            AgentFolder.workspace_id == self.workspace_id,
+            AgentFolder.path.startswith(parent_path, autoescape=True),
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().all()
+
+    @require_scope("agent:update")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def move_preset(
+        self, preset_id: uuid.UUID, folder: AgentFolder | None = None
+    ) -> AgentPreset:
+        """Move an agent preset to a different folder."""
+        statement = select(AgentPreset).where(
+            AgentPreset.workspace_id == self.workspace_id,
+            AgentPreset.id == preset_id,
+        )
+        result = await self.session.execute(statement)
+        preset = result.scalar_one_or_none()
+        if not preset:
+            raise TracecatNotFoundError(f"Agent preset {preset_id} not found")
+
+        preset.folder_id = folder.id if folder else None
+        self.session.add(preset)
+        await self.session.commit()
+        await self.session.refresh(preset)
+        return preset
+
+    @require_scope("agent:update")
+    async def rename_folder(self, folder_id: uuid.UUID, new_name: str) -> AgentFolder:
+        """Rename a folder. Updates the folder name and path."""
+        normalized_name = self._normalize_folder_name(new_name)
+
+        folder = await self.get_folder(folder_id)
+        if not folder:
+            raise self._folder_validation_error(
+                f"Folder {folder_id} not found",
+                code=AGENT_FOLDER_NOT_FOUND_CODE,
+            )
+
+        old_path = folder.path
+        parent_path = self._get_parent_path(folder.path)
+        new_path = (
+            f"{parent_path}{normalized_name}/"
+            if parent_path != "/"
+            else f"/{normalized_name}/"
+        )
+
+        if new_path != old_path:
+            path_exists = await self._folder_path_exists(new_path)
+            if path_exists:
+                raise self._folder_validation_error(
+                    f"Folder {new_path} already exists",
+                    code=AGENT_FOLDER_CONFLICT_CODE,
+                )
+
+        descendants = await self._get_descendants(old_path)
+
+        folder.name = normalized_name
+        folder.path = new_path
+        self.session.add(folder)
+
+        for descendant in descendants:
+            descendant.path = descendant.path.replace(old_path, new_path, 1)
+            self.session.add(descendant)
+
+        await self._write_folder_change(conflict_path=new_path, commit=True)
+        await self.session.refresh(folder)
+        return folder
+
+    @require_scope("agent:update")
+    async def move_folder(
+        self, folder_id: uuid.UUID, new_parent_id: uuid.UUID | None
+    ) -> AgentFolder:
+        """Move a folder to a different parent."""
+        folder = await self.get_folder(folder_id)
+        if not folder:
+            raise self._folder_validation_error(
+                f"Folder {folder_id} not found",
+                code=AGENT_FOLDER_NOT_FOUND_CODE,
+            )
+
+        new_parent_path = "/"
+        if new_parent_id is not None:
+            new_parent = await self.get_folder(new_parent_id)
+            if not new_parent:
+                raise self._folder_validation_error(
+                    f"Parent folder {new_parent_id} not found",
+                    code=AGENT_FOLDER_PARENT_NOT_FOUND_CODE,
+                )
+            new_parent_path = new_parent.path
+
+            if folder.path == new_parent_path:
+                raise self._folder_validation_error(
+                    "Cannot make a folder its own child",
+                    code=AGENT_FOLDER_INVALID_CODE,
+                )
+            if new_parent.path.startswith(folder.path):
+                raise self._folder_validation_error(
+                    "Cannot create cyclic folder structure",
+                    code=AGENT_FOLDER_INVALID_CODE,
+                )
+
+        old_path = folder.path
+        old_name = folder.name
+        new_path = (
+            f"{new_parent_path}{old_name}/"
+            if new_parent_path != "/"
+            else f"/{old_name}/"
+        )
+
+        if new_path != old_path:
+            path_exists = await self._folder_path_exists(new_path)
+            if path_exists:
+                raise self._folder_validation_error(
+                    f"Folder {new_path} already exists",
+                    code=AGENT_FOLDER_CONFLICT_CODE,
+                )
+
+        descendants = await self._get_descendants(old_path)
+
+        folder.path = new_path
+        self.session.add(folder)
+
+        for descendant in descendants:
+            descendant.path = descendant.path.replace(old_path, new_path, 1)
+            self.session.add(descendant)
+
+        await self._write_folder_change(conflict_path=new_path, commit=True)
+        await self.session.refresh(folder)
+        return folder
+
+    @require_scope("agent:delete")
+    async def delete_folder(
+        self, folder_id: uuid.UUID, recursive: bool = False
+    ) -> None:
+        """Delete a folder."""
+        folder = await self.get_folder(folder_id)
+        if not folder:
+            raise self._folder_validation_error(
+                f"Folder {folder_id} not found",
+                code=AGENT_FOLDER_NOT_FOUND_CODE,
+            )
+
+        if folder.path == "/":
+            raise self._folder_validation_error(
+                "Cannot delete root folder",
+                code=AGENT_FOLDER_INVALID_CODE,
+            )
+
+        if not recursive:
+            has_children = await self._has_children(folder.path)
+            has_presets = await self._has_presets(folder_id)
+            if has_children or has_presets:
+                raise self._folder_validation_error(
+                    "Folder is not empty. Please move or delete its contents first.",
+                    code=AGENT_FOLDER_INVALID_CODE,
+                )
+        else:
+            descendants = await self._get_descendants(folder.path)
+            for descendant in descendants:
+                statement = select(AgentPreset).where(
+                    AgentPreset.workspace_id == self.workspace_id,
+                    AgentPreset.folder_id == descendant.id,
+                )
+                result = await self.session.execute(statement)
+                presets = result.scalars().all()
+                for preset in presets:
+                    preset.folder_id = None
+                    self.session.add(preset)
+                await self.session.delete(descendant)
+
+            statement = select(AgentPreset).where(
+                AgentPreset.workspace_id == self.workspace_id,
+                AgentPreset.folder_id == folder.id,
+            )
+            result = await self.session.execute(statement)
+            presets = result.scalars().all()
+            for preset in presets:
+                preset.folder_id = None
+                self.session.add(preset)
+
+        await self.session.delete(folder)
+        await self.session.commit()
+
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def get_directory_items(
+        self, path: str = "/", *, order_by: Literal["asc", "desc"] = "desc"
+    ) -> Sequence[DirectoryItem]:
+        """Get all directory items (presets and folders) in the given path."""
+        path = self._normalize_folder_path(path)
+
+        if path != "/":
+            folder = await self.get_folder_by_path(path)
+            if not folder:
+                raise TracecatNotFoundError(f"Folder {path} not found")
+            folder_id = folder.id
+        else:
+            folder_id = None
+
+        # Fetch presets in this folder
+        preset_statement = (
+            select(AgentPreset)
+            .where(
+                AgentPreset.workspace_id == self.workspace_id,
+                AgentPreset.folder_id == folder_id,
+            )
+            .order_by(
+                AgentPreset.created_at.desc()
+                if order_by == "desc"
+                else AgentPreset.created_at.asc()
+            )
+            .options(selectinload(AgentPreset.tags))
+        )
+        preset_result = await self.session.execute(preset_statement)
+        presets = preset_result.scalars().all()
+
+        path_depth = path.count("/") + 1
+        folder_statement = select(AgentFolder).where(
+            AgentFolder.workspace_id == self.workspace_id,
+            AgentFolder.path.startswith(path, autoescape=True),
+            AgentFolder.path != path,
+            func.length(AgentFolder.path)
+            - func.length(func.replace(AgentFolder.path, "/", ""))
+            == path_depth,
+        )
+        folder_result = await self.session.execute(folder_statement)
+        folders = folder_result.scalars().all()
+
+        directory_items: list[DirectoryItem] = []
+        folder_ids = [folder.id for folder in folders]
+        folder_paths = {folder.path for folder in folders}
+        preset_counts_by_folder_id: dict[uuid.UUID, int] = {}
+        child_folder_counts_by_path: dict[str, int] = {}
+
+        if folder_ids:
+            preset_folder_result = await self.session.execute(
+                select(AgentPreset.folder_id, func.count(AgentPreset.id))
+                .where(
+                    AgentPreset.workspace_id == self.workspace_id,
+                    AgentPreset.folder_id.in_(folder_ids),
+                )
+                .group_by(AgentPreset.folder_id)
+            )
+            preset_counts_by_folder_id = {
+                folder_id: preset_count
+                for folder_id, preset_count in preset_folder_result.tuples().all()
+                if folder_id is not None
+            }
+
+            descendant_path_result = await self.session.execute(
+                select(AgentFolder.path).where(
+                    AgentFolder.workspace_id == self.workspace_id,
+                    AgentFolder.path.startswith(path, autoescape=True),
+                    AgentFolder.path != path,
+                )
+            )
+            for descendant_path in descendant_path_result.scalars().all():
+                parent_path = self._get_parent_path(descendant_path)
+                if parent_path in folder_paths:
+                    child_folder_counts_by_path[parent_path] = (
+                        child_folder_counts_by_path.get(parent_path, 0) + 1
+                    )
+
+        for f in folders:
+            num_items = child_folder_counts_by_path.get(
+                f.path, 0
+            ) + preset_counts_by_folder_id.get(f.id, 0)
+            directory_items.append(
+                AgentFolderDirectoryItem(
+                    type="folder",
+                    num_items=num_items,
+                    id=f.id,
+                    name=f.name,
+                    path=f.path,
+                    workspace_id=f.workspace_id,
+                    created_at=f.created_at,
+                    updated_at=f.updated_at,
+                )
+            )
+
+        for preset in presets:
+            directory_items.append(
+                AgentPresetDirectoryItem(
+                    type="preset",
+                    id=preset.id,
+                    name=preset.name,
+                    slug=preset.slug,
+                    description=preset.description,
+                    model_provider=preset.model_provider,
+                    model_name=preset.model_name,
+                    folder_id=preset.folder_id,
+                    tags=[
+                        TagRead.model_validate(tag, from_attributes=True)
+                        for tag in preset.tags
+                    ],
+                    created_at=preset.created_at,
+                    updated_at=preset.updated_at,
+                )
+            )
+
+        return directory_items
+
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def get_folder_tree(self, root_path: str = "/") -> Sequence[AgentFolder]:
+        """Get the full folder tree starting from the given root path."""
+        root_path = self._normalize_folder_path(root_path)
+
+        statement = (
+            select(AgentFolder)
+            .where(
+                AgentFolder.workspace_id == self.workspace_id,
+                AgentFolder.path.startswith(root_path, autoescape=True),
+            )
+            .order_by(AgentFolder.path)
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().all()
+
+    # Private helpers
+
+    async def _folder_path_exists(self, path: str) -> bool:
+        path = self._normalize_folder_path(path)
+        statement = (
+            select(func.count())
+            .select_from(AgentFolder)
+            .where(
+                AgentFolder.workspace_id == self.workspace_id,
+                AgentFolder.path == path,
+            )
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one() > 0
+
+    async def _has_children(self, path: str) -> bool:
+        path = self._normalize_folder_path(path)
+        statement = (
+            select(func.count())
+            .select_from(AgentFolder)
+            .where(
+                AgentFolder.workspace_id == self.workspace_id,
+                AgentFolder.path.startswith(path, autoescape=True),
+                AgentFolder.path != path,
+            )
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one() > 0
+
+    async def _has_presets(self, folder_id: uuid.UUID) -> bool:
+        statement = (
+            select(func.count())
+            .select_from(AgentPreset)
+            .where(
+                AgentPreset.workspace_id == self.workspace_id,
+                AgentPreset.folder_id == folder_id,
+            )
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one() > 0
+
+    async def _get_descendants(self, path: str) -> Sequence[AgentFolder]:
+        path = self._normalize_folder_path(path)
+        statement = select(AgentFolder).where(
+            AgentFolder.workspace_id == self.workspace_id,
+            AgentFolder.path.startswith(path, autoescape=True),
+            AgentFolder.path != path,
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().all()

--- a/tracecat/agent/folders/service.py
+++ b/tracecat/agent/folders/service.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Sequence
+from datetime import datetime
 from typing import Literal
 
+import sqlalchemy as sa
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
@@ -18,6 +20,11 @@ from tracecat.agent.folders.schemas import (
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import AgentFolder, AgentPreset
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.pagination import (
+    BaseCursorPaginator,
+    CursorPaginatedResponse,
+    CursorPaginationParams,
+)
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tags.schemas import TagRead
 from tracecat.tiers.enums import Entitlement
@@ -164,10 +171,7 @@ class AgentFolderService(BaseWorkspaceService):
         """Get a folder by its path."""
         return await self._get_folder_by_path(path)
 
-    @require_scope("agent:read")
-    @requires_entitlement(Entitlement.AGENT_ADDONS)
-    async def list_folders(self, parent_path: str = "/") -> Sequence[AgentFolder]:
-        """List all folders within the specified parent path subtree."""
+    async def _require_existing_parent_path(self, parent_path: str) -> str:
         parent_path = self._normalize_folder_path(parent_path)
         if parent_path != "/":
             parent_exists = await self._folder_path_exists(parent_path)
@@ -176,6 +180,13 @@ class AgentFolderService(BaseWorkspaceService):
                     f"Parent path {parent_path} not found",
                     code=AGENT_FOLDER_PARENT_NOT_FOUND_CODE,
                 )
+        return parent_path
+
+    @require_scope("agent:read")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def list_folders(self, parent_path: str = "/") -> Sequence[AgentFolder]:
+        """List all folders within the specified parent path subtree."""
+        parent_path = await self._require_existing_parent_path(parent_path)
 
         statement = select(AgentFolder).where(
             AgentFolder.workspace_id == self.workspace_id,
@@ -183,6 +194,100 @@ class AgentFolderService(BaseWorkspaceService):
         )
         result = await self.session.execute(statement)
         return result.scalars().all()
+
+    @require_scope("agent:read")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def list_folders_paginated(
+        self,
+        parent_path: str = "/",
+        params: CursorPaginationParams | None = None,
+    ) -> CursorPaginatedResponse[AgentFolder]:
+        """List folders within a parent path subtree with cursor pagination."""
+        params = params or CursorPaginationParams()
+        parent_path = await self._require_existing_parent_path(parent_path)
+        paginator = BaseCursorPaginator(self.session)
+        statement = select(AgentFolder).where(
+            AgentFolder.workspace_id == self.workspace_id,
+            AgentFolder.path.startswith(parent_path, autoescape=True),
+            AgentFolder.path != parent_path,
+        )
+
+        if params.cursor:
+            try:
+                cursor_data = paginator.decode_cursor(params.cursor)
+                cursor_id = uuid.UUID(cursor_data.id)
+            except ValueError as err:
+                raise TracecatValidationError(
+                    "Invalid cursor for agent folders"
+                ) from err
+
+            cursor_created_at = cursor_data.sort_value
+            if not isinstance(cursor_created_at, datetime):
+                raise TracecatValidationError("Invalid cursor for agent folders")
+
+            predicate = sa.or_(
+                AgentFolder.created_at < cursor_created_at,
+                sa.and_(
+                    AgentFolder.created_at == cursor_created_at,
+                    AgentFolder.id < cursor_id,
+                ),
+            )
+            if params.reverse:
+                predicate = sa.or_(
+                    AgentFolder.created_at > cursor_created_at,
+                    sa.and_(
+                        AgentFolder.created_at == cursor_created_at,
+                        AgentFolder.id > cursor_id,
+                    ),
+                )
+            statement = statement.where(predicate)
+
+        if params.reverse:
+            statement = statement.order_by(
+                AgentFolder.created_at.asc(), AgentFolder.id.asc()
+            )
+        else:
+            statement = statement.order_by(
+                AgentFolder.created_at.desc(), AgentFolder.id.desc()
+            )
+        statement = statement.limit(params.limit + 1)
+
+        folders = (await self.session.execute(statement)).scalars().all()
+        has_more = len(folders) > params.limit
+        items = list(folders[: params.limit])
+
+        next_cursor = None
+        if has_more and items:
+            last = items[-1]
+            next_cursor = paginator.encode_cursor(
+                last.id,
+                sort_column="created_at",
+                sort_value=last.created_at,
+            )
+
+        prev_cursor = None
+        if params.cursor and items:
+            first = items[0]
+            prev_cursor = paginator.encode_cursor(
+                first.id,
+                sort_column="created_at",
+                sort_value=first.created_at,
+            )
+
+        if params.reverse:
+            items.reverse()
+            next_cursor, prev_cursor = prev_cursor, next_cursor
+            has_more, has_previous = params.cursor is not None, has_more
+        else:
+            has_previous = params.cursor is not None
+
+        return CursorPaginatedResponse(
+            items=items,
+            next_cursor=next_cursor,
+            prev_cursor=prev_cursor,
+            has_more=has_more,
+            has_previous=has_previous,
+        )
 
     @require_scope("agent:update")
     @requires_entitlement(Entitlement.AGENT_ADDONS)

--- a/tracecat/agent/folders/service.py
+++ b/tracecat/agent/folders/service.py
@@ -344,15 +344,12 @@ class AgentFolderService(BaseWorkspaceService):
                     code=AgentFolderErrorCode.CONFLICT,
                 )
 
-        descendants = await self._get_descendants(old_path)
-
         folder.name = normalized_name
         folder.path = new_path
         self.session.add(folder)
 
-        for descendant in descendants:
-            descendant.path = descendant.path.replace(old_path, new_path, 1)
-            self.session.add(descendant)
+        if new_path != old_path:
+            await self._update_descendant_paths(old_path, new_path)
 
         await self._write_folder_change(conflict_path=new_path, commit=True)
         await self.session.refresh(folder)
@@ -408,14 +405,11 @@ class AgentFolderService(BaseWorkspaceService):
                     code=AgentFolderErrorCode.CONFLICT,
                 )
 
-        descendants = await self._get_descendants(old_path)
-
         folder.path = new_path
         self.session.add(folder)
 
-        for descendant in descendants:
-            descendant.path = descendant.path.replace(old_path, new_path, 1)
-            self.session.add(descendant)
+        if new_path != old_path:
+            await self._update_descendant_paths(old_path, new_path)
 
         await self._write_folder_change(conflict_path=new_path, commit=True)
         await self.session.refresh(folder)
@@ -449,28 +443,28 @@ class AgentFolderService(BaseWorkspaceService):
                     code=AgentFolderErrorCode.INVALID,
                 )
         else:
-            descendants = await self._get_descendants(folder.path)
-            for descendant in descendants:
-                statement = select(AgentPreset).where(
-                    AgentPreset.workspace_id == self.workspace_id,
-                    AgentPreset.folder_id == descendant.id,
-                )
-                result = await self.session.execute(statement)
-                presets = result.scalars().all()
-                for preset in presets:
-                    preset.folder_id = None
-                    self.session.add(preset)
-                await self.session.delete(descendant)
-
-            statement = select(AgentPreset).where(
-                AgentPreset.workspace_id == self.workspace_id,
-                AgentPreset.folder_id == folder.id,
+            folder_ids = select(AgentFolder.id).where(
+                AgentFolder.workspace_id == self.workspace_id,
+                AgentFolder.path.startswith(folder.path, autoescape=True),
             )
-            result = await self.session.execute(statement)
-            presets = result.scalars().all()
-            for preset in presets:
-                preset.folder_id = None
-                self.session.add(preset)
+            await self.session.execute(
+                sa.update(AgentPreset)
+                .where(
+                    AgentPreset.workspace_id == self.workspace_id,
+                    AgentPreset.folder_id.in_(folder_ids),
+                )
+                .values(folder_id=None)
+                .execution_options(synchronize_session=False)
+            )
+            await self.session.execute(
+                sa.delete(AgentFolder)
+                .where(
+                    AgentFolder.workspace_id == self.workspace_id,
+                    AgentFolder.path.startswith(folder.path, autoescape=True),
+                    AgentFolder.path != folder.path,
+                )
+                .execution_options(synchronize_session=False)
+            )
 
         await self.session.delete(folder)
         await self.session.commit()
@@ -541,15 +535,19 @@ class AgentFolderService(BaseWorkspaceService):
                 if folder_id is not None
             }
 
-            descendant_path_result = await self.session.execute(
+            child_depth = path_depth + 1
+            child_path_result = await self.session.execute(
                 select(AgentFolder.path).where(
                     AgentFolder.workspace_id == self.workspace_id,
                     AgentFolder.path.startswith(path, autoescape=True),
                     AgentFolder.path != path,
+                    func.length(AgentFolder.path)
+                    - func.length(func.replace(AgentFolder.path, "/", ""))
+                    == child_depth,
                 )
             )
-            for descendant_path in descendant_path_result.scalars().all():
-                parent_path = self._get_parent_path(descendant_path)
+            for child_path in child_path_result.scalars().all():
+                parent_path = self._get_parent_path(child_path)
                 if parent_path in folder_paths:
                     child_folder_counts_by_path[parent_path] = (
                         child_folder_counts_by_path.get(parent_path, 0) + 1
@@ -615,49 +613,43 @@ class AgentFolderService(BaseWorkspaceService):
 
     async def _folder_path_exists(self, path: str) -> bool:
         path = self._normalize_folder_path(path)
-        statement = (
-            select(func.count())
-            .select_from(AgentFolder)
+        exists_clause = sa.exists().where(
+            AgentFolder.workspace_id == self.workspace_id,
+            AgentFolder.path == path,
+        )
+        return bool(await self.session.scalar(select(exists_clause)))
+
+    async def _update_descendant_paths(self, old_path: str, new_path: str) -> None:
+        old_path = self._normalize_folder_path(old_path)
+        new_path = self._normalize_folder_path(new_path)
+        await self.session.execute(
+            sa.update(AgentFolder)
             .where(
                 AgentFolder.workspace_id == self.workspace_id,
-                AgentFolder.path == path,
+                AgentFolder.path.startswith(old_path, autoescape=True),
+                AgentFolder.path != old_path,
             )
+            .values(
+                path=func.concat(
+                    new_path,
+                    func.substring(AgentFolder.path, len(old_path) + 1),
+                )
+            )
+            .execution_options(synchronize_session=False)
         )
-        result = await self.session.execute(statement)
-        return result.scalar_one() > 0
 
     async def _has_children(self, path: str) -> bool:
         path = self._normalize_folder_path(path)
-        statement = (
-            select(func.count())
-            .select_from(AgentFolder)
-            .where(
-                AgentFolder.workspace_id == self.workspace_id,
-                AgentFolder.path.startswith(path, autoescape=True),
-                AgentFolder.path != path,
-            )
-        )
-        result = await self.session.execute(statement)
-        return result.scalar_one() > 0
-
-    async def _has_presets(self, folder_id: uuid.UUID) -> bool:
-        statement = (
-            select(func.count())
-            .select_from(AgentPreset)
-            .where(
-                AgentPreset.workspace_id == self.workspace_id,
-                AgentPreset.folder_id == folder_id,
-            )
-        )
-        result = await self.session.execute(statement)
-        return result.scalar_one() > 0
-
-    async def _get_descendants(self, path: str) -> Sequence[AgentFolder]:
-        path = self._normalize_folder_path(path)
-        statement = select(AgentFolder).where(
+        exists_clause = sa.exists().where(
             AgentFolder.workspace_id == self.workspace_id,
             AgentFolder.path.startswith(path, autoescape=True),
             AgentFolder.path != path,
         )
-        result = await self.session.execute(statement)
-        return result.scalars().all()
+        return bool(await self.session.scalar(select(exists_clause)))
+
+    async def _has_presets(self, folder_id: uuid.UUID) -> bool:
+        exists_clause = sa.exists().where(
+            AgentPreset.workspace_id == self.workspace_id,
+            AgentPreset.folder_id == folder_id,
+        )
+        return bool(await self.session.scalar(select(exists_clause)))

--- a/tracecat/agent/folders/service.py
+++ b/tracecat/agent/folders/service.py
@@ -169,6 +169,14 @@ class AgentFolderService(BaseWorkspaceService):
     async def list_folders(self, parent_path: str = "/") -> Sequence[AgentFolder]:
         """List all folders within the specified parent path subtree."""
         parent_path = self._normalize_folder_path(parent_path)
+        if parent_path != "/":
+            parent_exists = await self._folder_path_exists(parent_path)
+            if not parent_exists:
+                raise self._folder_validation_error(
+                    f"Parent path {parent_path} not found",
+                    code=AGENT_FOLDER_PARENT_NOT_FOUND_CODE,
+                )
+
         statement = select(AgentFolder).where(
             AgentFolder.workspace_id == self.workspace_id,
             AgentFolder.path.startswith(parent_path, autoescape=True),

--- a/tracecat/agent/folders/service.py
+++ b/tracecat/agent/folders/service.py
@@ -134,9 +134,7 @@ class AgentFolderService(BaseWorkspaceService):
         await self.session.refresh(folder)
         return folder
 
-    @requires_entitlement(Entitlement.AGENT_ADDONS)
-    async def get_folder(self, folder_id: uuid.UUID) -> AgentFolder | None:
-        """Get a folder by ID."""
+    async def _get_folder(self, folder_id: uuid.UUID) -> AgentFolder | None:
         statement = select(AgentFolder).where(
             AgentFolder.workspace_id == self.workspace_id,
             AgentFolder.id == folder_id,
@@ -144,9 +142,7 @@ class AgentFolderService(BaseWorkspaceService):
         result = await self.session.execute(statement)
         return result.scalar_one_or_none()
 
-    @requires_entitlement(Entitlement.AGENT_ADDONS)
-    async def get_folder_by_path(self, path: str) -> AgentFolder | None:
-        """Get a folder by its path."""
+    async def _get_folder_by_path(self, path: str) -> AgentFolder | None:
         path = self._normalize_folder_path(path)
 
         statement = select(AgentFolder).where(
@@ -156,6 +152,19 @@ class AgentFolderService(BaseWorkspaceService):
         result = await self.session.execute(statement)
         return result.scalar_one_or_none()
 
+    @require_scope("agent:read")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def get_folder(self, folder_id: uuid.UUID) -> AgentFolder | None:
+        """Get a folder by ID."""
+        return await self._get_folder(folder_id)
+
+    @require_scope("agent:read")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def get_folder_by_path(self, path: str) -> AgentFolder | None:
+        """Get a folder by its path."""
+        return await self._get_folder_by_path(path)
+
+    @require_scope("agent:read")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def list_folders(self, parent_path: str = "/") -> Sequence[AgentFolder]:
         """List all folders within the specified parent path subtree."""
@@ -297,7 +306,7 @@ class AgentFolderService(BaseWorkspaceService):
         self, folder_id: uuid.UUID, recursive: bool = False
     ) -> None:
         """Delete a folder."""
-        folder = await self.get_folder(folder_id)
+        folder = await self._get_folder(folder_id)
         if not folder:
             raise self._folder_validation_error(
                 f"Folder {folder_id} not found",
@@ -345,6 +354,7 @@ class AgentFolderService(BaseWorkspaceService):
         await self.session.delete(folder)
         await self.session.commit()
 
+    @require_scope("agent:read")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def get_directory_items(
         self, path: str = "/", *, order_by: Literal["asc", "desc"] = "desc"
@@ -463,6 +473,7 @@ class AgentFolderService(BaseWorkspaceService):
 
         return directory_items
 
+    @require_scope("agent:read")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def get_folder_tree(self, root_path: str = "/") -> Sequence[AgentFolder]:
         """Get the full folder tree starting from the given root path."""

--- a/tracecat/agent/folders/service.py
+++ b/tracecat/agent/folders/service.py
@@ -198,6 +198,7 @@ class AgentFolderService(BaseWorkspaceService):
         return preset
 
     @require_scope("agent:update")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def rename_folder(self, folder_id: uuid.UUID, new_name: str) -> AgentFolder:
         """Rename a folder. Updates the folder name and path."""
         normalized_name = self._normalize_folder_name(new_name)
@@ -240,6 +241,7 @@ class AgentFolderService(BaseWorkspaceService):
         return folder
 
     @require_scope("agent:update")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def move_folder(
         self, folder_id: uuid.UUID, new_parent_id: uuid.UUID | None
     ) -> AgentFolder:
@@ -302,6 +304,7 @@ class AgentFolderService(BaseWorkspaceService):
         return folder
 
     @require_scope("agent:delete")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def delete_folder(
         self, folder_id: uuid.UUID, recursive: bool = False
     ) -> None:

--- a/tracecat/agent/folders/service.py
+++ b/tracecat/agent/folders/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 from collections.abc import Sequence
 from datetime import datetime
+from enum import StrEnum
 from typing import Literal
 
 import sqlalchemy as sa
@@ -29,10 +30,14 @@ from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tags.schemas import TagRead
 from tracecat.tiers.enums import Entitlement
 
-AGENT_FOLDER_CONFLICT_CODE = "agent_folder_conflict"
-AGENT_FOLDER_NOT_FOUND_CODE = "agent_folder_not_found"
-AGENT_FOLDER_PARENT_NOT_FOUND_CODE = "agent_folder_parent_not_found"
-AGENT_FOLDER_INVALID_CODE = "agent_folder_invalid"
+
+class AgentFolderErrorCode(StrEnum):
+    """Machine-readable agent folder validation error codes."""
+
+    CONFLICT = "agent_folder_conflict"
+    NOT_FOUND = "agent_folder_not_found"
+    PARENT_NOT_FOUND = "agent_folder_parent_not_found"
+    INVALID = "agent_folder_invalid"
 
 
 class AgentFolderService(BaseWorkspaceService):
@@ -51,9 +56,9 @@ class AgentFolderService(BaseWorkspaceService):
     def _folder_validation_error(
         message: str,
         *,
-        code: str,
+        code: AgentFolderErrorCode,
     ) -> TracecatValidationError:
-        return TracecatValidationError(message, detail={"code": code})
+        return TracecatValidationError(message, detail={"code": code.value})
 
     @staticmethod
     def _normalize_folder_name(name: str) -> str:
@@ -62,12 +67,12 @@ class AgentFolderService(BaseWorkspaceService):
         if not normalized_name:
             raise AgentFolderService._folder_validation_error(
                 "Folder name cannot be empty",
-                code=AGENT_FOLDER_INVALID_CODE,
+                code=AgentFolderErrorCode.INVALID,
             )
         if "/" in normalized_name:
             raise AgentFolderService._folder_validation_error(
                 "Folder name cannot contain slashes",
-                code=AGENT_FOLDER_INVALID_CODE,
+                code=AgentFolderErrorCode.INVALID,
             )
         return normalized_name
 
@@ -97,7 +102,7 @@ class AgentFolderService(BaseWorkspaceService):
             await self.session.rollback()
             raise self._folder_validation_error(
                 f"Folder {conflict_path} already exists",
-                code=AGENT_FOLDER_CONFLICT_CODE,
+                code=AgentFolderErrorCode.CONFLICT,
             ) from exc
 
     @require_scope("agent:create")
@@ -115,7 +120,7 @@ class AgentFolderService(BaseWorkspaceService):
             if not parent_exists:
                 raise self._folder_validation_error(
                     f"Parent path {parent_path} not found",
-                    code=AGENT_FOLDER_PARENT_NOT_FOUND_CODE,
+                    code=AgentFolderErrorCode.PARENT_NOT_FOUND,
                 )
 
         full_path = (
@@ -128,7 +133,7 @@ class AgentFolderService(BaseWorkspaceService):
         if path_exists:
             raise self._folder_validation_error(
                 f"Folder {full_path} already exists",
-                code=AGENT_FOLDER_CONFLICT_CODE,
+                code=AgentFolderErrorCode.CONFLICT,
             )
 
         folder = AgentFolder(
@@ -178,7 +183,7 @@ class AgentFolderService(BaseWorkspaceService):
             if not parent_exists:
                 raise self._folder_validation_error(
                     f"Parent path {parent_path} not found",
-                    code=AGENT_FOLDER_PARENT_NOT_FOUND_CODE,
+                    code=AgentFolderErrorCode.PARENT_NOT_FOUND,
                 )
         return parent_path
 
@@ -320,7 +325,7 @@ class AgentFolderService(BaseWorkspaceService):
         if not folder:
             raise self._folder_validation_error(
                 f"Folder {folder_id} not found",
-                code=AGENT_FOLDER_NOT_FOUND_CODE,
+                code=AgentFolderErrorCode.NOT_FOUND,
             )
 
         old_path = folder.path
@@ -336,7 +341,7 @@ class AgentFolderService(BaseWorkspaceService):
             if path_exists:
                 raise self._folder_validation_error(
                     f"Folder {new_path} already exists",
-                    code=AGENT_FOLDER_CONFLICT_CODE,
+                    code=AgentFolderErrorCode.CONFLICT,
                 )
 
         descendants = await self._get_descendants(old_path)
@@ -363,7 +368,7 @@ class AgentFolderService(BaseWorkspaceService):
         if not folder:
             raise self._folder_validation_error(
                 f"Folder {folder_id} not found",
-                code=AGENT_FOLDER_NOT_FOUND_CODE,
+                code=AgentFolderErrorCode.NOT_FOUND,
             )
 
         new_parent_path = "/"
@@ -372,19 +377,19 @@ class AgentFolderService(BaseWorkspaceService):
             if not new_parent:
                 raise self._folder_validation_error(
                     f"Parent folder {new_parent_id} not found",
-                    code=AGENT_FOLDER_PARENT_NOT_FOUND_CODE,
+                    code=AgentFolderErrorCode.PARENT_NOT_FOUND,
                 )
             new_parent_path = new_parent.path
 
             if folder.path == new_parent_path:
                 raise self._folder_validation_error(
                     "Cannot make a folder its own child",
-                    code=AGENT_FOLDER_INVALID_CODE,
+                    code=AgentFolderErrorCode.INVALID,
                 )
             if new_parent.path.startswith(folder.path):
                 raise self._folder_validation_error(
                     "Cannot create cyclic folder structure",
-                    code=AGENT_FOLDER_INVALID_CODE,
+                    code=AgentFolderErrorCode.INVALID,
                 )
 
         old_path = folder.path
@@ -400,7 +405,7 @@ class AgentFolderService(BaseWorkspaceService):
             if path_exists:
                 raise self._folder_validation_error(
                     f"Folder {new_path} already exists",
-                    code=AGENT_FOLDER_CONFLICT_CODE,
+                    code=AgentFolderErrorCode.CONFLICT,
                 )
 
         descendants = await self._get_descendants(old_path)
@@ -426,13 +431,13 @@ class AgentFolderService(BaseWorkspaceService):
         if not folder:
             raise self._folder_validation_error(
                 f"Folder {folder_id} not found",
-                code=AGENT_FOLDER_NOT_FOUND_CODE,
+                code=AgentFolderErrorCode.NOT_FOUND,
             )
 
         if folder.path == "/":
             raise self._folder_validation_error(
                 "Cannot delete root folder",
-                code=AGENT_FOLDER_INVALID_CODE,
+                code=AgentFolderErrorCode.INVALID,
             )
 
         if not recursive:
@@ -441,7 +446,7 @@ class AgentFolderService(BaseWorkspaceService):
             if has_children or has_presets:
                 raise self._folder_validation_error(
                     "Folder is not empty. Please move or delete its contents first.",
-                    code=AGENT_FOLDER_INVALID_CODE,
+                    code=AgentFolderErrorCode.INVALID,
                 )
         else:
             descendants = await self._get_descendants(folder.path)

--- a/tracecat/agent/folders/service.py
+++ b/tracecat/agent/folders/service.py
@@ -475,17 +475,8 @@ class AgentFolderService(BaseWorkspaceService):
         self, path: str = "/", *, order_by: Literal["asc", "desc"] = "desc"
     ) -> Sequence[DirectoryItem]:
         """Get all directory items (presets and folders) in the given path."""
-        path = self._normalize_folder_path(path)
+        path, folder_id = await self._get_directory_context(path)
 
-        if path != "/":
-            folder = await self.get_folder_by_path(path)
-            if not folder:
-                raise TracecatNotFoundError(f"Folder {path} not found")
-            folder_id = folder.id
-        else:
-            folder_id = None
-
-        # Fetch presets in this folder
         preset_statement = (
             select(AgentPreset)
             .where(
@@ -502,8 +493,156 @@ class AgentFolderService(BaseWorkspaceService):
         preset_result = await self.session.execute(preset_statement)
         presets = preset_result.scalars().all()
 
+        folder_statement = self._directory_folders_statement(path)
+        folder_result = await self.session.execute(folder_statement)
+        folders = folder_result.scalars().all()
+
+        return await self._build_directory_items(
+            folders=folders, presets=presets, path=path
+        )
+
+    @require_scope("agent:read")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def get_directory_items_paginated(
+        self,
+        path: str = "/",
+        params: CursorPaginationParams | None = None,
+    ) -> CursorPaginatedResponse[DirectoryItem]:
+        """Get directory items in the given path with cursor pagination."""
+        params = params or CursorPaginationParams()
+        path, folder_id = await self._get_directory_context(path)
+        paginator = BaseCursorPaginator(self.session)
+
+        folder_statement = self._directory_folders_statement(path)
+        preset_statement = (
+            select(AgentPreset)
+            .where(
+                AgentPreset.workspace_id == self.workspace_id,
+                AgentPreset.folder_id == folder_id,
+            )
+            .options(selectinload(AgentPreset.tags))
+        )
+
+        if params.cursor:
+            try:
+                cursor_data = paginator.decode_cursor(params.cursor)
+                cursor_id = uuid.UUID(cursor_data.id)
+            except ValueError as err:
+                raise TracecatValidationError(
+                    "Invalid cursor for agent folder directory"
+                ) from err
+
+            cursor_created_at = cursor_data.sort_value
+            if not isinstance(cursor_created_at, datetime):
+                raise TracecatValidationError(
+                    "Invalid cursor for agent folder directory"
+                )
+
+            folder_statement = folder_statement.where(
+                self._directory_cursor_predicate(
+                    AgentFolder,
+                    cursor_created_at=cursor_created_at,
+                    cursor_id=cursor_id,
+                    reverse=params.reverse,
+                )
+            )
+            preset_statement = preset_statement.where(
+                self._directory_cursor_predicate(
+                    AgentPreset,
+                    cursor_created_at=cursor_created_at,
+                    cursor_id=cursor_id,
+                    reverse=params.reverse,
+                )
+            )
+
+        if params.reverse:
+            folder_statement = folder_statement.order_by(
+                AgentFolder.created_at.asc(), AgentFolder.id.asc()
+            )
+            preset_statement = preset_statement.order_by(
+                AgentPreset.created_at.asc(), AgentPreset.id.asc()
+            )
+        else:
+            folder_statement = folder_statement.order_by(
+                AgentFolder.created_at.desc(), AgentFolder.id.desc()
+            )
+            preset_statement = preset_statement.order_by(
+                AgentPreset.created_at.desc(), AgentPreset.id.desc()
+            )
+
+        folder_result = await self.session.execute(
+            folder_statement.limit(params.limit + 1)
+        )
+        preset_result = await self.session.execute(
+            preset_statement.limit(params.limit + 1)
+        )
+        folder_rows = folder_result.scalars().all()
+        preset_rows = preset_result.scalars().all()
+
+        rows = sorted(
+            [*folder_rows, *preset_rows],
+            key=lambda row: (row.created_at, row.id),
+            reverse=not params.reverse,
+        )
+        has_more = len(rows) > params.limit
+        page_rows = rows[: params.limit]
+
+        next_cursor = None
+        if has_more and page_rows:
+            last = page_rows[-1]
+            next_cursor = paginator.encode_cursor(
+                last.id,
+                sort_column="created_at",
+                sort_value=last.created_at,
+            )
+
+        prev_cursor = None
+        if params.cursor and page_rows:
+            first = page_rows[0]
+            prev_cursor = paginator.encode_cursor(
+                first.id,
+                sort_column="created_at",
+                sort_value=first.created_at,
+            )
+
+        if params.reverse:
+            page_rows.reverse()
+            next_cursor, prev_cursor = prev_cursor, next_cursor
+            has_more, has_previous = params.cursor is not None, has_more
+        else:
+            has_previous = params.cursor is not None
+
+        folders = [row for row in page_rows if isinstance(row, AgentFolder)]
+        presets = [row for row in page_rows if isinstance(row, AgentPreset)]
+        items = await self._build_directory_items(
+            folders=folders,
+            presets=presets,
+            path=path,
+            preserve_order=page_rows,
+        )
+
+        return CursorPaginatedResponse(
+            items=items,
+            next_cursor=next_cursor,
+            prev_cursor=prev_cursor,
+            has_more=has_more,
+            has_previous=has_previous,
+        )
+
+    async def _get_directory_context(self, path: str) -> tuple[str, uuid.UUID | None]:
+        path = self._normalize_folder_path(path)
+
+        if path != "/":
+            folder = await self._get_folder_by_path(path)
+            if not folder:
+                raise TracecatNotFoundError(f"Folder {path} not found")
+            return path, folder.id
+
+        return path, None
+
+    def _directory_folders_statement(self, path: str) -> sa.Select[tuple[AgentFolder]]:
         path_depth = path.count("/") + 1
-        folder_statement = select(AgentFolder).where(
+        return select(AgentFolder).where(
             AgentFolder.workspace_id == self.workspace_id,
             AgentFolder.path.startswith(path, autoescape=True),
             AgentFolder.path != path,
@@ -511,10 +650,35 @@ class AgentFolderService(BaseWorkspaceService):
             - func.length(func.replace(AgentFolder.path, "/", ""))
             == path_depth,
         )
-        folder_result = await self.session.execute(folder_statement)
-        folders = folder_result.scalars().all()
 
+    @staticmethod
+    def _directory_cursor_predicate(
+        model: type[AgentFolder] | type[AgentPreset],
+        *,
+        cursor_created_at: datetime,
+        cursor_id: uuid.UUID,
+        reverse: bool,
+    ) -> sa.ColumnElement[bool]:
+        if reverse:
+            return sa.or_(
+                model.created_at > cursor_created_at,
+                sa.and_(model.created_at == cursor_created_at, model.id > cursor_id),
+            )
+        return sa.or_(
+            model.created_at < cursor_created_at,
+            sa.and_(model.created_at == cursor_created_at, model.id < cursor_id),
+        )
+
+    async def _build_directory_items(
+        self,
+        *,
+        folders: Sequence[AgentFolder],
+        presets: Sequence[AgentPreset],
+        path: str,
+        preserve_order: Sequence[AgentFolder | AgentPreset] | None = None,
+    ) -> list[DirectoryItem]:
         directory_items: list[DirectoryItem] = []
+        path_depth = path.count("/") + 1
         folder_ids = [folder.id for folder in folders]
         folder_paths = {folder.path for folder in folders}
         preset_counts_by_folder_id: dict[uuid.UUID, int] = {}
@@ -553,42 +717,48 @@ class AgentFolderService(BaseWorkspaceService):
                         child_folder_counts_by_path.get(parent_path, 0) + 1
                     )
 
+        items_by_id: dict[uuid.UUID, DirectoryItem] = {}
         for f in folders:
             num_items = child_folder_counts_by_path.get(
                 f.path, 0
             ) + preset_counts_by_folder_id.get(f.id, 0)
-            directory_items.append(
-                AgentFolderDirectoryItem(
-                    type="folder",
-                    num_items=num_items,
-                    id=f.id,
-                    name=f.name,
-                    path=f.path,
-                    workspace_id=f.workspace_id,
-                    created_at=f.created_at,
-                    updated_at=f.updated_at,
-                )
+            items_by_id[f.id] = AgentFolderDirectoryItem(
+                type="folder",
+                num_items=num_items,
+                id=f.id,
+                name=f.name,
+                path=f.path,
+                workspace_id=f.workspace_id,
+                created_at=f.created_at,
+                updated_at=f.updated_at,
             )
 
         for preset in presets:
-            directory_items.append(
-                AgentPresetDirectoryItem(
-                    type="preset",
-                    id=preset.id,
-                    name=preset.name,
-                    slug=preset.slug,
-                    description=preset.description,
-                    model_provider=preset.model_provider,
-                    model_name=preset.model_name,
-                    folder_id=preset.folder_id,
-                    tags=[
-                        TagRead.model_validate(tag, from_attributes=True)
-                        for tag in preset.tags
-                    ],
-                    created_at=preset.created_at,
-                    updated_at=preset.updated_at,
-                )
+            items_by_id[preset.id] = AgentPresetDirectoryItem(
+                type="preset",
+                id=preset.id,
+                name=preset.name,
+                slug=preset.slug,
+                description=preset.description,
+                model_provider=preset.model_provider,
+                model_name=preset.model_name,
+                folder_id=preset.folder_id,
+                tags=[
+                    TagRead.model_validate(tag, from_attributes=True)
+                    for tag in preset.tags
+                ],
+                created_at=preset.created_at,
+                updated_at=preset.updated_at,
             )
+
+        if preserve_order is not None:
+            return [items_by_id[row.id] for row in preserve_order]
+
+        for f in folders:
+            directory_items.append(items_by_id[f.id])
+
+        for preset in presets:
+            directory_items.append(items_by_id[preset.id])
 
         return directory_items
 

--- a/tracecat/agent/preset/router.py
+++ b/tracecat/agent/preset/router.py
@@ -3,8 +3,10 @@ import uuid
 from fastapi import APIRouter, HTTPException, Query, status
 
 from tracecat import config
+from tracecat.agent.folders.service import AgentFolderService
 from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
+    AgentPresetMoveToFolder,
     AgentPresetRead,
     AgentPresetReadMinimal,
     AgentPresetUpdate,
@@ -16,7 +18,7 @@ from tracecat.agent.preset.service import AgentPresetService
 from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
-from tracecat.exceptions import TracecatValidationError
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 
 router = APIRouter(prefix="/agent/presets", tags=["agent-presets"])
@@ -249,3 +251,34 @@ async def restore_agent_preset_version(
             detail=str(exc),
         ) from exc
     return await service.build_preset_read(restored)
+
+
+@router.post(
+    "/{preset_id}/move",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["agent-presets"],
+)
+@require_scope("agent:update")
+async def move_agent_preset_to_folder(
+    *,
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    preset_id: uuid.UUID,
+    params: AgentPresetMoveToFolder,
+) -> None:
+    """Move an agent preset to a folder."""
+    folder_service = AgentFolderService(session, role=role)
+    if params.folder_path and params.folder_path != "/":
+        folder = await folder_service.get_folder_by_path(params.folder_path)
+        if not folder:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Folder with path '{params.folder_path}' not found",
+            )
+    else:
+        folder = None
+
+    try:
+        await folder_service.move_preset(preset_id, folder)
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e

--- a/tracecat/agent/preset/schemas.py
+++ b/tracecat/agent/preset/schemas.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 from tracecat.agent.types import AgentConfig, OutputType
 from tracecat.core.schemas import Schema
 from tracecat.identifiers import WorkspaceID
+from tracecat.tags.schemas import TagRead
 
 
 class AgentPresetSkillBindingBase(Schema):
@@ -106,6 +107,12 @@ class AgentPresetCreate(AgentPresetBase):
     slug: PresetSlug | None = None
 
 
+class AgentPresetMoveToFolder(BaseModel):
+    """Payload for moving an agent preset to a folder."""
+
+    folder_path: str | None = None
+
+
 class AgentPresetUpdate(BaseModel):
     """Payload for updating an existing agent preset."""
 
@@ -136,6 +143,10 @@ class AgentPresetReadMinimal(Schema):
     name: str
     slug: str
     description: str | None
+    model_provider: str
+    model_name: str
+    folder_id: uuid.UUID | None = None
+    tags: list[TagRead] = Field(default_factory=list)
     current_version_id: uuid.UUID | None = None
     created_at: datetime
     updated_at: datetime

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -11,9 +11,10 @@ from typing import TYPE_CHECKING, Any, cast
 import sqlalchemy as sa
 from slugify import slugify
 from sqlalchemy import func, select
+from sqlalchemy.orm import selectinload
 
 from tracecat.agent.access.service import AgentModelAccessService
-from tracecat.agent.common.types import MCPHttpServerConfig
+from tracecat.agent.common.types import MCPHttpServerConfig, MCPServerConfig
 from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
     AgentPresetRead,
@@ -32,7 +33,6 @@ from tracecat.agent.preset.types import SkillBindingSpec
 from tracecat.agent.skill.service import SkillService
 from tracecat.agent.types import (
     AgentConfig,
-    MCPServerConfig,
     OutputType,
 )
 from tracecat.audit.logger import audit_log
@@ -107,6 +107,7 @@ class AgentPresetService(BaseWorkspaceService):
             select(AgentPreset)
             .where(AgentPreset.workspace_id == self.workspace_id)
             .order_by(AgentPreset.created_at.desc())
+            .options(selectinload(AgentPreset.tags))
         )
         result = await self.session.execute(stmt)
         return result.scalars().all()

--- a/tracecat/agent/tags/definitions_router.py
+++ b/tracecat/agent/tags/definitions_router.py
@@ -1,30 +1,56 @@
 """HTTP routes for agent tag definition CRUD."""
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
+from tracecat import config
 from tracecat.agent.tags.schemas import AgentTagRead
 from tracecat.agent.tags.service import AgentTagsService
 from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.identifiers import AgentTagID
+from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 from tracecat.tags.schemas import TagCreate, TagUpdate
 
 router = APIRouter(prefix="/agent-tags", tags=["agent-tags"])
 
 
-@router.get("", response_model=list[AgentTagRead])
+@router.get("", response_model=CursorPaginatedResponse[AgentTagRead])
 @require_scope("agent:read")
 async def list_agent_tags(
     *,
     role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
-) -> list[AgentTagRead]:
+    limit: int = Query(
+        default=config.TRACECAT__LIMIT_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+    ),
+    cursor: str | None = Query(default=None),
+    reverse: bool = Query(default=False),
+) -> CursorPaginatedResponse[AgentTagRead]:
     """List all agent tags in the workspace."""
     service = AgentTagsService(session=session, role=role)
-    tags = await service.list_tags()
-    return [AgentTagRead.model_validate(tag, from_attributes=True) for tag in tags]
+    try:
+        page = await service.list_tags_paginated(
+            CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse)
+        )
+    except ValueError as err:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(err),
+        ) from err
+    return CursorPaginatedResponse(
+        items=[
+            AgentTagRead.model_validate(tag, from_attributes=True) for tag in page.items
+        ],
+        next_cursor=page.next_cursor,
+        prev_cursor=page.prev_cursor,
+        has_more=page.has_more,
+        has_previous=page.has_previous,
+        total_estimate=page.total_estimate,
+    )
 
 
 @router.get("/{tag_id}", response_model=AgentTagRead)

--- a/tracecat/agent/tags/definitions_router.py
+++ b/tracecat/agent/tags/definitions_router.py
@@ -1,7 +1,6 @@
 """HTTP routes for agent tag definition CRUD."""
 
 from fastapi import APIRouter, HTTPException, Query, status
-from sqlalchemy.exc import IntegrityError
 
 from tracecat import config
 from tracecat.agent.tags.schemas import AgentTagRead
@@ -95,11 +94,6 @@ async def create_agent_tag(
             status_code=status.HTTP_409_CONFLICT,
             detail=str(err),
         ) from err
-    except IntegrityError as err:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Agent tag already exists",
-        ) from err
     return AgentTagRead.model_validate(tag, from_attributes=True)
 
 
@@ -127,11 +121,6 @@ async def update_agent_tag(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=str(err),
-        ) from err
-    except IntegrityError as err:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Agent tag already exists",
         ) from err
     return AgentTagRead.model_validate(updated, from_attributes=True)
 

--- a/tracecat/agent/tags/definitions_router.py
+++ b/tracecat/agent/tags/definitions_router.py
@@ -1,7 +1,7 @@
 """HTTP routes for agent tag definition CRUD."""
 
 from fastapi import APIRouter, HTTPException, Query, status
-from sqlalchemy.exc import IntegrityError, NoResultFound
+from sqlalchemy.exc import IntegrityError
 
 from tracecat import config
 from tracecat.agent.tags.schemas import AgentTagRead
@@ -9,7 +9,11 @@ from tracecat.agent.tags.service import AgentTagsService
 from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
-from tracecat.exceptions import TracecatConflictError
+from tracecat.exceptions import (
+    TracecatConflictError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
 from tracecat.identifiers import AgentTagID
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 from tracecat.tags.schemas import TagCreate, TagUpdate
@@ -37,7 +41,7 @@ async def list_agent_tags(
         page = await service.list_tags_paginated(
             CursorPaginationParams(limit=limit, cursor=cursor, reverse=reverse)
         )
-    except ValueError as err:
+    except TracecatValidationError as err:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(err),
@@ -66,10 +70,10 @@ async def get_agent_tag(
     service = AgentTagsService(session=session, role=role)
     try:
         tag = await service.get_tag(tag_id)
-    except NoResultFound as err:
+    except TracecatNotFoundError as err:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Tag not found",
+            detail=str(err),
         ) from err
     return AgentTagRead.model_validate(tag, from_attributes=True)
 
@@ -112,10 +116,10 @@ async def update_agent_tag(
     service = AgentTagsService(session=session, role=role)
     try:
         tag = await service.get_tag(tag_id)
-    except NoResultFound as err:
+    except TracecatNotFoundError as err:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Tag not found",
+            detail=str(err),
         ) from err
     try:
         updated = await service.update_tag(tag, params)
@@ -144,8 +148,8 @@ async def delete_agent_tag(
     service = AgentTagsService(session=session, role=role)
     try:
         await service.delete_tag_by_id(tag_id)
-    except NoResultFound as err:
+    except TracecatNotFoundError as err:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Tag not found",
+            detail=str(err),
         ) from err

--- a/tracecat/agent/tags/definitions_router.py
+++ b/tracecat/agent/tags/definitions_router.py
@@ -1,0 +1,122 @@
+"""HTTP routes for agent tag definition CRUD."""
+
+from fastapi import APIRouter, HTTPException, status
+from sqlalchemy.exc import IntegrityError, NoResultFound
+
+from tracecat.agent.tags.schemas import AgentTagRead
+from tracecat.agent.tags.service import AgentTagsService
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
+from tracecat.authz.controls import require_scope
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.identifiers import AgentTagID
+from tracecat.tags.schemas import TagCreate, TagUpdate
+
+router = APIRouter(prefix="/agent-tags", tags=["agent-tags"])
+
+
+@router.get("", response_model=list[AgentTagRead])
+@require_scope("agent:read")
+async def list_agent_tags(
+    *,
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+) -> list[AgentTagRead]:
+    """List all agent tags in the workspace."""
+    service = AgentTagsService(session=session, role=role)
+    tags = await service.list_tags()
+    return [AgentTagRead.model_validate(tag, from_attributes=True) for tag in tags]
+
+
+@router.get("/{tag_id}", response_model=AgentTagRead)
+@require_scope("agent:read")
+async def get_agent_tag(
+    *,
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    tag_id: AgentTagID,
+) -> AgentTagRead:
+    """Get an agent tag by ID."""
+    service = AgentTagsService(session=session, role=role)
+    try:
+        tag = await service.get_tag(tag_id)
+    except NoResultFound as err:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tag not found",
+        ) from err
+    return AgentTagRead.model_validate(tag, from_attributes=True)
+
+
+@router.post("", response_model=AgentTagRead, status_code=status.HTTP_201_CREATED)
+async def create_agent_tag(
+    *,
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    params: TagCreate,
+) -> AgentTagRead:
+    """Create a new agent tag definition."""
+    service = AgentTagsService(session=session, role=role)
+    try:
+        tag = await service.create_tag(params)
+    except ValueError as err:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(err),
+        ) from err
+    except IntegrityError as err:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Agent tag already exists",
+        ) from err
+    return AgentTagRead.model_validate(tag, from_attributes=True)
+
+
+@router.patch("/{tag_id}", response_model=AgentTagRead)
+async def update_agent_tag(
+    *,
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    tag_id: AgentTagID,
+    params: TagUpdate,
+) -> AgentTagRead:
+    """Update an agent tag definition."""
+    service = AgentTagsService(session=session, role=role)
+    try:
+        tag = await service.get_tag(tag_id)
+    except NoResultFound as err:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tag not found",
+        ) from err
+    try:
+        updated = await service.update_tag(tag, params)
+    except ValueError as err:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(err),
+        ) from err
+    except IntegrityError as err:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Agent tag already exists",
+        ) from err
+    return AgentTagRead.model_validate(updated, from_attributes=True)
+
+
+@router.delete("/{tag_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_agent_tag(
+    *,
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    tag_id: AgentTagID,
+) -> None:
+    """Delete an agent tag definition."""
+    service = AgentTagsService(session=session, role=role)
+    try:
+        tag = await service.get_tag(tag_id)
+    except NoResultFound as err:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tag not found",
+        ) from err
+    await service.delete_tag(tag)

--- a/tracecat/agent/tags/definitions_router.py
+++ b/tracecat/agent/tags/definitions_router.py
@@ -48,6 +48,7 @@ async def get_agent_tag(
 
 
 @router.post("", response_model=AgentTagRead, status_code=status.HTTP_201_CREATED)
+@require_scope("agent:create")
 async def create_agent_tag(
     *,
     role: WorkspaceUserRouteRole,
@@ -72,6 +73,7 @@ async def create_agent_tag(
 
 
 @router.patch("/{tag_id}", response_model=AgentTagRead)
+@require_scope("agent:update")
 async def update_agent_tag(
     *,
     role: WorkspaceUserRouteRole,
@@ -104,6 +106,7 @@ async def update_agent_tag(
 
 
 @router.delete("/{tag_id}", status_code=status.HTTP_204_NO_CONTENT)
+@require_scope("agent:delete")
 async def delete_agent_tag(
     *,
     role: WorkspaceUserRouteRole,

--- a/tracecat/agent/tags/definitions_router.py
+++ b/tracecat/agent/tags/definitions_router.py
@@ -9,6 +9,7 @@ from tracecat.agent.tags.service import AgentTagsService
 from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import TracecatConflictError
 from tracecat.identifiers import AgentTagID
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 from tracecat.tags.schemas import TagCreate, TagUpdate
@@ -85,7 +86,7 @@ async def create_agent_tag(
     service = AgentTagsService(session=session, role=role)
     try:
         tag = await service.create_tag(params)
-    except ValueError as err:
+    except TracecatConflictError as err:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=str(err),
@@ -118,7 +119,7 @@ async def update_agent_tag(
         ) from err
     try:
         updated = await service.update_tag(tag, params)
-    except ValueError as err:
+    except TracecatConflictError as err:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=str(err),

--- a/tracecat/agent/tags/definitions_router.py
+++ b/tracecat/agent/tags/definitions_router.py
@@ -113,10 +113,9 @@ async def delete_agent_tag(
     """Delete an agent tag definition."""
     service = AgentTagsService(session=session, role=role)
     try:
-        tag = await service.get_tag(tag_id)
+        await service.delete_tag_by_id(tag_id)
     except NoResultFound as err:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Tag not found",
         ) from err
-    await service.delete_tag(tag)

--- a/tracecat/agent/tags/router.py
+++ b/tracecat/agent/tags/router.py
@@ -44,6 +44,11 @@ async def add_preset_tag(
     service = AgentTagsService(session, role=role)
     try:
         await service.add_preset_tag(preset_id, params.tag_id)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(e),
+        ) from e
     except NoResultFound as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/tracecat/agent/tags/router.py
+++ b/tracecat/agent/tags/router.py
@@ -2,13 +2,13 @@
 
 from fastapi import APIRouter, HTTPException, status
 from pydantic import UUID4
-from sqlalchemy.exc import NoResultFound
 
 from tracecat.agent.tags.schemas import AgentPresetTagCreate, AgentTagRead
 from tracecat.agent.tags.service import AgentTagsService
 from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import TracecatNotFoundError
 
 router = APIRouter(prefix="/agent/presets", tags=["agent-presets"])
 
@@ -24,12 +24,12 @@ async def list_preset_tags(
     service = AgentTagsService(session, role=role)
     try:
         db_tags = await service.list_tags_for_preset(preset_id)
-    except NoResultFound as e:
+    except TracecatNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Agent preset not found",
+            detail=str(e),
         ) from e
-    return [AgentTagRead.model_validate(tag, from_attributes=True) for tag in db_tags]
+    return AgentTagRead.list_adapter().validate_python(db_tags)
 
 
 @router.post("/{preset_id}/tags", status_code=status.HTTP_201_CREATED)
@@ -44,10 +44,10 @@ async def add_preset_tag(
     service = AgentTagsService(session, role=role)
     try:
         await service.add_preset_tag(preset_id, params.tag_id)
-    except NoResultFound as e:
+    except TracecatNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Agent preset or tag not found",
+            detail=str(e),
         ) from e
 
 
@@ -63,9 +63,9 @@ async def remove_preset_tag(
     service = AgentTagsService(session, role=role)
     try:
         link = await service.get_preset_tag(preset_id, tag_id)
-    except NoResultFound as e:
+    except TracecatNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Tag not found",
+            detail=str(e),
         ) from e
     await service.remove_preset_tag(link)

--- a/tracecat/agent/tags/router.py
+++ b/tracecat/agent/tags/router.py
@@ -44,11 +44,6 @@ async def add_preset_tag(
     service = AgentTagsService(session, role=role)
     try:
         await service.add_preset_tag(preset_id, params.tag_id)
-    except ValueError as e:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=str(e),
-        ) from e
     except NoResultFound as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/tracecat/agent/tags/router.py
+++ b/tracecat/agent/tags/router.py
@@ -22,7 +22,13 @@ async def list_preset_tags(
 ) -> list[AgentTagRead]:
     """List all tags for an agent preset."""
     service = AgentTagsService(session, role=role)
-    db_tags = await service.list_tags_for_preset(preset_id)
+    try:
+        db_tags = await service.list_tags_for_preset(preset_id)
+    except NoResultFound as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Agent preset not found",
+        ) from e
     return [AgentTagRead.model_validate(tag, from_attributes=True) for tag in db_tags]
 
 

--- a/tracecat/agent/tags/router.py
+++ b/tracecat/agent/tags/router.py
@@ -1,0 +1,65 @@
+"""HTTP routes for agent preset tag associations."""
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import UUID4
+from sqlalchemy.exc import NoResultFound
+
+from tracecat.agent.tags.schemas import AgentPresetTagCreate, AgentTagRead
+from tracecat.agent.tags.service import AgentTagsService
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
+from tracecat.authz.controls import require_scope
+from tracecat.db.dependencies import AsyncDBSession
+
+router = APIRouter(prefix="/agent/presets", tags=["agent-presets"])
+
+
+@router.get("/{preset_id}/tags", response_model=list[AgentTagRead])
+@require_scope("agent:read")
+async def list_preset_tags(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    preset_id: UUID4,
+) -> list[AgentTagRead]:
+    """List all tags for an agent preset."""
+    service = AgentTagsService(session, role=role)
+    db_tags = await service.list_tags_for_preset(preset_id)
+    return [AgentTagRead.model_validate(tag, from_attributes=True) for tag in db_tags]
+
+
+@router.post("/{preset_id}/tags", status_code=status.HTTP_201_CREATED)
+@require_scope("agent:update")
+async def add_preset_tag(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    preset_id: UUID4,
+    params: AgentPresetTagCreate,
+) -> None:
+    """Add a tag to an agent preset."""
+    service = AgentTagsService(session, role=role)
+    try:
+        await service.add_preset_tag(preset_id, params.tag_id)
+    except NoResultFound as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Agent preset or tag not found",
+        ) from e
+
+
+@router.delete("/{preset_id}/tags/{tag_id}", status_code=status.HTTP_204_NO_CONTENT)
+@require_scope("agent:update")
+async def remove_preset_tag(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    preset_id: UUID4,
+    tag_id: UUID4,
+) -> None:
+    """Remove a tag from an agent preset."""
+    service = AgentTagsService(session, role=role)
+    try:
+        link = await service.get_preset_tag(preset_id, tag_id)
+    except NoResultFound as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tag not found",
+        ) from e
+    await service.remove_preset_tag(link)

--- a/tracecat/agent/tags/router.py
+++ b/tracecat/agent/tags/router.py
@@ -1,35 +1,63 @@
 """HTTP routes for agent preset tag associations."""
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import UUID4
 
+from tracecat import config
 from tracecat.agent.tags.schemas import AgentPresetTagCreate, AgentTagRead
 from tracecat.agent.tags.service import AgentTagsService
 from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
-from tracecat.exceptions import TracecatNotFoundError
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 
 router = APIRouter(prefix="/agent/presets", tags=["agent-presets"])
 
 
-@router.get("/{preset_id}/tags", response_model=list[AgentTagRead])
+@router.get("/{preset_id}/tags", response_model=CursorPaginatedResponse[AgentTagRead])
 @require_scope("agent:read")
 async def list_preset_tags(
     role: WorkspaceUserRouteRole,
     session: AsyncDBSession,
     preset_id: UUID4,
-) -> list[AgentTagRead]:
+    limit: int = Query(
+        default=config.TRACECAT__LIMIT_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CURSOR_MAX,
+    ),
+    cursor: str | None = Query(default=None),
+    reverse: bool = Query(default=False),
+) -> CursorPaginatedResponse[AgentTagRead]:
     """List all tags for an agent preset."""
     service = AgentTagsService(session, role=role)
     try:
-        db_tags = await service.list_tags_for_preset(preset_id)
+        page = await service.list_tags_for_preset_paginated(
+            preset_id,
+            CursorPaginationParams(
+                limit=limit,
+                cursor=cursor,
+                reverse=reverse,
+            ),
+        )
     except TracecatNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         ) from e
-    return AgentTagRead.list_adapter().validate_python(db_tags)
+    except TracecatValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    return CursorPaginatedResponse(
+        items=AgentTagRead.list_adapter().validate_python(page.items),
+        next_cursor=page.next_cursor,
+        prev_cursor=page.prev_cursor,
+        has_more=page.has_more,
+        has_previous=page.has_previous,
+        total_estimate=page.total_estimate,
+    )
 
 
 @router.post("/{preset_id}/tags", status_code=status.HTTP_201_CREATED)

--- a/tracecat/agent/tags/schemas.py
+++ b/tracecat/agent/tags/schemas.py
@@ -1,0 +1,20 @@
+"""Pydantic schemas for agent tag resources."""
+
+from pydantic import BaseModel
+
+from tracecat.identifiers import AgentTagID
+
+
+class AgentTagRead(BaseModel):
+    """Tag data."""
+
+    id: AgentTagID
+    name: str
+    ref: str
+    color: str | None
+
+
+class AgentPresetTagCreate(BaseModel):
+    """Payload for adding a tag to an agent preset."""
+
+    tag_id: AgentTagID

--- a/tracecat/agent/tags/schemas.py
+++ b/tracecat/agent/tags/schemas.py
@@ -2,10 +2,11 @@
 
 from pydantic import BaseModel
 
+from tracecat.core.schemas import Schema
 from tracecat.identifiers import AgentTagID
 
 
-class AgentTagRead(BaseModel):
+class AgentTagRead(Schema):
     """Tag data."""
 
     id: AgentTagID

--- a/tracecat/agent/tags/service.py
+++ b/tracecat/agent/tags/service.py
@@ -1,0 +1,195 @@
+"""Service for agent tag definitions and preset-tag linking."""
+
+import uuid
+from collections.abc import Sequence
+
+from slugify import slugify
+from sqlalchemy import exists, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import NoResultFound
+
+from tracecat.authz.controls import require_scope
+from tracecat.db.models import AgentPreset, AgentTag, AgentTagLink
+from tracecat.identifiers import AgentTagID
+from tracecat.service import BaseWorkspaceService, requires_entitlement
+from tracecat.tags.schemas import TagCreate, TagUpdate
+from tracecat.tiers.enums import Entitlement
+
+
+class AgentTagsService(BaseWorkspaceService):
+    """Handles both agent tag definitions and preset-tag linking."""
+
+    service_name = "agent_tags"
+
+    # --- Tag definitions ---
+
+    @require_scope("agent:read")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def list_tags(self) -> Sequence[AgentTag]:
+        """List all agent tags in the workspace."""
+        statement = select(AgentTag).where(AgentTag.workspace_id == self.workspace_id)
+        result = await self.session.execute(statement)
+        return result.scalars().all()
+
+    @require_scope("agent:read")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def get_tag(self, tag_id: AgentTagID) -> AgentTag:
+        """Get an agent tag by ID."""
+        statement = select(AgentTag).where(
+            AgentTag.workspace_id == self.workspace_id,
+            AgentTag.id == tag_id,
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one()
+
+    async def get_tag_by_ref(self, ref: str) -> AgentTag:
+        """Get an agent tag by its ref."""
+        statement = select(AgentTag).where(
+            AgentTag.workspace_id == self.workspace_id,
+            AgentTag.ref == ref,
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one()
+
+    @require_scope("agent:create")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def create_tag(self, tag: TagCreate) -> AgentTag:
+        """Create a new agent tag."""
+        ref = slugify(tag.name)
+
+        existing = await self.session.execute(
+            select(AgentTag).where(
+                AgentTag.ref == ref,
+                AgentTag.workspace_id == self.workspace_id,
+            )
+        )
+        if existing.one_or_none():
+            raise ValueError(f"Agent tag with slug '{ref}' already exists")
+
+        db_tag = AgentTag(
+            name=tag.name,
+            ref=ref,
+            workspace_id=self.workspace_id,
+            color=tag.color,
+        )
+        self.session.add(db_tag)
+        await self.session.commit()
+        await self.session.refresh(db_tag)
+        return db_tag
+
+    @require_scope("agent:update")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def update_tag(self, tag: AgentTag, params: TagUpdate) -> AgentTag:
+        """Update an agent tag and regenerate ref if name changed."""
+        if params.name and params.name != tag.name:
+            new_ref = slugify(params.name)
+            if new_ref != tag.ref:
+                existing = await self.session.execute(
+                    select(AgentTag).where(
+                        AgentTag.workspace_id == self.workspace_id,
+                        AgentTag.ref == new_ref,
+                        AgentTag.id != tag.id,
+                    )
+                )
+                if existing.one_or_none():
+                    raise ValueError(f"Agent tag with slug '{new_ref}' already exists")
+                tag.ref = new_ref
+
+        for key, value in params.model_dump(exclude_unset=True).items():
+            setattr(tag, key, value)
+
+        await self.session.commit()
+        await self.session.refresh(tag)
+        return tag
+
+    @require_scope("agent:delete")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def delete_tag(self, tag: AgentTag) -> None:
+        """Delete an agent tag definition."""
+        await self.session.delete(tag)
+        await self.session.commit()
+
+    # --- Preset-tag linking ---
+
+    async def _require_preset_and_tag_in_workspace(
+        self, preset_id: uuid.UUID, tag_id: AgentTagID
+    ) -> None:
+        preset_exists = exists(
+            select(AgentPreset.id).where(
+                AgentPreset.id == preset_id,
+                AgentPreset.workspace_id == self.workspace_id,
+            )
+        )
+        tag_exists = exists(
+            select(AgentTag.id).where(
+                AgentTag.id == tag_id,
+                AgentTag.workspace_id == self.workspace_id,
+            )
+        )
+        is_allowed = await self.session.scalar(select(preset_exists & tag_exists))
+        if not is_allowed:
+            raise NoResultFound("Agent preset or tag not found")
+
+    @require_scope("agent:read")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def list_tags_for_preset(self, preset_id: uuid.UUID) -> Sequence[AgentTag]:
+        """List all tags on a preset."""
+        stmt = (
+            select(AgentTag)
+            .join(AgentTagLink, AgentTag.id == AgentTagLink.tag_id)
+            .join(AgentPreset, AgentPreset.id == AgentTagLink.preset_id)
+            .where(
+                AgentTagLink.preset_id == preset_id,
+                AgentPreset.workspace_id == self.workspace_id,
+                AgentTag.workspace_id == self.workspace_id,
+            )
+        )
+        result = await self.session.execute(stmt)
+        return result.scalars().all()
+
+    @require_scope("agent:update")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def get_preset_tag(
+        self, preset_id: uuid.UUID, tag_id: AgentTagID
+    ) -> AgentTagLink:
+        """Get a preset-tag association."""
+        stmt = (
+            select(AgentTagLink)
+            .join(AgentPreset, AgentPreset.id == AgentTagLink.preset_id)
+            .join(AgentTag, AgentTag.id == AgentTagLink.tag_id)
+            .where(
+                AgentTagLink.preset_id == preset_id,
+                AgentTagLink.tag_id == tag_id,
+                AgentPreset.workspace_id == self.workspace_id,
+                AgentTag.workspace_id == self.workspace_id,
+            )
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one()
+
+    @require_scope("agent:update")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def add_preset_tag(
+        self, preset_id: uuid.UUID, tag_id: AgentTagID
+    ) -> AgentTagLink:
+        """Add a tag to an agent preset."""
+        await self._require_preset_and_tag_in_workspace(preset_id, tag_id)
+        stmt = (
+            pg_insert(AgentTagLink)
+            .values(preset_id=preset_id, tag_id=tag_id)
+            .on_conflict_do_nothing(index_elements=["tag_id", "preset_id"])
+            .returning(AgentTagLink)
+        )
+        result = await self.session.execute(stmt)
+        link = result.scalar_one_or_none()
+        if link is None:
+            link = await self.get_preset_tag(preset_id, tag_id)
+        await self.session.commit()
+        return link
+
+    @require_scope("agent:update")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def remove_preset_tag(self, link: AgentTagLink) -> None:
+        """Remove a tag from an agent preset."""
+        await self.session.delete(link)
+        await self.session.commit()

--- a/tracecat/agent/tags/service.py
+++ b/tracecat/agent/tags/service.py
@@ -281,6 +281,102 @@ class AgentTagsService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         return result.scalars().all()
 
+    @require_scope("agent:read")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def list_tags_for_preset_paginated(
+        self,
+        preset_id: uuid.UUID,
+        params: CursorPaginationParams,
+    ) -> CursorPaginatedResponse[AgentTag]:
+        """List tags on a preset with cursor pagination."""
+        await self._require_preset_in_workspace(preset_id)
+        paginator = BaseCursorPaginator(self.session)
+        statement = (
+            select(AgentTag)
+            .join(AgentTagLink, AgentTag.id == AgentTagLink.tag_id)
+            .join(AgentPreset, AgentPreset.id == AgentTagLink.preset_id)
+            .where(
+                AgentTagLink.preset_id == preset_id,
+                AgentPreset.workspace_id == self.workspace_id,
+                AgentTag.workspace_id == self.workspace_id,
+            )
+        )
+
+        if params.cursor:
+            try:
+                cursor_data = paginator.decode_cursor(params.cursor)
+                cursor_id = uuid.UUID(cursor_data.id)
+            except ValueError as err:
+                raise TracecatValidationError(
+                    "Invalid cursor for agent preset tags"
+                ) from err
+
+            cursor_created_at = cursor_data.sort_value
+            if not isinstance(cursor_created_at, datetime):
+                raise TracecatValidationError("Invalid cursor for agent preset tags")
+
+            predicate = sa.or_(
+                AgentTag.created_at < cursor_created_at,
+                sa.and_(
+                    AgentTag.created_at == cursor_created_at,
+                    AgentTag.id < cursor_id,
+                ),
+            )
+            if params.reverse:
+                predicate = sa.or_(
+                    AgentTag.created_at > cursor_created_at,
+                    sa.and_(
+                        AgentTag.created_at == cursor_created_at,
+                        AgentTag.id > cursor_id,
+                    ),
+                )
+            statement = statement.where(predicate)
+
+        if params.reverse:
+            statement = statement.order_by(AgentTag.created_at.asc(), AgentTag.id.asc())
+        else:
+            statement = statement.order_by(
+                AgentTag.created_at.desc(), AgentTag.id.desc()
+            )
+        statement = statement.limit(params.limit + 1)
+
+        tags = (await self.session.execute(statement)).scalars().all()
+        has_more = len(tags) > params.limit
+        items = list(tags[: params.limit])
+
+        next_cursor = None
+        if has_more and items:
+            last = items[-1]
+            next_cursor = paginator.encode_cursor(
+                last.id,
+                sort_column="created_at",
+                sort_value=last.created_at,
+            )
+
+        prev_cursor = None
+        if params.cursor and items:
+            first = items[0]
+            prev_cursor = paginator.encode_cursor(
+                first.id,
+                sort_column="created_at",
+                sort_value=first.created_at,
+            )
+
+        if params.reverse:
+            items.reverse()
+            next_cursor, prev_cursor = prev_cursor, next_cursor
+            has_more, has_previous = params.cursor is not None, has_more
+        else:
+            has_previous = params.cursor is not None
+
+        return CursorPaginatedResponse(
+            items=items,
+            next_cursor=next_cursor,
+            prev_cursor=prev_cursor,
+            has_more=has_more,
+            has_previous=has_previous,
+        )
+
     @require_scope("agent:update")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def get_preset_tag(

--- a/tracecat/agent/tags/service.py
+++ b/tracecat/agent/tags/service.py
@@ -8,11 +8,14 @@ import sqlalchemy as sa
 from slugify import slugify
 from sqlalchemy import exists, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy.exc import NoResultFound
 
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import AgentPreset, AgentTag, AgentTagLink
-from tracecat.exceptions import TracecatConflictError
+from tracecat.exceptions import (
+    TracecatConflictError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
 from tracecat.identifiers import AgentTagID
 from tracecat.pagination import (
     BaseCursorPaginator,
@@ -37,7 +40,9 @@ class AgentTagsService(BaseWorkspaceService):
             AgentTag.id == tag_id,
         )
         result = await self.session.execute(statement)
-        return result.scalar_one()
+        if tag := result.scalar_one_or_none():
+            return tag
+        raise TracecatNotFoundError("Agent tag not found")
 
     @require_scope("agent:read")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
@@ -61,11 +66,11 @@ class AgentTagsService(BaseWorkspaceService):
                 cursor_data = paginator.decode_cursor(params.cursor)
                 cursor_id = uuid.UUID(cursor_data.id)
             except ValueError as err:
-                raise ValueError("Invalid cursor for agent tags") from err
+                raise TracecatValidationError("Invalid cursor for agent tags") from err
 
             cursor_created_at = cursor_data.sort_value
             if not isinstance(cursor_created_at, datetime):
-                raise ValueError("Invalid cursor for agent tags")
+                raise TracecatValidationError("Invalid cursor for agent tags")
 
             predicate = sa.or_(
                 AgentTag.created_at < cursor_created_at,
@@ -142,7 +147,9 @@ class AgentTagsService(BaseWorkspaceService):
             AgentTag.ref == ref,
         )
         result = await self.session.execute(statement)
-        return result.scalar_one()
+        if tag := result.scalar_one_or_none():
+            return tag
+        raise TracecatNotFoundError("Agent tag not found")
 
     @require_scope("agent:create")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
@@ -231,7 +238,7 @@ class AgentTagsService(BaseWorkspaceService):
         )
         is_allowed = await self.session.scalar(select(preset_exists & tag_exists))
         if not is_allowed:
-            raise NoResultFound("Agent preset or tag not found")
+            raise TracecatNotFoundError("Agent preset or tag not found")
 
     async def _require_preset_in_workspace(self, preset_id: uuid.UUID) -> None:
         preset_exists = exists(
@@ -242,7 +249,7 @@ class AgentTagsService(BaseWorkspaceService):
         )
         is_allowed = await self.session.scalar(select(preset_exists))
         if not is_allowed:
-            raise NoResultFound("Agent preset not found")
+            raise TracecatNotFoundError("Agent preset not found")
 
     @require_scope("agent:read")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
@@ -280,7 +287,9 @@ class AgentTagsService(BaseWorkspaceService):
             )
         )
         result = await self.session.execute(stmt)
-        return result.scalar_one()
+        if link := result.scalar_one_or_none():
+            return link
+        raise TracecatNotFoundError("Tag not found")
 
     @require_scope("agent:update")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
@@ -304,7 +313,9 @@ class AgentTagsService(BaseWorkspaceService):
                     AgentTagLink.tag_id == tag_id,
                 )
             )
-            link = existing.scalar_one()
+            link = existing.scalar_one_or_none()
+            if link is None:
+                raise TracecatNotFoundError("Agent preset or tag not found")
         await self.session.commit()
         return link
 

--- a/tracecat/agent/tags/service.py
+++ b/tracecat/agent/tags/service.py
@@ -23,6 +23,14 @@ class AgentTagsService(BaseWorkspaceService):
 
     # --- Tag definitions ---
 
+    async def _get_tag(self, tag_id: AgentTagID) -> AgentTag:
+        statement = select(AgentTag).where(
+            AgentTag.workspace_id == self.workspace_id,
+            AgentTag.id == tag_id,
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one()
+
     @require_scope("agent:read")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def list_tags(self) -> Sequence[AgentTag]:
@@ -35,12 +43,7 @@ class AgentTagsService(BaseWorkspaceService):
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def get_tag(self, tag_id: AgentTagID) -> AgentTag:
         """Get an agent tag by ID."""
-        statement = select(AgentTag).where(
-            AgentTag.workspace_id == self.workspace_id,
-            AgentTag.id == tag_id,
-        )
-        result = await self.session.execute(statement)
-        return result.scalar_one()
+        return await self._get_tag(tag_id)
 
     async def get_tag_by_ref(self, ref: str) -> AgentTag:
         """Get an agent tag by its ref."""
@@ -106,6 +109,14 @@ class AgentTagsService(BaseWorkspaceService):
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def delete_tag(self, tag: AgentTag) -> None:
         """Delete an agent tag definition."""
+        await self.session.delete(tag)
+        await self.session.commit()
+
+    @require_scope("agent:delete")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def delete_tag_by_id(self, tag_id: AgentTagID) -> None:
+        """Delete an agent tag definition by ID."""
+        tag = await self._get_tag(tag_id)
         await self.session.delete(tag)
         await self.session.commit()
 

--- a/tracecat/agent/tags/service.py
+++ b/tracecat/agent/tags/service.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import NoResultFound
 
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import AgentPreset, AgentTag, AgentTagLink
+from tracecat.exceptions import TracecatConflictError
 from tracecat.identifiers import AgentTagID
 from tracecat.pagination import (
     BaseCursorPaginator,
@@ -156,7 +157,7 @@ class AgentTagsService(BaseWorkspaceService):
             )
         )
         if existing.one_or_none():
-            raise ValueError(f"Agent tag with slug '{ref}' already exists")
+            raise TracecatConflictError(f"Agent tag with slug '{ref}' already exists")
 
         db_tag = AgentTag(
             name=tag.name,
@@ -184,7 +185,9 @@ class AgentTagsService(BaseWorkspaceService):
                     )
                 )
                 if existing.one_or_none():
-                    raise ValueError(f"Agent tag with slug '{new_ref}' already exists")
+                    raise TracecatConflictError(
+                        f"Agent tag with slug '{new_ref}' already exists"
+                    )
                 tag.ref = new_ref
 
         for key, value in params.model_dump(exclude_unset=True).items():

--- a/tracecat/agent/tags/service.py
+++ b/tracecat/agent/tags/service.py
@@ -2,7 +2,9 @@
 
 import uuid
 from collections.abc import Sequence
+from datetime import datetime
 
+import sqlalchemy as sa
 from slugify import slugify
 from sqlalchemy import exists, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -11,6 +13,11 @@ from sqlalchemy.exc import NoResultFound
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import AgentPreset, AgentTag, AgentTagLink
 from tracecat.identifiers import AgentTagID
+from tracecat.pagination import (
+    BaseCursorPaginator,
+    CursorPaginatedResponse,
+    CursorPaginationParams,
+)
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tags.schemas import TagCreate, TagUpdate
 from tracecat.tiers.enums import Entitlement
@@ -38,6 +45,81 @@ class AgentTagsService(BaseWorkspaceService):
         statement = select(AgentTag).where(AgentTag.workspace_id == self.workspace_id)
         result = await self.session.execute(statement)
         return result.scalars().all()
+
+    @require_scope("agent:read")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def list_tags_paginated(
+        self, params: CursorPaginationParams
+    ) -> CursorPaginatedResponse[AgentTag]:
+        """List all agent tags in the workspace with cursor pagination."""
+        paginator = BaseCursorPaginator(self.session)
+        statement = select(AgentTag).where(AgentTag.workspace_id == self.workspace_id)
+
+        if params.cursor:
+            try:
+                cursor_data = paginator.decode_cursor(params.cursor)
+                cursor_id = uuid.UUID(cursor_data.id)
+            except ValueError as err:
+                raise ValueError("Invalid cursor for agent tags") from err
+
+            cursor_created_at = cursor_data.sort_value
+            if not isinstance(cursor_created_at, datetime):
+                raise ValueError("Invalid cursor for agent tags")
+
+            predicate = sa.or_(
+                AgentTag.created_at < cursor_created_at,
+                sa.and_(
+                    AgentTag.created_at == cursor_created_at,
+                    AgentTag.id < cursor_id,
+                ),
+            )
+            if params.reverse:
+                predicate = sa.or_(
+                    AgentTag.created_at > cursor_created_at,
+                    sa.and_(
+                        AgentTag.created_at == cursor_created_at,
+                        AgentTag.id > cursor_id,
+                    ),
+                )
+            statement = statement.where(predicate)
+
+        if params.reverse:
+            statement = statement.order_by(AgentTag.created_at.asc(), AgentTag.id.asc())
+        else:
+            statement = statement.order_by(
+                AgentTag.created_at.desc(), AgentTag.id.desc()
+            )
+        statement = statement.limit(params.limit + 1)
+
+        tags = (await self.session.execute(statement)).scalars().all()
+        has_more = len(tags) > params.limit
+        items = list(tags[: params.limit])
+
+        next_cursor = None
+        if has_more and items:
+            last = items[-1]
+            next_cursor = paginator.encode_cursor(
+                last.id,
+                sort_column="created_at",
+                sort_value=last.created_at,
+            )
+
+        prev_cursor = None
+        if params.cursor and items:
+            first = items[0]
+            prev_cursor = paginator.encode_cursor(
+                first.id,
+                sort_column="created_at",
+                sort_value=first.created_at,
+            )
+
+        return CursorPaginatedResponse(
+            items=items,
+            next_cursor=next_cursor,
+            prev_cursor=prev_cursor,
+            has_more=has_more,
+            has_previous=params.cursor is not None,
+        )
 
     @require_scope("agent:read")
     @requires_entitlement(Entitlement.AGENT_ADDONS)

--- a/tracecat/agent/tags/service.py
+++ b/tracecat/agent/tags/service.py
@@ -288,7 +288,8 @@ class AgentTagsService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         link = result.scalar_one_or_none()
         if link is None:
-            link = await self.get_preset_tag(preset_id, tag_id)
+            await self.session.rollback()
+            raise ValueError("Agent preset tag already exists")
         await self.session.commit()
         return link
 

--- a/tracecat/agent/tags/service.py
+++ b/tracecat/agent/tags/service.py
@@ -113,12 +113,19 @@ class AgentTagsService(BaseWorkspaceService):
                 sort_value=first.created_at,
             )
 
+        if params.reverse:
+            items.reverse()
+            next_cursor, prev_cursor = prev_cursor, next_cursor
+            has_more, has_previous = params.cursor is not None, has_more
+        else:
+            has_previous = params.cursor is not None
+
         return CursorPaginatedResponse(
             items=items,
             next_cursor=next_cursor,
             prev_cursor=prev_cursor,
             has_more=has_more,
-            has_previous=params.cursor is not None,
+            has_previous=has_previous,
         )
 
     @require_scope("agent:read")

--- a/tracecat/agent/tags/service.py
+++ b/tracecat/agent/tags/service.py
@@ -141,10 +141,22 @@ class AgentTagsService(BaseWorkspaceService):
         if not is_allowed:
             raise NoResultFound("Agent preset or tag not found")
 
+    async def _require_preset_in_workspace(self, preset_id: uuid.UUID) -> None:
+        preset_exists = exists(
+            select(AgentPreset.id).where(
+                AgentPreset.id == preset_id,
+                AgentPreset.workspace_id == self.workspace_id,
+            )
+        )
+        is_allowed = await self.session.scalar(select(preset_exists))
+        if not is_allowed:
+            raise NoResultFound("Agent preset not found")
+
     @require_scope("agent:read")
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def list_tags_for_preset(self, preset_id: uuid.UUID) -> Sequence[AgentTag]:
         """List all tags on a preset."""
+        await self._require_preset_in_workspace(preset_id)
         stmt = (
             select(AgentTag)
             .join(AgentTagLink, AgentTag.id == AgentTagLink.tag_id)

--- a/tracecat/agent/tags/service.py
+++ b/tracecat/agent/tags/service.py
@@ -295,8 +295,13 @@ class AgentTagsService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         link = result.scalar_one_or_none()
         if link is None:
-            await self.session.rollback()
-            raise ValueError("Agent preset tag already exists")
+            existing = await self.session.execute(
+                select(AgentTagLink).where(
+                    AgentTagLink.preset_id == preset_id,
+                    AgentTagLink.tag_id == tag_id,
+                )
+            )
+            link = existing.scalar_one()
         await self.session.commit()
         return link
 

--- a/tracecat/agent/tags/service.py
+++ b/tracecat/agent/tags/service.py
@@ -8,6 +8,7 @@ import sqlalchemy as sa
 from slugify import slugify
 from sqlalchemy import exists, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
 
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import AgentPreset, AgentTag, AgentTagLink
@@ -33,6 +34,13 @@ class AgentTagsService(BaseWorkspaceService):
     service_name = "agent_tags"
 
     # --- Tag definitions ---
+
+    async def _commit_tag_definition_change(self, conflict_message: str) -> None:
+        try:
+            await self.session.commit()
+        except IntegrityError as err:
+            await self.session.rollback()
+            raise TracecatConflictError(conflict_message) from err
 
     async def _get_tag(self, tag_id: AgentTagID) -> AgentTag:
         statement = select(AgentTag).where(
@@ -173,7 +181,9 @@ class AgentTagsService(BaseWorkspaceService):
             color=tag.color,
         )
         self.session.add(db_tag)
-        await self.session.commit()
+        await self._commit_tag_definition_change(
+            f"Agent tag with slug '{ref}' already exists"
+        )
         await self.session.refresh(db_tag)
         return db_tag
 
@@ -200,7 +210,9 @@ class AgentTagsService(BaseWorkspaceService):
         for key, value in params.model_dump(exclude_unset=True).items():
             setattr(tag, key, value)
 
-        await self.session.commit()
+        await self._commit_tag_definition_change(
+            f"Agent tag with slug '{tag.ref}' already exists"
+        )
         await self.session.refresh(tag)
         return tag
 

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -34,6 +34,7 @@ from tracecat.agent.channels.management_router import (
     router as agent_channels_management_router,
 )
 from tracecat.agent.channels.router import router as agent_channels_router
+from tracecat.agent.folders.router import router as agent_folders_router
 from tracecat.agent.internal_router import router as internal_agent_router
 from tracecat.agent.preset.internal_router import (
     router as internal_agent_preset_router,
@@ -44,6 +45,10 @@ from tracecat.agent.router import router as agent_router
 from tracecat.agent.router import workspace_router as agent_workspace_router
 from tracecat.agent.session.router import router as agent_session_router
 from tracecat.agent.skill.router import router as agent_skill_router
+from tracecat.agent.tags.definitions_router import (
+    router as agent_tag_definitions_router,
+)
+from tracecat.agent.tags.router import router as agent_preset_tags_router
 from tracecat.api.common import (
     add_temporal_search_attributes,
     bootstrap_role,
@@ -523,6 +528,9 @@ def create_app(**kwargs) -> FastAPI:
     _include_workspace_scoped_router(app, agent_workspace_router)
     _include_workspace_scoped_router(app, agent_channels_management_router)
     _include_workspace_scoped_router(app, agent_preset_router)
+    _include_workspace_scoped_router(app, agent_preset_tags_router)
+    _include_workspace_scoped_router(app, agent_folders_router)
+    _include_workspace_scoped_router(app, agent_tag_definitions_router)
     _include_workspace_scoped_router(app, agent_skill_router)
     _include_workspace_scoped_router(app, agent_session_router)
     _include_workspace_scoped_router(app, approvals_router)

--- a/tracecat/exceptions.py
+++ b/tracecat/exceptions.py
@@ -31,6 +31,10 @@ class TracecatValidationError(TracecatException):
     """Tracecat user-facing validation error"""
 
 
+class TracecatConflictError(TracecatException):
+    """Tracecat user-facing resource conflict error"""
+
+
 class TracecatDSLError(TracecatValidationError):
     """Tracecat user-facing DSL error"""
 


### PR DESCRIPTION
## Summary

- Add workspace-scoped agent folder and agent tag APIs, services, schemas, and route registration.
- Extend agent preset create/update/read behavior with folder and tag support.
- Add focused API/service regression tests and regenerate the TypeScript API client.

## Testing

- `just gen-client-ci`
- `uv run ruff check tracecat/api/app.py tracecat/db/models.py tracecat/db/tenant_rls.py tracecat/agent/preset/router.py tracecat/agent/preset/service.py tracecat/agent/folders/router.py tracecat/agent/tags/router.py tracecat/agent/tags/definitions_router.py tests/unit/api/conftest.py`
- `uv run ruff format --check tracecat/api/app.py tracecat/db/models.py tracecat/db/tenant_rls.py tracecat/agent/preset/router.py tracecat/agent/preset/service.py tracecat/agent/folders/router.py tracecat/agent/tags/router.py tracecat/agent/tags/definitions_router.py tests/unit/api/conftest.py`
- `uv run basedpyright tracecat/api/app.py tracecat/db/models.py tracecat/db/tenant_rls.py tracecat/agent/preset/router.py tracecat/agent/preset/service.py tracecat/agent/folders/router.py tracecat/agent/tags/router.py tracecat/agent/tags/definitions_router.py tests/unit/api/conftest.py`
- `TRACECAT__SERVICE_KEY=test-service-key uv run pytest tests/unit/api/test_api_agent_folders.py tests/unit/test_agent_folders_service.py tests/unit/api/test_api_agent_presets.py -q`
