### PR TITLE
perf(agent): flush session history without stream latency

### DIFF
--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -5,6 +5,7 @@ Tests the runtime execution with mocked Claude SDK.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import tempfile
 import uuid
@@ -123,6 +124,7 @@ def mock_socket_writer() -> MagicMock:
     writer.send_stream_event = AsyncMock()
     writer.send_message = AsyncMock()
     writer.send_session_line = AsyncMock()
+    writer.send_result = AsyncMock()
     writer.send_error = AsyncMock()
     writer.send_done = AsyncMock()
     writer.close = AsyncMock()
@@ -302,6 +304,259 @@ class TestClaudeAgentRuntimeRun:
 
         # Should have called send_stream_event
         mock_socket_writer.send_stream_event.assert_awaited()
+
+    @pytest.mark.anyio
+    async def test_stream_events_flush_new_session_lines(
+        self,
+        mock_socket_writer: MagicMock,
+        mock_claude_sdk_client: MagicMock,
+        sample_init_payload: RuntimeInitPayload,
+        tmp_path: Path,
+    ) -> None:
+        """Stream progress should flush newly written Claude JSONL rows."""
+        sdk_session_id = "test-sdk-session"
+        session_line = {
+            "type": "user",
+            "uuid": "user-line-uuid",
+            "sessionId": sdk_session_id,
+            "message": {"role": "user", "content": "Hello"},
+        }
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+            cwd_setup_path=tmp_path / "claude-project",
+        )
+        session_file = runtime._get_session_file_path(sdk_session_id)
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_text(orjson.dumps(session_line).decode("utf-8") + "\n")
+
+        async def mock_receive() -> Any:
+            yield StreamEvent(
+                uuid="stream-event-uuid",
+                session_id=sdk_session_id,
+                event={
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "Hello"},
+                },
+            )
+
+        mock_claude_sdk_client.receive_response = mock_receive
+
+        mock_adapter = MagicMock()
+        mock_adapter.to_unified_event.return_value = UnifiedStreamEvent(
+            type=StreamEventType.TEXT_DELTA,
+            text="Hello",
+            part_id=0,
+        )
+
+        with (
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKClient",
+                return_value=mock_claude_sdk_client,
+            ),
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.create_proxy_mcp_server",
+                AsyncMock(return_value={}),
+            ),
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKAdapter",
+                return_value=mock_adapter,
+            ),
+        ):
+            await runtime.run(sample_init_payload)
+
+        mock_socket_writer.send_session_line.assert_awaited_once_with(
+            sdk_session_id,
+            orjson.dumps(session_line).decode("utf-8"),
+            internal=False,
+        )
+        mock_socket_writer.send_stream_event.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_stream_event_is_not_delayed_by_slow_session_line_flush(
+        self,
+        mock_socket_writer: MagicMock,
+        mock_claude_sdk_client: MagicMock,
+        sample_init_payload: RuntimeInitPayload,
+        tmp_path: Path,
+    ) -> None:
+        """Session-line persistence should run after the stream event is sent."""
+        sdk_session_id = "test-sdk-session"
+        session_line = {
+            "type": "user",
+            "uuid": "user-line-uuid",
+            "sessionId": sdk_session_id,
+            "message": {"role": "user", "content": "Hello"},
+        }
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+            cwd_setup_path=tmp_path / "claude-project",
+        )
+        session_file = runtime._get_session_file_path(sdk_session_id)
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_bytes(orjson.dumps(session_line) + b"\n")
+
+        stream_sent = asyncio.Event()
+        session_send_started = asyncio.Event()
+        release_session_send = asyncio.Event()
+        order: list[str] = []
+
+        async def record_stream_event(_event: UnifiedStreamEvent) -> None:
+            order.append("stream")
+            stream_sent.set()
+
+        async def slow_session_line(
+            _sdk_session_id: str,
+            _line: str,
+            *,
+            internal: bool = False,
+        ) -> None:
+            del internal
+            order.append("session")
+            session_send_started.set()
+            await release_session_send.wait()
+
+        mock_socket_writer.send_stream_event.side_effect = record_stream_event
+        mock_socket_writer.send_session_line.side_effect = slow_session_line
+
+        async def mock_receive() -> Any:
+            yield StreamEvent(
+                uuid="stream-event-uuid",
+                session_id=sdk_session_id,
+                event={
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "Hello"},
+                },
+            )
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id=sdk_session_id,
+                usage={},
+                result="done",
+            )
+
+        mock_claude_sdk_client.receive_response = mock_receive
+
+        mock_adapter = MagicMock()
+        mock_adapter.to_unified_event.return_value = UnifiedStreamEvent(
+            type=StreamEventType.TEXT_DELTA,
+            text="Hello",
+            part_id=0,
+        )
+
+        with (
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKClient",
+                return_value=mock_claude_sdk_client,
+            ),
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.create_proxy_mcp_server",
+                AsyncMock(return_value={}),
+            ),
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKAdapter",
+                return_value=mock_adapter,
+            ),
+        ):
+            run_task = asyncio.create_task(runtime.run(sample_init_payload))
+            await asyncio.wait_for(stream_sent.wait(), timeout=1.0)
+            assert order[0] == "stream"
+            await asyncio.wait_for(session_send_started.wait(), timeout=1.0)
+            release_session_send.set()
+            await run_task
+
+        assert order[:2] == ["stream", "session"]
+
+    @pytest.mark.anyio
+    async def test_final_flush_persists_session_lines_before_done_without_stream_events(
+        self,
+        mock_socket_writer: MagicMock,
+        mock_claude_sdk_client: MagicMock,
+        sample_init_payload: RuntimeInitPayload,
+        tmp_path: Path,
+    ) -> None:
+        """A result-only turn should still persist SDK JSONL before done."""
+        sdk_session_id = "test-sdk-session"
+        session_line = {
+            "type": "assistant",
+            "uuid": "assistant-line-uuid",
+            "sessionId": sdk_session_id,
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Done"}],
+            },
+        }
+        order: list[str] = []
+
+        async def record_session_line(
+            _sdk_session_id: str,
+            _line: str,
+            *,
+            internal: bool = False,
+        ) -> None:
+            del internal
+            order.append("session")
+
+        async def record_result(**_kwargs: Any) -> None:
+            order.append("result")
+
+        async def record_done() -> None:
+            order.append("done")
+
+        mock_socket_writer.send_session_line.side_effect = record_session_line
+        mock_socket_writer.send_result.side_effect = record_result
+        mock_socket_writer.send_done.side_effect = record_done
+
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+            cwd_setup_path=tmp_path / "claude-project",
+        )
+        session_file = runtime._get_session_file_path(sdk_session_id)
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_bytes(orjson.dumps(session_line) + b"\n")
+
+        async def mock_receive() -> Any:
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id=sdk_session_id,
+                usage={},
+                result="done",
+            )
+
+        mock_claude_sdk_client.receive_response = mock_receive
+
+        with (
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKClient",
+                return_value=mock_claude_sdk_client,
+            ),
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.create_proxy_mcp_server",
+                AsyncMock(return_value={}),
+            ),
+        ):
+            await runtime.run(sample_init_payload)
+
+        mock_socket_writer.send_session_line.assert_awaited_once()
+        assert order == ["result", "session", "done"]
 
     @pytest.mark.anyio
     async def test_sets_skip_version_check_before_sdk_connect(
@@ -1433,3 +1688,139 @@ class TestClaudeAgentRuntimeInternalSessionLines:
         assert internal_by_uuid[prompt_uuid] is True
         assert internal_by_uuid[thinking_uuid] is False
         assert internal_by_uuid[answer_uuid] is False
+
+
+class TestClaudeAgentRuntimeSessionLineFlushing:
+    """Tests for ClaudeAgentRuntime SDK JSONL flushing."""
+
+    @staticmethod
+    def _line_bytes(line: dict[str, Any]) -> bytes:
+        return orjson.dumps(line) + b"\n"
+
+    @pytest.mark.anyio
+    async def test_emit_new_session_lines_tails_by_byte_offset(
+        self,
+        mock_socket_writer: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Only bytes after the last flushed offset should be emitted."""
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+        )
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        runtime._sdk_session_id = sdk_session_id
+
+        first_line = {
+            "type": "user",
+            "uuid": "first-line",
+            "message": {"role": "user", "content": "old"},
+        }
+        second_line = {
+            "type": "assistant",
+            "uuid": "second-line",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "new"}],
+            },
+        }
+        first_bytes = self._line_bytes(first_line)
+        second_bytes = self._line_bytes(second_line)
+
+        session_file = runtime._get_session_file_path(sdk_session_id)
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_bytes(first_bytes + second_bytes)
+        runtime._last_seen_byte_offset = len(first_bytes)
+
+        await runtime._emit_new_session_lines()
+
+        mock_socket_writer.send_session_line.assert_awaited_once_with(
+            sdk_session_id,
+            second_bytes.rstrip(b"\n").decode("utf-8"),
+            internal=False,
+        )
+        assert runtime._last_seen_byte_offset == len(first_bytes + second_bytes)
+
+    @pytest.mark.anyio
+    async def test_emit_new_session_lines_retries_partial_line(
+        self,
+        mock_socket_writer: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A trailing incomplete JSONL row should not advance the byte offset."""
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+        )
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        runtime._sdk_session_id = sdk_session_id
+
+        first_bytes = self._line_bytes(
+            {
+                "type": "user",
+                "uuid": "first-line",
+                "message": {"role": "user", "content": "complete"},
+            }
+        )
+        second_bytes = self._line_bytes(
+            {
+                "type": "assistant",
+                "uuid": "second-line",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "complete later"}],
+                },
+            }
+        )
+
+        session_file = runtime._get_session_file_path(sdk_session_id)
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_bytes(first_bytes + second_bytes.rstrip(b"\n"))
+
+        await runtime._emit_new_session_lines()
+
+        mock_socket_writer.send_session_line.assert_awaited_once()
+        assert runtime._last_seen_byte_offset == len(first_bytes)
+
+        session_file.write_bytes(first_bytes + second_bytes)
+        await runtime._emit_new_session_lines()
+
+        assert mock_socket_writer.send_session_line.await_count == 2
+        assert runtime._last_seen_byte_offset == len(first_bytes + second_bytes)
+
+    @pytest.mark.anyio
+    async def test_prepare_resume_seeds_byte_offset_from_canonical_disk_data(
+        self,
+        mock_socket_writer: MagicMock,
+        sample_init_payload: RuntimeInitPayload,
+        tmp_path: Path,
+    ) -> None:
+        """Normal resume offsets should match the canonical JSONL written to disk."""
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        sdk_session_data = (
+            '{"type":"assistant","message":{"content":[{"type":"tool_use",'
+            '"name":"mcp__tracecat_registry__execute_tool"}]}}'
+        )
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+        )
+        payload = replace(
+            sample_init_payload,
+            sdk_session_id=sdk_session_id,
+            sdk_session_data=sdk_session_data,
+        )
+
+        await runtime._prepare_resume_and_mcp(payload, write_session_file=True)
+
+        expected_data = runtime._session_data_for_disk(sdk_session_data)
+        assert runtime._sdk_session_id == sdk_session_id
+        assert runtime._last_seen_byte_offset == len(expected_data.encode("utf-8"))
+        session_file = runtime._get_session_file_path(sdk_session_id)
+        assert session_file.read_text(encoding="utf-8") == expected_data

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -1824,3 +1824,59 @@ class TestClaudeAgentRuntimeSessionLineFlushing:
         assert runtime._last_seen_byte_offset == len(expected_data.encode("utf-8"))
         session_file = runtime._get_session_file_path(sdk_session_id)
         assert session_file.read_text(encoding="utf-8") == expected_data
