### PR TITLE
test(storage): cover cross-loop cache lock contention

### DIFF
--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -1,12 +1,74 @@
 """Tests for SizedMemoryCache."""
 
 import asyncio
+import multiprocessing
 import threading
+import traceback
 from concurrent.futures import ThreadPoolExecutor
+from multiprocessing.connection import Connection
 
 import pytest
 
 from tracecat.storage.utils import SizedMemoryCache
+
+
+def _run_shared_cache_lock_contention_probe(result_connection: Connection) -> None:
+    try:
+        worker_count = 3
+        cache = SizedMemoryCache(max_bytes=2048, ttl=300.0)
+        lock_acquired = threading.Event()
+        release_lock = threading.Event()
+        start_barrier = threading.Barrier(worker_count + 1)
+        workers_attempting_cache_access = threading.Semaphore(0)
+
+        def hold_cache_lock() -> None:
+            # This intentionally touches the lock internals: the regression is
+            # reintroducing an event-loop-bound lock on this process-global cache.
+            with cache._lock:
+                lock_acquired.set()
+                assert release_lock.wait(timeout=5)
+
+        async def exercise_cache(worker_id: int) -> None:
+            start_barrier.wait(timeout=5)
+            workers_attempting_cache_access.release()
+
+            key = f"key-{worker_id}"
+            value = f"value-{worker_id}".encode()
+            await cache.set(key, value)
+            assert await cache.get(key) == value
+
+        def run_in_new_loop(worker_id: int) -> None:
+            asyncio.run(exercise_cache(worker_id))
+
+        executor = ThreadPoolExecutor(max_workers=worker_count + 1)
+        try:
+            holder_future = executor.submit(hold_cache_lock)
+            if not lock_acquired.wait(timeout=5):
+                if holder_future.done():
+                    holder_future.result()
+                raise AssertionError("Cache lock was not acquired")
+
+            futures = [
+                executor.submit(run_in_new_loop, worker_id)
+                for worker_id in range(worker_count)
+            ]
+            start_barrier.wait(timeout=5)
+            for _ in range(worker_count):
+                assert workers_attempting_cache_access.acquire(timeout=5)
+
+            release_lock.set()
+            for future in futures:
+                future.result(timeout=5)
+            holder_future.result(timeout=5)
+        finally:
+            release_lock.set()
+            executor.shutdown(wait=False, cancel_futures=True)
+    except BaseException:
+        result_connection.send(("error", traceback.format_exc()))
+    else:
+        result_connection.send(("ok", ""))
+    finally:
+        result_connection.close()
 
 
 class TestSizedMemoryCache:
@@ -261,55 +323,30 @@ class TestSizedMemoryCache:
 
     def test_shared_cache_handles_cross_loop_lock_contention(self):
         """Test that cross-loop cache users can contend on the shared lock."""
-        worker_count = 3
-        cache = SizedMemoryCache(max_bytes=2048, ttl=300.0)
-        lock_acquired = threading.Event()
-        release_lock = threading.Event()
-        start_barrier = threading.Barrier(worker_count + 1)
-        workers_attempting_cache_access = threading.Semaphore(0)
+        context = multiprocessing.get_context("spawn")
+        parent_connection, child_connection = context.Pipe(duplex=False)
+        process = context.Process(
+            target=_run_shared_cache_lock_contention_probe,
+            args=(child_connection,),
+        )
 
-        def hold_cache_lock() -> None:
-            # This intentionally touches the lock internals: the regression is
-            # reintroducing an event-loop-bound lock on this process-global cache.
-            with cache._lock:
-                lock_acquired.set()
-                assert release_lock.wait(timeout=5)
+        process.start()
+        child_connection.close()
+        process.join(timeout=10)
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5)
+            if process.is_alive():
+                process.kill()
+                process.join()
+            pytest.fail("Cache lock contention probe timed out")
 
-        async def exercise_cache(worker_id: int) -> None:
-            start_barrier.wait(timeout=5)
-            workers_attempting_cache_access.release()
-
-            key = f"key-{worker_id}"
-            value = f"value-{worker_id}".encode()
-            await cache.set(key, value)
-            assert await cache.get(key) == value
-
-        def run_in_new_loop(worker_id: int) -> None:
-            asyncio.run(exercise_cache(worker_id))
-
-        executor = ThreadPoolExecutor(max_workers=worker_count + 1)
-        try:
-            holder_future = executor.submit(hold_cache_lock)
-            if not lock_acquired.wait(timeout=5):
-                if holder_future.done():
-                    holder_future.result()
-                pytest.fail("Cache lock was not acquired")
-
-            futures = [
-                executor.submit(run_in_new_loop, worker_id)
-                for worker_id in range(worker_count)
-            ]
-            start_barrier.wait(timeout=5)
-            for _ in range(worker_count):
-                assert workers_attempting_cache_access.acquire(timeout=5)
-
-            release_lock.set()
-            for future in futures:
-                future.result(timeout=5)
-            holder_future.result(timeout=5)
-        finally:
-            release_lock.set()
-            executor.shutdown(wait=False, cancel_futures=True)
+        if parent_connection.poll():
+            status, detail = parent_connection.recv()
+            if status == "error":
+                pytest.fail(detail)
+        elif process.exitcode != 0:
+            pytest.fail(f"Cache lock contention probe exited with {process.exitcode}")
 
     @pytest.mark.anyio
     async def test_empty_value(self):

