### PR TITLE
fix(agents): Avoid passing SDK session data through workflows

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -187,9 +187,6 @@ class DurableAgentWorkflow:
         self.approvals = ApprovalManager(role=self.role)
         self.max_requests = args.agent_args.max_requests
         self.max_tool_calls = args.agent_args.max_tool_calls
-        # Session state for Claude SDK resume
-        self._sdk_session_id: str | None = None
-        self._sdk_session_data: str | None = None
         # Registry lock for action resolution (set after build_tool_definitions)
         self._registry_lock: RegistryLock | None = None
 
@@ -472,24 +469,14 @@ class DurableAgentWorkflow:
             registry_lock_origins=list(self._registry_lock.origins.keys()),
         )
 
-        # Load existing session state for resume
+        # Load existing session metadata for resume. sdk_session_data is legacy
+        # replay compatibility only; new activity executions leave it unset.
         load_result = await workflow.execute_activity(
             load_session_activity,
             LoadSessionInput(role=self.role, session_id=self.session_id),
             start_to_close_timeout=timedelta(seconds=30),
             retry_policy=RETRY_POLICIES["activity:fail_fast"],
         )
-
-        is_fork = False
-        if load_result.found and load_result.sdk_session_data:
-            self._sdk_session_id = load_result.sdk_session_id
-            self._sdk_session_data = load_result.sdk_session_data
-            is_fork = load_result.is_fork
-            logger.info(
-                "Resuming from existing session",
-                sdk_session_id=self._sdk_session_id,
-                is_fork=is_fork,
-            )
 
         # Mint tokens for MCP server and LLM gateway auth
         # These tokens are opaque to the jailed runtime - it cannot decode them
@@ -527,12 +514,10 @@ class DurableAgentWorkflow:
             mcp_auth_token=mcp_auth_token,
             llm_gateway_auth_token=llm_gateway_auth_token,
             allowed_actions=allowed_actions,
-            sdk_session_id=self._sdk_session_id,
-            sdk_session_data=self._sdk_session_data,
-            is_fork=is_fork,
+            sdk_session_id=load_result.sdk_session_id,
+            sdk_session_data=load_result.sdk_session_data,
+            is_fork=load_result.is_fork,
         )
-
-        info = workflow.info()
 
         # Run the executor activity
         while True:
@@ -591,20 +576,14 @@ class DurableAgentWorkflow:
                         session_id=self.session_id,
                     )
 
-                # Reload session data from DB to get lines persisted during previous turn
+                # Reload session metadata after reconciliation. Full SDK history
+                # is loaded inside run_agent_activity.
                 reload_result = await workflow.execute_activity(
                     load_session_activity,
                     LoadSessionInput(role=self.role, session_id=self.session_id),
                     start_to_close_timeout=timedelta(seconds=30),
                     retry_policy=RETRY_POLICIES["activity:fail_fast"],
                 )
-                if reload_result.found and reload_result.sdk_session_data:
-                    self._sdk_session_id = reload_result.sdk_session_id
-                    self._sdk_session_data = reload_result.sdk_session_data
-                    logger.info(
-                        "Reloaded session data for continuation",
-                        sdk_session_id=self._sdk_session_id,
-                    )
 
                 # Update executor input for resume. Reconcile has replaced the
                 # interrupt artifacts with the real tool_result entry; the
@@ -618,8 +597,9 @@ class DurableAgentWorkflow:
                     mcp_auth_token=mcp_auth_token,
                     llm_gateway_auth_token=llm_gateway_auth_token,
                     allowed_actions=allowed_actions,
-                    sdk_session_id=self._sdk_session_id,
-                    sdk_session_data=self._sdk_session_data,
+                    sdk_session_id=reload_result.sdk_session_id,
+                    sdk_session_data=reload_result.sdk_session_data,
+                    is_fork=reload_result.is_fork,
                     is_approval_continuation=True,
                 )
                 self._turn += 1

