### PR TITLE
chore(dev): fix prerelease Python package versions

### DIFF
--- a/.agents/skills/gh-prerelease/SKILL.md
+++ b/.agents/skills/gh-prerelease/SKILL.md
@@ -17,10 +17,38 @@ Full argument string: `$ARGUMENTS`.
 
 Split `$ARGUMENTS` on whitespace into tokens:
 
-- Token 1 → `<tag>` (optional). Semver with a prerelease suffix, e.g. `0.20.0-rc.1`, `1.0.0-beta.48-rc.5`. Do not include a leading `v` — tags in this repo are bare semver.
+- Token 1 → `<tag>` (optional). Semver-style version with a prerelease suffix, e.g. `0.20.0-rc.1`, `1.0.0-beta.48-rc.5`. Do not include a leading `v` — tags in this repo are bare versions.
 - Token 2 → `<commit>` (optional, default `HEAD`). Anything `git rev-parse` accepts: a SHA, branch, `HEAD`, `HEAD~3`, `origin/main`, etc.
 
 Do not rely on `$1`, `$2` — only `$ARGUMENTS` is reliably substituted in skill markdown.
+
+## Version format
+
+Keep `<tag>` in Tracecat's public release/image tag convention. `just update-version <tag>` writes that value to `__version__`, and writes a separate PEP 440-compatible value to `__pep440_version__` for Hatchling package metadata. This lets Git branches, GitHub releases, and image tags stay as `1.0.0-beta.48-rc.5` while Python builds use `1.0.0b48+rc.5`.
+
+Examples:
+
+| Public `<tag>` | Python package version |
+|----------------|------------------------|
+| `1.0.0-alpha.1` | `1.0.0a1` |
+| `1.0.0-beta.48` | `1.0.0b48` |
+| `1.0.0-rc.5` | `1.0.0rc5` |
+| `1.0.0-beta.48-rc.5` | `1.0.0b48+rc.5` |
+| `1.0.0-dev.3` | `1.0.0.dev3` |
+| `1.0.0-post.1` | `1.0.0.post1` |
+
+After running `just update-version <tag>`, verify both fields:
+
+```sh
+PUBLIC_VERSION=$(grep -oP '__version__ = "\K[^"]+' tracecat/__init__.py)
+PYTHON_VERSION=$(grep -oP '__pep440_version__ = "\K[^"]+' tracecat/__init__.py)
+uv run python - "$PYTHON_VERSION" <<'PY'
+import sys
+from packaging.version import Version
+
+Version(sys.argv[1])
+PY
+```
 
 If `<tag>` is missing, suggest the next logical RC tag by inspecting recent tags:
 
@@ -39,7 +67,7 @@ LATEST_RC=$(git tag --sort=-v:refname | rg -m1 -- '-rc\.[0-9]+$' || true)
 
 Present the suggestion in one line and wait for explicit confirmation (`y` to accept, or have the user supply an alternative). Do not proceed silently. If the user accepts, use the suggestion as `<tag>` for the rest of the workflow.
 
-Validate `<tag>` against `^[0-9]+\.[0-9]+\.[0-9]+-[A-Za-z0-9][A-Za-z0-9.-]*$` (semver core + a prerelease suffix). If it lacks a prerelease suffix (e.g. plain `0.20.0`), refuse and point the user at `.github/workflows/create-release.yml` — this skill is for prereleases only.
+Validate `<tag>` against `^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z]+\.[0-9]+){1,2}$`. If it is a stable release (e.g. plain `0.20.0`), refuse and point the user at `.github/workflows/create-release.yml` — this skill is for prereleases only.
 
 ## Workflow
 
@@ -109,12 +137,23 @@ yes | just update-version <tag>
 
 `update-version.sh` prompts before overwriting files; `yes |` answers `y`.
 
