### PR TITLE
fix(registry): preserve API error details

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/sdk/client.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/client.py
@@ -190,7 +190,7 @@ class TracecatClient:
         elif status_code == 403:
             raise TracecatAuthError(detail=detail, status_code=403)
         elif status_code == 404:
-            raise TracecatNotFoundError(resource="Resource", identifier=detail)
+            raise TracecatNotFoundError(detail=detail)
         elif status_code == 409:
             raise TracecatConflictError(detail=detail)
         elif status_code in (400, 422):

--- a/packages/tracecat-registry/tracecat_registry/sdk/client.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/client.py
@@ -177,7 +177,11 @@ class TracecatClient:
             return response.text or None
 
         if isinstance(data, dict):
-            return data.get("detail") or data.get("message") or data
+            if "detail" in data:
+                return data["detail"]
+            if "message" in data:
+                return data["message"]
+            return data
         return data
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/packages/tracecat-registry/tracecat_registry/sdk/client.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/client.py
@@ -170,18 +170,20 @@ class TracecatClient:
             headers["Authorization"] = f"Bearer {self._token}"
         return headers
 
+    def _extract_error_detail(self, response: httpx.Response) -> Any | None:
+        try:
+            data = response.json()
+        except Exception:
+            return response.text or None
+
+        if isinstance(data, dict):
+            return data.get("detail") or data.get("message") or data
+        return data
+
     def _handle_error_response(self, response: httpx.Response) -> None:
         """Convert HTTP error responses to SDK exceptions."""
         status_code = response.status_code
-
-        # Try to extract detail from JSON response
-        detail: str | None = None
-        try:
-            data = response.json()
-            if isinstance(data, dict):
-                detail = data.get("detail")
-        except Exception:
-            detail = response.text or None
+        detail = self._extract_error_detail(response)
 
         if status_code == 401:
             raise TracecatAuthError(detail=detail, status_code=401)

--- a/packages/tracecat-registry/tracecat_registry/sdk/client.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/client.py
@@ -177,11 +177,12 @@ class TracecatClient:
             return response.text or None
 
         if isinstance(data, dict):
-            if "detail" in data:
-                return data["detail"]
+            detail = data.get("detail")
+            if detail is not None:
+                return detail
             if "message" in data:
                 return data["message"]
-            return data
+            return None if "detail" in data else data
         return data
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/packages/tracecat-registry/tracecat_registry/sdk/exceptions.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/exceptions.py
@@ -52,10 +52,16 @@ class TracecatAuthError(TracecatAPIError):
 class TracecatNotFoundError(TracecatAPIError):
     """Exception raised when a resource is not found (404)."""
 
-    def __init__(self, resource: str, identifier: str | None = None) -> None:
-        detail = f"{resource} not found"
-        if identifier:
-            detail = f"{resource} '{identifier}' not found"
+    def __init__(
+        self,
+        resource: str = "Resource",
+        identifier: str | None = None,
+        detail: Any | None = None,
+    ) -> None:
+        if detail is None:
+            detail = f"{resource} not found"
+            if identifier:
+                detail = f"{resource} '{identifier}' not found"
         super().__init__(
             message="Resource not found",
             status_code=404,

--- a/packages/tracecat-registry/tracecat_registry/sdk/exceptions.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/exceptions.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from typing import Any
+
 
 class TracecatSDKError(Exception):
     """Base exception for all Tracecat SDK errors."""
@@ -18,7 +21,7 @@ class TracecatAPIError(TracecatSDKError):
         self,
         message: str,
         status_code: int,
-        detail: str | None = None,
+        detail: Any | None = None,
     ) -> None:
         self.status_code = status_code
         self.detail = detail
@@ -26,14 +29,19 @@ class TracecatAPIError(TracecatSDKError):
 
     def __str__(self) -> str:
         if self.detail:
