### PR TITLE
fix(ui): adjust pending approvals badge styling

### DIFF
--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -368,7 +368,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                           {item.badgeCount ? (
                             <SidebarMenuBadge
                               aria-label={item.badgeLabel}
-                              className="bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-200"
+                              className="top-1/2 -translate-y-1/2 bg-violet-500/10 text-violet-700 peer-data-[size=default]/menu-button:top-1/2 peer-data-[size=lg]/menu-button:top-1/2 peer-data-[size=sm]/menu-button:top-1/2 dark:text-violet-300"
                             >
                               {formatPendingApprovalCount(item.badgeCount)}
                             </SidebarMenuBadge>


### PR DESCRIPTION
## Summary
- adjust the pending approvals sidebar badge to use the violet styling
- vertically center the badge across sidebar menu sizes

## Tests
- `uv run ruff check packages/tracecat-ee/tracecat_ee/inbox/providers/approvals.py`
- `pnpm -C frontend exec biome check src/components/sidebar/app-sidebar.tsx`
- `pnpm -C frontend run typecheck`
- pre-commit hooks during commit


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the pending approvals badge in the sidebar to use the violet theme and keep it vertically centered across all menu sizes. Improves legibility in light/dark modes and fixes misalignment.

<sup>Written for commit b3e1a83423072ce6bc9bbe94b83fb69c655a0f77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

