### PR TITLE
fix(registry): compare temporary beta rc release tags

### DIFF
--- a/tests/unit/test_registry_platform_startup_versioning.py
+++ b/tests/unit/test_registry_platform_startup_versioning.py
@@ -1,0 +1,34 @@
+"""Tests for platform registry startup version comparison."""
+
+from __future__ import annotations
+
+import pytest
+
+from tracecat.db.models import PlatformRegistryVersion
+
+
+@pytest.mark.parametrize(
+    ("current_version", "target_version", "expected"),
+    [
+        ("1.0.0-beta.47", "1.0.0-beta.48-rc.6", False),
+        ("1.0.0-beta.48-rc.5", "1.0.0-beta.48-rc.6", False),
+        ("1.0.0-beta.48-rc.6", "1.0.0-beta.48-rc.5", True),
+        ("1.0.0-beta.48-rc.6", "1.0.0-beta.48", False),
+        ("1.0.0-beta.48", "1.0.0-beta.48-rc.6", True),
+    ],
+)
+def test_is_downgrade_handles_temporary_beta_rc_release_tags(
+    current_version: str,
+    target_version: str,
+    expected: bool,
+) -> None:
+    """Test downgrade checks for the temporary stacked beta/rc release format."""
+    from tracecat.registry.sync.jobs import _is_downgrade
+
+    current = PlatformRegistryVersion(
+        version=current_version,
+        manifest={"version": "1.0", "actions": {}},
+        tarball_uri="s3://test/current.tar.gz",
+    )
+
+    assert _is_downgrade(current, target_version) is expected

--- a/tracecat/registry/sync/jobs.py
+++ b/tracecat/registry/sync/jobs.py
@@ -7,8 +7,10 @@ to prevent race conditions when multiple API processes start simultaneously.
 
 from __future__ import annotations
 
+import re
+
 import tracecat_registry
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -29,13 +31,53 @@ from tracecat.registry.versions.service import PlatformRegistryVersionsService
 
 MAX_SYNC_RETRIES = 3
 PLATFORM_SYNC_LOCK_KEY = derive_lock_key_from_parts("platform_registry_sync")
+_RELEASE_TAG_PATTERN = re.compile(
+    r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
+    r"(?:-(?P<stage>alpha|a|beta|b|rc|dev|post)\.(?P<number>\d+)"
+    r"(?:-(?P<sub_stage>alpha|a|beta|b|rc|dev|post)\.(?P<sub_number>\d+))?)?$"
+)
+_STAGE_RANK = {
+    "dev": 0,
+    "alpha": 1,
+    "a": 1,
+    "beta": 2,
+    "b": 2,
+    "rc": 3,
+    "final": 4,
+    "post": 5,
+}
+
+
+def _release_tag_key(version: str) -> tuple[int, int, int, int, int, int, int]:
+    """Return a sortable key for Tracecat release/image tag versions."""
+    match = _RELEASE_TAG_PATTERN.fullmatch(version)
+    if match is None:
+        raise InvalidVersion(f"Invalid Tracecat release tag: {version!r}")
+
+    stage = match.group("stage") or "final"
+    number = int(match.group("number") or 0)
+    sub_stage = match.group("sub_stage") or "final"
+    sub_number = int(match.group("sub_number") or 0)
+
+    return (
+        int(match.group("major")),
+        int(match.group("minor")),
+        int(match.group("patch")),
+        _STAGE_RANK[stage],
+        number,
+        _STAGE_RANK[sub_stage],
+        sub_number,
+    )
 
 
 def _is_downgrade(current_version: PlatformRegistryVersion | None, target: str) -> bool:
     """Check if target version would be a downgrade from current."""
     if current_version is None:
         return False
-    return Version(target) < Version(current_version.version)
+    try:
+        return Version(target) < Version(current_version.version)
+    except InvalidVersion:
+        return _release_tag_key(target) < _release_tag_key(current_version.version)
 
 
 async def sync_platform_registry_on_startup() -> None:


### PR DESCRIPTION
## Summary
- Add a fallback comparator for Tracecat release/image tags that are not valid PEP 440 versions.
- Keep platform registry startup sync from failing on temporary stacked tags like `1.0.0-beta.48-rc.6`.
- Add regression coverage for beta/rc ordering around the beta 48 release candidates.

## Testing
- `uv run python - <<'PY' ... PY` smoke check for `_is_downgrade` beta/rc cases
- `uv run ruff check .`
- `uv run ruff format --check tracecat/registry/sync/jobs.py tests/unit/test_registry_platform_startup_versioning.py`
- `uv run basedpyright tracecat/registry/sync/jobs.py tests/unit/test_registry_platform_startup_versioning.py`

Note: `uv run pytest tests/unit/test_registry_platform_startup_versioning.py` could not run locally because the repo's autouse test fixtures require Postgres on `127.0.0.1:5432`, which was not running in this worktree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes version comparison for temporary beta/rc Tracecat tags to prevent platform registry startup failures. Adds a fallback comparator so tags like 1.0.0-beta.48-rc.6 sort correctly even if not valid PEP 440.

- **Bug Fixes**
  - Updated `_is_downgrade` to try `packaging` `Version` and fall back to a structured tag key when parsing fails.
  - Implemented stage ranking (`dev` < `alpha`/`a` < `beta`/`b` < `rc` < `final` < `post`) with nested pre-release numbers.
  - Added unit tests for beta/rc ordering around the beta.48 release candidates.

<sup>Written for commit fc005ff05320feb4db3a96b525e5386ae9ed1b86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

