### PR TITLE
fix(cases): validate custom field value types

### DIFF
--- a/tests/unit/api/test_case_field_values.py
+++ b/tests/unit/api/test_case_field_values.py
@@ -1,0 +1,115 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tracecat.auth.types import Role
+from tracecat.cases.service import CaseFieldsService
+from tracecat.tables.enums import SqlType
+
+
+@pytest.mark.anyio
+async def test_normalize_field_values_rejects_structured_value_for_text_field(
+    test_admin_role: Role,
+) -> None:
+    service = CaseFieldsService(AsyncMock(), test_admin_role)
+    service.get_field_schema = AsyncMock(
+        return_value={"text_field": {"type": SqlType.TEXT.value}}
+    )
+    service.editor.get_columns = AsyncMock(
+        return_value=[{"name": "text_field", "type": SqlType.TEXT}]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Custom field 'text_field' expects TEXT but received list.",
+    ):
+        await service.normalize_field_values({"text_field": ["alpha", "beta"]})
+
+
+@pytest.mark.anyio
+async def test_normalize_field_values_allows_scalar_for_text_field(
+    test_admin_role: Role,
+) -> None:
+    service = CaseFieldsService(AsyncMock(), test_admin_role)
+    service.get_field_schema = AsyncMock(
+        return_value={"text_field": {"type": SqlType.TEXT.value}}
+    )
+    service.editor.get_columns = AsyncMock(
+        return_value=[{"name": "text_field", "type": SqlType.TEXT}]
+    )
+
+    assert await service.normalize_field_values({"text_field": 42}) == {
+        "text_field": "42"
+    }
+
+
+@pytest.mark.anyio
+async def test_normalize_field_values_rejects_unknown_select_option(
+    test_admin_role: Role,
+) -> None:
+    service = CaseFieldsService(AsyncMock(), test_admin_role)
+    service.get_field_schema = AsyncMock(
+        return_value={
+            "select_field": {
+                "type": SqlType.SELECT.value,
+                "options": ["allowed", "also_allowed"],
+            }
+        }
+    )
+    service.editor.get_columns = AsyncMock(
+        return_value=[{"name": "select_field", "type": SqlType.TEXT}]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Value 'blocked' is not in the available options",
+    ):
+        await service.normalize_field_values({"select_field": "blocked"})
+
+
+@pytest.mark.anyio
+async def test_normalize_field_values_rejects_non_list_multi_select(
+    test_admin_role: Role,
+) -> None:
+    service = CaseFieldsService(AsyncMock(), test_admin_role)
+    service.get_field_schema = AsyncMock(
+        return_value={
+            "multi_select_field": {
+                "type": SqlType.MULTI_SELECT.value,
+                "options": ["allowed", "also_allowed"],
+            }
+        }
+    )
+    service.editor.get_columns = AsyncMock(
+        return_value=[{"name": "multi_select_field", "type": SqlType.JSONB}]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="MULTI_SELECT values must be provided as a list of strings",
+    ):
+        await service.normalize_field_values({"multi_select_field": "allowed"})
+
+
+@pytest.mark.anyio
+async def test_normalize_field_values_rejects_unknown_multi_select_option(
+    test_admin_role: Role,
+) -> None:
+    service = CaseFieldsService(AsyncMock(), test_admin_role)
+    service.get_field_schema = AsyncMock(
+        return_value={
+            "multi_select_field": {
+                "type": SqlType.MULTI_SELECT.value,
+                "options": ["allowed", "also_allowed"],
+            }
+        }
+    )
+    service.editor.get_columns = AsyncMock(
+        return_value=[{"name": "multi_select_field", "type": SqlType.JSONB}]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Value\\(s\\) blocked are not in the available options",
+    ):
+        await service.normalize_field_values({"multi_select_field": ["blocked"]})

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -121,7 +121,9 @@ from tracecat.pagination import (
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tables.common import (
     coerce_integer_value,
+    coerce_multi_select_value,
     coerce_numeric_value,
+    coerce_select_value,
     normalize_column_options,
 )
 from tracecat.tables.enums import SqlType
@@ -1257,11 +1259,23 @@ class CaseFieldsService(CustomFieldsService):
 
         for field_name, value in fields.items():
             field_type = reflected_types.get(field_name)
+            field_options: list[str] | None = None
             if isinstance(schema_def := schema.get(field_name), dict):
-                if field_type is None and (raw_type := schema_def.get("type")):
-                    field_type = SqlType(
+                field_options = schema_def.get("options")
+                if raw_type := schema_def.get("type"):
+                    schema_field_type = SqlType(
                         _normalize_case_field_read_type(raw_type).value
                     )
+                    if field_type is None or (
+                        schema_field_type is SqlType.SELECT
+                        and field_type is SqlType.TEXT
+                    ):
+                        field_type = schema_field_type
+                    elif (
+                        schema_field_type is SqlType.MULTI_SELECT
+                        and field_type is SqlType.JSONB
+                    ):
+                        field_type = schema_field_type
 
             if value is None or field_type is None:
                 normalized[field_name] = value
@@ -1269,6 +1283,26 @@ class CaseFieldsService(CustomFieldsService):
                 normalized[field_name] = coerce_integer_value(value)
             elif field_type is SqlType.NUMERIC:
                 normalized[field_name] = coerce_numeric_value(value)
+            elif field_type is SqlType.TEXT:
+                if isinstance(value, dict | list | tuple | set):
+                    raise ValueError(
+                        f"Custom field '{field_name}' expects TEXT but received "
+                        f"{type(value).__name__}."
+                    )
+                normalized[field_name] = value if isinstance(value, str) else str(value)
+            elif field_type is SqlType.SELECT:
+                if isinstance(value, dict | list | tuple | set):
+                    raise ValueError(
+                        f"Custom field '{field_name}' expects SELECT but received "
+                        f"{type(value).__name__}."
+                    )
+                normalized[field_name] = coerce_select_value(
+                    value, options=field_options
+                )
+            elif field_type is SqlType.MULTI_SELECT:
+                normalized[field_name] = coerce_multi_select_value(
+                    value, options=field_options
+                )
             else:
                 normalized[field_name] = value
 


### PR DESCRIPTION
## Summary
- validate case custom field values before binding them to reflected SQL column types
- reject structured values for TEXT/SELECT case fields with a field-specific error
- normalize scalar TEXT values and SELECT/MULTI_SELECT values through existing table coercion helpers

## Verification
- `uv run pytest tests/unit/api/test_case_field_values.py`
- `uv run ruff check tracecat/cases/service.py tests/unit/api/test_case_field_values.py`
- `uv run basedpyright tracecat/cases/service.py tests/unit/api/test_case_field_values.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate and normalize case custom field values against reflected SQL types and schema options to prevent invalid data and enforce correct coercion.

- **New Features**
  - Added type checks in `CaseFieldsService.normalize_field_values` against reflected `SqlType`, with schema overrides for option-backed fields (SELECT over TEXT, MULTI_SELECT over JSONB).
  - Reject dict/list/tuple/set for TEXT and SELECT with clear field-specific errors; normalize TEXT scalars to strings.
  - Validate SELECT/MULTI_SELECT against provided `options` via `coerce_select_value` and `coerce_multi_select_value`; require list for MULTI_SELECT.

- **Tests**
  - Added unit tests for TEXT coercion and structured value rejection, unknown SELECT options, non-list MULTI_SELECT values, and unknown MULTI_SELECT options.

<sup>Written for commit decbdc20a54e13ae44afb50852f4c9ec81f96e48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

