### PR TITLE
feat(observability): platform audit logs

### DIFF
--- a/frontend/src/app/admin/audit/page.tsx
+++ b/frontend/src/app/admin/audit/page.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { PlatformAuditSettings } from "@/components/admin/platform-audit-settings"
+
+export default function AdminAuditSettingsPage() {
+  return (
+    <div className="size-full overflow-auto">
+      <div className="container flex h-full max-w-[1000px] flex-col space-y-12">
+        <div className="flex w-full">
+          <div className="items-start space-y-3 text-left">
+            <h2 className="text-2xl font-semibold tracking-tight">
+              Audit logging
+            </h2>
+            <p className="text-base text-muted-foreground">
+              Send platform audit logs to your logs collector endpoint.
+            </p>
+          </div>
+        </div>
+
+        <PlatformAuditSettings />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -18086,6 +18086,148 @@ export const $PayloadChangedEventRead = {
   description: "Event for when a case payload is changed.",
 } as const
 
+export const $PlatformAuditSettingsRead = {
+  properties: {
+    audit_webhook_url: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Url",
+    },
+    audit_webhook_custom_headers: {
+      anyOf: [
+        {
+          additionalProperties: {
+            type: "string",
+          },
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Custom Headers",
+    },
+    audit_webhook_custom_payload: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Custom Payload",
+    },
+    audit_webhook_payload_attribute: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Payload Attribute",
+    },
+    audit_webhook_verify_ssl: {
+      type: "boolean",
+      title: "Audit Webhook Verify Ssl",
+      default: true,
+    },
+    decryption_failed_keys: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+      title: "Decryption Failed Keys",
+      description:
+        "Encrypted setting keys that could not be decrypted with the current encryption key and must be reconfigured.",
+    },
+  },
+  type: "object",
+  required: ["audit_webhook_url"],
+  title: "PlatformAuditSettingsRead",
+  description: "Platform audit settings response.",
+} as const
+
+export const $PlatformAuditSettingsUpdate = {
+  properties: {
+    audit_webhook_url: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Url",
+      description:
+        "Webhook URL that receives streamed audit events. When unset, audit events are skipped.",
+    },
+    audit_webhook_custom_headers: {
+      anyOf: [
+        {
+          additionalProperties: {
+            type: "string",
+          },
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Custom Headers",
+      description:
+        "Custom headers to include in audit webhook requests. Header names are case-insensitive.",
+    },
+    audit_webhook_custom_payload: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Custom Payload",
+      description:
+        "Custom JSON payload merged into streamed audit event payloads. Custom keys override default audit event keys.",
+    },
+    audit_webhook_payload_attribute: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Audit Webhook Payload Attribute",
+      description:
+        "Optional wrapper key for audit payloads. When set to a value like 'event', payload is sent as {'event': <audit_payload>}.",
+    },
+    audit_webhook_verify_ssl: {
+      type: "boolean",
+      title: "Audit Webhook Verify Ssl",
+      description:
+        "Whether TLS certificates are verified for webhook requests. Disable only for trusted on-prem/self-signed endpoints.",
+      default: true,
+    },
+  },
+  type: "object",
+  title: "PlatformAuditSettingsUpdate",
+  description: "Update platform audit settings.",
+} as const
+
 export const $PlatformMCPCatalogListResponse = {
   properties: {
     items: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -38,6 +38,7 @@ import type {
   AdminDeleteUserResponse,
   AdminDemoteFromSuperuserData,
   AdminDemoteFromSuperuserResponse,
+  AdminGetAuditSettingsResponse,
   AdminGetOrganizationData,
   AdminGetOrganizationInvitationTokenData,
   AdminGetOrganizationInvitationTokenResponse,
@@ -85,6 +86,8 @@ import type {
   AdminRevokeOrganizationInvitationResponse,
   AdminSyncOrgRepositoryData,
   AdminSyncOrgRepositoryResponse,
+  AdminUpdateAuditSettingsData,
+  AdminUpdateAuditSettingsResponse,
   AdminUpdateOrganizationData,
   AdminUpdateOrganizationDomainData,
   AdminUpdateOrganizationDomainResponse,
@@ -7435,6 +7438,42 @@ export const adminPromoteOrgRepositoryVersion = (
       repository_id: data.repositoryId,
       version_id: data.versionId,
     },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Audit Settings
+ * Get platform audit settings.
+ * @returns PlatformAuditSettingsRead Successful Response
+ * @throws ApiError
+ */
+export const adminGetAuditSettings =
+  (): CancelablePromise<AdminGetAuditSettingsResponse> => {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/admin/settings/audit",
+    })
+  }
+
+/**
+ * Update Audit Settings
+ * Update platform audit settings.
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns PlatformAuditSettingsRead Successful Response
+ * @throws ApiError
+ */
+export const adminUpdateAuditSettings = (
+  data: AdminUpdateAuditSettingsData
+): CancelablePromise<AdminUpdateAuditSettingsResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/admin/settings/audit",
+    body: data.requestBody,
+    mediaType: "application/json",
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -5433,6 +5433,55 @@ export type PayloadChangedEventRead = {
 }
 
 /**
+ * Platform audit settings response.
+ */
+export type PlatformAuditSettingsRead = {
+  audit_webhook_url: string | null
+  audit_webhook_custom_headers?: {
+    [key: string]: string
+  } | null
+  audit_webhook_custom_payload?: {
+    [key: string]: unknown
+  } | null
+  audit_webhook_payload_attribute?: string | null
+  audit_webhook_verify_ssl?: boolean
+  /**
+   * Encrypted setting keys that could not be decrypted with the current encryption key and must be reconfigured.
+   */
+  decryption_failed_keys?: Array<string>
+}
+
+/**
+ * Update platform audit settings.
+ */
+export type PlatformAuditSettingsUpdate = {
+  /**
+   * Webhook URL that receives streamed audit events. When unset, audit events are skipped.
+   */
+  audit_webhook_url?: string | null
+  /**
+   * Custom headers to include in audit webhook requests. Header names are case-insensitive.
+   */
+  audit_webhook_custom_headers?: {
+    [key: string]: string
+  } | null
+  /**
+   * Custom JSON payload merged into streamed audit event payloads. Custom keys override default audit event keys.
+   */
+  audit_webhook_custom_payload?: {
+    [key: string]: unknown
+  } | null
+  /**
+   * Optional wrapper key for audit payloads. When set to a value like 'event', payload is sent as {'event': <audit_payload>}.
+   */
+  audit_webhook_payload_attribute?: string | null
+  /**
+   * Whether TLS certificates are verified for webhook requests. Disable only for trusted on-prem/self-signed endpoints.
+   */
+  audit_webhook_verify_ssl?: boolean
+}
+
+/**
  * Cursor-paginated platform MCP catalog response.
  */
 export type PlatformMCPCatalogListResponse = {
@@ -11493,6 +11542,14 @@ export type AdminPromoteOrgRepositoryVersionData = {
 export type AdminPromoteOrgRepositoryVersionResponse =
   OrgRegistryVersionPromoteResponse
 
+export type AdminGetAuditSettingsResponse = PlatformAuditSettingsRead
+
+export type AdminUpdateAuditSettingsData = {
+  requestBody: PlatformAuditSettingsUpdate
+}
+
+export type AdminUpdateAuditSettingsResponse = PlatformAuditSettingsRead
+
 export type AdminGetRegistrySettingsResponse = PlatformRegistrySettingsRead
 
 export type AdminUpdateRegistrySettingsData = {
@@ -16781,6 +16838,29 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: OrgRegistryVersionPromoteResponse
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/admin/settings/audit": {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: PlatformAuditSettingsRead
+      }
+    }
+    patch: {
+      req: AdminUpdateAuditSettingsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: PlatformAuditSettingsRead
         /**
          * Validation Error
          */

--- a/frontend/src/components/admin/platform-audit-settings.tsx
+++ b/frontend/src/components/admin/platform-audit-settings.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { AuditSettingsForm } from "@/components/organization/org-settings-audit"
+import { useAdminAuditSettings } from "@/hooks/use-admin"
+
+export function PlatformAuditSettings() {
+  const {
+    auditSettings,
+    auditSettingsIsLoading,
+    auditSettingsError,
+    updateAuditSettings,
+    updateAuditSettingsIsPending,
+  } = useAdminAuditSettings()
+
+  return (
+    <AuditSettingsForm
+      auditSettings={auditSettings}
+      auditSettingsIsLoading={auditSettingsIsLoading}
+      auditSettingsError={auditSettingsError}
+      updateAuditSettings={updateAuditSettings}
+      updateAuditSettingsIsPending={updateAuditSettingsIsPending}
+      decryptFailureTitle="Unable to decrypt platform settings"
+    />
+  )
+}

--- a/frontend/src/components/organization/org-settings-audit.tsx
+++ b/frontend/src/components/organization/org-settings-audit.tsx
@@ -126,6 +126,32 @@ const auditDialogFormSchema = z
 
 type AuditDialogFormValues = z.infer<typeof auditDialogFormSchema>
 type HeaderEntry = AuditDialogFormValues["headers"][number]
+type AuditSettingsValues = {
+  audit_webhook_url: string | null
+  audit_webhook_custom_headers?: Record<string, string> | null
+  audit_webhook_custom_payload?: Record<string, unknown> | null
+  audit_webhook_payload_attribute?: string | null
+  audit_webhook_verify_ssl?: boolean
+  decryption_failed_keys?: string[]
+}
+type AuditSettingsUpdateBody = {
+  audit_webhook_url?: string | null
+  audit_webhook_custom_headers?: Record<string, string> | null
+  audit_webhook_custom_payload?: Record<string, unknown> | null
+  audit_webhook_payload_attribute?: string | null
+  audit_webhook_verify_ssl?: boolean
+}
+
+interface AuditSettingsFormProps {
+  auditSettings: AuditSettingsValues | undefined
+  auditSettingsIsLoading: boolean
+  auditSettingsError: Error | null
+  updateAuditSettings: (params: {
+    requestBody: AuditSettingsUpdateBody
+  }) => Promise<unknown>
+  updateAuditSettingsIsPending: boolean
+  decryptFailureTitle?: string
+}
 
 function toHeaderEntries(
   headers: Record<string, string> | null | undefined
@@ -213,14 +239,14 @@ function maskWebhookUrl(url: string): string {
   }
 }
 
-export function OrgSettingsAuditForm() {
-  const {
-    auditSettings,
-    auditSettingsIsLoading,
-    auditSettingsError,
-    updateAuditSettings,
-    updateAuditSettingsIsPending,
-  } = useOrgAuditSettings()
+export function AuditSettingsForm({
+  auditSettings,
+  auditSettingsIsLoading,
+  auditSettingsError,
+  updateAuditSettings,
+  updateAuditSettingsIsPending,
+  decryptFailureTitle = "Unable to decrypt organization settings",
+}: AuditSettingsFormProps) {
   const [dialogOpen, setDialogOpen] = useState(false)
 
   const form = useForm<AuditDialogFormValues>({
@@ -373,7 +399,7 @@ export function OrgSettingsAuditForm() {
         <Alert>
           <AlertTriangleIcon className="size-4 !text-destructive" />
           <AlertTitle className="text-destructive">
-            Unable to decrypt organization settings
+            {decryptFailureTitle}
           </AlertTitle>
           <AlertDescription>
             Failed to decrypt existing values for {failedKeys.join(", ")}.
@@ -602,5 +628,25 @@ export function OrgSettingsAuditForm() {
         </DialogContent>
       </Dialog>
     </>
+  )
+}
+
+export function OrgSettingsAuditForm() {
+  const {
+    auditSettings,
+    auditSettingsIsLoading,
+    auditSettingsError,
+    updateAuditSettings,
+    updateAuditSettingsIsPending,
+  } = useOrgAuditSettings()
+
+  return (
+    <AuditSettingsForm
+      auditSettings={auditSettings}
+      auditSettingsIsLoading={auditSettingsIsLoading}
+      auditSettingsError={auditSettingsError}
+      updateAuditSettings={updateAuditSettings}
+      updateAuditSettingsIsPending={updateAuditSettingsIsPending}
+    />
   )
 }

--- a/frontend/src/components/sidebar/admin-sidebar.tsx
+++ b/frontend/src/components/sidebar/admin-sidebar.tsx
@@ -6,6 +6,7 @@ import {
   BuildingIcon,
   LayersIcon,
   LogOutIcon,
+  LogsIcon,
   UsersIcon,
 } from "lucide-react"
 import Link from "next/link"
@@ -61,6 +62,12 @@ export function AdminSidebar({
       url: "/admin/agent",
       icon: BotIcon,
       isActive: pathname?.includes("/admin/agent"),
+    },
+    {
+      title: "Audit Logs",
+      url: "/admin/audit",
+      icon: LogsIcon,
+      isActive: pathname?.includes("/admin/audit"),
     },
   ]
 

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -30,6 +30,7 @@ import {
   adminDeleteTier,
   adminDeleteUser,
   adminDemoteFromSuperuser,
+  adminGetAuditSettings,
   adminGetOrganization,
   adminGetOrganizationInvitationToken,
   adminGetOrgTier,
@@ -53,6 +54,7 @@ import {
   adminRegistrySyncRepository,
   adminRevokeOrganizationInvitation,
   adminSyncOrgRepository,
+  adminUpdateAuditSettings,
   adminUpdateOrganization,
   adminUpdateOrganizationDomain,
   adminUpdateOrgTier,
@@ -67,6 +69,8 @@ import {
   type OrgDomainUpdate,
   type tracecat_ee__admin__organizations__schemas__OrgRead as OrgRead,
   type OrgUpdate,
+  type PlatformAuditSettingsRead,
+  type PlatformAuditSettingsUpdate,
   type PlatformRegistrySettingsUpdate,
   type RegistryArtifactsBackfillStartRequest,
   type RegistryArtifactsBackfillStartResponse,
@@ -836,6 +840,45 @@ export function useAdminRegistrySettings() {
     error,
     updateSettings,
     updatePending,
+  }
+}
+
+export function useAdminAuditSettings() {
+  const queryClient = useQueryClient()
+
+  const {
+    data: auditSettings,
+    isLoading: auditSettingsIsLoading,
+    error: auditSettingsError,
+  } = useQuery<PlatformAuditSettingsRead, Error>({
+    queryKey: ["admin", "audit", "settings"],
+    queryFn: adminGetAuditSettings,
+  })
+
+  const {
+    mutateAsync: updateAuditSettings,
+    isPending: updateAuditSettingsIsPending,
+    error: updateAuditSettingsError,
+  } = useMutation<
+    PlatformAuditSettingsRead,
+    Error,
+    { requestBody: PlatformAuditSettingsUpdate }
+  >({
+    mutationFn: ({ requestBody }) => adminUpdateAuditSettings({ requestBody }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "audit", "settings"],
+      })
+    },
+  })
+
+  return {
+    auditSettings,
+    auditSettingsIsLoading,
+    auditSettingsError,
+    updateAuditSettings,
+    updateAuditSettingsIsPending,
+    updateAuditSettingsError,
   }
 }
 

--- a/packages/tracecat-ee/tracecat_ee/admin/organizations/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/organizations/service.py
@@ -13,6 +13,7 @@ from sqlalchemy.exc import IntegrityError, NoResultFound
 from sqlalchemy.orm import selectinload
 
 from tracecat.audit.enums import AuditEventStatus
+from tracecat.audit.logger import audit_log
 from tracecat.audit.service import AuditService
 from tracecat.audit.types import AuditAction
 from tracecat.auth.types import Role
@@ -81,6 +82,7 @@ class AdminOrgService(BasePlatformService):
         result = await self.session.execute(stmt)
         return OrgRead.list_adapter().validate_python(result.scalars().all())
 
+    @audit_log(resource_type="organization", action="create", resource_id_attr="id")
     async def create_organization(self, params: OrgCreate) -> OrgRead:
         """Create a new organization with default settings and workspace."""
         org = await create_organization_with_defaults(
@@ -105,6 +107,7 @@ class AdminOrgService(BasePlatformService):
         if await self.session.scalar(stmt) is None:
             raise ValueError(f"Organization {org_id} not found")
 
+    @audit_log(resource_type="organization", action="update")
     async def update_organization(
         self, org_id: uuid.UUID, params: OrgUpdate
     ) -> OrgRead:
@@ -126,6 +129,7 @@ class AdminOrgService(BasePlatformService):
         await self.session.refresh(org)
         return OrgRead.model_validate(org)
 
+    @audit_log(resource_type="organization", action="delete")
     async def delete_organization(
         self,
         org_id: uuid.UUID,
@@ -149,6 +153,11 @@ class AdminOrgService(BasePlatformService):
 
     # Org Invitation Methods
 
+    @audit_log(
+        resource_type="organization_invitation",
+        action="create",
+        resource_id_attr="id",
+    )
     async def create_organization_invitation(
         self,
         org_id: uuid.UUID,
@@ -326,6 +335,11 @@ class AdminOrgService(BasePlatformService):
         invitation = await self._get_platform_invitation(org_id, invitation_id)
         return AdminOrgInvitationTokenRead(token=invitation.token)
 
+    @audit_log(
+        resource_type="organization_invitation",
+        action="revoke",
+        resource_id_attr="invitation_id",
+    )
     async def revoke_organization_invitation(
         self,
         org_id: uuid.UUID,
@@ -724,6 +738,11 @@ class AdminOrgService(BasePlatformService):
             OrgRegistryVersionRead.model_validate(v) for v in result.scalars().all()
         ]
 
+    @audit_log(
+        resource_type="platform_registry_repository",
+        action="sync",
+        resource_id_attr="repository_id",
+    )
     async def sync_org_repository(
         self, org_id: uuid.UUID, repository_id: uuid.UUID, force: bool = False
     ) -> OrgRegistrySyncResponse:
@@ -866,6 +885,11 @@ class AdminOrgService(BasePlatformService):
             forced=force,
         )
 
+    @audit_log(
+        resource_type="platform_registry_version",
+        action="promote",
+        resource_id_attr="version_id",
+    )
     async def promote_org_repository_version(
         self, org_id: uuid.UUID, repository_id: uuid.UUID, version_id: uuid.UUID
     ) -> OrgRegistryVersionPromoteResponse:

--- a/packages/tracecat-ee/tracecat_ee/admin/settings/router.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/settings/router.py
@@ -7,12 +7,35 @@ from fastapi import APIRouter
 from tracecat.auth.credentials import SuperuserRole
 from tracecat.db.dependencies import AsyncDBSessionBypass
 from tracecat_ee.admin.settings.schemas import (
+    PlatformAuditSettingsRead,
+    PlatformAuditSettingsUpdate,
     PlatformRegistrySettingsRead,
     PlatformRegistrySettingsUpdate,
 )
 from tracecat_ee.admin.settings.service import AdminSettingsService
 
 router = APIRouter(prefix="/settings", tags=["admin:settings"])
+
+
+@router.get("/audit", response_model=PlatformAuditSettingsRead)
+async def get_audit_settings(
+    role: SuperuserRole,
+    session: AsyncDBSessionBypass,
+) -> PlatformAuditSettingsRead:
+    """Get platform audit settings."""
+    service = AdminSettingsService(session, role)
+    return await service.get_audit_settings()
+
+
+@router.patch("/audit", response_model=PlatformAuditSettingsRead)
+async def update_audit_settings(
+    role: SuperuserRole,
+    session: AsyncDBSessionBypass,
+    params: PlatformAuditSettingsUpdate,
+) -> PlatformAuditSettingsRead:
+    """Update platform audit settings."""
+    service = AdminSettingsService(session, role)
+    return await service.update_audit_settings(params)
 
 
 @router.get("/registry", response_model=PlatformRegistrySettingsRead)

--- a/packages/tracecat-ee/tracecat_ee/admin/settings/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/settings/schemas.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
+from tracecat.settings.schemas import AuditSettingsRead, AuditSettingsUpdate
+
 
 class PlatformRegistrySettingsRead(BaseModel):
     """Platform registry settings response."""
@@ -19,3 +21,11 @@ class PlatformRegistrySettingsUpdate(BaseModel):
     git_repo_url: str | None = None
     git_repo_package_name: str | None = None
     git_allowed_domains: set[str] | None = None
+
+
+class PlatformAuditSettingsRead(AuditSettingsRead):
+    """Platform audit settings response."""
+
+
+class PlatformAuditSettingsUpdate(AuditSettingsUpdate):
+    """Update platform audit settings."""

--- a/packages/tracecat-ee/tracecat_ee/admin/settings/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/settings/service.py
@@ -5,23 +5,32 @@ from __future__ import annotations
 from typing import Any
 
 import orjson
+from cryptography.fernet import InvalidToken
 from pydantic import SecretStr
 from pydantic_core import to_jsonable_python
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat.audit.logger import audit_log
 from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.auth.types import PlatformRole
 from tracecat.db.models import PlatformSetting
 from tracecat.secrets.encryption import decrypt_value, encrypt_value
 from tracecat.service import BasePlatformService
+from tracecat.settings.schemas import AuditSettingsUpdate
 from tracecat_ee.admin.settings.schemas import (
+    PlatformAuditSettingsRead,
+    PlatformAuditSettingsUpdate,
     PlatformRegistrySettingsRead,
     PlatformRegistrySettingsUpdate,
 )
 
 # Platform settings keys that should be encrypted
-SENSITIVE_PLATFORM_KEYS: set[str] = set()
+SENSITIVE_PLATFORM_KEYS: set[str] = {
+    "audit_webhook_url",
+    "audit_webhook_custom_headers",
+    "audit_webhook_custom_payload",
+}
 
 # Registry-related platform settings
 REGISTRY_SETTINGS_KEYS = {
@@ -29,6 +38,8 @@ REGISTRY_SETTINGS_KEYS = {
     "git_repo_package_name",
     "git_allowed_domains",
 }
+
+AUDIT_SETTINGS_KEYS = AuditSettingsUpdate.keys()
 
 
 class AdminSettingsService(BasePlatformService):
@@ -62,6 +73,29 @@ class AdminSettingsService(BasePlatformService):
         result = await self.session.execute(stmt)
         return {s.key: self._get_value(s) for s in result.scalars().all()}
 
+    async def _get_settings_with_decryption_fallback(
+        self, keys: set[str]
+    ) -> tuple[dict[str, Any], list[str]]:
+        """Get platform settings while tolerating encrypted decrypt failures."""
+        stmt = select(PlatformSetting).where(PlatformSetting.key.in_(keys))
+        result = await self.session.execute(stmt)
+        values: dict[str, Any] = {}
+        decryption_failed_keys: list[str] = []
+        for setting in result.scalars().all():
+            try:
+                values[setting.key] = self._get_value(setting)
+            except (InvalidToken, ValueError) as exc:
+                if not setting.is_encrypted:
+                    raise
+                values[setting.key] = None
+                decryption_failed_keys.append(setting.key)
+                self.logger.warning(
+                    "Failed to decrypt platform setting; returning null and marking for reconfiguration",
+                    key=setting.key,
+                    error=str(exc),
+                )
+        return values, decryption_failed_keys
+
     async def _upsert_setting(self, key: str, value: Any) -> None:
         """Create or update a platform setting."""
         stmt = select(PlatformSetting).where(PlatformSetting.key == key)
@@ -87,6 +121,33 @@ class AdminSettingsService(BasePlatformService):
             )
             self.session.add(setting)
 
+    async def get_audit_settings(self) -> PlatformAuditSettingsRead:
+        """Get platform audit settings."""
+        (
+            settings,
+            decryption_failed_keys,
+        ) = await self._get_settings_with_decryption_fallback(AUDIT_SETTINGS_KEYS)
+        return PlatformAuditSettingsRead(
+            audit_webhook_url=settings.get("audit_webhook_url"),
+            audit_webhook_custom_headers=settings.get("audit_webhook_custom_headers"),
+            audit_webhook_custom_payload=settings.get("audit_webhook_custom_payload"),
+            audit_webhook_payload_attribute=settings.get(
+                "audit_webhook_payload_attribute"
+            ),
+            audit_webhook_verify_ssl=settings.get("audit_webhook_verify_ssl", True),
+            decryption_failed_keys=decryption_failed_keys,
+        )
+
+    @audit_log(resource_type="platform_setting", action="update")
+    async def update_audit_settings(
+        self, params: PlatformAuditSettingsUpdate
+    ) -> PlatformAuditSettingsRead:
+        """Update platform audit settings."""
+        for key, value in params.model_dump(exclude_unset=True).items():
+            await self._upsert_setting(key, value)
+        await self.session.commit()
+        return await self.get_audit_settings()
+
     async def get_registry_settings(self) -> PlatformRegistrySettingsRead:
         """Get platform registry settings."""
         settings = await self._get_settings(REGISTRY_SETTINGS_KEYS)
@@ -96,6 +157,7 @@ class AdminSettingsService(BasePlatformService):
             git_allowed_domains=settings.get("git_allowed_domains"),
         )
 
+    @audit_log(resource_type="platform_setting", action="update")
     async def update_registry_settings(
         self, params: PlatformRegistrySettingsUpdate
     ) -> PlatformRegistrySettingsRead:

--- a/packages/tracecat-ee/tracecat_ee/admin/tiers/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/tiers/service.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
+from tracecat.audit.logger import audit_log
 from tracecat.db.models import Organization, OrganizationTier, Tier
 from tracecat.logger import logger
 from tracecat.service import BasePlatformService
@@ -56,6 +57,7 @@ class AdminTierService(BasePlatformService):
             raise TierNotFoundError(f"Tier {tier_id} not found")
         return TierRead.model_validate(tier)
 
+    @audit_log(resource_type="tier", action="create", resource_id_attr="id")
     async def create_tier(self, params: TierCreate) -> TierRead:
         """Create a new tier."""
         # If this tier is set as default, unset other defaults
@@ -84,6 +86,7 @@ class AdminTierService(BasePlatformService):
         await self.session.refresh(tier)
         return TierRead.model_validate(tier)
 
+    @audit_log(resource_type="tier", action="update")
     async def update_tier(self, tier_id: uuid.UUID, params: TierUpdate) -> TierRead:
         """Update a tier."""
         stmt = select(Tier).where(Tier.id == tier_id)
@@ -123,6 +126,7 @@ class AdminTierService(BasePlatformService):
                 )
         return TierRead.model_validate(tier)
 
+    @audit_log(resource_type="tier", action="delete")
     async def delete_tier(self, tier_id: uuid.UUID) -> None:
         """Delete a tier (only if no orgs are assigned to it)."""
         # Check if tier exists
@@ -228,6 +232,7 @@ class AdminTierService(BasePlatformService):
             tier=tier_read,
         )
 
+    @audit_log(resource_type="organization_tier", action="update")
     async def update_org_tier(
         self, org_id: uuid.UUID, params: OrganizationTierUpdate
     ) -> OrganizationTierRead:

--- a/packages/tracecat-ee/tracecat_ee/admin/users/service.py
+++ b/packages/tracecat-ee/tracecat_ee/admin/users/service.py
@@ -8,7 +8,7 @@ from sqlalchemy import delete, func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Mapped
 
-from tracecat.audit.service import AuditService
+from tracecat.audit.logger import audit_log
 from tracecat.auth.schemas import UserCreate, UserRole
 from tracecat.auth.users import get_user_db_context, get_user_manager_context
 from tracecat.db.models import AccessToken, Approval, Membership, User
@@ -26,6 +26,7 @@ class AdminUserService(BasePlatformService):
 
     service_name = "admin_user"
 
+    @audit_log(resource_type="user", action="create")
     async def create_user(self, params: AdminUserCreate) -> AdminUserRead:
         """Create a platform-level user."""
         async with get_user_db_context(self.session) as user_db:
@@ -59,15 +60,6 @@ class AdminUserService(BasePlatformService):
 
         await self.session.refresh(user)
 
-        async with AuditService.with_session(
-            role=self.role, session=self.session
-        ) as svc:
-            await svc.create_event(
-                resource_type="user",
-                action="create",
-                resource_id=user.id,
-            )
-
         return AdminUserRead.model_validate(user)
 
     async def list_users(self) -> Sequence[AdminUserRead]:
@@ -85,6 +77,7 @@ class AdminUserService(BasePlatformService):
             raise ValueError(f"User {user_id} not found")
         return AdminUserRead.model_validate(user)
 
+    @audit_log(resource_type="user", action="promote", resource_id_attr="user_id")
     async def promote_superuser(self, user_id: uuid.UUID) -> AdminUserRead:
         """Promote a user to superuser."""
         stmt = select(User).where(cast(Mapped[uuid.UUID], User.id) == user_id)
@@ -106,6 +99,7 @@ class AdminUserService(BasePlatformService):
         await self.session.refresh(user)
         return AdminUserRead.model_validate(user)
 
+    @audit_log(resource_type="user", action="demote", resource_id_attr="user_id")
     async def demote_superuser(
         self, user_id: uuid.UUID, current_user_id: uuid.UUID
     ) -> AdminUserRead:
@@ -140,6 +134,7 @@ class AdminUserService(BasePlatformService):
         await self.session.refresh(user)
         return AdminUserRead.model_validate(user)
 
+    @audit_log(resource_type="user", action="delete", resource_id_attr="user_id")
     async def delete_user(self, user_id: uuid.UUID, current_user_id: uuid.UUID) -> None:
         """Delete a global platform user and clear blocking dependencies.
 
@@ -190,12 +185,3 @@ class AdminUserService(BasePlatformService):
             raise ValueError(
                 "Cannot delete user because related records still reference them"
             ) from e
-
-        async with AuditService.with_session(
-            role=self.role, session=self.session
-        ) as svc:
-            await svc.create_event(
-                resource_type="user",
-                action="delete",
-                resource_id=user_id,
-            )

--- a/tests/unit/api/test_api_admin_settings.py
+++ b/tests/unit/api/test_api_admin_settings.py
@@ -6,7 +6,10 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 from tracecat_ee.admin.settings import router as settings_router
-from tracecat_ee.admin.settings.schemas import PlatformRegistrySettingsRead
+from tracecat_ee.admin.settings.schemas import (
+    PlatformAuditSettingsRead,
+    PlatformRegistrySettingsRead,
+)
 
 from tracecat.auth.types import Role
 
@@ -31,6 +34,47 @@ async def test_get_registry_settings_success(
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
     assert data["git_repo_url"] == "https://example.com/repo.git"
+
+
+@pytest.mark.anyio
+async def test_get_audit_settings_success(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    settings = PlatformAuditSettingsRead(
+        audit_webhook_url="https://example.com/audit",
+    )
+
+    with patch.object(settings_router, "AdminSettingsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_audit_settings.return_value = settings
+        MockService.return_value = mock_svc
+
+        response = client.get("/admin/settings/audit")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["audit_webhook_url"] == "https://example.com/audit"
+
+
+@pytest.mark.anyio
+async def test_update_audit_settings_success(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    settings = PlatformAuditSettingsRead(
+        audit_webhook_url="https://example.com/new-audit",
+    )
+
+    with patch.object(settings_router, "AdminSettingsService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.update_audit_settings.return_value = settings
+        MockService.return_value = mock_svc
+
+        response = client.patch(
+            "/admin/settings/audit",
+            json={"audit_webhook_url": "https://example.com/new-audit"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["audit_webhook_url"] == "https://example.com/new-audit"
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_admin_settings_service.py
+++ b/tests/unit/test_admin_settings_service.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import orjson
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from tracecat_ee.admin.settings.schemas import PlatformAuditSettingsUpdate
+from tracecat_ee.admin.settings.service import AdminSettingsService
+
+from tracecat.audit.service import AuditService
+from tracecat.auth.types import PlatformRole
+from tracecat.db.models import PlatformSetting
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+def platform_role() -> PlatformRole:
+    return PlatformRole(
+        type="user",
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+    )
+
+
+@pytest.fixture(autouse=True)
+def disable_audit_delivery(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(AuditService, "create_event", AsyncMock())
+
+
+@pytest.mark.anyio
+async def test_platform_audit_settings_default_to_disconnected(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+) -> None:
+    service = AdminSettingsService(session, platform_role)
+
+    settings = await service.get_audit_settings()
+
+    assert settings.audit_webhook_url is None
+    assert settings.audit_webhook_custom_headers is None
+    assert settings.audit_webhook_custom_payload is None
+    assert settings.audit_webhook_payload_attribute is None
+    assert settings.audit_webhook_verify_ssl is True
+    assert settings.decryption_failed_keys == []
+
+
+@pytest.mark.anyio
+async def test_platform_audit_settings_encrypt_sensitive_values(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+) -> None:
+    service = AdminSettingsService(session, platform_role)
+    custom_headers = {"Authorization": "Bearer secret"}
+    custom_payload = {"source": "tracecat-platform"}
+
+    settings = await service.update_audit_settings(
+        PlatformAuditSettingsUpdate(
+            audit_webhook_url="https://example.com/platform-audit",
+            audit_webhook_custom_headers=custom_headers,
+            audit_webhook_custom_payload=custom_payload,
+            audit_webhook_payload_attribute="event",
+            audit_webhook_verify_ssl=False,
+        )
+    )
+
+    assert settings.audit_webhook_url == "https://example.com/platform-audit"
+    assert settings.audit_webhook_custom_headers == custom_headers
+    assert settings.audit_webhook_custom_payload == custom_payload
+    assert settings.audit_webhook_payload_attribute == "event"
+    assert settings.audit_webhook_verify_ssl is False
+
+    rows = (await session.execute(select(PlatformSetting))).scalars().all()
+    settings_by_key = {setting.key: setting for setting in rows}
+    assert settings_by_key["audit_webhook_url"].is_encrypted is True
+    assert settings_by_key["audit_webhook_custom_headers"].is_encrypted is True
+    assert settings_by_key["audit_webhook_custom_payload"].is_encrypted is True
+    assert settings_by_key["audit_webhook_payload_attribute"].is_encrypted is False
+    assert settings_by_key["audit_webhook_verify_ssl"].is_encrypted is False
+    assert settings_by_key["audit_webhook_custom_headers"].value != orjson.dumps(
+        custom_headers, option=orjson.OPT_SORT_KEYS
+    )
+
+
+@pytest.mark.anyio
+async def test_platform_audit_settings_can_clear(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+) -> None:
+    service = AdminSettingsService(session, platform_role)
+
+    await service.update_audit_settings(
+        PlatformAuditSettingsUpdate(
+            audit_webhook_url="https://example.com/platform-audit"
+        )
+    )
+    settings = await service.update_audit_settings(
+        PlatformAuditSettingsUpdate(audit_webhook_url=None)
+    )
+
+    assert settings.audit_webhook_url is None

--- a/tests/unit/test_admin_users_service.py
+++ b/tests/unit/test_admin_users_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 from typing import cast
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import func, select, update
@@ -13,6 +14,8 @@ from tracecat_ee.admin.users.schemas import AdminUserCreate
 from tracecat_ee.admin.users.service import AdminUserService
 
 from tracecat import config
+from tracecat.audit.enums import AuditEventStatus
+from tracecat.audit.service import AuditService
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.types import PlatformRole
 from tracecat.db.models import (
@@ -105,6 +108,59 @@ async def test_create_user_respects_superuser_flag(
     )
     user = user_result.scalar_one()
     assert user.is_superuser is True
+
+
+@pytest.mark.anyio
+async def test_admin_user_audit_logs_target_user_ids(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+) -> None:
+    service = AdminUserService(session, role=platform_role)
+    create_event_calls: list[dict[str, object]] = []
+
+    async def mock_create_event(*args, **kwargs):
+        create_event_calls.append(kwargs)
+
+    with patch.object(AuditService, "create_event", side_effect=mock_create_event):
+        created = await service.create_user(
+            AdminUserCreate(
+                email="audit-created-user@example.com",
+                password="this-is-a-strong-password",
+                is_superuser=False,
+            )
+        )
+        promoted = await service.create_user(
+            AdminUserCreate(
+                email="audit-promoted-user@example.com",
+                password="this-is-a-strong-password",
+                is_superuser=False,
+            )
+        )
+        await service.promote_superuser(promoted.id)
+        current_superuser = await service.create_user(
+            AdminUserCreate(
+                email="audit-current-superuser@example.com",
+                password="this-is-a-strong-password",
+                is_superuser=True,
+            )
+        )
+        demoted = await service.create_user(
+            AdminUserCreate(
+                email="audit-demoted-user@example.com",
+                password="this-is-a-strong-password",
+                is_superuser=True,
+            )
+        )
+        await service.demote_superuser(demoted.id, current_superuser.id)
+
+    success_events = {
+        (call["action"], call["resource_id"])
+        for call in create_event_calls
+        if call["status"] == AuditEventStatus.SUCCESS
+    }
+    assert ("create", created.id) in success_events
+    assert ("promote", promoted.id) in success_events
+    assert ("demote", demoted.id) in success_events
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -12,9 +13,10 @@ from tracecat.audit.enums import AuditEventActor, AuditEventStatus
 from tracecat.audit.logger import audit_log
 from tracecat.audit.service import AuditService
 from tracecat.audit.types import AuditEvent
-from tracecat.auth.types import Role
+from tracecat.auth.types import PlatformRole, Role
+from tracecat.auth.users import UserManager
 from tracecat.authz.scopes import ADMIN_SCOPES
-from tracecat.contexts import ctx_role
+from tracecat.contexts import ctx_client_ip, ctx_role
 
 
 @pytest.fixture
@@ -55,6 +57,16 @@ async def test_create_event_streams_to_webhook(
     webhook_url = "https://example.com/audit"
     monkeypatch.setattr(
         audit_service, "_get_webhook_url", AsyncMock(return_value=webhook_url)
+    )
+    monkeypatch.setattr(
+        audit_service, "_get_custom_headers", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        audit_service, "_get_custom_payload", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(audit_service, "_get_verify_ssl", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        audit_service, "_get_payload_attribute", AsyncMock(return_value=None)
     )
     mock_user = MagicMock()
     mock_user.email = "user@example.com"
@@ -106,6 +118,196 @@ async def test_create_event_includes_case_comment_data_in_payload(
     payload = post_mock.await_args.kwargs["payload"]
     assert payload.resource_type == "case_comment"
     assert payload.data == data
+
+
+@pytest.mark.anyio
+async def test_create_event_can_emit_sanitized_platform_org_auth_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    webhook_url = "https://example.com/platform-audit"
+    client_ip = "203.0.113.10"
+    role = Role(
+        type="user",
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+    )
+    audit_service = AuditService(AsyncMock(), role=role, audit_sink="platform")
+    post_mock = AsyncMock()
+    actor_label_mock = AsyncMock()
+    monkeypatch.setattr(
+        audit_service, "_get_webhook_url", AsyncMock(return_value=webhook_url)
+    )
+    monkeypatch.setattr(audit_service, "_get_actor_label", actor_label_mock)
+    monkeypatch.setattr(audit_service, "_post_event", post_mock)
+    token = ctx_client_ip.set(client_ip)
+
+    try:
+        await audit_service.create_event(
+            resource_type="auth",
+            action="sign_in",
+            resource_id=role.user_id,
+            data={"auth_method": "saml"},
+            include_actor_label=False,
+        )
+    finally:
+        ctx_client_ip.reset(token)
+
+    actor_label_mock.assert_not_awaited()
+    assert post_mock.await_args is not None
+    payload = post_mock.await_args.kwargs["payload"]
+    assert payload.organization_id == role.organization_id
+    assert payload.actor_id == role.user_id
+    assert payload.actor_label is None
+    assert payload.ip_address == client_ip
+    assert payload.data == {"auth_method": "saml"}
+
+
+@pytest.mark.anyio
+async def test_auth_success_audit_emits_to_platform_and_org_sinks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    user = MagicMock()
+    user.id = user_id
+    user.is_superuser = False
+    calls: list[dict[str, object]] = []
+
+    @asynccontextmanager
+    async def fake_with_session(
+        role: Role | PlatformRole | None = None,
+        *,
+        session=None,
+        audit_sink=None,
+    ):
+        class FakeAuditService:
+            async def create_event(self, **kwargs):
+                calls.append(
+                    {
+                        "role": role,
+                        "session": session,
+                        "audit_sink": audit_sink,
+                        "kwargs": kwargs,
+                    }
+                )
+
+        yield FakeAuditService()
+
+    monkeypatch.setattr(AuditService, "with_session", fake_with_session)
+    manager = UserManager.__new__(UserManager)
+
+    await manager._emit_auth_success_audit(
+        user=user,
+        auth_method="basic",
+        org_ids={org_id},
+    )
+
+    assert [call["audit_sink"] for call in calls] == ["platform", "organization"]
+    for call in calls:
+        role = call["role"]
+        assert isinstance(role, Role)
+        assert role.user_id == user_id
+        assert role.organization_id == org_id
+        assert call["kwargs"] == {
+            "resource_type": "auth",
+            "action": "sign_in",
+            "resource_id": user_id,
+            "data": {"auth_method": "basic"},
+            "include_actor_label": False,
+        }
+
+
+@pytest.mark.anyio
+async def test_auth_success_audit_emits_superuser_auth_only_to_platform_sink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid.uuid4()
+    user = MagicMock()
+    user.id = user_id
+    user.is_superuser = True
+    calls: list[dict[str, object]] = []
+
+    @asynccontextmanager
+    async def fake_with_session(
+        role: Role | PlatformRole | None = None,
+        *,
+        session=None,
+        audit_sink=None,
+    ):
+        class FakeAuditService:
+            async def create_event(self, **kwargs):
+                calls.append(
+                    {
+                        "role": role,
+                        "session": session,
+                        "audit_sink": audit_sink,
+                        "kwargs": kwargs,
+                    }
+                )
+
+        yield FakeAuditService()
+
+    monkeypatch.setattr(AuditService, "with_session", fake_with_session)
+    manager = UserManager.__new__(UserManager)
+
+    await manager._emit_auth_success_audit(
+        user=user,
+        auth_method="basic",
+        org_ids=set(),
+    )
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["audit_sink"] == "platform"
+    role = call["role"]
+    assert isinstance(role, PlatformRole)
+    assert role.user_id == user_id
+    assert call["kwargs"] == {
+        "resource_type": "auth",
+        "action": "sign_in",
+        "resource_id": user_id,
+        "data": {"auth_method": "basic"},
+        "include_actor_label": False,
+    }
+
+
+@pytest.mark.anyio
+async def test_auth_success_audit_skips_platform_scoped_auth_for_non_superusers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.is_superuser = False
+    with_session = MagicMock()
+    monkeypatch.setattr(AuditService, "with_session", with_session)
+    manager = UserManager.__new__(UserManager)
+
+    await manager._emit_auth_success_audit(
+        user=user,
+        auth_method="basic",
+        org_ids=set(),
+    )
+
+    with_session.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_platform_role_defaults_to_platform_audit_sink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    role = PlatformRole(
+        type="user",
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+    )
+    audit_service = AuditService(AsyncMock(), role=role)
+    get_platform_setting = AsyncMock(return_value="https://example.com/audit")
+    monkeypatch.setattr(audit_service, "_get_platform_setting", get_platform_setting)
+
+    assert audit_service.audit_sink == "platform"
+    assert await audit_service._get_webhook_url() == "https://example.com/audit"
+    get_platform_setting.assert_awaited_once_with("audit_webhook_url")
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -273,6 +274,110 @@ async def test_auth_success_audit_emits_superuser_auth_only_to_platform_sink(
 
 
 @pytest.mark.anyio
+async def test_on_after_login_without_org_context_skips_org_sinks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A context-less login (basic/OIDC) must not fan out to org sinks.
+
+    Regression test for the smell where a non-org-specific login was attributed
+    into every organization the user belonged to. A platform superuser who is a
+    member of several orgs must only ever reach the platform sink here.
+    """
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "super@example.com"
+    user.is_superuser = True
+    calls: list[dict[str, object]] = []
+
+    @asynccontextmanager
+    async def fake_with_session(
+        role: Role | PlatformRole | None = None,
+        *,
+        session=None,
+        audit_sink=None,
+    ):
+        class FakeAuditService:
+            async def create_event(self, **kwargs):
+                calls.append({"role": role, "audit_sink": audit_sink})
+
+        yield FakeAuditService()
+
+    # If the fanout regressed, it would re-derive these memberships and write to
+    # their org sinks. Returning a non-empty set makes that regression fail.
+    async def fake_list_org_ids(self, user_id):
+        return {uuid.uuid4(), uuid.uuid4()}
+
+    monkeypatch.setattr(AuditService, "with_session", fake_with_session)
+    monkeypatch.setattr(UserManager, "_list_user_org_ids", fake_list_org_ids)
+    manager = UserManager.__new__(UserManager)
+    manager.logger = MagicMock()
+    manager.user_db = MagicMock()
+    manager.user_db.update = AsyncMock()
+
+    # Basic/OIDC caller shape: organization_id defaults to None.
+    await manager.on_after_login(user, request=None, response=None)
+
+    assert [call["audit_sink"] for call in calls] == ["platform"]
+    assert isinstance(calls[0]["role"], PlatformRole)
+
+
+@pytest.mark.anyio
+async def test_on_after_login_with_org_context_fans_out_to_that_org(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A login carrying explicit org context (SAML) writes that one org's sinks."""
+    org_id = uuid.uuid4()
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.email = "super@example.com"
+    user.is_superuser = True
+    calls: list[dict[str, object]] = []
+
+    @asynccontextmanager
+    async def fake_with_session(
+        role: Role | PlatformRole | None = None,
+        *,
+        session=None,
+        audit_sink=None,
+    ):
+        class FakeAuditService:
+            async def create_event(self, **kwargs):
+                calls.append(
+                    {
+                        "role": role,
+                        "audit_sink": audit_sink,
+                        "organization_id": getattr(role, "organization_id", None),
+                    }
+                )
+
+        yield FakeAuditService()
+
+    # Should never be consulted when explicit org context is supplied.
+    async def fake_list_org_ids(self, user_id):
+        raise AssertionError("must not re-derive memberships with explicit org context")
+
+    monkeypatch.setattr(AuditService, "with_session", fake_with_session)
+    monkeypatch.setattr(UserManager, "_list_user_org_ids", fake_list_org_ids)
+    manager = UserManager.__new__(UserManager)
+    manager.logger = MagicMock()
+    manager.user_db = MagicMock()
+    manager.user_db.update = AsyncMock()
+
+    await manager.on_after_login(
+        user, request=None, response=None, organization_id=org_id
+    )
+
+    # superuser platform event + the single org's (platform, organization) sinks.
+    assert [call["audit_sink"] for call in calls] == [
+        "platform",
+        "platform",
+        "organization",
+    ]
+    org_scoped = [c for c in calls if isinstance(c["role"], Role)]
+    assert {c["organization_id"] for c in org_scoped} == {org_id}
+
+
+@pytest.mark.anyio
 async def test_auth_success_audit_skips_platform_scoped_auth_for_non_superusers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -290,6 +395,66 @@ async def test_auth_success_audit_skips_platform_scoped_auth_for_non_superusers(
     )
 
     with_session.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_on_after_register_emits_user_create_audit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid.uuid4()
+    user = MagicMock()
+    user.id = user_id
+    user.email = "registered@example.com"
+    user.is_superuser = False
+    calls: list[dict[str, object]] = []
+
+    @asynccontextmanager
+    async def fake_with_session(
+        role: Role | PlatformRole | None = None,
+        *,
+        session=None,
+        audit_sink=None,
+    ):
+        class FakeAuditService:
+            async def create_event(self, **kwargs):
+                calls.append(
+                    {
+                        "role": role,
+                        "session": session,
+                        "audit_sink": audit_sink,
+                        "kwargs": kwargs,
+                    }
+                )
+
+        yield FakeAuditService()
+
+    monkeypatch.setattr(AuditService, "with_session", fake_with_session)
+    monkeypatch.setattr(
+        "tracecat.auth.users.ensure_single_tenant_user_defaults",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "tracecat.auth.users.config.TRACECAT__AUTH_SUPERADMIN_EMAIL",
+        "superadmin@example.com",
+    )
+
+    manager = UserManager.__new__(UserManager)
+    manager.logger = MagicMock()
+    manager._pending_invitation_token = None
+
+    await manager.on_after_register(user)
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["audit_sink"] == "platform"
+    role = call["role"]
+    assert isinstance(role, PlatformRole)
+    assert role.user_id == user_id
+    assert call["kwargs"] == {
+        "resource_type": "user",
+        "action": "create",
+        "resource_id": user_id,
+    }
 
 
 @pytest.mark.anyio
@@ -431,6 +596,77 @@ async def test_post_event_wraps_payload_when_attribute_configured(
     assert set(wrapped_payload.keys()) == {"event"}
     assert wrapped_payload["event"]["custom"] == "yes"
     assert wrapped_payload["event"]["actor_label"] == "user@example.com"
+
+
+@pytest.mark.anyio
+async def test_audit_log_organization_invitation_create_uses_returned_id(
+    role: Role,
+) -> None:
+    invitation_id = uuid.uuid4()
+
+    class MockService:
+        def __init__(self):
+            self.session = AsyncMock()
+
+        @audit_log(resource_type="organization_invitation", action="create")
+        async def create_invitation(self):
+            return SimpleNamespace(id=invitation_id)
+
+    service = MockService()
+    token = ctx_role.set(role)
+    create_event_calls: list[dict[str, object]] = []
+
+    async def mock_create_event(*args, **kwargs):
+        create_event_calls.append(kwargs)
+
+    try:
+        with patch.object(AuditService, "create_event", side_effect=mock_create_event):
+            await service.create_invitation()
+    finally:
+        ctx_role.reset(token)
+
+    success_call = next(
+        call
+        for call in create_event_calls
+        if call["status"] == AuditEventStatus.SUCCESS
+    )
+    assert success_call["resource_id"] == invitation_id
+
+
+@pytest.mark.anyio
+async def test_audit_log_explicit_invitation_id_overrides_result_id(
+    role: Role,
+) -> None:
+    invitation_id = uuid.uuid4()
+    unrelated_result_id = uuid.uuid4()
+
+    class MockService:
+        def __init__(self):
+            self.session = AsyncMock()
+
+        @audit_log(
+            resource_type="organization_invitation",
+            action="revoke",
+            resource_id_attr="invitation_id",
+        )
+        async def revoke_invitation(self, invitation_id: uuid.UUID):
+            return SimpleNamespace(id=unrelated_result_id)
+
+    service = MockService()
+    token = ctx_role.set(role)
+    create_event_calls: list[dict[str, object]] = []
+
+    async def mock_create_event(*args, **kwargs):
+        create_event_calls.append(kwargs)
+
+    try:
+        with patch.object(AuditService, "create_event", side_effect=mock_create_event):
+            await service.revoke_invitation(invitation_id)
+    finally:
+        ctx_role.reset(token)
+
+    resource_ids = [call["resource_id"] for call in create_event_calls]
+    assert resource_ids == [invitation_id, invitation_id]
 
 
 @pytest.mark.anyio

--- a/tracecat/admin/registry/service.py
+++ b/tracecat/admin/registry/service.py
@@ -26,6 +26,7 @@ from tracecat.admin.registry.schemas import (
     RepositoryStatus,
     RepositorySyncResult,
 )
+from tracecat.audit.logger import audit_log
 from tracecat.db.models import (
     PlatformRegistryIndex,
     PlatformRegistryRepository,
@@ -176,6 +177,7 @@ class AdminRegistryService(BasePlatformService):
                 )
         return actions
 
+    @audit_log(resource_type="platform_registry", action="sync")
     async def sync_all_repositories(self, force: bool = False) -> RegistrySyncResponse:
         """Sync all platform registry repositories."""
         repos = await self._ensure_platform_repositories()
@@ -191,6 +193,11 @@ class AdminRegistryService(BasePlatformService):
             repositories=results,
         )
 
+    @audit_log(
+        resource_type="platform_registry_repository",
+        action="sync",
+        resource_id_attr="repository_id",
+    )
     async def sync_repository(
         self, repository_id: uuid.UUID, force: bool = False
     ) -> RegistrySyncResponse:
@@ -614,6 +621,11 @@ class AdminRegistryService(BasePlatformService):
             requested_count=len(request.items),
         )
 
+    @audit_log(
+        resource_type="platform_registry_version",
+        action="promote",
+        resource_id_attr="version_id",
+    )
     async def promote_version(
         self,
         repository_id: uuid.UUID,

--- a/tracecat/audit/logger.py
+++ b/tracecat/audit/logger.py
@@ -9,10 +9,10 @@ from typing import Any, Concatenate, ParamSpec, TypeVar
 from tracecat.audit.enums import AuditEventStatus
 from tracecat.audit.service import AuditService
 from tracecat.audit.types import AuditAction, AuditResourceType
-from tracecat.auth.types import Role
+from tracecat.auth.types import PlatformRole, Role
 from tracecat.contexts import ctx_role
 from tracecat.logger import logger
-from tracecat.service import BaseService
+from tracecat.service import BasePlatformService, BaseService
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -23,6 +23,14 @@ _RESOURCE_ID_ATTR_MAP: dict[str, str] = {
     "workflow_execution": "wf_id",
     "organization_member": "user_id",
     "organization_session": "session_id",
+    "organization": "org_id",
+    "organization_domain": "domain_id",
+    "organization_invitation": "invitation_id",
+    "organization_tier": "org_id",
+    "platform_registry_repository": "repository_id",
+    "platform_registry_version": "version_id",
+    "tier": "tier_id",
+    "user": "user_id",
 }
 
 
@@ -56,7 +64,9 @@ def audit_log(
 
         @functools.wraps(func)
         async def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> R:
-            role: Role | None = ctx_role.get()
+            role: Role | PlatformRole | None = (
+                self.role if isinstance(self, BasePlatformService) else ctx_role.get()
+            )
 
             if role is None or role.actor_id is None:
                 return await func(self, *args, **kwargs)
@@ -100,7 +110,8 @@ def audit_log(
                 # Execute the actual function
                 result = await func(self, *args, **kwargs)
 
-                # Log success
+                # Log success, or a semantic failure for result objects that
+                # complete without raising but report success=False.
                 try:
                     resource_id = _extract_resource_id(
                         args,
@@ -114,7 +125,11 @@ def audit_log(
                             resource_type=resource_type,
                             action=action,
                             resource_id=resource_id,
-                            status=AuditEventStatus.SUCCESS,
+                            status=(
+                                AuditEventStatus.FAILURE
+                                if getattr(result, "success", None) is False
+                                else AuditEventStatus.SUCCESS
+                            ),
                         )
                 except Exception as exc:
                     logger.warning("Audit success log failed", error=str(exc))

--- a/tracecat/audit/logger.py
+++ b/tracecat/audit/logger.py
@@ -25,12 +25,12 @@ _RESOURCE_ID_ATTR_MAP: dict[str, str] = {
     "organization_session": "session_id",
     "organization": "org_id",
     "organization_domain": "domain_id",
-    "organization_invitation": "invitation_id",
+    "organization_invitation": "id",
     "organization_tier": "org_id",
     "platform_registry_repository": "repository_id",
     "platform_registry_version": "version_id",
     "tier": "tier_id",
-    "user": "user_id",
+    "user": "id",
 }
 
 

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -6,15 +6,19 @@ from contextlib import asynccontextmanager
 from typing import Any, Self
 
 import httpx
+import orjson
+from cryptography.fernet import InvalidToken
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.audit.enums import AuditEventActor, AuditEventStatus
-from tracecat.audit.types import AuditAction, AuditEvent, AuditResourceType
+from tracecat.audit.types import AuditAction, AuditEvent, AuditResourceType, AuditSink
+from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.auth.types import PlatformRole, Role
 from tracecat.contexts import ctx_client_ip, ctx_role
 from tracecat.db.engine import get_async_session_context_manager
-from tracecat.db.models import ServiceAccount, User
+from tracecat.db.models import PlatformSetting, ServiceAccount, User
+from tracecat.secrets.encryption import decrypt_value
 from tracecat.service import BaseService
 
 # Union type for roles that can be used for audit logging
@@ -34,9 +38,18 @@ class AuditService(BaseService):
     service_name = "audit"
     role: AuditableRole | None
 
-    def __init__(self, session: AsyncSession, role: AuditableRole | None = None):
+    def __init__(
+        self,
+        session: AsyncSession,
+        role: AuditableRole | None = None,
+        *,
+        audit_sink: AuditSink | None = None,
+    ):
         super().__init__(session)
         self.role = role or ctx_role.get()
+        self.audit_sink = audit_sink or (
+            "platform" if isinstance(self.role, PlatformRole) else "organization"
+        )
         # Don't require organization_id - platform ops won't have one
 
     @classmethod
@@ -46,6 +59,7 @@ class AuditService(BaseService):
         role: AuditableRole | None = None,
         *,
         session: AsyncSession | None = None,
+        audit_sink: AuditSink | None = None,
     ) -> AsyncGenerator[Self, None]:
         """Create an AuditService instance with a database session.
 
@@ -53,10 +67,30 @@ class AuditService(BaseService):
         Accepts both Role (org-scoped) and PlatformRole (platform-scoped).
         """
         if session is not None:
-            yield cls(session, role=role)
+            yield cls(session, role=role, audit_sink=audit_sink)
         else:
             async with get_async_session_context_manager() as session:
-                yield cls(session, role=role)
+                yield cls(session, role=role, audit_sink=audit_sink)
+
+    async def _get_platform_setting(self, key: str) -> Any | None:
+        """Fetch a platform setting for platform-scoped audit delivery."""
+        stmt = select(PlatformSetting).where(PlatformSetting.key == key)
+        setting = (await self.session.execute(stmt)).scalar_one_or_none()
+        if setting is None:
+            return None
+
+        value = setting.value
+        if setting.is_encrypted:
+            try:
+                value = decrypt_value(value, key=get_db_encryption_key())
+            except (InvalidToken, ValueError) as exc:
+                self.logger.warning(
+                    "Failed to decrypt platform audit setting",
+                    key=key,
+                    error=str(exc),
+                )
+                return None
+        return orjson.loads(value)
 
     async def _get_webhook_url(self) -> str | None:
         """Fetch the configured audit webhook URL.
@@ -66,9 +100,16 @@ class AuditService(BaseService):
         2. Organization setting `audit_webhook_url`
         """
 
-        from tracecat.settings.service import get_setting_cached
+        if self.audit_sink == "platform":
+            value = await self._get_platform_setting("audit_webhook_url")
+        else:
+            from tracecat.settings.service import get_setting
 
-        value = await get_setting_cached("audit_webhook_url")
+            value = await get_setting(
+                "audit_webhook_url",
+                role=self.role if isinstance(self.role, Role) else None,
+                session=self.session,
+            )
         if value is None:
             return None
         if not isinstance(value, str):
@@ -87,9 +128,16 @@ class AuditService(BaseService):
 
         Note: Uses get_setting (uncached) to ensure changes take effect immediately.
         """
-        from tracecat.settings.service import get_setting
+        if self.audit_sink == "platform":
+            value = await self._get_platform_setting("audit_webhook_custom_headers")
+        else:
+            from tracecat.settings.service import get_setting
 
-        value = await get_setting("audit_webhook_custom_headers", session=self.session)
+            value = await get_setting(
+                "audit_webhook_custom_headers",
+                role=self.role if isinstance(self.role, Role) else None,
+                session=self.session,
+            )
         if value is None:
             return None
         if not isinstance(value, dict):
@@ -103,9 +151,16 @@ class AuditService(BaseService):
 
     async def _get_custom_payload(self) -> dict[str, Any] | None:
         """Fetch the configured custom payload for the audit webhook."""
-        from tracecat.settings.service import get_setting
+        if self.audit_sink == "platform":
+            value = await self._get_platform_setting("audit_webhook_custom_payload")
+        else:
+            from tracecat.settings.service import get_setting
 
-        value = await get_setting("audit_webhook_custom_payload", session=self.session)
+            value = await get_setting(
+                "audit_webhook_custom_payload",
+                role=self.role if isinstance(self.role, Role) else None,
+                session=self.session,
+            )
         if value is None:
             return None
         if not isinstance(value, dict):
@@ -118,11 +173,19 @@ class AuditService(BaseService):
 
     async def _get_verify_ssl(self) -> bool:
         """Fetch SSL verification setting for audit webhook requests."""
-        from tracecat.settings.service import get_setting
+        if self.audit_sink == "platform":
+            value = await self._get_platform_setting("audit_webhook_verify_ssl")
+            if value is None:
+                value = True
+        else:
+            from tracecat.settings.service import get_setting
 
-        value = await get_setting(
-            "audit_webhook_verify_ssl", session=self.session, default=True
-        )
+            value = await get_setting(
+                "audit_webhook_verify_ssl",
+                role=self.role if isinstance(self.role, Role) else None,
+                session=self.session,
+                default=True,
+            )
         if not isinstance(value, bool):
             self.logger.warning(
                 "audit_webhook_verify_ssl must be a bool",
@@ -134,11 +197,16 @@ class AuditService(BaseService):
 
     async def _get_payload_attribute(self) -> str | None:
         """Fetch optional wrapper attribute for webhook payloads."""
-        from tracecat.settings.service import get_setting
+        if self.audit_sink == "platform":
+            value = await self._get_platform_setting("audit_webhook_payload_attribute")
+        else:
+            from tracecat.settings.service import get_setting
 
-        value = await get_setting(
-            "audit_webhook_payload_attribute", session=self.session
-        )
+            value = await get_setting(
+                "audit_webhook_payload_attribute",
+                role=self.role if isinstance(self.role, Role) else None,
+                session=self.session,
+            )
         if value is None:
             return None
         if not isinstance(value, str):
@@ -224,6 +292,7 @@ class AuditService(BaseService):
         resource_id: uuid.UUID | None,
         status: AuditEventStatus,
         actor_label: str | None,
+        ip_address: str | None,
         data: dict[str, Any] | None,
     ) -> AuditEvent:
         if self.role is None or self.role.actor_id is None:
@@ -245,7 +314,7 @@ class AuditService(BaseService):
             resource_id=resource_id,
             action=action,
             status=status,
-            ip_address=ctx_client_ip.get(),
+            ip_address=ip_address,
             data=data,
         )
 
@@ -257,6 +326,8 @@ class AuditService(BaseService):
         resource_id: uuid.UUID | None = None,
         status: AuditEventStatus = AuditEventStatus.SUCCESS,
         data: dict[str, Any] | None = None,
+        include_actor_label: bool = True,
+        include_ip_address: bool = True,
     ) -> None:
         if self.role is None or getattr(self.role, "actor_id", None) is None:
             self.logger.debug(
@@ -269,13 +340,14 @@ class AuditService(BaseService):
             self.logger.debug("Skipping audit log", reason="webhook_unconfigured")
             return
 
-        actor_label = await self._get_actor_label()
+        actor_label = await self._get_actor_label() if include_actor_label else None
         payload = self._build_payload(
             resource_type=resource_type,
             action=action,
             resource_id=resource_id,
             status=status,
             actor_label=actor_label,
+            ip_address=ctx_client_ip.get() if include_ip_address else None,
             data=data,
         )
         await self._post_event(webhook_url=webhook_url, payload=payload)

--- a/tracecat/audit/service.py
+++ b/tracecat/audit/service.py
@@ -92,6 +92,21 @@ class AuditService(BaseService):
                 return None
         return orjson.loads(value)
 
+    async def _get_audit_setting(self, key: str, *, default: Any = None) -> Any | None:
+        """Fetch an audit setting from the active audit sink."""
+        if self.audit_sink == "platform":
+            value = await self._get_platform_setting(key)
+            return default if value is None and default is not None else value
+
+        from tracecat.settings.service import get_setting
+
+        return await get_setting(
+            key,
+            role=self.role if isinstance(self.role, Role) else None,
+            session=self.session,
+            default=default,
+        )
+
     async def _get_webhook_url(self) -> str | None:
         """Fetch the configured audit webhook URL.
 
@@ -100,16 +115,7 @@ class AuditService(BaseService):
         2. Organization setting `audit_webhook_url`
         """
 
-        if self.audit_sink == "platform":
-            value = await self._get_platform_setting("audit_webhook_url")
-        else:
-            from tracecat.settings.service import get_setting
-
-            value = await get_setting(
-                "audit_webhook_url",
-                role=self.role if isinstance(self.role, Role) else None,
-                session=self.session,
-            )
+        value = await self._get_audit_setting("audit_webhook_url")
         if value is None:
             return None
         if not isinstance(value, str):
@@ -128,16 +134,7 @@ class AuditService(BaseService):
 
         Note: Uses get_setting (uncached) to ensure changes take effect immediately.
         """
-        if self.audit_sink == "platform":
-            value = await self._get_platform_setting("audit_webhook_custom_headers")
-        else:
-            from tracecat.settings.service import get_setting
-
-            value = await get_setting(
-                "audit_webhook_custom_headers",
-                role=self.role if isinstance(self.role, Role) else None,
-                session=self.session,
-            )
+        value = await self._get_audit_setting("audit_webhook_custom_headers")
         if value is None:
             return None
         if not isinstance(value, dict):
@@ -151,16 +148,7 @@ class AuditService(BaseService):
 
     async def _get_custom_payload(self) -> dict[str, Any] | None:
         """Fetch the configured custom payload for the audit webhook."""
-        if self.audit_sink == "platform":
-            value = await self._get_platform_setting("audit_webhook_custom_payload")
-        else:
-            from tracecat.settings.service import get_setting
-
-            value = await get_setting(
-                "audit_webhook_custom_payload",
-                role=self.role if isinstance(self.role, Role) else None,
-                session=self.session,
-            )
+        value = await self._get_audit_setting("audit_webhook_custom_payload")
         if value is None:
             return None
         if not isinstance(value, dict):
@@ -173,19 +161,7 @@ class AuditService(BaseService):
 
     async def _get_verify_ssl(self) -> bool:
         """Fetch SSL verification setting for audit webhook requests."""
-        if self.audit_sink == "platform":
-            value = await self._get_platform_setting("audit_webhook_verify_ssl")
-            if value is None:
-                value = True
-        else:
-            from tracecat.settings.service import get_setting
-
-            value = await get_setting(
-                "audit_webhook_verify_ssl",
-                role=self.role if isinstance(self.role, Role) else None,
-                session=self.session,
-                default=True,
-            )
+        value = await self._get_audit_setting("audit_webhook_verify_ssl", default=True)
         if not isinstance(value, bool):
             self.logger.warning(
                 "audit_webhook_verify_ssl must be a bool",
@@ -197,16 +173,7 @@ class AuditService(BaseService):
 
     async def _get_payload_attribute(self) -> str | None:
         """Fetch optional wrapper attribute for webhook payloads."""
-        if self.audit_sink == "platform":
-            value = await self._get_platform_setting("audit_webhook_payload_attribute")
-        else:
-            from tracecat.settings.service import get_setting
-
-            value = await get_setting(
-                "audit_webhook_payload_attribute",
-                role=self.role if isinstance(self.role, Role) else None,
-                session=self.session,
-            )
+        value = await self._get_audit_setting("audit_webhook_payload_attribute")
         if value is None:
             return None
         if not isinstance(value, str):

--- a/tracecat/audit/types.py
+++ b/tracecat/audit/types.py
@@ -8,10 +8,22 @@ from pydantic import BaseModel, Field
 
 from tracecat.audit.enums import AuditEventActor, AuditEventStatus
 
-AuditAction = Literal["create", "update", "delete", "accept", "revoke"]
+AuditSink = Literal["organization", "platform"]
+AuditAction = Literal[
+    "create",
+    "update",
+    "delete",
+    "accept",
+    "revoke",
+    "sign_in",
+    "sync",
+    "promote",
+    "demote",
+]
 AuditResourceType = Literal[
     "user",
     "organization",
+    "auth",
     "workspace",
     "workflow",
     "workflow_execution",
@@ -33,6 +45,7 @@ AuditResourceType = Literal[
     "organization_member",
     "organization_session",
     "organization_invitation",
+    "organization_tier",
     "workspace_invitation",
     "service_account",
     "service_account_api_key",
@@ -44,6 +57,12 @@ AuditResourceType = Literal[
     "rbac_group_member",
     "rbac_assignment",
     "rbac_user_assignment",
+    # Platform resources
+    "platform_setting",
+    "platform_registry",
+    "platform_registry_repository",
+    "platform_registry_version",
+    "tier",
 ]
 
 

--- a/tracecat/auth/saml.py
+++ b/tracecat/auth/saml.py
@@ -988,5 +988,7 @@ async def sso_acs(
         )
 
     response = await auth_backend.login(strategy, user)
-    await user_manager.on_after_login(user, request, response)
+    await user_manager.on_after_login(
+        user, request, response, organization_id=organization_id
+    )
     return response

--- a/tracecat/auth/users.py
+++ b/tracecat/auth/users.py
@@ -43,7 +43,7 @@ from tracecat.audit.service import AuditService
 from tracecat.auth.enums import AuthType
 from tracecat.auth.schemas import UserCreate, UserUpdate
 from tracecat.auth.secrets import get_user_auth_secret
-from tracecat.auth.types import PlatformRole
+from tracecat.auth.types import PlatformRole, Role
 from tracecat.contexts import ctx_role
 from tracecat.db.engine import (
     get_async_session,
@@ -337,6 +337,8 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         user: User,
         request: Request | None = None,
         response: Response | None = None,
+        *,
+        organization_id: OrganizationID | None = None,
     ) -> None:
         # Update last login info
         try:
@@ -349,22 +351,17 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 user=user.email,
                 error=e,
             )
+        org_ids = {organization_id} if organization_id is not None else None
+        await self._emit_auth_success_audit(
+            user=user,
+            auth_method=self._auth_method_from_request(request),
+            org_ids=org_ids,
+        )
 
     async def on_after_register(
         self, user: User, request: Request | None = None
     ) -> None:
         self.logger.info("User registered", user_id=str(user.id), email=user.email)
-
-        # Log audit event for user registration
-        platform_role = PlatformRole(
-            type="user", user_id=user.id, service_id="tracecat-api"
-        )
-        async with AuditService.with_session(role=platform_role) as audit_svc:
-            await audit_svc.create_event(
-                resource_type="user",
-                action="create",
-                resource_id=user.id,
-            )
 
         # Promote to superuser if email matches configured superadmin email
         # No count/lock needed - email uniqueness ensures only one user can have this email
@@ -376,15 +373,18 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
         # Accept invitation atomically if token was provided during registration
         # This eliminates race conditions in the invitation flow
+        org_ids: set[OrganizationID] = set()
         if self._pending_invitation_token:
-            await self._accept_invitation_atomically(user)
+            if invitation_org_id := await self._accept_invitation_atomically(user):
+                org_ids.add(invitation_org_id)
 
-        await ensure_single_tenant_user_defaults(
+        if default_org_id := await ensure_single_tenant_user_defaults(
             user_id=user.id,
             is_superuser=user.is_superuser,
-        )
+        ):
+            org_ids.add(default_org_id)
 
-    async def _accept_invitation_atomically(self, user: User) -> None:
+    async def _accept_invitation_atomically(self, user: User) -> OrganizationID | None:
         """Accept an invitation during registration if a token was provided.
 
         Errors during invitation acceptance are logged but do NOT fail registration.
@@ -397,7 +397,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         self._pending_invitation_token = None  # Clear to prevent reuse
 
         if not token:
-            return
+            return None
 
         try:
             async with get_async_session_bypass_rls_context_manager() as session:
@@ -410,6 +410,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     email=user.email,
                     org_id=str(membership.organization_id),
                 )
+                return membership.organization_id
         except TracecatNotFoundError:
             self.logger.warning(
                 "Invitation token not found during registration",
@@ -423,6 +424,90 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 email=user.email,
                 error=str(e),
             )
+        return None
+
+    def _auth_method_from_request(self, request: Request | None) -> str:
+        """Return a coarse auth method label without user-provided data."""
+        if request is None:
+            return "unknown"
+        path = request.url.path
+        if path.startswith("/auth/saml"):
+            return "saml"
+        if path.startswith("/auth/oauth"):
+            return "oidc"
+        if path.startswith("/auth/register"):
+            return "basic"
+        if path.startswith("/auth/login"):
+            return "basic"
+        return "unknown"
+
+    async def _emit_auth_success_audit(
+        self,
+        *,
+        user: User,
+        auth_method: str,
+        org_ids: set[OrganizationID] | None = None,
+    ) -> None:
+        """Emit sanitized auth success events to the relevant audit sinks."""
+        if user.is_superuser:
+            audit_role = PlatformRole(
+                type="user",
+                user_id=user.id,
+                service_id="tracecat-api",
+            )
+            try:
+                async with AuditService.with_session(
+                    role=audit_role,
+                    audit_sink="platform",
+                ) as audit_svc:
+                    await audit_svc.create_event(
+                        resource_type="auth",
+                        action="sign_in",
+                        resource_id=user.id,
+                        data={"auth_method": auth_method},
+                        include_actor_label=False,
+                    )
+            except Exception as exc:
+                self.logger.warning(
+                    "Failed to emit auth audit event",
+                    user_id=str(user.id),
+                    action="sign_in",
+                    audit_sink="platform",
+                    error=str(exc),
+                )
+
+        target_org_ids = (
+            await self._list_user_org_ids(user.id) if org_ids is None else org_ids
+        )
+        for org_id in target_org_ids:
+            audit_role = Role(
+                type="user",
+                user_id=user.id,
+                organization_id=org_id,
+                service_id="tracecat-api",
+            )
+            for audit_sink in ("platform", "organization"):
+                try:
+                    async with AuditService.with_session(
+                        role=audit_role,
+                        audit_sink=audit_sink,
+                    ) as audit_svc:
+                        await audit_svc.create_event(
+                            resource_type="auth",
+                            action="sign_in",
+                            resource_id=user.id,
+                            data={"auth_method": auth_method},
+                            include_actor_label=False,
+                        )
+                except Exception as exc:
+                    self.logger.warning(
+                        "Failed to emit auth audit event",
+                        user_id=str(user.id),
+                        organization_id=str(org_id),
+                        action="sign_in",
+                        audit_sink=audit_sink,
+                        error=str(exc),
+                    )
 
     async def on_after_forgot_password(
         self, user: User, token: str, request: Request | None = None

--- a/tracecat/auth/users.py
+++ b/tracecat/auth/users.py
@@ -351,7 +351,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 user=user.email,
                 error=e,
             )
-        org_ids = {organization_id} if organization_id is not None else None
+        # Only fan out to an organization sink when the login carries explicit
+        # org context (e.g. SAML against a specific org). A context-less login
+        # (basic/OIDC) has no org scope, so it is recorded in the platform sink
+        # only and must not be attributed into org-controlled audit sinks.
+        org_ids = {organization_id} if organization_id is not None else set()
         await self._emit_auth_success_audit(
             user=user,
             auth_method=self._auth_method_from_request(request),
@@ -362,6 +366,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         self, user: User, request: Request | None = None
     ) -> None:
         self.logger.info("User registered", user_id=str(user.id), email=user.email)
+        await self._emit_user_create_audit(user=user)
 
         # Promote to superuser if email matches configured superadmin email
         # No count/lock needed - email uniqueness ensures only one user can have this email
@@ -426,6 +431,32 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             )
         return None
 
+    async def _emit_user_create_audit(self, *, user: User) -> None:
+        """Emit a platform-scoped lifecycle event for self-service registration."""
+        audit_role = PlatformRole(
+            type="user",
+            user_id=user.id,
+            service_id="tracecat-api",
+        )
+        try:
+            async with AuditService.with_session(
+                role=audit_role,
+                audit_sink="platform",
+            ) as audit_svc:
+                await audit_svc.create_event(
+                    resource_type="user",
+                    action="create",
+                    resource_id=user.id,
+                )
+        except Exception as exc:
+            self.logger.warning(
+                "Failed to emit user registration audit event",
+                user_id=str(user.id),
+                action="create",
+                audit_sink="platform",
+                error=str(exc),
+            )
+
     def _auth_method_from_request(self, request: Request | None) -> str:
         """Return a coarse auth method label without user-provided data."""
         if request is None:
@@ -448,7 +479,16 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         auth_method: str,
         org_ids: set[OrganizationID] | None = None,
     ) -> None:
-        """Emit sanitized auth success events to the relevant audit sinks."""
+        """Emit sanitized auth success events to the relevant audit sinks.
+
+        ``org_ids`` is the set of organizations the login is explicitly scoped
+        to. It is empty (or ``None``) for context-less logins (basic/OIDC),
+        which are recorded in the platform sink only. Organization-scoped sinks
+        receive a sign-in event only for orgs in ``org_ids`` -- we never fan out
+        across all of a user's memberships for a login that carried no org
+        context, since that would attribute a non-org-specific login (including
+        platform-superuser sessions) into org-controlled audit sinks.
+        """
         if user.is_superuser:
             audit_role = PlatformRole(
                 type="user",
@@ -476,10 +516,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     error=str(exc),
                 )
 
-        target_org_ids = (
-            await self._list_user_org_ids(user.id) if org_ids is None else org_ids
-        )
-        for org_id in target_org_ids:
+        for org_id in org_ids or set():
             audit_role = Role(
                 type="user",
                 user_id=user.id,

--- a/tracecat/organization/service.py
+++ b/tracecat/organization/service.py
@@ -802,7 +802,11 @@ class OrgService(BaseOrgService):
         return membership
 
     @require_scope("org:member:invite")
-    @audit_log(resource_type="organization_invitation", action="revoke")
+    @audit_log(
+        resource_type="organization_invitation",
+        action="revoke",
+        resource_id_attr="invitation_id",
+    )
     async def revoke_invitation(
         self, invitation_id: uuid.UUID
     ) -> OrganizationInvitation:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds platform-wide audit logging with platform and org webhook sinks and a new Admin “Audit logging” page. Admin actions and sanitized sign-ins now emit structured events to the right sink for visibility and compliance.

- **New Features**
  - Admin UI/API: new page at `/admin/audit` with shared `AuditSettingsForm` and sidebar link; `GET/PATCH /admin/settings/audit` to read/update platform audit settings; sensitive fields are encrypted and responses include `decryption_failed_keys` when old values can’t be decrypted.
  - Audit pipeline: `AuditService` defaults PlatformRole logs to the platform sink and supports explicit sinks; reads platform/org settings with decryption fallback; supports custom headers/payload, optional payload wrapper, TLS verify; `create_event` can omit actor label/IP.
  - Instrumentation: `@audit_log` added for organizations, invitations (create/revoke with explicit IDs), tiers (create/update/delete, update_org_tier), registry (sync/promote across platform surfaces), users (create/promote/demote/delete), and admin settings updates; user registration emits `user.create`; auth success emits sanitized `auth.sign_in` to platform (and, for org-scoped logins, org) sinks.

- **Migration**
  - Configure `audit_webhook_url` (and optional headers/payload/wrapper, TLS verify) in Admin → Audit logging or via `/admin/settings/audit`; ensure the DB encryption key is set.
  - If `decryption_failed_keys` is returned, re-enter those settings.

<sup>Written for commit 3a6c5a8782a345ba158c1b577896cd314b28e000. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