+
+    @pytest.mark.anyio
+    async def test_forked_resume_keeps_zero_offset_when_child_file_missing(
+        self,
+        mock_socket_writer: MagicMock,
+        sample_init_payload: RuntimeInitPayload,
+        tmp_path: Path,
+    ) -> None:
+        """A fresh fork should not reuse the parent's byte offset."""
+        parent_sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        child_sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20705"
+        parent_history = (
+            '{"type":"user","message":{"content":"parent prompt"}}\n'
+            '{"type":"assistant","message":{"content":[{"type":"text","text":"parent answer"}]}}\n'
+        )
+        child_line = {
+            "type": "user",
+            "uuid": "child-first-line",
+            "message": {"role": "user", "content": "fork prompt"},
+        }
+        child_bytes = self._line_bytes(child_line)
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+        )
+        payload = replace(
+            sample_init_payload,
+            sdk_session_id=parent_sdk_session_id,
+            sdk_session_data=parent_history,
+            is_fork=True,
+        )
+
+        await runtime._prepare_resume_and_mcp(payload, write_session_file=True)
+        await runtime._capture_sdk_session_id(
+            child_sdk_session_id,
+            resume_session_id=parent_sdk_session_id,
+            fork_session=True,
+        )
+
+        assert runtime._sdk_session_id == child_sdk_session_id
+        assert runtime._last_seen_byte_offset == 0
+
+        child_session_file = runtime._get_session_file_path(child_sdk_session_id)
+        child_session_file.parent.mkdir(parents=True, exist_ok=True)
+        child_session_file.write_bytes(child_bytes)
+
+        await runtime._emit_new_session_lines()
+
+        mock_socket_writer.send_session_line.assert_awaited_once_with(
+            child_sdk_session_id,
+            child_bytes.rstrip(b"\n").decode("utf-8"),
+            internal=False,
+        )
+        assert runtime._last_seen_byte_offset == len(child_bytes)

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -559,6 +559,140 @@ class TestClaudeAgentRuntimeRun:
         assert order == ["result", "session", "done"]
 
     @pytest.mark.anyio
