### PR TITLE
feat(db): add agent subagent config columns

### DIFF
--- a/alembic/versions/9f0b5f6a2d1c_add_agent_subagent_config.py
+++ b/alembic/versions/9f0b5f6a2d1c_add_agent_subagent_config.py
@@ -1,0 +1,58 @@
+"""add agent subagent config
+
+Revision ID: 9f0b5f6a2d1c
+Revises: d0b32dce7f81
+Create Date: 2026-04-23 19:45:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "9f0b5f6a2d1c"
+down_revision: str | None = "d0b32dce7f81"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_DISABLED_AGENTS_SQL = sa.text("'{\"enabled\": false}'::jsonb")
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_preset",
+        sa.Column(
+            "agents",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=_DISABLED_AGENTS_SQL,
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "agent_preset_version",
+        sa.Column(
+            "agents",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=_DISABLED_AGENTS_SQL,
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "agent_session",
+        sa.Column(
+            "agents_binding",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_session", "agents_binding")
+    op.drop_column("agent_preset_version", "agents")
+    op.drop_column("agent_preset", "agents")

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -2820,6 +2820,11 @@ class AgentSession(WorkspaceModel):
         nullable=True,
         doc="Pinned agent preset version used for this session (if any)",
     )
+    agents_binding: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB,
+        nullable=True,
+        doc="Normalized subagent bindings for this session",
+    )
     # Agent harness fields
     harness_type: Mapped[str | None] = mapped_column(
         String(50),
@@ -3458,6 +3463,13 @@ class AgentPreset(WorkspaceModel):
         nullable=True,
         doc="MCP integrations to use",
     )
+    agents: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        default=lambda: {"enabled": False},
+        server_default=text("'{\"enabled\": false}'::jsonb"),
+        nullable=False,
+        doc="Subagent configuration for this preset",
+    )
     retries: Mapped[int] = mapped_column(
         Integer, default=3, nullable=False, doc="Maximum retry attempts per run"
     )
@@ -3585,6 +3597,13 @@ class AgentPresetVersion(WorkspaceModel):
         JSONB,
         nullable=True,
         doc="MCP integrations to use",
+    )
+    agents: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        default=lambda: {"enabled": False},
+        server_default=text("'{\"enabled\": false}'::jsonb"),
+        nullable=False,
+        doc="Subagent configuration for this preset version",
     )
     retries: Mapped[int] = mapped_column(
         Integer, default=3, nullable=False, doc="Maximum retry attempts per run"


### PR DESCRIPTION
## Summary

Adds the persistence shape needed for preset-backed agent subagents.

- Add `agent_preset.agents` and `agent_preset_version.agents` JSONB columns with disabled-by-default server defaults.
- Add nullable `agent_session.agents_binding` for resolved session bindings.
- Map the new columns in the SQLAlchemy models.

## Stack

Base PR for the subagents stack. Backend behavior is in #2661 and frontend/docs are in #2564.

## Validation

- `uv run ruff check $(git diff --name-only main...feat/subagents-1 -- '*.py')`
- `uv run basedpyright --warnings --threads 4 $(git diff --name-only main...feat/subagents-1 -- '*.py')`
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`
