### PR TITLE
infra(fargate): default WAF regex pattern names to name_prefix

### DIFF
--- a/deployments/fargate/modules/ecs/alb.tf
+++ b/deployments/fargate/modules/ecs/alb.tf
@@ -533,7 +533,7 @@ resource "aws_wafv2_web_acl" "this" {
 resource "aws_wafv2_regex_pattern_set" "attachments_endpoint" {
   count = var.enable_waf ? 1 : 0
 
-  name        = var.waf_attachments_endpoint_pattern_name
+  name        = local.waf_attachments_endpoint_pattern_name
   description = "Pattern to match attachments API endpoint"
   scope       = "REGIONAL"
 
@@ -549,7 +549,7 @@ resource "aws_wafv2_regex_pattern_set" "attachments_endpoint" {
 resource "aws_wafv2_regex_pattern_set" "mcp_oauth_endpoints" {
   count = var.enable_waf ? 1 : 0
 
-  name        = var.waf_mcp_oauth_endpoints_pattern_name
+  name        = local.waf_mcp_oauth_endpoints_pattern_name
   description = "Matches MCP OAuth endpoints that carry loopback redirect URIs"
   scope       = "REGIONAL"
 
@@ -567,7 +567,7 @@ resource "aws_wafv2_regex_pattern_set" "mcp_oauth_endpoints" {
 resource "aws_wafv2_regex_pattern_set" "mcp_public_endpoints" {
   count = var.enable_waf ? 1 : 0
 
-  name        = var.waf_mcp_public_endpoint_pattern_name
+  name        = local.waf_mcp_public_endpoint_pattern_name
   description = "Matches MCP discovery, transport, and OAuth endpoints"
   scope       = "REGIONAL"
 

--- a/deployments/fargate/modules/ecs/locals.tf
+++ b/deployments/fargate/modules/ecs/locals.tf
@@ -6,6 +6,13 @@ locals {
   tracecat_migrations_image     = coalesce(var.tracecat_migrations_image, var.tracecat_image)
   tracecat_migrations_image_tag = coalesce(var.tracecat_migrations_image_tag, local.tracecat_image_tag)
 
+  # WAF regex pattern set names. Default to "${name_prefix}-..." so each stack
+  # gets uniquely-named pattern sets within a shared AWS account; explicit
+  # variable values override (e.g. legacy stacks that already own bare names).
+  waf_attachments_endpoint_pattern_name = coalesce(var.waf_attachments_endpoint_pattern_name, "${var.name_prefix}-attachments-endpoint-pattern")
+  waf_mcp_oauth_endpoints_pattern_name  = coalesce(var.waf_mcp_oauth_endpoints_pattern_name, "${var.name_prefix}-mcp-oauth-endpoints-pattern")
+  waf_mcp_public_endpoint_pattern_name  = coalesce(var.waf_mcp_public_endpoint_pattern_name, "${var.name_prefix}-mcp-public-endpoint-pattern")
+
   # Tracecat common URLs
   public_app_url   = "https://${var.domain_name}"
   public_api_url   = "https://${var.domain_name}/api"

--- a/deployments/fargate/modules/ecs/variables.tf
+++ b/deployments/fargate/modules/ecs/variables.tf
@@ -48,20 +48,20 @@ variable "redis_default_user_id" {
 
 variable "waf_attachments_endpoint_pattern_name" {
   type        = string
-  description = "WAF regex pattern set name for attachments endpoint matching."
-  default     = "attachments-endpoint-pattern"
+  description = "WAF regex pattern set name for attachments endpoint matching. When null, defaults to \"$${name_prefix}-attachments-endpoint-pattern\"."
+  default     = null
 }
 
 variable "waf_mcp_oauth_endpoints_pattern_name" {
   type        = string
-  description = "WAF regex pattern set name for MCP OAuth endpoint matching."
-  default     = "mcp-oauth-endpoints-pattern"
+  description = "WAF regex pattern set name for MCP OAuth endpoint matching. When null, defaults to \"$${name_prefix}-mcp-oauth-endpoints-pattern\"."
+  default     = null
 }
 
 variable "waf_mcp_public_endpoint_pattern_name" {
   type        = string
-  description = "WAF regex pattern set name for MCP public endpoint matching."
-  default     = "mcp-public-endpoint-pattern"
+  description = "WAF regex pattern set name for MCP public endpoint matching. When null, defaults to \"$${name_prefix}-mcp-public-endpoint-pattern\"."
+  default     = null
 }
 
 ### Networking

--- a/deployments/fargate/variables.tf
+++ b/deployments/fargate/variables.tf
@@ -48,20 +48,20 @@ variable "redis_default_user_id" {
 
 variable "waf_attachments_endpoint_pattern_name" {
   type        = string
-  description = "WAF regex pattern set name for attachments endpoint matching."
-  default     = "attachments-endpoint-pattern"
+  description = "WAF regex pattern set name for attachments endpoint matching. When null, defaults to \"$${name_prefix}-attachments-endpoint-pattern\"."
+  default     = null
 }
 
 variable "waf_mcp_oauth_endpoints_pattern_name" {
   type        = string
-  description = "WAF regex pattern set name for MCP OAuth endpoint matching."
-  default     = "mcp-oauth-endpoints-pattern"
+  description = "WAF regex pattern set name for MCP OAuth endpoint matching. When null, defaults to \"$${name_prefix}-mcp-oauth-endpoints-pattern\"."
+  default     = null
 }
 
 variable "waf_mcp_public_endpoint_pattern_name" {
   type        = string
-  description = "WAF regex pattern set name for MCP public endpoint matching."
-  default     = "mcp-public-endpoint-pattern"
+  description = "WAF regex pattern set name for MCP public endpoint matching. When null, defaults to \"$${name_prefix}-mcp-public-endpoint-pattern\"."
+  default     = null
 }
 
 ### Networking


### PR DESCRIPTION
## Summary

- WAFv2 regex pattern set names are unique per region, so bare-name defaults like `attachments-endpoint-pattern` collide across stacks that share an AWS account.
- A stack whose existing pattern sets are prefixed (e.g. via `name_prefix`) hits `WAFDuplicateItemException` on apply when a second stack in the same account already owns the bare name. With `create_before_destroy = true` on these resources, the new resource is created first and the duplicate-name error stops the apply.
- Switch the three `waf_*_pattern_name` variables to `null` defaults and resolve them via locals as `coalesce(var, "${name_prefix}-...-pattern")`. This restores per-stack uniqueness by default while keeping the variable as an override for stacks that intentionally use bare names.

## Files changed

- `deployments/fargate/variables.tf` — default the three `waf_*_pattern_name` variables to `null`.
- `deployments/fargate/modules/ecs/variables.tf` — same on the module side.
- `deployments/fargate/modules/ecs/locals.tf` — add three locals that fall back to `"${name_prefix}-...-pattern"`.
- `deployments/fargate/modules/ecs/alb.tf` — three `aws_wafv2_regex_pattern_set` resources reference the new locals; `create_before_destroy = true` retained because the WebACL holds references.

## Test plan

- [ ] `terraform fmt -recursive -check` is clean.
- [ ] On a stack with `name_prefix` set and existing prefixed WAF pattern sets in state: `terraform plan` shows no changes for the three regex pattern set resources.
- [ ] On a stack that wants to keep bare pattern names: setting `waf_*_pattern_name` variables explicitly produces no plan diff.
- [ ] On a stack performing a legitimate rename (different `name_prefix`): apply succeeds via `create_before_destroy` (new prefixed name is unique within the account).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default WAFv2 regex pattern set names to "${name_prefix}-...-pattern" to avoid cross-stack name collisions in shared AWS accounts. Explicit overrides still work for stacks that want bare names.

- **Bug Fixes**
  - Set `waf_*_pattern_name` defaults to null and resolve via locals: `coalesce(var, "${name_prefix}-...-pattern")`.
  - Prevents `WAFDuplicateItemException` when `create_before_destroy = true` and another stack already owns the bare name.
  - `aws_wafv2_regex_pattern_set` now uses locals; no changes for stacks already using prefixed names.

- **Migration**
  - No action needed. To keep bare names, set `waf_attachments_endpoint_pattern_name`, `waf_mcp_oauth_endpoints_pattern_name`, and `waf_mcp_public_endpoint_pattern_name` explicitly.

<sup>Written for commit d3d9dbf1bbf06ca30e0ebf29fab19435aa520ce3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

