### PR TITLE
perf(agents): load agent messages at workflow completion

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -166,6 +166,11 @@ def _resolve_agent_output(
 UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH = (
     "durable-agent-upsert-tracecat-search-attributes-v1"
 )
+# Temporal patch IDs are persisted in each workflow execution's history. Use a
+# stable, unique ID for every command-producing workflow change, and never reuse
+# an ID for another change. Keep both branches until old histories that lack the
+# marker have aged out, then use workflow.deprecate_patch(...) before removing
+# the marker entirely in a later cleanup.
 LOAD_TERMINAL_MESSAGE_HISTORY_PATCH = "durable-agent-load-terminal-message-history-v1"
 
 
@@ -631,7 +636,20 @@ class DurableAgentWorkflow:
         self,
         result: AgentExecutorResult,
     ) -> list[ChatMessage] | None:
-        """Load terminal chat history, preserving legacy activity payloads."""
+        """Load terminal chat history in a replay-compatible way.
+
+        Legacy histories may already contain a completed run_agent_activity
+        result with messages populated. Preserve that payload and avoid
+        scheduling another activity.
+
+        If a legacy history has messages=None, it also lacks the patch marker
+        for the new load_session_messages_activity command. In that case,
+        workflow.patched(...) returns False during replay, so the workflow keeps
+        the old behavior and returns no terminal history.
+
+        New executions record the patch marker, schedule the message-loading
+        activity, and replay through the same branch later.
+        """
         if result.messages is not None:
             return result.messages
 

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -166,6 +166,7 @@ def _resolve_agent_output(
 UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH = (
     "durable-agent-upsert-tracecat-search-attributes-v1"
 )
+LOAD_TERMINAL_MESSAGE_HISTORY_PATCH = "durable-agent-load-terminal-message-history-v1"
 
 
 @workflow.defn
@@ -633,6 +634,9 @@ class DurableAgentWorkflow:
         """Load terminal chat history, preserving legacy activity payloads."""
         if result.messages is not None:
             return result.messages
+
+        if not workflow.patched(LOAD_TERMINAL_MESSAGE_HISTORY_PATCH):
+            return None
 
         try:
             load_result = await workflow.execute_activity(

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -17,6 +17,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.common.stream_types import HarnessType
     from tracecat.agent.executor.activity import (
         AgentExecutorInput,
+        AgentExecutorResult,
         ApprovedToolCall,
         DeniedToolCall,
         run_agent_activity,
@@ -39,10 +40,12 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.session.activities import (
         CreateSessionInput,
         LoadSessionInput,
+        LoadSessionMessagesInput,
         PendingToolResult,
         ReconcileToolResultsInput,
         create_session_activity,
         load_session_activity,
+        load_session_messages_activity,
         reconcile_tool_results_activity,
     )
     from tracecat.agent.session.types import AgentSessionEntity
@@ -54,6 +57,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.types import AgentConfig
     from tracecat.agent.workflow_config import agent_config_from_payload
     from tracecat.auth.types import Role
+    from tracecat.chat.schemas import ChatMessage
     from tracecat.contexts import ctx_role
     from tracecat.dsl.common import RETRY_POLICIES
     from tracecat.executor.activities import ExecutorActivities
@@ -609,9 +613,10 @@ class DurableAgentWorkflow:
             output = _resolve_agent_output(
                 output=result.output,
             )
+            message_history = await self._load_terminal_message_history(result)
             return AgentOutput(
                 output=output,
-                message_history=result.messages,  # Messages fetched from DB by activity
+                message_history=message_history,
                 duration=(datetime.now(UTC) - info.start_time).total_seconds(),
                 usage=RunUsage(
                     requests=result.result_num_turns or 0,
@@ -620,6 +625,37 @@ class DurableAgentWorkflow:
                 ),
                 session_id=self.session_id,
             )
+
+    async def _load_terminal_message_history(
+        self,
+        result: AgentExecutorResult,
+    ) -> list[ChatMessage] | None:
+        """Load terminal chat history, preserving legacy activity payloads."""
+        if result.messages is not None:
+            return result.messages
+
+        try:
+            load_result = await workflow.execute_activity(
+                load_session_messages_activity,
+                LoadSessionMessagesInput(role=self.role, session_id=self.session_id),
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
+        except ActivityError as e:
+            logger.warning(
+                "Failed to load terminal agent message history",
+                session_id=str(self.session_id),
+                error=str(e),
+            )
+            return None
+
+        if load_result.error is not None:
+            logger.warning(
+                "Terminal agent message history unavailable",
+                session_id=str(self.session_id),
+                error=load_result.error,
+            )
+        return load_result.messages
 
     def _build_tool_lists_from_approvals(
         self,

--- a/tests/integration/test_agent_worker.py
+++ b/tests/integration/test_agent_worker.py
@@ -47,6 +47,8 @@ from tracecat.agent.session.activities import (
     CreateSessionInput,
     CreateSessionResult,
     LoadSessionInput,
+    LoadSessionMessagesInput,
+    LoadSessionMessagesResult,
     LoadSessionResult,
     ReconcileToolResultsInput,
     ReconcileToolResultsResult,
@@ -100,6 +102,19 @@ def create_mock_load_session_activity() -> Callable[..., Any]:
     return mock_load_session_activity
 
 
+def create_mock_load_session_messages_activity() -> Callable[..., Any]:
+    """Create a mock load_session_messages_activity that returns no messages."""
+
+    @activity.defn(name="load_session_messages_activity")
+    async def mock_load_session_messages_activity(
+        input: LoadSessionMessagesInput,
+    ) -> LoadSessionMessagesResult:
+        del input
+        return LoadSessionMessagesResult(messages=[])
+
+    return mock_load_session_messages_activity
+
+
 def create_mock_run_agent_activity(
     response_callback: Callable[[AgentExecutorInput], AgentExecutorResult],
 ) -> Callable[..., Any]:
@@ -140,6 +155,7 @@ def create_activities_with_mock_executor(
     # Add mocked session activities (to avoid DB FK constraints)
     activities.append(create_mock_create_session_activity())
     activities.append(create_mock_load_session_activity())
+    activities.append(create_mock_load_session_messages_activity())
 
     # Add mocked runtime activity
     activities.append(create_mock_run_agent_activity(response_callback))
@@ -229,6 +245,7 @@ class TestAgentWorkerLifecycle:
         assert set(activity_names) == {
             "create_session_activity",
             "load_session_activity",
+            "load_session_messages_activity",
             "reconcile_tool_results_activity",
         }
 
@@ -496,6 +513,7 @@ class TestAgentWorkerSingleTenant:
             *agent_activities.get_activities(),
             mock_create_session_activity,
             mock_load_session_activity,
+            create_mock_load_session_messages_activity(),
             mock_record_approval_requests,
             mock_apply_approval_decisions,
             mock_execute_action_activity,

--- a/tests/integration/test_dsl_agent_wiring.py
+++ b/tests/integration/test_dsl_agent_wiring.py
@@ -22,6 +22,8 @@ from tracecat.agent.session.activities import (
     CreateSessionInput,
     CreateSessionResult,
     LoadSessionInput,
+    LoadSessionMessagesInput,
+    LoadSessionMessagesResult,
     LoadSessionResult,
 )
 from tracecat.agent.worker import (
@@ -109,6 +111,16 @@ def create_mock_load_session_activity() -> Callable[..., Any]:
     return mock_load_session_activity
 
 
+def create_mock_load_session_messages_activity() -> Callable[..., Any]:
+    @activity.defn(name="load_session_messages_activity")
+    async def mock_load_session_messages_activity(
+        _: LoadSessionMessagesInput,
+    ) -> LoadSessionMessagesResult:
+        return LoadSessionMessagesResult(messages=[])
+
+    return mock_load_session_messages_activity
+
+
 def create_mock_build_tool_definitions_activity() -> Callable[..., Any]:
     @activity.defn(name="build_tool_definitions")
     async def mock_build_tool_definitions(
@@ -179,6 +191,7 @@ class TestDSLAgentWiring:
         for replacement in (
             create_mock_create_session_activity(),
             create_mock_load_session_activity(),
+            create_mock_load_session_messages_activity(),
             create_mock_build_tool_definitions_activity(),
         ):
             agent_activities = _replace_activity(agent_activities, replacement)
@@ -246,6 +259,7 @@ class TestDSLAgentWiring:
         for replacement in (
             create_mock_create_session_activity(captured_inputs),
             create_mock_load_session_activity(),
+            create_mock_load_session_messages_activity(),
             create_mock_build_tool_definitions_activity(),
         ):
             agent_activities = _replace_activity(agent_activities, replacement)

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -21,15 +21,9 @@ pytestmark = [pytest.mark.temporal, pytest.mark.usefixtures("db")]
 
 from pydantic_ai.tools import ToolApproved, ToolDenied
 from temporalio import activity
-from temporalio.api.enums.v1 import EventType
-from temporalio.client import (
-    Client,
-    WorkflowFailureError,
-    WorkflowHandle,
-    WorkflowHistory,
-)
+from temporalio.client import Client, WorkflowFailureError
 from temporalio.exceptions import ApplicationError
-from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 from tracecat_ee.agent.activities import (
     ApplyApprovalResultsActivityInputs,
     BuildToolDefsArgs,
@@ -289,35 +283,6 @@ def create_activities_with_mock_executor(
         *ApprovalManager.get_activities(),
     ]
     return activities
-
-
-async def replay_durable_agent_workflow_history(
-    temporal_client: Client,
-    history: WorkflowHistory,
-) -> None:
-    """Replay a fetched durable-agent history against the current workflow code."""
-    replay_result = await Replayer(
-        workflows=[DurableAgentWorkflow],
-        workflow_runner=UnsandboxedWorkflowRunner(),
-        data_converter=temporal_client.data_converter,
-    ).replay_workflow(history, raise_on_replay_failure=False)
-    assert replay_result.replay_failure is None
-
-
-async def fetch_history_after_completed_workflow_task(
-    handle: WorkflowHandle[Any, Any],
-) -> WorkflowHistory:
-    """Fetch history once the workflow task that reached a wait state is recorded."""
-    for _ in range(100):
-        history = await handle.fetch_history()
-        if (
-            history.events
-            and history.events[-1].event_type
-            == EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED
-        ):
-            return history
-        await asyncio.sleep(0.05)
-    raise AssertionError("Timed out waiting for workflow task completion")
 
 
 # =============================================================================
@@ -1282,145 +1247,6 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
     }
     assert decisions_by_tool_call_id["call_risky"].approved is False
     assert decisions_by_tool_call_id["call_risky"].reason == "too risky"
-
-
-@pytest.mark.anyio
-@pytest.mark.integration
-async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
-    svc_role: Role,
-    temporal_client: Client,
-    agent_worker_factory,
-    mock_session_id: uuid.UUID,
-    agent_config_with_approvals: AgentConfig,
-) -> None:
-    """A suspended workflow with legacy SDK JSONL payloads should replay."""
-    queue = f"test-agent-queue-{mock_session_id}"
-    approval_request_recorded = asyncio.Event()
-    captured_agent_inputs: list[AgentExecutorInput] = []
-    legacy_sdk_session_data = (
-        '{"type":"user","message":{"content":"legacy prompt"}}\n'
-        '{"type":"assistant","message":{"content":[{"type":"text","text":"legacy"}]}}\n'
-    )
-
-    @activity.defn(name="load_session_activity")
-    async def mock_load_session_activity(
-        input: LoadSessionInput,
-    ) -> LoadSessionResult:
-        assert input.session_id == mock_session_id
-        if len(captured_agent_inputs) == 0:
-            return LoadSessionResult(
-                found=True,
-                sdk_session_id="legacy-sdk-session",
-                sdk_session_data=legacy_sdk_session_data,
-                is_fork=False,
-            )
-        return LoadSessionResult(
-            found=True,
-            sdk_session_id="legacy-sdk-session",
-            sdk_session_data=None,
-            is_fork=False,
-        )
-
-    @activity.defn(name="run_agent_activity")
-    async def mock_run_agent_activity(
-        input: AgentExecutorInput,
-    ) -> AgentExecutorResult:
-        captured_agent_inputs.append(input)
-        if len(captured_agent_inputs) == 1:
-            assert input.sdk_session_id == "legacy-sdk-session"
-            assert input.sdk_session_data == legacy_sdk_session_data
-            assert input.is_approval_continuation is False
-            return AgentExecutorResult(
-                success=True,
-                approval_requested=True,
-                approval_items=[
-                    ToolCallContent(
-                        id="call_123",
-                        name="core__http_request",
-                        input={"url": "https://example.com", "method": "GET"},
-                    )
-                ],
-            )
-
-        assert input.sdk_session_id == "legacy-sdk-session"
-        assert input.sdk_session_data is None
-        assert input.is_approval_continuation is True
-        return AgentExecutorResult(
-            success=True,
-            approval_requested=False,
-            output={"status": "continued"},
-        )
-
-    @activity.defn(name="record_approval_requests")
-    async def mock_record_approval_requests(
-        input: PersistApprovalsActivityInputs,
-    ) -> None:
-        assert [approval.tool_call_id for approval in input.approvals] == ["call_123"]
-        approval_request_recorded.set()
-
-    @activity.defn(name="apply_approval_decisions")
-    async def mock_apply_approval_decisions(
-        input: ApplyApprovalResultsActivityInputs,
-    ) -> None:
-        assert [decision.tool_call_id for decision in input.decisions] == ["call_123"]
-
-    workflow_args = AgentWorkflowArgs(
-        role=svc_role,
-        agent_args=RunAgentArgs(
-            session_id=mock_session_id,
-            user_prompt="Continue from legacy suspended workflow",
-            config=agent_config_with_approvals,
-        ),
-        entity_type=AgentSessionEntity.WORKFLOW,
-        entity_id=uuid.uuid4(),
-    )
-
-    activities = [
-        create_mock_create_session_activity(),
-        mock_load_session_activity,
-        create_mock_load_session_messages_activity(),
-        create_mock_build_tool_definitions_activity(),
-        mock_run_agent_activity,
-        create_mock_execute_action_activity(),
-        create_mock_reconcile_tool_results_activity(),
-        mock_record_approval_requests,
-        mock_apply_approval_decisions,
-    ]
-
-    async with agent_worker_factory(
-        temporal_client, task_queue=queue, custom_activities=activities
-    ):
-        wf_handle = await temporal_client.start_workflow(
-            DurableAgentWorkflow.run,
-            workflow_args,
-            id=AgentWorkflowID(mock_session_id),
-            task_queue=queue,
-            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
-            execution_timeout=timedelta(seconds=30),
-        )
-
-        await asyncio.wait_for(approval_request_recorded.wait(), timeout=10)
-        suspended_history = await fetch_history_after_completed_workflow_task(wf_handle)
-        await replay_durable_agent_workflow_history(temporal_client, suspended_history)
-
-        await wf_handle.execute_update(
-            DurableAgentWorkflow.set_approvals,
-            WorkflowApprovalSubmission(
-                approvals={"call_123": True},
-                approved_by=svc_role.user_id,
-            ),
-        )
-
-        result = await wf_handle.result()
-        completed_history = await wf_handle.fetch_history()
-        await replay_durable_agent_workflow_history(temporal_client, completed_history)
-
-    assert result.session_id == mock_session_id
-    assert result.output == {"status": "continued"}
-    assert [input.sdk_session_data for input in captured_agent_inputs] == [
-        legacy_sdk_session_data,
-        None,
-    ]
 
 
 @pytest.mark.anyio

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -63,11 +63,14 @@ from tracecat.agent.session.activities import (
     CreateSessionInput,
     CreateSessionResult,
     LoadSessionInput,
+    LoadSessionMessagesInput,
+    LoadSessionMessagesResult,
     LoadSessionResult,
     ReconcileToolResultsInput,
     ReconcileToolResultsResult,
     create_session_activity,
     load_session_activity,
+    load_session_messages_activity,
     reconcile_tool_results_activity,
 )
 from tracecat.agent.session.service import AgentSessionService
@@ -75,6 +78,7 @@ from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.chat.schemas import ChatMessage
 from tracecat.db.models import AgentSessionHistory, User
 from tracecat.dsl.common import RETRY_POLICIES
 from tracecat.dsl.schemas import RunActionInput
@@ -127,6 +131,26 @@ def create_mock_load_session_activity() -> Callable[..., Any]:
         )
 
     return mock_load_session_activity
+
+
+def create_mock_load_session_messages_activity(
+    *,
+    captured_inputs: list[LoadSessionMessagesInput] | None = None,
+    messages: list[ChatMessage] | None = None,
+    error: str | None = None,
+) -> Callable[..., Any]:
+    """Create a mock load_session_messages_activity for terminal history."""
+
+    @activity.defn(name="load_session_messages_activity")
+    async def mock_load_session_messages_activity(
+        input: LoadSessionMessagesInput,
+    ) -> LoadSessionMessagesResult:
+        if captured_inputs is not None:
+            captured_inputs.append(input)
+        result_messages = None if error is not None else messages or []
+        return LoadSessionMessagesResult(messages=result_messages, error=error)
+
+    return mock_load_session_messages_activity
 
 
 def create_mock_build_tool_definitions_activity(
@@ -238,6 +262,8 @@ def create_activities_with_mock_executor(
     tool_exec_callback: Callable[[RunActionInput], InlineObject[dict[str, str]]]
     | None = None,
     tool_definitions: dict[str, MCPToolDefinition] | None = None,
+    message_load_inputs: list[LoadSessionMessagesInput] | None = None,
+    session_messages: list[ChatMessage] | None = None,
 ) -> Sequence[Callable[..., Any]]:
     """Create a full activity list with mocked agent executor.
 
@@ -252,6 +278,10 @@ def create_activities_with_mock_executor(
     activities: list[Callable[..., Any]] = [
         create_mock_create_session_activity(),
         create_mock_load_session_activity(),
+        create_mock_load_session_messages_activity(
+            captured_inputs=message_load_inputs,
+            messages=session_messages,
+        ),
         create_mock_build_tool_definitions_activity(tool_definitions),
         create_mock_run_agent_activity(response_callback),
         create_mock_execute_action_activity(tool_exec_callback),
@@ -511,7 +541,13 @@ async def test_agent_workflow_simple_execution(
     ) -> AgentExecutorResult:
         return AgentExecutorResult(success=True, approval_requested=False)
 
-    activities = create_activities_with_mock_executor(mock_executor)
+    message_load_inputs: list[LoadSessionMessagesInput] = []
+    session_messages = [ChatMessage(id="msg-1")]
+    activities = create_activities_with_mock_executor(
+        mock_executor,
+        message_load_inputs=message_load_inputs,
+        session_messages=session_messages,
+    )
 
     async with agent_worker_factory(
         temporal_client, task_queue=queue, custom_activities=activities
@@ -527,6 +563,56 @@ async def test_agent_workflow_simple_execution(
 
         result = await wf_handle.result()
         assert result.session_id == mock_session_id
+        assert result.message_history == session_messages
+
+    assert [input.session_id for input in message_load_inputs] == [mock_session_id]
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
+async def test_agent_workflow_preserves_legacy_activity_message_history(
+    svc_role: Role,
+    temporal_client: Client,
+    agent_worker_factory,
+    agent_workflow_args: AgentWorkflowArgs,
+    mock_session_id: uuid.UUID,
+) -> None:
+    """Existing activity payloads with messages should not schedule a new load."""
+    queue = f"test-agent-queue-{mock_session_id}"
+    legacy_messages = [ChatMessage(id="legacy-msg")]
+
+    def mock_executor(
+        call_count: int, input: AgentExecutorInput
+    ) -> AgentExecutorResult:
+        return AgentExecutorResult(
+            success=True,
+            approval_requested=False,
+            messages=legacy_messages,
+        )
+
+    message_load_inputs: list[LoadSessionMessagesInput] = []
+    activities = create_activities_with_mock_executor(
+        mock_executor,
+        message_load_inputs=message_load_inputs,
+    )
+
+    async with agent_worker_factory(
+        temporal_client, task_queue=queue, custom_activities=activities
+    ):
+        wf_handle = await temporal_client.start_workflow(
+            DurableAgentWorkflow.run,
+            agent_workflow_args,
+            id=AgentWorkflowID(mock_session_id),
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+            execution_timeout=timedelta(seconds=30),
+        )
+
+        result = await wf_handle.result()
+        assert result.session_id == mock_session_id
+        assert result.message_history == legacy_messages
+
+    assert message_load_inputs == []
 
 
 @pytest.mark.anyio
@@ -807,6 +893,7 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
         activities=[
             create_session_activity,
             load_session_activity,
+            load_session_messages_activity,
             reconcile_tool_results_activity,
             mock_build_tool_definitions,
             mock_record_approval_requests,
@@ -1101,6 +1188,7 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
         activities=[
             mock_create_session_activity,
             mock_load_session_activity,
+            create_mock_load_session_messages_activity(),
             mock_build_tool_definitions,
             mock_record_approval_requests,
             mock_apply_approval_decisions,
@@ -1290,6 +1378,7 @@ async def test_agent_workflow_replays_suspended_legacy_sdk_session_data_history(
     activities = [
         create_mock_create_session_activity(),
         mock_load_session_activity,
+        create_mock_load_session_messages_activity(),
         create_mock_build_tool_definitions_activity(),
         mock_run_agent_activity,
         create_mock_execute_action_activity(),
@@ -1541,6 +1630,7 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
         activities=[
             create_session_activity,
             load_session_activity,
+            load_session_messages_activity,
             reconcile_tool_results_activity,
             mock_build_tool_definitions,
             mock_record_approval_requests,

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -28,6 +28,7 @@ from tracecat.agent.executor.activity import (
     _hydrate_sdk_session_history,
     run_agent_activity,
 )
+from tracecat.agent.executor.loopback import LoopbackResult
 from tracecat.agent.schemas import ToolFilters
 from tracecat.agent.session.activities import (
     CreateSessionInput,
@@ -709,6 +710,37 @@ class TestSandboxedAgentExecutorHelpers:
         assert payload.mcp_auth_token == executor_input.mcp_auth_token
         assert payload.llm_gateway_auth_token == executor_input.llm_gateway_auth_token
         assert payload.config.model_name == executor_input.config.model_name
+
+    def test_apply_loopback_result_omits_output_for_approval_turn(
+        self,
+    ) -> None:
+        result = AgentExecutorResult(success=False)
+        loopback_result = LoopbackResult(
+            success=True,
+            approval_requested=True,
+            output={"status": "waiting-for-approval"},
+        )
+
+        SandboxedAgentExecutor._apply_loopback_result(result, loopback_result)
+
+        assert result.success is True
+        assert result.approval_requested is True
+        assert result.output is None
+
+    def test_apply_loopback_result_keeps_output_for_final_turn(
+        self,
+    ) -> None:
+        result = AgentExecutorResult(success=False)
+        loopback_result = LoopbackResult(
+            success=True,
+            output={"status": "completed"},
+        )
+
+        SandboxedAgentExecutor._apply_loopback_result(result, loopback_result)
+
+        assert result.success is True
+        assert result.approval_requested is False
+        assert result.output == {"status": "completed"}
 
     @pytest.mark.anyio
     @patch("tracecat.agent.executor.activity.AgentSessionService.with_session")

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -33,10 +33,13 @@ from tracecat.agent.session.activities import (
     CreateSessionInput,
     CreateSessionResult,
     LoadSessionInput,
+    LoadSessionMessagesInput,
+    LoadSessionMessagesResult,
     LoadSessionResult,
     create_session_activity,
     get_session_activities,
     load_session_activity,
+    load_session_messages_activity,
 )
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.skill.types import ResolvedSkillRef
@@ -44,6 +47,7 @@ from tracecat.agent.tools import BuildToolsResult
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.chat.schemas import ChatMessage
 from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
 from tracecat.registry.lock.service import RegistryLockService
 
@@ -83,7 +87,7 @@ class TestSessionActivities:
         """Test that get_session_activities returns a list of activity functions."""
         activities = get_session_activities()
         assert isinstance(activities, list)
-        assert len(activities) == 3
+        assert len(activities) == 4
 
         # All returned items should have the temporal activity definition
         for activity in activities:
@@ -97,6 +101,7 @@ class TestSessionActivities:
         ]
         assert "create_session_activity" in activity_names
         assert "load_session_activity" in activity_names
+        assert "load_session_messages_activity" in activity_names
         assert "reconcile_tool_results_activity" in activity_names
 
 
@@ -503,6 +508,55 @@ class TestLoadSessionActivity:
         assert result.sdk_session_id == "parent-sdk-session"
         assert result.sdk_session_data is None
         assert result.is_fork is True
+
+
+class TestLoadSessionMessagesActivity:
+    """Tests for load_session_messages_activity."""
+
+    @pytest.mark.anyio
+    @patch("tracecat.agent.session.activities.AgentSessionService.with_session")
+    async def test_loads_messages(
+        self, mock_with_session, mock_role: Role, mock_session_id: uuid.UUID
+    ) -> None:
+        input = LoadSessionMessagesInput(
+            role=mock_role,
+            session_id=mock_session_id,
+        )
+        expected_messages = [ChatMessage(id="msg-1")]
+
+        mock_service = AsyncMock()
+        mock_service.list_messages.return_value = expected_messages
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        result = await load_session_messages_activity(input)
+
+        assert isinstance(result, LoadSessionMessagesResult)
+        assert result.messages == expected_messages
+        assert result.error is None
+        mock_service.list_messages.assert_awaited_once_with(mock_session_id)
+
+    @pytest.mark.anyio
+    @patch("tracecat.agent.session.activities.AgentSessionService.with_session")
+    async def test_returns_error_when_message_load_fails(
+        self, mock_with_session, mock_role: Role, mock_session_id: uuid.UUID
+    ) -> None:
+        input = LoadSessionMessagesInput(
+            role=mock_role,
+            session_id=mock_session_id,
+        )
+
+        mock_service = AsyncMock()
+        mock_service.list_messages.side_effect = RuntimeError("db unavailable")
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__.return_value = mock_service
+        mock_with_session.return_value = mock_ctx
+
+        result = await load_session_messages_activity(input)
+
+        assert result.messages is None
+        assert result.error == "db unavailable"
 
 
 class TestRunAgentActivity:

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -540,7 +540,7 @@ class TestLoadSessionMessagesActivity:
 
     @pytest.mark.anyio
     @patch("tracecat.agent.session.activities.AgentSessionService.with_session")
-    async def test_returns_error_when_message_load_fails(
+    async def test_raises_when_message_load_fails(
         self, mock_with_session, mock_role: Role, mock_session_id: uuid.UUID
     ) -> None:
         input = LoadSessionMessagesInput(
@@ -554,10 +554,8 @@ class TestLoadSessionMessagesActivity:
         mock_ctx.__aenter__.return_value = mock_service
         mock_with_session.return_value = mock_ctx
 
-        result = await load_session_messages_activity(input)
-
-        assert result.messages is None
-        assert result.error == "db unavailable"
+        with pytest.raises(RuntimeError, match="db unavailable"):
+            await load_session_messages_activity(input)
 
 
 class TestRunAgentActivity:

--- a/tests/unit/test_agent_sandbox_litellm.py
+++ b/tests/unit/test_agent_sandbox_litellm.py
@@ -590,7 +590,7 @@ async def _run_full_claude_harness_runtime_case(
     assert result.error is None
     assert result.output == "fake claude response"
     assert result.result_num_turns == 1
-    assert result.messages == []
+    assert result.messages is None
 
     assert len(_FakeLLMSocketProxy.instances) == 1
     proxy = _FakeLLMSocketProxy.instances[0]
@@ -980,7 +980,7 @@ async def test_run_agent_activity_with_fake_runtime_exercises_loopback_approval_
             input={"url": "https://example.com", "method": "GET"},
         )
     ]
-    assert result.messages == []
+    assert result.messages is None
 
     assert [event.type for event in stream_sink.events] == [
         StreamEventType.APPROVAL_REQUEST
@@ -1068,7 +1068,7 @@ async def test_run_agent_activity_with_fake_runtime_plumbs_resume_flags_to_loopb
     assert result.output == {"status": "continued"}
     assert result.result_usage == {"input_tokens": 3, "output_tokens": 5}
     assert result.result_num_turns == 2
-    assert result.messages == []
+    assert result.messages is None
 
     assert [event.type for event in stream_sink.events] == [StreamEventType.TEXT_DELTA]
     assert stream_sink.errors == []

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -11,12 +11,14 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from temporalio.common import TypedSearchAttributes
 from tracecat_ee.agent.workflows.durable import (
+    LOAD_TERMINAL_MESSAGE_HISTORY_PATCH,
     UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH,
     AgentWorkflowArgs,
     DurableAgentWorkflow,
     _build_approved_tool_run_input,
 )
 
+from tracecat.agent.executor.activity import AgentExecutorResult
 from tracecat.agent.executor.schemas import ApprovedToolCall
 from tracecat.agent.preset.activities import ResolveAgentPresetConfigActivityInput
 from tracecat.agent.schemas import AgentOutput, RunAgentArgs
@@ -197,6 +199,40 @@ async def test_run_skips_search_attribute_upsert_without_patch_marker() -> None:
     upsert_mock.assert_not_called()
     run_mock.assert_awaited_once_with(workflow_args, cfg)
     assert result == expected_output
+
+
+@pytest.mark.anyio
+async def test_load_terminal_message_history_skips_activity_without_patch_marker() -> (
+    None
+):
+    role = Role(
+        type="user",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute", "secret:read"}),
+    )
+    workflow_args = _build_workflow_args(role)
+    workflow_instance = DurableAgentWorkflow(workflow_args)
+
+    with (
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.patched",
+            return_value=False,
+        ) as patched_mock,
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.execute_activity",
+            new_callable=AsyncMock,
+        ) as execute_activity_mock,
+    ):
+        message_history = await workflow_instance._load_terminal_message_history(
+            AgentExecutorResult(success=True)
+        )
+
+    patched_mock.assert_called_once_with(LOAD_TERMINAL_MESSAGE_HISTORY_PATCH)
+    execute_activity_mock.assert_not_called()
+    assert message_history is None
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -205,6 +205,7 @@ async def test_run_skips_search_attribute_upsert_without_patch_marker() -> None:
 async def test_load_terminal_message_history_skips_activity_without_patch_marker() -> (
     None
 ):
+    """Legacy replays must not schedule the new terminal-history activity."""
     role = Role(
         type="user",
         service_id="tracecat-api",
@@ -226,6 +227,9 @@ async def test_load_terminal_message_history_skips_activity_without_patch_marker
             new_callable=AsyncMock,
         ) as execute_activity_mock,
     ):
+        execute_activity_mock.side_effect = AssertionError(
+            "legacy replay scheduled terminal message load"
+        )
         message_history = await workflow_instance._load_terminal_message_history(
             AgentExecutorResult(success=True)
         )

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -275,6 +275,8 @@ class SandboxedAgentExecutor:
         result.error = loopback_result.error
         result.approval_requested = loopback_result.approval_requested
         result.approval_items = loopback_result.approval_items or None
+        # Approval turns pause before a final answer exists. Preserve the
+        # existing output until the continuation completes and returns one.
         if not loopback_result.approval_requested:
             result.output = loopback_result.output
         result.result_usage = loopback_result.result_usage

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -275,7 +275,8 @@ class SandboxedAgentExecutor:
         result.error = loopback_result.error
         result.approval_requested = loopback_result.approval_requested
         result.approval_items = loopback_result.approval_items or None
-        result.output = loopback_result.output
+        if not loopback_result.approval_requested:
+            result.output = loopback_result.output
         result.result_usage = loopback_result.result_usage
         result.result_num_turns = loopback_result.result_num_turns
 

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -97,6 +97,8 @@ class AgentExecutorResult(BaseModel):
     error: str | None = None
     approval_requested: bool = False
     approval_items: list[ToolCallContent] | None = None
+    # Legacy replay compatibility only. New executions load terminal message
+    # history in the durable workflow after the final executor turn completes.
     messages: list[ChatMessage] | None = None
     output: Any = Field(
         default=None,
@@ -526,7 +528,7 @@ async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
     This activity:
     1. Creates a SandboxedAgentExecutor
     2. Dispatches the turn through the worker-global runtime broker
-    3. Returns the result with session updates
+    3. Returns runtime status, approval state, usage, and terminal output
 
     The broker-owned transport decides whether the runtime shim runs with nsjail
     or as a direct subprocess based on TRACECAT__DISABLE_NSJAIL.
@@ -539,7 +541,7 @@ async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
         input: Agent executor configuration and tokens.
 
     Returns:
-        AgentExecutorResult with execution status and session data.
+        AgentExecutorResult with execution status and terminal output.
     """
     sandbox_mode = "direct" if TRACECAT__DISABLE_NSJAIL else "nsjail"
     activity.heartbeat(
@@ -552,16 +554,6 @@ async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
 
     if result.success:
         activity.heartbeat(f"Agent execution completed: {input.session_id}")
-        # Fetch messages from database to include in result
-        try:
-            async with AgentSessionService.with_session(role=input.role) as svc:
-                result.messages = await svc.list_messages(input.session_id)
-        except Exception as e:
-            logger.warning(
-                "Failed to fetch session messages",
-                session_id=str(input.session_id),
-                error=str(e),
-            )
     else:
         activity.heartbeat(f"Agent execution failed: {result.error}")
 

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -21,6 +21,7 @@ from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.stream.connector import AgentStream
 from tracecat.auth.types import Role
+from tracecat.chat.schemas import ChatMessage
 from tracecat.contexts import ctx_role
 from tracecat.logger import logger
 from tracecat.storage.object import StoredObject, retrieve_stored_object
@@ -97,6 +98,20 @@ class LoadSessionResult(BaseModel):
     # SDK JSONL across Temporal boundaries.
     sdk_session_data: str | None = Field(default=None, deprecated=True)
     is_fork: bool = False  # If True, runtime should use fork_session=True with SDK
+    error: str | None = None
+
+
+class LoadSessionMessagesInput(BaseModel):
+    """Input for load_session_messages_activity."""
+
+    role: Role
+    session_id: uuid.UUID
+
+
+class LoadSessionMessagesResult(BaseModel):
+    """Result from load_session_messages_activity."""
+
+    messages: list[ChatMessage] | None = None
     error: str | None = None
 
 
@@ -226,6 +241,27 @@ async def load_session_activity(input: LoadSessionInput) -> LoadSessionResult:
 
 
 @activity.defn
+async def load_session_messages_activity(
+    input: LoadSessionMessagesInput,
+) -> LoadSessionMessagesResult:
+    """Load the full chat message history for a completed agent session."""
+    ctx_role.set(input.role)
+
+    try:
+        async with AgentSessionService.with_session(role=input.role) as service:
+            messages = await service.list_messages(input.session_id)
+        return LoadSessionMessagesResult(messages=messages)
+
+    except Exception as e:
+        logger.warning(
+            "Failed to load agent session messages",
+            session_id=str(input.session_id),
+            error=str(e),
+        )
+        return LoadSessionMessagesResult(error=str(e))
+
+
+@activity.defn
 async def reconcile_tool_results_activity(
     input: ReconcileToolResultsInput,
 ) -> ReconcileToolResultsResult:
@@ -285,5 +321,6 @@ def get_session_activities() -> list:
     return [
         create_session_activity,
         load_session_activity,
+        load_session_messages_activity,
         reconcile_tool_results_activity,
     ]

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -258,7 +258,7 @@ async def load_session_messages_activity(
             session_id=str(input.session_id),
             error=str(e),
         )
-        return LoadSessionMessagesResult(error=str(e))
+        raise
 
 
 @activity.defn


### PR DESCRIPTION
## Summary

- Stop loading chat messages from every `run_agent_activity` result.
- Add `load_session_messages_activity` and call it once when `DurableAgentWorkflow` reaches terminal success.
- Preserve legacy `AgentExecutorResult.messages` payloads for replay/backward compatibility.
- Add workflow replay coverage for suspended legacy SDK-session-data histories.

## Tests

- `uv run pytest tests/unit/test_agent_activities.py tests/unit/test_agent_sandbox_litellm.py tests/unit/test_worker_activity_registration.py`
- `uv run pytest tests/temporal/test_durable_agent_workflow.py tests/integration/test_agent_worker.py tests/integration/test_dsl_agent_wiring.py`
- `uv run pytest tests/unit/test_agent_activities.py::TestLoadSessionMessagesActivity tests/unit/test_agent_sandbox_litellm.py::test_run_agent_activity_with_fake_runtime_exercises_loopback_approval_path tests/temporal/test_durable_agent_workflow.py::test_agent_workflow_simple_execution tests/temporal/test_durable_agent_workflow.py::test_agent_workflow_preserves_legacy_activity_message_history`
- `uv run pytest tests/temporal/test_durable_agent_workflow.py::test_agent_workflow_replays_suspended_legacy_sdk_session_data_history`
- `uv run ruff check packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py tests/integration/test_agent_worker.py tests/integration/test_dsl_agent_wiring.py tests/temporal/test_durable_agent_workflow.py tests/unit/test_agent_activities.py tests/unit/test_agent_sandbox_litellm.py tracecat/agent/executor/activity.py tracecat/agent/session/activities.py`
- `uv run ruff format --check packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py tests/integration/test_agent_worker.py tests/integration/test_dsl_agent_wiring.py tests/temporal/test_durable_agent_workflow.py tests/unit/test_agent_activities.py tests/unit/test_agent_sandbox_litellm.py tracecat/agent/executor/activity.py tracecat/agent/session/activities.py`
- `uv run basedpyright --warnings --threads 4 packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py tests/integration/test_agent_worker.py tests/integration/test_dsl_agent_wiring.py tests/temporal/test_durable_agent_workflow.py tests/unit/test_agent_activities.py tests/unit/test_agent_sandbox_litellm.py tracecat/agent/executor/activity.py tracecat/agent/session/activities.py`
