### PR TITLE
fix: preserve skill name hyphens while typing

### DIFF
--- a/frontend/src/components/skills/create-skill-dialog.tsx
+++ b/frontend/src/components/skills/create-skill-dialog.tsx
@@ -68,7 +68,6 @@ export function CreateSkillDialog({
                     .replace(/_/g, "-")
                     .replace(/[^a-z0-9-\s]/g, "")
                     .replace(/[\s-]+/g, "-")
-                    .replace(/^-+|-+$/g, "")
                 )
               }
               placeholder="threat-intel"

--- a/frontend/tests/create-skill-dialog.test.tsx
+++ b/frontend/tests/create-skill-dialog.test.tsx
@@ -43,4 +43,27 @@ describe("CreateSkillDialog", () => {
 
     expect(onNameChange).toHaveBeenCalledWith("cafe-tools")
   })
+
+  it("preserves a trailing hyphen while the user composes a name", () => {
+    const onNameChange = jest.fn()
+
+    render(
+      <CreateSkillDialog
+        open={true}
+        onOpenChange={jest.fn()}
+        name=""
+        onNameChange={onNameChange}
+        description=""
+        onDescriptionChange={jest.fn()}
+        pending={false}
+        onCreate={jest.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "threat-" },
+    })
+
+    expect(onNameChange).toHaveBeenCalledWith("threat-")
+  })
 })


### PR DESCRIPTION
Closes [ENG-1427](https://linear.app/tracecat/issue/ENG-1427/preserve-skill-name-hyphens-while-typing-in-create-skill-dialog)
Reported in Pylon [#63](https://app.usepylon.com/issues?issueNumber=63)

## Summary
- Preserve transient hyphens while typing in the Create skill dialog name field.
- Add a regression test for composing a hyphenated skill name.

## Testing
- `pnpm -C frontend exec jest tests/create-skill-dialog.test.tsx --runInBand`
- `pnpm -C frontend exec biome check src/components/skills/create-skill-dialog.tsx tests/create-skill-dialog.test.tsx`
- `pnpm -C frontend run typecheck`
- `uv run ruff check .`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep trailing hyphens while typing in the Create Skill dialog name field so input like "threat-" isn't stripped mid-typing. Removed the hyphen-trim step from name normalization and added a test to verify the behavior.

<sup>Written for commit 0b64b76af105d60e0c7f5f0a93846fbd5d24b017. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
