### PR TITLE
fix(agent): index preset folder lookups

### DIFF
--- a/alembic/versions/a3d7c9e8b4f2_add_agent_preset_folder_index.py
+++ b/alembic/versions/a3d7c9e8b4f2_add_agent_preset_folder_index.py
@@ -1,0 +1,30 @@
+"""Add agent preset folder lookup index
+
+Revision ID: a3d7c9e8b4f2
+Revises: 9f0b5f6a2d1c
+Create Date: 2026-05-11 18:12:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a3d7c9e8b4f2"
+down_revision: str | None = "9f0b5f6a2d1c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_agent_preset_workspace_folder",
+        "agent_preset",
+        ["workspace_id", "folder_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_preset_workspace_folder", table_name="agent_preset")

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -3385,6 +3385,7 @@ class AgentPreset(WorkspaceModel):
     __tablename__ = "agent_preset"
     __table_args__ = (
         UniqueConstraint("workspace_id", "slug", name="uq_agent_preset_workspace_slug"),
+        Index("ix_agent_preset_workspace_folder", "workspace_id", "folder_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a composite index on `agent_preset` by workspace and folder to speed up folder lookups and reduce DB load. Includes an `alembic` migration and an updated `SQLAlchemy` model index.

- **Migration**
  - Run database migrations to create `ix_agent_preset_workspace_folder`.

<sup>Written for commit 48ac666e9c59e6b09db25bb6c423663a00c43da8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