+    async def test_approval_continuation_prompt_remains_internal_when_result_beats_flush(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_socket_writer: MagicMock,
+        mock_claude_sdk_client: MagicMock,
+        sample_init_payload: RuntimeInitPayload,
+        tmp_path: Path,
+    ) -> None:
+        """A result should not expose a hidden approval continuation prompt."""
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        parent_history = '{"type":"user","message":{"content":"parent prompt"}}\n'
+
+        # This is the control row produced by the approval-continuation meta prompt.
+        # It should always be persisted as internal, even if the final result arrives
+        # before the background flush consumes it.
+        prompt_uuid = "approval-continuation-prompt"
+        prompt_line = {
+            "type": "user",
+            "uuid": prompt_uuid,
+            "message": {
+                "role": "user",
+                "content": runtime_module.APPROVAL_CONTINUATION_PROMPT,
+            },
+        }
+        prompt_bytes = orjson.dumps(prompt_line) + b"\n"
+        payload = replace(
+            sample_init_payload,
+            sdk_session_id=sdk_session_id,
+            sdk_session_data=parent_history,
+            is_approval_continuation=True,
+        )
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _options: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+            cwd_setup_path=tmp_path / "claude-project",
+        )
+        session_file = runtime._get_session_file_path(sdk_session_id)
+
+        read_tail_started = asyncio.Event()
+        release_read_tail = asyncio.Event()
+        result_sent = asyncio.Event()
+        original_to_thread = asyncio.to_thread
+
+        async def controlled_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+            if getattr(func, "__name__", "") == "_read_tail":
+                # Pause the background flush after it has started, but before it has
+                # read and classified the hidden "Continue." JSONL row.
+                read_tail_started.set()
+                await release_read_tail.wait()
+            return await original_to_thread(func, *args, **kwargs)
+
+        monkeypatch.setattr(runtime_module.asyncio, "to_thread", controlled_to_thread)
+
+        async def record_result(**_kwargs: Any) -> None:
+            result_sent.set()
+
+        mock_socket_writer.send_result.side_effect = record_result
+
+        async def mock_receive() -> Any:
+            # Simulate Claude writing the next row before emitting stream progress.
+            session_file.write_bytes(parent_history.encode("utf-8") + prompt_bytes)
+            yield StreamEvent(
+                uuid="stream-event-uuid",
+                session_id=sdk_session_id,
+                event={
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "continued"},
+                },
+            )
+            # The stream event schedules the background flush. Yield the result only
+            # after that flush is blocked at _read_tail.
+            await asyncio.wait_for(read_tail_started.wait(), timeout=1.0)
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id=sdk_session_id,
+                usage={},
+                result="done",
+            )
+
+        mock_claude_sdk_client.receive_response = mock_receive
+
+        mock_adapter = MagicMock()
+        mock_adapter.to_unified_event.return_value = UnifiedStreamEvent(
+            type=StreamEventType.TEXT_DELTA,
+            text="continued",
+            part_id=0,
+        )
+
+        with (
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKClient",
+                return_value=mock_claude_sdk_client,
+            ),
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.create_proxy_mcp_server",
+                AsyncMock(return_value={}),
+            ),
+            patch(
+                "tracecat.agent.runtime.claude_code.runtime.ClaudeSDKAdapter",
+                return_value=mock_adapter,
+            ),
+        ):
+            run_task = asyncio.create_task(runtime.run(payload))
+            try:
+                # Hold the flush, wait for ResultMessage handling to complete, then
+                # release the flush so it classifies the row afterward.
+                await asyncio.wait_for(read_tail_started.wait(), timeout=1.0)
+                await asyncio.wait_for(result_sent.wait(), timeout=1.0)
+                release_read_tail.set()
+                await run_task
+            finally:
+                release_read_tail.set()
+
+        persisted = [
+            (orjson.loads(call.args[1]), call.kwargs["internal"])
+            for call in mock_socket_writer.send_session_line.await_args_list
+        ]
+        internal_by_uuid = {
+            line["uuid"]: internal
+            for line, internal in persisted
+            if isinstance(line.get("uuid"), str)
+        }
+        # Desired behavior: the hidden continuation prompt remains internal despite
+        # the result beating the background flush.
+        assert internal_by_uuid[prompt_uuid] is True
+
+    @pytest.mark.anyio
     async def test_sets_skip_version_check_before_sdk_connect(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1590,7 +1724,6 @@ class TestClaudeAgentRuntimeInternalSessionLines:
         )
         sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
         runtime._sdk_session_id = sdk_session_id
-        runtime._hide_next_approval_continuation_prompt = True
 
         tool_result_uuid = "tool-result-uuid"
         meta_uuid = "meta-uuid"
@@ -1671,7 +1804,7 @@ class TestClaudeAgentRuntimeInternalSessionLines:
             "\n".join(orjson.dumps(line).decode("utf-8") for line in lines) + "\n"
         )
 
-        await runtime._emit_new_session_lines()
+        await runtime._emit_new_session_lines(is_approval_continuation=True)
 
         persisted = [
             (orjson.loads(call.args[1]), call.kwargs["internal"])
@@ -1742,6 +1875,43 @@ class TestClaudeAgentRuntimeSessionLineFlushing:
             internal=False,
         )
         assert runtime._last_seen_byte_offset == len(first_bytes + second_bytes)
