### PR TITLE
Fix cross-loop storage cache and platform stream errors

### DIFF
--- a/tests/unit/test_dsl_scheduler_errors.py
+++ b/tests/unit/test_dsl_scheduler_errors.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from temporalio.exceptions import ApplicationError
+
+from tracecat.auth.types import Role
+from tracecat.dsl.common import DSLEntrypoint, DSLInput
+from tracecat.dsl.scheduler import DSLScheduler
+from tracecat.dsl.schemas import (
+    ROOT_STREAM,
+    ActionStatement,
+    ExecutionContext,
+    RunContext,
+    StreamID,
+)
+from tracecat.dsl.types import ActionErrorInfo, ActionErrorInfoAdapter, Task
+from tracecat.identifiers.workflow import WorkflowUUID
+
+
+def _make_scheduler(*actions: ActionStatement) -> DSLScheduler:
+    async def executor(_: ActionStatement) -> None:
+        return None
+
+    wf_id = WorkflowUUID.new_uuid4()
+    return DSLScheduler(
+        executor=executor,
+        dsl=DSLInput(
+            title="test",
+            description="test",
+            entrypoint=DSLEntrypoint(ref=actions[0].ref),
+            actions=list(actions),
+        ),
+        max_pending_tasks=16,
+        context=ExecutionContext(ACTIONS={}, TRIGGER=None),
+        role=Role(
+            type="service",
+            service_id="tracecat-runner",
+            workspace_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+        ),
+        run_context=RunContext(
+            wf_id=wf_id,
+            wf_exec_id=f"{wf_id.short()}/exec_test",
+            wf_run_id=uuid.uuid4(),
+            environment="test",
+            logical_time=datetime.now(UTC),
+        ),
+    )
+
+
+@pytest.mark.anyio
+async def test_platform_stream_error_promotes_to_workflow_failure() -> None:
+    scheduler = _make_scheduler(
+        ActionStatement(
+            ref="call_child",
+            action="core.workflow.execute",
+            args={"workflow_alias": "child"},
+        ),
+        ActionStatement(
+            ref="handle_error",
+            action="core.noop",
+            depends_on=["call_child.error"],
+        ),
+    )
+    stream_id = StreamID.new("scatter", 0, base_stream_id=ROOT_STREAM)
+    error = ApplicationError("Failed to materialize context", non_retryable=True)
+
+    await scheduler._handle_error_path(
+        Task(ref="call_child", stream_id=stream_id), error
+    )
+
+    assert scheduler.task_exceptions["call_child"].exception is error
+    assert stream_id not in scheduler.stream_exceptions
+    assert scheduler.queue.empty()
+
+
+@pytest.mark.anyio
+async def test_action_stream_error_uses_gather_error_strategy() -> None:
+    scheduler = _make_scheduler(
+        ActionStatement(ref="throw", action="core.transform.reshape")
+    )
+    stream_id = StreamID.new("scatter", 0, base_stream_id=ROOT_STREAM)
+    error_info = ActionErrorInfo(
+        ref="throw",
+        message="User action failed",
+        type="ExecutionError",
+        stream_id=stream_id,
+    )
+    error = ApplicationError(
+        "Action failed",
+        ActionErrorInfoAdapter.dump_python(error_info),
+        non_retryable=True,
+    )
+
+    await scheduler._handle_error_path(Task(ref="throw", stream_id=stream_id), error)
+
+    assert not scheduler.task_exceptions
+    assert scheduler.stream_exceptions[stream_id].exception is error
+    assert scheduler.stream_exceptions[stream_id].details == error_info

--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -1,6 +1,7 @@
 """Tests for SizedMemoryCache."""
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -149,6 +150,30 @@ class TestSizedMemoryCache:
 
         # Should complete without errors
         assert cache.item_count <= 2
+
+    def test_concurrent_access_from_multiple_event_loops(self):
+        """Test that one cache can be used from separate event loops."""
+        cache = SizedMemoryCache(max_bytes=100, ttl=300.0)
+
+        async def exercise_cache(prefix: str) -> None:
+            for i in range(100):
+                key = f"{prefix}-{i % 10}"
+                await cache.set(key, f"value-{i}".encode())
+                await cache.get(key)
+                await asyncio.sleep(0)
+
+        def run_in_new_loop(prefix: str) -> None:
+            asyncio.run(exercise_cache(prefix))
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(run_in_new_loop, "a"),
+                executor.submit(run_in_new_loop, "b"),
+            ]
+            for future in futures:
+                future.result()
+
+        assert cache.total_bytes <= 100
 
     @pytest.mark.anyio
     async def test_empty_value(self):

