### PR TITLE
fix(agent): remove hard-coded 1h execution timeout for chat workflows

### DIFF
--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -7,7 +7,7 @@ import hashlib
 import uuid
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 import orjson
@@ -1086,7 +1086,6 @@ class AgentSessionService(BaseWorkspaceService):
                 workflow_args,
                 id=str(workflow_id),
                 task_queue=config.TRACECAT__AGENT_QUEUE,
-                execution_timeout=timedelta(hours=1),
                 retry_policy=RETRY_POLICIES["workflow:fail_fast"],
                 search_attributes=self._build_direct_agent_search_attributes(
                     session_id


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the hard-coded 1-hour execution timeout for direct chat workflows to prevent premature timeouts on long-running approvals. Workflows now use default or configured timeouts instead of a fixed limit.

- **Bug Fixes**
  - Approvals and long chat sessions no longer fail after 1 hour; retry policy and queue remain unchanged.

<sup>Written for commit ce680f791b6e8f545463495bd695d7b72032d0b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

