### PR TITLE
fix(cases): idempotent link rows

### DIFF
--- a/tracecat/cases/rows/service.py
+++ b/tracecat/cases/rows/service.py
@@ -200,6 +200,14 @@ class CaseTableRowsService(BaseWorkspaceService):
             row_id=params.row_id,
         )
         self.session.add(link)
+        try:
+            await self.session.flush()
+        except sa_exc.IntegrityError:
+            await self.session.rollback()
+            existing = (await self.session.execute(dedupe_stmt)).scalars().first()
+            if existing is None:
+                raise
+            return existing
 
         await CaseEventsService(self.session, self.role).create_event(
             case,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make linking case rows idempotent by returning the existing link when a duplicate insert happens. This prevents duplicate link rows and avoids extra events.

- **Bug Fixes**
  - Catch `sa_exc.IntegrityError` on `flush`; rollback, fetch via `dedupe_stmt`, and return the existing link.
  - Skip event creation when the link already exists.

<sup>Written for commit 4141116097aa04efc3382889ef6bbe117b152d05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

