### PR TITLE
fix(agents): keep current preset chats floating

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3020,7 +3020,8 @@ export const $AgentSessionCreate = {
         },
       ],
       title: "Agent Preset Version Id",
-      description: "Pinned preset version used for this session (if any)",
+      description:
+        "Pinned preset version used for this session. If null, the session follows the preset's current version.",
     },
     harness_type: {
       $ref: "#/components/schemas/HarnessType",
@@ -3604,7 +3605,8 @@ export const $AgentSessionUpdate = {
         },
       ],
       title: "Agent Preset Version Id",
-      description: "Pinned preset version to use for this session",
+      description:
+        "Pinned preset version to use for this session. Set null to follow the preset's current version.",
     },
     harness_type: {
       anyOf: [

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -699,7 +699,7 @@ export type AgentSessionCreate = {
    */
   agent_preset_id?: string | null
   /**
-   * Pinned preset version used for this session (if any)
+   * Pinned preset version used for this session. If null, the session follows the preset's current version.
    */
   agent_preset_version_id?: string | null
   /**
@@ -833,7 +833,7 @@ export type AgentSessionUpdate = {
    */
   agent_preset_id?: string | null
   /**
-   * Pinned preset version to use for this session
+   * Pinned preset version to use for this session. Set null to follow the preset's current version.
    */
   agent_preset_version_id?: string | null
   /**

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -592,15 +592,12 @@ function AgentPresetChatPane({
     { enabled: Boolean(preset && workspaceId) }
   )
   const selectedVersionId = chat?.agent_preset_version_id ?? null
-  const currentVersionId =
-    preset?.current_version_id ?? versions?.[0]?.id ?? null
   const {
     presetVersion: selectedVersionConfig,
     presetVersionIsLoading: selectedVersionConfigIsLoading,
   } = useAgentPresetVersion(workspaceId, preset?.id, selectedVersionId, {
     enabled: Boolean(workspaceId && preset?.id && selectedVersionId),
   })
-  const newChatVersionId = selectedVersionId ?? currentVersionId
   const effectiveModelConfig = selectedVersionId
     ? (selectedVersionConfig ?? null)
     : preset
@@ -655,7 +652,7 @@ function AgentPresetChatPane({
         entity_id: preset.id,
         tools: selectedVersionConfig?.actions ?? preset.actions ?? undefined,
         agent_preset_id: preset.id,
-        agent_preset_version_id: newChatVersionId,
+        agent_preset_version_id: selectedVersionId,
       })
       setSelectedChatId(newChat.id)
       await refetchChats()

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -131,7 +131,11 @@ class AgentWorkflowArgs(BaseModel):
         default=None, description="Agent preset used for this session"
     )
     agent_preset_version_id: uuid.UUID | None = Field(
-        default=None, description="Pinned preset version used for this session"
+        default=None,
+        description=(
+            "Pinned preset version used for this workflow run. "
+            "If null, the run follows the preset's current version."
+        ),
     )
     harness_type: HarnessType | None = Field(
         default=None,

--- a/tests/unit/test_agent_session_preset_versioning.py
+++ b/tests/unit/test_agent_session_preset_versioning.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from tracecat.agent.session.schemas import AgentSessionUpdate
+from tracecat.agent.session.schemas import AgentSessionCreate, AgentSessionUpdate
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.auth.types import Role
@@ -33,12 +33,42 @@ def _build_service() -> tuple[AgentSessionService, SimpleNamespace, Role]:
 
 
 @pytest.mark.anyio
-async def test_update_session_resolves_current_version_when_preset_changes() -> None:
+async def test_create_session_preserves_null_preset_version_for_current() -> None:
+    service, session, _role = _build_service()
+    preset_id = uuid.uuid4()
+    agent_session_id = uuid.uuid4()
+    validate_mock = AsyncMock(return_value=None)
+    service._validate_preset_version_for_assignment = validate_mock
+
+    created = await service.create_session(
+        AgentSessionCreate(
+            id=agent_session_id,
+            title="Chat",
+            entity_type=AgentSessionEntity.AGENT_PRESET,
+            entity_id=preset_id,
+            agent_preset_version_id=None,
+        )
+    )
+
+    validate_mock.assert_awaited_once_with(
+        entity_type=AgentSessionEntity.AGENT_PRESET,
+        entity_id=preset_id,
+        agent_preset_id=None,
+        agent_preset_version_id=None,
+    )
+    assert created.agent_preset_id == preset_id
+    assert created.agent_preset_version_id is None
+    session.add.assert_called_once_with(created)
+    session.commit.assert_awaited_once()
+    session.refresh.assert_awaited_once_with(created)
+
+
+@pytest.mark.anyio
+async def test_update_session_preserves_null_version_when_preset_changes() -> None:
     service, session, role = _build_service()
     old_preset_id = uuid.uuid4()
     new_preset_id = uuid.uuid4()
     old_version_id = uuid.uuid4()
-    resolved_version_id = uuid.uuid4()
     agent_session = AgentSession(
         workspace_id=role.workspace_id,
         title="Chat",
@@ -48,46 +78,36 @@ async def test_update_session_resolves_current_version_when_preset_changes() -> 
         agent_preset_id=old_preset_id,
         agent_preset_version_id=old_version_id,
     )
-    resolve_mock = AsyncMock(return_value=resolved_version_id)
-    service._resolve_preset_version_for_assignment = resolve_mock
+    validate_mock = AsyncMock(return_value=None)
+    service._validate_preset_version_for_assignment = validate_mock
 
     updated = await service.update_session(
         agent_session,
         params=AgentSessionUpdate(agent_preset_id=new_preset_id),
     )
 
-    resolve_mock.assert_awaited_once_with(
+    validate_mock.assert_awaited_once_with(
         entity_type=AgentSessionEntity.CASE,
         entity_id=agent_session.entity_id,
         agent_preset_id=new_preset_id,
         agent_preset_version_id=None,
     )
     assert updated.agent_preset_id == new_preset_id
-    assert updated.agent_preset_version_id == resolved_version_id
+    assert updated.agent_preset_version_id is None
     session.commit.assert_awaited_once()
     session.refresh.assert_awaited_once_with(agent_session)
 
 
 @pytest.mark.anyio
-async def test_ensure_session_preset_version_id_uses_current_version() -> None:
-    service, session, role = _build_service()
+async def test_validate_preset_assignment_preserves_null_without_resolving_current() -> (
+    None
+):
+    service, _session, _role = _build_service()
     preset_id = uuid.uuid4()
-    resolved_version_id = uuid.uuid4()
-    agent_session = AgentSession(
-        workspace_id=role.workspace_id,
-        title="Chat",
-        created_by=uuid.uuid4(),
-        entity_type="case",
-        entity_id=uuid.uuid4(),
-        agent_preset_id=preset_id,
-        agent_preset_version_id=None,
-    )
-    resolve_agent_preset_version = AsyncMock(
-        return_value=SimpleNamespace(id=resolved_version_id)
-    )
 
     preset_service = Mock()
-    preset_service.resolve_agent_preset_version = resolve_agent_preset_version
+    preset_service.get_preset = AsyncMock(return_value=SimpleNamespace(id=preset_id))
+    preset_service.resolve_agent_preset_version = AsyncMock()
 
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(
@@ -95,15 +115,16 @@ async def test_ensure_session_preset_version_id_uses_current_version() -> None:
             Mock(return_value=preset_service),
         )
 
-        resolved = await service._ensure_session_preset_version_id(agent_session)
+        pinned_version_id = await service._validate_preset_version_for_assignment(
+            entity_type=AgentSessionEntity.AGENT_PRESET,
+            entity_id=preset_id,
+            agent_preset_id=None,
+            agent_preset_version_id=None,
+        )
 
-    assert resolved == resolved_version_id
-    assert agent_session.agent_preset_version_id == resolved_version_id
-    resolve_agent_preset_version.assert_awaited_once_with(
-        preset_id=preset_id,
-    )
-    session.add.assert_called_with(agent_session)
-    session.commit.assert_awaited_once()
+    assert pinned_version_id is None
+    preset_service.get_preset.assert_awaited_once_with(preset_id)
+    preset_service.resolve_agent_preset_version.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -120,15 +141,15 @@ async def test_update_session_allows_version_only_repin_for_preset_sessions() ->
         agent_preset_id=None,
         agent_preset_version_id=uuid.uuid4(),
     )
-    resolve_mock = AsyncMock(return_value=new_version_id)
-    service._resolve_preset_version_for_assignment = resolve_mock
+    validate_mock = AsyncMock(return_value=new_version_id)
+    service._validate_preset_version_for_assignment = validate_mock
 
     updated = await service.update_session(
         agent_session,
         params=AgentSessionUpdate(agent_preset_version_id=new_version_id),
     )
 
-    resolve_mock.assert_awaited_once_with(
+    validate_mock.assert_awaited_once_with(
         entity_type=AgentSessionEntity.AGENT_PRESET,
         entity_id=preset_id,
         agent_preset_id=None,
@@ -136,6 +157,34 @@ async def test_update_session_allows_version_only_repin_for_preset_sessions() ->
     )
     assert updated.agent_preset_id == preset_id
     assert updated.agent_preset_version_id == new_version_id
+    session.commit.assert_awaited_once()
+    session.refresh.assert_awaited_once_with(agent_session)
+
+
+@pytest.mark.anyio
+async def test_update_session_clears_pinned_version_to_follow_current() -> None:
+    service, session, role = _build_service()
+    preset_id = uuid.uuid4()
+    agent_session = AgentSession(
+        workspace_id=role.workspace_id,
+        title="Chat",
+        created_by=uuid.uuid4(),
+        entity_type="agent_preset",
+        entity_id=preset_id,
+        agent_preset_id=preset_id,
+        agent_preset_version_id=uuid.uuid4(),
+    )
+    validate_mock = AsyncMock()
+    service._validate_preset_version_for_assignment = validate_mock
+
+    updated = await service.update_session(
+        agent_session,
+        params=AgentSessionUpdate(agent_preset_version_id=None),
+    )
+
+    validate_mock.assert_not_awaited()
+    assert updated.agent_preset_id == preset_id
+    assert updated.agent_preset_version_id is None
     session.commit.assert_awaited_once()
     session.refresh.assert_awaited_once_with(agent_session)
 
@@ -157,8 +206,8 @@ async def test_update_session_ignores_mismatched_preset_id_for_preset_sessions()
         agent_preset_id=preset_id,
         agent_preset_version_id=uuid.uuid4(),
     )
-    resolve_mock = AsyncMock(return_value=new_version_id)
-    service._resolve_preset_version_for_assignment = resolve_mock
+    validate_mock = AsyncMock(return_value=new_version_id)
+    service._validate_preset_version_for_assignment = validate_mock
 
     updated = await service.update_session(
         agent_session,
@@ -168,7 +217,7 @@ async def test_update_session_ignores_mismatched_preset_id_for_preset_sessions()
         ),
     )
 
-    resolve_mock.assert_awaited_once_with(
+    validate_mock.assert_awaited_once_with(
         entity_type=AgentSessionEntity.AGENT_PRESET,
         entity_id=preset_id,
         agent_preset_id=mismatched_preset_id,

--- a/tracecat/agent/session/schemas.py
+++ b/tracecat/agent/session/schemas.py
@@ -50,7 +50,10 @@ class AgentSessionCreate(BaseModel):
     )
     agent_preset_version_id: uuid.UUID | None = Field(
         default=None,
-        description="Pinned preset version used for this session (if any)",
+        description=(
+            "Pinned preset version used for this session. "
+            "If null, the session follows the preset's current version."
+        ),
     )
     # Harness fields
     harness_type: HarnessType = Field(
@@ -72,7 +75,10 @@ class AgentSessionUpdate(BaseModel):
     )
     agent_preset_version_id: uuid.UUID | None = Field(
         default=None,
-        description="Pinned preset version to use for this session",
+        description=(
+            "Pinned preset version to use for this session. "
+            "Set null to follow the preset's current version."
+        ),
     )
     harness_type: HarnessType | None = Field(
         default=None, description="Agent harness type"

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -160,7 +160,7 @@ class AgentSessionService(BaseWorkspaceService):
             entity_id=args.entity_id,
             agent_preset_id=args.agent_preset_id,
         )
-        pinned_preset_version_id = await self._resolve_preset_version_for_assignment(
+        pinned_preset_version_id = await self._validate_preset_version_for_assignment(
             entity_type=args.entity_type,
             entity_id=args.entity_id,
             agent_preset_id=args.agent_preset_id,
@@ -205,7 +205,7 @@ class AgentSessionService(BaseWorkspaceService):
             return entity_id
         return None
 
-    async def _resolve_preset_version_for_assignment(
+    async def _validate_preset_version_for_assignment(
         self,
         *,
         entity_type: AgentSessionEntity,
@@ -213,7 +213,7 @@ class AgentSessionService(BaseWorkspaceService):
         agent_preset_id: uuid.UUID | None,
         agent_preset_version_id: uuid.UUID | None,
     ) -> uuid.UUID | None:
-        """Resolve the pinned preset version for a session assignment."""
+        """Validate and return the pinned preset version for a session assignment."""
         logical_preset_id = self._resolve_logical_preset_id(
             entity_type=entity_type,
             entity_id=entity_id,
@@ -227,39 +227,18 @@ class AgentSessionService(BaseWorkspaceService):
             return None
 
         preset_service = AgentPresetService(self.session, self.role)
+        if not await preset_service.get_preset(logical_preset_id):
+            raise TracecatNotFoundError(
+                f"Agent preset with ID '{logical_preset_id}' not found"
+            )
+
+        if agent_preset_version_id is None:
+            return None
+
         version = await preset_service.resolve_agent_preset_version(
             preset_id=logical_preset_id,
             preset_version_id=agent_preset_version_id,
         )
-        return version.id
-
-    async def _ensure_session_preset_version_id(
-        self, agent_session: AgentSession
-    ) -> uuid.UUID | None:
-        """Backfill a pinned preset version for unexpected unpinned sessions."""
-        if agent_session.agent_preset_version_id is not None:
-            return agent_session.agent_preset_version_id
-
-        try:
-            entity_type = AgentSessionEntity(agent_session.entity_type)
-        except ValueError:
-            return None
-
-        logical_preset_id = self._resolve_logical_preset_id(
-            entity_type=entity_type,
-            entity_id=agent_session.entity_id,
-            agent_preset_id=agent_session.agent_preset_id,
-        )
-        if logical_preset_id is None:
-            return None
-
-        preset_service = AgentPresetService(self.session, self.role)
-        version = await preset_service.resolve_agent_preset_version(
-            preset_id=logical_preset_id,
-        )
-        agent_session.agent_preset_version_id = version.id
-        self.session.add(agent_session)
-        await self.session.commit()
         return version.id
 
     async def get_session(
@@ -470,8 +449,8 @@ class AgentSessionService(BaseWorkspaceService):
                 if preset_id_updated and (
                     requested_preset_id != agent_session.agent_preset_id
                 ):
-                    resolved_version_id = (
-                        await self._resolve_preset_version_for_assignment(
+                    pinned_version_id = (
+                        await self._validate_preset_version_for_assignment(
                             entity_type=entity_type,
                             entity_id=agent_session.entity_id,
                             agent_preset_id=requested_preset_id,
@@ -481,17 +460,10 @@ class AgentSessionService(BaseWorkspaceService):
                         )
                     )
                 elif version_id_updated and requested_version_id is None:
-                    resolved_version_id = (
-                        await self._resolve_preset_version_for_assignment(
-                            entity_type=entity_type,
-                            entity_id=agent_session.entity_id,
-                            agent_preset_id=requested_preset_id,
-                            agent_preset_version_id=None,
-                        )
-                    )
+                    pinned_version_id = None
                 elif version_id_updated:
-                    resolved_version_id = (
-                        await self._resolve_preset_version_for_assignment(
+                    pinned_version_id = (
+                        await self._validate_preset_version_for_assignment(
                             entity_type=entity_type,
                             entity_id=agent_session.entity_id,
                             agent_preset_id=requested_preset_id,
@@ -499,9 +471,9 @@ class AgentSessionService(BaseWorkspaceService):
                         )
                     )
                 else:
-                    resolved_version_id = requested_version_id
+                    pinned_version_id = requested_version_id
                 agent_session.agent_preset_id = logical_preset_id
-                agent_session.agent_preset_version_id = resolved_version_id
+                agent_session.agent_preset_version_id = pinned_version_id
 
         # Update remaining fields if provided
         for field, value in set_fields.items():
@@ -1309,16 +1281,13 @@ class AgentSessionService(BaseWorkspaceService):
             return
 
         session_entity = AgentSessionEntity(agent_session.entity_type)
-        pinned_preset_version_id = await self._ensure_session_preset_version_id(
-            agent_session
-        )
 
         if session_entity is AgentSessionEntity.CASE:
             entity_instructions = await self._entity_to_prompt(agent_session)
             if agent_session.agent_preset_id:
                 async with agent_svc.with_preset_config(
                     preset_id=agent_session.agent_preset_id,
-                    preset_version_id=pinned_preset_version_id,
+                    preset_version_id=agent_session.agent_preset_version_id,
                 ) as preset_config:
                     combined_instructions = (
                         f"{preset_config.instructions}\n\n{entity_instructions}"
@@ -1340,7 +1309,7 @@ class AgentSessionService(BaseWorkspaceService):
         elif session_entity is AgentSessionEntity.AGENT_PRESET:
             async with agent_svc.with_preset_config(
                 preset_id=agent_session.entity_id,
-                preset_version_id=pinned_preset_version_id,
+                preset_version_id=agent_session.agent_preset_version_id,
             ) as preset_config:
                 yield preset_config
         elif session_entity is AgentSessionEntity.EXTERNAL_CHANNEL:
@@ -1348,7 +1317,7 @@ class AgentSessionService(BaseWorkspaceService):
             preset_id = agent_session.agent_preset_id or agent_session.entity_id
             async with agent_svc.with_preset_config(
                 preset_id=preset_id,
-                preset_version_id=pinned_preset_version_id,
+                preset_version_id=agent_session.agent_preset_version_id,
             ) as preset_config:
                 yield preset_config
         elif session_entity is AgentSessionEntity.AGENT_PRESET_BUILDER:
@@ -1377,7 +1346,7 @@ class AgentSessionService(BaseWorkspaceService):
             if agent_session.agent_preset_id:
                 async with agent_svc.with_preset_config(
                     preset_id=agent_session.agent_preset_id,
-                    preset_version_id=pinned_preset_version_id,
+                    preset_version_id=agent_session.agent_preset_version_id,
                 ) as preset_config:
                     combined_instructions = (
                         f"{preset_config.instructions}\n\n{entity_instructions}"
@@ -1412,13 +1381,10 @@ class AgentSessionService(BaseWorkspaceService):
                 # Get parent session to check for preset
                 parent_session = await self.get_session(agent_session.parent_session_id)
                 if parent_session and parent_session.agent_preset_id:
-                    parent_version_id = await self._ensure_session_preset_version_id(
-                        parent_session
-                    )
                     # Use parent's preset with forked context prepended
                     async with agent_svc.with_preset_config(
                         preset_id=parent_session.agent_preset_id,
-                        preset_version_id=parent_version_id,
+                        preset_version_id=parent_session.agent_preset_version_id,
                     ) as preset_config:
                         combined_instructions = (
                             f"{fork_context}{preset_config.instructions}"
@@ -1447,7 +1413,7 @@ class AgentSessionService(BaseWorkspaceService):
                 # Workflow sessions with preset use the preset config
                 async with agent_svc.with_preset_config(
                     preset_id=agent_session.agent_preset_id,
-                    preset_version_id=pinned_preset_version_id,
+                    preset_version_id=agent_session.agent_preset_version_id,
                 ) as preset_config:
                     yield preset_config
             else:


### PR DESCRIPTION
## Summary
- Preserve `agent_preset_version_id: null` as the floating “current version” selection for agent preset sessions.
- Let preset config resolution handle `null` as current at runtime instead of resolving and storing an effective version in the session service.
- Update the agent builder live chat create path and generated API client descriptions.
- Add regression coverage for null/current sessions, repinning, clearing pins, assignment validation, and preset changes.

## Rationale
- `null` is the intentional representation of “follow the preset’s current version”; a non-null `agent_preset_version_id` is the representation of an exact pin.
- Runtime config resolution already owns the latest/current lookup: `AgentManagementService.with_preset_config()` calls `AgentPresetService.resolve_agent_preset_config()`, which calls `resolve_agent_preset_version()`.
- When no version ID or numeric version is supplied, `resolve_agent_preset_version()` falls through to `get_current_version_for_preset()`. That first uses `AgentPreset.current_version_id`, then falls back to the newest immutable version by version number if needed.
- Keeping `null` in the session therefore avoids snapshotting a moving selection at chat creation time while still letting pinned chats stay pinned to an exact immutable version.

## QA
- `just cluster up -d`
- Chrome DevTools QA on `https://c2.fix-chat-latest-version.tracecat.localhost`: created a preset, confirmed live chat creation sends `agent_preset_version_id: null`, saved version 2, verified the selector fast-forwarded to `Version 2, current`, and confirmed the session record still stores `agent_preset_version_id: null`.
- `PG_PORT=5532 MINIO_PORT=9100 REDIS_PORT=6479 uv run pytest tests/unit/test_agent_session_preset_versioning.py tests/unit/test_agent_session_approval_sink.py::test_run_turn_merges_basic_chat_request_instructions`
- `uv run ruff check tracecat/agent/session/service.py packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py tests/unit/test_agent_session_preset_versioning.py tests/unit/test_agent_session_approval_sink.py`
- `uv run ruff format --check tracecat/agent/session/service.py packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py tests/unit/test_agent_session_preset_versioning.py tests/unit/test_agent_session_approval_sink.py`
- `uv run basedpyright --warnings --threads 4 tracecat/agent/session/service.py tracecat/agent/session/schemas.py packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py tests/unit/test_agent_session_preset_versioning.py tests/unit/test_agent_session_approval_sink.py`
- Pre-commit hooks passed during commit.
