### PR TITLE
fix(cases): make row links idempotent

### DIFF
--- a/tests/unit/test_case_table_rows_service.py
+++ b/tests/unit/test_case_table_rows_service.py
@@ -9,6 +9,7 @@ from tracecat.auth.types import Role
 from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
 from tracecat.cases.rows.schemas import CaseTableRowLinkCreate
 from tracecat.cases.rows.service import (
+    MAX_LINKED_ROWS_PER_CASE,
     MAX_TABLES_PER_CASE,
     CaseTableRowsService,
 )
@@ -156,6 +157,67 @@ async def test_link_row_returns_existing_link_for_duplicate(
     )
     assert second_link.id == first_link.id
     assert count == 1
+
+
+@pytest.mark.anyio
+async def test_link_row_returns_existing_link_when_limit_reached_after_initial_miss(
+    monkeypatch: pytest.MonkeyPatch,
+    session: AsyncSession,
+    cases_service: CasesService,
+    case_rows_service: CaseTableRowsService,
+    tables_service: TablesService,
+) -> None:
+    case = await _create_case(cases_service)
+    table_id, row_id = await _create_table_with_row(
+        tables_service,
+        name=f"case_rows_race_duplicate_{uuid.uuid4().hex[:8]}",
+        value="seed",
+    )
+
+    existing_link = CaseTableRow(
+        workspace_id=case_rows_service.workspace_id,
+        case_id=case.id,
+        table_id=table_id,
+        row_id=row_id,
+    )
+    filler_links = [
+        CaseTableRow(
+            workspace_id=case_rows_service.workspace_id,
+            case_id=case.id,
+            table_id=table_id,
+            row_id=uuid.uuid4(),
+        )
+        for _ in range(MAX_LINKED_ROWS_PER_CASE - 1)
+    ]
+    session.add_all([existing_link, *filler_links])
+    await session.commit()
+    await session.refresh(existing_link)
+
+    original_get_existing_link = case_rows_service._get_existing_link
+    calls = 0
+
+    async def miss_initial_lookup(
+        *, case_id: uuid.UUID, table_id: uuid.UUID, row_id: uuid.UUID
+    ) -> CaseTableRow | None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return None
+        return await original_get_existing_link(
+            case_id=case_id,
+            table_id=table_id,
+            row_id=row_id,
+        )
+
+    monkeypatch.setattr(case_rows_service, "_get_existing_link", miss_initial_lookup)
+
+    link = await case_rows_service.link_row(
+        case=case,
+        params=CaseTableRowLinkCreate(table_id=table_id, row_id=row_id),
+    )
+
+    assert link.id == existing_link.id
+    assert calls == 2
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_case_table_rows_service.py
+++ b/tests/unit/test_case_table_rows_service.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.types import Role
@@ -118,6 +119,43 @@ async def test_link_row_allows_existing_table_when_table_limit_reached(
     assert link.case_id == case.id
     assert link.table_id == first_table_id
     assert link.row_id == extra_row_id
+
+
+@pytest.mark.anyio
+async def test_link_row_returns_existing_link_for_duplicate(
+    session: AsyncSession,
+    cases_service: CasesService,
+    case_rows_service: CaseTableRowsService,
+    tables_service: TablesService,
+) -> None:
+    case = await _create_case(cases_service)
+    table_id, row_id = await _create_table_with_row(
+        tables_service,
+        name=f"case_rows_duplicate_{uuid.uuid4().hex[:8]}",
+        value="seed",
+    )
+
+    first_link = await case_rows_service.link_row(
+        case=case,
+        params=CaseTableRowLinkCreate(table_id=table_id, row_id=row_id),
+    )
+    second_link = await case_rows_service.link_row(
+        case=case,
+        params=CaseTableRowLinkCreate(table_id=table_id, row_id=row_id),
+    )
+
+    count = await session.scalar(
+        select(func.count())
+        .select_from(CaseTableRow)
+        .where(
+            CaseTableRow.workspace_id == case_rows_service.workspace_id,
+            CaseTableRow.case_id == case.id,
+            CaseTableRow.table_id == table_id,
+            CaseTableRow.row_id == row_id,
+        )
+    )
+    assert second_link.id == first_link.id
+    assert count == 1
 
 
 @pytest.mark.anyio

--- a/tracecat/cases/rows/service.py
+++ b/tracecat/cases/rows/service.py
@@ -176,6 +176,13 @@ class CaseTableRowsService(BaseWorkspaceService):
         )
         total_links = int((await self.session.scalar(total_links_stmt)) or 0)
         if total_links >= MAX_LINKED_ROWS_PER_CASE:
+            existing = await self._get_existing_link(
+                case_id=case.id,
+                table_id=table.id,
+                row_id=params.row_id,
+            )
+            if existing is not None:
+                return existing
             raise ValueError(
                 f"A case can have at most {MAX_LINKED_ROWS_PER_CASE} linked rows"
             )
