### PR TITLE
fix: Provision default org membership in single tenant

### DIFF
--- a/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
+++ b/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
@@ -15,7 +15,6 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tracecat import config
 from tracecat.auth.schemas import UserCreate, UserRole, UserUpdate
 from tracecat.auth.users import (
     get_or_create_user,
@@ -39,7 +38,7 @@ from tracecat.db.models import (
 from tracecat.db.models import Role as DBRole
 from tracecat.organization.management import (
     ensure_default_organization,
-    ensure_single_tenant_user_defaults_in_session,
+    ensure_single_tenant_user_defaults_for_session,
 )
 from tracecat.tiers import defaults as tier_defaults
 from tracecat.tiers.enums import Entitlement
@@ -142,7 +141,7 @@ async def create_superuser(
                     user_update = UserUpdate(role=UserRole.ADMIN)
                     user = await user_manager.admin_update(user_update, user)
 
-            await _ensure_single_tenant_user_defaults(
+            await ensure_single_tenant_user_defaults_for_session(
                 session=session,
                 user_id=user.id,
                 is_superuser=True,
@@ -166,7 +165,7 @@ async def create_superuser(
             # Promote to superuser
             user.is_superuser = True
             user.role = UserRole.ADMIN
-            await _ensure_single_tenant_user_defaults(
+            await ensure_single_tenant_user_defaults_for_session(
                 session=session,
                 user_id=user.id,
                 is_superuser=True,
@@ -316,25 +315,6 @@ async def _ensure_platform_superuser(
     return user, True
 
 
-async def _ensure_single_tenant_user_defaults(
-    *,
-    session: AsyncSession,
-    user_id: UUID,
-    is_superuser: bool,
-    organization_id: UUID | None = None,
-) -> None:
-    if config.TRACECAT__EE_MULTI_TENANT:
-        return
-    if organization_id is None:
-        organization_id = await ensure_default_organization()
-    await ensure_single_tenant_user_defaults_in_session(
-        session=session,
-        user_id=user_id,
-        organization_id=organization_id,
-        is_superuser=is_superuser,
-    )
-
-
 async def _get_or_create_local_user(
     *,
     session: AsyncSession,
@@ -479,7 +459,7 @@ async def create_dev_user(
             email=superuser_email,
             password=superuser_password,
         )
-        await _ensure_single_tenant_user_defaults(
+        await ensure_single_tenant_user_defaults_for_session(
             session=session,
             user_id=superuser.id,
             is_superuser=True,

--- a/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
+++ b/packages/tracecat-admin/tracecat_admin/services/bootstrap.py
@@ -15,6 +15,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat import config
 from tracecat.auth.schemas import UserCreate, UserRole, UserUpdate
 from tracecat.auth.users import (
     get_or_create_user,
@@ -36,7 +37,10 @@ from tracecat.db.models import (
     Workspace,
 )
 from tracecat.db.models import Role as DBRole
-from tracecat.organization.management import ensure_default_organization
+from tracecat.organization.management import (
+    ensure_default_organization,
+    ensure_single_tenant_user_defaults_in_session,
+)
 from tracecat.tiers import defaults as tier_defaults
 from tracecat.tiers.enums import Entitlement
 from tracecat.tiers.types import EntitlementsDict
@@ -138,6 +142,13 @@ async def create_superuser(
                     user_update = UserUpdate(role=UserRole.ADMIN)
                     user = await user_manager.admin_update(user_update, user)
 
+            await _ensure_single_tenant_user_defaults(
+                session=session,
+                user_id=user.id,
+                is_superuser=True,
+            )
+            await session.commit()
+
             return CreateSuperuserResult(
                 email=user.email,
                 user_id=str(user.id),
@@ -155,6 +166,11 @@ async def create_superuser(
             # Promote to superuser
             user.is_superuser = True
             user.role = UserRole.ADMIN
+            await _ensure_single_tenant_user_defaults(
+                session=session,
+                user_id=user.id,
+                is_superuser=True,
+            )
             await session.commit()
             await session.refresh(user)
 
@@ -300,6 +316,25 @@ async def _ensure_platform_superuser(
     return user, True
 
 
+async def _ensure_single_tenant_user_defaults(
+    *,
+    session: AsyncSession,
+    user_id: UUID,
+    is_superuser: bool,
+    organization_id: UUID | None = None,
+) -> None:
+    if config.TRACECAT__EE_MULTI_TENANT:
+        return
+    if organization_id is None:
+        organization_id = await ensure_default_organization()
+    await ensure_single_tenant_user_defaults_in_session(
+        session=session,
+        user_id=user_id,
+        organization_id=organization_id,
+        is_superuser=is_superuser,
+    )
+
+
 async def _get_or_create_local_user(
     *,
     session: AsyncSession,
@@ -443,6 +478,12 @@ async def create_dev_user(
             session=session,
             email=superuser_email,
             password=superuser_password,
+        )
+        await _ensure_single_tenant_user_defaults(
+            session=session,
+            user_id=superuser.id,
+            is_superuser=True,
+            organization_id=organization_id,
         )
         user, created = await _get_or_create_local_user(
             session=session,

--- a/packages/tracecat-ee/tracecat_ee/admin/users/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/users/service.py
@@ -8,14 +8,12 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Mapped
 
-from tracecat import config
 from tracecat.audit.service import AuditService
 from tracecat.auth.schemas import UserCreate, UserRole
 from tracecat.auth.users import get_user_db_context, get_user_manager_context
 from tracecat.db.models import User
 from tracecat.organization.management import (
-    ensure_single_tenant_user_defaults_in_session,
-    get_default_organization_id,
+    ensure_single_tenant_user_defaults_for_session,
 )
 from tracecat.service import BasePlatformService
 
@@ -26,17 +24,6 @@ class AdminUserService(BasePlatformService):
     """Platform-level user management."""
 
     service_name = "admin_user"
-
-    async def _ensure_single_tenant_defaults(self, user: User) -> None:
-        if config.TRACECAT__EE_MULTI_TENANT:
-            return
-        organization_id = await get_default_organization_id(self.session)
-        await ensure_single_tenant_user_defaults_in_session(
-            session=self.session,
-            user_id=user.id,
-            organization_id=organization_id,
-            is_superuser=user.is_superuser,
-        )
 
     async def create_user(self, params: AdminUserCreate) -> AdminUserRead:
         """Create a platform-level user."""
@@ -59,7 +46,11 @@ class AdminUserService(BasePlatformService):
         self.session.add(user)
         try:
             await self.session.flush()
-            await self._ensure_single_tenant_defaults(user)
+            await ensure_single_tenant_user_defaults_for_session(
+                session=self.session,
+                user_id=user.id,
+                is_superuser=user.is_superuser,
+            )
             await self.session.commit()
         except IntegrityError as e:
             await self.session.rollback()
@@ -105,7 +96,11 @@ class AdminUserService(BasePlatformService):
             raise ValueError(f"User {user_id} is already a superuser")
 
         user.is_superuser = True
-        await self._ensure_single_tenant_defaults(user)
+        await ensure_single_tenant_user_defaults_for_session(
+            session=self.session,
+            user_id=user.id,
+            is_superuser=user.is_superuser,
+        )
         await self.session.commit()
         await self.session.refresh(user)
         return AdminUserRead.model_validate(user)

--- a/packages/tracecat-ee/tracecat_ee/admin/users/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/users/service.py
@@ -8,10 +8,15 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Mapped
 
+from tracecat import config
 from tracecat.audit.service import AuditService
 from tracecat.auth.schemas import UserCreate, UserRole
 from tracecat.auth.users import get_user_db_context, get_user_manager_context
 from tracecat.db.models import User
+from tracecat.organization.management import (
+    ensure_single_tenant_user_defaults_in_session,
+    get_default_organization_id,
+)
 from tracecat.service import BasePlatformService
 
 from .schemas import AdminUserCreate, AdminUserRead
@@ -22,8 +27,19 @@ class AdminUserService(BasePlatformService):
 
     service_name = "admin_user"
 
+    async def _ensure_single_tenant_defaults(self, user: User) -> None:
+        if config.TRACECAT__EE_MULTI_TENANT:
+            return
+        organization_id = await get_default_organization_id(self.session)
+        await ensure_single_tenant_user_defaults_in_session(
+            session=self.session,
+            user_id=user.id,
+            organization_id=organization_id,
+            is_superuser=user.is_superuser,
+        )
+
     async def create_user(self, params: AdminUserCreate) -> AdminUserRead:
-        """Create a platform-level user without org/workspace memberships."""
+        """Create a platform-level user."""
         async with get_user_db_context(self.session) as user_db:
             async with get_user_manager_context(user_db) as user_manager:
                 user_create = UserCreate(email=params.email, password=params.password)
@@ -42,6 +58,8 @@ class AdminUserService(BasePlatformService):
         )
         self.session.add(user)
         try:
+            await self.session.flush()
+            await self._ensure_single_tenant_defaults(user)
             await self.session.commit()
         except IntegrityError as e:
             await self.session.rollback()
@@ -87,6 +105,7 @@ class AdminUserService(BasePlatformService):
             raise ValueError(f"User {user_id} is already a superuser")
 
         user.is_superuser = True
+        await self._ensure_single_tenant_defaults(user)
         await self.session.commit()
         await self.session.refresh(user)
         return AdminUserRead.model_validate(user)

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -3,7 +3,7 @@
 # Tracecat multi-cluster management script
 #
 # Usage:
-#   ./cluster [cluster_num] [-p profile] <command> [args...]
+#   ./cluster [cluster_num] [-p profile] [tenant mode] <command> [args...]
 #
 # Profiles:
 #   dev     docker-compose.dev.yml (default)
@@ -12,6 +12,7 @@
 #
 # Examples:
 #   ./cluster up -d                # Start next available cluster (auto-selects number)
+#   ./cluster up -d --single-tenant # Start cluster with multi-tenancy disabled
 #   ./cluster down                 # Stop cluster (auto-selects if only one running)
 #   ./cluster restart api          # Restart the api service
 #   ./cluster 2 up -d              # Start cluster 2 explicitly
@@ -37,6 +38,7 @@ ENV_FILE="${REPO_ROOT}/.env"
 
 # Default profile
 PROFILE="dev"
+CLUSTER_EE_MULTI_TENANT=""
 
 # Get worktree identifier for namespacing clusters
 # Returns "main" for the main worktree, or a sanitized branch/directory name for worktrees
@@ -359,7 +361,7 @@ get_compose_file() {
 
 usage() {
     cat <<EOF
-Usage: ./cluster [cluster_num] [-p profile] <command> [args...]
+Usage: ./cluster [cluster_num] [-p profile] [tenant mode] <command> [args...]
        ./cluster list
 
 Cluster number is optional:
@@ -371,10 +373,18 @@ Profiles:
   local     docker-compose.local.yml
   prod      docker-compose.yml
 
+Tenant mode:
+  Defaults to TRACECAT__EE_MULTI_TENANT from the environment/.env when set,
+  otherwise true for cluster development.
+  --single-tenant                 Set TRACECAT__EE_MULTI_TENANT=false
+  --multi-tenant                  Set TRACECAT__EE_MULTI_TENANT=true
+  --ee-multi-tenant true|false    Set TRACECAT__EE_MULTI_TENANT explicitly
+
 Commands:
   up [args]     Start the cluster (e.g., up -d)
                 Reuses existing cluster for this worktree if one is running.
                 Use --new/-n to force a new cluster instead.
+                Use --single-tenant or --multi-tenant to override tenant mode.
                 Seeds test@tracecat.com superuser, dev@tracecat.com tenant
                 user, and all default tier entitlements by default for the dev
                 profile. Use --no-seed to skip.
@@ -401,6 +411,10 @@ Nuke options:
 
 Examples:
   ./cluster up -d                Start cluster and create dev users
+  ./cluster up -d --single-tenant
+                                  Start cluster with multi-tenancy disabled
+  ./cluster --ee-multi-tenant false up -d
+                                  Start cluster with explicit tenant mode
   ./cluster up -d --new          Force a new cluster on next available number
   ./cluster up -d --no-seed      Start cluster without creating dev tenant user
   ./cluster up -d --default-tier-entitlements none
@@ -423,6 +437,24 @@ Examples:
 Current worktree: ${WORKTREE_ID}
 EOF
     exit 0
+}
+
+normalize_bool() {
+    local value
+    value=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+
+    case "$value" in
+        true|1|yes|y|on)
+            echo "true"
+            ;;
+        false|0|no|n|off)
+            echo "false"
+            ;;
+        *)
+            echo "Error: expected a boolean value, got '$1'" >&2
+            exit 1
+            ;;
+    esac
 }
 
 # Calculate ports for a given cluster number
@@ -487,8 +519,9 @@ build_env() {
     # Default to direct executor backend for development
     export TRACECAT__EXECUTOR_BACKEND="${TRACECAT__EXECUTOR_BACKEND:-direct}"
 
-    # Enable multitenancy and all feature flags for development
-    export TRACECAT__EE_MULTI_TENANT=true
+    # Default cluster development to multi-tenant mode, but let .env/shell
+    # configuration override it unless an explicit cluster flag was provided.
+    export TRACECAT__EE_MULTI_TENANT="${CLUSTER_EE_MULTI_TENANT:-${TRACECAT__EE_MULTI_TENANT:-true}}"
     FEATURE_FLAGS=$(cd "$REPO_ROOT" && uv run python -c "from tracecat.feature_flags.enums import FeatureFlag; print(','.join(f.value for f in FeatureFlag))" 2>/dev/null) || FEATURE_FLAGS=""
     if [[ -n "$FEATURE_FLAGS" ]]; then
         export TRACECAT__FEATURE_FLAGS="$FEATURE_FLAGS"
@@ -575,15 +608,42 @@ if [[ $# -lt 1 ]]; then
     usage
 fi
 
-# Parse optional -p/--profile flag
-if [[ "$1" == "-p" ]] || [[ "$1" == "--profile" ]]; then
-    if [[ $# -lt 2 ]]; then
-        echo "Error: -p/--profile requires a profile name"
-        exit 1
-    fi
-    PROFILE="$2"
-    shift 2
-fi
+# Parse cluster-level flags that appear before the command.
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -p|--profile)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: -p/--profile requires a profile name" >&2
+                exit 1
+            fi
+            PROFILE="$2"
+            shift 2
+            ;;
+        --single-tenant)
+            CLUSTER_EE_MULTI_TENANT="false"
+            shift
+            ;;
+        --multi-tenant)
+            CLUSTER_EE_MULTI_TENANT="true"
+            shift
+            ;;
+        --ee-multi-tenant)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --ee-multi-tenant requires true or false" >&2
+                exit 1
+            fi
+            CLUSTER_EE_MULTI_TENANT=$(normalize_bool "$2")
+            shift 2
+            ;;
+        --ee-multi-tenant=*)
+            CLUSTER_EE_MULTI_TENANT=$(normalize_bool "${1#*=}")
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
 
 if [[ $# -lt 1 ]]; then
     usage
@@ -618,6 +678,44 @@ if [[ "$COMMAND" == "docs" ]]; then
 
     portless_install_tip
     exec mint dev "$@"
+fi
+
+# Parse cluster-level flags that appear after the command, so both of these work:
+#   ./cluster --single-tenant up -d
+#   ./cluster up -d --single-tenant
+FILTERED_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --single-tenant)
+            CLUSTER_EE_MULTI_TENANT="false"
+            shift
+            ;;
+        --multi-tenant)
+            CLUSTER_EE_MULTI_TENANT="true"
+            shift
+            ;;
+        --ee-multi-tenant)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --ee-multi-tenant requires true or false" >&2
+                exit 1
+            fi
+            CLUSTER_EE_MULTI_TENANT=$(normalize_bool "$2")
+            shift 2
+            ;;
+        --ee-multi-tenant=*)
+            CLUSTER_EE_MULTI_TENANT=$(normalize_bool "${1#*=}")
+            shift
+            ;;
+        *)
+            FILTERED_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+if [[ ${#FILTERED_ARGS[@]} -gt 0 ]]; then
+    set -- "${FILTERED_ARGS[@]}"
+else
+    set --
 fi
 
 # Parse --new/-n flag from remaining args (only meaningful for 'up')
@@ -953,6 +1051,10 @@ if [[ -f "$ENV_FILE" ]]; then
     set +a
     # Re-apply our overrides (source may have overwritten them)
     build_env "$CLUSTER_NUM"
+fi
+
+if [[ "$COMMAND" == "up" ]]; then
+    echo "EE multi-tenant: ${TRACECAT__EE_MULTI_TENANT}"
 fi
 
 # Sync dependencies before starting cluster

--- a/tests/unit/test_admin_users_service.py
+++ b/tests/unit/test_admin_users_service.py
@@ -12,9 +12,16 @@ from sqlalchemy.orm import Mapped
 from tracecat_ee.admin.users.schemas import AdminUserCreate
 from tracecat_ee.admin.users.service import AdminUserService
 
+from tracecat import config
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import PlatformRole
-from tracecat.db.models import Membership, OrganizationMembership, User
+from tracecat.db.models import (
+    Membership,
+    OrganizationMembership,
+    User,
+    UserRoleAssignment,
+)
+from tracecat.db.models import Role as DBRole
 
 pytestmark = pytest.mark.usefixtures("db")
 
@@ -32,7 +39,9 @@ def platform_role() -> PlatformRole:
 async def test_create_user_creates_platform_user_without_memberships(
     session: AsyncSession,
     platform_role: PlatformRole,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
     service = AdminUserService(session, role=platform_role)
     params = AdminUserCreate(
         email="platform-user@example.com",
@@ -93,6 +102,75 @@ async def test_create_user_respects_superuser_flag(
     )
     user = user_result.scalar_one()
     assert user.is_superuser is True
+
+
+@pytest.mark.anyio
+async def test_create_user_provisions_default_org_in_single_tenant(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", False)
+    service = AdminUserService(session, role=platform_role)
+    params = AdminUserCreate(
+        email="single-tenant-user@example.com",
+        password="this-is-a-strong-password",
+        is_superuser=False,
+    )
+
+    created = await service.create_user(params)
+
+    membership_count = await session.scalar(
+        select(func.count())
+        .select_from(OrganizationMembership)
+        .where(OrganizationMembership.user_id == created.id)
+    )
+    role_slug = await session.scalar(
+        select(DBRole.slug)
+        .join(UserRoleAssignment, UserRoleAssignment.role_id == DBRole.id)
+        .where(
+            UserRoleAssignment.user_id == created.id,
+            UserRoleAssignment.workspace_id.is_(None),
+        )
+    )
+    workspace_membership_count = await session.scalar(
+        select(func.count())
+        .select_from(Membership)
+        .where(Membership.user_id == created.id)
+    )
+
+    assert membership_count == 1
+    assert role_slug == "organization-member"
+    assert workspace_membership_count == 0
+
+
+@pytest.mark.anyio
+async def test_promote_superuser_provisions_owner_in_single_tenant(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", False)
+    service = AdminUserService(session, role=platform_role)
+    created = await service.create_user(
+        AdminUserCreate(
+            email="promoted-single-tenant-user@example.com",
+            password="this-is-a-strong-password",
+            is_superuser=False,
+        )
+    )
+
+    await service.promote_superuser(created.id)
+
+    role_slug = await session.scalar(
+        select(DBRole.slug)
+        .join(UserRoleAssignment, UserRoleAssignment.role_id == DBRole.id)
+        .where(
+            UserRoleAssignment.user_id == created.id,
+            UserRoleAssignment.workspace_id.is_(None),
+        )
+    )
+    assert role_slug == "organization-owner"
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -354,9 +354,13 @@ async def test_auth_cache_middleware_initializes_cache():
 
 
 @pytest.mark.anyio
-async def test_auth_cache_reduces_database_queries(mocker):
+async def test_auth_cache_reduces_database_queries(
+    mocker, monkeypatch: pytest.MonkeyPatch
+):
     """Test that the cache reduces database queries for multiple workspace checks."""
     from tracecat.authz.service import MembershipService
+
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
 
     # Create mock user and memberships with proper UUID4
     mock_user = MagicMock(spec=User)
@@ -602,9 +606,11 @@ async def test_performance_improvement(mocker):
 
 
 @pytest.mark.anyio
-async def test_cache_user_id_validation():
+async def test_cache_user_id_validation(monkeypatch: pytest.MonkeyPatch):
     """Test that cache validates user ID to prevent cross-user data leakage."""
     from tracecat.authz.service import MembershipService
+
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
 
     # Create two different users
     user1 = MagicMock(spec=User)
@@ -697,9 +703,11 @@ async def test_cache_user_id_validation():
 
 
 @pytest.mark.anyio
-async def test_cache_size_limit():
+async def test_cache_size_limit(monkeypatch: pytest.MonkeyPatch):
     """Test that cache has size limits to prevent memory exhaustion."""
     from tracecat.authz.service import MembershipService
+
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
 
     # Create user with excessive memberships
     user = MagicMock(spec=User)
@@ -781,8 +789,12 @@ async def test_cache_size_limit():
 
 
 @pytest.mark.anyio
-async def test_organization_id_populated_when_require_workspace_no(mocker):
+async def test_organization_id_populated_when_require_workspace_no(
+    mocker, monkeypatch: pytest.MonkeyPatch
+):
     """Test that organization_id is inferred from OrganizationMembership when require_workspace="no"."""
+
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
 
     # Create mock user (non-superuser to exercise org membership resolution)
     mock_user = MagicMock(spec=User)
@@ -844,8 +856,10 @@ async def test_organization_id_populated_when_require_workspace_no(mocker):
 @pytest.mark.anyio
 @pytest.mark.usefixtures("db")
 async def test_role_dependency_infers_org_from_single_membership(
-    session: AsyncSession,
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ):
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
+
     org_id = uuid.uuid4()
     org = Organization(
         id=org_id,
@@ -906,8 +920,10 @@ async def test_role_dependency_infers_org_from_single_membership(
 @pytest.mark.anyio
 @pytest.mark.usefixtures("db")
 async def test_role_dependency_requires_workspace_for_multi_org(
-    session: AsyncSession,
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ):
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
+
     org_a_id = uuid.uuid4()
     org_b_id = uuid.uuid4()
     org_a = Organization(

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -11,7 +11,12 @@ from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
-from tracecat.auth.credentials import RoleACL, _role_dependency, authenticated_user_only
+from tracecat.auth.credentials import (
+    RoleACL,
+    _authenticate_user,
+    _role_dependency,
+    authenticated_user_only,
+)
 from tracecat.auth.org_context import resolve_auth_organization_id
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import Role
@@ -26,6 +31,7 @@ from tracecat.db.models import (
     Workspace,
 )
 from tracecat.middleware import AuthorizationCacheMiddleware
+from tracecat.organization.management import SingleTenantUserDefaultsResult
 
 
 @pytest.fixture
@@ -234,6 +240,55 @@ async def test_role_dependency_resolves_multi_tenant_superuser_as_regular_org_us
     assert role.is_platform_superuser is False
     assert role.scopes == scopes
     mock_resolve_org.assert_awaited_once_with(session, user)
+
+
+@pytest.mark.anyio
+async def test_authenticate_user_only_invalidates_scope_cache_when_defaults_change() -> (
+    None
+):
+    request = MagicMock(spec=Request)
+    request.state = MagicMock()
+    request.state.auth_cache = None
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.is_superuser = False
+    org_id = uuid.uuid4()
+
+    for changed, expected_invalidations in ((False, 0), (True, 1)):
+        session = AsyncMock()
+        with (
+            patch(
+                "tracecat.auth.credentials.ensure_single_tenant_user_defaults_for_session",
+                new=AsyncMock(
+                    return_value=SingleTenantUserDefaultsResult(
+                        organization_id=org_id,
+                        changed=changed,
+                    )
+                ),
+            ),
+            patch(
+                "tracecat.auth.credentials.set_rls_context",
+                new=AsyncMock(),
+            ) as mock_set_rls,
+            patch(
+                "tracecat.auth.credentials._invalidate_user_scope_cache"
+            ) as mock_invalidate,
+        ):
+            role = await _authenticate_user(
+                request=request,
+                session=session,
+                user=user,
+                workspace_id=None,
+            )
+
+        assert role.organization_id == org_id
+        assert mock_invalidate.call_count == expected_invalidations
+        if changed:
+            session.commit.assert_awaited_once()
+            mock_set_rls.assert_awaited_once()
+        else:
+            session.commit.assert_not_awaited()
+            mock_set_rls.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_single_tenant_user_defaults.py
+++ b/tests/unit/test_single_tenant_user_defaults.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import asyncio
 import uuid
+from typing import cast
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped
 
 from tracecat import config
 from tracecat.auth.schemas import UserRole
 from tracecat.authz.seeding import seed_system_roles_for_org
+from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import (
     Organization,
     OrganizationMembership,
@@ -18,6 +22,7 @@ from tracecat.db.models import (
 from tracecat.db.models import Role as DBRole
 from tracecat.organization.management import (
     ensure_single_tenant_user_defaults,
+    ensure_single_tenant_user_defaults_for_session,
     ensure_single_tenant_user_defaults_in_session,
 )
 
@@ -84,6 +89,47 @@ async def test_single_tenant_defaults_noop_in_multi_tenant(
     )
 
     assert organization_id is None
+
+
+@pytest.mark.anyio
+async def test_single_tenant_defaults_for_session_noop_in_multi_tenant(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
+
+    result = await ensure_single_tenant_user_defaults_for_session(
+        session=session,
+        user_id=uuid.uuid4(),
+        is_superuser=False,
+    )
+
+    assert result.organization_id is None
+    assert result.changed is False
+
+
+@pytest.mark.anyio
+async def test_single_tenant_defaults_for_session_resolves_default_org(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", False)
+    user = await _create_user(session)
+
+    result = await ensure_single_tenant_user_defaults_for_session(
+        session=session,
+        user_id=user.id,
+        is_superuser=False,
+    )
+    await session.flush()
+
+    assert result.organization_id is not None
+    assert result.changed is True
+    membership = await session.get(
+        OrganizationMembership,
+        {"user_id": user.id, "organization_id": result.organization_id},
+    )
+    assert membership is not None
 
 
 @pytest.mark.anyio
@@ -168,6 +214,91 @@ async def test_single_tenant_defaults_are_idempotent(
     )
     assert membership_count is not None
     assert len(assignment_result.scalars().all()) == 1
+
+
+@pytest.mark.anyio
+async def test_single_tenant_defaults_handle_concurrent_repairs() -> None:
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    org_slug = f"single-tenant-concurrent-{uuid.uuid4().hex[:8]}"
+
+    async with get_async_session_bypass_rls_context_manager() as setup_session:
+        setup_session.add(
+            Organization(
+                id=org_id,
+                name="Single Tenant Concurrent Test Org",
+                slug=org_slug,
+                is_active=True,
+            )
+        )
+        setup_session.add(
+            User(
+                id=user_id,
+                email=f"concurrent-{uuid.uuid4().hex[:8]}@example.com",
+                hashed_password="hashed",
+                role=UserRole.BASIC,
+                is_active=True,
+                is_superuser=False,
+                is_verified=True,
+            )
+        )
+        await setup_session.flush()
+        await seed_system_roles_for_org(setup_session, org_id)
+        await setup_session.commit()
+
+    async def repair_defaults() -> None:
+        async with get_async_session_bypass_rls_context_manager() as repair_session:
+            await ensure_single_tenant_user_defaults_in_session(
+                session=repair_session,
+                user_id=user_id,
+                organization_id=org_id,
+                is_superuser=False,
+            )
+            await repair_session.commit()
+
+    try:
+        await asyncio.gather(repair_defaults(), repair_defaults())
+
+        async with get_async_session_bypass_rls_context_manager() as verify_session:
+            membership_count = await verify_session.scalar(
+                select(func.count())
+                .select_from(OrganizationMembership)
+                .where(
+                    OrganizationMembership.user_id == user_id,
+                    OrganizationMembership.organization_id == org_id,
+                )
+            )
+            assignment_count = await verify_session.scalar(
+                select(func.count())
+                .select_from(UserRoleAssignment)
+                .where(
+                    UserRoleAssignment.user_id == user_id,
+                    UserRoleAssignment.organization_id == org_id,
+                    UserRoleAssignment.workspace_id.is_(None),
+                )
+            )
+
+        assert membership_count == 1
+        assert assignment_count == 1
+    finally:
+        async with get_async_session_bypass_rls_context_manager() as cleanup_session:
+            await cleanup_session.execute(
+                delete(UserRoleAssignment).where(UserRoleAssignment.user_id == user_id)
+            )
+            await cleanup_session.execute(
+                delete(OrganizationMembership).where(
+                    OrganizationMembership.user_id == user_id
+                )
+            )
+            await cleanup_session.execute(
+                delete(User).where(cast(Mapped[uuid.UUID], User.id) == user_id)
+            )
+            await cleanup_session.execute(
+                delete(Organization).where(
+                    cast(Mapped[uuid.UUID], Organization.id) == org_id
+                )
+            )
+            await cleanup_session.commit()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_single_tenant_user_defaults.py
+++ b/tests/unit/test_single_tenant_user_defaults.py
@@ -302,7 +302,49 @@ async def test_single_tenant_defaults_handle_concurrent_repairs() -> None:
 
 
 @pytest.mark.anyio
-async def test_single_tenant_defaults_do_not_downgrade_existing_role(
+async def test_single_tenant_defaults_keep_existing_role_after_repair(
+    session: AsyncSession,
+) -> None:
+    org = await _create_org_with_roles(session)
+    user = await _create_user(session)
+    session.add(OrganizationMembership(user_id=user.id, organization_id=org.id))
+    owner_role = (
+        await session.execute(
+            select(DBRole).where(
+                DBRole.organization_id == org.id,
+                DBRole.slug == "organization-owner",
+            )
+        )
+    ).scalar_one()
+    session.add(
+        UserRoleAssignment(
+            organization_id=org.id,
+            user_id=user.id,
+            workspace_id=None,
+            role_id=owner_role.id,
+        )
+    )
+    await session.flush()
+
+    changed = await ensure_single_tenant_user_defaults_in_session(
+        session=session,
+        user_id=user.id,
+        organization_id=org.id,
+        is_superuser=False,
+    )
+    await session.flush()
+
+    assert (
+        await _get_org_role_assignment_slug(
+            session, user_id=user.id, organization_id=org.id
+        )
+        == "organization-owner"
+    )
+    assert changed is False
+
+
+@pytest.mark.anyio
+async def test_single_tenant_defaults_normalize_existing_role_during_repair(
     session: AsyncSession,
 ) -> None:
     org = await _create_org_with_roles(session)
@@ -325,7 +367,7 @@ async def test_single_tenant_defaults_do_not_downgrade_existing_role(
     )
     await session.flush()
 
-    await ensure_single_tenant_user_defaults_in_session(
+    changed = await ensure_single_tenant_user_defaults_in_session(
         session=session,
         user_id=user.id,
         organization_id=org.id,
@@ -333,12 +375,18 @@ async def test_single_tenant_defaults_do_not_downgrade_existing_role(
     )
     await session.flush()
 
+    membership = await session.get(
+        OrganizationMembership,
+        {"user_id": user.id, "organization_id": org.id},
+    )
+    assert membership is not None
     assert (
         await _get_org_role_assignment_slug(
             session, user_id=user.id, organization_id=org.id
         )
-        == "organization-owner"
+        == "organization-member"
     )
+    assert changed is True
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_single_tenant_user_defaults.py
+++ b/tests/unit/test_single_tenant_user_defaults.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat import config
+from tracecat.auth.schemas import UserRole
+from tracecat.authz.seeding import seed_system_roles_for_org
+from tracecat.db.models import (
+    Organization,
+    OrganizationMembership,
+    User,
+    UserRoleAssignment,
+)
+from tracecat.db.models import Role as DBRole
+from tracecat.organization.management import (
+    ensure_single_tenant_user_defaults,
+    ensure_single_tenant_user_defaults_in_session,
+)
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+async def _create_org_with_roles(session: AsyncSession) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        name="Single Tenant Test Org",
+        slug=f"single-tenant-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session.add(org)
+    await session.flush()
+    await seed_system_roles_for_org(session, org.id)
+    return org
+
+
+async def _create_user(session: AsyncSession, *, is_superuser: bool = False) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"user-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hashed",
+        role=UserRole.ADMIN if is_superuser else UserRole.BASIC,
+        is_active=True,
+        is_superuser=is_superuser,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def _get_org_role_assignment_slug(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+) -> str:
+    result = await session.execute(
+        select(DBRole.slug)
+        .join(UserRoleAssignment, UserRoleAssignment.role_id == DBRole.id)
+        .where(
+            UserRoleAssignment.user_id == user_id,
+            UserRoleAssignment.organization_id == organization_id,
+            UserRoleAssignment.workspace_id.is_(None),
+        )
+    )
+    role_slug = result.scalar_one()
+    assert role_slug is not None
+    return role_slug
+
+
+@pytest.mark.anyio
+async def test_single_tenant_defaults_noop_in_multi_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "TRACECAT__EE_MULTI_TENANT", True)
+
+    organization_id = await ensure_single_tenant_user_defaults(
+        user_id=uuid.uuid4(),
+        is_superuser=False,
+    )
+
+    assert organization_id is None
+
+
+@pytest.mark.anyio
+async def test_single_tenant_defaults_assign_member_role(
+    session: AsyncSession,
+) -> None:
+    org = await _create_org_with_roles(session)
+    user = await _create_user(session)
+
+    await ensure_single_tenant_user_defaults_in_session(
+        session=session,
+        user_id=user.id,
+        organization_id=org.id,
+        is_superuser=False,
+    )
+    await session.flush()
+
+    membership = await session.get(
+        OrganizationMembership,
+        {"user_id": user.id, "organization_id": org.id},
+    )
+    assert membership is not None
+    assert (
+        await _get_org_role_assignment_slug(
+            session, user_id=user.id, organization_id=org.id
+        )
+        == "organization-member"
+    )
+
+
+@pytest.mark.anyio
+async def test_single_tenant_defaults_assign_owner_for_superuser(
+    session: AsyncSession,
+) -> None:
+    org = await _create_org_with_roles(session)
+    user = await _create_user(session, is_superuser=True)
+
+    await ensure_single_tenant_user_defaults_in_session(
+        session=session,
+        user_id=user.id,
+        organization_id=org.id,
+        is_superuser=True,
+    )
+    await session.flush()
+
+    assert (
+        await _get_org_role_assignment_slug(
+            session, user_id=user.id, organization_id=org.id
+        )
+        == "organization-owner"
+    )
+
+
+@pytest.mark.anyio
+async def test_single_tenant_defaults_are_idempotent(
+    session: AsyncSession,
+) -> None:
+    org = await _create_org_with_roles(session)
+    user = await _create_user(session)
+
+    for _ in range(2):
+        await ensure_single_tenant_user_defaults_in_session(
+            session=session,
+            user_id=user.id,
+            organization_id=org.id,
+            is_superuser=False,
+        )
+    await session.flush()
+
+    membership_count = await session.scalar(
+        select(OrganizationMembership).where(
+            OrganizationMembership.user_id == user.id,
+            OrganizationMembership.organization_id == org.id,
+        )
+    )
+    assignment_result = await session.execute(
+        select(UserRoleAssignment).where(
+            UserRoleAssignment.user_id == user.id,
+            UserRoleAssignment.organization_id == org.id,
+            UserRoleAssignment.workspace_id.is_(None),
+        )
+    )
+    assert membership_count is not None
+    assert len(assignment_result.scalars().all()) == 1
+
+
+@pytest.mark.anyio
+async def test_single_tenant_defaults_do_not_downgrade_existing_role(
+    session: AsyncSession,
+) -> None:
+    org = await _create_org_with_roles(session)
+    user = await _create_user(session)
+    owner_role = (
+        await session.execute(
+            select(DBRole).where(
+                DBRole.organization_id == org.id,
+                DBRole.slug == "organization-owner",
+            )
+        )
+    ).scalar_one()
+    session.add(
+        UserRoleAssignment(
+            organization_id=org.id,
+            user_id=user.id,
+            workspace_id=None,
+            role_id=owner_role.id,
+        )
+    )
+    await session.flush()
+
+    await ensure_single_tenant_user_defaults_in_session(
+        session=session,
+        user_id=user.id,
+        organization_id=org.id,
+        is_superuser=False,
+    )
+    await session.flush()
+
+    assert (
+        await _get_org_role_assignment_slug(
+            session, user_id=user.id, organization_id=org.id
+        )
+        == "organization-owner"
+    )
+
+
+@pytest.mark.anyio
+async def test_single_tenant_defaults_upgrade_superuser_to_owner(
+    session: AsyncSession,
+) -> None:
+    org = await _create_org_with_roles(session)
+    user = await _create_user(session, is_superuser=True)
+    member_role = (
+        await session.execute(
+            select(DBRole).where(
+                DBRole.organization_id == org.id,
+                DBRole.slug == "organization-member",
+            )
+        )
+    ).scalar_one()
+    session.add(
+        UserRoleAssignment(
+            organization_id=org.id,
+            user_id=user.id,
+            workspace_id=None,
+            role_id=member_role.id,
+        )
+    )
+    await session.flush()
+
+    await ensure_single_tenant_user_defaults_in_session(
+        session=session,
+        user_id=user.id,
+        organization_id=org.id,
+        is_superuser=True,
+    )
+    await session.flush()
+
+    assert (
+        await _get_org_role_assignment_slug(
+            session, user_id=user.id, organization_id=org.id
+        )
+        == "organization-owner"
+    )

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -26,7 +26,6 @@ from fastapi.security import (
     OAuth2PasswordBearer,
 )
 from sqlalchemy import or_, select
-from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -69,9 +68,7 @@ from tracecat.db.rls import set_rls_context, set_rls_context_from_role
 from tracecat.identifiers import InternalServiceID
 from tracecat.logger import logger
 from tracecat.organization.management import (
-    ensure_default_organization,
-    ensure_single_tenant_user_defaults_in_session,
-    get_default_organization_id,
+    ensure_single_tenant_user_defaults_for_session,
 )
 from tracecat.tiers.access import is_org_entitled
 from tracecat.tiers.enums import Entitlement
@@ -662,20 +659,14 @@ async def _authenticate_user(
     """
     organization_id: uuid.UUID
     single_tenant_org_id: uuid.UUID | None = None
-    if not config.TRACECAT__EE_MULTI_TENANT:
-        try:
-            single_tenant_org_id = await get_default_organization_id(session)
-        except NoResultFound:
-            single_tenant_org_id = await ensure_default_organization()
-        single_tenant_defaults_changed = (
-            await ensure_single_tenant_user_defaults_in_session(
-                session=session,
-                user_id=user.id,
-                organization_id=single_tenant_org_id,
-                is_superuser=user.is_superuser,
-            )
-        )
-        if single_tenant_defaults_changed:
+    single_tenant_defaults = await ensure_single_tenant_user_defaults_for_session(
+        session=session,
+        user_id=user.id,
+        is_superuser=user.is_superuser,
+    )
+    single_tenant_org_id = single_tenant_defaults.organization_id
+    if single_tenant_org_id is not None:
+        if single_tenant_defaults.changed:
             await session.commit()
             await set_rls_context(
                 session,
@@ -684,11 +675,11 @@ async def _authenticate_user(
                 user_id=user.id,
                 bypass=True,
             )
-        _invalidate_user_scope_cache(
-            user_id=user.id,
-            organization_id=single_tenant_org_id,
-            workspace_id=workspace_id,
-        )
+            _invalidate_user_scope_cache(
+                user_id=user.id,
+                organization_id=single_tenant_org_id,
+                workspace_id=workspace_id,
+            )
 
     if workspace_id is not None:
         resolved_org_id = await _get_workspace_org_id(workspace_id)

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -26,6 +26,7 @@ from fastapi.security import (
     OAuth2PasswordBearer,
 )
 from sqlalchemy import or_, select
+from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -67,6 +68,11 @@ from tracecat.db.models import (
 from tracecat.db.rls import set_rls_context, set_rls_context_from_role
 from tracecat.identifiers import InternalServiceID
 from tracecat.logger import logger
+from tracecat.organization.management import (
+    ensure_default_organization,
+    ensure_single_tenant_user_defaults_in_session,
+    get_default_organization_id,
+)
 from tracecat.tiers.access import is_org_entitled
 from tracecat.tiers.enums import Entitlement
 
@@ -608,6 +614,19 @@ async def _resolve_org_for_regular_user(
     )
 
 
+def _invalidate_user_scope_cache(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    workspace_id: uuid.UUID | None,
+) -> None:
+    _compute_effective_scopes_cached.cache_invalidate(user_id, organization_id, None)
+    if workspace_id is not None:
+        _compute_effective_scopes_cached.cache_invalidate(
+            user_id, organization_id, workspace_id
+        )
+
+
 async def _is_org_admin_via_rbac(
     user_id: uuid.UUID,
     organization_id: uuid.UUID,
@@ -642,6 +661,34 @@ async def _authenticate_user(
     3. Role construction (authorization is enforced via scopes, not enum roles)
     """
     organization_id: uuid.UUID
+    single_tenant_org_id: uuid.UUID | None = None
+    if not config.TRACECAT__EE_MULTI_TENANT:
+        try:
+            single_tenant_org_id = await get_default_organization_id(session)
+        except NoResultFound:
+            single_tenant_org_id = await ensure_default_organization()
+        single_tenant_defaults_changed = (
+            await ensure_single_tenant_user_defaults_in_session(
+                session=session,
+                user_id=user.id,
+                organization_id=single_tenant_org_id,
+                is_superuser=user.is_superuser,
+            )
+        )
+        if single_tenant_defaults_changed:
+            await session.commit()
+            await set_rls_context(
+                session,
+                org_id=None,
+                workspace_id=None,
+                user_id=user.id,
+                bypass=True,
+            )
+        _invalidate_user_scope_cache(
+            user_id=user.id,
+            organization_id=single_tenant_org_id,
+            workspace_id=workspace_id,
+        )
 
     if workspace_id is not None:
         resolved_org_id = await _get_workspace_org_id(workspace_id)
@@ -651,6 +698,10 @@ async def _authenticate_user(
                 detail="Workspace not found",
             )
         organization_id = resolved_org_id
+        if single_tenant_org_id is not None and organization_id != single_tenant_org_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+            )
 
         # Check if user is an org owner/admin via RBAC - they can access all workspaces
         is_org_admin = await _is_org_admin_via_rbac(
@@ -674,7 +725,9 @@ async def _authenticate_user(
                 user=user,
             )
     else:
-        organization_id = await _resolve_org_for_regular_user(session, user)
+        organization_id = single_tenant_org_id or await _resolve_org_for_regular_user(
+            session, user
+        )
 
     return get_role_from_user(
         user,

--- a/tracecat/auth/users.py
+++ b/tracecat/auth/users.py
@@ -60,6 +60,7 @@ from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundErro
 from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
 from tracecat.organization.domains import normalize_domain
+from tracecat.organization.management import ensure_single_tenant_user_defaults
 from tracecat.settings.service import get_setting
 
 
@@ -370,7 +371,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         superadmin_email = config.TRACECAT__AUTH_SUPERADMIN_EMAIL
         if superadmin_email and user.email == superadmin_email:
             update_params = UserUpdate(is_superuser=True)
-            await self.admin_update(user_update=update_params, user=user)
+            user = await self.admin_update(user_update=update_params, user=user)
             self.logger.info("User promoted to superadmin", email=user.email)
 
         # Accept invitation atomically if token was provided during registration
@@ -378,11 +379,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         if self._pending_invitation_token:
             await self._accept_invitation_atomically(user)
 
-        # NOTE: We do NOT add users to any organization/workspace here unless invited.
-        # - Superusers get platform admin eligibility via User.is_superuser
-        # - Tenant access still comes from org/workspace membership and RBAC
-        # - Regular users get org membership via invitation acceptance flow
-        # - Workspace membership is managed separately by workspace admins
+        await ensure_single_tenant_user_defaults(
+            user_id=user.id,
+            is_superuser=user.is_superuser,
+        )
 
     async def _accept_invitation_atomically(self, user: User) -> None:
         """Accept an invitation during registration if a token was provided.

--- a/tracecat/organization/management.py
+++ b/tracecat/organization/management.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
 
 from pydantic import UUID4
 from sqlalchemy import delete, func, select
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError, NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat import config
@@ -36,6 +38,14 @@ from tracecat.tiers.exceptions import DefaultTierNotConfiguredError
 from tracecat.tiers.service import TierService
 from tracecat.workflow.schedules.service import WorkflowSchedulesService
 from tracecat.workspaces.service import WorkspaceService
+
+
+@dataclass(frozen=True)
+class SingleTenantUserDefaultsResult:
+    """Result of ensuring single-tenant user organization defaults."""
+
+    organization_id: OrganizationID | None
+    changed: bool
 
 
 async def ensure_organization_defaults(
@@ -316,14 +326,47 @@ async def ensure_single_tenant_user_defaults(
 
     organization_id = await ensure_default_organization()
     async with get_async_session_bypass_rls_context_manager() as session:
-        await ensure_single_tenant_user_defaults_in_session(
+        result = await ensure_single_tenant_user_defaults_for_session(
             session=session,
             user_id=user_id,
             organization_id=organization_id,
             is_superuser=is_superuser,
         )
         await session.commit()
-    return organization_id
+    return result.organization_id
+
+
+async def ensure_single_tenant_user_defaults_for_session(
+    *,
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    is_superuser: bool,
+    organization_id: OrganizationID | None = None,
+) -> SingleTenantUserDefaultsResult:
+    """Ensure single-tenant user defaults in a caller-owned session.
+
+    This checks tenant mode, resolves or creates the default organization, and
+    applies membership/RBAC without committing the caller's session.
+    """
+    if config.TRACECAT__EE_MULTI_TENANT:
+        return SingleTenantUserDefaultsResult(organization_id=None, changed=False)
+
+    if organization_id is None:
+        try:
+            organization_id = await get_default_organization_id(session)
+        except NoResultFound:
+            organization_id = await ensure_default_organization()
+
+    changed = await ensure_single_tenant_user_defaults_in_session(
+        session=session,
+        user_id=user_id,
+        organization_id=organization_id,
+        is_superuser=is_superuser,
+    )
+    return SingleTenantUserDefaultsResult(
+        organization_id=organization_id,
+        changed=changed,
+    )
 
 
 async def ensure_single_tenant_user_defaults_in_session(
@@ -361,13 +404,18 @@ async def ensure_single_tenant_user_defaults_in_session(
 
     changed = False
     if membership is None:
-        session.add(
-            OrganizationMembership(
-                user_id=user_id,
-                organization_id=organization_id,
-            )
+        membership_insert = pg_insert(OrganizationMembership).values(
+            user_id=user_id,
+            organization_id=organization_id,
         )
-        changed = True
+        membership_insert = membership_insert.on_conflict_do_nothing(
+            index_elements=[
+                OrganizationMembership.user_id,
+                OrganizationMembership.organization_id,
+            ]
+        )
+        membership_result = await session.execute(membership_insert)
+        changed = (membership_result.rowcount or 0) > 0  # pyright: ignore[reportAttributeAccessIssue]
 
     role_slug = "organization-owner" if is_superuser else "organization-member"
     role_result = await session.execute(
@@ -380,15 +428,31 @@ async def ensure_single_tenant_user_defaults_in_session(
 
     assignment = assignment_row[0] if assignment_row is not None else None
     if assignment is None:
-        session.add(
-            UserRoleAssignment(
-                organization_id=organization_id,
-                user_id=user_id,
-                workspace_id=None,
-                role_id=role.id,
-            )
+        assignment_insert = pg_insert(UserRoleAssignment).values(
+            organization_id=organization_id,
+            user_id=user_id,
+            workspace_id=None,
+            role_id=role.id,
         )
-        return True
+        conflict_target = {
+            "index_elements": [UserRoleAssignment.user_id],
+            "index_where": UserRoleAssignment.workspace_id.is_(None),
+        }
+        if is_superuser:
+            assignment_insert = assignment_insert.on_conflict_do_update(
+                **conflict_target,
+                set_={
+                    "organization_id": organization_id,
+                    "role_id": role.id,
+                },
+            )
+        else:
+            assignment_insert = assignment_insert.on_conflict_do_nothing(
+                **conflict_target
+            )
+        assignment_result = await session.execute(assignment_insert)
+        changed = changed or (assignment_result.rowcount or 0) > 0  # pyright: ignore[reportAttributeAccessIssue]
+        return changed
 
     if is_superuser:
         assignment.role_id = role.id

--- a/tracecat/organization/management.py
+++ b/tracecat/organization/management.py
@@ -9,6 +9,7 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.authz.seeding import seed_system_roles_for_org
 from tracecat.cases.service import CaseFieldsService
@@ -16,14 +17,17 @@ from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import (
     Membership,
     Organization,
+    OrganizationMembership,
     OrganizationSecret,
     Ownership,
     RegistryAction,
     RegistryIndex,
     RegistryRepository,
     RegistryVersion,
+    UserRoleAssignment,
     Workspace,
 )
+from tracecat.db.models import Role as DBRole
 from tracecat.exceptions import TracecatValidationError
 from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
@@ -293,3 +297,100 @@ async def ensure_default_organization() -> OrganizationID:
         )
         await ensure_organization_defaults(session, org.id)
         return org.id
+
+
+async def ensure_single_tenant_user_defaults(
+    *,
+    user_id: uuid.UUID,
+    is_superuser: bool,
+) -> OrganizationID | None:
+    """Ensure single-tenant users are real members of the default organization.
+
+    In multi-tenant deployments this is a no-op. In single-tenant deployments,
+    every user receives default organization membership. Superusers receive the
+    organization-owner role; regular users receive organization-member unless
+    they already have an org-wide assignment.
+    """
+    if config.TRACECAT__EE_MULTI_TENANT:
+        return None
+
+    organization_id = await ensure_default_organization()
+    async with get_async_session_bypass_rls_context_manager() as session:
+        await ensure_single_tenant_user_defaults_in_session(
+            session=session,
+            user_id=user_id,
+            organization_id=organization_id,
+            is_superuser=is_superuser,
+        )
+        await session.commit()
+    return organization_id
+
+
+async def ensure_single_tenant_user_defaults_in_session(
+    *,
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    organization_id: OrganizationID,
+    is_superuser: bool,
+) -> bool:
+    """Ensure single-tenant org membership and org-wide RBAC in a session."""
+    membership_result = await session.execute(
+        select(OrganizationMembership).where(
+            OrganizationMembership.user_id == user_id,
+            OrganizationMembership.organization_id == organization_id,
+        )
+    )
+    membership = membership_result.scalar_one_or_none()
+
+    assignment_result = await session.execute(
+        select(UserRoleAssignment, DBRole.slug)
+        .join(DBRole, UserRoleAssignment.role_id == DBRole.id)
+        .where(
+            UserRoleAssignment.user_id == user_id,
+            UserRoleAssignment.organization_id == organization_id,
+            UserRoleAssignment.workspace_id.is_(None),
+        )
+    )
+    assignment_row = assignment_result.tuples().one_or_none()
+    if membership is not None and assignment_row is not None:
+        _, current_role_slug = assignment_row
+        if not is_superuser or current_role_slug == "organization-owner":
+            return False
+
+    await seed_system_roles_for_org(session, organization_id)
+
+    changed = False
+    if membership is None:
+        session.add(
+            OrganizationMembership(
+                user_id=user_id,
+                organization_id=organization_id,
+            )
+        )
+        changed = True
+
+    role_slug = "organization-owner" if is_superuser else "organization-member"
+    role_result = await session.execute(
+        select(DBRole).where(
+            DBRole.organization_id == organization_id,
+            DBRole.slug == role_slug,
+        )
+    )
+    role = role_result.scalar_one()
+
+    assignment = assignment_row[0] if assignment_row is not None else None
+    if assignment is None:
+        session.add(
+            UserRoleAssignment(
+                organization_id=organization_id,
+                user_id=user_id,
+                workspace_id=None,
+                role_id=role.id,
+            )
+        )
+        return True
+
+    if is_superuser:
+        assignment.role_id = role.id
+        changed = True
+    return changed

--- a/tracecat/organization/management.py
+++ b/tracecat/organization/management.py
@@ -377,6 +377,8 @@ async def ensure_single_tenant_user_defaults_in_session(
     is_superuser: bool,
 ) -> bool:
     """Ensure single-tenant org membership and org-wide RBAC in a session."""
+    # Fast path: if the user already has default-org membership and an
+    # acceptable org-wide role, there is nothing to repair.
     membership_result = await session.execute(
         select(OrganizationMembership).where(
             OrganizationMembership.user_id == user_id,
@@ -400,10 +402,15 @@ async def ensure_single_tenant_user_defaults_in_session(
         if not is_superuser or current_role_slug == "organization-owner":
             return False
 
+    # Role lookup below depends on the preset roles existing. This is idempotent
+    # and only runs after the fast path determines a repair may be needed.
     await seed_system_roles_for_org(session, organization_id)
 
     changed = False
     if membership is None:
+        # Auth-path lazy repair can run concurrently for the same legacy user.
+        # Use an idempotent insert so one request repairs the row and the other
+        # continues without surfacing a unique-constraint failure.
         membership_insert = pg_insert(OrganizationMembership).values(
             user_id=user_id,
             organization_id=organization_id,
@@ -417,6 +424,8 @@ async def ensure_single_tenant_user_defaults_in_session(
         membership_result = await session.execute(membership_insert)
         changed = (membership_result.rowcount or 0) > 0  # pyright: ignore[reportAttributeAccessIssue]
 
+    # Single-tenant defaults are intentionally minimal for regular users, while
+    # superusers are granted default-org owner permissions.
     role_slug = "organization-owner" if is_superuser else "organization-member"
     role_result = await session.execute(
         select(DBRole).where(
@@ -428,6 +437,11 @@ async def ensure_single_tenant_user_defaults_in_session(
 
     assignment = assignment_row[0] if assignment_row is not None else None
     if assignment is None:
+        # There can only be one org-wide assignment per user. For superusers, a
+        # conflict means another request created or found a stale org-wide
+        # assignment, so upgrade it to owner. Regular users do not update on
+        # insert conflict; existing rows observed by this session are handled by
+        # the normalization branch below.
         assignment_insert = pg_insert(UserRoleAssignment).values(
             organization_id=organization_id,
             user_id=user_id,
@@ -454,7 +468,11 @@ async def ensure_single_tenant_user_defaults_in_session(
         changed = changed or (assignment_result.rowcount or 0) > 0  # pyright: ignore[reportAttributeAccessIssue]
         return changed
 
-    if is_superuser:
+    # At this point a repair is needed: either the membership row was missing,
+    # or a superuser still had a non-owner org-wide role. Keep the org-wide
+    # assignment aligned with the default role for this user type, but skip
+    # no-op writes.
+    if assignment.role_id != role.id:
         assignment.role_id = role.id
         changed = True
     return changed


### PR DESCRIPTION
## Summary

- Auto-provision default organization membership for users in single-tenant mode.
- Assign `organization-owner` to superusers and `organization-member` to regular users, preserving stronger existing roles and upgrading promoted superusers to owner.
- Wire provisioning through registration, login/auth lazy repair, EE admin user creation/promotion, and tracecat-admin bootstrap flows.
- Keep workspace membership separate: users are added to the default org, while workspace access still follows existing workspace/org-owner rules.
- Update `scripts/cluster` so dev clusters can run single-tenant via `--single-tenant`, multi-tenant via `--multi-tenant`, or explicit `--ee-multi-tenant true|false`; `.env` can now set `TRACECAT__EE_MULTI_TENANT` instead of being overwritten to `true`.

## QA

### Automated checks

- `uv run pytest tests/unit/test_single_tenant_user_defaults.py tests/unit/test_admin_users_service.py -q`
- `uv run pytest tests/unit/test_auth_middleware.py -q`
- `uv run pytest tests/unit/test_user_manager_auth_policy.py tests/unit/test_saml_client_config.py -q`
- `uv run pytest packages/tracecat-admin/tests/test_admin_commands.py::TestCreateDevUser::test_create_dev_user_success packages/tracecat-admin/tests/test_admin_commands.py::TestCreateDevUser::test_role_assignment_lookup_is_organization_scoped -q`
- `uv run ruff check tracecat/organization/management.py tracecat/auth/credentials.py tracecat/auth/users.py packages/tracecat-ee/tracecat_ee/admin/users/service.py packages/tracecat-admin/tracecat_admin/services/bootstrap.py tests/unit/test_single_tenant_user_defaults.py tests/unit/test_admin_users_service.py tests/unit/test_auth_middleware.py`
- `uv run ruff format --check tracecat/organization/management.py tracecat/auth/credentials.py tracecat/auth/users.py packages/tracecat-ee/tracecat_ee/admin/users/service.py packages/tracecat-admin/tracecat_admin/services/bootstrap.py tests/unit/test_single_tenant_user_defaults.py tests/unit/test_admin_users_service.py tests/unit/test_auth_middleware.py`
- `uv run basedpyright tracecat/organization/management.py tracecat/auth/credentials.py tracecat/auth/users.py packages/tracecat-ee/tracecat_ee/admin/users/service.py packages/tracecat-admin/tracecat_admin/services/bootstrap.py tests/unit/test_single_tenant_user_defaults.py tests/unit/test_admin_users_service.py tests/unit/test_auth_middleware.py`
- `bash -n scripts/cluster`
- `shellcheck -x scripts/cluster`
- `TRACECAT__USE_PORTLESS=0 ./scripts/cluster 98 config | rg 'TRACECAT__EE_MULTI_TENANT' | sort -u` -> `false` from `.env`
- `TRACECAT__USE_PORTLESS=0 ./scripts/cluster 98 config --multi-tenant | rg 'TRACECAT__EE_MULTI_TENANT' | sort -u` -> `true`
- `TRACECAT__USE_PORTLESS=0 ./scripts/cluster 98 config --single-tenant | rg 'TRACECAT__EE_MULTI_TENANT' | sort -u` -> `false`
- `TRACECAT__USE_PORTLESS=0 ./scripts/cluster 98 --ee-multi-tenant true config | rg 'TRACECAT__EE_MULTI_TENANT' | sort -u` -> `true`
- `TRACECAT__USE_PORTLESS=0 ./scripts/cluster 98 config --ee-multi-tenant=false | rg 'TRACECAT__EE_MULTI_TENANT' | sort -u` -> `false`
- `TRACECAT__USE_PORTLESS=0 ./scripts/cluster 98 config --ee-multi-tenant maybe` -> fails early with boolean validation
- `uv run ruff check .`
- `git diff --check`
- Commit hooks also passed: large-file check, Ruff, Ruff format, Gitleaks, frontend client generation check, and Python type check where applicable.

### Chrome DevTools UI QA

I brought up a separate single-tenant stack for this worktree using `docker-compose.dev.yml`. At the time, `just cluster` forced `TRACECAT__EE_MULTI_TENANT=true`; this PR now updates `scripts/cluster` so future QA can use `just cluster up -d --single-tenant` instead.

Manual stack configuration:

- App: `http://localhost:380`
- API: `http://localhost:380/api`
- API container env confirmed `TRACECAT__EE_MULTI_TENANT=false`
- `/api/info` confirmed `ee_multi_tenant: false`
- Seeded `test@tracecat.com` / `password1234` and `dev@tracecat.com` / `password1234`

Chrome DevTools checks performed in isolated browser contexts:

- Logged in as seeded superuser `test@tracecat.com`.
  - Browser landed on `/workspaces/{workspace_id}/workflows`, not `/admin`.
  - Network showed `POST /api/auth/login` -> `204`, then `/api/users/me`, `/api/workspaces`, `/api/users/me/scopes`, `/api/organization`, `/api/organization/entitlements`, and workspace folder calls returning `200`.
  - No unexpected console errors; only expected pre-login `/api/users/me` `401`.
- Created legacy superuser `legacy-superuser-uiqa@example.com` directly in the QA database with no organization membership or role assignment.
  - Logged in through the UI.
  - Browser landed on `/workspaces/{workspace_id}/workflows`.
  - Post-login DB check showed membership in the default organization with `organization-owner`.
- Created legacy regular user `legacy-user-uiqa@example.com` directly in the QA database with no organization membership or role assignment.
  - Logged in through the UI.
  - Post-login DB check showed membership in the default organization with `organization-member`.
  - UI showed the existing `No workspaces` state because regular users are not automatically given workspace membership. This matches the implementation: single-tenant auto-provisions org membership, while workspace membership remains separate.

Note: I also ran the full `packages/tracecat-admin/tests` package. It had 3 failures unrelated to this change: two Rich table output assertions expecting untruncated text, and one CLI env/service-key expectation affected by the current environment. Focused tracecat-admin coverage relevant to this change passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-provisions default org membership in single-tenant and assigns org-wide roles (superusers → owners, others → members). Enforces org isolation and makes the provisioning idempotent and cache-safe with clear role repair rules.

- **New Features**
  - Added `ensure_single_tenant_user_defaults` (+ `for_session`/`in_session`) to create org membership and assign `organization-owner`/`organization-member`; preserve existing roles when membership exists, normalize inconsistent org-wide assignments, and upgrade superusers.
  - Wired into registration (`tracecat/auth/users.py`), login/auth lazy repair (`tracecat/auth/credentials.py`), EE admin create/promote (`packages/tracecat-ee/tracecat_ee/admin/users/service.py`), and `tracecat-admin` bootstrap (`packages/tracecat-admin/tracecat_admin/services/bootstrap.py`).
  - Enforced single-tenant isolation: block workspace access outside the default org.
  - Updated `scripts/cluster` to support `--single-tenant`, `--multi-tenant`, and `--ee-multi-tenant true|false` before or after the command; defaults to `.env` or multi-tenant for dev without overwriting env.

- **Bug Fixes**
  - Made single-tenant defaults idempotent with upserts to prevent duplicate memberships/role assignments under concurrent repairs.
  - In auth, only commit, reset RLS, and invalidate the scope cache when defaults change; preserve cache otherwise.

<sup>Written for commit f6ab5dd4e4191bb915c2b14daf350eccdae9338a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

