### PR TITLE
fix(agent): remove stale models from catalog on custom provider refresh

### DIFF
--- a/tests/unit/test_agent_catalog_service.py
+++ b/tests/unit/test_agent_catalog_service.py
@@ -214,6 +214,101 @@ async def test_upsert_discovered_models_inserts_rows(
 
 
 @pytest.mark.anyio
+async def test_upsert_discovered_models_removes_stale_models(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    service = AgentCatalogService(session=session)
+    provider = AgentCustomProvider(
+        organization_id=svc_organization.id,
+        display_name="Provider",
+        base_url="https://api.example.com",
+    )
+    session.add(provider)
+    await session.commit()
+
+    await service.upsert_discovered_models(
+        org_id=svc_organization.id,
+        custom_provider_id=provider.id,
+        model_provider="custom-model-provider",
+        models=[
+            {"id": "model-a"},
+            {"id": "model-b"},
+            {"id": "model-c"},
+        ],
+    )
+
+    count = await service.upsert_discovered_models(
+        org_id=svc_organization.id,
+        custom_provider_id=provider.id,
+        model_provider="custom-model-provider",
+        models=[
+            {"id": "model-b"},
+            {"id": "model-d"},
+        ],
+    )
+
+    rows = (
+        (
+            await session.execute(
+                select(AgentCatalog).where(
+                    AgentCatalog.custom_provider_id == provider.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert count == 2
+    assert {row.model_name for row in rows} == {"model-b", "model-d"}
+
+
+@pytest.mark.anyio
+async def test_upsert_discovered_models_clears_catalog_when_empty(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    service = AgentCatalogService(session=session)
+    provider = AgentCustomProvider(
+        organization_id=svc_organization.id,
+        display_name="Provider",
+        base_url="https://api.example.com",
+    )
+    session.add(provider)
+    await session.commit()
+
+    await service.upsert_discovered_models(
+        org_id=svc_organization.id,
+        custom_provider_id=provider.id,
+        model_provider="custom-model-provider",
+        models=[{"id": "model-a"}, {"id": "model-b"}],
+    )
+
+    count = await service.upsert_discovered_models(
+        org_id=svc_organization.id,
+        custom_provider_id=provider.id,
+        model_provider="custom-model-provider",
+        models=[],
+    )
+
+    rows = (
+        (
+            await session.execute(
+                select(AgentCatalog).where(
+                    AgentCatalog.custom_provider_id == provider.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert count == 0
+    assert rows == []
+
+
+@pytest.mark.anyio
 async def test_get_catalog_entry_returns_platform_row(
     session: AsyncSession,
     svc_organization: Organization,

--- a/tracecat/agent/catalog/service.py
+++ b/tracecat/agent/catalog/service.py
@@ -360,22 +360,33 @@ class AgentCatalogService(BaseService):
                     "last_refreshed_at": now,
                 }
             )
-        if not values:
-            return 0
+        if values:
+            stmt = insert(AgentCatalog).values(values)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=[
+                    "organization_id",
+                    "custom_provider_id",
+                    "model_provider",
+                    "model_name",
+                ],
+                set_={
+                    "model_metadata": stmt.excluded.model_metadata,
+                    "last_refreshed_at": stmt.excluded.last_refreshed_at,
+                },
+            )
+            await self.session.execute(stmt)
 
-        stmt = insert(AgentCatalog).values(values)
-        stmt = stmt.on_conflict_do_update(
-            index_elements=[
-                "organization_id",
-                "custom_provider_id",
-                "model_provider",
-                "model_name",
-            ],
-            set_={
-                "model_metadata": stmt.excluded.model_metadata,
-                "last_refreshed_at": stmt.excluded.last_refreshed_at,
-            },
+        # Remove models that are no longer returned by the provider.
+        # Runs even when values is empty so a provider returning no models
+        # clears its entire catalog rather than leaving stale rows.
+        current_model_names = [v["model_name"] for v in values]
+        delete_stmt = sa.delete(AgentCatalog).where(
+            and_(
+                AgentCatalog.organization_id == org_id,
+                AgentCatalog.custom_provider_id == custom_provider_id,
+                AgentCatalog.model_name.not_in(current_model_names),
+            )
         )
-        await self.session.execute(stmt)
+        await self.session.execute(delete_stmt)
         await self.session.commit()
         return len(values)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove stale models from the catalog when refreshing a custom provider so the catalog always matches the provider’s current model list. Also clears the provider’s catalog if it returns no models.

- **Bug Fixes**
  - During model refresh, delete catalog rows for the org/provider whose `model_name` is not in the latest response, including clearing all rows on an empty response.
  - Added tests for stale removals and for clearing the catalog when the provider returns no models.

<sup>Written for commit 8cd6a1689a58d3367ce5b48967e0ca52aac9c534. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