--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, replace
 from datetime import timedelta
 from typing import Any
@@ -395,6 +395,30 @@ class DSLScheduler:
     def __repr__(self) -> str:
         return to_json(self.__dict__, fallback=str, indent=2).decode()
 
+    @staticmethod
+    def _is_action_error_info_payload(payload: Any) -> bool:
+        if isinstance(payload, ActionErrorInfo):
+            return True
+        try:
+            ActionErrorInfoAdapter.validate_python(payload)
+            return True
+        except Exception:
+            pass
+
+        if isinstance(payload, Mapping):
+            return any(
+                DSLScheduler._is_action_error_info_payload(value)
+                for value in payload.values()
+            )
+        return False
+
+    @classmethod
+    def _can_follow_user_error_handling(cls, exc: Exception) -> bool:
+        """Return whether an error is safe for error edges or gather strategy."""
+        if not isinstance(exc, ApplicationError) or not exc.details:
+            return False
+        return cls._is_action_error_info_payload(exc.details[0])
+
     async def _handle_error_path(self, task: Task, exc: Exception) -> None:
         ref = task.ref
 
@@ -410,10 +434,18 @@ class DSLScheduler:
             for dst, edge_type in self.adj[ref]
             if edge_type != EdgeType.ERROR
         }
-        if len(non_err_edges) < len(self.adj[ref]):
+        follows_user_error_handling = self._can_follow_user_error_handling(exc)
+        if len(non_err_edges) < len(self.adj[ref]) and follows_user_error_handling:
             await self._queue_tasks(task, unreachable=non_err_edges)
         else:
-            self.logger.info("Task failed with no error paths", task=task)
+            if follows_user_error_handling:
+                self.logger.info("Task failed with no error paths", task=task)
+            else:
+                self.logger.warning(
+                    "Task failed with platform error, bypassing user error handling",
+                    task=task,
+                    error=exc,
+                )
             # XXX: This can sometimes return null because the exception isn't an ApplicationError
             # But rather a ChildWorkflowError or CancelledError
             if isinstance(exc, ApplicationError) and exc.details:
@@ -509,7 +541,7 @@ class DSLScheduler:
                         )
             else:
                 self.logger.info(
-                    "Task failed with non-application error",
+                    "Task failed without structured application error details",
                     ref=ref,
                     exc=exc,
                 )
@@ -528,9 +560,12 @@ class DSLScheduler:
                     type=exc.__class__.__name__,
                     stream_id=task.stream_id,
                 )
