### PR TITLE
feat(integrations): Add Slack assistant templates

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/integrations/slack_sdk.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/slack_sdk.py
@@ -28,7 +28,7 @@ slack_secret = RegistrySecret(name="slack", keys=["SLACK_BOT_TOKEN"])
 
 @registry.register(
     default_title="Call method",
-    description="Instantiate a Slack client and call a Slack SDK method.",
+    description="Instantiate a Slack client and call a Slack SDK or Web API method.",
     display_group="Slack SDK",
     doc_url="https://docs.slack.dev/reference/methods",
     namespace="tools.slack_sdk",
@@ -39,7 +39,10 @@ async def call_method(
         str,
         Field(
             ...,
-            description="Slack Python SDK method name (e.g. `chat_postMessage`)",
+            description=(
+                "Slack Python SDK method name or Web API method name "
+                "(e.g. `chat_postMessage` or `chat.postMessage`)"
+            ),
         ),
     ],
     params: Annotated[
@@ -50,7 +53,10 @@ async def call_method(
     bot_token = secrets.get("SLACK_BOT_TOKEN")
     client = AsyncWebClient(token=bot_token)
     params = params or {}
-    result: AsyncSlackResponse = await getattr(client, sdk_method)(**params)
+    if method := getattr(client, sdk_method, None):
+        result: AsyncSlackResponse = await method(**params)
+    else:
+        result = await client.api_call(api_method=sdk_method, json=params)
     data = result.data
     return cast(dict[str, Any], data)
 

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/assistant/assistant_search_context.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/assistant/assistant_search_context.yml
@@ -1,0 +1,114 @@
+type: action
+definition:
+  title: Assistant search context
+  description: Search Slack messages, files, channels, and users for AI assistant context.
+  display_group: Slack
+  doc_url: https://docs.slack.dev/reference/methods/assistant.search.context/
+  namespace: tools.slack
+  name: assistant_search_context
+  expects:
+    query:
+      type: str
+      description: User prompt or search query.
+    action_token:
+      type: str
+      description: Action token from a Slack assistant message event.
+    channel_types:
+      type: list[str]
+      description: Slack channel types to search.
+      default: ["public_channel"]
+    content_types:
+      type: list[str]
+      description: Slack content types to include in search results.
+      default: ["messages"]
+    include_bots:
+      type: bool
+      description: Whether to include bot-authored results.
+      default: false
+    include_deleted_users:
+      type: bool
+      description: Whether to include deleted users in user search results.
+      default: false
+    before:
+      type: int | None
+      description: UNIX timestamp filter for results before this time.
+      default: null
+    after:
+      type: int | None
+      description: UNIX timestamp filter for results after this time.
+      default: null
+    include_context_messages:
+      type: bool
+      description: Whether to include context messages around message results.
+      default: false
+    context_channel_id:
+      type: str | None
+      description: Context channel ID to scope the search when applicable.
+      default: null
+    cursor:
+      type: str | None
+      description: Cursor returned by Slack for the next page of results.
+      default: null
+    limit:
+      type: int
+      description: Number of results to return, up to a maximum of 20.
+      default: 20
+    sort:
+      type: str
+      description: Field to sort results by. Supported values are score and timestamp.
+      default: score
+    sort_dir:
+      type: str
+      description: Direction to sort results by. Supported values are asc and desc.
+      default: desc
+    include_message_blocks:
+      type: bool
+      description: Whether to include message blocks in the response.
+      default: false
+    highlight:
+      type: bool
+      description: Whether to highlight the search query in results.
+      default: false
+    term_clauses:
+      type: list[str]
+      description: Term clauses that every returned search result should match.
+      default: []
+    modifiers:
+      type: str | None
+      description: Slack search modifiers, such as has:pin before:yesterday.
+      default: null
+    include_archived_channels:
+      type: bool
+      description: Whether to include archived channels in search results.
+      default: false
+    disable_semantic_search:
+      type: bool
+      description: Whether to disable semantic search and use keyword search only.
+      default: false
+  steps:
+    - ref: assistant_search_context
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: assistant.search.context
+        params:
+          query: ${{ inputs.query }}
+          action_token: ${{ inputs.action_token }}
+          channel_types: ${{ inputs.channel_types }}
+          content_types: ${{ inputs.content_types }}
+          include_bots: ${{ inputs.include_bots }}
+          include_deleted_users: ${{ inputs.include_deleted_users }}
+          before: ${{ inputs.before }}
+          after: ${{ inputs.after }}
+          include_context_messages: ${{ inputs.include_context_messages }}
+          context_channel_id: ${{ inputs.context_channel_id }}
+          cursor: ${{ inputs.cursor }}
+          limit: ${{ inputs.limit }}
+          sort: ${{ inputs.sort }}
+          sort_dir: ${{ inputs.sort_dir }}
+          include_message_blocks: ${{ inputs.include_message_blocks }}
+          highlight: ${{ inputs.highlight }}
+          term_clauses: ${{ inputs.term_clauses }}
+          modifiers: ${{ inputs.modifiers }}
+          include_archived_channels: ${{ inputs.include_archived_channels }}
+          disable_semantic_search: ${{ inputs.disable_semantic_search }}
+  returns: ${{ steps.assistant_search_context.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/assistant/assistant_search_info.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/assistant/assistant_search_info.yml
@@ -1,0 +1,16 @@
+type: action
+definition:
+  title: Assistant search info
+  description: Return Slack assistant search capabilities for the workspace.
+  display_group: Slack
+  doc_url: https://docs.slack.dev/reference/methods/assistant.search.info/
+  namespace: tools.slack
+  name: assistant_search_info
+  expects: {}
+  steps:
+    - ref: assistant_search_info
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: assistant.search.info
+        params: {}
+  returns: ${{ steps.assistant_search_info.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/assistant/set_assistant_thread_status.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/assistant/set_assistant_thread_status.yml
@@ -1,0 +1,48 @@
+type: action
+definition:
+  title: Set assistant thread status
+  description: Set the status for a Slack AI assistant thread.
+  display_group: Slack
+  doc_url: https://docs.slack.dev/reference/methods/assistant.threads.setStatus/
+  namespace: tools.slack
+  name: set_assistant_thread_status
+  expects:
+    channel_id:
+      type: str
+      description: Channel ID containing the assistant thread.
+    thread_ts:
+      type: str
+      description: Message timestamp of the assistant thread.
+    status:
+      type: str
+      description: Status to display for the bot user. Use an empty string to clear it.
+    loading_messages:
+      type: list[str]
+      description: Loading indicator messages to rotate through, up to 10 messages.
+      default: []
+    icon_emoji:
+      type: str | None
+      description: Emoji to use as the icon for this message.
+      default: null
+    icon_url:
+      type: str | None
+      description: Image URL to use as the icon for this message.
+      default: null
+    username:
+      type: str | None
+      description: Bot username to display.
+      default: null
+  steps:
+    - ref: set_assistant_thread_status
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: assistant.threads.setStatus
+        params:
+          channel_id: ${{ inputs.channel_id }}
+          thread_ts: ${{ inputs.thread_ts }}
+          status: ${{ inputs.status }}
+          loading_messages: ${{ inputs.loading_messages }}
+          icon_emoji: ${{ inputs.icon_emoji }}
+          icon_url: ${{ inputs.icon_url }}
+          username: ${{ inputs.username }}
+  returns: ${{ steps.set_assistant_thread_status.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/assistant/set_assistant_thread_suggested_prompts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/assistant/set_assistant_thread_suggested_prompts.yml
@@ -1,0 +1,33 @@
+type: action
+definition:
+  title: Set assistant thread suggested prompts
+  description: Set suggested prompts for a Slack AI assistant thread.
+  display_group: Slack
+  doc_url: https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts/
+  namespace: tools.slack
+  name: set_assistant_thread_suggested_prompts
+  expects:
+    channel_id:
+      type: str
+      description: Channel ID containing the assistant thread.
+    thread_ts:
+      type: str
+      description: Message timestamp of the assistant thread.
+    prompts:
+      type: list[dict[str, str]]
+      description: Suggested prompts, each with title and message attributes.
+    title:
+      type: str | None
+      description: Optional title for the suggested prompts list.
+      default: null
+  steps:
+    - ref: set_assistant_thread_suggested_prompts
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: assistant.threads.setSuggestedPrompts
+        params:
+          channel_id: ${{ inputs.channel_id }}
+          thread_ts: ${{ inputs.thread_ts }}
+          prompts: ${{ inputs.prompts }}
+          title: ${{ inputs.title }}
+  returns: ${{ steps.set_assistant_thread_suggested_prompts.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/assistant/set_assistant_thread_title.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/assistant/set_assistant_thread_title.yml
@@ -1,0 +1,28 @@
+type: action
+definition:
+  title: Set assistant thread title
+  description: Set the title for a Slack AI assistant thread.
+  display_group: Slack
+  doc_url: https://docs.slack.dev/reference/methods/assistant.threads.setTitle/
+  namespace: tools.slack
+  name: set_assistant_thread_title
+  expects:
+    channel_id:
+      type: str
+      description: Channel ID containing the assistant thread.
+    thread_ts:
+      type: str
+      description: Message timestamp of the assistant thread.
+    title:
+      type: str
+      description: Title to use for the assistant thread.
+  steps:
+    - ref: set_assistant_thread_title
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: assistant.threads.setTitle
+        params:
+          channel_id: ${{ inputs.channel_id }}
+          thread_ts: ${{ inputs.thread_ts }}
+          title: ${{ inputs.title }}
+  returns: ${{ steps.set_assistant_thread_title.result }}

--- a/tests/registry/test_slack_sdk.py
+++ b/tests/registry/test_slack_sdk.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from tracecat_registry.integrations import slack_sdk
+
+
+@pytest.mark.anyio
+async def test_call_method_uses_sdk_method_when_available(monkeypatch) -> None:
+    client = SimpleNamespace(
+        chat_postMessage=AsyncMock(return_value=SimpleNamespace(data={"ok": True})),
+        api_call=AsyncMock(),
+    )
+
+    monkeypatch.setattr(slack_sdk.secrets, "get", lambda _key: "xoxb-token")
+    monkeypatch.setattr(slack_sdk, "AsyncWebClient", lambda token: client)
+
+    result = await slack_sdk.call_method(
+        sdk_method="chat_postMessage",
+        params={"channel": "C123", "text": "hello"},
+    )
+
+    assert result == {"ok": True}
+    client.chat_postMessage.assert_awaited_once_with(channel="C123", text="hello")
+    client.api_call.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_call_method_falls_back_to_raw_web_api_method(monkeypatch) -> None:
+    client = SimpleNamespace(
+        api_call=AsyncMock(return_value=SimpleNamespace(data={"ok": True})),
+    )
+
+    monkeypatch.setattr(slack_sdk.secrets, "get", lambda _key: "xoxb-token")
+    monkeypatch.setattr(slack_sdk, "AsyncWebClient", lambda token: client)
+
+    result = await slack_sdk.call_method(
+        sdk_method="assistant.threads.setStatus",
+        params={
+            "channel_id": "C123",
+            "thread_ts": "1700000000.001",
+            "status": "is thinking...",
+        },
+    )
+
+    assert result == {"ok": True}
+    client.api_call.assert_awaited_once_with(
+        api_method="assistant.threads.setStatus",
+        json={
+            "channel_id": "C123",
+            "thread_ts": "1700000000.001",
+            "status": "is thinking...",
+        },
+    )


### PR DESCRIPTION
## Summary

- Adds Slack assistant registry templates for the assistant search and assistant thread Web API methods.
- Extends `tools.slack_sdk.call_method` to fall back to raw dotted Slack Web API method names when the installed Slack SDK does not expose a generated helper.
- Adds regression coverage for both generated SDK method calls and raw Web API fallback calls.

## Validation

- `uv run pytest tests/registry/test_templates.py -q` -> 349 passed
- `uv run pytest tests/registry/test_slack_sdk.py -q` -> 2 passed
- `uv run ruff check packages/tracecat-registry/tracecat_registry/integrations/slack_sdk.py tests/registry/test_slack_sdk.py`
- `uv run ruff format --check packages/tracecat-registry/tracecat_registry/integrations/slack_sdk.py tests/registry/test_slack_sdk.py`
- `uv run basedpyright packages/tracecat-registry/tracecat_registry/integrations/slack_sdk.py tests/registry/test_slack_sdk.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Slack assistant templates and updates `tools.slack_sdk.call_method` to support dotted Web API methods via fallback to `api_call`. This enables assistant search and thread management even when the Slack SDK lacks generated helpers.

- **New Features**
  - Added Slack assistant templates: `assistant.search.context`, `assistant.search.info`, `assistant.threads.setStatus`, `assistant.threads.setTitle`, and `assistant.threads.setSuggestedPrompts`.
  - Extended `tools.slack_sdk.call_method` to call either SDK helpers (e.g., `chat_postMessage`) or raw methods (e.g., `assistant.threads.setStatus`) using `client.api_call` when needed, with tests covering both paths.

<sup>Written for commit f411ab7b16a774795edb3372d151a0ee489e5f4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

