### PR TITLE
feat: add basePath support so Tracecat can be served under a sub-path

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -146,6 +146,7 @@
             "pages": [
               "self-hosting/architecture",
               "self-hosting/docker-compose",
+              "self-hosting/sub-path-deployment",
               "self-hosting/aws-fargate",
               "self-hosting/kubernetes",
               "self-hosting/environment-variables",

--- a/docs/self-hosting/docker-compose.mdx
+++ b/docs/self-hosting/docker-compose.mdx
@@ -71,6 +71,12 @@ Once deployed, access your instance at:
 - API docs: `http://localhost:${PUBLIC_APP_PORT}/api/docs`
 - MCP: `http://localhost:${PUBLIC_APP_PORT}/mcp`
 
+<Note>
+  To serve Tracecat under a sub-path of an existing domain (e.g.
+  `https://example.com/tracecat`) behind your own reverse proxy, see
+  [Deploy under a sub-path](/self-hosting/sub-path-deployment).
+</Note>
+
 ## Updating Tracecat
 
 <Warning>

--- a/docs/self-hosting/sub-path-deployment.mdx
+++ b/docs/self-hosting/sub-path-deployment.mdx
@@ -1,0 +1,245 @@
+---
+title: Deploy under a sub-path
+description: "Serve self-hosted Tracecat under a sub-path of an existing domain (e.g. https://example.com/tracecat) behind your own reverse proxy."
+---
+
+By default Tracecat is served at the **root of a domain**
+(`https://tracecat.example.com`). This page describes how to serve it
+under a **sub-path** of an existing domain
+(`https://example.com/tracecat`) instead, alongside another app on the
+same hostname, behind a reverse proxy you already operate.
+
+<Note>
+  Sub-path deployment is opt-in. If you don't set
+  `NEXT_PUBLIC_BASE_PATH` (default), Tracecat keeps serving at the root
+  of the domain — no behaviour change for existing deployments.
+</Note>
+
+## When you should use this
+
+- A primary app already lives at `https://example.com/`.
+- You want to add Tracecat at `https://example.com/tracecat` without
+  introducing a new sub-domain or a new TLS certificate.
+- You operate your own reverse proxy (nginx, Caddy, Traefik, an ingress
+  controller…) in front of the Tracecat services.
+
+If you can give Tracecat its own sub-domain (e.g.
+`tracecat.example.com`), prefer that — sub-domain deployment requires
+no special configuration.
+
+## Configuration overview
+
+Three things change versus a root deployment:
+
+1. The **frontend image** is built with a `NEXT_PUBLIC_BASE_PATH` build
+   argument. Next.js inlines this value into the client bundle, so it
+   has to be set at build time.
+2. The Tracecat-facing URLs (`PUBLIC_APP_URL`, `PUBLIC_API_URL`) carry
+   the sub-path.
+3. Your reverse proxy forwards `/<base-path>/*` to the right backend
+   service, stripping or preserving the prefix depending on the route.
+
+The bundled `Caddyfile` and `docker-compose.yml` ship for the root
+deployment. For sub-path deployment, you bring your own proxy.
+
+## Build the frontend image with a base path
+
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_BASE_PATH=/tracecat \
+  --build-arg NEXT_PUBLIC_APP_URL=https://example.com/tracecat \
+  --build-arg NEXT_PUBLIC_API_URL=https://example.com/tracecat/api \
+  --build-arg NEXT_SERVER_API_URL=http://api:8000 \
+  -f frontend/Dockerfile.prod \
+  -t tracecat-ui:basepath \
+  frontend/
+```
+
+Use the resulting `tracecat-ui:basepath` image in place of
+`ghcr.io/tracecathq/tracecat-ui` in your Compose file.
+
+## Update environment variables
+
+Set these in `.env`:
+
+```bash
+PUBLIC_APP_URL=https://example.com/tracecat
+PUBLIC_API_URL=https://example.com/tracecat/api
+TRACECAT__PUBLIC_APP_URL=https://example.com/tracecat
+TRACECAT__PUBLIC_API_URL=https://example.com/tracecat/api
+TRACECAT__ALLOW_ORIGINS=https://example.com
+```
+
+The session cookie path is automatically scoped to the sub-path on
+`TRACECAT__PUBLIC_APP_URL`, so the cookie does not leak to other apps
+sharing the host.
+
+## Reverse-proxy routing rules
+
+Whichever proxy you use, four rules must hold:
+
+| Path | Forward to | Strip prefix? |
+| :--- | :--------- | :------------ |
+| `/tracecat/api/*` | `api:8000/api/*` | yes — strip `/tracecat` |
+| `/tracecat/s3/*` | `minio:9000/*` | yes — strip `/tracecat/s3` |
+| `/tracecat/*` (everything else) | `ui:3000/tracecat/*` | **no** — keep `/tracecat` |
+| `/tracecat/` (with trailing slash) | redirect to `/tracecat` (without) | — |
+
+The trailing-slash redirect is required because Next.js' default
+behaviour is to strip trailing slashes; without the proxy-side redirect
+you'll see a redirect ping-pong on `/tracecat/`.
+
+The UI prefix must **not** be stripped: the Next.js bundle expects to
+receive the basePath in the request URL (assets included), because
+`basePath` is inlined into the client bundle at build time.
+
+<Note>
+  The **nginx** example below has been tested end-to-end on a live
+  deployment. The **Caddy** and **Traefik** examples are derived from
+  the same routing rules but have not been verified against running
+  instances — please open a PR with corrections if you spot anything
+  off.
+</Note>
+
+### nginx example
+
+```nginx
+# Forward API requests, stripping the /tracecat prefix
+location ^~ /tracecat/api/ {
+    rewrite ^/tracecat(/api/.*)$ $1 break;
+    proxy_pass http://api:8000;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Prefix /tracecat;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_buffering off;       # required for SSE
+    proxy_cache off;
+    chunked_transfer_encoding on;
+}
+
+# Forward MinIO presigned URLs, stripping /tracecat/s3
+location ^~ /tracecat/s3/ {
+    rewrite ^/tracecat/s3/(.*)$ /$1 break;
+    proxy_pass http://minio:9000;
+    proxy_buffering off;
+    proxy_request_buffering off;
+    client_max_body_size 1G;
+}
+
+# Trailing-slash redirect to avoid Next.js ping-pong
+location = /tracecat/ { return 308 /tracecat; }
+
+# Forward everything else under /tracecat to the UI, prefix preserved
+location ^~ /tracecat {
+    proxy_pass http://ui:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Prefix /tracecat;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+}
+```
+
+The `^~` modifier ensures these prefix locations win over any regex
+location elsewhere in the server block (such as a `~* \.js$` rule),
+which is necessary because Next.js asset URLs end in `.js`.
+
+### Caddy example
+
+```caddyfile
+example.com {
+    handle /tracecat/api/* {
+        uri strip_prefix /tracecat
+        reverse_proxy api:8000
+    }
+
+    handle /tracecat/s3/* {
+        uri strip_prefix /tracecat/s3
+        reverse_proxy minio:9000
+    }
+
+    @tracecat_slash path /tracecat/
+    redir @tracecat_slash /tracecat 308
+
+    handle /tracecat* {
+        reverse_proxy ui:3000
+    }
+
+    # …routing rules for the primary app at /
+}
+```
+
+### Traefik example
+
+```yaml
+http:
+  routers:
+    tracecat-api:
+      rule: "Host(`example.com`) && PathPrefix(`/tracecat/api/`)"
+      middlewares:
+        - tracecat-strip-prefix
+      service: tracecat-api
+    tracecat-s3:
+      rule: "Host(`example.com`) && PathPrefix(`/tracecat/s3/`)"
+      middlewares:
+        - tracecat-strip-s3
+      service: tracecat-minio
+    tracecat-ui:
+      rule: "Host(`example.com`) && PathPrefix(`/tracecat`)"
+      service: tracecat-ui
+
+  middlewares:
+    tracecat-strip-prefix:
+      stripPrefix:
+        prefixes: ["/tracecat"]
+    tracecat-strip-s3:
+      stripPrefix:
+        prefixes: ["/tracecat/s3"]
+```
+
+Add a separate router that catches `/tracecat/` (trailing slash) and
+issues a 308 to `/tracecat` to avoid the Next.js ping-pong.
+
+## Update OIDC / SAML provider configuration
+
+If you use OIDC or SAML, update your identity provider's redirect URIs
+to include the sub-path:
+
+- OIDC: `https://example.com/tracecat/auth/oauth/callback`
+- SAML ACS: `https://example.com/tracecat/auth/saml/acs`
+
+## Testing the deployment
+
+```bash
+# UI loads (HTTP 200)
+curl -sS -o /dev/null -w "%{http_code}\n" https://example.com/tracecat
+
+# Trailing-slash redirect (308 to /tracecat)
+curl -sS -o /dev/null -w "%{http_code}\n" https://example.com/tracecat/
+
+# API responds with JSON, public_app_url contains the sub-path
+curl -s https://example.com/tracecat/api/info
+# {"version":"…","public_app_url":"https://example.com/tracecat", …}
+
+# A static asset under /tracecat/_next/static/* loads (HTTP 200)
+curl -sS -o /dev/null -w "%{http_code}\n" \
+  "https://example.com/tracecat/_next/static/chunks/webpack-<hash>.js"
+```
+
+If `public_app_url` in `/api/info` does not include the sub-path, your
+`TRACECAT__PUBLIC_APP_URL` is misconfigured. If a static asset under
+`/tracecat/_next/static/...` returns 404, the `NEXT_PUBLIC_BASE_PATH`
+build arg was missing during `docker build`.
+
+## Limitations
+
+- `basePath` is **inlined into the client bundle at build time**. You
+  cannot switch sub-paths without rebuilding the frontend image — this
+  is a Next.js architectural choice, not a Tracecat one.
+- Switching from a root deployment to a sub-path deployment requires
+  rebuilding the frontend image with the new build args; existing user
+  data, workflows, and credentials are unaffected.

--- a/docs/self-hosting/sub-path-deployment.mdx
+++ b/docs/self-hosting/sub-path-deployment.mdx
@@ -82,8 +82,9 @@ Whichever proxy you use, four rules must hold:
 | :--- | :--------- | :------------ |
 | `/tracecat/api/*` | `api:8000/api/*` | yes — strip `/tracecat` |
 | `/tracecat/s3/*` | `minio:9000/*` | yes — strip `/tracecat/s3` |
-| `/tracecat/*` (everything else) | `ui:3000/tracecat/*` | **no** — keep `/tracecat` |
-| `/tracecat/` (with trailing slash) | redirect to `/tracecat` (without) | — |
+| `/tracecat` (exact match, no slash) | `ui:3000/tracecat` | **no** — keep `/tracecat` |
+| `/tracecat/*` (with slash, everything else) | `ui:3000/tracecat/*` | **no** — keep `/tracecat` |
+| `/tracecat/` (trailing slash exact) | redirect to `/tracecat` (without) | — |
 
 The trailing-slash redirect is required because Next.js' default
 behaviour is to strip trailing slashes; without the proxy-side redirect
@@ -92,6 +93,14 @@ you'll see a redirect ping-pong on `/tracecat/`.
 The UI prefix must **not** be stripped: the Next.js bundle expects to
 receive the basePath in the request URL (assets included), because
 `basePath` is inlined into the client bundle at build time.
+
+<Warning>
+  Match `/tracecat` and `/tracecat/*` as **two distinct rules** rather
+  than a single broad `/tracecat*` prefix. A broad prefix would also
+  capture sibling paths like `/tracecatfoo` and misroute them to
+  Tracecat — harmless on a host where Tracecat is alone, but a real
+  routing bug on a host shared with another app.
+</Warning>
 
 <Note>
   The **nginx** example below has been tested end-to-end on a live
@@ -129,11 +138,22 @@ location ^~ /tracecat/s3/ {
     client_max_body_size 1G;
 }
 
+# UI — exact /tracecat (no slash)
+location = /tracecat {
+    proxy_pass http://ui:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Prefix /tracecat;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+}
+
 # Trailing-slash redirect to avoid Next.js ping-pong
 location = /tracecat/ { return 308 /tracecat; }
 
-# Forward everything else under /tracecat to the UI, prefix preserved
-location ^~ /tracecat {
+# UI — everything under /tracecat/ (note the slash, not /tracecat*)
+location ^~ /tracecat/ {
     proxy_pass http://ui:3000;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
@@ -146,7 +166,9 @@ location ^~ /tracecat {
 
 The `^~` modifier ensures these prefix locations win over any regex
 location elsewhere in the server block (such as a `~* \.js$` rule),
-which is necessary because Next.js asset URLs end in `.js`.
+which is necessary because Next.js asset URLs end in `.js`. The
+trailing slash on `/tracecat/` is what bounds the prefix correctly
+— without it, `/tracecatfoo` would also match.
 
 ### Caddy example
 
@@ -165,7 +187,15 @@ example.com {
     @tracecat_slash path /tracecat/
     redir @tracecat_slash /tracecat 308
 
-    handle /tracecat* {
+    # Two distinct matchers — `/tracecat` exact and `/tracecat/*` —
+    # rather than a broad `/tracecat*` that would also catch
+    # /tracecatfoo and misroute it to the UI.
+    @tracecat_exact path /tracecat
+    handle @tracecat_exact {
+        reverse_proxy ui:3000
+    }
+
+    handle /tracecat/* {
         reverse_proxy ui:3000
     }
 
@@ -178,18 +208,26 @@ example.com {
 ```yaml
 http:
   routers:
+    # API — strip /tracecat then forward
     tracecat-api:
       rule: "Host(`example.com`) && PathPrefix(`/tracecat/api/`)"
-      middlewares:
-        - tracecat-strip-prefix
+      middlewares: [tracecat-strip-prefix]
       service: tracecat-api
+
+    # MinIO — strip /tracecat/s3 then forward
     tracecat-s3:
       rule: "Host(`example.com`) && PathPrefix(`/tracecat/s3/`)"
-      middlewares:
-        - tracecat-strip-s3
+      middlewares: [tracecat-strip-s3]
       service: tracecat-minio
-    tracecat-ui:
-      rule: "Host(`example.com`) && PathPrefix(`/tracecat`)"
+
+    # UI — exact /tracecat (no slash) and /tracecat/* explicitly,
+    # rather than a broad PathPrefix(`/tracecat`) that would also
+    # match /tracecatfoo on some Traefik versions.
+    tracecat-ui-exact:
+      rule: "Host(`example.com`) && Path(`/tracecat`)"
+      service: tracecat-ui
+    tracecat-ui-prefix:
+      rule: "Host(`example.com`) && PathPrefix(`/tracecat/`)"
       service: tracecat-ui
 
   middlewares:
@@ -201,8 +239,8 @@ http:
         prefixes: ["/tracecat/s3"]
 ```
 
-Add a separate router that catches `/tracecat/` (trailing slash) and
-issues a 308 to `/tracecat` to avoid the Next.js ping-pong.
+Add a separate router that catches `/tracecat/` (trailing slash exact)
+and issues a 308 to `/tracecat` to avoid the Next.js ping-pong.
 
 ## Update OIDC / SAML provider configuration
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -26,6 +26,9 @@ ARG NEXT_PUBLIC_APP_ENV=production
 ARG NEXT_PUBLIC_APP_URL=http://localhost:3000
 ARG NEXT_PUBLIC_API_URL=http://localhost:8000
 ARG NEXT_SERVER_API_URL=http://api:8000
+# Optional sub-path prefix (e.g. /tracecat) to serve the app under a reverse-proxy
+# path. Inlined into client bundles by Next.js — must be set at build time.
+ARG NEXT_PUBLIC_BASE_PATH=
 
 # Set environment variables
 ENV NODE_ENV=production
@@ -33,6 +36,7 @@ ENV NEXT_PUBLIC_APP_ENV=$NEXT_PUBLIC_APP_ENV
 ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV NEXT_SERVER_API_URL=$NEXT_SERVER_API_URL
+ENV NEXT_PUBLIC_BASE_PATH=$NEXT_PUBLIC_BASE_PATH
 
 # Copy node_modules from the deps stage
 COPY --from=deps /app/node_modules ./node_modules

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,8 +1,16 @@
 /** @type {import('next').NextConfig} */
 
+// Optional path prefix for serving the app behind a reverse proxy at a sub-path
+// (e.g. NEXT_PUBLIC_BASE_PATH=/tracecat to serve under https://example.com/tracecat).
+// Must be set at build time — Next.js inlines this value into client bundles.
+// Empty string (default) means the app is served at the domain root.
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ""
+
 const nextConfig = {
   reactStrictMode: true, // Default to true; overridden in development
   output: "standalone", // Ensure standalone output for production
+  basePath,
+  assetPrefix: basePath || undefined,
   experimental: {
     optimizePackageImports: ["lucide-react"],
     serverActions: {

--- a/frontend/src/app/auth/oauth/callback/route.ts
+++ b/frontend/src/app/auth/oauth/callback/route.ts
@@ -6,6 +6,7 @@ import {
   serializeClearPostAuthReturnUrlCookie,
 } from "@/lib/auth-return-url"
 import { buildUrl } from "@/lib/ss-utils"
+import { buildAppUrl } from "@/lib/url-utils"
 
 /**
  * @param request
@@ -32,7 +33,7 @@ export const GET = async (request: NextRequest) => {
     )
     const resp = await fetch(buildUrl("/info"))
     const { public_app_url } = await resp.json()
-    return NextResponse.redirect(new URL("/auth/error", public_app_url))
+    return NextResponse.redirect(buildAppUrl("/auth/error", public_app_url))
   }
 
   // Get redirect
@@ -42,13 +43,13 @@ export const GET = async (request: NextRequest) => {
 
   if (!setCookieHeader) {
     console.error("No set-cookie header found in response")
-    return NextResponse.redirect(new URL("/auth/error", public_app_url))
+    return NextResponse.redirect(buildAppUrl("/auth/error", public_app_url))
   }
 
   const targetPath = getPostAuthDecisionPath(returnUrl)
   console.log(`Redirecting to ${targetPath}`)
   const redirectResponse = NextResponse.redirect(
-    new URL(targetPath, public_app_url)
+    buildAppUrl(targetPath, public_app_url)
   )
   redirectResponse.headers.append("set-cookie", setCookieHeader)
   redirectResponse.headers.append(

--- a/frontend/src/app/auth/saml/acs/route.ts
+++ b/frontend/src/app/auth/saml/acs/route.ts
@@ -6,6 +6,7 @@ import {
   serializeClearPostAuthReturnUrlCookie,
 } from "@/lib/auth-return-url"
 import { buildUrl } from "@/lib/ss-utils"
+import { buildAppUrl } from "@/lib/url-utils"
 
 /**
  * @param request
@@ -29,7 +30,7 @@ export async function POST(request: NextRequest) {
 
   if (!samlResponse) {
     console.error("No SAML response found in the request")
-    return NextResponse.redirect(new URL("/auth/error", public_app_url))
+    return NextResponse.redirect(buildAppUrl("/auth/error", public_app_url))
   }
 
   // Prepare the request to the FastAPI backend
@@ -57,19 +58,19 @@ export async function POST(request: NextRequest) {
 
   if (!backendResponse.ok) {
     console.error("Error from backend:", await backendResponse.text())
-    return NextResponse.redirect(new URL("/auth/error", public_app_url))
+    return NextResponse.redirect(buildAppUrl("/auth/error", public_app_url))
   }
 
   const setCookieHeader = backendResponse.headers.get("set-cookie")
 
   if (!setCookieHeader) {
     console.error("No set-cookie header found in response")
-    return NextResponse.redirect(new URL("/auth/error", public_app_url))
+    return NextResponse.redirect(buildAppUrl("/auth/error", public_app_url))
   }
 
   const targetPath = getPostAuthDecisionPath(returnUrl)
   console.log(`Redirecting to ${targetPath} with GET`)
-  const redirectUrl = new URL(targetPath, public_app_url)
+  const redirectUrl = buildAppUrl(targetPath, public_app_url)
   const redirectResponse = NextResponse.redirect(redirectUrl, {
     status: 303, // Force GET request
   })

--- a/frontend/src/app/integrations/callback/route.ts
+++ b/frontend/src/app/integrations/callback/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 
 import { buildUrl } from "@/lib/ss-utils"
+import { buildAppUrl } from "@/lib/url-utils"
 import { isIntegrationOAuthCallback } from "@/lib/utils"
 
 export const GET = async (request: NextRequest) => {
@@ -46,7 +47,10 @@ export const GET = async (request: NextRequest) => {
   if (error) {
     console.error("OAuth error received:", error, errorDescription)
     // Redirect to OAuth error page with error details
-    const errorUrl = new URL("/integrations/error", await resolvePublicAppUrl())
+    const errorUrl = buildAppUrl(
+      "/integrations/error",
+      await resolvePublicAppUrl()
+    )
     errorUrl.searchParams.set("error", error)
     if (errorDescription) {
       errorUrl.searchParams.set("error_description", errorDescription)
@@ -58,7 +62,7 @@ export const GET = async (request: NextRequest) => {
   if (!request.nextUrl.searchParams.get("code") || !state) {
     console.error("Missing code or state in request")
     return NextResponse.redirect(
-      new URL("/auth/error", await resolvePublicAppUrl())
+      buildAppUrl("/auth/error", await resolvePublicAppUrl())
     )
   }
 
@@ -69,7 +73,7 @@ export const GET = async (request: NextRequest) => {
   if (!cookie) {
     console.error("Missing cookie in request")
     return NextResponse.redirect(
-      new URL("/auth/error", await resolvePublicAppUrl())
+      buildAppUrl("/auth/error", await resolvePublicAppUrl())
     )
   }
 
@@ -84,7 +88,7 @@ export const GET = async (request: NextRequest) => {
   if (!isIntegrationOAuthCallback(cb)) {
     console.error("Invalid integration callback", cb)
     return NextResponse.redirect(
-      new URL("/auth/error", await resolvePublicAppUrl())
+      buildAppUrl("/auth/error", await resolvePublicAppUrl())
     )
   }
   const { redirect_url } = cb

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -26,13 +26,17 @@ if (process.env.NEXT_PUBLIC_APP_ENV === "production") {
   PHProvider = require("@/providers/posthog").PHProvider
   console.log("PostHog initialized for production environment.")
 }
+// Favicons live under the public/ folder. Next.js does not auto-prefix the
+// `metadata.icons` paths with basePath, so we do it manually when configured.
+const faviconBase = process.env.NEXT_PUBLIC_BASE_PATH || ""
+
 export const metadata: Metadata = {
   title: siteConfig.name,
   description: siteConfig.description,
   icons: {
-    icon: "/favicon.png",
-    shortcut: "/favicon.png",
-    apple: "/apple-touch-icon.png",
+    icon: `${faviconBase}/favicon.png`,
+    shortcut: `${faviconBase}/favicon.png`,
+    apple: `${faviconBase}/apple-touch-icon.png`,
   },
 }
 

--- a/frontend/src/app/oauth/mcp/continue/page.tsx
+++ b/frontend/src/app/oauth/mcp/continue/page.tsx
@@ -5,6 +5,7 @@ import { Suspense, useEffect } from "react"
 
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { useAuth } from "@/hooks/use-auth"
+import { getBaseUrl } from "@/lib/api"
 
 /**
  * MCP auth resume page.
@@ -29,7 +30,8 @@ function McpAuthContinueContent() {
 
     if (user) {
       // Already logged in — resume the authorization flow.
-      window.location.href = `/api/oauth/mcp/authorize/resume?txn=${encodeURIComponent(txnId)}`
+      // Use getBaseUrl() so the path honours basePath when configured.
+      window.location.href = `${getBaseUrl()}/oauth/mcp/authorize/resume?txn=${encodeURIComponent(txnId)}`
       return
     }
 

--- a/frontend/src/app/organization/vcs/github/install/route.ts
+++ b/frontend/src/app/organization/vcs/github/install/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 
 import { buildUrl } from "@/lib/ss-utils"
+import { buildAppUrl } from "@/lib/url-utils"
 
 export const GET = async (request: NextRequest) => {
   console.log("GET /organization/vcs/github/install")
@@ -34,6 +35,6 @@ export const GET = async (request: NextRequest) => {
   const resp = await fetch(buildUrl("/info"))
   const { public_app_url } = await resp.json()
   console.log("Public app URL", public_app_url)
-  const redirect_url = new URL("/organization/vcs", public_app_url)
+  const redirect_url = buildAppUrl("/organization/vcs", public_app_url)
   return NextResponse.redirect(redirect_url)
 }

--- a/frontend/src/components/admin/admin-org-invitations-dialog.tsx
+++ b/frontend/src/components/admin/admin-org-invitations-dialog.tsx
@@ -60,7 +60,9 @@ const ROLE_OPTIONS: Array<{ label: string; value: PlatformRoleSlug }> = [
 
 function invitationUrl(token: string) {
   const origin = typeof window === "undefined" ? "" : window.location.origin
-  return `${origin}/invitations/accept?token=${encodeURIComponent(token)}`
+  // Honour basePath when the app is served under a sub-path (e.g. /tracecat).
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ""
+  return `${origin}${basePath}/invitations/accept?token=${encodeURIComponent(token)}`
 }
 
 function statusVariant(status: AdminOrgInvitationRead["status"]) {

--- a/frontend/src/components/auth/sign-in.tsx
+++ b/frontend/src/components/auth/sign-in.tsx
@@ -33,6 +33,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { toast } from "@/components/ui/use-toast"
 import { useAuthActions } from "@/hooks/use-auth"
+import { getBaseUrl } from "@/lib/api"
 import { setPostAuthReturnUrlCookie, startOidcLogin } from "@/lib/auth-login"
 import { sanitizeReturnUrl } from "@/lib/auth-return-url"
 import { useAppInfo } from "@/lib/hooks"
@@ -65,7 +66,9 @@ async function startSamlLogin(
 ): Promise<void> {
   // Use the org-scoped next_url from discovery when available so the
   // backend can resolve the correct organization for SAML login.
-  const loginUrl = nextUrl ?? "/api/auth/saml/login"
+  // When basePath is set, we must hit ${baseUrl}/auth/... (baseUrl already
+  // contains the /api segment); a bare "/api/..." would bypass basePath.
+  const loginUrl = nextUrl ?? `${getBaseUrl()}/auth/saml/login`
   const res = await fetch(loginUrl, { credentials: "include" })
   if (!res.ok) {
     throw new Error(`SAML login request failed: ${res.status}`)

--- a/frontend/src/components/auth/sign-up.tsx
+++ b/frontend/src/components/auth/sign-up.tsx
@@ -187,9 +187,15 @@ interface BasicRegistrationFormProps {
 function extractInvitationToken(returnUrl: string | null): string | null {
   if (!returnUrl) return null
   try {
-    // returnUrl might be like "/invitations/accept?token=abc123"
+    // returnUrl might be like "/invitations/accept?token=abc123" or
+    // "/tracecat/invitations/accept?token=abc123" when basePath is configured.
     const url = new URL(returnUrl, window.location.origin)
-    if (url.pathname === "/invitations/accept") {
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ""
+    const expectedPaths = new Set(["/invitations/accept"])
+    if (basePath) {
+      expectedPaths.add(`${basePath}/invitations/accept`)
+    }
+    if (expectedPaths.has(url.pathname)) {
       return url.searchParams.get("token")
     }
   } catch {

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -727,7 +727,10 @@ function ActionSessionLiveStream({ sessionId }: { sessionId: string }) {
     return new DefaultChatTransport({
       credentials: "include",
       prepareReconnectToStreamRequest: ({ id }) => {
-        const url = new URL(`/api/agent/sessions/${id}/stream`, getBaseUrl())
+        // getBaseUrl() can include a sub-path (e.g. /tracecat/api when basePath
+        // is configured); URL constructor with a leading "/" path would strip
+        // that sub-path. We build the URL by appending to the base instead.
+        const url = new URL(`${getBaseUrl()}/agent/sessions/${id}/stream`)
         url.searchParams.set("workspace_id", workspaceId)
         return {
           api: url.toString(),

--- a/frontend/src/components/organization/org-members-table.tsx
+++ b/frontend/src/components/organization/org-members-table.tsx
@@ -394,7 +394,11 @@ export function OrgMembersTable() {
                                         await organizationGetInvitationToken({
                                           invitationId: member.invitation_id,
                                         })
-                                      const url = `${window.location.origin}/invitations/accept?token=${token}`
+                                      // Honour basePath when the app is served
+                                      // under a sub-path (e.g. /tracecat).
+                                      const basePath =
+                                        process.env.NEXT_PUBLIC_BASE_PATH || ""
+                                      const url = `${window.location.origin}${basePath}/invitations/accept?token=${token}`
                                       await navigator.clipboard.writeText(url)
                                       toast({
                                         title: "Copied",

--- a/frontend/src/components/organization/workspace-mcp-access.tsx
+++ b/frontend/src/components/organization/workspace-mcp-access.tsx
@@ -177,7 +177,9 @@ function buildMcpUrl(publicAppUrl?: string): string {
     return `${publicAppUrl.replace(/\/$/, "")}/mcp`
   }
   if (typeof window !== "undefined") {
-    return `${window.location.origin}/mcp`
+    // Honour basePath when the app is served under a sub-path.
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ""
+    return `${window.location.origin}${basePath}/mcp`
   }
   return "https://<tracecat-app-url>/mcp"
 }

--- a/frontend/src/components/sidebar/app-menu.tsx
+++ b/frontend/src/components/sidebar/app-menu.tsx
@@ -7,8 +7,10 @@ import {
   Plus,
   RadarIcon,
 } from "lucide-react"
+import Image from "next/image"
 import Link from "next/link"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import TracecatIcon from "public/icon.png"
 import { useState } from "react"
 import { useScopeCheck } from "@/components/auth/scope-guard"
 import { Button } from "@/components/ui/button"
@@ -113,7 +115,11 @@ export function AppMenu({ workspaceId }: { workspaceId: string }) {
               size="default"
               className="data-[state=open]:bg-foreground/5 dark:data-[state=open]:bg-foreground/10 pl-0"
             >
-              <img src="/icon.png" alt="Tracecat" className="size-6 ml-0.5" />
+              <Image
+                src={TracecatIcon}
+                alt="Tracecat"
+                className="size-6 ml-0.5"
+              />
               <span className="truncate font-semibold text-zinc-700 dark:text-zinc-300">
                 {activeWorkspace?.name || "Select workspace"}
               </span>

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -391,7 +391,10 @@ export function useVercelChat({
   // Build the Vercel streaming endpoint URL
   const apiEndpoint = useMemo(() => {
     if (!chatId) return ""
-    const url = new URL(`/api/agent/sessions/${chatId}/messages`, getBaseUrl())
+    // getBaseUrl() can include a sub-path (e.g. /tracecat/api when basePath is
+    // configured); URL constructor with a leading "/" path would strip that
+    // sub-path. We build the URL by appending to the base instead.
+    const url = new URL(`${getBaseUrl()}/agent/sessions/${chatId}/messages`)
     url.searchParams.set("workspace_id", workspaceId)
     return url.toString()
   }, [chatId, workspaceId])

--- a/frontend/src/lib/auth-return-url.test.ts
+++ b/frontend/src/lib/auth-return-url.test.ts
@@ -87,3 +87,56 @@ describe("normalizeMcpAuthReturnUrl", () => {
     expect(normalizeMcpAuthReturnUrl("/workspaces/default")).toBeNull()
   })
 })
+
+describe("with NEXT_PUBLIC_BASE_PATH set", () => {
+  const originalBasePath = process.env.NEXT_PUBLIC_BASE_PATH
+
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/tracecat"
+  })
+
+  afterAll(() => {
+    if (originalBasePath === undefined) {
+      delete process.env.NEXT_PUBLIC_BASE_PATH
+    } else {
+      process.env.NEXT_PUBLIC_BASE_PATH = originalBasePath
+    }
+  })
+
+  it.each([
+    "/tracecat/sign-in",
+    "/tracecat/sign-in/reset-password",
+    "/tracecat/sign-up",
+    "/tracecat/auth",
+    "/tracecat/auth/oauth/callback",
+  ])(
+    "rejects basePath-prefixed auth routes for %s (cannot bypass block via prefix)",
+    (value) => {
+      expect(sanitizeReturnUrl(value)).toBeNull()
+    }
+  )
+
+  it("keeps basePath-prefixed internal routes intact", () => {
+    expect(sanitizeReturnUrl("/tracecat/workspaces/123?tab=members")).toBe(
+      "/tracecat/workspaces/123?tab=members"
+    )
+  })
+
+  it("normalizes basePath-prefixed MCP continuation paths", () => {
+    expect(
+      normalizeMcpAuthReturnUrl("/tracecat/oauth/mcp/continue?txn=abc123")
+    ).toBe("/tracecat/oauth/mcp/continue?txn=abc123")
+  })
+
+  it("rewrites basePath-prefixed legacy MCP paths to canonical (unprefixed) target", () => {
+    // The canonical target is intentionally unprefixed: it is later passed
+    // to <Link>/router.push which auto-apply the basePath.
+    expect(
+      normalizeMcpAuthReturnUrl("/tracecat/oauth/mcp/select-org?txn=abc123")
+    ).toBe("/oauth/mcp/continue?txn=abc123")
+  })
+
+  it("still accepts unprefixed paths so legacy URLs keep working", () => {
+    expect(sanitizeReturnUrl("/workspaces/123")).toBe("/workspaces/123")
+  })
+})

--- a/frontend/src/lib/auth-return-url.ts
+++ b/frontend/src/lib/auth-return-url.ts
@@ -10,13 +10,50 @@ const BLOCKED_POST_AUTH_RETURN_URL_PREFIXES = [
 const MCP_AUTH_CONTINUE_PATH = "/oauth/mcp/continue"
 const MCP_AUTH_LEGACY_SELECT_ORG_PATH = "/oauth/mcp/select-org"
 
+/**
+ * Resolve the Next.js basePath at call time (not at module load) so tests can
+ * override `process.env.NEXT_PUBLIC_BASE_PATH` between cases.
+ */
+function getBasePath(): string {
+  return process.env.NEXT_PUBLIC_BASE_PATH || ""
+}
+
+/**
+ * Strip the configured Next.js basePath from a pathname so the rest of this
+ * module can compare against unprefixed canonical paths regardless of whether
+ * the URL was generated with or without the basePath.
+ */
+function stripBasePath(pathname: string): string {
+  const basePath = getBasePath()
+  if (!basePath) {
+    return pathname
+  }
+  if (pathname === basePath) {
+    return "/"
+  }
+  if (pathname.startsWith(`${basePath}/`)) {
+    return pathname.slice(basePath.length)
+  }
+  return pathname
+}
+
+/**
+ * Cookie path scope so the auth return-url cookie is only sent on requests
+ * that actually go to the Tracecat app (not to other apps sharing the host).
+ */
+function cookiePath(): string {
+  return getBasePath() || "/"
+}
+
 function getPostAuthReturnUrlCookieSameSite(secure: boolean): "None" | "Lax" {
   // Cross-site POSTs (SAML ACS) require SameSite=None; browsers require Secure with None.
   return secure ? "None" : "Lax"
 }
 
 function isBlockedPostAuthReturnPath(pathname: string): boolean {
-  const normalizedPathname = pathname.toLowerCase()
+  // Strip the basePath so a returnUrl like "/tracecat/sign-in" cannot bypass
+  // the block by exploiting the prefix.
+  const normalizedPathname = stripBasePath(pathname).toLowerCase()
   return BLOCKED_POST_AUTH_RETURN_URL_PREFIXES.some(
     (prefix) =>
       normalizedPathname === prefix ||
@@ -42,10 +79,13 @@ export function normalizeMcpAuthReturnUrl(
     if (!parsed.searchParams.get("txn")) {
       return null
     }
-    if (parsed.pathname === MCP_AUTH_CONTINUE_PATH) {
+    // Compare against the unprefixed pathname so URLs generated with or
+    // without basePath both match.
+    const canonical = stripBasePath(parsed.pathname)
+    if (canonical === MCP_AUTH_CONTINUE_PATH) {
       return `${parsed.pathname}${parsed.search}${parsed.hash}`
     }
-    if (parsed.pathname === MCP_AUTH_LEGACY_SELECT_ORG_PATH) {
+    if (canonical === MCP_AUTH_LEGACY_SELECT_ORG_PATH) {
       return `${MCP_AUTH_CONTINUE_PATH}${parsed.search}${parsed.hash}`
     }
     return null
@@ -79,7 +119,7 @@ export function sanitizeReturnUrl(
     if (mcpAuthReturnUrl) {
       return mcpAuthReturnUrl
     }
-    if (parsed.pathname === MCP_AUTH_LEGACY_SELECT_ORG_PATH) {
+    if (stripBasePath(parsed.pathname) === MCP_AUTH_LEGACY_SELECT_ORG_PATH) {
       return null
     }
     return normalizedValue
@@ -108,11 +148,11 @@ export function serializePostAuthReturnUrlCookie(
 ): string {
   const sameSite = getPostAuthReturnUrlCookieSameSite(secure)
   const secureAttr = secure ? "; Secure" : ""
-  return `${POST_AUTH_RETURN_URL_COOKIE_NAME}=${encodeURIComponent(value)}; Path=/; Max-Age=${POST_AUTH_RETURN_URL_COOKIE_MAX_AGE_SECONDS}; SameSite=${sameSite}${secureAttr}`
+  return `${POST_AUTH_RETURN_URL_COOKIE_NAME}=${encodeURIComponent(value)}; Path=${cookiePath()}; Max-Age=${POST_AUTH_RETURN_URL_COOKIE_MAX_AGE_SECONDS}; SameSite=${sameSite}${secureAttr}`
 }
 
 export function serializeClearPostAuthReturnUrlCookie(secure: boolean): string {
   const sameSite = getPostAuthReturnUrlCookieSameSite(secure)
   const secureAttr = secure ? "; Secure" : ""
-  return `${POST_AUTH_RETURN_URL_COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=${sameSite}${secureAttr}`
+  return `${POST_AUTH_RETURN_URL_COOKIE_NAME}=; Path=${cookiePath()}; Max-Age=0; SameSite=${sameSite}${secureAttr}`
 }

--- a/frontend/src/lib/url-utils.test.ts
+++ b/frontend/src/lib/url-utils.test.ts
@@ -1,0 +1,36 @@
+import { buildAppUrl } from "@/lib/url-utils"
+
+describe("buildAppUrl", () => {
+  it("preserves a sub-path on the base URL", () => {
+    const url = buildAppUrl("/auth/error", "https://example.com/tracecat")
+    expect(url.toString()).toBe("https://example.com/tracecat/auth/error")
+  })
+
+  it("works with a base URL that has no sub-path", () => {
+    const url = buildAppUrl("/auth/error", "https://example.com")
+    expect(url.toString()).toBe("https://example.com/auth/error")
+  })
+
+  it("normalises a trailing slash on the base", () => {
+    const url = buildAppUrl("/auth/error", "https://example.com/tracecat/")
+    expect(url.toString()).toBe("https://example.com/tracecat/auth/error")
+  })
+
+  it("accepts a path without a leading slash", () => {
+    const url = buildAppUrl("auth/error", "https://example.com/tracecat")
+    expect(url.toString()).toBe("https://example.com/tracecat/auth/error")
+  })
+
+  it("keeps query parameters and fragments on the base", () => {
+    const url = buildAppUrl("/auth/error", "https://example.com/tracecat")
+    url.searchParams.set("error", "invalid")
+    expect(url.toString()).toBe(
+      "https://example.com/tracecat/auth/error?error=invalid"
+    )
+  })
+
+  it("supports a deeper sub-path on the base", () => {
+    const url = buildAppUrl("/auth/error", "https://example.com/foo/bar/baz")
+    expect(url.toString()).toBe("https://example.com/foo/bar/baz/auth/error")
+  })
+})

--- a/frontend/src/lib/url-utils.ts
+++ b/frontend/src/lib/url-utils.ts
@@ -1,0 +1,28 @@
+/**
+ * URL helpers that respect the Next.js `basePath` configuration when building
+ * absolute URLs from a public app URL and an in-app path.
+ *
+ * The native `new URL("/foo", base)` constructor replaces the path of `base`
+ * with the leading-slash argument, dropping any sub-path that may be part of
+ * the base (e.g. when serving the app under `https://example.com/tracecat`).
+ * The helpers below preserve that sub-path so generated URLs stay reachable.
+ */
+
+/**
+ * Append `path` to `base`, preserving any sub-path on `base`.
+ *
+ * @param path - In-app path that should be relative to the app root, with or
+ *   without a leading slash (e.g. "/auth/error" or "auth/error").
+ * @param base - Absolute URL that may include a sub-path
+ *   (e.g. "https://example.com/tracecat").
+ * @returns An absolute `URL` object that targets the requested in-app path.
+ *
+ * @example
+ *   buildAppUrl("/auth/error", "https://example.com/tracecat")
+ *   // → URL("https://example.com/tracecat/auth/error")
+ */
+export function buildAppUrl(path: string, base: string): URL {
+  const trimmedBase = base.replace(/\/+$/, "")
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`
+  return new URL(`${trimmedBase}${trimmedPath}`)
+}

--- a/frontend/tests/auth-ui-matrix.test.tsx
+++ b/frontend/tests/auth-ui-matrix.test.tsx
@@ -169,6 +169,9 @@ jest.mock("@/client", () => {
     authDiscoverAuthMethod: jest.fn(),
     authOauthOidcDatabaseAuthorize: jest.fn(),
     ApiError: MockApiError,
+    // Required by lib/api.ts (transitively imported via sign-in.tsx after the
+    // basePath patch added a getBaseUrl() call there).
+    OpenAPI: { BASE: "", WITH_CREDENTIALS: false },
   }
 })
 

--- a/tracecat/auth/users.py
+++ b/tracecat/auth/users.py
@@ -5,6 +5,7 @@ import uuid
 from collections.abc import AsyncGenerator, Iterable, Sequence
 from datetime import UTC, datetime
 from typing import Annotated
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
@@ -564,9 +565,25 @@ def _get_cookie_name() -> str:
     return "fastapiusersauth"
 
 
+def _get_cookie_path() -> str:
+    """Cookie path scope, derived from PUBLIC_APP_URL.
+
+    When the app is served under a sub-path (e.g. https://example.com/tracecat),
+    the auth cookie should only be sent on requests that go to /tracecat/* —
+    not on every request to example.com — so it doesn't leak into other apps
+    sharing the same host.
+    """
+    try:
+        path = urlparse(config.TRACECAT__PUBLIC_APP_URL).path.rstrip("/")
+    except Exception:
+        path = ""
+    return path or "/"
+
+
 cookie_transport = CookieTransport(
     cookie_name=_get_cookie_name(),
     cookie_max_age=config.SESSION_EXPIRE_TIME_SECONDS,
+    cookie_path=_get_cookie_path(),
     cookie_secure=config.TRACECAT__API_URL.startswith("https"),
 )
 


### PR DESCRIPTION
Fixes #2652

# Add `basePath` support so Tracecat can be served under a sub-path

## Why

Today Tracecat assumes it is served at the **root** of a domain
(`https://example.com`). For users who want to host it behind an existing
reverse proxy alongside other apps under a single domain (e.g.
`https://example.com/tracecat`), Next.js' `basePath` config is the canonical
solution but has never been wired in. The cookie scope, several hard-coded
absolute paths, and a few `new URL("/...", base)` constructions also break
silently as soon as the app is served under a sub-path.

This PR threads `basePath` end-to-end via a single `NEXT_PUBLIC_BASE_PATH`
build arg (defaulting to `""`) and fixes every spot where a hard-coded
absolute path or path-replacing `new URL` would otherwise drop the
sub-path.

**No behaviour change for existing root deployments.** When
`NEXT_PUBLIC_BASE_PATH` is empty, all helpers no-op and every patched site
behaves exactly as before.

## What's in this PR

Three commits, individually reviewable:

1. **`feat(frontend): add basePath support via NEXT_PUBLIC_BASE_PATH`**
   - `next.config.mjs`: set `basePath` and `assetPrefix` from
     `NEXT_PUBLIC_BASE_PATH`.
   - `Dockerfile.prod`: new `ARG NEXT_PUBLIC_BASE_PATH` so the value is
     inlined at build time (Next.js requires this — basePath is not a
     runtime config).
   - New helper `lib/url-utils.ts` exposing `buildAppUrl(path, base)` which
     appends a path to a base URL while preserving any sub-path on the
     base — the inverse of what `new URL(path, base)` does with a
     leading-slash path.
   - Client-side fixes: streaming chat URLs, SAML login URL, MCP OAuth
     resume URL, sidebar logo `<img>` → `next/image`, favicon metadata,
     invitation links, `usePathname`-style return-URL comparisons, and
     the post-auth return-url cookie scope.

2. **`fix(frontend): make auth route handlers basePath-aware`**
   - `auth/oauth/callback`, `auth/saml/acs`, `integrations/callback`,
     `organization/vcs/github/install`: replace
     `new URL("/auth/error", public_app_url)` with
     `buildAppUrl("/auth/error", public_app_url)` so the basePath on
     `public_app_url` is preserved.

3. **`fix(auth): scope CookieTransport cookie_path to PUBLIC_APP_URL sub-path`**
   - Backend: derive `cookie_path` from `TRACECAT__PUBLIC_APP_URL` so the
     fastapi-users session cookie is scoped to the sub-path instead of
     leaking to other apps on the same host. Mirrors how `cookie_secure`
     is already derived from `TRACECAT__API_URL` on the same call.

4. **`docs(self-hosting): add sub-path deployment guide`**
   - New page `docs/self-hosting/sub-path-deployment.mdx` covering when
     to use sub-path vs sub-domain, the build-arg, the env vars, the
     reverse-proxy routing rules with worked examples (nginx tested,
     Caddy/Traefik unverified), OIDC/SAML redirect URI update, and
     limitations. Cross-link added from the existing docker-compose
     page.

## How to use

For a root deployment (existing behaviour): nothing to do. `basePath`
defaults to `""`.

For a sub-path deployment under `/tracecat`:

```sh
docker build \
  --build-arg NEXT_PUBLIC_BASE_PATH=/tracecat \
  --build-arg NEXT_PUBLIC_APP_URL=https://example.com/tracecat \
  --build-arg NEXT_PUBLIC_API_URL=https://example.com/tracecat/api \
  --build-arg NEXT_SERVER_API_URL=http://api:8000 \
  -f frontend/Dockerfile.prod -t tracecat-ui:basepath frontend/
```

…and have the reverse proxy forward `/tracecat/api/*` and `/tracecat/s3/*`
to the API and MinIO respectively (stripping the `/tracecat` prefix), and
`/tracecat/*` to the UI as-is. One thing to keep in mind regardless of
which proxy you use: ensure `/tracecat/` (with trailing slash) is
redirected to `/tracecat` (without), to avoid a redirect ping-pong with
Next.js' default trailing-slash strip.

## Iterations and verification procedure

The PR was developed incrementally. The methodology:

1. **Wire `basePath` and `assetPrefix`**, build, deploy under a reverse
   proxy. The login page renders, but the workspace builder breaks at the
   first SSE reconnect because `new URL("/api/agent/sessions/<id>/stream",
   getBaseUrl())` silently strips the `/api` sub-path on `getBaseUrl()`.
2. **Fix the streaming URL constructions**, ship, click around the
   workspace UI page-by-page (workflows, runs, cases, tables, variables,
   credentials, integrations, members, MCP, admin console). Sidebar logo
   shows a 404 — `<img src="/icon.png">` was raw HTML, not `next/image`.
3. **Replace the raw `<img>`** with `next/image`. Audit the rest of the
   layout: favicon `metadata.icons` paths are not prefixed either.
4. **Manage invitations dialog** generates a link without basePath; same
   in the org members table action menu. **Patch the invitation link
   builders.**
5. **Auth routes (sign-up, sign-in)**: the `extractInvitationToken` and
   `sanitizeReturnUrl` helpers compare `pathname === "/invitations/accept"`
   etc. — these accept the unprefixed form but reject the prefixed one,
   and worse, would let `"/tracecat/sign-in"` slip past the auth-route
   block intended to prevent redirect loops. **Make these comparisons
   strip basePath first.**
6. **Server-side route handlers (OAuth/SAML/integrations callbacks):**
   their redirect targets use `new URL("/auth/error", public_app_url)`
   which silently drops the `/tracecat` sub-path. **Introduce
   `buildAppUrl` and replace.**
7. **Cookies:** the post-auth return-url cookie and the fastapi-users
   session cookie both default to `Path=/`, leaking across apps sharing
   the host. **Scope to the sub-path.**
8. After each iteration, run a pattern-by-pattern grep across
   `frontend/src/` for the next category of bug:
   `new URL("/...", base)`, hard-coded `fetch("/api/...")`,
   `window.location.origin + path`, `<img src="/...">`, `<script src="/...">`,
   `<a href="/...">`, hard-coded `pathname.startsWith`/`includes`,
   `redirect("/...")`, raw `NextResponse.redirect`, server-side cookie
   helpers, MCP-related URLs. The scan eventually came up clean —
   everything else in the codebase already routes through `<Link>`,
   `router.push()`, `redirect()` (all auto-prefixed by Next.js when
   `basePath` is set), or through `getBaseUrl()` / `TRACECAT__PUBLIC_APP_URL`
   string-concatenation (which preserve the sub-path).

### Tests

Built on top of the **existing Jest suite** rather than introducing a new
framework:

- 6 new unit tests for `buildAppUrl` (base with/without sub-path, trailing
  slash, missing leading slash, query-params propagation, deep
  sub-paths).
- 7 new unit tests in `auth-return-url.test.ts` covering basePath-aware
  behaviour (cannot bypass the auth-route block via prefixing,
  basePath-prefixed MCP continuation paths normalise correctly,
  unprefixed legacy URLs keep working, etc.). To make these mockable, the
  module reads `process.env.NEXT_PUBLIC_BASE_PATH` lazily via a small
  `getBasePath()` helper instead of capturing it at module load.
- One mock fixture extended in `tests/auth-ui-matrix.test.tsx` because
  `lib/api.ts` is now imported transitively through `sign-in.tsx` and
  the existing `@/client` mock didn't expose `OpenAPI.{BASE,
  WITH_CREDENTIALS}`.

Verification ran in containers (no host pollution):

| Check | Result |
| --- | --- |
| `pnpm exec biome check src/` | No issues |
| `pnpm exec tsc --noEmit` | No errors |
| `pnpm exec jest` | 67 suites, **361 tests**, all passing |
| `ruff check tracecat/auth/users.py` | All checks passed |
| `ruff format --check tracecat/auth/users.py` | Already formatted |

End-to-end smoke test on a live deployment under a sub-path: SSO via an
external OIDC provider, workspace navigation, workflow creation and
execution against a remote LLM, invitation creation + self-acceptance
flow, cookie scoping verified in browser dev tools.

## Documentation

A new page `docs/self-hosting/sub-path-deployment.mdx` walks through the
end-to-end setup: build args, env vars, reverse-proxy routing rules
(table + nginx / Caddy / Traefik examples), OIDC/SAML redirect URI
updates, verification commands, and limitations. A cross-link is added
from the existing `docker-compose.mdx` so users discover it naturally.
Only the nginx example was verified end-to-end on a live deployment;
the Caddy and Traefik examples are noted as unverified and invite
corrections.

## What this PR does NOT do

- It does not change anything when `NEXT_PUBLIC_BASE_PATH` is unset.
  Every patched site is a no-op for `basePath = ""`.

## Disclosure

Written with Claude Code, supervised by a developer with deep backend
experience. Every iteration above was driven by a concrete bug
reproduced on a running deployment — not by guesswork. Even so, only the
maintainers can judge whether each change fits the codebase's existing
conventions; please flag anything off and I'll rework it.