+
+    @pytest.mark.anyio
+    async def test_emit_new_session_lines_keeps_normal_continue_prompt_visible(
+        self,
+        mock_socket_writer: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A normal user "Continue." row should not be hidden."""
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=tmp_path / "claude-home",
+            cwd=tmp_path / "claude-project",
+        )
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        runtime._sdk_session_id = sdk_session_id
+        continue_line = {
+            "type": "user",
+            "uuid": "normal-continue-line",
+            "message": {
+                "role": "user",
+                "content": runtime_module.APPROVAL_CONTINUATION_PROMPT,
+            },
+        }
+        continue_bytes = self._line_bytes(continue_line)
+
+        session_file = runtime._get_session_file_path(sdk_session_id)
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_bytes(continue_bytes)
+
+        await runtime._emit_new_session_lines()
+
+        mock_socket_writer.send_session_line.assert_awaited_once_with(
+            sdk_session_id,
+            continue_bytes.rstrip(b"\n").decode("utf-8"),
+            internal=False,
+        )
 
     @pytest.mark.anyio
     async def test_emit_new_session_lines_retries_partial_line(

--- a/tests/unit/test_agent_session_messages.py
+++ b/tests/unit/test_agent_session_messages.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import orjson
 import pytest
@@ -15,10 +15,12 @@ from tracecat.db.models import AgentSession
 
 
 def _mock_scalar_result(items: list[Any]) -> Mock:
-    scalars = Mock()
+    scalars = MagicMock()
     scalars.all.return_value = items
+    scalars.__iter__.return_value = iter(items)
     result = Mock()
     result.scalars.return_value = scalars
+    result.scalar_one_or_none.return_value = items[0] if items else None
     return result
 
 
@@ -40,6 +42,7 @@ def _build_service() -> tuple[AgentSessionService, AgentSession]:
         entity_type="case",
         entity_id=uuid.uuid4(),
     )
+    agent_session.id = uuid.uuid4()
     return service, agent_session
 
 

--- a/tests/unit/test_agent_socket_io.py
+++ b/tests/unit/test_agent_socket_io.py
@@ -14,7 +14,7 @@ import asyncio
 import tempfile
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import orjson
@@ -150,6 +150,39 @@ class TestRuntimeSocketCommunication:
             finally:
                 server.close()
                 await server.wait_closed()
+
+    @pytest.mark.anyio
+    async def test_socket_writer_serializes_concurrent_sends(self) -> None:
+        """Concurrent send calls should not overlap socket drains."""
+        active_drains = 0
+        max_active_drains = 0
+        raw_writer = MagicMock()
+
+        async def drain() -> None:
+            nonlocal active_drains, max_active_drains
+            active_drains += 1
+            max_active_drains = max(max_active_drains, active_drains)
+            await asyncio.sleep(0)
+            active_drains -= 1
+
+        raw_writer.write = MagicMock()
+        raw_writer.drain = AsyncMock(side_effect=drain)
+        socket_writer = SocketStreamWriter(cast(asyncio.StreamWriter, raw_writer))
+
+        await asyncio.gather(
+            socket_writer.send_stream_event(
+                UnifiedStreamEvent(
+                    type=StreamEventType.TEXT_DELTA,
+                    text="hello",
+                    part_id=0,
+                )
+            ),
+            socket_writer.send_session_line("sdk-session", "{}"),
+            socket_writer.send_done(),
+        )
+
+        assert raw_writer.write.call_count == 3
+        assert max_active_drains == 1
 
     @pytest.mark.anyio
     async def test_runtime_streams_sdk_events(

--- a/tracecat/agent/common/socket_io.py
+++ b/tracecat/agent/common/socket_io.py
@@ -111,13 +111,15 @@ class SocketStreamWriter:
 
     def __init__(self, writer: asyncio.StreamWriter):
         self._writer = writer
+        self._send_lock = asyncio.Lock()
 
     async def _send(self, envelope: RuntimeEventEnvelope) -> None:
         """Send an envelope over the socket."""
         payload = orjson.dumps(envelope.to_dict())
         message = build_message(MessageType.EVENT, payload)
-        self._writer.write(message)
-        await self._writer.drain()
+        async with self._send_lock:
+            self._writer.write(message)
+            await self._writer.drain()
 
     async def send_stream_event(self, event: UnifiedStreamEvent) -> None:
         """Send a stream event (partial delta) to the orchestrator."""

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -16,9 +16,10 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from time import perf_counter
-from typing import Any, Protocol
+from typing import Any, Literal, NotRequired, Protocol, TypedDict, cast
 
 import orjson
 from sqlalchemy import select
@@ -45,6 +46,35 @@ from tracecat.db.models import AgentChannelToken, AgentSession, AgentSessionHist
 from tracecat.exceptions import TracecatValidationError
 from tracecat.logger import logger
 
+type JsonScalar = str | int | float | bool | None
+type JsonValue = JsonScalar | list[JsonValue] | dict[str, JsonValue]
+type JsonObject = dict[str, JsonValue]
+type ResultUsage = dict[str, JsonValue]
+type RuntimeOutput = JsonValue
+type SessionLineKind = Literal["chat-message", "internal", "compaction"]
+type CompactionPhase = Literal["started", "completed", "failed"]
+
+
+class ClaudeSessionMessage(TypedDict):
+    """Message payload embedded in a Claude Code JSONL session line."""
+
+    role: NotRequired[str]
+    content: NotRequired[str | list[JsonObject]]
+
+
+class ClaudeSessionLine(TypedDict):
+    """Subset of Claude Code JSONL fields used by loopback persistence."""
+
+    uuid: NotRequired[str]
+    parentUuid: NotRequired[str]
+    sessionId: NotRequired[str]
+    type: NotRequired[str]
+    subtype: NotRequired[str]
+    message: NotRequired[ClaudeSessionMessage | JsonObject]
+
+
+type SinkOperation = Callable[[LoopbackEventSink], Awaitable[None]]
+
 
 @dataclass(kw_only=True, slots=True)
 class LoopbackInput:
@@ -62,8 +92,8 @@ class LoopbackResult:
     error: str | None = None
     approval_requested: bool = False
     approval_items: list[ToolCallContent] = field(default_factory=list)
-    output: Any = None
-    result_usage: dict[str, Any] | None = None
+    output: RuntimeOutput | None = None
+    result_usage: ResultUsage | None = None
     result_num_turns: int | None = None
 
 
@@ -78,7 +108,10 @@ class ResolvedSlackContext:
     reaction_ts: str | None = None
 
     @classmethod
-    def from_channel_context(cls, ctx: dict[str, Any]) -> ResolvedSlackContext | None:
+    def from_channel_context(
+        cls,
+        ctx: Mapping[str, object],
+    ) -> ResolvedSlackContext | None:
         """Parse a channel_context dict into a validated context, or None on failure."""
         channel_id = ctx.get("channel_id")
         thread_ts = ctx.get("thread_ts")
@@ -143,31 +176,55 @@ class FanoutStreamSink:
 
     sinks: tuple[LoopbackEventSink, ...]
 
-    async def _broadcast(self, method_name: str, *args: Any) -> None:
+    async def _broadcast(
+        self,
+        operation_name: str,
+        operation: SinkOperation,
+    ) -> None:
         failures = 0
         for sink in self.sinks:
-            method = getattr(sink, method_name)
             try:
-                await method(*args)
+                await operation(sink)
             except Exception as exc:
                 failures += 1
                 logger.warning(
                     "Fanout stream sink target failed",
-                    method=method_name,
+                    method=operation_name,
                     sink_type=type(sink).__name__,
                     error=str(exc),
                 )
         if failures == len(self.sinks):
-            raise RuntimeError(f"All fanout sinks failed for method '{method_name}'")
+            raise RuntimeError(f"All fanout sinks failed for method '{operation_name}'")
 
     async def append(self, event: UnifiedStreamEvent) -> None:
-        await self._broadcast("append", event)
+        await self._broadcast("append", lambda sink: sink.append(event))
 
     async def error(self, error: str) -> None:
-        await self._broadcast("error", error)
+        await self._broadcast("error", lambda sink: sink.error(error))
 
     async def done(self) -> None:
-        await self._broadcast("done")
+        await self._broadcast("done", lambda sink: sink.done())
+
+
+def _runtime_envelope_from_json(payload: bytes) -> RuntimeEventEnvelope:
+    """Decode a socket payload into a typed runtime event envelope."""
+    decoded = orjson.loads(payload)
+    if not isinstance(decoded, dict):
+        raise ValueError("Runtime event payload must be a JSON object")
+    return RuntimeEventEnvelope.from_dict(cast(dict[str, Any], decoded))
+
+
+def _session_line_from_json(session_line: str) -> ClaudeSessionLine:
+    """Decode and validate the outer shape of a Claude Code JSONL line."""
+    decoded = orjson.loads(session_line)
+    if not isinstance(decoded, dict):
+        raise ValueError("Claude session line must be a JSON object")
+    return cast(ClaudeSessionLine, decoded)
+
+
+def _session_line_db_content(line: ClaudeSessionLine) -> dict[str, Any]:
+    """Return a SQLAlchemy JSONB payload for an already validated session line."""
+    return cast(dict[str, Any], line)
 
 
 class LoopbackHandler:
@@ -212,7 +269,7 @@ class LoopbackHandler:
         )
 
     @staticmethod
-    def _tool_output_contains_internal_interrupt(value: Any) -> bool:
+    def _tool_output_contains_internal_interrupt(value: object) -> bool:
         """Return True when tool output matches approval interruption artifacts."""
         markers = (
             "doesn't want to take this action",
@@ -220,17 +277,18 @@ class LoopbackHandler:
             "request interrupted by user",
         )
 
-        stack: list[Any] = [value]
+        stack: list[object] = [value]
         while stack:
             current = stack.pop()
-            if isinstance(current, str):
-                lowered = current.lower()
-                if any(marker in lowered for marker in markers):
-                    return True
-            elif isinstance(current, list):
-                stack.extend(current)
-            elif isinstance(current, dict):
-                stack.extend(current.values())
+            match current:
+                case str() as text:
+                    lowered = text.lower()
+                    if any(marker in lowered for marker in markers):
+                        return True
+                case list() as items:
+                    stack.extend(items)
+                case Mapping() as mapping:
+                    stack.extend(mapping.values())
         return False
 
     def _should_suppress_stream_event(self, event: UnifiedStreamEvent) -> bool:
@@ -249,6 +307,14 @@ class LoopbackHandler:
             return False
 
         return self._tool_output_contains_internal_interrupt(event.tool_output)
+
+    @staticmethod
+    def _compaction_phase(event: UnifiedStreamEvent) -> CompactionPhase | None:
+        match event.metadata:
+            case {"phase": "started" | "completed" | "failed" as phase}:
+                return phase
+            case _:
+                return None
 
     async def prepare(self) -> LoopbackEventSink:
         """Initialize and cache the stream sink before runtime connection."""
@@ -388,7 +454,7 @@ class LoopbackHandler:
                     await self._stream_sink.error(self._result.error)
                 break
 
-            envelope = RuntimeEventEnvelope.from_dict(orjson.loads(payload_bytes))
+            envelope = _runtime_envelope_from_json(payload_bytes)
             if await self.process_envelope(envelope):
                 break
 
@@ -478,7 +544,7 @@ class LoopbackHandler:
             session_id=self.input.session_id,
         )
         if event.type == StreamEventType.COMPACTION:
-            phase = (event.metadata or {}).get("phase")
+            phase = self._compaction_phase(event)
             if phase == "started":
                 self._started_compaction_event = True
                 self._terminal_compaction_event = False
@@ -525,10 +591,10 @@ class LoopbackHandler:
 
     async def send_result(
         self,
-        usage: dict[str, Any] | None = None,
+        usage: ResultUsage | None = None,
         num_turns: int | None = None,
         duration_ms: int | None = None,
-        output: Any = None,
+        output: RuntimeOutput | None = None,
     ) -> None:
         """Store the final Claude result payload."""
         del duration_ms
@@ -749,13 +815,13 @@ class LoopbackHandler:
             internal: If True, this is internal state not shown in UI timeline.
         """
         # Parse and sanitize to prevent XSS from untrusted content (e.g., tool results)
-        line_data = orjson.loads(session_line)
+        line_data = _session_line_from_json(session_line)
         if not internal and line_data.get("type") == "assistant":
             self._received_assistant_content = True
 
         # Deduplicate by UUID - each JSONL line has a unique uuid field
         line_uuid = line_data.get("uuid")
-        if line_uuid and line_uuid in self._persisted_line_uuids:
+        if isinstance(line_uuid, str) and line_uuid in self._persisted_line_uuids:
             logger.debug(
                 "Skipping duplicate session line",
                 uuid=line_uuid,
@@ -790,7 +856,7 @@ class LoopbackHandler:
                     )
 
             # Use explicit internal flag from runtime, not content-based heuristics
-            kind = "internal" if internal else "chat-message"
+            kind: SessionLineKind = "internal" if internal else "chat-message"
 
             # Compaction system message (compact_boundary) marked with its own kind for badge rendering
             # The system compact_boundary message carries the metadata (pre_tokens, trigger)
@@ -803,14 +869,14 @@ class LoopbackHandler:
             history_entry = AgentSessionHistory(
                 session_id=self.input.session_id,
                 workspace_id=self.input.workspace_id,
-                content=line_data,
+                content=_session_line_db_content(line_data),
                 kind=kind,
             )
             session.add(history_entry)
             await session.commit()
 
         # Track as persisted after successful commit
-        if line_uuid:
+        if isinstance(line_uuid, str):
             self._persisted_line_uuids.add(line_uuid)
 
     def _validate_runtime_completion(self) -> str | None:
@@ -830,7 +896,7 @@ class LoopbackHandler:
         return None
 
     @staticmethod
-    def _is_effectively_empty_output(value: Any) -> bool:
+    def _is_effectively_empty_output(value: object | None) -> bool:
         """Return True when the result output carries no meaningful content."""
         if value is None:
             return True
@@ -841,7 +907,7 @@ class LoopbackHandler:
         return False
 
     @staticmethod
-    def _is_zero_usage(usage: dict[str, Any] | None) -> bool:
+    def _is_zero_usage(usage: ResultUsage | None) -> bool:
         """Return True when usage is missing or contains no positive numeric values."""
         if not usage:
             return True

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -347,9 +347,9 @@ class ClaudeAgentRuntime:
         if payload.sdk_session_id and payload.sdk_session_data:
             resume_session_id = payload.sdk_session_id
             fork_session = payload.is_fork
-            session_data = self._session_data_for_disk(payload.sdk_session_data)
-            self._last_seen_byte_offset = len(session_data.encode("utf-8"))
             if not fork_session:
+                session_data = self._session_data_for_disk(payload.sdk_session_data)
+                self._last_seen_byte_offset = len(session_data.encode("utf-8"))
                 self._sdk_session_id = resume_session_id
 
         async with asyncio.TaskGroup() as tg:

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -229,9 +229,6 @@ class ClaudeAgentRuntime:
         self._last_seen_byte_offset: int = 0
         self._session_flush_lock = asyncio.Lock()
         self._session_flush_event = asyncio.Event()
-        # One-shot guard for hiding our neutral approval-continuation prompt.
-        # Other SDK metadata rows are hidden structurally by `_is_internal_session_line`.
-        self._hide_next_approval_continuation_prompt: bool = False
         # Adapter for converting Claude SDK events - must be reused to track state
         self._stream_adapter = ClaudeSDKAdapter()
         # Working directory for session file path resolution
@@ -388,6 +385,7 @@ class ClaudeAgentRuntime:
     def _session_data_for_disk(self, sdk_session_data: str) -> str:
         """Return canonical SDK JSONL exactly as written to the local session file."""
         sdk_session_data = self._canonicalize_sdk_session_data(sdk_session_data)
+        # Ensure JSONL readers do not treat the final record as truncated.
         if sdk_session_data and not sdk_session_data.endswith("\n"):
             return f"{sdk_session_data}\n"
         return sdk_session_data
@@ -512,13 +510,13 @@ class ClaudeAgentRuntime:
 
     async def _capture_sdk_session_id(
         self,
-        sdk_session_id: object,
+        sdk_session_id: str | None,
         *,
         resume_session_id: str | None,
         fork_session: bool,
     ) -> None:
         """Capture the SDK session ID from any SDK message that carries it."""
-        if not isinstance(sdk_session_id, str) or not sdk_session_id:
+        if not sdk_session_id:
             return
         if self._sdk_session_id == sdk_session_id:
             return
@@ -541,19 +539,29 @@ class ClaudeAgentRuntime:
             previous_sdk_session_id=previous,
         )
 