--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -259,6 +259,57 @@ class TestSizedMemoryCache:
 
         assert cache.total_bytes <= 2048
 
+    def test_shared_cache_handles_cross_loop_lock_contention(self):
+        """Test that cross-loop cache users can contend on the shared lock."""
+        worker_count = 3
+        cache = SizedMemoryCache(max_bytes=2048, ttl=300.0)
+        lock_acquired = threading.Event()
+        release_lock = threading.Event()
+        start_barrier = threading.Barrier(worker_count + 1)
+        workers_attempting_cache_access = threading.Semaphore(0)
+
+        def hold_cache_lock() -> None:
+            # This intentionally touches the lock internals: the regression is
+            # reintroducing an event-loop-bound lock on this process-global cache.
+            with cache._lock:
+                lock_acquired.set()
+                assert release_lock.wait(timeout=5)
+
+        async def exercise_cache(worker_id: int) -> None:
+            start_barrier.wait(timeout=5)
+            workers_attempting_cache_access.release()
+
+            key = f"key-{worker_id}"
+            value = f"value-{worker_id}".encode()
+            await cache.set(key, value)
+            assert await cache.get(key) == value
+
+        def run_in_new_loop(worker_id: int) -> None:
+            asyncio.run(exercise_cache(worker_id))
+
+        with ThreadPoolExecutor(max_workers=worker_count + 1) as executor:
+            holder_future = executor.submit(hold_cache_lock)
+            try:
+                if not lock_acquired.wait(timeout=5):
+                    if holder_future.done():
+                        holder_future.result()
+                    pytest.fail("Cache lock was not acquired")
+
+                futures = [
+                    executor.submit(run_in_new_loop, worker_id)
+                    for worker_id in range(worker_count)
+                ]
+                start_barrier.wait(timeout=5)
+                for _ in range(worker_count):
+                    assert workers_attempting_cache_access.acquire(timeout=5)
+
+                release_lock.set()
+                for future in futures:
+                    future.result(timeout=5)
+                holder_future.result(timeout=5)
+            finally:
+                release_lock.set()
+
     @pytest.mark.anyio
     async def test_empty_value(self):
         """Test caching empty bytes."""

--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -287,28 +287,29 @@ class TestSizedMemoryCache:
         def run_in_new_loop(worker_id: int) -> None:
             asyncio.run(exercise_cache(worker_id))
 
-        with ThreadPoolExecutor(max_workers=worker_count + 1) as executor:
+        executor = ThreadPoolExecutor(max_workers=worker_count + 1)
+        try:
             holder_future = executor.submit(hold_cache_lock)
-            try:
-                if not lock_acquired.wait(timeout=5):
-                    if holder_future.done():
-                        holder_future.result()
-                    pytest.fail("Cache lock was not acquired")
+            if not lock_acquired.wait(timeout=5):
+                if holder_future.done():
+                    holder_future.result()
+                pytest.fail("Cache lock was not acquired")
 
-                futures = [
-                    executor.submit(run_in_new_loop, worker_id)
-                    for worker_id in range(worker_count)
-                ]
-                start_barrier.wait(timeout=5)
-                for _ in range(worker_count):
-                    assert workers_attempting_cache_access.acquire(timeout=5)
+            futures = [
+                executor.submit(run_in_new_loop, worker_id)
+                for worker_id in range(worker_count)
+            ]
+            start_barrier.wait(timeout=5)
+            for _ in range(worker_count):
+                assert workers_attempting_cache_access.acquire(timeout=5)
 
-                release_lock.set()
-                for future in futures:
-                    future.result(timeout=5)
-                holder_future.result(timeout=5)
-            finally:
-                release_lock.set()
+            release_lock.set()
+            for future in futures:
+                future.result(timeout=5)
+            holder_future.result(timeout=5)
+        finally:
+            release_lock.set()
+            executor.shutdown(wait=False, cancel_futures=True)
 
     @pytest.mark.anyio
     async def test_empty_value(self):


### PR DESCRIPTION
## Summary

- add a targeted regression test for cross-event-loop contention on the shared storage cache lock
- hold the cache lock from one thread while separate event loops attempt cache operations
- verify all event-loop workers complete after the lock is released

## Stack

Base: `fix/threadsafe-storage-cache` / PR #2640

## Tests

- `uv run pytest tests/unit/test_storage_cache.py -q`
- `uv run pytest tests/unit/test_storage_cache.py -q -n 2`
- `uv run ruff check tracecat/storage/utils.py tests/unit/test_storage_cache.py`
- `uv run pyright tracecat/storage/utils.py tests/unit/test_storage_cache.py`
- `uv run ruff format --check tracecat/storage/utils.py tests/unit/test_storage_cache.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test to verify `SizedMemoryCache` handles cross-event-loop lock contention without deadlocks. The probe now runs in a spawned process: one thread holds the shared lock while workers use fresh event loops to set/get; start is synced with a barrier, results are sent via a pipe, and the process is force-terminated on timeout to avoid hangs.

<sup>Written for commit 9f4bb0d7147798620dfcd5b8d206de434914a914. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

