### PR TITLE
feat(agents): chat stream resumption

### DIFF
--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -399,10 +399,19 @@ export function useVercelChat({
   // Use Vercel's useChat hook for streaming
   const chat = aiSdk.useChat({
     id: chatId,
+    resume: !!chatId,
     messages,
     transport: new DefaultChatTransport({
       api: apiEndpoint,
       credentials: "include",
+      prepareReconnectToStreamRequest: ({ id }) => {
+        const url = new URL(`/api/agent/sessions/${id}/stream`, getBaseUrl())
+        url.searchParams.set("workspace_id", workspaceId)
+        return {
+          api: url.toString(),
+          credentials: "include",
+        }
+      },
       prepareSendMessagesRequest: ({ messages }) => {
         // Support both normal vercel chat turns and approval continuations.
         const last = messages[messages.length - 1]

--- a/tests/unit/test_agent_session_router.py
+++ b/tests/unit/test_agent_session_router.py
@@ -65,6 +65,7 @@ async def test_send_message_continue_uses_path_session_id_for_stream_key() -> No
     )
     fake_stream = SimpleNamespace(
         reset_for_new_turn=AsyncMock(return_value=None),
+        abort_new_turn=AsyncMock(return_value=None),
         sse=Mock(return_value=_empty_event_stream()),
     )
 
@@ -133,6 +134,7 @@ async def test_send_message_new_turn_resets_stream_before_streaming() -> None:
     )
     fake_stream = SimpleNamespace(
         reset_for_new_turn=AsyncMock(return_value=None),
+        abort_new_turn=AsyncMock(return_value=None),
         sse=Mock(return_value=_empty_event_stream()),
     )
 
@@ -160,8 +162,73 @@ async def test_send_message_new_turn_resets_stream_before_streaming() -> None:
     assert isinstance(response, StreamingResponse)
     with_session_mock.assert_called_once_with(role=role)
     fake_stream.reset_for_new_turn.assert_awaited_once()
+    fake_stream.abort_new_turn.assert_not_awaited()
     fake_stream.sse.assert_called_once()
     assert fake_stream.sse.call_args.kwargs["last_id"] == "0-0"
+
+
+@pytest.mark.anyio
+async def test_send_message_new_turn_clears_stream_when_startup_fails() -> None:
+    session_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute"}),
+    )
+    request = VercelChatRequest(
+        message=UIMessage(
+            id="msg-1",
+            role="user",
+            parts=[{"type": "text", "text": "hello"}],
+        ),
+        model="gpt-4o-mini",
+        model_provider="openai",
+    )
+
+    fake_svc = SimpleNamespace(
+        is_legacy_session=AsyncMock(return_value=False),
+        validate_turn_request=AsyncMock(return_value=None),
+        run_turn=AsyncMock(side_effect=RuntimeError("temporal unavailable")),
+    )
+    fake_stream = SimpleNamespace(
+        reset_for_new_turn=AsyncMock(return_value=None),
+        abort_new_turn=AsyncMock(return_value=None),
+        sse=Mock(return_value=_empty_event_stream()),
+    )
+
+    with (
+        patch(
+            "tracecat.agent.session.router.AgentSessionService.with_session",
+            return_value=_AsyncContext(fake_svc),
+        ),
+        patch(
+            "tracecat.agent.session.router.AgentStream.new",
+            AsyncMock(return_value=fake_stream),
+        ),
+    ):
+        raw_send_message = cast(Any, send_message).__wrapped__
+        with pytest.raises(HTTPException) as exc_info:
+            await raw_send_message(
+                session_id=session_id,
+                request=request,
+                role=role,
+                http_request=cast(
+                    Any,
+                    SimpleNamespace(is_disconnected=AsyncMock(return_value=False)),
+                ),
+            )
+
+    assert exc_info.value.status_code == 500
+    fake_stream.reset_for_new_turn.assert_awaited_once()
+    fake_svc.run_turn.assert_awaited_once_with(
+        session_id=session_id,
+        request=request,
+    )
+    fake_stream.abort_new_turn.assert_awaited_once()
+    fake_stream.sse.assert_not_called()
 
 
 @pytest.mark.anyio
@@ -194,6 +261,7 @@ async def test_send_message_does_not_reset_stream_when_validation_fails() -> Non
     )
     fake_stream = SimpleNamespace(
         reset_for_new_turn=AsyncMock(return_value=None),
+        abort_new_turn=AsyncMock(return_value=None),
         sse=Mock(return_value=_empty_event_stream()),
     )
 
@@ -223,5 +291,6 @@ async def test_send_message_does_not_reset_stream_when_validation_fails() -> Non
     with_session_mock.assert_called_once_with(role=role)
     stream_new_mock.assert_awaited_once_with(session_id, workspace_id)
     fake_stream.reset_for_new_turn.assert_not_awaited()
+    fake_stream.abort_new_turn.assert_not_awaited()
     fake_stream.sse.assert_not_called()
     fake_svc.run_turn.assert_not_awaited()

--- a/tests/unit/test_agent_session_router.py
+++ b/tests/unit/test_agent_session_router.py
@@ -8,10 +8,11 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi import HTTPException
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
+from starlette import status
 
 from tracecat.agent.adapter.vercel import UIMessage
-from tracecat.agent.session.router import send_message
+from tracecat.agent.session.router import send_message, stream_session_events
 from tracecat.auth.types import Role
 from tracecat.chat.schemas import (
     ApprovalDecision,
@@ -294,3 +295,121 @@ async def test_send_message_does_not_reset_stream_when_validation_fails() -> Non
     fake_stream.abort_new_turn.assert_not_awaited()
     fake_stream.sse.assert_not_called()
     fake_svc.run_turn.assert_not_awaited()
+
+
+def _make_stream_role(workspace_id: uuid.UUID) -> Role:
+    return Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+        scopes=frozenset({"agent:read"}),
+    )
+
+
+@pytest.mark.anyio
+async def test_stream_session_events_returns_204_when_no_turn_started() -> None:
+    """last_stream_id=None with no Last-Event-ID header → 204, no stream attached."""
+    session_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    role = _make_stream_role(workspace_id)
+
+    fake_session = SimpleNamespace(last_stream_id=None)
+    fake_svc = SimpleNamespace(get_session=AsyncMock(return_value=fake_session))
+    fake_stream = SimpleNamespace(sse=Mock(return_value=_empty_event_stream()))
+
+    with (
+        patch(
+            "tracecat.agent.session.router.AgentSessionService.with_session",
+            return_value=_AsyncContext(fake_svc),
+        ),
+        patch(
+            "tracecat.agent.session.router.AgentStream.new",
+            AsyncMock(return_value=fake_stream),
+        ),
+    ):
+        raw = cast(Any, stream_session_events).__wrapped__
+        response = await raw(
+            role=role,
+            request=SimpleNamespace(headers={}),
+            session_id=session_id,
+        )
+
+    assert isinstance(response, Response)
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    fake_stream.sse.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_stream_session_events_attaches_when_turn_in_progress_no_events_yet() -> (
+    None
+):
+    """last_stream_id="0-0" (reset_for_new_turn written, key not yet in Redis) → stream, no 204.
+
+    This is the regression case: the stream key doesn't exist yet but a turn is
+    active. The old Redis-exists check would have incorrectly returned 204 here.
+    """
+    session_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    role = _make_stream_role(workspace_id)
+
+    fake_session = SimpleNamespace(last_stream_id="0-0")
+    fake_svc = SimpleNamespace(get_session=AsyncMock(return_value=fake_session))
+    fake_stream = SimpleNamespace(sse=Mock(return_value=_empty_event_stream()))
+
+    with (
+        patch(
+            "tracecat.agent.session.router.AgentSessionService.with_session",
+            return_value=_AsyncContext(fake_svc),
+        ),
+        patch(
+            "tracecat.agent.session.router.AgentStream.new",
+            AsyncMock(return_value=fake_stream),
+        ),
+    ):
+        raw = cast(Any, stream_session_events).__wrapped__
+        response = await raw(
+            role=role,
+            request=SimpleNamespace(
+                headers={}, is_disconnected=AsyncMock(return_value=False)
+            ),
+            session_id=session_id,
+        )
+
+    assert isinstance(response, StreamingResponse)
+    fake_stream.sse.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_stream_session_events_attaches_when_last_event_id_present() -> None:
+    """Last-Event-ID header present → always attach regardless of last_stream_id."""
+    session_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    role = _make_stream_role(workspace_id)
+
+    fake_session = SimpleNamespace(last_stream_id=None)
+    fake_svc = SimpleNamespace(get_session=AsyncMock(return_value=fake_session))
+    fake_stream = SimpleNamespace(sse=Mock(return_value=_empty_event_stream()))
+
+    with (
+        patch(
+            "tracecat.agent.session.router.AgentSessionService.with_session",
+            return_value=_AsyncContext(fake_svc),
+        ),
+        patch(
+            "tracecat.agent.session.router.AgentStream.new",
+            AsyncMock(return_value=fake_stream),
+        ),
+    ):
+        raw = cast(Any, stream_session_events).__wrapped__
+        response = await raw(
+            role=role,
+            request=SimpleNamespace(
+                headers={"Last-Event-ID": "1234-0"},
+                is_disconnected=AsyncMock(return_value=False),
+            ),
+            session_id=session_id,
+        )
+
+    assert isinstance(response, StreamingResponse)
+    fake_stream.sse.assert_called_once()

--- a/tests/unit/test_agent_stream_connector.py
+++ b/tests/unit/test_agent_stream_connector.py
@@ -14,6 +14,25 @@ from tracecat.redis.client import RedisClient
 
 
 @pytest.mark.anyio
+async def test_abort_new_turn_clears_buffer_and_saved_cursor() -> None:
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    client = SimpleNamespace(delete=AsyncMock(return_value=1))
+    stream = AgentStream(
+        client=cast(RedisClient, client),
+        workspace_id=workspace_id,
+        session_id=session_id,
+    )
+
+    stream._set_last_stream_id = AsyncMock()
+
+    await stream.abort_new_turn()
+
+    client.delete.assert_awaited_once_with(stream._stream_key)
+    stream._set_last_stream_id.assert_awaited_once_with(None)
+
+
+@pytest.mark.anyio
 async def test_stream_events_clears_buffer_after_terminal_marker() -> None:
     workspace_id = uuid.uuid4()
     session_id = uuid.uuid4()

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -6,7 +6,7 @@ This router consolidates chat and session endpoints into a unified /agent/sessio
 import uuid
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 
 from tracecat import config
 from tracecat.agent.adapter import vercel
@@ -406,7 +406,13 @@ async def stream_session_events(
         if agent_session is not None:
             last_stream_id = agent_session.last_stream_id
 
-    start_id = last_stream_id or request.headers.get("Last-Event-ID", "0-0")
+    # No active stream — return immediately so the client releases the input lock.
+    # last_stream_id is None when the stream completed or never started.
+    last_event_id = request.headers.get("Last-Event-ID")
+    if last_stream_id is None and not last_event_id:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    start_id = last_stream_id or last_event_id or "0-0"
     stream_key = StreamKey(workspace_id, session_id)
     logger.info(
         "Starting session stream",

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -22,7 +22,6 @@ from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.stream.connector import AgentStream
 from tracecat.agent.stream.events import StreamFormat
-from tracecat.agent.types import StreamKey
 from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.chat.schemas import (
@@ -35,7 +34,6 @@ from tracecat.chat.schemas import (
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.logger import logger
-from tracecat.redis.client import get_redis_client
 
 router = APIRouter(prefix="/agent/sessions", tags=["agent-sessions"])
 
@@ -419,22 +417,12 @@ async def stream_session_events(
         if agent_session is not None:
             last_stream_id = agent_session.last_stream_id
 
-    # Use Redis key existence as the authoritative signal for whether a turn is
-    # active. last_stream_id is only advanced by stream consumers, so it can be
-    # None while a turn is already writing (e.g. the continuation path skips
-    # reset_for_new_turn). Returning 204 based on last_stream_id alone would
-    # terminate reconnects without Last-Event-ID before they attach to Redis.
     last_event_id = request.headers.get("Last-Event-ID")
-    stream_key = StreamKey(workspace_id, session_id)
-    redis = await get_redis_client()
-    stream_key_exists = await redis.exists(stream_key)
-    if not stream_key_exists and not last_event_id:
+    if last_stream_id is None and not last_event_id:
         return Response(status_code=status.HTTP_204_NO_CONTENT)
-
-    start_id = last_stream_id or last_event_id or "0-0"
+    start_id = last_event_id or last_stream_id or "0-0"
     logger.info(
         "Starting session stream",
-        stream_key=stream_key,
         last_id=start_id,
         session_id=session_id,
     )

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -35,6 +35,7 @@ from tracecat.chat.schemas import (
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.logger import logger
+from tracecat.redis.client import get_redis_client
 
 router = APIRouter(prefix="/agent/sessions", tags=["agent-sessions"])
 
@@ -418,14 +419,19 @@ async def stream_session_events(
         if agent_session is not None:
             last_stream_id = agent_session.last_stream_id
 
-    # No active stream — return immediately so the client releases the input lock.
-    # last_stream_id is None when the stream completed or never started.
+    # Use Redis key existence as the authoritative signal for whether a turn is
+    # active. last_stream_id is only advanced by stream consumers, so it can be
+    # None while a turn is already writing (e.g. the continuation path skips
+    # reset_for_new_turn). Returning 204 based on last_stream_id alone would
+    # terminate reconnects without Last-Event-ID before they attach to Redis.
     last_event_id = request.headers.get("Last-Event-ID")
-    if last_stream_id is None and not last_event_id:
+    stream_key = StreamKey(workspace_id, session_id)
+    redis = await get_redis_client()
+    stream_key_exists = await redis.exists(stream_key)
+    if not stream_key_exists and not last_event_id:
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     start_id = last_stream_id or last_event_id or "0-0"
-    stream_key = StreamKey(workspace_id, session_id)
     logger.info(
         "Starting session stream",
         stream_key=stream_key,

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -327,10 +327,22 @@ async def send_message(
                 start_id = "0-0"
 
             # Run session turn (spawns DurableAgentWorkflow)
-            await svc.run_turn(
-                session_id=session_id,
-                request=request,
-            )
+            try:
+                await svc.run_turn(
+                    session_id=session_id,
+                    request=request,
+                )
+            except Exception:
+                if not isinstance(request, ContinueRunRequest):
+                    try:
+                        await stream.abort_new_turn()
+                    except Exception as rollback_exc:
+                        logger.warning(
+                            "Failed to clear stream state after turn startup failure",
+                            session_id=session_id,
+                            error=str(rollback_exc),
+                        )
+                raise
 
         logger.info(
             "Starting Vercel streaming session",

--- a/tracecat/agent/stream/connector.py
+++ b/tracecat/agent/stream/connector.py
@@ -73,6 +73,11 @@ class AgentStream:
         # Write "0-0" immediately so a reconnect during the turn has a valid cursor.
         await self._set_last_stream_id("0-0")
 
+    async def abort_new_turn(self) -> None:
+        """Clear stream state after startup fails before a turn can produce events."""
+        await self.client.delete(self._stream_key)
+        await self._set_last_stream_id(None)
+
     async def _expire_completed_stream(self) -> None:
         """Keep completed streams briefly for reconnects, then let Redis evict them."""
         try:

--- a/tracecat/agent/stream/connector.py
+++ b/tracecat/agent/stream/connector.py
@@ -70,7 +70,8 @@ class AgentStream:
     async def reset_for_new_turn(self) -> None:
         """Delete the persisted stream buffer and reset the saved cursor."""
         await self.client.delete(self._stream_key)
-        await self._set_last_stream_id(None)
+        # Write "0-0" immediately so a reconnect during the turn has a valid cursor.
+        await self._set_last_stream_id("0-0")
 
     async def _expire_completed_stream(self) -> None:
         """Keep completed streams briefly for reconnects, then let Redis evict them."""


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable reliable chat stream resumption across reconnects and reloads. The server now honors `Last-Event-ID` and handles turn startup failures to avoid stuck input, stale cursors, and missing history.

- **New Features**
  - Enable resume mode in the chat hook and add `prepareReconnectToStreamRequest` for `/api/agent/sessions/{id}/stream?workspace_id=...` with credentials.
  - Persist the pending user message in `sessionStorage` (`chat-pending-msg:<id>`) until echoed, then clear.
  - On new turns, immediately set the saved stream cursor to "0-0" and flush SDK session history in the background.

- **Bug Fixes**
  - If a new turn fails to start, clear the stream buffer and reset the saved cursor via `abort_new_turn`; skip for `ContinueRunRequest`.
  - Stream start logic: return 204 only when there’s no saved `last_stream_id` and no `Last-Event-ID`. Otherwise attach starting from `Last-Event-ID`, then `last_stream_id`, else "0-0".
  - Improve reliability: persist session lines before `done`, handle partial JSONL lines, serialize concurrent socket sends, and keep the approval continuation prompt internal even if results arrive early.

<sup>Written for commit 581eab49b29ddda8c77bb85bf48ae1d5aa0c8d7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