-    async def _flush_session_lines_when_signaled(self) -> None:
+    async def _flush_session_lines_when_signaled(
+        self,
+        *,
+        is_approval_continuation: bool,
+    ) -> None:
         """Flush SDK JSONL lines when stream progress marks the session dirty."""
         while True:
             await self._session_flush_event.wait()
             self._session_flush_event.clear()
             try:
-                await self._emit_new_session_lines()
+                await self._emit_new_session_lines(
+                    is_approval_continuation=is_approval_continuation
+                )
             except asyncio.CancelledError:
                 raise
             except Exception as e:
                 logger.warning("Failed to flush session lines", error=str(e))
 
-    async def _emit_new_session_lines(self) -> None:
+    async def _emit_new_session_lines(
+        self,
+        *,
+        is_approval_continuation: bool = False,
+    ) -> None:
         """Read and emit new JSONL lines from the SDK session file.
 
         This tails the session file written by Claude SDK and emits complete new
@@ -614,14 +622,10 @@ class ClaudeAgentRuntime:
                     )
                     break
 
-                internal = self._is_internal_session_line(line_data)
-
-                if (
-                    self._hide_next_approval_continuation_prompt
+                internal = self._is_internal_session_line(line_data) or (
+                    is_approval_continuation
                     and is_approval_continuation_prompt_line(line_data)
-                ):
-                    internal = True
-                    self._hide_next_approval_continuation_prompt = False
+                )
 
                 await self._event_writer.send_session_line(
                     sdk_session_id, line, internal=internal
@@ -958,7 +962,6 @@ class ClaudeAgentRuntime:
             _configure_claude_sdk_process_env()
             if payload.is_approval_continuation:
                 query_input = self._meta_text_input_stream(APPROVAL_CONTINUATION_PROMPT)
-                self._hide_next_approval_continuation_prompt = True
                 query_log_extra = {
                     "prompt_length": len(APPROVAL_CONTINUATION_PROMPT),
                     "is_meta": True,
@@ -977,7 +980,9 @@ class ClaudeAgentRuntime:
                 log_benchmark_phase("runtime_client_connected")
                 stderr_task = asyncio.create_task(drain_stderr())
                 session_flush_task = asyncio.create_task(
-                    self._flush_session_lines_when_signaled()
+                    self._flush_session_lines_when_signaled(
+                        is_approval_continuation=payload.is_approval_continuation
+                    )
                 )
                 try:
                     await self._event_writer.send_log(
@@ -1004,8 +1009,14 @@ class ClaudeAgentRuntime:
                         logger.debug(
                             "Received message", message_type=type(message).__name__
                         )
+                        raw_sdk_session_id = getattr(message, "session_id", None)
+                        sdk_session_id = (
+                            raw_sdk_session_id
+                            if isinstance(raw_sdk_session_id, str)
+                            else None
+                        )
                         await self._capture_sdk_session_id(
-                            getattr(message, "session_id", None),
+                            sdk_session_id,
                             resume_session_id=resume_session_id,
                             fork_session=fork_session,
                         )
@@ -1043,7 +1054,6 @@ class ClaudeAgentRuntime:
                                 duration_ms=message.duration_ms,
                                 output=result_output,
                             )
-                            self._hide_next_approval_continuation_prompt = False
 
                         elif isinstance(message, SystemMessage):
                             # init: emitted once at session start; surfaces MCP
@@ -1114,7 +1124,9 @@ class ClaudeAgentRuntime:
                         pass
 
             # CLI has exited — session file is fully flushed.
-            await self._emit_new_session_lines()
+            await self._emit_new_session_lines(
+                is_approval_continuation=payload.is_approval_continuation
+            )
             log_benchmark_phase("runtime_complete")
 
         except Exception as e:

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -16,6 +16,7 @@ import os
 import tempfile
 import uuid
 from collections.abc import AsyncIterator, Callable
+from contextlib import suppress
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Literal, Protocol, cast
@@ -225,7 +226,9 @@ class ClaudeAgentRuntime:
         self._was_interrupted: bool = False
         # For incremental JSONL line tracking
         self._sdk_session_id: str | None = None
-        self._last_seen_line_index: int = 0
+        self._last_seen_byte_offset: int = 0
+        self._session_flush_lock = asyncio.Lock()
+        self._session_flush_event = asyncio.Event()
         # One-shot guard for hiding our neutral approval-continuation prompt.
         # Other SDK metadata rows are hidden structurally by `_is_internal_session_line`.
         self._hide_next_approval_continuation_prompt: bool = False
@@ -317,16 +320,11 @@ class ClaudeAgentRuntime:
     ) -> Path:
         """Write session data to local filesystem for SDK resume."""
         session_file_path = self._get_session_file_path(sdk_session_id)
-        sdk_session_data = self._canonicalize_sdk_session_data(sdk_session_data)
-
-        # Ensure the file ends with a newline so JSONL readers don't treat the last
-        # record as truncated (some implementations are strict about this).
-        if sdk_session_data and not sdk_session_data.endswith("\n"):
-            sdk_session_data = f"{sdk_session_data}\n"
+        sdk_session_data = self._session_data_for_disk(sdk_session_data)
 
         def _write() -> None:
             session_file_path.parent.mkdir(parents=True, exist_ok=True)
-            session_file_path.write_text(sdk_session_data)
+            session_file_path.write_text(sdk_session_data, encoding="utf-8")
 
         await asyncio.to_thread(_write)
         logger.debug("Wrote session file", path=str(session_file_path))
@@ -349,9 +347,10 @@ class ClaudeAgentRuntime:
         if payload.sdk_session_id and payload.sdk_session_data:
             resume_session_id = payload.sdk_session_id
             fork_session = payload.is_fork
+            session_data = self._session_data_for_disk(payload.sdk_session_data)
+            self._last_seen_byte_offset = len(session_data.encode("utf-8"))
             if not fork_session:
                 self._sdk_session_id = resume_session_id
-                self._last_seen_line_index = len(payload.sdk_session_data.splitlines())
 
         async with asyncio.TaskGroup() as tg:
             if (
@@ -385,6 +384,13 @@ class ClaudeAgentRuntime:
         return sdk_session_data.replace(
             LEGACY_REGISTRY_MCP_TOOL_PREFIX, REGISTRY_MCP_TOOL_PREFIX
         ).replace(LEGACY_REGISTRY_MCP_DOT_PREFIX, REGISTRY_MCP_DOT_PREFIX)
+
+    def _session_data_for_disk(self, sdk_session_data: str) -> str:
+        """Return canonical SDK JSONL exactly as written to the local session file."""
+        sdk_session_data = self._canonicalize_sdk_session_data(sdk_session_data)
+        if sdk_session_data and not sdk_session_data.endswith("\n"):
+            return f"{sdk_session_data}\n"
+        return sdk_session_data
 
     @staticmethod
     def _is_internal_compaction_prompt(text: str) -> bool:
@@ -504,49 +510,107 @@ class ClaudeAgentRuntime:
 
         return False
 
+    async def _capture_sdk_session_id(
+        self,
+        sdk_session_id: object,
+        *,
+        resume_session_id: str | None,
+        fork_session: bool,
+    ) -> None:
+        """Capture the SDK session ID from any SDK message that carries it."""
+        if not isinstance(sdk_session_id, str) or not sdk_session_id:
+            return
+        if self._sdk_session_id == sdk_session_id:
+            return
+
+        previous = self._sdk_session_id
+        self._sdk_session_id = sdk_session_id
+
+        if previous is None and resume_session_id and fork_session:
+            session_file = self._get_session_file_path(sdk_session_id)
+            try:
+                stat = session_file.stat()
+            except FileNotFoundError:
+                pass
+            else:
+                self._last_seen_byte_offset = stat.st_size
+
+        logger.debug(
+            "Captured SDK session ID",
+            sdk_session_id=self._sdk_session_id,
+            previous_sdk_session_id=previous,
+        )
+
+    async def _flush_session_lines_when_signaled(self) -> None:
+        """Flush SDK JSONL lines when stream progress marks the session dirty."""
+        while True:
+            await self._session_flush_event.wait()
+            self._session_flush_event.clear()
+            try:
+                await self._emit_new_session_lines()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning("Failed to flush session lines", error=str(e))
+
     async def _emit_new_session_lines(self) -> None:
         """Read and emit new JSONL lines from the SDK session file.
 