-            if task.stream_id == ROOT_STREAM:
+            if task.stream_id == ROOT_STREAM or not follows_user_error_handling:
                 self.logger.debug(
-                    "Setting task exception in root stream", task=task, details=details
+                    "Setting task exception",
+                    task=task,
+                    details=details,
+                    follows_user_error_handling=follows_user_error_handling,
                 )
                 self.task_exceptions[ref] = TaskExceptionInfo(
                     exception=exc, details=details

--- a/tracecat/storage/utils.py
+++ b/tracecat/storage/utils.py
@@ -2,20 +2,18 @@
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
+import threading
+import time
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any
 
 import orjson
-from aiocache import Cache
 
 from tracecat.logger import logger
 from tracecat.storage import blob
 
 if TYPE_CHECKING:
-    from aiocache.base import BaseCache
-
     from tracecat.storage.object import InlineObject, StoredObject
 
 # Cache configuration
@@ -25,28 +23,33 @@ BLOB_CACHE_TTL = 300.0  # 5 minutes
 
 
 class SizedMemoryCache:
-    """Byte-aware wrapper around aiocache SimpleMemoryCache with LRU eviction."""
+    """Thread-safe byte-aware memory cache with TTL and LRU eviction."""
 
     def __init__(self, max_bytes: int, ttl: float = 300.0):
-        self._cache: BaseCache = Cache(Cache.MEMORY, ttl=ttl)
+        self._cache: dict[str, tuple[bytes, float | None]] = {}
         self._sizes: OrderedDict[str, int] = OrderedDict()
         self._total_bytes = 0
         self._max_bytes = max_bytes
-        self._lock = asyncio.Lock()
+        self._ttl = ttl
+        # Temporal can execute async activities on multiple event loops in a
+        # thread pool. asyncio locks are bound to one loop under contention.
+        self._lock = threading.RLock()
 
     async def get(self, key: str) -> bytes | None:
-        value: bytes | None = await self._cache.get(key)
-        if value is None and key in self._sizes:
-            # TTL expired in underlying cache, sync our tracking
-            async with self._lock:
+        with self._lock:
+            cached = self._cache.get(key)
+            if cached is None:
+                return None
+
+            value, expires_at = cached
+            if expires_at is not None and expires_at <= time.monotonic():
+                self._cache.pop(key, None)
                 if key in self._sizes:
                     self._total_bytes -= self._sizes.pop(key)
-        elif value is not None:
-            # Mark as recently used (LRU)
-            async with self._lock:
-                if key in self._sizes:
-                    self._sizes.move_to_end(key)
-        return value
+                return None
+
+            self._sizes.move_to_end(key)
+            return value
 
     async def set(self, key: str, value: bytes) -> None:
         size = len(value)
@@ -58,28 +61,32 @@ class SizedMemoryCache:
                 max_bytes=self._max_bytes,
             )
             return
-        async with self._lock:
+        expires_at = time.monotonic() + self._ttl if self._ttl > 0 else None
+        with self._lock:
             # Remove old entry if exists
             if key in self._sizes:
                 self._total_bytes -= self._sizes.pop(key)
+                self._cache.pop(key, None)
 
             # Evict LRU items until we have room
             while self._total_bytes + size > self._max_bytes and self._sizes:
                 oldest_key, oldest_size = self._sizes.popitem(last=False)
                 self._total_bytes -= oldest_size
-                await self._cache.delete(oldest_key)
+                self._cache.pop(oldest_key, None)
 
-            await self._cache.set(key, value)
+            self._cache[key] = (value, expires_at)
             self._sizes[key] = size
             self._total_bytes += size
 
     @property
     def total_bytes(self) -> int:
-        return self._total_bytes
+        with self._lock:
+            return self._total_bytes
 
     @property
     def item_count(self) -> int:
-        return len(self._sizes)
+        with self._lock:
+            return len(self._sizes)
 
 
 # Module-level cache for blob downloads and S3 Select results


### PR DESCRIPTION
## Summary

- replace the shared async blob cache lock with a thread-safe in-memory TTL/LRU cache so activity workers can use it across multiple event loops
- classify scheduler errors before applying user error handling so platform/orchestration failures inside scatter streams fail the workflow
- keep structured action errors eligible for scatter/gather business error handling

## Tests

- `uv run pytest tests/unit/test_storage_cache.py tests/unit/test_dsl_scheduler_errors.py -q`
- `uv run ruff check tracecat/dsl/scheduler.py tracecat/storage/utils.py tests/unit/test_dsl_scheduler_errors.py tests/unit/test_storage_cache.py`
- `uv run pyright tracecat/dsl/scheduler.py tracecat/storage/utils.py tests/unit/test_dsl_scheduler_errors.py tests/unit/test_storage_cache.py`
- `uv run ruff format --check tracecat/dsl/scheduler.py tracecat/storage/utils.py tests/unit/test_dsl_scheduler_errors.py tests/unit/test_storage_cache.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the storage cache thread-safe across event loops and fix scatter/gather error handling so platform failures fail the workflow while structured action errors still follow user error handling.

- **Bug Fixes**
  - Replaced the async blob cache with a thread-safe in-memory TTL/LRU cache using `threading.RLock`, so one cache works across multiple event loops.
  - Classified scheduler errors before applying error edges: platform/orchestration errors bypass user handling and fail the workflow; structured `ActionErrorInfo` errors still use gather/error paths.
  - Added tests for cross-loop cache access and for error classification in scatter streams.

<sup>Written for commit 42f4187881bc5013f2e4d09af30b544f23729066. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