@@ -199,6 +206,13 @@ class CaseTableRowsService(BaseWorkspaceService):
                 (await self.session.scalar(distinct_tables_stmt)) or 0
             )
             if distinct_tables >= MAX_TABLES_PER_CASE:
+                existing = await self._get_existing_link(
+                    case_id=case.id,
+                    table_id=table.id,
+                    row_id=params.row_id,
+                )
+                if existing is not None:
+                    return existing
                 raise ValueError(
                     f"A case can link rows from at most {MAX_TABLES_PER_CASE} tables"
                 )

--- a/tracecat/cases/rows/service.py
+++ b/tracecat/cases/rows/service.py
@@ -10,6 +10,7 @@ import sqlalchemy as sa
 from asyncpg.exceptions import UndefinedTableError
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy import exc as sa_exc
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -37,6 +38,17 @@ class CaseTableRowsService(BaseWorkspaceService):
     def __init__(self, session: AsyncSession, role: Role | None = None):
         super().__init__(session, role)
         self.tables = TablesService(session=self.session, role=self.role)
+
+    async def _get_existing_link(
+        self, *, case_id: uuid.UUID, table_id: uuid.UUID, row_id: uuid.UUID
+    ) -> CaseTableRow | None:
+        stmt = select(CaseTableRow).where(
+            CaseTableRow.workspace_id == self.workspace_id,
+            CaseTableRow.case_id == case_id,
+            CaseTableRow.table_id == table_id,
+            CaseTableRow.row_id == row_id,
+        )
+        return (await self.session.execute(stmt)).scalars().first()
 
     async def list_rows(
         self,
@@ -146,13 +158,11 @@ class CaseTableRowsService(BaseWorkspaceService):
         table = await self.tables.get_table(params.table_id)
         await self.tables.get_row(table, params.row_id)
 
-        dedupe_stmt = select(CaseTableRow).where(
-            CaseTableRow.workspace_id == self.workspace_id,
-            CaseTableRow.case_id == case.id,
-            CaseTableRow.table_id == params.table_id,
-            CaseTableRow.row_id == params.row_id,
+        existing = await self._get_existing_link(
+            case_id=case.id,
+            table_id=params.table_id,
+            row_id=params.row_id,
         )
-        existing = (await self.session.execute(dedupe_stmt)).scalars().first()
         if existing is not None:
             return existing
 
@@ -193,13 +203,32 @@ class CaseTableRowsService(BaseWorkspaceService):
                     f"A case can link rows from at most {MAX_TABLES_PER_CASE} tables"
                 )
 
-        link = CaseTableRow(
-            workspace_id=self.workspace_id,
-            case_id=case.id,
-            table_id=table.id,
-            row_id=params.row_id,
+        stmt = (
+            insert(CaseTableRow)
+            .values(
+                workspace_id=self.workspace_id,
+                case_id=case.id,
+                table_id=table.id,
+                row_id=params.row_id,
+            )
+            .on_conflict_do_nothing(constraint="uq_case_table_row_link")
+            .returning(CaseTableRow.surrogate_id)
         )
-        self.session.add(link)
+        link_surrogate_id = await self.session.scalar(stmt)
+
+        if link_surrogate_id is None:
+            existing = await self._get_existing_link(
+                case_id=case.id,
+                table_id=table.id,
+                row_id=params.row_id,
+            )
+            if existing is not None:
+                return existing
+            raise TracecatNotFoundError("Case row link was not created")
+
+        link = await self.session.get(CaseTableRow, link_surrogate_id)
+        if link is None:
+            raise TracecatNotFoundError("Case row link was not created")
 
         await CaseEventsService(self.session, self.role).create_event(
             case,


### PR DESCRIPTION
## Summary
- make `CaseTableRowsService.link_row` return an existing link for duplicate case/table/row input
- use `ON CONFLICT DO NOTHING` against `uq_case_table_row_link` to avoid duplicate-key 500s under retry/race conditions
- add a regression test that duplicate linking creates one row and returns the original link

## Verification
- `uv run pytest tests/unit/test_case_table_rows_service.py tests/unit/api/test_api_case_rows.py`
- `uv run ruff check tracecat/cases/rows/service.py tests/unit/test_case_table_rows_service.py`
- `uv run basedpyright tracecat/cases/rows/service.py tests/unit/test_case_table_rows_service.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make case row linking idempotent to prevent duplicates and 500s under retries or races, including when link limits are reached. Duplicate case/table/row requests now return the existing link instead of erroring.

- **Bug Fixes**
  - Updated `CaseTableRowsService.link_row` to use Postgres `insert(...).on_conflict_do_nothing` on `uq_case_table_row_link` and to return the existing link even when `MAX_LINKED_ROWS_PER_CASE` or `MAX_TABLES_PER_CASE` are hit.
  - Added regression tests for duplicate linking and limit-reached race scenarios to ensure only one `CaseTableRow` is created and the original link is returned.

<sup>Written for commit 11b1c04827653c7bd4d8313d87fa1c566b20538a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