-        This reads the session file written by Claude SDK and emits any new lines
-        (past _last_seen_line_index) to the orchestrator for persistence.
+        This tails the session file written by Claude SDK and emits complete new
+        lines from the last byte offset to the orchestrator for persistence.
         The lines contain the full JSONL envelope (uuid, timestamp, parentUuid, etc.)
         needed for proper resume.
 
-        If a line fails to parse (e.g., incomplete write by SDK), we stop processing
-        at that point and keep the index there. The incomplete line will be retried
-        on the next call once the SDK finishes writing it.
+        If a line is incomplete or fails to parse, we stop processing at that byte
+        offset. The incomplete line will be retried on the next call once the SDK
+        finishes writing it.
 
         Race condition handling: If called before _sdk_session_id is set (i.e., before
         the first StreamEvent), this is a no-op. The loopback handler uses UUID-based
         deduplication to handle any duplicates that might occur from out-of-order events.
         """
-        if not self._sdk_session_id:
-            return
+        async with self._session_flush_lock:
+            if not self._sdk_session_id:
+                return
 
-        session_file = self._get_session_file_path(self._sdk_session_id)
-        if not session_file.exists():
-            return
+            sdk_session_id = self._sdk_session_id
+            session_file = self._get_session_file_path(sdk_session_id)
+            start_offset = self._last_seen_byte_offset
 
-        try:
-            file_content = await asyncio.to_thread(session_file.read_text)
-            lines = file_content.splitlines()
-            new_lines = lines[self._last_seen_line_index :]
+            def _read_tail() -> bytes | None:
+                try:
+                    with session_file.open("rb") as file:
+                        file.seek(start_offset)
+                        return file.read()
+                except FileNotFoundError:
+                    return None
 
-            for line in new_lines:
-                if not line.strip():
-                    # Empty line - advance index and continue
-                    self._last_seen_line_index += 1
+            tail = await asyncio.to_thread(_read_tail)
+            if not tail:
+                return
+
+            line_offset = start_offset
+            for raw_line in tail.splitlines(keepends=True):
+                if not raw_line.endswith(b"\n"):
+                    break
+
+                next_offset = line_offset + len(raw_line)
+                line_bytes = raw_line.rstrip(b"\r\n")
+                if not line_bytes.strip():
+                    self._last_seen_byte_offset = next_offset
+                    line_offset = next_offset
                     continue
 
                 # Parse to determine visibility, but send raw line for SDK resume
                 try:
+                    line = line_bytes.decode("utf-8")
                     line_data = orjson.loads(line)
-                except orjson.JSONDecodeError:
+                except (UnicodeDecodeError, orjson.JSONDecodeError):
                     # Stop at the first decode failure - this line may be incomplete
                     # because the SDK is still writing it. We'll retry on the next pass.
                     logger.debug(
                         "Stopping at incomplete session line, will retry",
-                        line_index=self._last_seen_line_index,
+                        byte_offset=line_offset,
                     )
                     break
 
@@ -560,14 +624,12 @@ class ClaudeAgentRuntime:
                     self._hide_next_approval_continuation_prompt = False
 
                 await self._event_writer.send_session_line(
-                    self._sdk_session_id, line, internal=internal
+                    sdk_session_id, line, internal=internal
                 )
 
-                # Only advance the index after successfully processing the line
-                self._last_seen_line_index += 1
-
-        except Exception as e:
-            logger.warning("Failed to read session file", error=str(e))
+                # Only advance the offset after successfully processing the line.
+                self._last_seen_byte_offset = next_offset
+                line_offset = next_offset
 
     async def _handle_approval_request(
         self,
@@ -738,6 +800,9 @@ class ClaudeAgentRuntime:
             )
 
         self._session_id = payload.session_id
+        self._sdk_session_id = None
+        self._last_seen_byte_offset = 0
+        self._session_flush_event.clear()
         log_benchmark_phase("runtime_start")
         await self._event_writer.send_log(
             "info",
@@ -747,6 +812,7 @@ class ClaudeAgentRuntime:
         # Use resolved tool definitions from orchestrator
         self.registry_tools = payload.allowed_actions
         self.tool_approvals = payload.config.tool_approvals
+        session_flush_task: asyncio.Task[None] | None = None
 
         # Stable per-session working directory for the Claude Code CLI.
         # IMPORTANT: Must be deterministic per session_id. The CLI indexes
@@ -910,6 +976,9 @@ class ClaudeAgentRuntime:
                 self.client = client
                 log_benchmark_phase("runtime_client_connected")
                 stderr_task = asyncio.create_task(drain_stderr())
+                session_flush_task = asyncio.create_task(
+                    self._flush_session_lines_when_signaled()
+                )
                 try:
                     await self._event_writer.send_log(
                         "info",
@@ -935,48 +1004,22 @@ class ClaudeAgentRuntime:
                         logger.debug(
                             "Received message", message_type=type(message).__name__
                         )
+                        await self._capture_sdk_session_id(
+                            getattr(message, "session_id", None),
+                            resume_session_id=resume_session_id,
+                            fork_session=fork_session,
+                        )
                         if isinstance(message, StreamEvent):
                             if not first_stream_event_logged:
                                 first_stream_event_logged = True
                                 log_benchmark_phase("runtime_first_stream_event")
-                            # Capture SDK session ID from first StreamEvent
-                            if (
-                                message.session_id
-                                and self._sdk_session_id != message.session_id
-                            ):
-                                previous = self._sdk_session_id
-                                self._sdk_session_id = message.session_id
-                                # If the CLI started a different session (e.g. fork), avoid
-                                # re-persisting old history by jumping to current file length.
-                                # For normal resumes we pre-seed `_last_seen_line_index` above.
-                                if (
-                                    previous is None
-                                    and resume_session_id
-                                    and fork_session
-                                ):
-                                    session_file = self._get_session_file_path(
-                                        self._sdk_session_id
-                                    )
-                                    if session_file.exists():
-                                        file_content = await asyncio.to_thread(
-                                            session_file.read_text
-                                        )
-                                        self._last_seen_line_index = len(
-                                            file_content.splitlines()
-                                        )
-                                logger.debug(
-                                    "Captured SDK session ID",
-                                    sdk_session_id=self._sdk_session_id,
-                                    previous_sdk_session_id=previous,
-                                )
 
                             # Partial streaming delta - forward to UI
                             unified = self._stream_adapter.to_unified_event(message)
                             await self._event_writer.send_stream_event(unified)
+                            self._session_flush_event.set()
 
                         elif isinstance(message, ResultMessage):
-                            # Final result - emit any remaining lines
-                            await self._emit_new_session_lines()
                             await self._event_writer.send_log(
                                 "info",
                                 "Agent turn completed",
@@ -1003,8 +1046,6 @@ class ClaudeAgentRuntime:
                             self._hide_next_approval_continuation_prompt = False
 
                         elif isinstance(message, SystemMessage):
-                            await self._emit_new_session_lines()
-
                             # init: emitted once at session start; surfaces MCP
                             # server connection results so we can flag failures.
                             if message.subtype == "init":
@@ -1041,11 +1082,10 @@ class ClaudeAgentRuntime:
                                         pre_tokens=pre_tokens,
                                     )
                                 )
+                                self._session_flush_event.set()
 
                         else:
                             # AssistantMessage, UserMessage, etc.
-                            await self._emit_new_session_lines()
-
                             # Stream tool results for UI
                             if isinstance(message, UserMessage) and isinstance(
                                 message.content, list
@@ -1065,6 +1105,7 @@ class ClaudeAgentRuntime:
                                                 is_error=block.is_error or False,
                                             )
                                         )
+                                        self._session_flush_event.set()
                 finally:
                     stderr_task.cancel()
                     try:
@@ -1086,5 +1127,9 @@ class ClaudeAgentRuntime:
             await self._event_writer.send_error(str(e))
             raise
         finally:
+            if session_flush_task is not None:
+                session_flush_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await session_flush_task
             self.client = None
             await self._event_writer.send_done()


### PR DESCRIPTION
## Summary
- Persist Claude Code JSONL session lines during turns by tailing appended bytes instead of rereading the full file on every stream event.
- Coalesce eager persistence with an `asyncio.Event`, keeping stream events on the fast path and preserving a final flush before `done`.
- Serialize socket writes so foreground stream frames and background session-line frames cannot interleave.
- Tighten session-line persistence typing and add regression coverage for byte tailing, partial lines, resume/fork offsets, final-only turns, stream latency, and socket serialization.

## Review Notes
The runtime now treats SDK session persistence as a side channel: foreground stream events are sent first, then the flusher tails new JSONL rows by byte offset under its own lock. The final flush still runs before `done`, so result-only turns and races with the background task persist their session rows before completion.

```mermaid
sequenceDiagram
    participant SDK as Claude SDK
    participant Runtime as Runtime loop
    participant Flusher as Session flusher
    participant Socket as Event writer
    participant Parent as Orchestrator

    SDK-->>Runtime: stream / system / result message
    Runtime->>Socket: send foreground runtime event
    Runtime->>Flusher: signal flush event
    Flusher->>Flusher: tail JSONL from last byte offset
    Flusher->>Flusher: classify line visibility
    Flusher->>Socket: send_session_line(..., internal=...)
    Socket->>Parent: serialized socket write
    Runtime->>Flusher: final flush before done
    Runtime->>Socket: send done
```

Approval continuation prompts are classified at emit time instead of using a mutable "hide next prompt" flag. Both the background flush and final flush receive the same immutable approval-continuation context for the current SDK query, so whichever wins the race applies the same classification.

```mermaid
sequenceDiagram
    participant Runtime as Runtime loop
    participant SDK as Claude SDK
    participant File as SDK JSONL file
    participant Flusher as Session flusher
    participant Socket as Event writer

    Runtime->>SDK: query(..., is_approval_continuation=True)
    SDK->>File: append continuation prompt row
    par Background flush wins
        Runtime->>Flusher: signal flush with approval context
    and Result arrives first
        SDK-->>Runtime: ResultMessage
        Runtime->>Flusher: final flush with approval context
    end
    Flusher->>File: read new rows by byte offset
    Flusher->>Flusher: internal = existing_internal || approval_prompt_match
    Flusher->>Socket: persist continuation prompt as internal
```

## Session Interrupt Safety
This change does not make the streamed UI state the source of truth. The Claude SDK JSONL file remains canonical; the runtime only copies complete, parseable rows out of that file sooner.

For a graceful interrupt, such as the existing approval path, the runtime emits the approval request, calls `client.interrupt()`, and lets the SDK append its normal interrupt/control rows. Those rows then flow through the same downstream session-line path: the flusher tails them, the socket writer sends serialized `session_line` envelopes, and loopback persists them in `AgentSessionHistory` with UUID dedupe.

That means future user interrupts should use the same shape: send a graceful interrupt to the runtime, let the SDK write the interruption rows, then let the existing flush/final-drain path persist them. The safeguards are byte-offset tailing, complete-line parsing, offset advancement only after successful send, a flush lock, socket write serialization, loopback UUID dedupe, and a final flush before `done`.

The caveat is hard cancellation. Killing the runtime task/process or closing the socket would not corrupt persisted history, because partial lines are ignored, but it can still drop the final rows the SDK wrote but we never drained. User interrupt should therefore be implemented as a graceful `client.interrupt()`-style control action, not as process cancellation.

## Testing
- `uv run ruff check tests/unit/test_agent_runtime.py tests/unit/test_agent_session_messages.py tests/unit/test_agent_socket_io.py tracecat/agent/common/socket_io.py tracecat/agent/executor/loopback.py tracecat/agent/runtime/claude_code/runtime.py`
- `uv run ruff format --check tests/unit/test_agent_runtime.py tests/unit/test_agent_session_messages.py tests/unit/test_agent_socket_io.py tracecat/agent/common/socket_io.py tracecat/agent/executor/loopback.py tracecat/agent/runtime/claude_code/runtime.py`
- `uv run basedpyright tests/unit/test_agent_runtime.py tests/unit/test_agent_session_messages.py tests/unit/test_agent_socket_io.py tracecat/agent/common/socket_io.py tracecat/agent/executor/loopback.py tracecat/agent/runtime/claude_code/runtime.py`
- `PG_PORT=5532 MINIO_PORT=9100 REDIS_PORT=6479 TEMPORAL_PORT=7333 uv run pytest tests/unit/test_agent_runtime.py tests/unit/test_agent_socket_io.py tests/unit/test_agent_session_messages.py tests/unit/test_agent_session_list_sessions.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flush Claude Code session history in the background without delaying stream frames by tailing SDK JSONL files by byte offset. Also serialize socket sends and keep approval-continuation prompts internal even if the result arrives first.

- **Refactors**
  - Tail session files by byte offset and retry partial lines; seed offset from canonicalized on-disk data on resume; on fork, reset to zero unless a child file exists (then use its size).
  - Background flusher runs as a task gated by an `asyncio.Event` and a lock; stream/system/tool-result events signal flush; final flush on CLI exit; capture SDK session ID from any message; send stream frames before scheduling flush.
  - Add typed parsers for runtime envelopes and Claude session lines with explicit compaction phase parsing.

- **Bug Fixes**
  - Serialize socket writes with a lock to prevent overlapping drains and interleaved frames.
  - Keep stream events on the fast path even when session-line flush is slow; persist result-only turns before `done` with correct ordering.
  - Always mark approval-continuation prompts as internal across races; reset forked session offsets correctly.

<sup>Written for commit 9412f04213f1f4ac9e9580bd40440b641c254c75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

