### PR TITLE
fix(agents): add deprecated model_name/model_provider params to MCP…

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/ai.py
+++ b/packages/tracecat-registry/tracecat_registry/core/ai.py
@@ -41,7 +41,7 @@ DEFAULT_RANKING_REFINEMENT_RATIO: float = 0.5
 """Default ranking refinement ratio to use."""
 
 
-def _resolve_model_selection(
+def resolve_model_selection(
     *,
     model: ModelSelection | dict[str, Any] | None,
     model_name: str | None,
@@ -136,7 +136,7 @@ async def rank_documents(
     dict_items: list[RankableItem] = [
         {"id": i, "text": item} for i, item in enumerate(items)
     ]
-    resolved_model = _resolve_model_selection(
+    resolved_model = resolve_model_selection(
         model=model,
         model_name=model_name,
         model_provider=model_provider,
@@ -248,7 +248,7 @@ async def select_field(
         raise ValueError(f"Expected at most {MAX_KEYS} keys, got {len(keys)} keys.")
 
     # Rank keys by criteria
-    resolved_model = _resolve_model_selection(
+    resolved_model = resolve_model_selection(
         model=model,
         model_name=model_name,
         model_provider=model_provider,
@@ -371,7 +371,7 @@ async def select_fields(
     # Get keys
     keys = _get_keys(json)
     # Rank keys by criteria
-    resolved_model = _resolve_model_selection(
+    resolved_model = resolve_model_selection(
         model=model,
         model_name=model_name,
         model_provider=model_provider,

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/github.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/github.py
@@ -1,10 +1,15 @@
 from typing import Annotated
 
+from pydantic import Field
 from typing_extensions import Doc
 
 from tracecat_registry import RegistryOAuthSecret, registry, secrets
 from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.core.ai import (
+    LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
+    _resolve_model_selection,
+)
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
 from tracecat_registry.types import AgentOutputRead
@@ -33,20 +38,33 @@ async def mcp(
     user_prompt: Annotated[str, Doc("User prompt to the agent.")],
     instructions: Annotated[str, Doc("Instructions for the agent.")],
     model: Annotated[
-        ModelSelection,
+        ModelSelection | None,
         Doc("Model to use. Pick from the list of models enabled for this workspace."),
         AgentModel(),
-    ],
+    ] = None,
+    model_name: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
+    model_provider: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with GitHub."""
+    resolved_model = _resolve_model_selection(
+        model=model, model_name=model_name, model_provider=model_provider
+    )
     token = secrets.get(github_mcp_oauth_secret.token_name)
     ctx = get_context()
     result = await ctx.agents.run(
         user_prompt=user_prompt,
         config=AgentConfig(
-            model_name=model.model_name,
-            model_provider=model.model_provider,
-            catalog_id=model.catalog_id,
+            model_name=resolved_model.model_name,
+            model_provider=resolved_model.model_provider,
+            catalog_id=resolved_model.catalog_id,
             instructions=instructions,
             mcp_servers=[
                 MCPServerConfig(

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/github.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/github.py
@@ -8,7 +8,7 @@ from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
-    _resolve_model_selection,
+    resolve_model_selection,
 )
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
@@ -54,7 +54,7 @@ async def mcp(
     ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with GitHub."""
-    resolved_model = _resolve_model_selection(
+    resolved_model = resolve_model_selection(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(github_mcp_oauth_secret.token_name)

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/jira.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/jira.py
@@ -8,7 +8,7 @@ from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
-    _resolve_model_selection,
+    resolve_model_selection,
 )
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
@@ -57,7 +57,7 @@ async def mcp(
     ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with Jira through Atlassian's remote MCP server."""
-    resolved_model = _resolve_model_selection(
+    resolved_model = resolve_model_selection(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(jira_mcp_oauth_secret.token_name)

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/jira.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/jira.py
@@ -1,10 +1,15 @@
 from typing import Annotated
 
+from pydantic import Field
 from typing_extensions import Doc
 
 from tracecat_registry import RegistryOAuthSecret, registry, secrets
 from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.core.ai import (
+    LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
+    _resolve_model_selection,
+)
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
 from tracecat_registry.types import AgentOutputRead
@@ -36,20 +41,33 @@ async def mcp(
     user_prompt: Annotated[str, Doc("User prompt to the agent.")],
     instructions: Annotated[str, Doc("Instructions for the agent.")],
     model: Annotated[
-        ModelSelection,
+        ModelSelection | None,
         Doc("Model to use. Pick from the list of models enabled for this workspace."),
         AgentModel(),
-    ],
+    ] = None,
+    model_name: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
+    model_provider: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with Jira through Atlassian's remote MCP server."""
+    resolved_model = _resolve_model_selection(
+        model=model, model_name=model_name, model_provider=model_provider
+    )
     token = secrets.get(jira_mcp_oauth_secret.token_name)
     ctx = get_context()
     result = await ctx.agents.run(
         user_prompt=user_prompt,
         config=AgentConfig(
-            model_name=model.model_name,
-            model_provider=model.model_provider,
-            catalog_id=model.catalog_id,
+            model_name=resolved_model.model_name,
+            model_provider=resolved_model.model_provider,
+            catalog_id=resolved_model.catalog_id,
             instructions=instructions,
             mcp_servers=[
                 MCPServerConfig(

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/linear.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/linear.py
@@ -1,10 +1,15 @@
 from typing import Annotated
 
+from pydantic import Field
 from typing_extensions import Doc
 
 from tracecat_registry import RegistryOAuthSecret, registry, secrets
 from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.core.ai import (
+    LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
+    _resolve_model_selection,
+)
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
 from tracecat_registry.types import AgentOutputRead
@@ -33,20 +38,33 @@ async def mcp(
     user_prompt: Annotated[str, Doc("User prompt to the agent.")],
     instructions: Annotated[str, Doc("Instructions for the agent.")],
     model: Annotated[
-        ModelSelection,
+        ModelSelection | None,
         Doc("Model to use. Pick from the list of models enabled for this workspace."),
         AgentModel(),
-    ],
+    ] = None,
+    model_name: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
+    model_provider: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with Linear."""
+    resolved_model = _resolve_model_selection(
+        model=model, model_name=model_name, model_provider=model_provider
+    )
     token = secrets.get(linear_mcp_oauth_secret.token_name)
     ctx = get_context()
     result = await ctx.agents.run(
         user_prompt=user_prompt,
         config=AgentConfig(
-            model_name=model.model_name,
-            model_provider=model.model_provider,
-            catalog_id=model.catalog_id,
+            model_name=resolved_model.model_name,
+            model_provider=resolved_model.model_provider,
+            catalog_id=resolved_model.catalog_id,
             instructions=instructions,
             mcp_servers=[
                 MCPServerConfig(

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/linear.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/linear.py
@@ -8,7 +8,7 @@ from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
-    _resolve_model_selection,
+    resolve_model_selection,
 )
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
@@ -54,7 +54,7 @@ async def mcp(
     ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with Linear."""
-    resolved_model = _resolve_model_selection(
+    resolved_model = resolve_model_selection(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(linear_mcp_oauth_secret.token_name)

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/notion.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/notion.py
@@ -1,10 +1,15 @@
 from typing import Annotated
 
+from pydantic import Field
 from typing_extensions import Doc
 
 from tracecat_registry import RegistryOAuthSecret, registry, secrets
 from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.core.ai import (
+    LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
+    _resolve_model_selection,
+)
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
 from tracecat_registry.types import AgentOutputRead
@@ -33,20 +38,33 @@ async def mcp(
     user_prompt: Annotated[str, Doc("User prompt to the agent.")],
     instructions: Annotated[str, Doc("Instructions for the agent.")],
     model: Annotated[
-        ModelSelection,
+        ModelSelection | None,
         Doc("Model to use. Pick from the list of models enabled for this workspace."),
         AgentModel(),
-    ],
+    ] = None,
+    model_name: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
+    model_provider: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with Notion."""
+    resolved_model = _resolve_model_selection(
+        model=model, model_name=model_name, model_provider=model_provider
+    )
     token = secrets.get(notion_mcp_oauth_secret.token_name)
     ctx = get_context()
     result = await ctx.agents.run(
         user_prompt=user_prompt,
         config=AgentConfig(
-            model_name=model.model_name,
-            model_provider=model.model_provider,
-            catalog_id=model.catalog_id,
+            model_name=resolved_model.model_name,
+            model_provider=resolved_model.model_provider,
+            catalog_id=resolved_model.catalog_id,
             instructions=instructions,
             mcp_servers=[
                 MCPServerConfig(

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/notion.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/notion.py
@@ -8,7 +8,7 @@ from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
-    _resolve_model_selection,
+    resolve_model_selection,
 )
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
@@ -54,7 +54,7 @@ async def mcp(
     ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with Notion."""
-    resolved_model = _resolve_model_selection(
+    resolved_model = resolve_model_selection(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(notion_mcp_oauth_secret.token_name)

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/runreveal.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/runreveal.py
@@ -8,7 +8,7 @@ from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
-    _resolve_model_selection,
+    resolve_model_selection,
 )
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
@@ -54,7 +54,7 @@ async def mcp(
     ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with RunReveal."""
-    resolved_model = _resolve_model_selection(
+    resolved_model = resolve_model_selection(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(runreveal_mcp_oauth_secret.token_name)

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/runreveal.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/runreveal.py
@@ -1,10 +1,15 @@
 from typing import Annotated
 
+from pydantic import Field
 from typing_extensions import Doc
 
 from tracecat_registry import RegistryOAuthSecret, registry, secrets
 from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.core.ai import (
+    LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
+    _resolve_model_selection,
+)
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
 from tracecat_registry.types import AgentOutputRead
@@ -33,20 +38,33 @@ async def mcp(
     user_prompt: Annotated[str, Doc("User prompt to the agent.")],
     instructions: Annotated[str, Doc("Instructions for the agent.")],
     model: Annotated[
-        ModelSelection,
+        ModelSelection | None,
         Doc("Model to use. Pick from the list of models enabled for this workspace."),
         AgentModel(),
-    ],
+    ] = None,
+    model_name: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
+    model_provider: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with RunReveal."""
+    resolved_model = _resolve_model_selection(
+        model=model, model_name=model_name, model_provider=model_provider
+    )
     token = secrets.get(runreveal_mcp_oauth_secret.token_name)
     ctx = get_context()
     result = await ctx.agents.run(
         user_prompt=user_prompt,
         config=AgentConfig(
-            model_name=model.model_name,
-            model_provider=model.model_provider,
-            catalog_id=model.catalog_id,
+            model_name=resolved_model.model_name,
+            model_provider=resolved_model.model_provider,
+            catalog_id=resolved_model.catalog_id,
             instructions=instructions,
             mcp_servers=[
                 MCPServerConfig(

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/sentry.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/sentry.py
@@ -8,7 +8,7 @@ from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
-    _resolve_model_selection,
+    resolve_model_selection,
 )
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
@@ -54,7 +54,7 @@ async def mcp(
     ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with Sentry."""
-    resolved_model = _resolve_model_selection(
+    resolved_model = resolve_model_selection(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(sentry_mcp_oauth_secret.token_name)

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/sentry.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/sentry.py
@@ -1,10 +1,15 @@
 from typing import Annotated
 
+from pydantic import Field
 from typing_extensions import Doc
 
 from tracecat_registry import RegistryOAuthSecret, registry, secrets
 from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.core.ai import (
+    LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
+    _resolve_model_selection,
+)
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
 from tracecat_registry.types import AgentOutputRead
@@ -33,20 +38,33 @@ async def mcp(
     user_prompt: Annotated[str, Doc("User prompt to the agent.")],
     instructions: Annotated[str, Doc("Instructions for the agent.")],
     model: Annotated[
-        ModelSelection,
+        ModelSelection | None,
         Doc("Model to use. Pick from the list of models enabled for this workspace."),
         AgentModel(),
-    ],
+    ] = None,
+    model_name: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
+    model_provider: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with Sentry."""
+    resolved_model = _resolve_model_selection(
+        model=model, model_name=model_name, model_provider=model_provider
+    )
     token = secrets.get(sentry_mcp_oauth_secret.token_name)
     ctx = get_context()
     result = await ctx.agents.run(
         user_prompt=user_prompt,
         config=AgentConfig(
-            model_name=model.model_name,
-            model_provider=model.model_provider,
-            catalog_id=model.catalog_id,
+            model_name=resolved_model.model_name,
+            model_provider=resolved_model.model_provider,
+            catalog_id=resolved_model.catalog_id,
             instructions=instructions,
             mcp_servers=[
                 MCPServerConfig(

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/wiz.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/wiz.py
@@ -8,7 +8,7 @@ from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
-    _resolve_model_selection,
+    resolve_model_selection,
 )
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
@@ -54,7 +54,7 @@ async def mcp(
     ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with Wiz."""
-    resolved_model = _resolve_model_selection(
+    resolved_model = resolve_model_selection(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(wiz_mcp_oauth_secret.token_name)

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/wiz.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/wiz.py
@@ -1,10 +1,15 @@
 from typing import Annotated
 
+from pydantic import Field
 from typing_extensions import Doc
 
 from tracecat_registry import RegistryOAuthSecret, registry, secrets
 from tracecat_registry.context import get_context
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry.core.ai import (
+    LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
+    _resolve_model_selection,
+)
 from tracecat_registry.fields import AgentModel, ModelSelection
 from tracecat_registry.sdk.agents import AgentConfig, MCPServerConfig
 from tracecat_registry.types import AgentOutputRead
@@ -33,20 +38,33 @@ async def mcp(
     user_prompt: Annotated[str, Doc("User prompt to the agent.")],
     instructions: Annotated[str, Doc("Instructions for the agent.")],
     model: Annotated[
-        ModelSelection,
+        ModelSelection | None,
         Doc("Model to use. Pick from the list of models enabled for this workspace."),
         AgentModel(),
-    ],
+    ] = None,
+    model_name: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
+    model_provider: Annotated[
+        str | None,
+        Doc("Deprecated. Use `model` instead."),
+        Field(deprecated=True, json_schema_extra=LEGACY_MODEL_FIELD_SCHEMA_EXTRA),
+    ] = None,
 ) -> AgentOutputRead:
     """Use AI to interact with Wiz."""
+    resolved_model = _resolve_model_selection(
+        model=model, model_name=model_name, model_provider=model_provider
+    )
     token = secrets.get(wiz_mcp_oauth_secret.token_name)
     ctx = get_context()
     result = await ctx.agents.run(
         user_prompt=user_prompt,
         config=AgentConfig(
-            model_name=model.model_name,
-            model_provider=model.model_provider,
-            catalog_id=model.catalog_id,
+            model_name=resolved_model.model_name,
+            model_provider=resolved_model.model_provider,
+            catalog_id=resolved_model.catalog_id,
             instructions=instructions,
             mcp_servers=[
                 MCPServerConfig(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restore backward compatibility for MCP agent actions by accepting deprecated `model_name` and `model_provider` and reconciling with the new `model` field. Prevents breaks for pre-beta.47 users while marking legacy fields as deprecated.

- **Bug Fixes**
  - Added deprecated `model_name`/`model_provider` to MCP actions for GitHub, Jira, Linear, Notion, RunReveal, Sentry, and Wiz.
  - Made `model` optional and now use the public resolve_model_selection to populate `AgentConfig`.
  - Marked legacy fields as deprecated with `LEGACY_MODEL_FIELD_SCHEMA_EXTRA`; existing workflows continue to work.

<sup>Written for commit bc332f52e49ff30eb72bb88304be6530d342084f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

