### PR TITLE
fix(registry): suppress git submodule recursion during custom registr…

### DIFF
--- a/tracecat/registry/repository.py
+++ b/tracecat/registry/repository.py
@@ -61,6 +61,12 @@ from tracecat.ssh import SshEnv, ssh_context
 ArgsClsT = type[BaseModel]
 type F = Callable[..., Any]
 
+_NO_SUBMODULE_GIT_ENV: dict[str, str] = {
+    "GIT_CONFIG_COUNT": "1",
+    "GIT_CONFIG_KEY_0": "submodule.recurse",
+    "GIT_CONFIG_VALUE_0": "false",
+}
+
 
 def get_custom_registry_target() -> Path:
     """Get the target directory for installing custom registry packages.
@@ -1093,7 +1099,7 @@ async def install_remote_repository(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            env=os.environ.copy() | env.to_dict(),
+            env=os.environ.copy() | env.to_dict() | _NO_SUBMODULE_GIT_ENV,
         )
         _, stderr = await process.communicate()
         if process.returncode != 0:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable Git submodule recursion during custom registry installs to avoid cloning submodules and prevent slow or failing syncs.

- **Bug Fixes**
  - Forces `submodule.recurse=false` via `GIT_CONFIG_*` env in `install_remote_repository`, so `git` ignores submodules during custom registry sync.

<sup>Written for commit 9ba11d99e400d608ef8eb82545f91983c9e731c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