+Important: pass the public release tag, e.g. `1.0.0-beta.48-rc.5`. `update-version.sh` keeps that value in `__version__` and writes the PEP 440 equivalent, e.g. `1.0.0b48+rc.5`, to `__pep440_version__` for Python package builds.
+
 Sanity-check the result:
 
 ```sh
 git diff --quiet && { echo "update-version produced no changes" >&2; exit 1; }
 NEW_VERSION=$(grep -oP '__version__ = "\K[^"]+' tracecat/__init__.py)
 [ "$NEW_VERSION" = "<tag>" ] || { echo "version mismatch: got $NEW_VERSION, expected <tag>" >&2; exit 1; }
+PYTHON_VERSION=$(grep -oP '__pep440_version__ = "\K[^"]+' tracecat/__init__.py)
+REGISTRY_PYTHON_VERSION=$(grep -oP '__pep440_version__ = "\K[^"]+' packages/tracecat-registry/tracecat_registry/__init__.py)
+[ "$PYTHON_VERSION" = "$REGISTRY_PYTHON_VERSION" ] || { echo "Python version mismatch: tracecat=$PYTHON_VERSION registry=$REGISTRY_PYTHON_VERSION" >&2; exit 1; }
+uv run python - "$PYTHON_VERSION" <<'PY'
+import sys
+from packaging.version import Version
+
+Version(sys.argv[1])
+PY
 ```
 
 If it fails: `git restore .` (after confirming with the user) and abort.

--- a/packages/tracecat-registry/pyproject.toml
+++ b/packages/tracecat-registry/pyproject.toml
@@ -64,6 +64,7 @@ Repository = "https://github.com/TracecatHQ/tracecat"
 
 [tool.hatch.version]
 path = "tracecat_registry/__init__.py"
+pattern = '^__pep440_version__ = "(?P<version>[^"]+)"'
 
 [tool.mypy]
 strict = true

--- a/packages/tracecat-registry/tracecat_registry/__init__.py
+++ b/packages/tracecat-registry/tracecat_registry/__init__.py
@@ -1,6 +1,7 @@
 """Tracecat managed actions and integrations registry."""
 
 __version__ = "1.0.0-beta.47"
