### PR TITLE
fix(ui): Add Enter organization action

### DIFF
--- a/frontend/src/app/admin/organizations/page.tsx
+++ b/frontend/src/app/admin/organizations/page.tsx
@@ -4,9 +4,12 @@ import { AdminOrganizationsTable } from "@/components/admin/admin-organizations-
 import { CreateOrganizationDialog } from "@/components/admin/create-organization-dialog"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { useAdminOrganizations } from "@/hooks/use-admin"
+import { useAppInfo } from "@/lib/hooks"
 
 export default function AdminOrganizationsPage() {
   const { isLoading, error } = useAdminOrganizations()
+  const { appInfo } = useAppInfo()
+  const multiTenantEnabled = appInfo?.ee_multi_tenant === true
 
   if (isLoading) {
     return <CenteredSpinner />
@@ -33,7 +36,7 @@ export default function AdminOrganizationsPage() {
             </p>
           </div>
           <div className="ml-auto flex items-center space-x-2">
-            <CreateOrganizationDialog />
+            {multiTenantEnabled && <CreateOrganizationDialog />}
           </div>
         </div>
         <AdminOrganizationsTable />

--- a/frontend/src/components/admin/admin-org-delete-dialog.tsx
+++ b/frontend/src/components/admin/admin-org-delete-dialog.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { useState } from "react"
+import type { tracecat_ee__admin__organizations__schemas__OrgRead as OrgRead } from "@/client"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Input } from "@/components/ui/input"
+import { useAdminOrganizations } from "@/hooks/use-admin"
+
+/**
+ * Confirmation dialog for deleting an organization. Owns the confirmation
+ * input state and the delete mutation. Rendered only when there is an org
+ * staged for deletion, so the dialog tree is absent when no delete is in
+ * flight (and absent entirely in single-tenant mode, where the trigger
+ * for staging an org is hidden).
+ */
+export function AdminOrgDeleteDialog({
+  org,
+  open,
+  onOpenChange,
+}: {
+  org: OrgRead
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const [confirmation, setConfirmation] = useState("")
+  const { deleteOrganization } = useAdminOrganizations({ enabled: false })
+
+  const handleDelete = async () => {
+    if (confirmation.trim() !== org.name) {
+      return
+    }
+    try {
+      await deleteOrganization({
+        orgId: org.id,
+        confirmation: confirmation.trim(),
+      })
+    } catch (error) {
+      console.error("Failed to delete organization", error)
+    } finally {
+      setConfirmation("")
+      onOpenChange(false)
+    }
+  }
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          setConfirmation("")
+        }
+        onOpenChange(next)
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete organization</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete the organization &quot;{org.name}
+            &quot;? This action cannot be undone and will delete all associated
+            data.
+          </AlertDialogDescription>
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              Type <span className="font-medium">{org.name}</span> to confirm.
+            </p>
+            <Input
+              value={confirmation}
+              onChange={(event) => setConfirmation(event.target.value)}
+              placeholder={org.name}
+              autoComplete="off"
+            />
+          </div>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={confirmation.trim() !== org.name}
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/src/components/admin/admin-organizations-table.tsx
+++ b/frontend/src/components/admin/admin-organizations-table.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
+import Cookies from "js-cookie"
 import { useRouter } from "next/navigation"
 import { useState } from "react"
 import type { tracecat_ee__admin__organizations__schemas__OrgRead as OrgRead } from "@/client"
@@ -209,7 +210,19 @@ export function AdminOrganizationsTable() {
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
                       <DropdownMenuItem
-                        onSelect={() => router.push("/workspaces")}
+                        onSelect={() => {
+                          Cookies.set(
+                            "tracecat:active-org-id",
+                            row.original.id,
+                            {
+                              sameSite: "lax",
+                              secure:
+                                typeof window !== "undefined" &&
+                                window.location.protocol === "https:",
+                            }
+                          )
+                          router.push("/workspaces")
+                        }}
                       >
                         Enter organization
                       </DropdownMenuItem>

--- a/frontend/src/components/admin/admin-organizations-table.tsx
+++ b/frontend/src/components/admin/admin-organizations-table.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
 import { useAdminOrganizations, useAdminOrgTiers } from "@/hooks/use-admin"
+import { useAppInfo } from "@/lib/hooks"
 
 export function AdminOrganizationsTable() {
   const [editOrgId, setEditOrgId] = useState<string | null>(null)
@@ -46,6 +47,8 @@ export function AdminOrganizationsTable() {
   const [selectedOrg, setSelectedOrg] = useState<OrgRead | null>(null)
   const [deleteConfirmation, setDeleteConfirmation] = useState("")
   const router = useRouter()
+  const { appInfo } = useAppInfo()
+  const multiTenantEnabled = appInfo?.ee_multi_tenant === true
   const { organizations, deleteOrganization } = useAdminOrganizations()
   const orgIds = organizations?.map((org) => org.id) ?? []
   const { orgTiersByOrgId, isLoading: orgTiersLoading } =
@@ -259,16 +262,20 @@ export function AdminOrganizationsTable() {
                       >
                         Manage registry
                       </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <AlertDialogTrigger asChild>
-                        <DropdownMenuItem
-                          className="text-rose-500 focus:text-rose-600"
-                          onClick={() => setSelectedOrg(row.original)}
-                          onSelect={() => setDeleteConfirmation("")}
-                        >
-                          Delete organization
-                        </DropdownMenuItem>
-                      </AlertDialogTrigger>
+                      {multiTenantEnabled && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <AlertDialogTrigger asChild>
+                            <DropdownMenuItem
+                              className="text-rose-500 focus:text-rose-600"
+                              onClick={() => setSelectedOrg(row.original)}
+                              onSelect={() => setDeleteConfirmation("")}
+                            >
+                              Delete organization
+                            </DropdownMenuItem>
+                          </AlertDialogTrigger>
+                        </>
+                      )}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 )

--- a/frontend/src/components/admin/admin-organizations-table.tsx
+++ b/frontend/src/components/admin/admin-organizations-table.tsx
@@ -5,6 +5,7 @@ import Cookies from "js-cookie"
 import { useRouter } from "next/navigation"
 import { useState } from "react"
 import type { tracecat_ee__admin__organizations__schemas__OrgRead as OrgRead } from "@/client"
+import { AdminOrgDeleteDialog } from "@/components/admin/admin-org-delete-dialog"
 import { AdminOrgDomainsDialog } from "@/components/admin/admin-org-domains-dialog"
 import { AdminOrgInvitationsDialog } from "@/components/admin/admin-org-invitations-dialog"
 import { AdminOrgRegistryDialog } from "@/components/admin/admin-org-registry-dialog"
@@ -15,17 +16,6 @@ import {
   DataTableColumnHeader,
   type DataTableToolbarProps,
 } from "@/components/data-table"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -34,7 +24,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { Input } from "@/components/ui/input"
 import { useAdminOrganizations, useAdminOrgTiers } from "@/hooks/use-admin"
 import { useAppInfo } from "@/lib/hooks"
 
@@ -44,281 +33,214 @@ export function AdminOrganizationsTable() {
   const [domainsOrgId, setDomainsOrgId] = useState<string | null>(null)
   const [invitationsOrgId, setInvitationsOrgId] = useState<string | null>(null)
   const [registryOrgId, setRegistryOrgId] = useState<string | null>(null)
-  const [selectedOrg, setSelectedOrg] = useState<OrgRead | null>(null)
-  const [deleteConfirmation, setDeleteConfirmation] = useState("")
+  const [deleteOrg, setDeleteOrg] = useState<OrgRead | null>(null)
   const router = useRouter()
   const { appInfo } = useAppInfo()
   const multiTenantEnabled = appInfo?.ee_multi_tenant === true
-  const { organizations, deleteOrganization } = useAdminOrganizations()
+  const { organizations } = useAdminOrganizations()
   const orgIds = organizations?.map((org) => org.id) ?? []
   const { orgTiersByOrgId, isLoading: orgTiersLoading } =
     useAdminOrgTiers(orgIds)
 
-  const handleDeleteOrganization = async () => {
-    if (selectedOrg && deleteConfirmation.trim() === selectedOrg.name) {
-      try {
-        await deleteOrganization({
-          orgId: selectedOrg.id,
-          confirmation: deleteConfirmation.trim(),
-        })
-      } catch (error) {
-        console.error("Failed to delete organization", error)
-      } finally {
-        setSelectedOrg(null)
-        setDeleteConfirmation("")
-      }
-    }
-  }
-
   return (
     <>
-      <AlertDialog
-        onOpenChange={(isOpen) => {
-          if (!isOpen) {
-            setSelectedOrg(null)
-            setDeleteConfirmation("")
-          }
-        }}
-      >
-        <DataTable
-          data={organizations ?? []}
-          initialSortingState={[{ id: "name", desc: false }]}
-          columns={[
-            {
-              accessorKey: "name",
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Name"
-                />
-              ),
-              cell: ({ row }) => (
-                <button
-                  type="button"
-                  className="text-xs font-medium hover:underline"
-                  onClick={() => setEditOrgId(row.original.id)}
-                >
-                  {row.getValue<OrgRead["name"]>("name")}
-                </button>
-              ),
-              enableSorting: true,
-              enableHiding: false,
-            },
-            {
-              accessorKey: "slug",
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Slug"
-                />
-              ),
-              cell: ({ row }) => (
-                <div className="text-xs font-mono text-muted-foreground">
-                  {row.getValue<OrgRead["slug"]>("slug")}
-                </div>
-              ),
-              enableSorting: true,
-              enableHiding: false,
-            },
-            {
-              id: "tier",
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Tier"
-                />
-              ),
-              cell: ({ row }) => {
-                const orgTier = orgTiersByOrgId.get(row.original.id)
-                const tier = orgTier?.tier
+      <DataTable
+        data={organizations ?? []}
+        initialSortingState={[{ id: "name", desc: false }]}
+        columns={[
+          {
+            accessorKey: "name",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Name"
+              />
+            ),
+            cell: ({ row }) => (
+              <button
+                type="button"
+                className="text-xs font-medium hover:underline"
+                onClick={() => setEditOrgId(row.original.id)}
+              >
+                {row.getValue<OrgRead["name"]>("name")}
+              </button>
+            ),
+            enableSorting: true,
+            enableHiding: false,
+          },
+          {
+            accessorKey: "slug",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Slug"
+              />
+            ),
+            cell: ({ row }) => (
+              <div className="text-xs font-mono text-muted-foreground">
+                {row.getValue<OrgRead["slug"]>("slug")}
+              </div>
+            ),
+            enableSorting: true,
+            enableHiding: false,
+          },
+          {
+            id: "tier",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Tier"
+              />
+            ),
+            cell: ({ row }) => {
+              const orgTier = orgTiersByOrgId.get(row.original.id)
+              const tier = orgTier?.tier
 
-                if (tier) {
-                  return (
-                    <div className="flex items-center gap-2 text-xs">
-                      <span className="font-medium">{tier.display_name}</span>
-                    </div>
-                  )
-                }
-
-                if (orgTiersLoading) {
-                  return (
-                    <span className="text-xs text-muted-foreground">
-                      Loading...
-                    </span>
-                  )
-                }
-
+              if (tier) {
                 return (
-                  <span className="text-xs text-muted-foreground">Default</span>
-                )
-              },
-              enableSorting: false,
-              enableHiding: false,
-            },
-            {
-              accessorKey: "is_active",
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Active"
-                />
-              ),
-              cell: ({ row }) => (
-                <div className="text-xs">
-                  {row.getValue<OrgRead["is_active"]>("is_active")
-                    ? "Active"
-                    : "Inactive"}
-                </div>
-              ),
-              enableSorting: true,
-              enableHiding: false,
-            },
-            {
-              accessorKey: "created_at",
-              header: ({ column }) => (
-                <DataTableColumnHeader
-                  className="text-xs"
-                  column={column}
-                  title="Created"
-                />
-              ),
-              cell: ({ row }) => {
-                const createdAt =
-                  row.getValue<OrgRead["created_at"]>("created_at")
-                const date = new Date(createdAt)
-                return (
-                  <div className="text-xs text-muted-foreground">
-                    {date.toLocaleDateString()}
+                  <div className="flex items-center gap-2 text-xs">
+                    <span className="font-medium">{tier.display_name}</span>
                   </div>
                 )
-              },
-              enableSorting: true,
-              enableHiding: false,
-            },
-            {
-              id: "actions",
-              enableHiding: false,
-              cell: ({ row }) => {
-                return (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" className="size-8 p-0">
-                        <span className="sr-only">Open menu</span>
-                        <DotsHorizontalIcon className="size-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem
-                        onSelect={() => {
-                          Cookies.set(
-                            "tracecat:active-org-id",
-                            row.original.id,
-                            {
-                              sameSite: "lax",
-                              secure:
-                                typeof window !== "undefined" &&
-                                window.location.protocol === "https:",
-                            }
-                          )
-                          router.push("/workspaces")
-                        }}
-                      >
-                        Enter organization
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        onClick={() =>
-                          navigator.clipboard.writeText(row.original.id)
-                        }
-                      >
-                        Copy ID
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onSelect={() => setEditOrgId(row.original.id)}
-                      >
-                        Edit organization
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onSelect={() => setTierOrgId(row.original.id)}
-                      >
-                        Manage tier
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onSelect={() => setDomainsOrgId(row.original.id)}
-                      >
-                        Manage domains
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onSelect={() => setInvitationsOrgId(row.original.id)}
-                      >
-                        Manage invitations
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onSelect={() => setRegistryOrgId(row.original.id)}
-                      >
-                        Manage registry
-                      </DropdownMenuItem>
-                      {multiTenantEnabled && (
-                        <>
-                          <DropdownMenuSeparator />
-                          <AlertDialogTrigger asChild>
-                            <DropdownMenuItem
-                              className="text-rose-500 focus:text-rose-600"
-                              onClick={() => setSelectedOrg(row.original)}
-                              onSelect={() => setDeleteConfirmation("")}
-                            >
-                              Delete organization
-                            </DropdownMenuItem>
-                          </AlertDialogTrigger>
-                        </>
-                      )}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )
-              },
-            },
-          ]}
-          toolbarProps={defaultToolbarProps}
-        />
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete organization</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete the organization &quot;
-              {selectedOrg?.name}&quot;? This action cannot be undone and will
-              delete all associated data.
-            </AlertDialogDescription>
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground">
-                Type <span className="font-medium">{selectedOrg?.name}</span> to
-                confirm.
-              </p>
-              <Input
-                value={deleteConfirmation}
-                onChange={(event) => setDeleteConfirmation(event.target.value)}
-                placeholder={selectedOrg?.name ?? ""}
-                autoComplete="off"
-              />
-            </div>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              variant="destructive"
-              onClick={handleDeleteOrganization}
-              disabled={
-                !selectedOrg || deleteConfirmation.trim() !== selectedOrg.name
               }
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+
+              if (orgTiersLoading) {
+                return (
+                  <span className="text-xs text-muted-foreground">
+                    Loading...
+                  </span>
+                )
+              }
+
+              return (
+                <span className="text-xs text-muted-foreground">Default</span>
+              )
+            },
+            enableSorting: false,
+            enableHiding: false,
+          },
+          {
+            accessorKey: "is_active",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Active"
+              />
+            ),
+            cell: ({ row }) => (
+              <div className="text-xs">
+                {row.getValue<OrgRead["is_active"]>("is_active")
+                  ? "Active"
+                  : "Inactive"}
+              </div>
+            ),
+            enableSorting: true,
+            enableHiding: false,
+          },
+          {
+            accessorKey: "created_at",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Created"
+              />
+            ),
+            cell: ({ row }) => {
+              const createdAt =
+                row.getValue<OrgRead["created_at"]>("created_at")
+              const date = new Date(createdAt)
+              return (
+                <div className="text-xs text-muted-foreground">
+                  {date.toLocaleDateString()}
+                </div>
+              )
+            },
+            enableSorting: true,
+            enableHiding: false,
+          },
+          {
+            id: "actions",
+            enableHiding: false,
+            cell: ({ row }) => {
+              return (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" className="size-8 p-0">
+                      <span className="sr-only">Open menu</span>
+                      <DotsHorizontalIcon className="size-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      onSelect={() => {
+                        Cookies.set("tracecat:active-org-id", row.original.id, {
+                          sameSite: "lax",
+                          secure:
+                            typeof window !== "undefined" &&
+                            window.location.protocol === "https:",
+                        })
+                        router.push("/workspaces")
+                      }}
+                    >
+                      Enter organization
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onClick={() =>
+                        navigator.clipboard.writeText(row.original.id)
+                      }
+                    >
+                      Copy ID
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={() => setEditOrgId(row.original.id)}
+                    >
+                      Edit organization
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={() => setTierOrgId(row.original.id)}
+                    >
+                      Manage tier
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={() => setDomainsOrgId(row.original.id)}
+                    >
+                      Manage domains
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={() => setInvitationsOrgId(row.original.id)}
+                    >
+                      Manage invitations
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={() => setRegistryOrgId(row.original.id)}
+                    >
+                      Manage registry
+                    </DropdownMenuItem>
+                    {multiTenantEnabled && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          className="text-rose-500 focus:text-rose-600"
+                          onSelect={() => setDeleteOrg(row.original)}
+                        >
+                          Delete organization
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )
+            },
+          },
+        ]}
+        toolbarProps={defaultToolbarProps}
+      />
       {editOrgId && (
         <AdminOrganizationEditDialog
           orgId={editOrgId}
@@ -352,6 +274,17 @@ export function AdminOrganizationsTable() {
           orgId={registryOrgId}
           open
           onOpenChange={() => setRegistryOrgId(null)}
+        />
+      )}
+      {deleteOrg && (
+        <AdminOrgDeleteDialog
+          org={deleteOrg}
+          open
+          onOpenChange={(open) => {
+            if (!open) {
+              setDeleteOrg(null)
+            }
+          }}
         />
       )}
     </>

--- a/frontend/src/components/admin/admin-organizations-table.tsx
+++ b/frontend/src/components/admin/admin-organizations-table.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { DotsHorizontalIcon } from "@radix-ui/react-icons"
+import { useRouter } from "next/navigation"
 import { useState } from "react"
 import type { tracecat_ee__admin__organizations__schemas__OrgRead as OrgRead } from "@/client"
 import { AdminOrgDomainsDialog } from "@/components/admin/admin-org-domains-dialog"
@@ -43,6 +44,7 @@ export function AdminOrganizationsTable() {
   const [registryOrgId, setRegistryOrgId] = useState<string | null>(null)
   const [selectedOrg, setSelectedOrg] = useState<OrgRead | null>(null)
   const [deleteConfirmation, setDeleteConfirmation] = useState("")
+  const router = useRouter()
   const { organizations, deleteOrganization } = useAdminOrganizations()
   const orgIds = organizations?.map((org) => org.id) ?? []
   const { orgTiersByOrgId, isLoading: orgTiersLoading } =
@@ -206,6 +208,12 @@ export function AdminOrganizationsTable() {
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onSelect={() => router.push("/workspaces")}
+                      >
+                        Enter organization
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
                       <DropdownMenuItem
                         onClick={() =>
                           navigator.clipboard.writeText(row.original.id)

--- a/frontend/src/components/sidebar/admin-sidebar.tsx
+++ b/frontend/src/components/sidebar/admin-sidebar.tsx
@@ -92,7 +92,7 @@ export function AdminSidebar({
             <SidebarMenuButton asChild>
               <Link href="/workspaces" className="text-muted-foreground">
                 <ChevronLeftIcon />
-                <span>Admin console</span>
+                <span>Back to workspaces</span>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/frontend/src/components/sidebar/admin-sidebar.tsx
+++ b/frontend/src/components/sidebar/admin-sidebar.tsx
@@ -4,7 +4,6 @@ import {
   BookOpenIcon,
   BotIcon,
   BuildingIcon,
-  ChevronLeftIcon,
   LayersIcon,
   LogOutIcon,
   UsersIcon,
@@ -19,7 +18,6 @@ import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
-  SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -86,18 +84,6 @@ export function AdminSidebar({
 
   return (
     <Sidebar collapsible="offcanvas" variant="inset" {...props}>
-      <SidebarHeader>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton asChild>
-              <Link href="/workspaces" className="text-muted-foreground">
-                <ChevronLeftIcon />
-                <span>Back to workspaces</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupLabel>Platform</SidebarGroupLabel>

--- a/frontend/src/components/sidebar/sidebar-user-nav.tsx
+++ b/frontend/src/components/sidebar/sidebar-user-nav.tsx
@@ -18,7 +18,6 @@ import {
 import { siteConfig } from "@/config/site"
 import { useAuth } from "@/hooks/use-auth"
 import { useOrganization } from "@/hooks/use-organization"
-import { useAppInfo } from "@/lib/hooks"
 
 type SidebarUserNavManageItem = {
   title: string
@@ -37,9 +36,6 @@ export function SidebarUserNav({
   const { user } = useAuth()
   const { setOpen } = useSettingsModal()
   const { organization, isLoading } = useOrganization()
-  const { appInfo } = useAppInfo()
-  const multiTenantEnabled = appInfo?.ee_multi_tenant ?? true
-  const adminUrl = multiTenantEnabled ? "/admin" : "/admin/registry"
 
   return (
     <SidebarMenu>
@@ -73,7 +69,7 @@ export function SidebarUserNav({
           <Tooltip>
             <TooltipTrigger asChild>
               <SidebarMenuButton asChild>
-                <Link href={adminUrl}>
+                <Link href="/admin">
                   <ShieldCheckIcon className="size-4" />
                   <span>Admin</span>
                 </Link>

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useQuery, useQueryClient } from "@tanstack/react-query"
+import Cookies from "js-cookie"
 import { useRouter } from "next/navigation"
 import { useCallback } from "react"
 import {
@@ -33,6 +34,7 @@ export function useAuthActions() {
   const logout = useCallback(
     async (redirectUrl?: string) => {
       const logoutResponse = await authAuthDatabaseLogout()
+      Cookies.remove("tracecat:active-org-id")
       await queryClient.invalidateQueries({
         queryKey: ["auth"],
       })

--- a/tests/unit/test_active_org_cookie.py
+++ b/tests/unit/test_active_org_cookie.py
@@ -1,0 +1,169 @@
+"""Tests for the tracecat:active-org-id cookie honored by _resolve_org_for_regular_user."""
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.credentials import (
+    ACTIVE_ORG_COOKIE,
+    _resolve_org_for_regular_user,
+)
+from tracecat.auth.schemas import UserRole
+from tracecat.db.models import (
+    Organization,
+    OrganizationMembership,
+    User,
+)
+
+
+def _request_with_cookie(value: str | None) -> Request:
+    request = MagicMock(spec=Request)
+    request.cookies = {ACTIVE_ORG_COOKIE: value} if value is not None else {}
+    return request
+
+
+async def _seed_user(session: AsyncSession, *, is_superuser: bool = False) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"active-org-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hashed",
+        role=UserRole.BASIC,
+        is_active=True,
+        is_superuser=is_superuser,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def _seed_org(session: AsyncSession, slug_prefix: str) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        name=f"Org {slug_prefix}",
+        slug=f"{slug_prefix}-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    session.add(org)
+    await session.flush()
+    return org
+
+
+async def _add_membership(
+    session: AsyncSession, *, user_id: uuid.UUID, organization_id: uuid.UUID
+) -> None:
+    session.add(
+        OrganizationMembership(user_id=user_id, organization_id=organization_id)
+    )
+    await session.flush()
+
+
+@pytest.mark.anyio
+async def test_cookie_honored_when_user_is_member(session: AsyncSession) -> None:
+    user = await _seed_user(session)
+    org_a = await _seed_org(session, "a")
+    org_b = await _seed_org(session, "b")
+    await _add_membership(session, user_id=user.id, organization_id=org_a.id)
+    await _add_membership(session, user_id=user.id, organization_id=org_b.id)
+
+    request = _request_with_cookie(str(org_b.id))
+    resolved = await _resolve_org_for_regular_user(request, session, user)
+    assert resolved == org_b.id
+
+
+@pytest.mark.anyio
+async def test_cookie_ignored_when_user_is_not_member(session: AsyncSession) -> None:
+    """Untrusted cookie must not grant access to an org the user does not belong to."""
+    user = await _seed_user(session)
+    org_a = await _seed_org(session, "a")
+    other_org = await _seed_org(session, "other")
+    await _add_membership(session, user_id=user.id, organization_id=org_a.id)
+
+    request = _request_with_cookie(str(other_org.id))
+    resolved = await _resolve_org_for_regular_user(request, session, user)
+    # Falls through to the user's only real membership.
+    assert resolved == org_a.id
+
+
+@pytest.mark.anyio
+async def test_cookie_ignored_when_user_is_not_member_multi_org_falls_through_to_400(
+    session: AsyncSession,
+) -> None:
+    user = await _seed_user(session)
+    org_a = await _seed_org(session, "a")
+    org_b = await _seed_org(session, "b")
+    other_org = await _seed_org(session, "other")
+    await _add_membership(session, user_id=user.id, organization_id=org_a.id)
+    await _add_membership(session, user_id=user.id, organization_id=org_b.id)
+
+    request = _request_with_cookie(str(other_org.id))
+    with pytest.raises(HTTPException) as exc:
+        await _resolve_org_for_regular_user(request, session, user)
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Multiple organizations found" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_cookie_ignored_for_garbage_value(session: AsyncSession) -> None:
+    user = await _seed_user(session)
+    org_a = await _seed_org(session, "a")
+    await _add_membership(session, user_id=user.id, organization_id=org_a.id)
+
+    request = _request_with_cookie("not-a-uuid")
+    resolved = await _resolve_org_for_regular_user(request, session, user)
+    assert resolved == org_a.id
+
+
+@pytest.mark.anyio
+async def test_cookie_ignored_for_superuser_who_is_not_member(
+    session: AsyncSession,
+) -> None:
+    """The superuser flag must NOT grant access to an org without explicit membership."""
+    user = await _seed_user(session, is_superuser=True)
+    org_a = await _seed_org(session, "a")
+    other_org = await _seed_org(session, "other")
+    await _add_membership(session, user_id=user.id, organization_id=org_a.id)
+
+    request = _request_with_cookie(str(other_org.id))
+    resolved = await _resolve_org_for_regular_user(request, session, user)
+    assert resolved == org_a.id
+
+
+@pytest.mark.anyio
+async def test_no_cookie_single_membership_returns_it(session: AsyncSession) -> None:
+    user = await _seed_user(session)
+    org_a = await _seed_org(session, "a")
+    await _add_membership(session, user_id=user.id, organization_id=org_a.id)
+
+    request = _request_with_cookie(None)
+    resolved = await _resolve_org_for_regular_user(request, session, user)
+    assert resolved == org_a.id
+
+
+@pytest.mark.anyio
+async def test_no_cookie_multi_membership_raises_400(session: AsyncSession) -> None:
+    user = await _seed_user(session)
+    org_a = await _seed_org(session, "a")
+    org_b = await _seed_org(session, "b")
+    await _add_membership(session, user_id=user.id, organization_id=org_a.id)
+    await _add_membership(session, user_id=user.id, organization_id=org_b.id)
+
+    request = _request_with_cookie(None)
+    with pytest.raises(HTTPException) as exc:
+        await _resolve_org_for_regular_user(request, session, user)
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Multiple organizations found" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_no_cookie_no_memberships_raises_400(session: AsyncSession) -> None:
+    user = await _seed_user(session)
+
+    request = _request_with_cookie(None)
+    with pytest.raises(HTTPException) as exc:
+        await _resolve_org_for_regular_user(request, session, user)
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "no organization memberships" in exc.value.detail

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -239,7 +239,7 @@ async def test_role_dependency_resolves_multi_tenant_superuser_as_regular_org_us
     assert role.user_id == user.id
     assert role.is_platform_superuser is False
     assert role.scopes == scopes
-    mock_resolve_org.assert_awaited_once_with(session, user)
+    mock_resolve_org.assert_awaited_once_with(request, session, user)
 
 
 @pytest.mark.anyio

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -583,15 +583,40 @@ async def _get_membership_with_cache(
     return membership_with_org
 
 
+ACTIVE_ORG_COOKIE = "tracecat:active-org-id"
+
+
 async def _resolve_org_for_regular_user(
+    request: Request,
     session: AsyncSession,
     user: User,
 ) -> uuid.UUID:
     """Resolve organization context for a regular user from their memberships.
 
+    Honors the ``tracecat:active-org-id`` cookie when the user is a confirmed
+    member of the cookie's organization. The cookie is an untrusted hint —
+    membership is re-validated here on every request, so a tampered or stale
+    value cannot grant access to an org the user does not belong to.
+
     Raises:
         HTTPException(400): If user has no org memberships or multiple orgs.
     """
+    if cookie_value := request.cookies.get(ACTIVE_ORG_COOKIE):
+        try:
+            cookie_org_id = uuid.UUID(cookie_value)
+        except ValueError:
+            cookie_org_id = None
+        if cookie_org_id is not None:
+            membership_stmt = select(OrganizationMembership.organization_id).where(
+                OrganizationMembership.user_id == user.id,
+                OrganizationMembership.organization_id == cookie_org_id,
+            )
+            membership_row = (
+                await session.execute(membership_stmt)
+            ).scalar_one_or_none()
+            if membership_row is not None:
+                return cookie_org_id
+
     org_mem_stmt = select(OrganizationMembership.organization_id).where(
         OrganizationMembership.user_id == user.id
     )
@@ -717,7 +742,7 @@ async def _authenticate_user(
             )
     else:
         organization_id = single_tenant_org_id or await _resolve_org_for_regular_user(
-            session, user
+            request, session, user
         )
 
     return get_role_from_user(


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an “Enter organization” action in the admin organizations table that sets a `tracecat:active-org-id` cookie and routes to `/workspaces`. The backend validates the cookie against membership on each request and clears it on logout; the admin back link is removed; in single-tenant, the UI hides “New organization” and “Delete organization,” and the “Admin” link always points to `/admin`.

- **Refactors**
  - Extracted `AdminOrgDeleteDialog` so the confirmation dialog mounts only when needed; the delete option is shown only in multi-tenant.

<sup>Written for commit 85c5ce8006e183bb6d81cf3a8f87ac318d639ca6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<img width="1647" height="801" alt="Screenshot 2026-05-08 at 1 47 01 PM" src="https://github.com/user-attachments/assets/d81d177a-0b6b-45eb-a6c8-86b2778d54dc" />