--- a/tests/integration/test_agent_worker.py
+++ b/tests/integration/test_agent_worker.py
@@ -411,18 +411,6 @@ class TestAgentWorkerSingleTenant:
         queue = TEST_AGENT_QUEUE
         approval_request_recorded = asyncio.Event()
         captured_inputs: list[AgentExecutorInput] = []
-        sdk_history_without_tool_result = (
-            '{"type":"user","message":{"content":"Run approved tool"}}\n'
-            '{"type":"assistant","message":{"content":[{"type":"tool_use",'
-            '"id":"call_123","name":"core__http_request","input":{"url":'
-            '"https://example.com","method":"GET"}}]}}\n'
-        )
-        sdk_history_with_tool_result = (
-            sdk_history_without_tool_result
-            + '{"type":"user","message":{"content":[{"type":"tool_result",'
-            '"tool_use_id":"call_123","content":"{\\"status\\":\\"success\\"}",'
-            '"is_error":false}]}}\n'
-        )
 
         @activity.defn(name="create_session_activity")
         async def mock_create_session_activity(
@@ -444,7 +432,7 @@ class TestAgentWorkerSingleTenant:
             return LoadSessionResult(
                 found=True,
                 sdk_session_id="sdk-session",
-                sdk_session_data=sdk_history_with_tool_result,
+                sdk_session_data=None,
             )
 
         @activity.defn(name="record_approval_requests")
@@ -496,9 +484,7 @@ class TestAgentWorkerSingleTenant:
 
             assert input.is_approval_continuation is True
             assert input.sdk_session_id == "sdk-session"
-            assert input.sdk_session_data == sdk_history_with_tool_result
-            assert '"type":"tool_result"' in input.sdk_session_data
-            assert "Continue." not in input.sdk_session_data
+            assert input.sdk_session_data is None
             return AgentExecutorResult(
                 success=True,
                 approval_requested=False,

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -721,26 +721,7 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
 
         assert input.is_approval_continuation is True
         assert input.sdk_session_id == "sdk-session"
-        assert input.sdk_session_data is not None
-
-        session_lines = [
-            orjson.loads(line)
-            for line in input.sdk_session_data.splitlines()
-            if line.strip()
-        ]
-        tool_result_blocks = [
-            block
-            for entry in session_lines
-            for block in entry.get("message", {}).get("content", [])
-            if isinstance(block, dict) and block.get("type") == "tool_result"
-        ]
-        assert len(tool_result_blocks) == 1
-        assert tool_result_blocks[0]["tool_use_id"] == "call_123"
-        assert tool_result_blocks[0]["is_error"] is False
-        assert orjson.loads(tool_result_blocks[0]["content"]) == {
-            "status": "success",
-            "executor_queue": executor_queue,
-        }
+        assert input.sdk_session_data is None
 
         resumed_after_approval.set()
         run_agent_call_count += 1
@@ -1339,23 +1320,7 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
 
         assert input.is_approval_continuation is True
         assert input.sdk_session_id == "sdk-session"
-        assert input.sdk_session_data is not None
-
-        session_lines = [
-            orjson.loads(line)
-            for line in input.sdk_session_data.splitlines()
-            if line.strip()
-        ]
-        tool_result_blocks = [
-            block
-            for entry in session_lines
-            for block in entry.get("message", {}).get("content", [])
-            if isinstance(block, dict) and block.get("type") == "tool_result"
-        ]
-        assert len(tool_result_blocks) == 1
-        assert tool_result_blocks[0]["tool_use_id"] == "call_123"
-        assert tool_result_blocks[0]["is_error"] is True
-        assert "transient tool failure" in tool_result_blocks[0]["content"]
+        assert input.sdk_session_data is None
 
         resumed_after_approval.set()
         run_agent_call_count += 1

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -21,9 +21,15 @@ pytestmark = [pytest.mark.temporal, pytest.mark.usefixtures("db")]
 
 from pydantic_ai.tools import ToolApproved, ToolDenied
 from temporalio import activity
-from temporalio.client import Client, WorkflowFailureError
+from temporalio.api.enums.v1 import EventType
+from temporalio.client import (
+    Client,
+    WorkflowFailureError,
+    WorkflowHandle,
+    WorkflowHistory,
+)
 from temporalio.exceptions import ApplicationError
-from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
 from tracecat_ee.agent.activities import (
     ApplyApprovalResultsActivityInputs,
     BuildToolDefsArgs,
@@ -253,6 +259,35 @@ def create_activities_with_mock_executor(
         *ApprovalManager.get_activities(),
     ]
     return activities
+
+
+async def replay_durable_agent_workflow_history(
+    temporal_client: Client,
+    history: WorkflowHistory,
+) -> None:
+    """Replay a fetched durable-agent history against the current workflow code."""
+    replay_result = await Replayer(
+        workflows=[DurableAgentWorkflow],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+        data_converter=temporal_client.data_converter,
+    ).replay_workflow(history, raise_on_replay_failure=False)
+    assert replay_result.replay_failure is None
+
+
+async def fetch_history_after_completed_workflow_task(
+    handle: WorkflowHandle[Any, Any],
+) -> WorkflowHistory:
+    """Fetch history once the workflow task that reached a wait state is recorded."""
+    for _ in range(100):
+        history = await handle.fetch_history()
+        if (
+            history.events
+            and history.events[-1].event_type
+            == EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+        ):
+            return history
+        await asyncio.sleep(0.05)
+    raise AssertionError("Timed out waiting for workflow task completion")
 
 
 # =============================================================================
@@ -1159,6 +1194,144 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
     }
     assert decisions_by_tool_call_id["call_risky"].approved is False
     assert decisions_by_tool_call_id["call_risky"].reason == "too risky"
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
+async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
+    svc_role: Role,
+    temporal_client: Client,
+    agent_worker_factory,
+    mock_session_id: uuid.UUID,
+    agent_config_with_approvals: AgentConfig,
+) -> None:
+    """A suspended workflow with legacy SDK JSONL payloads should replay."""
+    queue = f"test-agent-queue-{mock_session_id}"
+    approval_request_recorded = asyncio.Event()
+    captured_agent_inputs: list[AgentExecutorInput] = []
+    legacy_sdk_session_data = (
+        '{"type":"user","message":{"content":"legacy prompt"}}\n'
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"legacy"}]}}\n'
+    )
+
+    @activity.defn(name="load_session_activity")
+    async def mock_load_session_activity(
+        input: LoadSessionInput,
+    ) -> LoadSessionResult:
+        assert input.session_id == mock_session_id
+        if len(captured_agent_inputs) == 0:
+            return LoadSessionResult(
+                found=True,
+                sdk_session_id="legacy-sdk-session",
+                sdk_session_data=legacy_sdk_session_data,
+                is_fork=False,
+            )
+        return LoadSessionResult(
+            found=True,
+            sdk_session_id="legacy-sdk-session",
+            sdk_session_data=None,
+            is_fork=False,
+        )
+
+    @activity.defn(name="run_agent_activity")
+    async def mock_run_agent_activity(
+        input: AgentExecutorInput,
+    ) -> AgentExecutorResult:
+        captured_agent_inputs.append(input)
+        if len(captured_agent_inputs) == 1:
+            assert input.sdk_session_id == "legacy-sdk-session"
+            assert input.sdk_session_data == legacy_sdk_session_data
+            assert input.is_approval_continuation is False
+            return AgentExecutorResult(
+                success=True,
+                approval_requested=True,
+                approval_items=[
+                    ToolCallContent(
+                        id="call_123",
+                        name="core__http_request",
+                        input={"url": "https://example.com", "method": "GET"},
+                    )
+                ],
+            )
+
+        assert input.sdk_session_id == "legacy-sdk-session"
+        assert input.sdk_session_data is None
+        assert input.is_approval_continuation is True
+        return AgentExecutorResult(
+            success=True,
+            approval_requested=False,
+            output={"status": "continued"},
+        )
+
+    @activity.defn(name="record_approval_requests")
+    async def mock_record_approval_requests(
+        input: PersistApprovalsActivityInputs,
+    ) -> None:
+        assert [approval.tool_call_id for approval in input.approvals] == ["call_123"]
+        approval_request_recorded.set()
+
+    @activity.defn(name="apply_approval_decisions")
+    async def mock_apply_approval_decisions(
+        input: ApplyApprovalResultsActivityInputs,
+    ) -> None:
+        assert [decision.tool_call_id for decision in input.decisions] == ["call_123"]
+
+    workflow_args = AgentWorkflowArgs(
+        role=svc_role,
+        agent_args=RunAgentArgs(
+            session_id=mock_session_id,
+            user_prompt="Continue from legacy suspended workflow",
+            config=agent_config_with_approvals,
+        ),
+        entity_type=AgentSessionEntity.WORKFLOW,
+        entity_id=uuid.uuid4(),
+    )
+
+    activities = [
+        create_mock_create_session_activity(),
+        mock_load_session_activity,
+        create_mock_build_tool_definitions_activity(),
+        mock_run_agent_activity,
+        create_mock_execute_action_activity(),
+        create_mock_reconcile_tool_results_activity(),
+        mock_record_approval_requests,
+        mock_apply_approval_decisions,
+    ]
+
+    async with agent_worker_factory(
+        temporal_client, task_queue=queue, custom_activities=activities
+    ):
+        wf_handle = await temporal_client.start_workflow(
+            DurableAgentWorkflow.run,
+            workflow_args,
+            id=AgentWorkflowID(mock_session_id),
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+            execution_timeout=timedelta(seconds=30),
+        )
+
+        await asyncio.wait_for(approval_request_recorded.wait(), timeout=10)
+        suspended_history = await fetch_history_after_completed_workflow_task(wf_handle)
+        await replay_durable_agent_workflow_history(temporal_client, suspended_history)
+
+        await wf_handle.execute_update(
+            DurableAgentWorkflow.set_approvals,
+            WorkflowApprovalSubmission(
+                approvals={"call_123": True},
+                approved_by=svc_role.user_id,
+            ),
+        )
+
+        result = await wf_handle.result()
+        completed_history = await wf_handle.fetch_history()
+        await replay_durable_agent_workflow_history(temporal_client, completed_history)
+
+    assert result.session_id == mock_session_id
+    assert result.output == {"status": "continued"}
+    assert [input.sdk_session_data for input in captured_agent_inputs] == [
+        legacy_sdk_session_data,
+        None,
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -25,6 +25,7 @@ from tracecat.agent.executor.activity import (
     AgentExecutorInput,
     AgentExecutorResult,
     SandboxedAgentExecutor,
+    _hydrate_sdk_session_history,
     run_agent_activity,
 )
 from tracecat.agent.schemas import ToolFilters
@@ -418,11 +419,12 @@ class TestLoadSessionActivity:
         )
 
         mock_agent_session = MagicMock()
