### PR TITLE
fix(storage): make blob cache safe across activity event loops

### DIFF
--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -1,6 +1,7 @@
 """Tests for SizedMemoryCache."""
 
 import asyncio
+import threading
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -227,28 +228,36 @@ class TestSizedMemoryCache:
         assert cache.item_count <= 2
 
     def test_concurrent_access_from_multiple_event_loops(self):
-        """Test that one cache can be used from separate event loops."""
-        cache = SizedMemoryCache(max_bytes=100, ttl=300.0)
+        """Test that one cache can be shared by separate event loops."""
+        worker_count = 4
+        iteration_count = 250
+        cache = SizedMemoryCache(max_bytes=2048, ttl=300.0)
+        barrier = threading.Barrier(worker_count)
 
-        async def exercise_cache(prefix: str) -> None:
-            for i in range(100):
-                key = f"{prefix}-{i % 10}"
-                await cache.set(key, f"value-{i}".encode())
-                await cache.get(key)
+        async def exercise_cache(worker_id: int) -> None:
+            barrier.wait(timeout=5)
+            for i in range(iteration_count):
+                shared_key = f"shared-{i % 8}"
+                worker_key = f"worker-{worker_id}-{i % 8}"
+
+                await cache.set(shared_key, f"shared-value-{worker_id}-{i}".encode())
+                await cache.get(shared_key)
+                await cache.set(worker_key, f"worker-value-{worker_id}-{i}".encode())
+                await cache.get(worker_key)
                 await asyncio.sleep(0)
 
-        def run_in_new_loop(prefix: str) -> None:
-            asyncio.run(exercise_cache(prefix))
+        def run_in_new_loop(worker_id: int) -> None:
+            asyncio.run(exercise_cache(worker_id))
 
-        with ThreadPoolExecutor(max_workers=2) as executor:
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
             futures = [
-                executor.submit(run_in_new_loop, "a"),
-                executor.submit(run_in_new_loop, "b"),
+                executor.submit(run_in_new_loop, worker_id)
+                for worker_id in range(worker_count)
             ]
             for future in futures:
                 future.result()
 
-        assert cache.total_bytes <= 100
+        assert cache.total_bytes <= 2048
 
     @pytest.mark.anyio
     async def test_empty_value(self):

--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -140,6 +140,39 @@ class TestSizedMemoryCache:
         assert await cache.get("fresh") == b"world"
 
     @pytest.mark.anyio
+    async def test_set_purges_expired_mru_before_lru_eviction(self):
+        """Test that expired MRU entries do not cause fresh LRU eviction."""
+        cache = SizedMemoryCache(max_bytes=100, ttl=0.2)
+
+        await cache.set("expires_first", b"a" * 50)
+        await asyncio.sleep(0.05)
+        await cache.set("fresh_lru", b"b" * 40)
+        assert await cache.get("expires_first") == b"a" * 50
+
+        await asyncio.sleep(0.17)
+        await cache.set("new", b"c" * 40)
+
+        assert await cache.get("expires_first") is None
+        assert await cache.get("fresh_lru") == b"b" * 40
+        assert await cache.get("new") == b"c" * 40
+        assert cache.total_bytes == 80
+
+    @pytest.mark.anyio
+    async def test_oversized_set_purges_expired_entries(self):
+        """Test that rejected writes still purge expired entries."""
+        cache = SizedMemoryCache(max_bytes=100, ttl=0.1)
+
+        await cache.set("expired", b"a" * 50)
+        assert cache.total_bytes == 50
+
+        await asyncio.sleep(0.15)
+        await cache.set("too_big", b"b" * 101)
+
+        assert cache.total_bytes == 0
+        assert cache.item_count == 0
+        assert await cache.get("too_big") is None
+
+    @pytest.mark.anyio
     async def test_concurrent_access(self):
         """Test that concurrent access is safe."""
         cache = SizedMemoryCache(max_bytes=10000, ttl=300.0)

--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -1,6 +1,7 @@
 """Tests for SizedMemoryCache."""
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -149,6 +150,30 @@ class TestSizedMemoryCache:
 
         # Should complete without errors
         assert cache.item_count <= 2