-            return f"{self.message} (status={self.status_code}): {self.detail}"
+            detail = (
+                self.detail
+                if isinstance(self.detail, str)
+                else json.dumps(self.detail, default=str, sort_keys=True)
+            )
+            return f"{self.message} (status={self.status_code}): {detail}"
         return f"{self.message} (status={self.status_code})"
 
 
 class TracecatAuthError(TracecatAPIError):
     """Exception raised for authentication/authorization errors (401, 403)."""
 
-    def __init__(self, detail: str | None = None, status_code: int = 401) -> None:
+    def __init__(self, detail: Any | None = None, status_code: int = 401) -> None:
         super().__init__(
             message="Authentication failed",
             status_code=status_code,
@@ -58,7 +66,7 @@ class TracecatNotFoundError(TracecatAPIError):
 class TracecatValidationError(TracecatAPIError):
     """Exception raised for validation errors (400, 422)."""
 
-    def __init__(self, detail: str | None = None, status_code: int = 400) -> None:
+    def __init__(self, detail: Any | None = None, status_code: int = 400) -> None:
         super().__init__(
             message="Validation error",
             status_code=status_code,
@@ -69,7 +77,7 @@ class TracecatValidationError(TracecatAPIError):
 class TracecatConflictError(TracecatAPIError):
     """Exception raised for conflict errors (409)."""
 
-    def __init__(self, detail: str | None = None) -> None:
+    def __init__(self, detail: Any | None = None) -> None:
         super().__init__(
             message="Conflict",
             status_code=409,

--- a/packages/tracecat-registry/tracecat_registry/sdk/exceptions.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/exceptions.py
@@ -28,7 +28,7 @@ class TracecatAPIError(TracecatSDKError):
         super().__init__(message)
 
     def __str__(self) -> str:
-        if self.detail:
+        if self.detail is not None:
             detail = (
                 self.detail
                 if isinstance(self.detail, str)

--- a/tests/registry/test_sdk_errors.py
+++ b/tests/registry/test_sdk_errors.py
@@ -1,0 +1,31 @@
+import httpx
+import pytest
+from tracecat_registry.sdk.client import TracecatClient
+from tracecat_registry.sdk.exceptions import TracecatAPIError, TracecatValidationError
+
+
+def test_error_response_preserves_message_field() -> None:
+    client = TracecatClient(api_url="http://api", token="", workspace_id="")
+    response = httpx.Response(500, json={"message": "database temporarily unavailable"})
+
+    with pytest.raises(TracecatAPIError) as exc_info:
+        client._handle_error_response(response)
+
+    assert exc_info.value.detail == "database temporarily unavailable"
+    assert "database temporarily unavailable" in str(exc_info.value)
+
+
+def test_error_response_preserves_structured_detail() -> None:
+    client = TracecatClient(api_url="http://api", token="", workspace_id="")
+    detail = {
+        "code": "DATABASE_VALUE_TYPE_MISMATCH",
+        "message": "A field received a value with an incompatible type.",
+    }
+    response = httpx.Response(422, json={"detail": detail})
+
+    with pytest.raises(TracecatValidationError) as exc_info:
+        client._handle_error_response(response)
+
+    assert exc_info.value.detail == detail
+    assert "DATABASE_VALUE_TYPE_MISMATCH" in str(exc_info.value)
+    assert "incompatible type" in str(exc_info.value)

--- a/tests/registry/test_sdk_errors.py
+++ b/tests/registry/test_sdk_errors.py
@@ -1,7 +1,11 @@
 import httpx
 import pytest
 from tracecat_registry.sdk.client import TracecatClient
-from tracecat_registry.sdk.exceptions import TracecatAPIError, TracecatValidationError
+from tracecat_registry.sdk.exceptions import (
+    TracecatAPIError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
 
 
 def test_error_response_preserves_message_field() -> None:
@@ -29,3 +33,15 @@ def test_error_response_preserves_structured_detail() -> None:
     assert exc_info.value.detail == detail
     assert "DATABASE_VALUE_TYPE_MISMATCH" in str(exc_info.value)
     assert "incompatible type" in str(exc_info.value)
+
+
+def test_not_found_response_preserves_message_field() -> None:
+    client = TracecatClient(api_url="http://api", token="", workspace_id="")
+    response = httpx.Response(404, json={"message": "variable not found"})
+
+    with pytest.raises(TracecatNotFoundError) as exc_info:
+        client._handle_error_response(response)
+
+    assert exc_info.value.detail == "variable not found"
+    assert "variable not found" in str(exc_info.value)
+    assert "Resource 'variable not found' not found" not in str(exc_info.value)

--- a/tests/registry/test_sdk_errors.py
+++ b/tests/registry/test_sdk_errors.py
@@ -35,6 +35,24 @@ def test_error_response_preserves_structured_detail() -> None:
     assert "incompatible type" in str(exc_info.value)
 
 
+@pytest.mark.parametrize("detail", ["", [], {}, 0, False])
+def test_error_response_preserves_falsey_detail_field(detail: object) -> None:
+    client = TracecatClient(api_url="http://api", token="", workspace_id="")
+    response = httpx.Response(500, json={"detail": detail, "message": "fallback"})
+
+    with pytest.raises(TracecatAPIError) as exc_info:
+        client._handle_error_response(response)
+
+    assert exc_info.value.detail == detail
+    assert "fallback" not in str(exc_info.value)
+
+
+def test_error_string_renders_empty_structured_detail() -> None:
+    err = TracecatAPIError(message="API request failed", status_code=500, detail={})
+
+    assert str(err) == "API request failed (status=500): {}"
+
+
 def test_not_found_response_preserves_message_field() -> None:
     client = TracecatClient(api_url="http://api", token="", workspace_id="")
     response = httpx.Response(404, json={"message": "variable not found"})

--- a/tests/registry/test_sdk_errors.py
+++ b/tests/registry/test_sdk_errors.py
@@ -47,6 +47,20 @@ def test_error_response_preserves_falsey_detail_field(detail: object) -> None:
     assert "fallback" not in str(exc_info.value)
 
 
+def test_error_response_uses_message_when_detail_is_null() -> None:
+    client = TracecatClient(api_url="http://api", token="", workspace_id="")
+    response = httpx.Response(
+        500,
+        json={"detail": None, "message": "database temporarily unavailable"},
+    )
+
+    with pytest.raises(TracecatAPIError) as exc_info:
+        client._handle_error_response(response)
+
+    assert exc_info.value.detail == "database temporarily unavailable"
+    assert "database temporarily unavailable" in str(exc_info.value)
+
+
 def test_error_string_renders_empty_structured_detail() -> None:
     err = TracecatAPIError(message="API request failed", status_code=500, detail={})
 


### PR DESCRIPTION
## Summary
- preserve API `message` fields when `detail` is absent
- preserve structured API `detail` objects on SDK exceptions
- render non-string details as stable JSON in exception strings so action failures include useful context

## Verification
- `uv run pytest tests/registry/test_sdk_errors.py`
- `uv run ruff check packages/tracecat-registry/tracecat_registry/sdk/client.py packages/tracecat-registry/tracecat_registry/sdk/exceptions.py tests/registry/test_sdk_errors.py`
- `uv run basedpyright packages/tracecat-registry/tracecat_registry/sdk/client.py packages/tracecat-registry/tracecat_registry/sdk/exceptions.py tests/registry/test_sdk_errors.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves API error details in the registry SDK so exceptions include accurate context, including for 404s. We now keep `detail` exactly as sent (even empty/falsey), fall back to `message` only when `detail` is null/absent, and render non-strings as stable JSON for clearer logs.

- **Bug Fixes**
  - Added `_extract_error_detail` to return `detail` when present; if `detail` is null, use `message`; else JSON/body text.
  - `TracecatNotFoundError` now accepts `detail` directly; exceptions accept `detail: Any` and JSON-stringify non-strings with sorted keys.
  - Added tests for null-`detail` fallback, 500/404/422 cases, falsey `detail` values, and empty-object rendering in error strings.

<sup>Written for commit 249ec8a23fe8a9900f9a00ee4f22fa81df219ba2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