+        mock_agent_session.sdk_session_id = None
+        mock_agent_session.parent_session_id = None
 
         # Set up the mock service
         mock_service = AsyncMock()
         mock_service.get_session.return_value = mock_agent_session
-        mock_service.load_session_history.return_value = None
 
         # Set up the context manager's __aenter__ to return the mock service
         mock_ctx = AsyncMock()
@@ -434,6 +436,7 @@ class TestLoadSessionActivity:
         assert result.found is True
         assert result.sdk_session_id is None
         assert result.sdk_session_data is None
+        assert result.is_fork is False
 
     @pytest.mark.anyio
     @patch("tracecat.agent.session.activities.AgentSessionService.with_session")
@@ -447,15 +450,12 @@ class TestLoadSessionActivity:
         )
 
         mock_agent_session = MagicMock()
-
-        mock_history = MagicMock()
-        mock_history.sdk_session_id = "sdk-session-123"
-        mock_history.sdk_session_data = '{"messages": []}'
+        mock_agent_session.sdk_session_id = "sdk-session-123"
+        mock_agent_session.parent_session_id = None
 
         # Set up the mock service
         mock_service = AsyncMock()
         mock_service.get_session.return_value = mock_agent_session
-        mock_service.load_session_history.return_value = mock_history
 
         # Set up the context manager's __aenter__ to return the mock service
         mock_ctx = AsyncMock()