+
+    def test_concurrent_access_from_multiple_event_loops(self):
+        """Test that one cache can be used from separate event loops."""
+        cache = SizedMemoryCache(max_bytes=100, ttl=300.0)
+
+        async def exercise_cache(prefix: str) -> None:
+            for i in range(100):
+                key = f"{prefix}-{i % 10}"
+                await cache.set(key, f"value-{i}".encode())
+                await cache.get(key)
+                await asyncio.sleep(0)
+
+        def run_in_new_loop(prefix: str) -> None:
+            asyncio.run(exercise_cache(prefix))
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(run_in_new_loop, "a"),
+                executor.submit(run_in_new_loop, "b"),
+            ]
+            for future in futures:
+                future.result()
+
+        assert cache.total_bytes <= 100
 
     @pytest.mark.anyio
     async def test_empty_value(self):

--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -184,6 +184,22 @@ class TestSizedMemoryCache:
         assert await cache.get("too_big") is None
 
     @pytest.mark.anyio
+    async def test_non_positive_ttl_disables_expiry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Test that non-positive TTL preserves existing no-expiry behavior."""
+        now = 100.0
+        monkeypatch.setattr("tracecat.storage.utils.time.monotonic", lambda: now)
+        cache = SizedMemoryCache(max_bytes=1024, ttl=0.0)
+
+        await cache.set("key1", b"hello")
+
+        now = 10_000.0
+        assert await cache.get("key1") == b"hello"
+        assert cache.total_bytes == 5
+        assert cache.item_count == 1
+
+    @pytest.mark.anyio
     async def test_concurrent_access(self):
         """Test that concurrent access is safe."""
         cache = SizedMemoryCache(max_bytes=10000, ttl=300.0)

--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -108,31 +108,34 @@ class TestSizedMemoryCache:
         assert await cache.get("key2") is None  # Evicted (was LRU)
 
     @pytest.mark.anyio
-    async def test_ttl_expiry_syncs_tracking(self):
+    async def test_ttl_expiry_syncs_tracking(self, monkeypatch: pytest.MonkeyPatch):
         """Test that TTL expiry syncs size tracking on get."""
-        cache = SizedMemoryCache(max_bytes=1024, ttl=0.1)  # 100ms TTL
+        now = 100.0
+        monkeypatch.setattr("tracecat.storage.utils.time.monotonic", lambda: now)
+        cache = SizedMemoryCache(max_bytes=1024, ttl=0.1)
 
         await cache.set("key1", b"hello")
         assert cache.total_bytes == 5
 
-        # Wait for TTL to expire
-        await asyncio.sleep(0.15)
-
-        # Get should return None and sync tracking
+        now = 100.11
         result = await cache.get("key1")
         assert result is None
         assert cache.total_bytes == 0
         assert cache.item_count == 0
 
     @pytest.mark.anyio
-    async def test_set_purges_expired_entries_without_read(self):
+    async def test_set_purges_expired_entries_without_read(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         """Test that writes purge expired entries before capacity accounting."""
-        cache = SizedMemoryCache(max_bytes=1024, ttl=0.1)  # 100ms TTL
+        now = 100.0
+        monkeypatch.setattr("tracecat.storage.utils.time.monotonic", lambda: now)
+        cache = SizedMemoryCache(max_bytes=1024, ttl=0.1)
 
         await cache.set("expired", b"hello")
         assert cache.total_bytes == 5
 
-        await asyncio.sleep(0.15)
+        now = 100.11
         await cache.set("fresh", b"world")
 
         assert cache.total_bytes == 5
@@ -140,16 +143,20 @@ class TestSizedMemoryCache:
         assert await cache.get("fresh") == b"world"
 
     @pytest.mark.anyio
-    async def test_set_purges_expired_mru_before_lru_eviction(self):
+    async def test_set_purges_expired_mru_before_lru_eviction(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         """Test that expired MRU entries do not cause fresh LRU eviction."""
+        now = 100.0
+        monkeypatch.setattr("tracecat.storage.utils.time.monotonic", lambda: now)
         cache = SizedMemoryCache(max_bytes=100, ttl=0.2)
 
         await cache.set("expires_first", b"a" * 50)
-        await asyncio.sleep(0.05)
+        now = 100.05
         await cache.set("fresh_lru", b"b" * 40)
         assert await cache.get("expires_first") == b"a" * 50
 
-        await asyncio.sleep(0.17)
+        now = 100.21
         await cache.set("new", b"c" * 40)
 
         assert await cache.get("expires_first") is None
@@ -158,14 +165,18 @@ class TestSizedMemoryCache:
         assert cache.total_bytes == 80
 
     @pytest.mark.anyio
-    async def test_oversized_set_purges_expired_entries(self):
+    async def test_oversized_set_purges_expired_entries(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         """Test that rejected writes still purge expired entries."""
+        now = 100.0
+        monkeypatch.setattr("tracecat.storage.utils.time.monotonic", lambda: now)
         cache = SizedMemoryCache(max_bytes=100, ttl=0.1)
 
         await cache.set("expired", b"a" * 50)
         assert cache.total_bytes == 50
 
-        await asyncio.sleep(0.15)
+        now = 100.11
         await cache.set("too_big", b"b" * 101)
 
         assert cache.total_bytes == 0

--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -125,6 +125,21 @@ class TestSizedMemoryCache:
         assert cache.item_count == 0
 
     @pytest.mark.anyio
+    async def test_set_purges_expired_entries_without_read(self):
+        """Test that writes purge expired entries before capacity accounting."""
+        cache = SizedMemoryCache(max_bytes=1024, ttl=0.1)  # 100ms TTL
+
+        await cache.set("expired", b"hello")
+        assert cache.total_bytes == 5
+
+        await asyncio.sleep(0.15)
+        await cache.set("fresh", b"world")
+
+        assert cache.total_bytes == 5
+        assert cache.item_count == 1
+        assert await cache.get("fresh") == b"world"
+
+    @pytest.mark.anyio
     async def test_concurrent_access(self):
         """Test that concurrent access is safe."""
         cache = SizedMemoryCache(max_bytes=10000, ttl=300.0)

--- a/tracecat/storage/utils.py
+++ b/tracecat/storage/utils.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import hashlib
+import math
 import threading
 import time
-from collections import OrderedDict
 from typing import TYPE_CHECKING, Any
 
 import orjson
+from cachetools import TTLCache
 
 from tracecat.logger import logger
 from tracecat.storage import blob
@@ -26,50 +27,27 @@ class SizedMemoryCache:
     """Thread-safe byte-aware memory cache with TTL and LRU eviction."""
 
     def __init__(self, max_bytes: int, ttl: float = 300.0):
-        self._cache: dict[str, tuple[bytes, float | None]] = {}
-        self._sizes: OrderedDict[str, int] = OrderedDict()
-        self._total_bytes = 0
+        self._cache: TTLCache[str, bytes] = TTLCache(
+            maxsize=max_bytes,
+            ttl=ttl if ttl > 0 else math.inf,
+            timer=time.monotonic,
+            getsizeof=len,
+        )
         self._max_bytes = max_bytes
-        self._ttl = ttl
         # Temporal can execute async activities on multiple event loops in a
-        # thread pool. asyncio locks are bound to one loop under contention.
+        # thread pool. asyncio locks are bound to one loop under contention, and
+        # cachetools caches are not thread-safe without external synchronization.
         self._lock = threading.RLock()
 
-    def _delete_locked(self, key: str) -> None:
-        self._cache.pop(key, None)
-        if key in self._sizes:
-            self._total_bytes -= self._sizes.pop(key)
-
-    def _purge_expired_locked(self, now: float) -> None:
-        expired_keys = [
-            key
-            for key, (_, expires_at) in self._cache.items()
-            if expires_at is not None and expires_at <= now
-        ]
-        for key in expired_keys:
-            self._delete_locked(key)
-
     async def get(self, key: str) -> bytes | None:
-        now = time.monotonic()
         with self._lock:
-            cached = self._cache.get(key)
-            if cached is None:
-                return None
-
-            value, expires_at = cached
-            if expires_at is not None and expires_at <= now:
-                self._delete_locked(key)
-                return None
-
-            self._sizes.move_to_end(key)
-            return value
+            self._cache.expire()
+            return self._cache.get(key)
 
     async def set(self, key: str, value: bytes) -> None:
-        now = time.monotonic()
         size = len(value)
-        expires_at = now + self._ttl if self._ttl > 0 else None
         with self._lock:
-            self._purge_expired_locked(now)
+            self._cache.expire()
             if size > self._max_bytes:
                 logger.debug(
                     "Cache entry too large to store",
@@ -79,28 +57,17 @@ class SizedMemoryCache:
                 )
                 return
 
-            # Remove old entry if exists
-            self._delete_locked(key)
-
-            # Evict LRU items until we have room
-            while self._total_bytes + size > self._max_bytes and self._sizes:
-                oldest_key, oldest_size = self._sizes.popitem(last=False)
-                self._total_bytes -= oldest_size
-                self._cache.pop(oldest_key, None)
-
-            self._cache[key] = (value, expires_at)
-            self._sizes[key] = size
-            self._total_bytes += size
+            self._cache[key] = value
 
     @property
     def total_bytes(self) -> int:
         with self._lock:
-            return self._total_bytes
+            return int(self._cache.currsize)
 
     @property
     def item_count(self) -> int:
         with self._lock:
-            return len(self._sizes)
+            return len(self._cache)
 
 
 # Module-level cache for blob downloads and S3 Select results

--- a/tracecat/storage/utils.py
+++ b/tracecat/storage/utils.py
@@ -2,20 +2,18 @@
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
+import threading
+import time
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any
 
 import orjson
-from aiocache import Cache
 
 from tracecat.logger import logger
 from tracecat.storage import blob
 
 if TYPE_CHECKING:
-    from aiocache.base import BaseCache
-
     from tracecat.storage.object import InlineObject, StoredObject
 
 # Cache configuration
@@ -25,28 +23,33 @@ BLOB_CACHE_TTL = 300.0  # 5 minutes
 
 
 class SizedMemoryCache:
-    """Byte-aware wrapper around aiocache SimpleMemoryCache with LRU eviction."""
+    """Thread-safe byte-aware memory cache with TTL and LRU eviction."""
 
     def __init__(self, max_bytes: int, ttl: float = 300.0):
-        self._cache: BaseCache = Cache(Cache.MEMORY, ttl=ttl)
+        self._cache: dict[str, tuple[bytes, float | None]] = {}
         self._sizes: OrderedDict[str, int] = OrderedDict()
         self._total_bytes = 0
         self._max_bytes = max_bytes
-        self._lock = asyncio.Lock()
+        self._ttl = ttl
+        # Temporal can execute async activities on multiple event loops in a
+        # thread pool. asyncio locks are bound to one loop under contention.
+        self._lock = threading.RLock()
 
     async def get(self, key: str) -> bytes | None:
-        value: bytes | None = await self._cache.get(key)
-        if value is None and key in self._sizes:
-            # TTL expired in underlying cache, sync our tracking
-            async with self._lock:
+        with self._lock:
+            cached = self._cache.get(key)
+            if cached is None:
+                return None
+
+            value, expires_at = cached
+            if expires_at is not None and expires_at <= time.monotonic():
+                self._cache.pop(key, None)
                 if key in self._sizes:
                     self._total_bytes -= self._sizes.pop(key)
-        elif value is not None:
-            # Mark as recently used (LRU)
-            async with self._lock:
-                if key in self._sizes:
-                    self._sizes.move_to_end(key)
-        return value
+                return None
+
+            self._sizes.move_to_end(key)
+            return value
 
     async def set(self, key: str, value: bytes) -> None:
         size = len(value)
@@ -58,28 +61,32 @@ class SizedMemoryCache:
                 max_bytes=self._max_bytes,
             )
             return
-        async with self._lock:
+        expires_at = time.monotonic() + self._ttl if self._ttl > 0 else None
+        with self._lock:
             # Remove old entry if exists
             if key in self._sizes:
                 self._total_bytes -= self._sizes.pop(key)
+                self._cache.pop(key, None)
 
             # Evict LRU items until we have room
             while self._total_bytes + size > self._max_bytes and self._sizes:
                 oldest_key, oldest_size = self._sizes.popitem(last=False)
                 self._total_bytes -= oldest_size
-                await self._cache.delete(oldest_key)
+                self._cache.pop(oldest_key, None)
 
-            await self._cache.set(key, value)
+            self._cache[key] = (value, expires_at)
             self._sizes[key] = size
             self._total_bytes += size
 
     @property
     def total_bytes(self) -> int:
-        return self._total_bytes
+        with self._lock:
+            return self._total_bytes
 
     @property
     def item_count(self) -> int:
-        return len(self._sizes)
+        with self._lock:
+            return len(self._sizes)
 
 
 # Module-level cache for blob downloads and S3 Select results

--- a/tracecat/storage/utils.py
+++ b/tracecat/storage/utils.py
@@ -57,7 +57,15 @@ class SizedMemoryCache:
                 )
                 return
 
-            self._cache[key] = value
+            try:
+                self._cache[key] = value
+            except ValueError:
+                logger.debug(
+                    "Cache entry too large to store",
+                    key=key,
+                    size_bytes=size,
+                    max_bytes=self._max_bytes,
+                )
 
     @property
     def total_bytes(self) -> int:

--- a/tracecat/storage/utils.py
+++ b/tracecat/storage/utils.py
@@ -35,38 +35,52 @@ class SizedMemoryCache:
         # thread pool. asyncio locks are bound to one loop under contention.
         self._lock = threading.RLock()
 
+    def _delete_locked(self, key: str) -> None:
+        self._cache.pop(key, None)
+        if key in self._sizes:
+            self._total_bytes -= self._sizes.pop(key)
+
+    def _purge_expired_locked(self, now: float) -> None:
+        expired_keys = [
+            key
+            for key, (_, expires_at) in self._cache.items()
+            if expires_at is not None and expires_at <= now
+        ]
+        for key in expired_keys:
+            self._delete_locked(key)
+
     async def get(self, key: str) -> bytes | None:
+        now = time.monotonic()
         with self._lock:
             cached = self._cache.get(key)
             if cached is None:
                 return None
 
             value, expires_at = cached
-            if expires_at is not None and expires_at <= time.monotonic():
-                self._cache.pop(key, None)
-                if key in self._sizes:
-                    self._total_bytes -= self._sizes.pop(key)
+            if expires_at is not None and expires_at <= now:
+                self._delete_locked(key)
                 return None
 
             self._sizes.move_to_end(key)
             return value
 
     async def set(self, key: str, value: bytes) -> None:
+        now = time.monotonic()
         size = len(value)
-        if size > self._max_bytes:
-            logger.debug(
-                "Cache entry too large to store",
-                key=key,
-                size_bytes=size,
-                max_bytes=self._max_bytes,
-            )
-            return
-        expires_at = time.monotonic() + self._ttl if self._ttl > 0 else None
+        expires_at = now + self._ttl if self._ttl > 0 else None
         with self._lock:
+            self._purge_expired_locked(now)
+            if size > self._max_bytes:
+                logger.debug(
+                    "Cache entry too large to store",
+                    key=key,
+                    size_bytes=size,
+                    max_bytes=self._max_bytes,
+                )
+                return
+
             # Remove old entry if exists
-            if key in self._sizes:
-                self._total_bytes -= self._sizes.pop(key)
-                self._cache.pop(key, None)
+            self._delete_locked(key)
 
             # Evict LRU items until we have room
             while self._total_bytes + size > self._max_bytes and self._sizes:


### PR DESCRIPTION
## Summary

- replace the shared async blob cache lock with a thread-safe in-memory TTL/LRU cache
- avoid binding the process-global blob cache to one asyncio event loop under Temporal activity worker contention
- add a regression test that uses one cache instance from multiple event loops in separate threads

## Tests

- `uv run pytest tests/unit/test_storage_cache.py -q`
- `uv run ruff check tracecat/storage/utils.py tests/unit/test_storage_cache.py`
- `uv run pyright tracecat/storage/utils.py tests/unit/test_storage_cache.py`
- `uv run ruff format --check tracecat/storage/utils.py tests/unit/test_storage_cache.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the blob cache thread-safe across threads and event loops by switching from `aiocache` to a process-local `cachetools` TTL+LRU cache guarded by `threading.RLock`. Added a stress test to validate sharing one cache across multiple event loops.

- **Bug Fixes**
  - No single-loop binding; safe across threads and event loops.
  - Purge expired entries on write before capacity checks; fix LRU eviction and size tracking; safely reject oversized writes.
  - Non-positive TTL disables expiry to preserve previous no-expiry behavior.

<sup>Written for commit 4f657ce10b25a68bd46f6775d1ebc584eab64826. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

