### PR TITLE
fix(agent): log full error message in discover_tools

### DIFF
--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -68,9 +68,8 @@ class UserMCPClient:
                 logger.error(
                     "Failed to discover tools from user MCP server",
                     server_name=server_name,
-                    error_type=type(e).__name__,
+                    error=str(e),
                 )
-                # Continue with other servers - don't fail completely
 
         logger.info(
             "Discovered user MCP tools",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Log the full error message in discover_tools when a user MCP server fails, replacing the logged error type with the full exception text to improve debugging during tool discovery.

<sup>Written for commit 8157e2f573e6447d919eb4679a24651e01ffd397. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