@@ -466,7 +466,43 @@ class TestLoadSessionActivity:
 
         assert result.found is True
         assert result.sdk_session_id == "sdk-session-123"
-        assert result.sdk_session_data == '{"messages": []}'
+        assert result.sdk_session_data is None
+        assert result.is_fork is False
+
+    @pytest.mark.anyio
+    @patch("tracecat.agent.session.activities.AgentSessionService.with_session")
+    async def test_loads_forked_parent_session_metadata(
+        self, mock_with_session, mock_role: Role, mock_session_id: uuid.UUID
+    ):
+        """Forked first turns resume from parent metadata without SDK JSONL."""
+        parent_session_id = uuid.uuid4()
+        input = LoadSessionInput(
+            role=mock_role,
+            session_id=mock_session_id,
+        )
+
+        mock_agent_session = MagicMock()
+        mock_agent_session.sdk_session_id = None
+        mock_agent_session.parent_session_id = parent_session_id
+        mock_parent_session = MagicMock()
+        mock_parent_session.sdk_session_id = "parent-sdk-session"
+
+        mock_service = AsyncMock()
+        mock_service.get_session.side_effect = [
+            mock_agent_session,
+            mock_parent_session,
+        ]
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        result = await load_session_activity(input)
+
+        assert result.found is True
+        assert result.sdk_session_id == "parent-sdk-session"
+        assert result.sdk_session_data is None
+        assert result.is_fork is True
 
 
 class TestRunAgentActivity:
