### PR TITLE
fix(agents): converse knob for bedrock

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4874,6 +4874,11 @@ export const $BedrockCatalogCreate = {
       ],
       title: "Model Id",
     },
+    use_converse: {
+      type: "boolean",
+      title: "Use Converse",
+      default: false,
+    },
   },
   additionalProperties: false,
   type: "object",
@@ -4924,6 +4929,11 @@ export const $BedrockCatalogUpdate = {
         },
       ],
       title: "Model Id",
+    },
+    use_converse: {
+      type: "boolean",
+      title: "Use Converse",
+      default: false,
     },
   },
   additionalProperties: false,

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1241,6 +1241,7 @@ export type BedrockCatalogCreate = {
   model_name: string
   inference_profile_id?: string | null
   model_id?: string | null
+  use_converse?: boolean
 }
 
 export type BedrockCatalogUpdate = {
@@ -1248,6 +1249,7 @@ export type BedrockCatalogUpdate = {
   model_provider: "bedrock"
   inference_profile_id?: string | null
   model_id?: string | null
+  use_converse?: boolean
 }
 
 /**

--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -182,6 +182,7 @@ const bedrockCloudModelSchema = z.object({
   display_name: z.string().trim().optional(),
   inference_profile_id: z.string().trim().optional(),
   model_id: z.string().trim().optional(),
+  use_converse: z.boolean().default(false),
 })
 
 const azureOpenAICloudModelSchema = z.object({
@@ -219,7 +220,13 @@ const cloudCatalogModelSchema = z
     if (value.provider === "bedrock") {
       const hasProfile = !!value.inference_profile_id
       const hasModelId = !!value.model_id
-      if (hasProfile === hasModelId) {
+      if (hasProfile && hasModelId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Provide at most one of Inference profile ID or Model ID.",
+          path: ["inference_profile_id"],
+        })
+      } else if (!hasProfile && !hasModelId) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "Provide exactly one of Inference profile ID or Model ID.",
@@ -260,6 +267,7 @@ function buildCloudCatalogDefaults(
           "inference_profile_id"
         ),
         model_id: getCatalogMetadataString(metadata, "model_id"),
+        use_converse: metadata?.use_converse === true,
       }
     case "azure_openai":
       return {
@@ -304,6 +312,7 @@ function buildCatalogCreatePayload(
         display_name: displayName,
         inference_profile_id: values.inference_profile_id || null,
         model_id: values.model_id || null,
+        use_converse: values.use_converse,
       }
     case "azure_openai":
       return {
@@ -342,6 +351,7 @@ function buildCatalogUpdatePayload(values: CloudCatalogModelFormValues) {
         display_name: displayName,
         inference_profile_id: values.inference_profile_id || null,
         model_id: values.model_id || null,
+        use_converse: values.use_converse,
       }
     case "azure_openai":
       return {
@@ -1745,6 +1755,29 @@ function CloudCatalogModelDialog({
                         Direct model ID for older on-demand models.
                       </FormDescription>
                       <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="use_converse"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center justify-between gap-4 rounded-md border p-3">
+                      <div className="space-y-1">
+                        <FormLabel className="text-sm">
+                          Use Converse API
+                        </FormLabel>
+                        <FormDescription>
+                          Force the Bedrock Converse API instead of InvokeModel.
+                          Enable this for models that require the Converse API.
+                        </FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
                     </FormItem>
                   )}
                 />

--- a/tests/unit/test_agent_catalog_service.py
+++ b/tests/unit/test_agent_catalog_service.py
@@ -8,7 +8,10 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tracecat.agent.catalog.schemas import AzureOpenAICatalogUpdate
+from tracecat.agent.catalog.schemas import (
+    AzureOpenAICatalogUpdate,
+    BedrockCatalogUpdate,
+)
 from tracecat.agent.catalog.service import AgentCatalogService
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
@@ -502,3 +505,43 @@ async def test_delete_catalog_entry_rejects_platform_row(
             )
     finally:
         ctx_role.reset(token)
+
+
+# --- BedrockCatalogUpdate validator ---
+
+
+def test_bedrock_update_use_converse_only_requires_no_ref() -> None:
+    """use_converse-only patch is valid; model ref unchanged in DB."""
+    update = BedrockCatalogUpdate(model_provider="bedrock", use_converse=True)
+    assert update.use_converse is True
+    assert update.inference_profile_id is None
+    assert update.model_id is None
+
+
+def test_bedrock_update_with_ref_and_use_converse_is_valid() -> None:
+    update = BedrockCatalogUpdate(
+        model_provider="bedrock",
+        inference_profile_id="us.anthropic.claude-3-haiku",
+        use_converse=True,
+    )
+    assert update.inference_profile_id == "us.anthropic.claude-3-haiku"
+    assert update.use_converse is True
+
+
+def test_bedrock_update_rejects_both_refs_set() -> None:
+    with pytest.raises(ValueError, match="at most one"):
+        BedrockCatalogUpdate(
+            model_provider="bedrock",
+            inference_profile_id="us.anthropic.claude-3-haiku",
+            model_id="anthropic.claude-3-haiku-20240307-v1:0",
+        )
+
+
+def test_bedrock_update_rejects_both_refs_explicitly_null() -> None:
+    """Explicitly sending null for both refs must be rejected."""
+    with pytest.raises(ValueError, match="At least one"):
+        BedrockCatalogUpdate(
+            model_provider="bedrock",
+            inference_profile_id=None,
+            model_id=None,
+        )

--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -182,6 +182,53 @@ def test_bedrock_rejects_ambient_credential_fallback() -> None:
     assert "resolved before request dispatch" in exc_info.value.message
 
 
+def test_bedrock_uses_invoke_prefix_when_use_converse_absent() -> None:
+    data = {"model": "bedrock"}
+    creds = {
+        "AWS_ACCESS_KEY_ID": "AKIA123",
+        "AWS_SECRET_ACCESS_KEY": "secret",
+        "AWS_MODEL_ID": "anthropic.claude-3-haiku-20240307-v1:0",
+    }
+    _inject_provider_credentials(data, "bedrock", creds)
+    assert data["model"] == "bedrock/anthropic.claude-3-haiku-20240307-v1:0"
+
+
+def test_bedrock_uses_converse_prefix_for_model_id_when_flag_true() -> None:
+    data = {"model": "bedrock"}
+    creds = {
+        "AWS_ACCESS_KEY_ID": "AKIA123",
+        "AWS_SECRET_ACCESS_KEY": "secret",
+        "AWS_MODEL_ID": "anthropic.claude-3-haiku-20240307-v1:0",
+        "AWS_BEDROCK_USE_CONVERSE": "true",
+    }
+    _inject_provider_credentials(data, "bedrock", creds)
+    assert data["model"] == "bedrock/converse/anthropic.claude-3-haiku-20240307-v1:0"
+
+
+def test_bedrock_uses_converse_prefix_for_inference_profile_when_flag_true() -> None:
+    data = {"model": "bedrock"}
+    creds = {
+        "AWS_ACCESS_KEY_ID": "AKIA123",
+        "AWS_SECRET_ACCESS_KEY": "secret",
+        "AWS_INFERENCE_PROFILE_ID": "us.anthropic.claude-3-haiku-20240307-v1:0",
+        "AWS_BEDROCK_USE_CONVERSE": "true",
+    }
+    _inject_provider_credentials(data, "bedrock", creds)
+    assert data["model"] == "bedrock/converse/us.anthropic.claude-3-haiku-20240307-v1:0"
+
+
+def test_bedrock_false_flag_does_not_use_converse_prefix() -> None:
+    data = {"model": "bedrock"}
+    creds = {
+        "AWS_ACCESS_KEY_ID": "AKIA123",
+        "AWS_SECRET_ACCESS_KEY": "secret",
+        "AWS_MODEL_ID": "anthropic.claude-3-haiku-20240307-v1:0",
+        "AWS_BEDROCK_USE_CONVERSE": "false",
+    }
+    _inject_provider_credentials(data, "bedrock", creds)
+    assert data["model"] == "bedrock/anthropic.claude-3-haiku-20240307-v1:0"
+
+
 def test_litellm_config_routes_provider_placeholders_before_catch_all() -> None:
     config_path = (
         Path(__file__).resolve().parents[2]

--- a/tests/unit/test_agent_management_service.py
+++ b/tests/unit/test_agent_management_service.py
@@ -779,6 +779,36 @@ async def test_with_model_config_injects_bedrock_external_id(role: Role) -> None
     assert secrets_manager.get("TRACECAT_AWS_EXTERNAL_ID") is None
 
 
+def test_catalog_target_credentials_serializes_bool_use_converse_true() -> None:
+    """use_converse=True stored in JSONB as a bool must project to the string 'true'."""
+    row = SimpleNamespace(
+        model_provider="bedrock",
+        model_metadata={
+            "inference_profile_id": "us.anthropic.claude-3-haiku",
+            "use_converse": True,
+        },
+    )
+    svc = AgentManagementService.__new__(AgentManagementService)
+    creds = svc._catalog_target_credentials(cast(AgentCatalog, row))
+    assert creds["AWS_INFERENCE_PROFILE_ID"] == "us.anthropic.claude-3-haiku"
+    assert creds["AWS_BEDROCK_USE_CONVERSE"] == "true"
+
+
+def test_catalog_target_credentials_serializes_bool_use_converse_false() -> None:
+    """use_converse=False stored in JSONB must project to the string 'false'."""
+    row = SimpleNamespace(
+        model_provider="bedrock",
+        model_metadata={
+            "model_id": "anthropic.claude-3-haiku-20240307-v1:0",
+            "use_converse": False,
+        },
+    )
+    svc = AgentManagementService.__new__(AgentManagementService)
+    creds = svc._catalog_target_credentials(cast(AgentCatalog, row))
+    assert creds["AWS_MODEL_ID"] == "anthropic.claude-3-haiku-20240307-v1:0"
+    assert creds["AWS_BEDROCK_USE_CONVERSE"] == "false"
+
+
 @pytest.mark.anyio
 async def test_get_runtime_provider_credentials_resolves_azure_openai_client_credentials(
     role: Role,

--- a/tracecat/agent/catalog/schemas.py
+++ b/tracecat/agent/catalog/schemas.py
@@ -46,6 +46,7 @@ class BedrockCatalogCreate(CloudCatalogModelBase):
     model_name: str = Field(min_length=1, max_length=500)
     inference_profile_id: str | None = Field(default=None, min_length=1)
     model_id: str | None = Field(default=None, min_length=1)
+    use_converse: bool = False
 
     @model_validator(mode="after")
     def _require_one_model_ref(self) -> "BedrockCatalogCreate":
@@ -93,13 +94,23 @@ class BedrockCatalogUpdate(CloudCatalogModelBase):
     model_provider: Literal["bedrock"]
     inference_profile_id: str | None = Field(default=None, min_length=1)
     model_id: str | None = Field(default=None, min_length=1)
+    use_converse: bool = False
 
     @model_validator(mode="after")
     def _require_one_model_ref(self) -> "BedrockCatalogUpdate":
+        ref_fields = {"inference_profile_id", "model_id"}
+        refs_sent = ref_fields & self.model_fields_set
+        if not refs_sent:
+            # use_converse-only update; model ref unchanged in DB
+            return self
         has_profile = self.inference_profile_id is not None
         has_model_id = self.model_id is not None
-        if has_profile == has_model_id:
-            raise ValueError("Provide exactly one of inference_profile_id or model_id")
+        if has_profile and has_model_id:
+            raise ValueError("Provide at most one of inference_profile_id or model_id")
+        if not has_profile and not has_model_id:
+            raise ValueError(
+                "At least one of inference_profile_id or model_id must be non-null when updating model refs"
+            )
         return self
 
 

--- a/tracecat/agent/gateway.py
+++ b/tracecat/agent/gateway.py
@@ -556,10 +556,15 @@ def _inject_provider_credentials(
                 )
             if region := creds.get("AWS_REGION"):
                 data["aws_region_name"] = region
+            bedrock_prefix = (
+                "bedrock/converse"
+                if creds.get("AWS_BEDROCK_USE_CONVERSE") == "true"
+                else "bedrock"
+            )
             if inference_profile_id := creds.get("AWS_INFERENCE_PROFILE_ID"):
-                data["model"] = f"bedrock/{inference_profile_id}"
+                data["model"] = f"{bedrock_prefix}/{inference_profile_id}"
             elif model_id := creds.get("AWS_MODEL_ID"):
-                data["model"] = f"bedrock/{model_id}"
+                data["model"] = f"{bedrock_prefix}/{model_id}"
             else:
                 raise ProxyException(
                     message="No Bedrock model configured. Set AWS_INFERENCE_PROFILE_ID or AWS_MODEL_ID in your credentials.",

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -72,6 +72,7 @@ _CLOUD_PROVIDER_TARGET_KEYS: dict[CloudProviderSlug, tuple[CloudTargetKey, ...]]
     "bedrock": (
         CloudTargetKey("inference_profile_id", "AWS_INFERENCE_PROFILE_ID"),
         CloudTargetKey("model_id", "AWS_MODEL_ID"),
+        CloudTargetKey("use_converse", "AWS_BEDROCK_USE_CONVERSE"),
     ),
     "azure_openai": (CloudTargetKey("deployment_name", "AZURE_DEPLOYMENT_NAME"),),
     "azure_ai": (CloudTargetKey("azure_ai_model_name", "AZURE_AI_MODEL_NAME"),),
@@ -522,7 +523,9 @@ class AgentManagementService(BaseOrgService):
         credentials: dict[str, str] = {}
         for spec in target_keys:
             value = metadata.get(spec.metadata_key)
-            if isinstance(value, str) and value:
+            if isinstance(value, bool):
+                credentials[spec.credential_key] = "true" if value else "false"
+            elif isinstance(value, str) and value:
                 credentials[spec.credential_key] = value
         return credentials
 


### PR DESCRIPTION
## Problem

When litellm cannot pattern recognize against a bedrock model that needs converse support, our current hardcoded invoke path (/bedrock) will fail for said models.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Use Converse” toggle for Bedrock models to route requests via the Bedrock Converse API. Also allow Bedrock updates that only change this flag, while keeping model reference rules strict.

- **New Features**
  - UI: Add “Use Converse API” switch for Bedrock in Org Settings; included in create/update payloads; defaults to false and pre-fills from metadata.
  - Catalog schemas: Add `use_converse` to Bedrock create/update models.
  - Credentials: Map `use_converse` to `AWS_BEDROCK_USE_CONVERSE` as "true"/"false".
  - Gateway: Use `bedrock/converse/...` prefix when `AWS_BEDROCK_USE_CONVERSE` is "true"; otherwise `bedrock/...`.
  - Tests: Add unit tests for prefix selection, credential serialization, and Bedrock update validator.

- **Bug Fixes**
  - Validation: Bedrock updates can change only `use_converse` (no ref fields). If refs are sent, require at most one; reject both explicitly null.

<sup>Written for commit bd7a195d8896c693e71258e5f26a8fdf71acd3a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<img width="553" height="673" alt="image" src="https://github.com/user-attachments/assets/848037a9-959c-490c-9851-71ebc2236552" />