+__pep440_version__ = "1.0.0b47"
 
 
 from tracecat_registry import types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ dev = [
 
 [tool.hatch.version]
 path = "tracecat/__init__.py"
+pattern = '^__pep440_version__ = "(?P<version>[^"]+)"'
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -6,8 +6,8 @@ usage() {
     echo "Options:"
     echo "  --major      # Increment major version (1.2.3 -> 2.0.0)"
     echo "  --minor      # Increment minor version (1.2.3 -> 1.3.0)"
-    echo "  --beta       # Create or increment beta version (1.2.3 -> 1.2.3-beta.0, 1.2.3-beta.0 -> 1.2.3-beta.1)"
-    echo "  --rc         # Create or increment release candidate (1.2.3 -> 1.2.3-rc.0, 1.2.3-rc.0 -> 1.2.3-rc.1)"
+    echo "  --beta       # Create or increment beta tag (1.2.3 -> 1.2.3-beta.0, 1.2.3-beta.0 -> 1.2.3-beta.1)"
+    echo "  --rc         # Create or increment release candidate tag (1.2.3 -> 1.2.3-rc.0, 1.2.3-rc.0 -> 1.2.3-rc.1)"
     echo "  --release    # Strip prerelease suffix (1.2.3-beta.1 -> 1.2.3)"
     echo "Examples:"
     echo "  $0           # Automatically increment patch version (or prerelease if current is prerelease)"
@@ -17,31 +17,67 @@ usage() {
     echo "  $0 --rc      # Create or increment release candidate"
     echo "  $0 --release # Strip prerelease suffix for stable release"
     echo "  $0 1.0.1     # Set specific version"
-    echo "  $0 1.0.0-beta.0  # Set specific prerelease version"
+    echo "  $0 1.0.0-beta.0  # Set specific prerelease tag"
+    echo "  $0 1.0.0-beta.48-rc.5  # Keep release/image tag convention"
     exit 1
+}
+
+PUBLIC_SUFFIX_PATTERN='(alpha|a|beta|b|rc|dev|post)\.[0-9]+'
+PUBLIC_VERSION_PATTERN="[0-9]+\.[0-9]+\.[0-9]+(-${PUBLIC_SUFFIX_PATTERN}){0,2}"
+VERSION_SEARCH_PATTERN='[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+){0,2}'
+
+to_python_version() {
+    local python_version=$1
+
+    if [[ $python_version =~ ^(.+-[a-z]+\.[0-9]+)-([a-z]+)\.([0-9]+)$ ]]; then
+        python_version="${BASH_REMATCH[1]}+${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+    fi
+
+    python_version=${python_version//-alpha./a}
+    python_version=${python_version//-a./a}
+    python_version=${python_version//-beta./b}
+    python_version=${python_version//-b./b}
+    python_version=${python_version//-rc./rc}
+    python_version=${python_version//-dev./.dev}
+    python_version=${python_version//-post./.post}
+
+    printf '%s\n' "$python_version"
+}
+
+escape_version_regex() {
+    printf '%s\n' "$1" | sed 's/[.]/\\./g; s/-/\\-/g'
+}
+
+escape_sed_replacement() {
+    printf '%s\n' "$1" | sed 's/[&/]/\\&/g'
 }
 
 # Extract current version from __init__.py
 INIT_FILE="tracecat/__init__.py"
+REGISTRY_INIT_FILE="packages/tracecat-registry/tracecat_registry/__init__.py"
 if [ ! -f "$INIT_FILE" ]; then
     echo "Error: Cannot find $INIT_FILE"
     exit 1
 fi
 
-# Match both regular semver (1.2.3) and prerelease versions (1.2.3-beta.0, 1.2.3-rc.1)
-CURRENT_VERSION=$(grep -E '__version__ = "[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+){0,2}"' "$INIT_FILE" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+){0,2}')
+# Match release/image tag versions (1.2.3, 1.2.3-beta.0, 1.2.3-beta.0-rc.1)
+CURRENT_VERSION=$(sed -nE "s/^__version__ = \"($PUBLIC_VERSION_PATTERN)\"$/\1/p" "$INIT_FILE")
 if [ -z "$CURRENT_VERSION" ]; then
     echo "Error: Could not extract version from $INIT_FILE"
     exit 1
 fi
 
+CURRENT_PYTHON_VERSION=$(sed -nE 's/^__pep440_version__ = "([^"]+)"$/\1/p' "$INIT_FILE")
+if [ -z "$CURRENT_PYTHON_VERSION" ]; then
+    CURRENT_PYTHON_VERSION=$(to_python_version "$CURRENT_VERSION")
+fi
+
 # Parse version components
-if [[ $CURRENT_VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-zA-Z]+)\.([0-9]+)){0,2}$ ]]; then
+if [[ $CURRENT_VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-.*)?$ ]]; then
     CURRENT_MAJOR="${BASH_REMATCH[1]}"
     CURRENT_MINOR="${BASH_REMATCH[2]}"
     CURRENT_PATCH="${BASH_REMATCH[3]}"
-    CURRENT_PRERELEASE_TAG="${BASH_REMATCH[5]}"  # e.g., "beta", "rc"
-    CURRENT_PRERELEASE_NUM="${BASH_REMATCH[6]}"  # e.g., "0", "1"
+    CURRENT_CORE_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${CURRENT_PATCH}"
 else
     echo "Error: Could not parse version components from $CURRENT_VERSION"
     exit 1
@@ -50,8 +86,8 @@ fi
 # Parse arguments and determine new version
 if [ "$#" -eq 0 ]; then
     # Auto-increment: if prerelease, increment prerelease number; otherwise increment patch
-    if [ -n "$CURRENT_PRERELEASE_TAG" ]; then
-        NEW_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${CURRENT_PATCH}-${CURRENT_PRERELEASE_TAG}.$((CURRENT_PRERELEASE_NUM + 1))"
+    if [[ $CURRENT_VERSION =~ ^(.+-[a-zA-Z]+\.)([0-9]+)$ ]]; then
+        NEW_VERSION="${BASH_REMATCH[1]}$((BASH_REMATCH[2] + 1))"
         echo "No version specified. Incrementing prerelease version to $NEW_VERSION"
     else
         NEW_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.$((CURRENT_PATCH + 1))"
@@ -71,30 +107,30 @@ elif [ "$#" -eq 1 ]; then
             ;;
         --beta)
             # Create or increment beta version
-            if [ "$CURRENT_PRERELEASE_TAG" = "beta" ]; then
-                NEW_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${CURRENT_PATCH}-beta.$((CURRENT_PRERELEASE_NUM + 1))"
+            if [[ $CURRENT_VERSION =~ ^(.+-beta\.)([0-9]+)$ ]]; then
+                NEW_VERSION="${BASH_REMATCH[1]}$((BASH_REMATCH[2] + 1))"
                 echo "Incrementing beta version to $NEW_VERSION"
             else
                 # Strip any existing prerelease and start beta.0
-                NEW_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${CURRENT_PATCH}-beta.0"
+                NEW_VERSION="${CURRENT_CORE_VERSION}-beta.0"
                 echo "Creating beta version $NEW_VERSION"
             fi
             ;;
         --rc)
             # Create or increment release candidate
-            if [ "$CURRENT_PRERELEASE_TAG" = "rc" ]; then
-                NEW_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${CURRENT_PATCH}-rc.$((CURRENT_PRERELEASE_NUM + 1))"
+            if [[ $CURRENT_VERSION =~ ^(.+-rc\.)([0-9]+)$ ]]; then
+                NEW_VERSION="${BASH_REMATCH[1]}$((BASH_REMATCH[2] + 1))"
                 echo "Incrementing release candidate to $NEW_VERSION"
             else
                 # Strip any existing prerelease and start rc.0
-                NEW_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${CURRENT_PATCH}-rc.0"
+                NEW_VERSION="${CURRENT_CORE_VERSION}-rc.0"
                 echo "Creating release candidate $NEW_VERSION"
             fi
             ;;
         --release)
             # Strip prerelease suffix for stable release
-            if [ -n "$CURRENT_PRERELEASE_TAG" ]; then
-                NEW_VERSION="${CURRENT_MAJOR}.${CURRENT_MINOR}.${CURRENT_PATCH}"
+            if [ "$CURRENT_VERSION" != "$CURRENT_CORE_VERSION" ]; then
+                NEW_VERSION="$CURRENT_CORE_VERSION"
                 echo "Stripping prerelease suffix for stable release $NEW_VERSION"
             else
                 echo "Error: Current version $CURRENT_VERSION is already a stable release"
@@ -113,11 +149,16 @@ else
     usage
 fi
 
-# Validate version numbers (semver format with optional prerelease)
-if ! [[ $NEW_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+){0,2}$ ]]; then
-    echo "Error: Version must be in semver format (e.g., 1.0.0 or 1.0.0-beta.0)"
+# Validate release/image tag version numbers (semver-style with optional prerelease)
+if ! [[ $NEW_VERSION =~ ^${PUBLIC_VERSION_PATTERN}$ ]]; then
+    echo "Error: Version must use the release tag format (e.g., 1.0.0, 1.0.0-beta.0, 1.0.0-beta.48-rc.5)"
     exit 1
 fi
+
+NEW_PYTHON_VERSION=$(to_python_version "$NEW_VERSION") || {
+    echo "Error: Could not convert $NEW_VERSION to a PEP 440-compatible Python package version"
+    exit 1
+}
 
 # List of files to update
 FILES=(
@@ -156,7 +197,7 @@ append_matching_files < <(
         -g 'docker-compose*.yml' \
         -g 'docs/**/*' \
         -g 'deployments/**/*' \
-        '\$\{TRACECAT__IMAGE_TAG:-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+){0,2}\}|variable "tracecat_image_tag"|raw\.githubusercontent\.com/TracecatHQ/tracecat/[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+){0,2}/|TF_VAR_tracecat_image_tag=[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+){0,2}' \
+        "\\$\\{TRACECAT__IMAGE_TAG:-${VERSION_SEARCH_PATTERN}\\}|variable \"tracecat_image_tag\"|raw\\.githubusercontent\\.com/TracecatHQ/tracecat/${VERSION_SEARCH_PATTERN}/|TF_VAR_tracecat_image_tag=${VERSION_SEARCH_PATTERN}" \
         .
 )
 
@@ -180,9 +221,10 @@ run_sed_in_place() {
     fi
 }
 
-# Function to update version in a file
-update_version() {
+update_python_version_file() {
     local file=$1
+    local escaped_new_version
+    local escaped_new_python_version
 
     if [ ! -f "$file" ]; then
         echo "Warning: File not found - $file"
@@ -190,22 +232,42 @@ update_version() {
     fi
 
     echo "Updating $file..."
-    # Escape special characters in version strings for sed
-    local ESCAPED_CURRENT=$(echo "$CURRENT_VERSION" | sed 's/[.]/\\./g; s/-/\\-/g')
-    local ESCAPED_NEW=$(echo "$NEW_VERSION" | sed 's/[&/]/\\&/g')
 
-    run_sed_in_place "s/$ESCAPED_CURRENT/$ESCAPED_NEW/g" "$file" && \
-    run_sed_in_place "s/\/blob\/[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+){0,2}\//\/blob\/$NEW_VERSION\//g" "$file" && \
-    run_sed_in_place "s/\`[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+){0,2}\`/\`$NEW_VERSION\`/g" "$file" && \
-    run_sed_in_place 's/(\$\{TRACECAT__IMAGE_TAG:-)[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+){0,2}(\})/\1'"$NEW_VERSION"'\3/g' "$file" && \
-    run_sed_in_place '/variable "tracecat_image_tag"/,/\}/ s/(default[[:space:]]*=[[:space:]]*)"[^"]*"/\1"'"$NEW_VERSION"'"/' "$file" && \
-    run_sed_in_place 's#(raw\.githubusercontent\.com/TracecatHQ/tracecat/)[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+){0,2}/#\1'"$NEW_VERSION"'/#g' "$file" && \
-    run_sed_in_place 's/(TF_VAR_tracecat_image_tag=)[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+\.[0-9]+){0,2}/\1'"$NEW_VERSION"'/g' "$file" && \
+    escaped_new_version=$(escape_sed_replacement "$NEW_VERSION")
+    escaped_new_python_version=$(escape_sed_replacement "$NEW_PYTHON_VERSION")
+
+    run_sed_in_place "s/^(__version__ = \")[^\"]+(\")/\\1${escaped_new_version}\\2/" "$file" && \
+    run_sed_in_place "s/^(__pep440_version__ = \")[^\"]+(\")/\\1${escaped_new_python_version}\\2/" "$file" && \
+    echo "✓ Updated $file" || echo "✗ Failed to update $file"
+}
+
+update_release_tag_file() {
+    local file=$1
+    local escaped_current_version
+    local escaped_new_version
+
+    if [ ! -f "$file" ]; then
+        echo "Warning: File not found - $file"
+        return
+    fi
+
+    echo "Updating $file..."
+    escaped_current_version=$(escape_version_regex "$CURRENT_VERSION")
+    escaped_new_version=$(escape_sed_replacement "$NEW_VERSION")
+
+    run_sed_in_place "s/$escaped_current_version/$escaped_new_version/g" "$file" && \
+    run_sed_in_place "s#(/blob/)${VERSION_SEARCH_PATTERN}/#\\1${escaped_new_version}/#g" "$file" && \
+    run_sed_in_place "s/\`${VERSION_SEARCH_PATTERN}\`/\`${escaped_new_version}\`/g" "$file" && \
+    run_sed_in_place "s/(\\$\\{TRACECAT__IMAGE_TAG:-)${VERSION_SEARCH_PATTERN}(\\})/\\1${escaped_new_version}\\3/g" "$file" && \
+    run_sed_in_place '/variable "tracecat_image_tag"/,/\}/ s/(default[[:space:]]*=[[:space:]]*)"[^"]*"/\1"'"$escaped_new_version"'"/' "$file" && \
+    run_sed_in_place "s#(raw\\.githubusercontent\\.com/TracecatHQ/tracecat/)${VERSION_SEARCH_PATTERN}/#\\1${escaped_new_version}/#g" "$file" && \
+    run_sed_in_place "s/(TF_VAR_tracecat_image_tag=)${VERSION_SEARCH_PATTERN}/\\1${escaped_new_version}/g" "$file" && \
     echo "✓ Updated $file" || echo "✗ Failed to update $file"
 }
 
 # Main execution
-echo "Updating version from $CURRENT_VERSION to $NEW_VERSION"
+echo "Updating release tag from $CURRENT_VERSION to $NEW_VERSION"
+echo "Updating Python package version from $CURRENT_PYTHON_VERSION to $NEW_PYTHON_VERSION"
 echo "The following files will be modified:"
 echo "----------------------------------------"
 for file in "${FILES[@]}"; do
@@ -229,7 +291,11 @@ fi
 # Proceed with updates
 echo "Proceeding with updates..."
 for file in "${FILES[@]}"; do
-    update_version "$file"
+    if [ "$file" = "$INIT_FILE" ] || [ "$file" = "$REGISTRY_INIT_FILE" ]; then
+        update_python_version_file "$file"
+    else
+        update_release_tag_file "$file"
+    fi
 done
 
 echo "----------------------------------------"
@@ -239,13 +305,13 @@ echo -e "\033[33mPlease review the changes before committing.\033[0m"
 # Copy new version to clipboard
 if command -v pbcopy &> /dev/null; then
     echo -n "$NEW_VERSION" | pbcopy
-    echo -e "\033[36mNew version ($NEW_VERSION) copied to clipboard!\033[0m"
+    echo -e "\033[36mNew release tag ($NEW_VERSION) copied to clipboard!\033[0m"
 elif command -v xclip &> /dev/null; then
     echo -n "$NEW_VERSION" | xclip -selection clipboard
-    echo -e "\033[36mNew version ($NEW_VERSION) copied to clipboard!\033[0m"
+    echo -e "\033[36mNew release tag ($NEW_VERSION) copied to clipboard!\033[0m"
 elif command -v wl-copy &> /dev/null; then
     echo -n "$NEW_VERSION" | wl-copy
-    echo -e "\033[36mNew version ($NEW_VERSION) copied to clipboard!\033[0m"
+    echo -e "\033[36mNew release tag ($NEW_VERSION) copied to clipboard!\033[0m"
 else
     echo -e "\033[33mClipboard functionality not available (pbcopy/xclip/wl-copy not found)\033[0m"
 fi

--- a/tracecat/__init__.py
+++ b/tracecat/__init__.py
@@ -1,3 +1,4 @@
 """Tracecat is open source AI automation platform for mission critical workflows."""
 
 __version__ = "1.0.0-beta.47"
+__pep440_version__ = "1.0.0b47"


### PR DESCRIPTION
## Summary

- keep public release/image tags like `1.0.0-beta.48-rc.5` in `__version__`
- add `__pep440_version__` for Hatchling package metadata in Tracecat and registry packages
- update `scripts/update-version.sh` and `gh-prerelease` docs to map release tags to PEP 440 package versions

## Testing

- `bash -n scripts/update-version.sh`
- `shellcheck -x scripts/update-version.sh`
- dry-run mappings for alpha, beta, rc, and beta+rc prerelease tags
- `uv run hatchling version` from repo root
- `uv run hatchling version` from `packages/tracecat-registry`
- `uv run ruff check tracecat/__init__.py packages/tracecat-registry/tracecat_registry/__init__.py`
- `uv run basedpyright tracecat/__init__.py packages/tracecat-registry/tracecat_registry/__init__.py`

`shfmt` was not available locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make prerelease package versions PEP 440-compliant without changing public release/image tags. Adds `__pep440_version__` for `Hatchling` while keeping `__version__` as the public tag.

- **Bug Fixes**
  - Keep `__version__` as the public tag (e.g., `1.0.0-beta.48-rc.5`) and write PEP 440 to `__pep440_version__` (e.g., `1.0.0b48+rc.5`) in Tracecat and the registry.
  - Update `pyproject.toml` to read versions from `__pep440_version__` via `[tool.hatch.version].pattern`.
  - Revise `scripts/update-version.sh` to convert tags to PEP 440, update both version fields, and safely update release tag references across the repo.
  - Expand `.agents/skills/gh-prerelease/SKILL.md` with the new tag validation, examples, and verification steps.

<sup>Written for commit eaac2bc5ffd5e57408f0e059de3560695c750dc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