@@ -619,6 +655,45 @@ class TestSandboxedAgentExecutorHelpers:
         assert payload.mcp_auth_token == executor_input.mcp_auth_token
         assert payload.llm_gateway_auth_token == executor_input.llm_gateway_auth_token
         assert payload.config.model_name == executor_input.config.model_name
+
+    @pytest.mark.anyio
+    @patch("tracecat.agent.executor.activity.AgentSessionService.with_session")
+    async def test_hydrates_session_history_for_runtime(
+        self,
+        mock_with_session,
+        executor_input: AgentExecutorInput,
+    ) -> None:
+        executor_input.sdk_session_id = "sdk-session-123"
+        mock_history = MagicMock()
+        mock_history.sdk_session_id = "sdk-session-123"
+        mock_history.sdk_session_data = '{"type":"user"}\n'
+        mock_history.is_fork = True
+        mock_service = AsyncMock()
+        mock_service.load_session_history.return_value = mock_history
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        hydrated = await _hydrate_sdk_session_history(executor_input)
+
+        assert hydrated.sdk_session_id == "sdk-session-123"
+        assert hydrated.sdk_session_data == '{"type":"user"}\n'
+        assert hydrated.is_fork is True
+
+    @pytest.mark.anyio
+    @patch("tracecat.agent.executor.activity.AgentSessionService.with_session")
+    async def test_preserves_legacy_session_data(
+        self,
+        mock_with_session,
+        executor_input: AgentExecutorInput,
+    ) -> None:
+        executor_input.sdk_session_id = "legacy-sdk-session"
+        executor_input.sdk_session_data = '{"type":"legacy"}\n'
+
+        hydrated = await _hydrate_sdk_session_history(executor_input)
+
+        assert hydrated is executor_input
+        mock_with_session.assert_not_called()
 
 
 class TestSandboxedAgentExecutorSkillCaching:

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -58,11 +58,7 @@ from .schemas import (
 
 
 class AgentExecutorInput(BaseModel):
-    """Input for the agent executor activity.
-
-    On resume after approval, sdk_session_data already includes the reconciled
-    user tool_result entry.
-    """
+    """Input for the agent executor activity."""
 
     # ``extra="ignore"`` keeps Temporal activity replay working after the
     # legacy ``use_workspace_credentials`` field was removed: activity input
@@ -85,7 +81,9 @@ class AgentExecutorInput(BaseModel):
     allowed_actions: dict[str, MCPToolDefinition] | None = None
     # Session resume data from previous runs
     sdk_session_id: str | None = None
-    sdk_session_data: str | None = None
+    # Legacy replay compatibility only. New executions hydrate this inside
+    # run_agent_activity instead of passing it over Temporal boundaries.
+    sdk_session_data: str | None = Field(default=None, deprecated=True)
     # True when resuming after an approval decision.
     is_approval_continuation: bool = False
     # True when forking from parent session (SDK should use fork_session=True)
@@ -522,9 +520,7 @@ class SandboxedAgentExecutor:
 
 
 @activity.defn
-async def run_agent_activity(
-    input: AgentExecutorInput,
-) -> AgentExecutorResult:
+async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
     """Temporal activity that runs one brokered agent turn.
 
     This activity:
@@ -550,6 +546,7 @@ async def run_agent_activity(
         f"Starting agent execution ({sandbox_mode} mode): {input.session_id}"
     )
 
+    input = await _hydrate_sdk_session_history(input)
     executor = SandboxedAgentExecutor(input=input)
     result = await executor.run()
 
@@ -569,3 +566,37 @@ async def run_agent_activity(
         activity.heartbeat(f"Agent execution failed: {result.error}")
 
     return result
+
+
+async def _hydrate_sdk_session_history(input: AgentExecutorInput) -> AgentExecutorInput:
+    """Inject SDK JSONL into activity input before runtime startup."""
+    # sdk_session_data is deprecated for new Temporal payloads, but old
+    # scheduled/replayed activity inputs may still carry it and must remain
+    # executable.
+    if input.sdk_session_id and input.sdk_session_data:
+        return input
+
+    if input.sdk_session_id is None:
+        return input.model_copy(
+            update={"sdk_session_data": None, "is_fork": False},
+        )
+
+    async with AgentSessionService.with_session(role=input.role) as svc:
+        history = await svc.load_session_history(input.session_id)
+
+    if history is None:
+        return input.model_copy(
+            update={
+                "sdk_session_id": None,
+                "sdk_session_data": None,
+                "is_fork": False,
+            },
+        )
+
+    return input.model_copy(
+        update={
+            "sdk_session_id": history.sdk_session_id,
+            "sdk_session_data": history.sdk_session_data,
+            "is_fork": history.is_fork,
+        },
+    )

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import uuid
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
@@ -93,7 +93,9 @@ class LoadSessionResult(BaseModel):
 
     found: bool
     sdk_session_id: str | None = None
-    sdk_session_data: str | None = None
+    # Legacy replay compatibility only. New activity executions do not populate
+    # SDK JSONL across Temporal boundaries.
+    sdk_session_data: str | None = Field(default=None, deprecated=True)
     is_fork: bool = False  # If True, runtime should use fork_session=True with SDK
     error: str | None = None
 
@@ -174,10 +176,11 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
 
 @activity.defn
 async def load_session_activity(input: LoadSessionInput) -> LoadSessionResult:
-    """Load agent session history for resume.
+    """Load lightweight agent session resume metadata.
 
-    Retrieves the stored SDK session data (JSONL) so the runtime
-    can resume from where it left off.
+    The full SDK JSONL history is loaded inside run_agent_activity. Keeping this
+    activity metadata-only avoids carrying joined session history through
+    Temporal workflow/activity payloads while preserving workflow command shape.
     """
     ctx_role.set(input.role)
 
@@ -188,21 +191,33 @@ async def load_session_activity(input: LoadSessionInput) -> LoadSessionResult:
             if agent_session is None:
                 return LoadSessionResult(found=False)
 
-            # Load the session history
-            history = await service.load_session_history(input.session_id)
+            is_fork = False
+            sdk_session_id = agent_session.sdk_session_id
 
-            if history is None:
-                return LoadSessionResult(
-                    found=True,
-                    sdk_session_id=None,
-                    sdk_session_data=None,
+            # For forked sessions, only fork on the first turn (when child has
+            # no sdk_session_id yet). Subsequent turns resume the child's own
+            # SDK session normally.
+            if (
+                agent_session.parent_session_id is not None
+                and agent_session.sdk_session_id is None
+            ):
+                parent_session = await service.get_session(
+                    agent_session.parent_session_id
                 )
+                if parent_session is None:
+                    logger.warning(
+                        "Forked session references non-existent parent",
+                        session_id=input.session_id,
+                        parent_session_id=agent_session.parent_session_id,
+                    )
+                    return LoadSessionResult(found=True)
+                is_fork = True
+                sdk_session_id = parent_session.sdk_session_id
 
             return LoadSessionResult(
                 found=True,
-                sdk_session_id=history.sdk_session_id,
-                sdk_session_data=history.sdk_session_data,
-                is_fork=history.is_fork,
+                sdk_session_id=sdk_session_id,
+                is_fork=is_fork,
             )
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- Stop returning joined Claude SDK session JSONL from `load_session_activity`; it now returns metadata only for new executions.
- Hydrate SDK session history inside `run_agent_activity` before constructing the runtime executor, while preserving legacy `sdk_session_data` payload compatibility.
- Keep `sdk_session_data` fields deprecated and update workflow/tests so new approval continuations pass only the SDK session ID across Temporal boundaries.

## Safety / Backward compatibility
- Existing suspended approval workflows remain replay-safe: the workflow still schedules the same `load_session_activity` / `run_agent_activity` command sequence, and old activity results that include `sdk_session_data` still deserialize because the field remains on `LoadSessionResult`.
- If a suspended workflow already has a recorded `run_agent_activity` input with `sdk_session_data`, `AgentExecutorInput` still accepts it and `_hydrate_sdk_session_history` preserves that payload instead of reloading from storage.
- New continuations pass only `sdk_session_id`; `run_agent_activity` reloads the JSONL from persisted session history immediately before starting the runtime. This does not require a DB migration or stored-session format change, so previously persisted SDK sessions and fork metadata remain valid.

## Tests
- `uv run pytest tests/unit/test_agent_activities.py`
- `uv run pytest tests/temporal/test_durable_agent_workflow.py`
- `uv run pytest tests/integration/test_agent_worker.py tests/integration/test_dsl_agent_wiring.py`
- `uv run ruff check tracecat/agent/session/activities.py tracecat/agent/executor/activity.py packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py tests/unit/test_agent_activities.py tests/temporal/test_durable_agent_workflow.py tests/integration/test_agent_worker.py`
- `uv run basedpyright tracecat/agent/session/activities.py tracecat/agent/executor/activity.py packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py tests/unit/test_agent_activities.py tests/temporal/test_durable_agent_workflow.py tests/integration/test_agent_worker.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop passing SDK session JSONL through workflows and hydrate it inside the executor activity at runtime. Adds replay-safety for suspended workflows that still carry legacy `sdk_session_data`.

- **Refactors**
  - `load_session_activity` now returns metadata only (`sdk_session_id`, `is_fork`); `sdk_session_data` is deprecated and unset for new executions.
  - `run_agent_activity` hydrates full history via `_hydrate_sdk_session_history` using `AgentSessionService`; legacy inputs with `sdk_session_data` are preserved; missing history clears fields safely.
  - Durable workflow no longer stores local SDK session state; it forwards `sdk_session_id`/`is_fork` and reloads metadata between turns. Forks resume the parent SDK session on the first turn only.
  - Added Temporal history replay tests using `Replayer` to ensure suspended workflows with legacy `sdk_session_data` replay and complete; unit tests cover hydration and forked-parent metadata.

- **Migration**
  - Approval continuations should pass only `sdk_session_id` across Temporal boundaries; stop sending `sdk_session_data`. Existing scheduled runs with `sdk_session_data` remain compatible.

<sup>Written for commit 6032900ab1a640ff8b9ed7b09d72238c323b9925. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

