### PR TITLE
feat(agent): expose per-source allowed_tools control on custom providers

### DIFF
--- a/alembic/versions/73d6e838c5aa_add_allowed_tools_to_agent_custom_provider.py
+++ b/alembic/versions/73d6e838c5aa_add_allowed_tools_to_agent_custom_provider.py
@@ -1,0 +1,41 @@
+"""add allowed_tools to agent_custom_provider
+
+Revision ID: 73d6e838c5aa
+Revises: d0b32dce7f81
+Create Date: 2026-05-08 17:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "73d6e838c5aa"
+down_revision: str | None = "d0b32dce7f81"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``allowed_tools`` to ``agent_custom_provider``.
+
+    Nullable JSONB list. ``NULL`` means "no override at the source
+    level"; the runtime keeps its default (full SDK toolset). An empty
+    list ``[]`` is a deliberate "disable all built-in tools" override.
+    """
+    op.add_column(
+        "agent_custom_provider",
+        sa.Column(
+            "allowed_tools",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_custom_provider", "allowed_tools")

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -405,6 +405,7 @@ export type AgentCustomProviderCreate = {
   custom_headers?: {
     [key: string]: string
   } | null
+  allowed_tools?: Array<string> | null
 }
 
 /**
@@ -426,6 +427,7 @@ export type AgentCustomProviderRead = {
   passthrough: boolean
   api_key_header: string | null
   last_refreshed_at: string | null
+  allowed_tools?: Array<string> | null
 }
 
 /**
@@ -440,6 +442,7 @@ export type AgentCustomProviderUpdate = {
   custom_headers?: {
     [key: string]: string
   } | null
+  allowed_tools?: Array<string> | null
 }
 
 export type AgentModel = {

--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -114,6 +114,8 @@ const customProviderSchema = z
     apiKey: z.string().optional(),
     customHeadersJson: z.string().optional(),
     passthrough: z.boolean(),
+    allowedToolsMode: z.enum(["default", "disable_all", "whitelist"]),
+    allowedToolsList: z.string().optional(),
   })
   .superRefine((value, ctx) => {
     const raw = value.customHeadersJson?.trim()
@@ -159,6 +161,8 @@ const DEFAULT_CUSTOM_PROVIDER_VALUES: CustomProviderFormValues = {
   apiKey: "",
   customHeadersJson: "",
   passthrough: false,
+  allowedToolsMode: "default",
+  allowedToolsList: "",
 }
 
 const CLOUD_CATALOG_PROVIDERS = [
@@ -698,12 +702,45 @@ function ProviderMetaPill({
   )
 }
 
+function allowedToolsToFormState(
+  allowedTools: readonly string[] | null | undefined
+): {
+  mode: "default" | "disable_all" | "whitelist"
+  list: string
+} {
+  if (allowedTools == null) {
+    return { mode: "default", list: "" }
+  }
+  if (allowedTools.length === 0) {
+    return { mode: "disable_all", list: "" }
+  }
+  return { mode: "whitelist", list: allowedTools.join(", ") }
+}
+
+function allowedToolsFromFormState(
+  mode: "default" | "disable_all" | "whitelist",
+  list: string | undefined
+): string[] | null {
+  if (mode === "default") {
+    return null
+  }
+  if (mode === "disable_all") {
+    return []
+  }
+  // whitelist: split CSV, trim, drop empties
+  return (list ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
 function getProviderDialogDefaults(
   provider: AgentCustomProviderRead | null
 ): CustomProviderFormValues {
   if (!provider) {
     return DEFAULT_CUSTOM_PROVIDER_VALUES
   }
+  const tools = allowedToolsToFormState(provider.allowed_tools)
   return {
     displayName: provider.display_name,
     baseUrl: provider.base_url ?? "",
@@ -711,6 +748,8 @@ function getProviderDialogDefaults(
     apiKey: "",
     customHeadersJson: "",
     passthrough: provider.passthrough,
+    allowedToolsMode: tools.mode,
+    allowedToolsList: tools.list,
   }
 }
 
@@ -724,6 +763,10 @@ function buildProviderCreatePayload(
     api_key: normalizeOptional(values.apiKey),
     custom_headers: parseCustomHeaders(values.customHeadersJson),
     passthrough: values.passthrough,
+    allowed_tools: allowedToolsFromFormState(
+      values.allowedToolsMode,
+      values.allowedToolsList
+    ),
   }
 }
 
@@ -735,6 +778,10 @@ function buildProviderUpdatePayload(
     base_url: normalizeOptional(values.baseUrl),
     api_key_header: normalizeOptional(values.apiKeyHeader),
     passthrough: values.passthrough,
+    allowed_tools: allowedToolsFromFormState(
+      values.allowedToolsMode,
+      values.allowedToolsList
+    ),
   }
 
   const apiKey = normalizeOptional(values.apiKey)
@@ -889,7 +936,7 @@ function CustomProviderDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[560px]">
+      <DialogContent className="flex max-h-[90vh] flex-col sm:max-w-[560px]">
         <DialogHeader>
           <DialogTitle>
             {provider ? "Edit custom source" : "Add custom source"}
@@ -903,35 +950,77 @@ function CustomProviderDialog({
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(handleSubmit)}
-            className="space-y-4"
+            className="flex min-h-0 flex-1 flex-col"
           >
-            <FormField
-              control={form.control}
-              name="displayName"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Name</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder="Local gateway" />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div className="-mx-1 min-h-0 flex-1 space-y-4 overflow-y-auto px-1 pb-2">
               <FormField
                 control={form.control}
-                name="baseUrl"
+                name="displayName"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Base URL</FormLabel>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder="Local gateway" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="baseUrl"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Base URL</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          placeholder="http://localhost:11434/v1"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="apiKeyHeader"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>API key header</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder="Authorization" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="apiKey"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>API key</FormLabel>
                     <FormControl>
                       <Input
                         {...field}
-                        placeholder="http://localhost:11434/v1"
+                        type="password"
+                        placeholder={
+                          provider
+                            ? "Leave blank to keep the current saved key"
+                            : "Optional"
+                        }
                       />
                     </FormControl>
+                    <FormDescription>
+                      Stored encrypted. Leave blank while editing to keep the
+                      current value.
+                    </FormDescription>
                     <FormMessage />
                   </FormItem>
                 )}
@@ -939,90 +1028,114 @@ function CustomProviderDialog({
 
               <FormField
                 control={form.control}
-                name="apiKeyHeader"
+                name="customHeadersJson"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>API key header</FormLabel>
+                    <FormLabel>Custom headers JSON</FormLabel>
                     <FormControl>
-                      <Input {...field} placeholder="Authorization" />
+                      <Textarea
+                        {...field}
+                        className="min-h-28 font-mono text-xs"
+                        placeholder='{"X-API-Key":"value"}'
+                      />
                     </FormControl>
+                    <FormDescription>
+                      Optional JSON object of static headers. Saving new JSON
+                      while editing replaces the saved value.
+                    </FormDescription>
                     <FormMessage />
                   </FormItem>
                 )}
               />
+
+              <FormField
+                control={form.control}
+                name="passthrough"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between gap-4 rounded-md border p-3">
+                    <div className="space-y-1">
+                      <FormLabel className="text-sm">
+                        Passthrough mode
+                      </FormLabel>
+                      <FormDescription>
+                        Skip gateway transforms and forward requests directly to
+                        the upstream endpoint.
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="allowedToolsMode"
+                render={({ field }) => (
+                  <FormItem className="space-y-2 rounded-md border p-3">
+                    <div className="space-y-1">
+                      <FormLabel className="text-sm">
+                        Built-in tools (Claude SDK)
+                      </FormLabel>
+                      <FormDescription>
+                        Controls which Claude SDK built-in tools (Bash, Read,
+                        Edit, …) the runtime exposes for `ai.action` invocations
+                        using this source. Disabling them removes ~96 % of the
+                        per-call token overhead for backends that cannot execute
+                        these tools anyway.
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="default">
+                            Default (full SDK toolset)
+                          </SelectItem>
+                          <SelectItem value="disable_all">
+                            Disable all built-in tools
+                          </SelectItem>
+                          <SelectItem value="whitelist">
+                            Whitelist specific tools
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              {form.watch("allowedToolsMode") === "whitelist" ? (
+                <FormField
+                  control={form.control}
+                  name="allowedToolsList"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Allowed tools</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Bash, Read, Edit" {...field} />
+                      </FormControl>
+                      <FormDescription>
+                        Comma-separated list of Claude SDK built-in tool names.
+                        Empty list with whitelist mode behaves like disable all.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              ) : null}
             </div>
 
-            <FormField
-              control={form.control}
-              name="apiKey"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>API key</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      type="password"
-                      placeholder={
-                        provider
-                          ? "Leave blank to keep the current saved key"
-                          : "Optional"
-                      }
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Stored encrypted. Leave blank while editing to keep the
-                    current value.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="customHeadersJson"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Custom headers JSON</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      {...field}
-                      className="min-h-28 font-mono text-xs"
-                      placeholder='{"X-API-Key":"value"}'
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Optional JSON object of static headers. Saving new JSON
-                    while editing replaces the saved value.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="passthrough"
-              render={({ field }) => (
-                <FormItem className="flex items-center justify-between gap-4 rounded-md border p-3">
-                  <div className="space-y-1">
-                    <FormLabel className="text-sm">Passthrough mode</FormLabel>
-                    <FormDescription>
-                      Skip gateway transforms and forward requests directly to
-                      the upstream endpoint.
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-
-            <DialogFooter className="gap-2 sm:gap-0">
+            <DialogFooter className="gap-2 pt-4 sm:gap-0">
               <Button
                 type="button"
                 variant="outline"

--- a/tests/unit/test_agent_provider_tool_cascade.py
+++ b/tests/unit/test_agent_provider_tool_cascade.py
@@ -1,0 +1,71 @@
+"""Tests for the tools allowlist cascade resolver.
+
+Covers the action > source > default precedence rule and the
+tristate ``None`` / ``[]`` / ``[...]`` semantics surfaced by
+``resolve_allowed_tools``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tracecat.agent.provider.tool_cascade import (
+    ResolvedAllowedTools,
+    resolve_allowed_tools,
+)
+
+
+class TestCascadePrecedence:
+    """Action > source > default."""
+
+    def test_no_overrides_returns_default(self) -> None:
+        result = resolve_allowed_tools(source_value=None, action_value=None)
+        assert result.allowed_tools is None
+        assert result.source == "default"
+
+    def test_source_only(self) -> None:
+        result = resolve_allowed_tools(source_value=["Read", "Grep"], action_value=None)
+        assert result.allowed_tools == ["Read", "Grep"]
+        assert result.source == "source"
+
+    def test_action_only(self) -> None:
+        result = resolve_allowed_tools(source_value=None, action_value=["Bash"])
+        assert result.allowed_tools == ["Bash"]
+        assert result.source == "action"
+
+    def test_action_overrides_source(self) -> None:
+        result = resolve_allowed_tools(source_value=["Read"], action_value=["Bash"])
+        assert result.allowed_tools == ["Bash"]
+        assert result.source == "action"
+
+
+class TestEmptyListSemantics:
+    """Empty list is a value, not absence."""
+
+    def test_action_empty_list_overrides_source_whitelist(self) -> None:
+        """Action ``[]`` (disable all) wins over source whitelist."""
+        result = resolve_allowed_tools(source_value=["Read", "Grep"], action_value=[])
+        assert result.allowed_tools == []
+        assert result.source == "action"
+
+    def test_source_empty_list_kept_when_no_action_override(self) -> None:
+        """Source ``[]`` propagates when action is ``None``."""
+        result = resolve_allowed_tools(source_value=[], action_value=None)
+        assert result.allowed_tools == []
+        assert result.source == "source"
+
+    def test_action_whitelist_overrides_source_empty(self) -> None:
+        """Action whitelist beats source ``[]``."""
+        result = resolve_allowed_tools(source_value=[], action_value=["Read"])
+        assert result.allowed_tools == ["Read"]
+        assert result.source == "action"
+
+
+class TestResultShape:
+    """Frozen dataclass."""
+
+    def test_result_is_immutable(self) -> None:
+        result = resolve_allowed_tools(source_value=None, action_value=None)
+        assert isinstance(result, ResolvedAllowedTools)
+        with pytest.raises(AttributeError):
+            result.allowed_tools = ["Read"]  # type: ignore[misc]

--- a/tracecat/agent/common/types.py
+++ b/tracecat/agent/common/types.py
@@ -113,6 +113,10 @@ class SandboxAgentConfig:
     # Tools
     tool_approvals: dict[str, bool] | None = None
     """Map of action names to whether they require approval."""
+    allowed_tools: list[str] | None = None
+    """Whitelist of Claude SDK built-in tools the runtime should enable.
+    ``None`` keeps the SDK default; ``[]`` disables all built-ins; a
+    specific list whitelists those tool names."""
 
     # MCP
     mcp_servers: list[MCPServerConfig] | None = None
@@ -138,6 +142,7 @@ class SandboxAgentConfig:
             passthrough=data.get("passthrough", False),
             instructions=data.get("instructions"),
             tool_approvals=data.get("tool_approvals"),
+            allowed_tools=data.get("allowed_tools"),
             mcp_servers=data.get("mcp_servers"),
             output_type=data.get("output_type"),
             enable_thinking=data.get("enable_thinking", True),
@@ -160,6 +165,7 @@ class SandboxAgentConfig:
             passthrough=getattr(config, "passthrough", False),
             instructions=config.instructions,
             tool_approvals=config.tool_approvals,
+            allowed_tools=getattr(config, "allowed_tools", None),
             mcp_servers=config.mcp_servers,
             output_type=config.output_type,
             enable_thinking=getattr(config, "enable_thinking", True),
@@ -179,6 +185,8 @@ class SandboxAgentConfig:
             result["instructions"] = self.instructions
         if self.tool_approvals is not None:
             result["tool_approvals"] = self.tool_approvals
+        if self.allowed_tools is not None:
+            result["allowed_tools"] = self.allowed_tools
         if self.mcp_servers is not None:
             result["mcp_servers"] = self.mcp_servers
         if self.output_type is not None:

--- a/tracecat/agent/internal_router.py
+++ b/tracecat/agent/internal_router.py
@@ -153,6 +153,7 @@ async def run_agent_endpoint(
                 tool_approvals=config.tool_approvals,
                 mcp_servers=mcp_servers,
                 instructions=config.instructions,
+                allowed_tools=getattr(config, "allowed_tools", None),
                 output_type=_normalize_output_type(config.output_type),
                 model_settings=config.model_settings,
                 max_tool_calls=params.max_tool_calls or 40,

--- a/tracecat/agent/provider/schemas.py
+++ b/tracecat/agent/provider/schemas.py
@@ -28,6 +28,14 @@ class AgentCustomProviderCreate(BaseModel):
     api_key_header: str | None = Field(default=None, max_length=120)
     api_key: str | None = Field(default=None)
     custom_headers: dict[str, str] | None = Field(default=None)
+    allowed_tools: list[str] | None = Field(default=None)
+    """Optional whitelist of Claude SDK built-in tools the runtime is
+    allowed to enable for ``ai.action`` invocations using this source.
+    ``None`` keeps the SDK default (full toolset). An empty list ``[]``
+    disables all built-in tools — useful for upstream backends that do
+    not have access to the SDK's host environment (Bash, Read, Edit,
+    etc. cannot run on a remote LLM endpoint anyway). A specific list
+    such as ``["Read", "Grep"]`` whitelists those tool names only."""
 
     @field_validator("base_url")
     @classmethod
@@ -47,6 +55,7 @@ class AgentCustomProviderRead(BaseModel):
     passthrough: bool
     api_key_header: str | None
     last_refreshed_at: datetime | None
+    allowed_tools: list[str] | None = None
 
 
 class AgentCustomProviderUpdate(BaseModel):
@@ -58,6 +67,7 @@ class AgentCustomProviderUpdate(BaseModel):
     api_key_header: str | None = Field(default=None, max_length=120)
     api_key: str | None = None
     custom_headers: dict[str, str] | None = None
+    allowed_tools: list[str] | None = None
 
     @field_validator("base_url")
     @classmethod

--- a/tracecat/agent/provider/service.py
+++ b/tracecat/agent/provider/service.py
@@ -91,6 +91,7 @@ class AgentCustomProviderService(BaseOrgService):
             passthrough=provider.passthrough,
             api_key_header=provider.api_key_header,
             encrypted_config=encrypted_config,
+            allowed_tools=provider.allowed_tools,
         )
         self.session.add(model)
         await self.session.commit()

--- a/tracecat/agent/provider/tool_cascade.py
+++ b/tracecat/agent/provider/tool_cascade.py
@@ -1,0 +1,56 @@
+"""Pure resolution helper for the agent tools allowlist cascade.
+
+Kept dependency-free (no Temporal, no DB, no Pydantic) so it can be
+unit tested in isolation and replayed inside Temporal workflows
+without sandbox passthrough concerns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+ToolsSource = Literal["default", "source", "action"]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedAllowedTools:
+    """Cascaded ``allowed_tools`` value ready to hand to the runtime.
+
+    ``allowed_tools`` keeps the tristate semantics of the underlying
+    SDK option:
+
+    - ``None``: no override at any level — the runtime keeps the SDK
+      default (full built-in toolset).
+    - ``[]``: explicit empty list — the runtime disables every
+      built-in tool. Distinct from ``None``.
+    - non-empty list: whitelist of tool names the runtime is allowed
+      to enable.
+
+    ``source`` carries diagnostic metadata indicating which level of
+    the cascade actually contributed the value, useful for logs and
+    troubleshooting output.
+    """
+
+    allowed_tools: list[str] | None
+    source: ToolsSource
+
+
+def resolve_allowed_tools(
+    *,
+    source_value: list[str] | None,
+    action_value: list[str] | None,
+) -> ResolvedAllowedTools:
+    """Apply the action > source > default cascade.
+
+    Action-level value wins over source-level value. ``None`` at a
+    given level means "no opinion at this layer, defer to the next".
+    An empty list at either level is a value (it carries the explicit
+    "disable all" intent), so it propagates through the cascade
+    untouched.
+    """
+    if action_value is not None:
+        return ResolvedAllowedTools(allowed_tools=action_value, source="action")
+    if source_value is not None:
+        return ResolvedAllowedTools(allowed_tools=source_value, source="source")
+    return ResolvedAllowedTools(allowed_tools=None, source="default")

--- a/tracecat/agent/provider/tool_overrides.py
+++ b/tracecat/agent/provider/tool_overrides.py
@@ -1,0 +1,87 @@
+"""Temporal activity exposing custom-provider tool whitelist to the DSL.
+
+Lives in the OSS layer so the DSL workflow can read the per-source
+tools allowlist without depending on the EE schema definitions.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from pydantic import BaseModel
+from sqlalchemy import select
+from temporalio import activity
+
+from tracecat.auth.types import Role
+from tracecat.db.engine import get_async_session_context_manager
+from tracecat.db.models import AgentCatalog, AgentCustomProvider
+
+
+class ResolveCustomProviderToolsInput(BaseModel):
+    """Input for ``resolve_custom_provider_tools_activity``."""
+
+    role: Role
+    catalog_id: uuid.UUID
+
+
+class CustomProviderToolsResult(BaseModel):
+    """Source-level tools allowlist resolved from an ``AgentCustomProvider`` row.
+
+    ``allowed_tools`` is nullable. ``None`` means the source did not
+    configure an override at this level; the caller should fall back
+    to the next layer of the cascade (action-level override, then SDK
+    default toolset). An empty list ``[]`` is a deliberate "disable
+    all built-in tools" override.
+    """
+
+    allowed_tools: list[str] | None = None
+
+
+@activity.defn
+async def resolve_custom_provider_tools_activity(
+    args: ResolveCustomProviderToolsInput,
+) -> CustomProviderToolsResult:
+    """Resolve source-level tools allowlist for the given catalog row.
+
+    Returns an empty ``CustomProviderToolsResult`` (``allowed_tools=None``)
+    when:
+    - the catalog row is not backed by a custom provider (e.g. a
+      platform catalog row pointing at a built-in provider);
+    - no row matches at all;
+    - the database query fails for any reason (logged warning, never
+      raises — the cascade is best-effort and must not break the
+      ``ai.action`` run).
+    """
+    activity.logger.info(
+        "Resolving custom provider tools allowlist",
+        extra={"catalog_id": str(args.catalog_id)},
+    )
+    try:
+        async with get_async_session_context_manager() as session:
+            stmt = (
+                select(AgentCustomProvider.allowed_tools)
+                .join(
+                    AgentCatalog,
+                    sa.and_(
+                        AgentCatalog.organization_id
+                        == AgentCustomProvider.organization_id,
+                        AgentCatalog.custom_provider_id == AgentCustomProvider.id,
+                    ),
+                )
+                .where(AgentCatalog.id == args.catalog_id)
+            )
+            row = (await session.execute(stmt)).first()
+    except Exception as exc:  # noqa: BLE001 - any DB error must fall back to defaults
+        activity.logger.warning(
+            "Custom provider tools lookup failed; falling back to SDK default",
+            extra={
+                "catalog_id": str(args.catalog_id),
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            },
+        )
+        return CustomProviderToolsResult()
+    if row is None:
+        return CustomProviderToolsResult()
+    return CustomProviderToolsResult(allowed_tools=row.allowed_tools)

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -865,6 +865,12 @@ class ClaudeAgentRuntime:
                 system_prompt=self._build_system_prompt(
                     payload.config.instructions, payload.config.output_type
                 ),
+                # ``tools`` is omitted when ``allowed_tools is None`` so the
+                # CLI applies its default (full built-in toolset). When
+                # explicitly set — including the empty list — it's
+                # forwarded as-is, mapping onto ``--tools "..."`` /
+                # ``--tools ""`` on the underlying Claude Code CLI.
+                tools=payload.config.allowed_tools,
                 mcp_servers=mcp_servers,
                 disallowed_tools=disallowed_tools,
                 stderr=handle_claude_stderr,

--- a/tracecat/agent/runtime/pydantic_ai/runtime.py
+++ b/tracecat/agent/runtime/pydantic_ai/runtime.py
@@ -86,6 +86,7 @@ async def run_agent(
     mcp_server_headers: dict[str, str] | None = None,
     mcp_servers: list[MCPServerConfig] | None = None,
     instructions: str | None = None,
+    allowed_tools: list[str] | None = None,
     output_type: OutputType | None = None,
     model_settings: dict[str, Any] | None = None,
     max_tool_calls: int = TRACECAT__AGENT_MAX_TOOL_CALLS,
@@ -157,6 +158,18 @@ async def run_agent(
     if max_requests > TRACECAT__AGENT_MAX_REQUESTS:
         raise ValueError(
             f"Cannot request more than {TRACECAT__AGENT_MAX_REQUESTS} requests"
+        )
+
+    if allowed_tools is not None:
+        # pydantic-ai does not have an implicit built-in toolset to
+        # filter — it only sees the tools explicitly registered on the
+        # agent. Honour the parameter at the API level so callers can
+        # set it without errors, but warn so it doesn't silently look
+        # like a no-op when callers expect the Claude SDK semantics.
+        logger.warning(
+            "allowed_tools is set but has no effect on the pydantic_ai "
+            "runtime (no implicit built-in toolset to filter)",
+            allowed_tools_count=len(allowed_tools),
         )
 
     start_time = default_timer()

--- a/tracecat/agent/schemas.py
+++ b/tracecat/agent/schemas.py
@@ -283,6 +283,7 @@ class AgentConfigSchema(BaseModel):
     actions: list[str] | None = None
     namespaces: list[str] | None = None
     tool_approvals: dict[str, bool] | None = None
+    allowed_tools: list[str] | None = None
     model_settings: dict[str, Any] | None = None
     mcp_servers: list[MCPServerConfigSchema] | None = None
     retries: int = Field(default=20)

--- a/tracecat/agent/types.py
+++ b/tracecat/agent/types.py
@@ -130,6 +130,12 @@ class AgentConfig:
     actions: list[str] | None = None
     namespaces: list[str] | None = None
     tool_approvals: dict[str, bool] | None = None
+    allowed_tools: list[str] | None = None
+    """Optional whitelist of Claude SDK built-in tools the runtime should
+    enable. ``None`` keeps the SDK default (full toolset). An empty list
+    disables all built-ins. A specific list whitelists those names only.
+    Already cascade-resolved by the DSL layer (action override > custom
+    source default > None)."""
     # MCP
     model_settings: dict[str, Any] | None = None
     mcp_servers: list[MCPServerConfig] | None = None

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -33,6 +33,9 @@ with workflow.unsafe.imports_passed_through():
         resolve_agent_preset_version_ref_activity,
         resolve_custom_model_provider_config_activity,
     )
+    from tracecat.agent.provider.tool_overrides import (
+        resolve_custom_provider_tools_activity,
+    )
     from tracecat.agent.session.activities import get_session_activities
     from tracecat.dsl.client import get_temporal_client
     from tracecat.dsl.interceptor import SentryInterceptor
@@ -81,6 +84,7 @@ def get_activities() -> list[Callable[..., object]]:
     activities.append(resolve_agent_preset_config_activity)
     activities.append(resolve_agent_preset_version_ref_activity)
     activities.append(resolve_custom_model_provider_config_activity)
+    activities.append(resolve_custom_provider_tools_activity)
     activities.extend(get_session_activities())
     return activities
 

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -2643,6 +2643,7 @@ class AgentCustomProvider(OrganizationModel):
     last_refreshed_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True), nullable=True
     )
+    allowed_tools: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
 
     catalog_rows: Mapped[list[AgentCatalog]] = relationship(
         "AgentCatalog",

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -22,6 +22,9 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.preset.activities import (
         resolve_agent_preset_version_ref_activity,
     )
+    from tracecat.agent.provider.tool_overrides import (
+        resolve_custom_provider_tools_activity,
+    )
     from tracecat.dsl.action import DSLActivities
     from tracecat.dsl.client import get_temporal_client
     from tracecat.dsl.init_activities import (
@@ -91,6 +94,7 @@ def get_activities() -> list[Callable]:
         *DSLActivities.load(),
         *CollectionActivities.get_activities(),
         resolve_agent_preset_version_ref_activity,
+        resolve_custom_provider_tools_activity,
         get_workflow_definition_activity,
         resolve_registry_lock_activity,
         get_workspace_organization_id_activity,

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -40,6 +40,12 @@ with workflow.unsafe.imports_passed_through():
         ResolveAgentPresetVersionRefActivityInput,
         resolve_agent_preset_version_ref_activity,
     )
+    from tracecat.agent.provider.tool_cascade import resolve_allowed_tools
+    from tracecat.agent.provider.tool_overrides import (
+        CustomProviderToolsResult,
+        ResolveCustomProviderToolsInput,
+        resolve_custom_provider_tools_activity,
+    )
     from tracecat.agent.schemas import RunAgentArgs
     from tracecat.agent.session.types import AgentSessionEntity
     from tracecat.agent.types import AgentConfig
@@ -1027,6 +1033,51 @@ class DSLWorkflow:
                         start_to_close_timeout=timedelta(seconds=60),
                         retry_policy=RETRY_POLICIES["activity:fail_fast"],
                     )
+                    # Resolve source-level tools allowlist if a catalog row
+                    # backs this invocation. Best-effort: the activity
+                    # swallows DB failures internally, and we wrap the
+                    # ``execute_activity`` call too so a Temporal-level
+                    # failure (timeout, worker death) also falls back to
+                    # the SDK default toolset rather than aborting the run.
+                    source_tools = CustomProviderToolsResult()
+                    if action_args.catalog_id is not None:
+                        try:
+                            source_tools = await workflow.execute_activity(
+                                resolve_custom_provider_tools_activity,
+                                arg=ResolveCustomProviderToolsInput(
+                                    role=self.role,
+                                    catalog_id=action_args.catalog_id,
+                                ),
+                                start_to_close_timeout=timedelta(seconds=10),
+                                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                            )
+                        except (ActivityError, ApplicationError) as exc:
+                            self.logger.warning(
+                                "Custom provider tools activity failed; "
+                                "falling back to SDK default toolset",
+                                catalog_id=str(action_args.catalog_id),
+                                error=str(exc),
+                            )
+                    # Cascade: action overrides win over source overrides.
+                    # Action-level field is read defensively via ``getattr``
+                    # because ``AgentActionArgs`` (defined in the EE schema
+                    # module) does not yet expose it. When EE adds the
+                    # field, this code starts honouring it with no further
+                    # change.
+                    resolved_tools = resolve_allowed_tools(
+                        source_value=source_tools.allowed_tools,
+                        action_value=getattr(action_args, "allowed_tools", None),
+                    )
+                    self.logger.info(
+                        "Resolved agent allowed_tools",
+                        catalog_id=str(action_args.catalog_id)
+                        if action_args.catalog_id
+                        else None,
+                        allowed_tools_source=resolved_tools.source,
+                        allowed_tools_count=len(resolved_tools.allowed_tools)
+                        if resolved_tools.allowed_tools is not None
+                        else None,
+                    )
                     wf_info = workflow.info()
                     child_search_attributes = _build_agent_child_search_attributes(
                         wf_info, task.ref
@@ -1042,6 +1093,7 @@ class DSLWorkflow:
                                 model_provider=action_args.model_provider,
                                 catalog_id=action_args.catalog_id,
                                 instructions=action_args.instructions,
+                                allowed_tools=resolved_tools.allowed_tools,
                                 output_type=action_args.output_type,
                                 model_settings=action_args.model_settings,
                                 retries=action_args.retries,


### PR DESCRIPTION
Closes #2655

# Per-source `allowed_tools` control on custom providers

## Why

`ai.action` runs through `claude_code/runtime.py` with no `tools=`
argument set on `ClaudeAgentOptions`, so the bundled CLI activates
its **full built-in toolset** and inlines every tool's JSON schema
in the system prompt sent to the model — even when
`max_tool_calls=0`, the documented mode for `ai.action`.

Measured against `qwen3.5:9b` via Ollama with a one-line user prompt
(`"Reply: hi"`):

| Configuration | `input_tokens` | Delta |
|---|---:|---:|
| Defaults (current behaviour) | 4 096 | reference |
| `tools=""` on the CLI (this PR's wire effect) | 158 | **−96 %** |

For workflows that fire `ai.action` thousands of times a day, ~3.9 M
tokens of pure overhead per 1k calls — meaningful on hosted models,
meaningful in latency and context budget on local models.

The capability already exists in `claude-agent-sdk==0.1.51`:
`ClaudeAgentOptions.tools` accepts `None` (SDK default), `[]`
(disable everything), or a whitelist; all three map directly to
`--tools "..."` on the bundled CLI 2.1.85. This PR surfaces those
three states at the custom-source level (and forward-compatibly at
the action level pending the EE schema discussion in #2654).

## Design choice

This PR uses the same shape as #2657 (per-source DB column +
cascade + modal UI), deliberately. We considered the env-var
fallback you suggested on #2657, and it doesn't fit:

- a global env var resolved at process start can't differentiate
  between two custom sources running side by side;
- it can't be overridden at trigger time via `${{ TRIGGER.* }}`;
- it doesn't survive the "self-service custom source" UX promise
  that already exists for passthrough mode and credentials.

Reusing the same design as #2657 isn't a way to relitigate that PR
— it's a consistency point. If the per-source / cascade pattern is
the right shape for one piece of agent configuration, it's the
right shape for another. Happy to be arbitrated on the functional
case rather than ship two different shoehorned alternatives.

The maintenance cost is bounded: the cascade lives in a pure
function (`tracecat/agent/provider/tool_cascade.py`), the activity
is dependency-free, and the runtime change is a one-line forward
to `ClaudeAgentOptions.tools`. None of the existing routing or
auth surfaces are touched.

## What this PR does NOT do

- No behaviour change at the default. `allowed_tools = NULL`
  preserves today's full SDK toolset for every existing source.
- No EE module touched. Action-level overrides are read defensively
  via `getattr` so the cascade is forward-compatible the day
  `AgentActionArgs` exposes the field.

## Tests

Lint / format / typecheck pass on the touched files. Cascade
resolver covered by unit tests; runtime mapping (`tools=None` /
`[]` / whitelist → `--tools` flag) verified against the live SDK
end-to-end on a Tracecat dev deployment, with the token math above
reproducible from inside the agent_executor container.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-source `allowed_tools` on custom providers to control which Claude SDK built-in tools are exposed to `ai.action`, reducing prompt tokens and latency. Defaults unchanged; sources with null keep the full toolset.

- **New Features**
  - DB/API: `agent_custom_provider.allowed_tools` (nullable JSONB) with create/read/update support.
  - UI: custom source modal adds “Built-in tools (Claude SDK)” with Default / Disable all / Whitelist (CSV); form-to-API mapping preserves the tristate; modal made scrollable.
  - Orchestration: new activity resolves source-level tools by `catalog_id`; pure helper applies cascade (action > source > default).
  - Runtime: resolved list passed to `ClaudeAgentOptions.tools`; `pydantic_ai` accepts, warns, and ignores.
  - Tests: unit tests for cascade precedence and empty-list semantics.

<sup>Written for commit 43902d69b4c755f1333e1ce27d6a735795004313. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

