### PR TITLE
fix(agents): auto enable cloud providers

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -4770,10 +4770,7 @@ export const listCatalog = (
 
 /**
  * Create Catalog Entry
- * Create an org-scoped catalog entry.
- *
- * Does not auto-enable the model; enablement is handled separately via the
- * model-access API or a one-time migration.
+ * Create an org-scoped catalog entry and auto-enable it at the org level.
  * @param data The data for the request.
  * @param data.requestBody
  * @returns AgentCatalogRead Successful Response

--- a/tracecat/agent/catalog/router.py
+++ b/tracecat/agent/catalog/router.py
@@ -89,16 +89,13 @@ async def create_catalog_entry(
     session: AsyncDBSession,
     params: AgentCatalogCreate = Body(...),
 ) -> AgentCatalogRead:
-    """Create an org-scoped catalog entry.
-
-    Does not auto-enable the model; enablement is handled separately via the
-    model-access API or a one-time migration.
-    """
+    """Create an org-scoped catalog entry and auto-enable it at the org level."""
     assert role.organization_id is not None  # OrgUserRole guarantees this
-    service = AgentCatalogService(session=session)
+    catalog_service = AgentCatalogService(session=session)
+    access_service = AgentModelAccessService(session=session, role=role)
     metadata = params.model_dump(exclude={"model_provider", "model_name"})
     try:
-        row = await service.create_catalog_entry(
+        row = await catalog_service.create_catalog_entry(
             org_id=role.organization_id,
             model_provider=params.model_provider,
             model_name=params.model_name,
@@ -109,6 +106,11 @@ async def create_catalog_entry(
             status_code=status.HTTP_409_CONFLICT,
             detail=str(e),
         ) from e
+    try:
+        await access_service.enable_model(row.id)
+    except TracecatValidationError:
+        # Already enabled — ignore duplicate access row
+        pass
     return AgentCatalogRead.model_validate(row)
 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Auto-enable org access when creating cloud catalog entries, and relax model entitlement gates so users can browse providers and models without `agent_addons`; management controls remain gated.

- **Bug Fixes**
  - API: `create_catalog_entry` now auto-enables the model at the org level and ignores duplicate-enable errors; client docs updated.
  - Settings: Provider sections are always expandable and list models; Access column and Allow/Disallow controls only show when entitled. Disconnect and error details are always visible.
  - Navigation: Workspace Models nav is no longer blocked; if not entitled, users see an upgrade empty state with clearer copy.

<sup>Written for commit fa9962bc34919e0b164cbedaf0bf136bdf4fb31b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

