### PR TITLE
fix(cluster): always default just cluster to multi-tenant

### DIFF
--- a/scripts/cluster
+++ b/scripts/cluster
@@ -374,8 +374,8 @@ Profiles:
   prod      docker-compose.yml
 
 Tenant mode:
-  Defaults to TRACECAT__EE_MULTI_TENANT from the environment/.env when set,
-  otherwise true for cluster development.
+  Always defaults to TRACECAT__EE_MULTI_TENANT=true for cluster development.
+  .env and shell values are ignored; only the flags below override it.
   --single-tenant                 Set TRACECAT__EE_MULTI_TENANT=false
   --multi-tenant                  Set TRACECAT__EE_MULTI_TENANT=true
   --ee-multi-tenant true|false    Set TRACECAT__EE_MULTI_TENANT explicitly
@@ -519,9 +519,11 @@ build_env() {
     # Default to direct executor backend for development
     export TRACECAT__EXECUTOR_BACKEND="${TRACECAT__EXECUTOR_BACKEND:-direct}"
 
-    # Default cluster development to multi-tenant mode, but let .env/shell
-    # configuration override it unless an explicit cluster flag was provided.
-    export TRACECAT__EE_MULTI_TENANT="${CLUSTER_EE_MULTI_TENANT:-${TRACECAT__EE_MULTI_TENANT:-true}}"
+    # Cluster development always defaults to multi-tenant mode. Only the
+    # explicit cluster flags (--single-tenant / --multi-tenant /
+    # --ee-multi-tenant) override it; .env and shell values are ignored so
+    # fresh worktrees behave consistently.
+    export TRACECAT__EE_MULTI_TENANT="${CLUSTER_EE_MULTI_TENANT:-true}"
     FEATURE_FLAGS=$(cd "$REPO_ROOT" && uv run python -c "from tracecat.feature_flags.enums import FeatureFlag; print(','.join(f.value for f in FeatureFlag))" 2>/dev/null) || FEATURE_FLAGS=""
     if [[ -n "$FEATURE_FLAGS" ]]; then
         export TRACECAT__FEATURE_FLAGS="$FEATURE_FLAGS"


### PR DESCRIPTION
## Summary
- `just cluster` now always defaults `TRACECAT__EE_MULTI_TENANT` to `true`; `.env` and shell values are ignored so fresh worktrees boot multi-tenant consistently.
- Only the explicit `--single-tenant`, `--multi-tenant`, and `--ee-multi-tenant <bool>` flags override the default.
- Help text updated to match the new precedence.

## Why
A fresh worktree has no `.env` (it's gitignored), so `scripts/cluster` auto-generates one from `.env.example`, which ships `TRACECAT__EE_MULTI_TENANT=false`. The previous fallback (`${CLUSTER_EE_MULTI_TENANT:-${TRACECAT__EE_MULTI_TENANT:-true}}`) then resolved to `false`, so every new worktree silently booted single-tenant even when the main checkout had it set to `true`.

## Test plan
- [ ] `just cluster up -d` in a worktree with `TRACECAT__EE_MULTI_TENANT=false` in `.env` -> boot log prints `EE multi-tenant: true`.
- [ ] `just cluster up -d --single-tenant` -> boot log prints `EE multi-tenant: false`.
- [ ] `just cluster up -d --ee-multi-tenant false` -> boot log prints `EE multi-tenant: false`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaulted `just cluster` to multi-tenant and ignore `.env`/shell `TRACECAT__EE_MULTI_TENANT`; only explicit flags can change it. Fixes inconsistent tenant mode in fresh worktrees and updates help text.

- **Bug Fixes**
  - Always sets `TRACECAT__EE_MULTI_TENANT=true` unless `--single-tenant`, `--multi-tenant`, or `--ee-multi-tenant <bool>` is provided.
  - Help text updated to reflect the new precedence and ensure consistent multi-tenant boots in fresh worktrees.

<sup>Written for commit c2fb50afb6c905a5616ce471d49a91cf3bd29c5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

