### PR TITLE
feat(agents): test bedrock connection

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5505,18 +5505,6 @@ export const $BedrockCatalogTest = {
       title: "Use Converse",
       default: true,
     },
-    workspace_id: {
-      anyOf: [
-        {
-          type: "string",
-          format: "uuid",
-        },
-        {
-          type: "null",
-        },
-      ],
-      title: "Workspace Id",
-    },
   },
   additionalProperties: false,
   type: "object",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5458,7 +5458,7 @@ export const $BedrockCatalogCreate = {
     use_converse: {
       type: "boolean",
       title: "Use Converse",
-      default: true,
+      default: false,
     },
   },
   additionalProperties: false,
@@ -5503,7 +5503,7 @@ export const $BedrockCatalogTest = {
     use_converse: {
       type: "boolean",
       title: "Use Converse",
-      default: true,
+      default: false,
     },
   },
   additionalProperties: false,
@@ -5538,9 +5538,14 @@ export const $BedrockCatalogTestResponse = {
       description: "Error message if verification failed",
     },
     details: {
-      additionalProperties: true,
-      type: "object",
-      title: "Details",
+      anyOf: [
+        {
+          $ref: "#/components/schemas/BedrockVerificationDetails",
+        },
+        {
+          type: "null",
+        },
+      ],
       description:
         "Non-sensitive provider details returned during verification",
     },
@@ -5596,13 +5601,78 @@ export const $BedrockCatalogUpdate = {
     use_converse: {
       type: "boolean",
       title: "Use Converse",
-      default: true,
+      default: false,
     },
   },
   additionalProperties: false,
   type: "object",
   required: ["model_provider"],
   title: "BedrockCatalogUpdate",
+} as const
+
+export const $BedrockInferenceProfileDetails = {
+  properties: {
+    target_type: {
+      type: "string",
+      const: "inference_profile",
+      title: "Target Type",
+    },
+    model_count: {
+      type: "integer",
+      title: "Model Count",
+    },
+    status: {
+      type: "string",
+      title: "Status",
+    },
+    inference_profile_id: {
+      type: "string",
+      title: "Inference Profile Id",
+    },
+    inference_profile_arn: {
+      type: "string",
+      title: "Inference Profile Arn",
+    },
+  },
+  type: "object",
+  required: ["target_type", "model_count"],
+  title: "BedrockInferenceProfileDetails",
+} as const
+
+export const $BedrockModelAvailabilityDetails = {
+  properties: {
+    target_type: {
+      type: "string",
+      const: "model_id",
+      title: "Target Type",
+    },
+    authorization_status: {
+      type: "string",
+      title: "Authorization Status",
+    },
+    entitlement_availability: {
+      type: "string",
+      title: "Entitlement Availability",
+    },
+    region_availability: {
+      type: "string",
+      title: "Region Availability",
+    },
+  },
+  type: "object",
+  required: ["target_type"],
+  title: "BedrockModelAvailabilityDetails",
+} as const
+
+export const $BedrockVerificationDetails = {
+  anyOf: [
+    {
+      $ref: "#/components/schemas/BedrockInferenceProfileDetails",
+    },
+    {
+      $ref: "#/components/schemas/BedrockModelAvailabilityDetails",
+    },
+  ],
 } as const
 
 export const $BinaryContent = {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -5458,7 +5458,7 @@ export const $BedrockCatalogCreate = {
     use_converse: {
       type: "boolean",
       title: "Use Converse",
-      default: false,
+      default: true,
     },
   },
   additionalProperties: false,
@@ -5467,6 +5467,100 @@ export const $BedrockCatalogCreate = {
   title: "BedrockCatalogCreate",
   description:
     "Bedrock catalog entry. Requires exactly one of inference_profile_id or model_id.",
+} as const
+
+export const $BedrockCatalogTest = {
+  properties: {
+    model_provider: {
+      type: "string",
+      const: "bedrock",
+      title: "Model Provider",
+    },
+    inference_profile_id: {
+      anyOf: [
+        {
+          type: "string",
+          minLength: 1,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Inference Profile Id",
+    },
+    model_id: {
+      anyOf: [
+        {
+          type: "string",
+          minLength: 1,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Model Id",
+    },
+    use_converse: {
+      type: "boolean",
+      title: "Use Converse",
+      default: true,
+    },
+    workspace_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Workspace Id",
+    },
+  },
+  additionalProperties: false,
+  type: "object",
+  required: ["model_provider"],
+  title: "BedrockCatalogTest",
+  description: "Request to verify an unsaved Bedrock catalog target.",
+} as const
+
+export const $BedrockCatalogTestResponse = {
+  properties: {
+    success: {
+      type: "boolean",
+      title: "Success",
+      description: "Whether the Bedrock target verification succeeded",
+    },
+    message: {
+      type: "string",
+      title: "Message",
+      description: "Message describing the verification result",
+    },
+    error: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Error",
+      description: "Error message if verification failed",
+    },
+    details: {
+      additionalProperties: true,
+      type: "object",
+      title: "Details",
+      description:
+        "Non-sensitive provider details returned during verification",
+    },
+  },
+  type: "object",
+  required: ["success", "message"],
+  title: "BedrockCatalogTestResponse",
+  description: "Response for Bedrock catalog target verification.",
 } as const
 
 export const $BedrockCatalogUpdate = {
@@ -5514,7 +5608,7 @@ export const $BedrockCatalogUpdate = {
     use_converse: {
       type: "boolean",
       title: "Use Converse",
-      default: false,
+      default: true,
     },
   },
   additionalProperties: false,

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -718,6 +718,8 @@ import type {
   TagsListTagsResponse,
   TagsUpdateTagData,
   TagsUpdateTagResponse,
+  TestBedrockCatalogTargetData,
+  TestBedrockCatalogTargetResponse,
   TriggersCreateCaseTriggerData,
   TriggersCreateCaseTriggerResponse,
   TriggersCreateWebhookData,
@@ -4820,6 +4822,28 @@ export const createCatalogEntry = (
   return __request(OpenAPI, {
     method: "POST",
     url: "/organization/agent-catalog",
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Test Bedrock Catalog Target
+ * Verify an unsaved Bedrock catalog target.
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns BedrockCatalogTestResponse Successful Response
+ * @throws ApiError
+ */
+export const testBedrockCatalogTarget = (
+  data: TestBedrockCatalogTargetData
+): CancelablePromise<TestBedrockCatalogTargetResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/organization/agent-catalog/bedrock/test",
     body: data.requestBody,
     mediaType: "application/json",
     errors: {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1396,7 +1396,6 @@ export type BedrockCatalogTest = {
   inference_profile_id?: string | null
   model_id?: string | null
   use_converse?: boolean
-  workspace_id?: string | null
 }
 
 /**

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1388,6 +1388,41 @@ export type BedrockCatalogCreate = {
   use_converse?: boolean
 }
 
+/**
+ * Request to verify an unsaved Bedrock catalog target.
+ */
+export type BedrockCatalogTest = {
+  model_provider: "bedrock"
+  inference_profile_id?: string | null
+  model_id?: string | null
+  use_converse?: boolean
+  workspace_id?: string | null
+}
+
+/**
+ * Response for Bedrock catalog target verification.
+ */
+export type BedrockCatalogTestResponse = {
+  /**
+   * Whether the Bedrock target verification succeeded
+   */
+  success: boolean
+  /**
+   * Message describing the verification result
+   */
+  message: string
+  /**
+   * Error message if verification failed
+   */
+  error?: string | null
+  /**
+   * Non-sensitive provider details returned during verification
+   */
+  details?: {
+    [key: string]: unknown
+  }
+}
+
 export type BedrockCatalogUpdate = {
   display_name?: string | null
   model_provider: "bedrock"
@@ -10178,6 +10213,12 @@ export type CreateCatalogEntryData = {
 
 export type CreateCatalogEntryResponse = AgentCatalogRead
 
+export type TestBedrockCatalogTargetData = {
+  requestBody: BedrockCatalogTest
+}
+
+export type TestBedrockCatalogTargetResponse = BedrockCatalogTestResponse
+
 export type GetCatalogEntryData = {
   catalogId: string
 }
@@ -14751,6 +14792,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         201: AgentCatalogRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/organization/agent-catalog/bedrock/test": {
+    post: {
+      req: TestBedrockCatalogTargetData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: BedrockCatalogTestResponse
         /**
          * Validation Error
          */

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1417,9 +1417,7 @@ export type BedrockCatalogTestResponse = {
   /**
    * Non-sensitive provider details returned during verification
    */
-  details?: {
-    [key: string]: unknown
-  }
+  details?: BedrockVerificationDetails | null
 }
 
 export type BedrockCatalogUpdate = {
@@ -1429,6 +1427,25 @@ export type BedrockCatalogUpdate = {
   model_id?: string | null
   use_converse?: boolean
 }
+
+export type BedrockInferenceProfileDetails = {
+  target_type: "inference_profile"
+  model_count: number
+  status?: string
+  inference_profile_id?: string
+  inference_profile_arn?: string
+}
+
+export type BedrockModelAvailabilityDetails = {
+  target_type: "model_id"
+  authorization_status?: string
+  entitlement_availability?: string
+  region_availability?: string
+}
+
+export type BedrockVerificationDetails =
+  | BedrockInferenceProfileDetails
+  | BedrockModelAvailabilityDetails
 
 /**
  * Binary content, e.g. an audio or image file.

--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -27,6 +27,7 @@ import {
   listCustomProviders,
   listEnabledModels,
   refreshCustomProviderCatalog,
+  testBedrockCatalogTarget,
   updateCatalogEntry,
   updateCustomProvider,
   type VertexAICatalogCreate,
@@ -187,7 +188,7 @@ const bedrockCloudModelSchema = z.object({
   display_name: z.string().trim().optional(),
   inference_profile_id: z.string().trim().optional(),
   model_id: z.string().trim().optional(),
-  use_converse: z.boolean().default(false),
+  use_converse: z.boolean().default(true),
 })
 
 const azureOpenAICloudModelSchema = z.object({
@@ -272,7 +273,7 @@ function buildCloudCatalogDefaults(
           "inference_profile_id"
         ),
         model_id: getCatalogMetadataString(metadata, "model_id"),
-        use_converse: metadata?.use_converse === true,
+        use_converse: entry ? metadata?.use_converse === true : true,
       }
     case "azure_openai":
       return {
@@ -344,6 +345,19 @@ function buildCatalogCreatePayload(
       throw new Error(
         `Unsupported cloud provider: ${(values as { provider: string }).provider}`
       )
+  }
+}
+
+function buildBedrockCatalogTestPayload(values: CloudCatalogModelFormValues) {
+  if (values.provider !== "bedrock") {
+    throw new Error("Bedrock verification requires a Bedrock model.")
+  }
+  return {
+    model_provider: "bedrock" as const,
+    inference_profile_id: values.inference_profile_id || null,
+    model_id: values.model_id || null,
+    use_converse: values.use_converse,
+    workspace_id: Cookies.get("__tracecat:workspaces:last-viewed") || null,
   }
 }
 
@@ -1662,6 +1676,31 @@ function CloudCatalogModelDialog({
       })
     },
   })
+  const verifyMutation = useMutation({
+    mutationFn: async (values: CloudCatalogModelFormValues) =>
+      await testBedrockCatalogTarget({
+        requestBody: buildBedrockCatalogTestPayload(values),
+      }),
+    onSuccess: (result) => {
+      if (result.success) {
+        toast({
+          title: "Model verified",
+          description: result.message,
+        })
+        return
+      }
+      toast({
+        title: "Verification failed",
+        description: result.error || result.message,
+      })
+    },
+    onError: (error: ApiError) => {
+      toast({
+        title: "Verification failed",
+        description: getApiErrorDetail(error) ?? "Unable to verify the model.",
+      })
+    },
+  })
 
   async function handleSubmit(values: CloudCatalogModelFormValues) {
     await saveMutation.mutateAsync(values)
@@ -1673,6 +1712,11 @@ function CloudCatalogModelDialog({
 
   const label = getCloudProviderLabel(provider)
   const isEdit = entry !== null
+  const inferenceProfileId = form.watch("inference_profile_id") ?? ""
+  const modelId = form.watch("model_id") ?? ""
+  const canVerifyBedrock =
+    provider === "bedrock" &&
+    Boolean(inferenceProfileId.trim()) !== Boolean(modelId.trim())
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -1854,16 +1898,30 @@ function CloudCatalogModelDialog({
               />
             ) : null}
 
-            <DialogFooter>
+            <DialogFooter className="gap-2 sm:gap-0">
+              {provider === "bedrock" ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={
+                    !canVerifyBedrock ||
+                    verifyMutation.isPending ||
+                    saveMutation.isPending
+                  }
+                  onClick={() => {
+                    verifyMutation.mutate(form.getValues())
+                  }}
+                >
+                  {verifyMutation.isPending ? (
+                    <Loader2 className="mr-2 size-4 animate-spin" />
+                  ) : null}
+                  Test connection
+                </Button>
+              ) : null}
               <Button
-                type="button"
-                variant="outline"
-                disabled={saveMutation.isPending}
-                onClick={() => onOpenChange(false)}
+                type="submit"
+                disabled={saveMutation.isPending || verifyMutation.isPending}
               >
-                Cancel
-              </Button>
-              <Button type="submit" disabled={saveMutation.isPending}>
                 {saveMutation.isPending ? (
                   <Loader2 className="mr-2 size-4 animate-spin" />
                 ) : null}

--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -188,7 +188,7 @@ const bedrockCloudModelSchema = z.object({
   display_name: z.string().trim().optional(),
   inference_profile_id: z.string().trim().optional(),
   model_id: z.string().trim().optional(),
-  use_converse: z.boolean().default(true),
+  use_converse: z.boolean().default(false),
 })
 
 const azureOpenAICloudModelSchema = z.object({
@@ -273,7 +273,7 @@ function buildCloudCatalogDefaults(
           "inference_profile_id"
         ),
         model_id: getCatalogMetadataString(metadata, "model_id"),
-        use_converse: entry ? metadata?.use_converse === true : true,
+        use_converse: entry ? metadata?.use_converse === true : false,
       }
     case "azure_openai":
       return {

--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -32,7 +32,6 @@ import {
   updateCustomProvider,
   type VertexAICatalogCreate,
   validateCustomProviderConnection,
-  workspacesListWorkspaces,
 } from "@/client"
 import { ProviderIcon } from "@/components/icons"
 import { CenteredSpinner } from "@/components/loading/spinner"
@@ -349,10 +348,7 @@ function buildCatalogCreatePayload(
   }
 }
 
-function buildBedrockCatalogTestPayload(
-  values: CloudCatalogModelFormValues,
-  workspaceId: string | null
-) {
+function buildBedrockCatalogTestPayload(values: CloudCatalogModelFormValues) {
   if (values.provider !== "bedrock") {
     throw new Error("Bedrock verification requires a Bedrock model.")
   }
@@ -361,7 +357,6 @@ function buildBedrockCatalogTestPayload(
     inference_profile_id: values.inference_profile_id?.trim() || null,
     model_id: values.model_id?.trim() || null,
     use_converse: values.use_converse,
-    workspace_id: workspaceId,
   }
 }
 
@@ -1634,13 +1629,6 @@ function CloudCatalogModelDialog({
 }: CloudCatalogModelDialogProps) {
   const queryClient = useQueryClient()
   const activeProvider = provider ?? "bedrock"
-  const { data: workspaces } = useQuery({
-    queryKey: ["workspaces"],
-    queryFn: async () => await workspacesListWorkspaces(),
-    staleTime: 5 * 60 * 1000,
-    retry: retryHandler,
-  })
-  const firstWorkspaceId = workspaces?.[0]?.id ?? null
   const form = useForm<CloudCatalogModelFormValues>({
     resolver: zodResolver(cloudCatalogModelSchema),
     mode: "onBlur",
@@ -1690,7 +1678,7 @@ function CloudCatalogModelDialog({
   const verifyMutation = useMutation({
     mutationFn: async (values: CloudCatalogModelFormValues) =>
       await testBedrockCatalogTarget({
-        requestBody: buildBedrockCatalogTestPayload(values, firstWorkspaceId),
+        requestBody: buildBedrockCatalogTestPayload(values),
       }),
     onSuccess: (result) => {
       if (result.success) {

--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -32,6 +32,7 @@ import {
   updateCustomProvider,
   type VertexAICatalogCreate,
   validateCustomProviderConnection,
+  workspacesListWorkspaces,
 } from "@/client"
 import { ProviderIcon } from "@/components/icons"
 import { CenteredSpinner } from "@/components/loading/spinner"
@@ -348,16 +349,19 @@ function buildCatalogCreatePayload(
   }
 }
 
-function buildBedrockCatalogTestPayload(values: CloudCatalogModelFormValues) {
+function buildBedrockCatalogTestPayload(
+  values: CloudCatalogModelFormValues,
+  workspaceId: string | null
+) {
   if (values.provider !== "bedrock") {
     throw new Error("Bedrock verification requires a Bedrock model.")
   }
   return {
     model_provider: "bedrock" as const,
-    inference_profile_id: values.inference_profile_id || null,
-    model_id: values.model_id || null,
+    inference_profile_id: values.inference_profile_id?.trim() || null,
+    model_id: values.model_id?.trim() || null,
     use_converse: values.use_converse,
-    workspace_id: Cookies.get("__tracecat:workspaces:last-viewed") || null,
+    workspace_id: workspaceId,
   }
 }
 
@@ -1630,6 +1634,13 @@ function CloudCatalogModelDialog({
 }: CloudCatalogModelDialogProps) {
   const queryClient = useQueryClient()
   const activeProvider = provider ?? "bedrock"
+  const { data: workspaces } = useQuery({
+    queryKey: ["workspaces"],
+    queryFn: async () => await workspacesListWorkspaces(),
+    staleTime: 5 * 60 * 1000,
+    retry: retryHandler,
+  })
+  const firstWorkspaceId = workspaces?.[0]?.id ?? null
   const form = useForm<CloudCatalogModelFormValues>({
     resolver: zodResolver(cloudCatalogModelSchema),
     mode: "onBlur",
@@ -1679,7 +1690,7 @@ function CloudCatalogModelDialog({
   const verifyMutation = useMutation({
     mutationFn: async (values: CloudCatalogModelFormValues) =>
       await testBedrockCatalogTarget({
-        requestBody: buildBedrockCatalogTestPayload(values),
+        requestBody: buildBedrockCatalogTestPayload(values, firstWorkspaceId),
       }),
     onSuccess: (result) => {
       if (result.success) {

--- a/tests/unit/test_agent_catalog_service.py
+++ b/tests/unit/test_agent_catalog_service.py
@@ -644,20 +644,20 @@ def test_bedrock_update_rejects_both_refs_explicitly_null() -> None:
         )
 
 
-def test_bedrock_create_defaults_to_converse() -> None:
+def test_bedrock_create_defaults_to_non_converse() -> None:
     create = BedrockCatalogCreate(
         model_provider="bedrock",
         model_name="claude-sonnet",
         inference_profile_id="us.anthropic.claude-sonnet-4",
     )
 
-    assert create.use_converse is True
+    assert create.use_converse is False
 
 
-def test_bedrock_test_defaults_to_converse() -> None:
+def test_bedrock_test_defaults_to_non_converse() -> None:
     request = BedrockCatalogTest(
         model_provider="bedrock",
         inference_profile_id="us.anthropic.claude-sonnet-4",
     )
 
-    assert request.use_converse is True
+    assert request.use_converse is False

--- a/tests/unit/test_agent_catalog_service.py
+++ b/tests/unit/test_agent_catalog_service.py
@@ -10,6 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.catalog.schemas import (
     AzureOpenAICatalogUpdate,
+    BedrockCatalogCreate,
+    BedrockCatalogTest,
     BedrockCatalogUpdate,
 )
 from tracecat.agent.catalog.service import AgentCatalogService
@@ -640,3 +642,22 @@ def test_bedrock_update_rejects_both_refs_explicitly_null() -> None:
             inference_profile_id=None,
             model_id=None,
         )
+
+
+def test_bedrock_create_defaults_to_converse() -> None:
+    create = BedrockCatalogCreate(
+        model_provider="bedrock",
+        model_name="claude-sonnet",
+        inference_profile_id="us.anthropic.claude-sonnet-4",
+    )
+
+    assert create.use_converse is True
+
+
+def test_bedrock_test_defaults_to_converse() -> None:
+    request = BedrockCatalogTest(
+        model_provider="bedrock",
+        inference_profile_id="us.anthropic.claude-sonnet-4",
+    )
+
+    assert request.use_converse is True

--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -166,7 +166,7 @@ async def test_bedrock_role_credentials_require_external_id() -> None:
         )
 
     assert exc_info.value.code == "400"
-    assert "workspace External ID" in exc_info.value.message
+    assert "AWS External ID" in exc_info.value.message
 
 
 def test_bedrock_rejects_ambient_credential_fallback() -> None:

--- a/tests/unit/test_agent_management_service.py
+++ b/tests/unit/test_agent_management_service.py
@@ -28,7 +28,10 @@ from tracecat.db.models import (
     OrganizationSecret,
     Workspace,
 )
-from tracecat.integrations.aws_assume_role import build_workspace_external_id
+from tracecat.integrations.aws_assume_role import (
+    build_organization_external_id,
+    build_workspace_external_id,
+)
 from tracecat.secrets import secrets_manager
 from tracecat.secrets.encryption import encrypt_keyvalues
 from tracecat.secrets.enums import SecretType
@@ -249,6 +252,57 @@ async def test_get_catalog_credentials_uses_live_cloud_secret_with_catalog_metad
     assert credentials["AWS_ACCESS_KEY_ID"] == "live-key"
     assert credentials["AWS_SECRET_ACCESS_KEY"] == "live-secret"
     assert credentials["AWS_INFERENCE_PROFILE_ID"] == "metadata-target"
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("db")
+async def test_get_catalog_credentials_injects_bedrock_org_external_id(
+    session: AsyncSession,
+    svc_organization: Organization,
+    svc_workspace: Workspace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    encryption_key = Fernet.generate_key().decode()
+    monkeypatch.setattr(
+        tracecat_config,
+        "TRACECAT__DB_ENCRYPTION_KEY",
+        encryption_key,
+    )
+    catalog = await _seed_catalog(
+        session,
+        org_id=svc_organization.id,
+        provider="bedrock",
+        model_name="Claude Sonnet",
+        metadata={"inference_profile_id": "metadata-target"},
+    )
+    await _grant_access(
+        session,
+        org_id=svc_organization.id,
+        catalog_id=catalog.id,
+    )
+    await _seed_org_secret(
+        session,
+        org_id=svc_organization.id,
+        name="agent-bedrock-credentials",
+        values={
+            "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/customer-role",
+            "AWS_REGION": "us-east-1",
+        },
+        encryption_key=encryption_key,
+    )
+    await session.commit()
+
+    service = AgentManagementService(
+        session=session,
+        role=_db_role(svc_organization, svc_workspace),
+    )
+
+    credentials = await service.get_catalog_credentials(catalog.id)
+
+    assert credentials is not None
+    assert credentials["TRACECAT_AWS_EXTERNAL_ID"] == build_organization_external_id(
+        svc_organization.id
+    )
 
 
 @pytest.mark.anyio
@@ -718,7 +772,7 @@ async def test_list_providers_excludes_removed_litellm_provider(role: Role) -> N
 
 
 @pytest.mark.anyio
-async def test_get_runtime_provider_credentials_injects_bedrock_external_id(
+async def test_get_runtime_provider_credentials_injects_bedrock_org_external_id(
     role: Role,
 ) -> None:
     service = AgentManagementService(AsyncMock(), role=role)
@@ -729,9 +783,31 @@ async def test_get_runtime_provider_credentials_injects_bedrock_external_id(
             "AWS_INFERENCE_PROFILE_ID": "us.anthropic.claude-sonnet-4-20250514-v1:0",
         }
     )
-    assert role.workspace_id is not None
+    assert role.organization_id is not None
 
     credentials = await service.get_runtime_provider_credentials("bedrock")
+
+    assert credentials is not None
+    assert credentials["TRACECAT_AWS_EXTERNAL_ID"] == build_organization_external_id(
+        role.organization_id
+    )
+
+
+@pytest.mark.anyio
+async def test_get_workspace_runtime_provider_credentials_injects_bedrock_workspace_external_id(
+    role: Role,
+) -> None:
+    service = AgentManagementService(AsyncMock(), role=role)
+    service.get_workspace_provider_credentials = AsyncMock(
+        return_value={
+            "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/customer-role",
+            "AWS_REGION": "us-east-1",
+            "AWS_INFERENCE_PROFILE_ID": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+        }
+    )
+    assert role.workspace_id is not None
+
+    credentials = await service.get_workspace_runtime_provider_credentials("bedrock")
 
     assert credentials is not None
     assert credentials["TRACECAT_AWS_EXTERNAL_ID"] == build_workspace_external_id(
@@ -742,8 +818,8 @@ async def test_get_runtime_provider_credentials_injects_bedrock_external_id(
 @pytest.mark.anyio
 async def test_with_model_config_injects_bedrock_external_id(role: Role) -> None:
     service = AgentManagementService(AsyncMock(), role=role)
-    assert role.workspace_id is not None
-    external_id = build_workspace_external_id(role.workspace_id)
+    assert role.organization_id is not None
+    external_id = build_organization_external_id(role.organization_id)
     catalog_id = uuid.uuid4()
     service._get_default_model_catalog_id_setting = AsyncMock(return_value=catalog_id)
     service._get_default_model_name_setting = AsyncMock(

--- a/tests/unit/test_bedrock_catalog_validation.py
+++ b/tests/unit/test_bedrock_catalog_validation.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
+import orjson
 import pytest
 
 from tracecat.agent.catalog import bedrock_validation
@@ -47,14 +48,14 @@ async def test_verify_bedrock_catalog_target_uses_static_credentials(
 ) -> None:
     captured: dict[str, Any] = {}
 
-    def fake_verify_with_boto3(**kwargs: Any) -> dict[str, Any]:
+    async def fake_verify_with_aws_credentials(**kwargs: Any) -> dict[str, Any]:
         captured.update(kwargs)
-        return {"runtime_test": "converse"}
+        return {"target_type": "inference_profile", "model_count": 1}
 
     monkeypatch.setattr(
         bedrock_validation,
-        "_verify_with_boto3",
-        fake_verify_with_boto3,
+        "_verify_with_aws_credentials",
+        fake_verify_with_aws_credentials,
     )
 
     details = await verify_bedrock_catalog_target(
@@ -68,10 +69,53 @@ async def test_verify_bedrock_catalog_target_uses_static_credentials(
         use_converse=True,
     )
 
-    assert details == {"runtime_test": "converse"}
+    assert details == {"target_type": "inference_profile", "model_count": 1}
     assert captured["region"] == "us-east-1"
     assert captured["target_id"] == "us.anthropic.claude-sonnet-4"
     assert captured["is_inference_profile"] is True
+
+
+@pytest.mark.anyio
+async def test_verify_bedrock_catalog_target_preserves_static_auth_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_verify_with_aws_credentials(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {"target_type": "model_id"}
+
+    async def fake_verify_with_api_key(**_: Any) -> dict[str, Any]:
+        pytest.fail("Bearer token auth should not be used when static keys are set")
+
+    monkeypatch.setattr(
+        bedrock_validation,
+        "_verify_with_aws_credentials",
+        fake_verify_with_aws_credentials,
+    )
+    monkeypatch.setattr(
+        bedrock_validation,
+        "_verify_with_api_key",
+        fake_verify_with_api_key,
+    )
+
+    details = await verify_bedrock_catalog_target(
+        credentials={
+            "AWS_ACCESS_KEY_ID": "access-key",
+            "AWS_SECRET_ACCESS_KEY": "secret-key",
+            "AWS_BEARER_TOKEN_BEDROCK": "stale-bedrock-api-key",
+            "AWS_REGION": "us-east-1",
+        },
+        inference_profile_id=None,
+        model_id="anthropic.claude-3-haiku-20240307-v1:0",
+        use_converse=True,
+    )
+
+    assert details == {"target_type": "model_id"}
+    assert captured["credentials"]["AWS_ACCESS_KEY_ID"] == "access-key"
+    assert captured["credentials"]["AWS_BEARER_TOKEN_BEDROCK"] == (
+        "stale-bedrock-api-key"
+    )
 
 
 @pytest.mark.anyio
@@ -82,7 +126,7 @@ async def test_verify_bedrock_catalog_target_uses_api_key(
 
     async def fake_verify_with_api_key(**kwargs: Any) -> dict[str, Any]:
         captured.update(kwargs)
-        return {"runtime_test": "converse"}
+        return {"target_type": "model_id"}
 
     monkeypatch.setattr(
         bedrock_validation,
@@ -100,10 +144,136 @@ async def test_verify_bedrock_catalog_target_uses_api_key(
         use_converse=True,
     )
 
-    assert details == {"runtime_test": "converse"}
+    assert details == {"target_type": "model_id"}
     assert captured["api_key"] == "bedrock-api-key"
     assert captured["target_id"] == "anthropic.claude-3-haiku-20240307-v1:0"
     assert captured["is_inference_profile"] is False
+
+
+@pytest.mark.anyio
+async def test_verify_with_sdk_clients_uses_invoke_model_when_not_converse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    captured_invoke: dict[str, Any] = {}
+
+    class FakeBedrockControlClient:
+        async def get_foundation_model_availability(
+            self,
+            *,
+            modelId: str,
+        ) -> dict[str, str]:
+            return {
+                "authorizationStatus": "AUTHORIZED",
+                "entitlementAvailability": "AVAILABLE",
+                "regionAvailability": "AVAILABLE",
+            }
+
+    class FakeBedrockRuntimeClient:
+        async def invoke_model(self, **kwargs: Any) -> object:
+            captured_invoke.update(kwargs)
+            return {}
+
+    class FakeClientContext:
+        def __init__(self, client: object) -> None:
+            self.client = client
+
+        async def __aenter__(self) -> object:
+            return self.client
+
+        async def __aexit__(self, *_: object) -> None:
+            return None
+
+    def fake_client_context(
+        _session: object,
+        service_name: str,
+        **_: object,
+    ) -> FakeClientContext:
+        calls.append(service_name)
+        if service_name == "bedrock":
+            return FakeClientContext(FakeBedrockControlClient())
+        if service_name == "bedrock-runtime":
+            return FakeClientContext(FakeBedrockRuntimeClient())
+        pytest.fail(f"Unexpected service {service_name}")
+
+    monkeypatch.setattr(bedrock_validation, "_client_context", fake_client_context)
+
+    details = await bedrock_validation._verify_with_sdk_clients(
+        session=cast(Any, object()),
+        region="us-east-1",
+        target_id="anthropic.claude-3-haiku-20240307-v1:0",
+        is_inference_profile=False,
+        use_converse=False,
+    )
+
+    assert details == {
+        "target_type": "model_id",
+        "authorization_status": "AUTHORIZED",
+        "entitlement_availability": "AVAILABLE",
+        "region_availability": "AVAILABLE",
+    }
+    assert calls == ["bedrock", "bedrock-runtime"]
+    assert captured_invoke["modelId"] == "anthropic.claude-3-haiku-20240307-v1:0"
+    assert captured_invoke["contentType"] == "application/json"
+    assert captured_invoke["accept"] == "application/json"
+    assert orjson.loads(captured_invoke["body"]) == {
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "ping"}]}],
+    }
+
+
+@pytest.mark.anyio
+async def test_verify_with_sdk_clients_rejects_unknown_invoke_payload_family(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeBedrockControlClient:
+        async def get_foundation_model_availability(
+            self,
+            *,
+            modelId: str,
+        ) -> dict[str, str]:
+            return {
+                "authorizationStatus": "AUTHORIZED",
+                "entitlementAvailability": "AVAILABLE",
+                "regionAvailability": "AVAILABLE",
+            }
+
+    class FakeBedrockRuntimeClient:
+        async def invoke_model(self, **_: Any) -> object:
+            pytest.fail("Unsupported invoke payload family should fail before invoke")
+
+    class FakeClientContext:
+        def __init__(self, client: object) -> None:
+            self.client = client
+
+        async def __aenter__(self) -> object:
+            return self.client
+
+        async def __aexit__(self, *_: object) -> None:
+            return None
+
+    def fake_client_context(
+        _session: object,
+        service_name: str,
+        **_: object,
+    ) -> FakeClientContext:
+        if service_name == "bedrock":
+            return FakeClientContext(FakeBedrockControlClient())
+        if service_name == "bedrock-runtime":
+            return FakeClientContext(FakeBedrockRuntimeClient())
+        pytest.fail(f"Unexpected service {service_name}")
+
+    monkeypatch.setattr(bedrock_validation, "_client_context", fake_client_context)
+
+    with pytest.raises(BedrockVerificationError, match="Anthropic Claude"):
+        await bedrock_validation._verify_with_sdk_clients(
+            session=cast(Any, object()),
+            region="us-east-1",
+            target_id="amazon.titan-text-lite-v1",
+            is_inference_profile=False,
+            use_converse=False,
+        )
 
 
 def test_check_profile_response_rejects_inactive_profile() -> None:
@@ -111,12 +281,16 @@ def test_check_profile_response_rejects_inactive_profile() -> None:
         bedrock_validation._check_profile_response({"status": "CREATING"})
 
 
-def test_check_model_availability_response_rejects_unavailable_region() -> None:
-    with pytest.raises(BedrockVerificationError, match="NOT_AVAILABLE"):
-        bedrock_validation._check_model_availability_response(
-            {
-                "authorizationStatus": "AUTHORIZED",
-                "entitlementAvailability": "AVAILABLE",
-                "regionAvailability": "NOT_AVAILABLE",
-            }
-        )
+def test_check_model_availability_response_returns_status_details() -> None:
+    assert bedrock_validation._check_model_availability_response(
+        {
+            "authorizationStatus": "AUTHORIZED",
+            "entitlementAvailability": "AVAILABLE",
+            "regionAvailability": "NOT_AVAILABLE",
+        }
+    ) == {
+        "target_type": "model_id",
+        "authorization_status": "AUTHORIZED",
+        "entitlement_availability": "AVAILABLE",
+        "region_availability": "NOT_AVAILABLE",
+    }

--- a/tests/unit/test_bedrock_catalog_validation.py
+++ b/tests/unit/test_bedrock_catalog_validation.py
@@ -29,7 +29,7 @@ async def test_verify_bedrock_catalog_target_requires_region() -> None:
 
 @pytest.mark.anyio
 async def test_verify_bedrock_catalog_target_requires_external_id_for_role() -> None:
-    with pytest.raises(BedrockVerificationError, match="workspace"):
+    with pytest.raises(BedrockVerificationError, match="AWS External ID"):
         await verify_bedrock_catalog_target(
             credentials={
                 "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/customer-role",

--- a/tests/unit/test_bedrock_catalog_validation.py
+++ b/tests/unit/test_bedrock_catalog_validation.py
@@ -1,0 +1,122 @@
+"""Tests for Bedrock catalog target verification helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tracecat.agent.catalog import bedrock_validation
+from tracecat.agent.catalog.bedrock_validation import (
+    BedrockVerificationError,
+    verify_bedrock_catalog_target,
+)
+
+
+@pytest.mark.anyio
+async def test_verify_bedrock_catalog_target_requires_region() -> None:
+    with pytest.raises(BedrockVerificationError, match="AWS_REGION"):
+        await verify_bedrock_catalog_target(
+            credentials={
+                "AWS_ACCESS_KEY_ID": "access-key",
+                "AWS_SECRET_ACCESS_KEY": "secret-key",
+            },
+            inference_profile_id="us.anthropic.claude-sonnet-4",
+            model_id=None,
+            use_converse=True,
+        )
+
+
+@pytest.mark.anyio
+async def test_verify_bedrock_catalog_target_requires_external_id_for_role() -> None:
+    with pytest.raises(BedrockVerificationError, match="workspace"):
+        await verify_bedrock_catalog_target(
+            credentials={
+                "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/customer-role",
+                "AWS_REGION": "us-east-1",
+            },
+            inference_profile_id="us.anthropic.claude-sonnet-4",
+            model_id=None,
+            use_converse=True,
+        )
+
+
+@pytest.mark.anyio
+async def test_verify_bedrock_catalog_target_uses_static_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_verify_with_boto3(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {"runtime_test": "converse"}
+
+    monkeypatch.setattr(
+        bedrock_validation,
+        "_verify_with_boto3",
+        fake_verify_with_boto3,
+    )
+
+    details = await verify_bedrock_catalog_target(
+        credentials={
+            "AWS_ACCESS_KEY_ID": "access-key",
+            "AWS_SECRET_ACCESS_KEY": "secret-key",
+            "AWS_REGION": "us-east-1",
+        },
+        inference_profile_id="us.anthropic.claude-sonnet-4",
+        model_id=None,
+        use_converse=True,
+    )
+
+    assert details == {"runtime_test": "converse"}
+    assert captured["region"] == "us-east-1"
+    assert captured["target_id"] == "us.anthropic.claude-sonnet-4"
+    assert captured["is_inference_profile"] is True
+
+
+@pytest.mark.anyio
+async def test_verify_bedrock_catalog_target_uses_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_verify_with_api_key(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {"runtime_test": "converse"}
+
+    monkeypatch.setattr(
+        bedrock_validation,
+        "_verify_with_api_key",
+        fake_verify_with_api_key,
+    )
+
+    details = await verify_bedrock_catalog_target(
+        credentials={
+            "AWS_BEARER_TOKEN_BEDROCK": "bedrock-api-key",
+            "AWS_REGION": "us-east-1",
+        },
+        inference_profile_id=None,
+        model_id="anthropic.claude-3-haiku-20240307-v1:0",
+        use_converse=True,
+    )
+
+    assert details == {"runtime_test": "converse"}
+    assert captured["api_key"] == "bedrock-api-key"
+    assert captured["target_id"] == "anthropic.claude-3-haiku-20240307-v1:0"
+    assert captured["is_inference_profile"] is False
+
+
+def test_check_profile_response_rejects_inactive_profile() -> None:
+    with pytest.raises(BedrockVerificationError, match="CREATING"):
+        bedrock_validation._check_profile_response({"status": "CREATING"})
+
+
+def test_check_model_availability_response_rejects_unavailable_region() -> None:
+    with pytest.raises(BedrockVerificationError, match="NOT_AVAILABLE"):
+        bedrock_validation._check_model_availability_response(
+            {
+                "authorizationStatus": "AUTHORIZED",
+                "entitlementAvailability": "AVAILABLE",
+                "regionAvailability": "NOT_AVAILABLE",
+            }
+        )

--- a/tracecat/agent/catalog/bedrock_validation.py
+++ b/tracecat/agent/catalog/bedrock_validation.py
@@ -1,0 +1,308 @@
+"""Bedrock catalog target verification helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from urllib.parse import quote
+
+import boto3
+import httpx
+from botocore.exceptions import BotoCoreError, ClientError
+
+_AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY = "TRACECAT_AWS_EXTERNAL_ID"
+_DEFAULT_AWS_ROLE_SESSION_NAME = "tracecat-session"
+_PING_MESSAGES: list[dict[str, Any]] = [
+    {"role": "user", "content": [{"text": "ping"}]},
+]
+_PING_INFERENCE_CONFIG = {"maxTokens": 1}
+
+
+class BedrockVerificationError(Exception):
+    """Raised when Bedrock target verification fails."""
+
+
+def _get_required_region(credentials: dict[str, str]) -> str:
+    if region := credentials.get("AWS_REGION"):
+        return region
+    raise BedrockVerificationError("AWS_REGION is required to verify Bedrock models.")
+
+
+def _get_aws_role_session_name(credentials: dict[str, str]) -> str:
+    if session_name := credentials.get("AWS_ROLE_SESSION_NAME"):
+        if session_name := session_name.strip():
+            return session_name
+    return _DEFAULT_AWS_ROLE_SESSION_NAME
+
+
+def _assume_bedrock_role(credentials: dict[str, str]) -> dict[str, str]:
+    role_arn = credentials["AWS_ROLE_ARN"]
+    external_id = credentials.get(_AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY)
+    if not external_id:
+        raise BedrockVerificationError(
+            "Bedrock role credentials require a workspace to build the AWS External ID."
+        )
+
+    sts_client = boto3.Session().client("sts")
+    response = sts_client.assume_role(
+        RoleArn=role_arn,
+        RoleSessionName=_get_aws_role_session_name(credentials),
+        ExternalId=external_id,
+    )
+    session_credentials = response["Credentials"]
+    return credentials | {
+        "AWS_ACCESS_KEY_ID": session_credentials["AccessKeyId"],
+        "AWS_SECRET_ACCESS_KEY": session_credentials["SecretAccessKey"],
+        "AWS_SESSION_TOKEN": session_credentials["SessionToken"],
+    }
+
+
+async def _resolve_bedrock_credentials(
+    credentials: dict[str, str],
+) -> dict[str, str]:
+    """Resolve configured Bedrock credentials into an explicit auth shape."""
+    if credentials.get("AWS_ROLE_ARN"):
+        try:
+            return await asyncio.to_thread(_assume_bedrock_role, credentials)
+        except BedrockVerificationError:
+            raise
+        except (BotoCoreError, ClientError, KeyError) as exc:
+            raise BedrockVerificationError(
+                "Failed to assume configured AWS role for Bedrock."
+            ) from exc
+
+    access_key = credentials.get("AWS_ACCESS_KEY_ID")
+    secret_key = credentials.get("AWS_SECRET_ACCESS_KEY")
+    session_token = credentials.get("AWS_SESSION_TOKEN")
+    if access_key and secret_key:
+        return credentials
+    if access_key or secret_key or session_token:
+        raise BedrockVerificationError(
+            "Bedrock static credentials require AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY."
+        )
+
+    if credentials.get("AWS_BEARER_TOKEN_BEDROCK"):
+        return credentials
+
+    raise BedrockVerificationError(
+        "Bedrock requires AWS_ROLE_ARN, AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, or AWS_BEARER_TOKEN_BEDROCK."
+    )
+
+
+def _boto3_session(credentials: dict[str, str], region: str) -> boto3.Session:
+    return boto3.Session(
+        aws_access_key_id=credentials["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key=credentials["AWS_SECRET_ACCESS_KEY"],
+        aws_session_token=credentials.get("AWS_SESSION_TOKEN"),
+        region_name=region,
+    )
+
+
+def _check_profile_response(response: dict[str, Any]) -> dict[str, Any]:
+    status = response.get("status")
+    details = {
+        "target_type": "inference_profile",
+        "status": status,
+        "inference_profile_id": response.get("inferenceProfileId"),
+        "inference_profile_arn": response.get("inferenceProfileArn"),
+        "model_count": len(response.get("models") or []),
+    }
+    if status and status != "ACTIVE":
+        raise BedrockVerificationError(
+            f"Inference profile is {status}; expected ACTIVE."
+        )
+    return {key: value for key, value in details.items() if value is not None}
+
+
+def _check_model_availability_response(response: dict[str, Any]) -> dict[str, Any]:
+    authorization_status = response.get("authorizationStatus")
+    entitlement_availability = response.get("entitlementAvailability")
+    region_availability = response.get("regionAvailability")
+    details = {
+        "target_type": "model_id",
+        "authorization_status": authorization_status,
+        "entitlement_availability": entitlement_availability,
+        "region_availability": region_availability,
+    }
+    failures: list[str] = []
+    if authorization_status and authorization_status != "AUTHORIZED":
+        failures.append(f"authorization status is {authorization_status}")
+    if entitlement_availability and entitlement_availability != "AVAILABLE":
+        failures.append(f"entitlement availability is {entitlement_availability}")
+    if region_availability and region_availability != "AVAILABLE":
+        failures.append(f"region availability is {region_availability}")
+    if failures:
+        raise BedrockVerificationError(
+            "Foundation model is not available: " + ", ".join(failures) + "."
+        )
+    return {key: value for key, value in details.items() if value is not None}
+
+
+def _verify_with_boto3(
+    *,
+    credentials: dict[str, str],
+    region: str,
+    target_id: str,
+    is_inference_profile: bool,
+    use_converse: bool,
+) -> dict[str, Any]:
+    session = _boto3_session(credentials, region)
+    bedrock = session.client("bedrock", region_name=region)
+    runtime = session.client("bedrock-runtime", region_name=region)
+    if is_inference_profile:
+        control_response = bedrock.get_inference_profile(
+            inferenceProfileIdentifier=target_id,
+        )
+        details = _check_profile_response(control_response)
+    else:
+        control_response = bedrock.get_foundation_model_availability(
+            modelId=target_id,
+        )
+        details = _check_model_availability_response(control_response)
+
+    if not use_converse:
+        raise BedrockVerificationError(
+            "Runtime verification requires the Bedrock Converse API. Enable Use Converse API and try again."
+        )
+
+    runtime.converse(
+        modelId=target_id,
+        messages=_PING_MESSAGES,
+        inferenceConfig=_PING_INFERENCE_CONFIG,
+    )
+    return details | {"runtime_test": "converse"}
+
+
+def _bedrock_url(region: str, path: str) -> str:
+    return f"https://bedrock.{region}.amazonaws.com{path}"
+
+
+def _bedrock_runtime_url(region: str, path: str) -> str:
+    return f"https://bedrock-runtime.{region}.amazonaws.com{path}"
+
+
+def _extract_http_error(response: httpx.Response) -> str:
+    try:
+        payload = response.json()
+    except ValueError:
+        return response.text or response.reason_phrase
+    if isinstance(payload, dict):
+        message = payload.get("message") or payload.get("Message")
+        error_type = payload.get("__type") or payload.get("code")
+        if message and error_type:
+            return f"{error_type}: {message}"
+        if message:
+            return str(message)
+    return response.text or response.reason_phrase
+
+
+async def _request_bedrock_api_key(
+    *,
+    method: str,
+    url: str,
+    api_key: str,
+    json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        response = await client.request(method, url, headers=headers, json=json)
+    if response.is_error:
+        raise BedrockVerificationError(_extract_http_error(response))
+    if not response.content:
+        return {}
+    payload = response.json()
+    return payload if isinstance(payload, dict) else {}
+
+
+async def _verify_with_api_key(
+    *,
+    api_key: str,
+    region: str,
+    target_id: str,
+    is_inference_profile: bool,
+    use_converse: bool,
+) -> dict[str, Any]:
+    encoded_target = quote(target_id, safe="")
+    if is_inference_profile:
+        response = await _request_bedrock_api_key(
+            method="GET",
+            url=_bedrock_url(region, f"/inference-profiles/{encoded_target}"),
+            api_key=api_key,
+        )
+        details = _check_profile_response(response)
+    else:
+        response = await _request_bedrock_api_key(
+            method="GET",
+            url=_bedrock_url(
+                region, f"/foundation-model-availability/{encoded_target}"
+            ),
+            api_key=api_key,
+        )
+        details = _check_model_availability_response(response)
+
+    if not use_converse:
+        raise BedrockVerificationError(
+            "Runtime verification requires the Bedrock Converse API. Enable Use Converse API and try again."
+        )
+
+    await _request_bedrock_api_key(
+        method="POST",
+        url=_bedrock_runtime_url(region, f"/model/{encoded_target}/converse"),
+        api_key=api_key,
+        json={
+            "messages": _PING_MESSAGES,
+            "inferenceConfig": _PING_INFERENCE_CONFIG,
+        },
+    )
+    return details | {"runtime_test": "converse"}
+
+
+async def verify_bedrock_catalog_target(
+    *,
+    credentials: dict[str, str],
+    inference_profile_id: str | None,
+    model_id: str | None,
+    use_converse: bool,
+) -> dict[str, Any]:
+    """Verify a Bedrock catalog target with control-plane and runtime calls."""
+    region = _get_required_region(credentials)
+    target_id = inference_profile_id or model_id
+    if target_id is None:
+        raise BedrockVerificationError(
+            "Provide exactly one of inference_profile_id or model_id."
+        )
+
+    resolved = await _resolve_bedrock_credentials(credentials)
+    is_inference_profile = inference_profile_id is not None
+    if api_key := resolved.get("AWS_BEARER_TOKEN_BEDROCK"):
+        return await _verify_with_api_key(
+            api_key=api_key,
+            region=region,
+            target_id=target_id,
+            is_inference_profile=is_inference_profile,
+            use_converse=use_converse,
+        )
+
+    try:
+        return await asyncio.to_thread(
+            _verify_with_boto3,
+            credentials=resolved,
+            region=region,
+            target_id=target_id,
+            is_inference_profile=is_inference_profile,
+            use_converse=use_converse,
+        )
+    except BedrockVerificationError:
+        raise
+    except ClientError as exc:
+        error = exc.response.get("Error", {})
+        code = error.get("Code")
+        message = error.get("Message")
+        if code and message:
+            raise BedrockVerificationError(f"{code}: {message}") from exc
+        raise BedrockVerificationError(str(exc)) from exc
+    except BotoCoreError as exc:
+        raise BedrockVerificationError(str(exc)) from exc

--- a/tracecat/agent/catalog/bedrock_validation.py
+++ b/tracecat/agent/catalog/bedrock_validation.py
@@ -27,7 +27,7 @@ def _assume_bedrock_role(credentials: dict[str, str]) -> dict[str, str]:
     external_id = credentials.get(_AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY)
     if not external_id:
         raise BedrockVerificationError(
-            "Bedrock role credentials require a workspace to build the AWS External ID."
+            "Bedrock role credentials require a Tracecat-provided AWS External ID."
         )
     session_name = (
         credentials.get("AWS_ROLE_SESSION_NAME", "").strip()

--- a/tracecat/agent/catalog/bedrock_validation.py
+++ b/tracecat/agent/catalog/bedrock_validation.py
@@ -22,19 +22,6 @@ class BedrockVerificationError(Exception):
     """Raised when Bedrock target verification fails."""
 
 
-def _get_required_region(credentials: dict[str, str]) -> str:
-    if region := credentials.get("AWS_REGION"):
-        return region
-    raise BedrockVerificationError("AWS_REGION is required to verify Bedrock models.")
-
-
-def _get_aws_role_session_name(credentials: dict[str, str]) -> str:
-    if session_name := credentials.get("AWS_ROLE_SESSION_NAME"):
-        if session_name := session_name.strip():
-            return session_name
-    return _DEFAULT_AWS_ROLE_SESSION_NAME
-
-
 def _assume_bedrock_role(credentials: dict[str, str]) -> dict[str, str]:
     role_arn = credentials["AWS_ROLE_ARN"]
     external_id = credentials.get(_AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY)
@@ -42,11 +29,14 @@ def _assume_bedrock_role(credentials: dict[str, str]) -> dict[str, str]:
         raise BedrockVerificationError(
             "Bedrock role credentials require a workspace to build the AWS External ID."
         )
-
+    session_name = (
+        credentials.get("AWS_ROLE_SESSION_NAME", "").strip()
+        or _DEFAULT_AWS_ROLE_SESSION_NAME
+    )
     sts_client = boto3.Session().client("sts")
     response = sts_client.assume_role(
         RoleArn=role_arn,
-        RoleSessionName=_get_aws_role_session_name(credentials),
+        RoleSessionName=session_name,
         ExternalId=external_id,
     )
     session_credentials = response["Credentials"]
@@ -86,15 +76,6 @@ async def _resolve_bedrock_credentials(
 
     raise BedrockVerificationError(
         "Bedrock requires AWS_ROLE_ARN, AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, or AWS_BEARER_TOKEN_BEDROCK."
-    )
-
-
-def _boto3_session(credentials: dict[str, str], region: str) -> boto3.Session:
-    return boto3.Session(
-        aws_access_key_id=credentials["AWS_ACCESS_KEY_ID"],
-        aws_secret_access_key=credentials["AWS_SECRET_ACCESS_KEY"],
-        aws_session_token=credentials.get("AWS_SESSION_TOKEN"),
-        region_name=region,
     )
 
 
@@ -146,19 +127,22 @@ def _verify_with_boto3(
     is_inference_profile: bool,
     use_converse: bool,
 ) -> dict[str, Any]:
-    session = _boto3_session(credentials, region)
+    session = boto3.Session(
+        aws_access_key_id=credentials["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key=credentials["AWS_SECRET_ACCESS_KEY"],
+        aws_session_token=credentials.get("AWS_SESSION_TOKEN"),
+        region_name=region,
+    )
     bedrock = session.client("bedrock", region_name=region)
     runtime = session.client("bedrock-runtime", region_name=region)
     if is_inference_profile:
-        control_response = bedrock.get_inference_profile(
-            inferenceProfileIdentifier=target_id,
+        details = _check_profile_response(
+            bedrock.get_inference_profile(inferenceProfileIdentifier=target_id)
         )
-        details = _check_profile_response(control_response)
     else:
-        control_response = bedrock.get_foundation_model_availability(
-            modelId=target_id,
+        details = _check_model_availability_response(
+            bedrock.get_foundation_model_availability(modelId=target_id)
         )
-        details = _check_model_availability_response(control_response)
 
     if not use_converse:
         raise BedrockVerificationError(
@@ -171,14 +155,6 @@ def _verify_with_boto3(
         inferenceConfig=_PING_INFERENCE_CONFIG,
     )
     return details | {"runtime_test": "converse"}
-
-
-def _bedrock_url(region: str, path: str) -> str:
-    return f"https://bedrock.{region}.amazonaws.com{path}"
-
-
-def _bedrock_runtime_url(region: str, path: str) -> str:
-    return f"https://bedrock-runtime.{region}.amazonaws.com{path}"
 
 
 def _extract_http_error(response: httpx.Response) -> str:
@@ -207,8 +183,15 @@ async def _request_bedrock_api_key(
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
-    async with httpx.AsyncClient(timeout=15.0) as client:
-        response = await client.request(method, url, headers=headers, json=json)
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.request(method, url, headers=headers, json=json)
+    except httpx.TimeoutException as exc:
+        raise BedrockVerificationError(
+            "Bedrock API request timed out. Check connectivity and try again."
+        ) from exc
+    except httpx.RequestError as exc:
+        raise BedrockVerificationError(f"Bedrock API request failed: {exc}") from exc
     if response.is_error:
         raise BedrockVerificationError(_extract_http_error(response))
     if not response.content:
@@ -227,21 +210,21 @@ async def _verify_with_api_key(
 ) -> dict[str, Any]:
     encoded_target = quote(target_id, safe="")
     if is_inference_profile:
-        response = await _request_bedrock_api_key(
-            method="GET",
-            url=_bedrock_url(region, f"/inference-profiles/{encoded_target}"),
-            api_key=api_key,
+        details = _check_profile_response(
+            await _request_bedrock_api_key(
+                method="GET",
+                url=f"https://bedrock.{region}.amazonaws.com/inference-profiles/{encoded_target}",
+                api_key=api_key,
+            )
         )
-        details = _check_profile_response(response)
     else:
-        response = await _request_bedrock_api_key(
-            method="GET",
-            url=_bedrock_url(
-                region, f"/foundation-model-availability/{encoded_target}"
-            ),
-            api_key=api_key,
+        details = _check_model_availability_response(
+            await _request_bedrock_api_key(
+                method="GET",
+                url=f"https://bedrock.{region}.amazonaws.com/foundation-model-availability/{encoded_target}",
+                api_key=api_key,
+            )
         )
-        details = _check_model_availability_response(response)
 
     if not use_converse:
         raise BedrockVerificationError(
@@ -250,7 +233,7 @@ async def _verify_with_api_key(
 
     await _request_bedrock_api_key(
         method="POST",
-        url=_bedrock_runtime_url(region, f"/model/{encoded_target}/converse"),
+        url=f"https://bedrock-runtime.{region}.amazonaws.com/model/{encoded_target}/converse",
         api_key=api_key,
         json={
             "messages": _PING_MESSAGES,
@@ -268,7 +251,11 @@ async def verify_bedrock_catalog_target(
     use_converse: bool,
 ) -> dict[str, Any]:
     """Verify a Bedrock catalog target with control-plane and runtime calls."""
-    region = _get_required_region(credentials)
+    region = credentials.get("AWS_REGION")
+    if not region:
+        raise BedrockVerificationError(
+            "AWS_REGION is required to verify Bedrock models."
+        )
     target_id = inference_profile_id or model_id
     if target_id is None:
         raise BedrockVerificationError(
@@ -278,13 +265,18 @@ async def verify_bedrock_catalog_target(
     resolved = await _resolve_bedrock_credentials(credentials)
     is_inference_profile = inference_profile_id is not None
     if api_key := resolved.get("AWS_BEARER_TOKEN_BEDROCK"):
-        return await _verify_with_api_key(
-            api_key=api_key,
-            region=region,
-            target_id=target_id,
-            is_inference_profile=is_inference_profile,
-            use_converse=use_converse,
-        )
+        try:
+            return await _verify_with_api_key(
+                api_key=api_key,
+                region=region,
+                target_id=target_id,
+                is_inference_profile=is_inference_profile,
+                use_converse=use_converse,
+            )
+        except BedrockVerificationError:
+            raise
+        except Exception as exc:
+            raise BedrockVerificationError(str(exc)) from exc
 
     try:
         return await asyncio.to_thread(
@@ -305,4 +297,6 @@ async def verify_bedrock_catalog_target(
             raise BedrockVerificationError(f"{code}: {message}") from exc
         raise BedrockVerificationError(str(exc)) from exc
     except BotoCoreError as exc:
+        raise BedrockVerificationError(str(exc)) from exc
+    except Exception as exc:
         raise BedrockVerificationError(str(exc)) from exc

--- a/tracecat/agent/catalog/bedrock_validation.py
+++ b/tracecat/agent/catalog/bedrock_validation.py
@@ -2,27 +2,63 @@
 
 from __future__ import annotations
 
-import asyncio
-from typing import Any
-from urllib.parse import quote
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from typing import cast
 
-import boto3
-import httpx
+import aioboto3
+import aiobotocore.session
+import orjson
+from aiobotocore.config import AioConfig
 from botocore.exceptions import BotoCoreError, ClientError
+from botocore.tokens import FrozenAuthToken
+
+from tracecat.agent.catalog.types import (
+    AnthropicInvokePayload,
+    BedrockControlClient,
+    BedrockInferenceConfig,
+    BedrockInferenceProfileDetails,
+    BedrockInferenceProfileResponse,
+    BedrockMessage,
+    BedrockModelAvailabilityDetails,
+    BedrockModelAvailabilityResponse,
+    BedrockRuntimeClient,
+    BedrockVerificationDetails,
+)
 
 _AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY = "TRACECAT_AWS_EXTERNAL_ID"
 _DEFAULT_AWS_ROLE_SESSION_NAME = "tracecat-session"
-_PING_MESSAGES: list[dict[str, Any]] = [
+_BEDROCK_BEARER_CONFIG = AioConfig(signature_version="bearer")
+
+
+class StaticBearerTokenProvider:
+    """Botocore token provider for Bedrock bearer-token SDK auth."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def load_token(self, **_: object) -> FrozenAuthToken:
+        return FrozenAuthToken(self._token)
+
+
+_PING_MESSAGES: list[BedrockMessage] = [
     {"role": "user", "content": [{"text": "ping"}]},
 ]
-_PING_INFERENCE_CONFIG = {"maxTokens": 1}
+_PING_INFERENCE_CONFIG: BedrockInferenceConfig = {"maxTokens": 1}
+_ANTHROPIC_INVOKE_PING: AnthropicInvokePayload = {
+    "anthropic_version": "bedrock-2023-05-31",
+    "max_tokens": 1,
+    "messages": [
+        {"role": "user", "content": [{"type": "text", "text": "ping"}]},
+    ],
+}
 
 
 class BedrockVerificationError(Exception):
     """Raised when Bedrock target verification fails."""
 
 
-def _assume_bedrock_role(credentials: dict[str, str]) -> dict[str, str]:
+async def _assume_bedrock_role(credentials: dict[str, str]) -> dict[str, str]:
     role_arn = credentials["AWS_ROLE_ARN"]
     external_id = credentials.get(_AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY)
     if not external_id:
@@ -33,12 +69,13 @@ def _assume_bedrock_role(credentials: dict[str, str]) -> dict[str, str]:
         credentials.get("AWS_ROLE_SESSION_NAME", "").strip()
         or _DEFAULT_AWS_ROLE_SESSION_NAME
     )
-    sts_client = boto3.Session().client("sts")
-    response = sts_client.assume_role(
-        RoleArn=role_arn,
-        RoleSessionName=session_name,
-        ExternalId=external_id,
-    )
+    session = aioboto3.Session()
+    async with session.client("sts") as client:
+        response = await client.assume_role(
+            RoleArn=role_arn,
+            RoleSessionName=session_name,
+            ExternalId=external_id,
+        )
     session_credentials = response["Credentials"]
     return credentials | {
         "AWS_ACCESS_KEY_ID": session_credentials["AccessKeyId"],
@@ -53,7 +90,7 @@ async def _resolve_bedrock_credentials(
     """Resolve configured Bedrock credentials into an explicit auth shape."""
     if credentials.get("AWS_ROLE_ARN"):
         try:
-            return await asyncio.to_thread(_assume_bedrock_role, credentials)
+            return await _assume_bedrock_role(credentials)
         except BedrockVerificationError:
             raise
         except (BotoCoreError, ClientError, KeyError) as exc:
@@ -79,125 +116,153 @@ async def _resolve_bedrock_credentials(
     )
 
 
-def _check_profile_response(response: dict[str, Any]) -> dict[str, Any]:
+def _check_profile_response(
+    response: BedrockInferenceProfileResponse,
+) -> BedrockInferenceProfileDetails:
     status = response.get("status")
-    details = {
+    details: BedrockInferenceProfileDetails = {
         "target_type": "inference_profile",
-        "status": status,
-        "inference_profile_id": response.get("inferenceProfileId"),
-        "inference_profile_arn": response.get("inferenceProfileArn"),
         "model_count": len(response.get("models") or []),
     }
+    if status is not None:
+        details["status"] = status
+    if (inference_profile_id := response.get("inferenceProfileId")) is not None:
+        details["inference_profile_id"] = inference_profile_id
+    if (inference_profile_arn := response.get("inferenceProfileArn")) is not None:
+        details["inference_profile_arn"] = inference_profile_arn
     if status and status != "ACTIVE":
         raise BedrockVerificationError(
             f"Inference profile is {status}; expected ACTIVE."
         )
-    return {key: value for key, value in details.items() if value is not None}
+    return details
 
 
-def _check_model_availability_response(response: dict[str, Any]) -> dict[str, Any]:
+def _check_model_availability_response(
+    response: BedrockModelAvailabilityResponse,
+) -> BedrockModelAvailabilityDetails:
     authorization_status = response.get("authorizationStatus")
     entitlement_availability = response.get("entitlementAvailability")
     region_availability = response.get("regionAvailability")
-    details = {
+    details: BedrockModelAvailabilityDetails = {
         "target_type": "model_id",
-        "authorization_status": authorization_status,
-        "entitlement_availability": entitlement_availability,
-        "region_availability": region_availability,
     }
-    failures: list[str] = []
-    if authorization_status and authorization_status != "AUTHORIZED":
-        failures.append(f"authorization status is {authorization_status}")
-    if entitlement_availability and entitlement_availability != "AVAILABLE":
-        failures.append(f"entitlement availability is {entitlement_availability}")
-    if region_availability and region_availability != "AVAILABLE":
-        failures.append(f"region availability is {region_availability}")
-    if failures:
+    if authorization_status is not None:
+        details["authorization_status"] = authorization_status
+    if entitlement_availability is not None:
+        details["entitlement_availability"] = entitlement_availability
+    if region_availability is not None:
+        details["region_availability"] = region_availability
+    return details
+
+
+def _build_static_bearer_session(api_key: str, region: str) -> aioboto3.Session:
+    botocore_session = aiobotocore.session.get_session()
+    botocore_session.register_component(
+        "token_provider",
+        StaticBearerTokenProvider(api_key),
+    )
+    return aioboto3.Session(botocore_session=botocore_session, region_name=region)
+
+
+def _client_context(
+    session: aioboto3.Session,
+    service_name: str,
+    *,
+    region: str,
+    config: AioConfig | None = None,
+) -> AbstractAsyncContextManager[object]:
+    client = cast(Callable[..., AbstractAsyncContextManager[object]], session.client)
+    return client(service_name, region_name=region, config=config)
+
+
+def _is_anthropic_claude_target(target_id: str) -> bool:
+    return "anthropic.claude" in target_id.lower()
+
+
+async def _verify_with_invoke_model(
+    runtime_client: BedrockRuntimeClient,
+    target_id: str,
+) -> None:
+    if not _is_anthropic_claude_target(target_id):
         raise BedrockVerificationError(
-            "Foundation model is not available: " + ", ".join(failures) + "."
+            "InvokeModel runtime verification is currently supported for Anthropic Claude Bedrock targets only. Enable Use Converse API or use an Anthropic Claude model ID/inference profile."
         )
-    return {key: value for key, value in details.items() if value is not None}
+    await runtime_client.invoke_model(
+        modelId=target_id,
+        body=orjson.dumps(_ANTHROPIC_INVOKE_PING),
+        contentType="application/json",
+        accept="application/json",
+    )
 
 
-def _verify_with_boto3(
+async def _verify_with_sdk_clients(
+    *,
+    session: aioboto3.Session,
+    region: str,
+    target_id: str,
+    is_inference_profile: bool,
+    use_converse: bool,
+    client_config: AioConfig | None = None,
+) -> BedrockVerificationDetails:
+    async with _client_context(
+        session,
+        "bedrock",
+        region=region,
+        config=client_config,
+    ) as bedrock:
+        bedrock_client = cast(BedrockControlClient, bedrock)
+        if is_inference_profile:
+            details = _check_profile_response(
+                await bedrock_client.get_inference_profile(
+                    inferenceProfileIdentifier=target_id,
+                )
+            )
+        else:
+            details = _check_model_availability_response(
+                await bedrock_client.get_foundation_model_availability(
+                    modelId=target_id,
+                )
+            )
+
+    async with _client_context(
+        session,
+        "bedrock-runtime",
+        region=region,
+        config=client_config,
+    ) as runtime:
+        runtime_client = cast(BedrockRuntimeClient, runtime)
+        if use_converse:
+            await runtime_client.converse(
+                modelId=target_id,
+                messages=_PING_MESSAGES,
+                inferenceConfig=_PING_INFERENCE_CONFIG,
+            )
+        else:
+            await _verify_with_invoke_model(runtime_client, target_id)
+    return details
+
+
+async def _verify_with_aws_credentials(
     *,
     credentials: dict[str, str],
     region: str,
     target_id: str,
     is_inference_profile: bool,
     use_converse: bool,
-) -> dict[str, Any]:
-    session = boto3.Session(
+) -> BedrockVerificationDetails:
+    session = aioboto3.Session(
         aws_access_key_id=credentials["AWS_ACCESS_KEY_ID"],
         aws_secret_access_key=credentials["AWS_SECRET_ACCESS_KEY"],
         aws_session_token=credentials.get("AWS_SESSION_TOKEN"),
         region_name=region,
     )
-    bedrock = session.client("bedrock", region_name=region)
-    runtime = session.client("bedrock-runtime", region_name=region)
-    if is_inference_profile:
-        details = _check_profile_response(
-            bedrock.get_inference_profile(inferenceProfileIdentifier=target_id)
-        )
-    else:
-        details = _check_model_availability_response(
-            bedrock.get_foundation_model_availability(modelId=target_id)
-        )
-
-    if not use_converse:
-        raise BedrockVerificationError(
-            "Runtime verification requires the Bedrock Converse API. Enable Use Converse API and try again."
-        )
-
-    runtime.converse(
-        modelId=target_id,
-        messages=_PING_MESSAGES,
-        inferenceConfig=_PING_INFERENCE_CONFIG,
+    return await _verify_with_sdk_clients(
+        session=session,
+        region=region,
+        target_id=target_id,
+        is_inference_profile=is_inference_profile,
+        use_converse=use_converse,
     )
-    return details | {"runtime_test": "converse"}
-
-
-def _extract_http_error(response: httpx.Response) -> str:
-    try:
-        payload = response.json()
-    except ValueError:
-        return response.text or response.reason_phrase
-    if isinstance(payload, dict):
-        message = payload.get("message") or payload.get("Message")
-        error_type = payload.get("__type") or payload.get("code")
-        if message and error_type:
-            return f"{error_type}: {message}"
-        if message:
-            return str(message)
-    return response.text or response.reason_phrase
-
-
-async def _request_bedrock_api_key(
-    *,
-    method: str,
-    url: str,
-    api_key: str,
-    json: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-    }
-    try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.request(method, url, headers=headers, json=json)
-    except httpx.TimeoutException as exc:
-        raise BedrockVerificationError(
-            "Bedrock API request timed out. Check connectivity and try again."
-        ) from exc
-    except httpx.RequestError as exc:
-        raise BedrockVerificationError(f"Bedrock API request failed: {exc}") from exc
-    if response.is_error:
-        raise BedrockVerificationError(_extract_http_error(response))
-    if not response.content:
-        return {}
-    payload = response.json()
-    return payload if isinstance(payload, dict) else {}
 
 
 async def _verify_with_api_key(
@@ -207,40 +272,16 @@ async def _verify_with_api_key(
     target_id: str,
     is_inference_profile: bool,
     use_converse: bool,
-) -> dict[str, Any]:
-    encoded_target = quote(target_id, safe="")
-    if is_inference_profile:
-        details = _check_profile_response(
-            await _request_bedrock_api_key(
-                method="GET",
-                url=f"https://bedrock.{region}.amazonaws.com/inference-profiles/{encoded_target}",
-                api_key=api_key,
-            )
-        )
-    else:
-        details = _check_model_availability_response(
-            await _request_bedrock_api_key(
-                method="GET",
-                url=f"https://bedrock.{region}.amazonaws.com/foundation-model-availability/{encoded_target}",
-                api_key=api_key,
-            )
-        )
-
-    if not use_converse:
-        raise BedrockVerificationError(
-            "Runtime verification requires the Bedrock Converse API. Enable Use Converse API and try again."
-        )
-
-    await _request_bedrock_api_key(
-        method="POST",
-        url=f"https://bedrock-runtime.{region}.amazonaws.com/model/{encoded_target}/converse",
-        api_key=api_key,
-        json={
-            "messages": _PING_MESSAGES,
-            "inferenceConfig": _PING_INFERENCE_CONFIG,
-        },
+) -> BedrockVerificationDetails:
+    session = _build_static_bearer_session(api_key, region)
+    return await _verify_with_sdk_clients(
+        session=session,
+        region=region,
+        target_id=target_id,
+        is_inference_profile=is_inference_profile,
+        use_converse=use_converse,
+        client_config=_BEDROCK_BEARER_CONFIG,
     )
-    return details | {"runtime_test": "converse"}
 
 
 async def verify_bedrock_catalog_target(
@@ -249,7 +290,7 @@ async def verify_bedrock_catalog_target(
     inference_profile_id: str | None,
     model_id: str | None,
     use_converse: bool,
-) -> dict[str, Any]:
+) -> BedrockVerificationDetails:
     """Verify a Bedrock catalog target with control-plane and runtime calls."""
     region = credentials.get("AWS_REGION")
     if not region:
@@ -264,8 +305,13 @@ async def verify_bedrock_catalog_target(
 
     resolved = await _resolve_bedrock_credentials(credentials)
     is_inference_profile = inference_profile_id is not None
-    if api_key := resolved.get("AWS_BEARER_TOKEN_BEDROCK"):
-        try:
+    try:
+        has_aws_credentials = bool(
+            resolved.get("AWS_ACCESS_KEY_ID") and resolved.get("AWS_SECRET_ACCESS_KEY")
+        )
+        if not has_aws_credentials and (
+            api_key := resolved.get("AWS_BEARER_TOKEN_BEDROCK")
+        ):
             return await _verify_with_api_key(
                 api_key=api_key,
                 region=region,
@@ -273,14 +319,8 @@ async def verify_bedrock_catalog_target(
                 is_inference_profile=is_inference_profile,
                 use_converse=use_converse,
             )
-        except BedrockVerificationError:
-            raise
-        except Exception as exc:
-            raise BedrockVerificationError(str(exc)) from exc
 
-    try:
-        return await asyncio.to_thread(
-            _verify_with_boto3,
+        return await _verify_with_aws_credentials(
             credentials=resolved,
             region=region,
             target_id=target_id,

--- a/tracecat/agent/catalog/router.py
+++ b/tracecat/agent/catalog/router.py
@@ -23,7 +23,6 @@ from tracecat.auth.dependencies import OrgUserRole, WorkspaceUserPathRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
-from tracecat.integrations.aws_assume_role import build_organization_external_id
 from tracecat.pagination import CursorPaginationParams
 
 router = APIRouter()
@@ -72,7 +71,11 @@ async def create_catalog_entry(
     params: AgentCatalogCreate = Body(...),
 ) -> AgentCatalogRead:
     """Create an org-scoped catalog entry and auto-enable it at the org level."""
-    assert role.organization_id is not None  # OrgUserRole guarantees this
+    if role.organization_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No organization context",
+        )
     catalog_service = AgentCatalogService(session=session)
     access_service = AgentModelAccessService(session=session, role=role)
     metadata = params.model_dump(exclude={"model_provider", "model_name"})
@@ -107,22 +110,19 @@ async def test_bedrock_catalog_target(
     params: BedrockCatalogTest = Body(...),
 ) -> BedrockCatalogTestResponse:
     """Verify an unsaved Bedrock catalog target."""
-    assert role.organization_id is not None  # OrgUserRole guarantees this
+    if role.organization_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No organization context",
+        )
     credentials_service = AgentManagementService(session=session, role=role)
-    credentials = await credentials_service.get_provider_credentials("bedrock")
+    credentials = await credentials_service.get_runtime_provider_credentials("bedrock")
     if not credentials:
         return BedrockCatalogTestResponse(
             success=False,
             message="Bedrock credentials are not configured.",
             error="Configure AWS Bedrock credentials before verifying a model.",
         )
-
-    if "AWS_ROLE_ARN" in credentials and "TRACECAT_AWS_EXTERNAL_ID" not in credentials:
-        credentials = credentials | {
-            "TRACECAT_AWS_EXTERNAL_ID": build_organization_external_id(
-                role.organization_id
-            )
-        }
 
     try:
         details = await verify_bedrock_catalog_target(
@@ -155,7 +155,11 @@ async def get_catalog_entry(
     session: AsyncDBSession,
 ) -> AgentCatalogRead:
     """Get a specific catalog entry."""
-    assert role.organization_id is not None  # OrgUserRole guarantees this
+    if role.organization_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No organization context",
+        )
     service = AgentCatalogService(session=session)
     try:
         row = await service.get_catalog_entry(
@@ -182,7 +186,11 @@ async def update_catalog_entry(
     params: AgentCatalogUpdate = Body(...),
 ) -> AgentCatalogRead:
     """Update metadata on an org-scoped catalog entry."""
-    assert role.organization_id is not None  # OrgUserRole guarantees this
+    if role.organization_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No organization context",
+        )
     service = AgentCatalogService(session=session)
     try:
         row = await service.get_catalog_entry(
@@ -226,7 +234,11 @@ async def delete_catalog_entry(
     session: AsyncDBSession,
 ) -> None:
     """Delete an org-scoped catalog entry."""
-    assert role.organization_id is not None  # OrgUserRole guarantees this
+    if role.organization_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No organization context",
+        )
     service = AgentCatalogService(session=session)
     try:
         row = await service.get_catalog_entry(

--- a/tracecat/agent/catalog/router.py
+++ b/tracecat/agent/catalog/router.py
@@ -3,19 +3,29 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Body, HTTPException, Query, status
+from sqlalchemy import select
 
 from tracecat.agent.access.service import AgentModelAccessService
+from tracecat.agent.catalog.bedrock_validation import (
+    BedrockVerificationError,
+    verify_bedrock_catalog_target,
+)
 from tracecat.agent.catalog.schemas import (
     AgentCatalogCreate,
     AgentCatalogListResponse,
     AgentCatalogRead,
     AgentCatalogUpdate,
+    BedrockCatalogTest,
+    BedrockCatalogTestResponse,
 )
 from tracecat.agent.catalog.service import AgentCatalogService
+from tracecat.agent.service import AgentManagementService
 from tracecat.auth.dependencies import OrgUserRole, WorkspaceUserPathRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
+from tracecat.db.models import Workspace
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.integrations.aws_assume_role import build_workspace_external_id
 from tracecat.pagination import CursorPaginationParams
 
 router = APIRouter()
@@ -52,32 +62,6 @@ async def list_catalog(
         ) from e
 
 
-@router.get(
-    "/organization/agent-catalog/{catalog_id}",
-    response_model=AgentCatalogRead,
-)
-@require_scope("agent:read")
-async def get_catalog_entry(
-    catalog_id: UUID,
-    role: OrgUserRole,
-    session: AsyncDBSession,
-) -> AgentCatalogRead:
-    """Get a specific catalog entry."""
-    assert role.organization_id is not None  # OrgUserRole guarantees this
-    service = AgentCatalogService(session=session)
-    try:
-        row = await service.get_catalog_entry(
-            org_id=role.organization_id,
-            catalog_id=catalog_id,
-        )
-    except TracecatNotFoundError as e:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=str(e),
-        ) from e
-    return AgentCatalogRead.model_validate(row)
-
-
 @router.post(
     "/organization/agent-catalog",
     response_model=AgentCatalogRead,
@@ -111,6 +95,89 @@ async def create_catalog_entry(
     except TracecatValidationError:
         # Already enabled — ignore duplicate access row
         pass
+    return AgentCatalogRead.model_validate(row)
+
+
+@router.post(
+    "/organization/agent-catalog/bedrock/test",
+    response_model=BedrockCatalogTestResponse,
+)
+@require_scope("agent:update")
+async def test_bedrock_catalog_target(
+    role: OrgUserRole,
+    session: AsyncDBSession,
+    params: BedrockCatalogTest = Body(...),
+) -> BedrockCatalogTestResponse:
+    """Verify an unsaved Bedrock catalog target."""
+    assert role.organization_id is not None  # OrgUserRole guarantees this
+    credentials_service = AgentManagementService(session=session, role=role)
+    credentials = await credentials_service.get_provider_credentials("bedrock")
+    if not credentials:
+        return BedrockCatalogTestResponse(
+            success=False,
+            message="Bedrock credentials are not configured.",
+            error="Configure AWS Bedrock credentials before verifying a model.",
+        )
+
+    if params.workspace_id is not None:
+        workspace_id = await session.scalar(
+            select(Workspace.id).where(
+                Workspace.id == params.workspace_id,
+                Workspace.organization_id == role.organization_id,
+            )
+        )
+        if workspace_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Workspace {params.workspace_id} not found",
+            )
+        credentials = credentials | {
+            "TRACECAT_AWS_EXTERNAL_ID": build_workspace_external_id(params.workspace_id)
+        }
+
+    try:
+        details = await verify_bedrock_catalog_target(
+            credentials=credentials,
+            inference_profile_id=params.inference_profile_id,
+            model_id=params.model_id,
+            use_converse=params.use_converse,
+        )
+    except BedrockVerificationError as e:
+        return BedrockCatalogTestResponse(
+            success=False,
+            message="Bedrock model verification failed.",
+            error=str(e),
+        )
+    return BedrockCatalogTestResponse(
+        success=True,
+        message="Bedrock model verified successfully.",
+        details=details,
+    )
+
+
+@router.get(
+    "/organization/agent-catalog/{catalog_id}",
+    response_model=AgentCatalogRead,
+)
+@require_scope("agent:read")
+async def get_catalog_entry(
+    catalog_id: UUID,
+    role: OrgUserRole,
+    session: AsyncDBSession,
+) -> AgentCatalogRead:
+    """Get a specific catalog entry."""
+    assert role.organization_id is not None  # OrgUserRole guarantees this
+    service = AgentCatalogService(session=session)
+    try:
+        row = await service.get_catalog_entry(
+            org_id=role.organization_id,
+            catalog_id=catalog_id,
+        )
+    except TracecatNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from e
     return AgentCatalogRead.model_validate(row)
 
 

--- a/tracecat/agent/catalog/router.py
+++ b/tracecat/agent/catalog/router.py
@@ -102,7 +102,7 @@ async def create_catalog_entry(
     "/organization/agent-catalog/bedrock/test",
     response_model=BedrockCatalogTestResponse,
 )
-@require_scope("agent:update")
+@require_scope("agent:create", "agent:update", require_all=False)
 async def test_bedrock_catalog_target(
     role: OrgUserRole,
     session: AsyncDBSession,

--- a/tracecat/agent/catalog/router.py
+++ b/tracecat/agent/catalog/router.py
@@ -3,7 +3,6 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Body, HTTPException, Query, status
-from sqlalchemy import select
 
 from tracecat.agent.access.service import AgentModelAccessService
 from tracecat.agent.catalog.bedrock_validation import (
@@ -23,9 +22,8 @@ from tracecat.agent.service import AgentManagementService
 from tracecat.auth.dependencies import OrgUserRole, WorkspaceUserPathRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
-from tracecat.db.models import Workspace
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
-from tracecat.integrations.aws_assume_role import build_workspace_external_id
+from tracecat.integrations.aws_assume_role import build_organization_external_id
 from tracecat.pagination import CursorPaginationParams
 
 router = APIRouter()
@@ -102,7 +100,7 @@ async def create_catalog_entry(
     "/organization/agent-catalog/bedrock/test",
     response_model=BedrockCatalogTestResponse,
 )
-@require_scope("agent:create", "agent:update", require_all=False)
+@require_scope("agent:execute")
 async def test_bedrock_catalog_target(
     role: OrgUserRole,
     session: AsyncDBSession,
@@ -119,20 +117,11 @@ async def test_bedrock_catalog_target(
             error="Configure AWS Bedrock credentials before verifying a model.",
         )
 
-    if params.workspace_id is not None:
-        workspace_id = await session.scalar(
-            select(Workspace.id).where(
-                Workspace.id == params.workspace_id,
-                Workspace.organization_id == role.organization_id,
-            )
-        )
-        if workspace_id is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Workspace {params.workspace_id} not found",
-            )
+    if "AWS_ROLE_ARN" in credentials and "TRACECAT_AWS_EXTERNAL_ID" not in credentials:
         credentials = credentials | {
-            "TRACECAT_AWS_EXTERNAL_ID": build_workspace_external_id(params.workspace_id)
+            "TRACECAT_AWS_EXTERNAL_ID": build_organization_external_id(
+                role.organization_id
+            )
         }
 
     try:

--- a/tracecat/agent/catalog/schemas.py
+++ b/tracecat/agent/catalog/schemas.py
@@ -5,6 +5,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from tracecat.agent.catalog.types import BedrockVerificationDetails
+
 
 class AgentCatalogRead(BaseModel):
     """Single catalog model entry."""
@@ -46,7 +48,7 @@ class BedrockCatalogCreate(CloudCatalogModelBase):
     model_name: str = Field(min_length=1, max_length=500)
     inference_profile_id: str | None = Field(default=None, min_length=1)
     model_id: str | None = Field(default=None, min_length=1)
-    use_converse: bool = True
+    use_converse: bool = False
 
     @model_validator(mode="after")
     def _require_one_model_ref(self) -> "BedrockCatalogCreate":
@@ -94,7 +96,7 @@ class BedrockCatalogUpdate(CloudCatalogModelBase):
     model_provider: Literal["bedrock"]
     inference_profile_id: str | None = Field(default=None, min_length=1)
     model_id: str | None = Field(default=None, min_length=1)
-    use_converse: bool = True
+    use_converse: bool = False
 
     @model_validator(mode="after")
     def _require_one_model_ref(self) -> "BedrockCatalogUpdate":
@@ -146,7 +148,7 @@ class BedrockCatalogTest(BaseModel):
     model_provider: Literal["bedrock"]
     inference_profile_id: str | None = Field(default=None, min_length=1)
     model_id: str | None = Field(default=None, min_length=1)
-    use_converse: bool = True
+    use_converse: bool = False
 
     @model_validator(mode="after")
     def _require_one_model_ref(self) -> "BedrockCatalogTest":
@@ -172,7 +174,7 @@ class BedrockCatalogTestResponse(BaseModel):
         default=None,
         description="Error message if verification failed",
     )
-    details: dict[str, Any] = Field(
-        default_factory=dict,
+    details: BedrockVerificationDetails | None = Field(
+        default=None,
         description="Non-sensitive provider details returned during verification",
     )

--- a/tracecat/agent/catalog/schemas.py
+++ b/tracecat/agent/catalog/schemas.py
@@ -46,7 +46,7 @@ class BedrockCatalogCreate(CloudCatalogModelBase):
     model_name: str = Field(min_length=1, max_length=500)
     inference_profile_id: str | None = Field(default=None, min_length=1)
     model_id: str | None = Field(default=None, min_length=1)
-    use_converse: bool = False
+    use_converse: bool = True
 
     @model_validator(mode="after")
     def _require_one_model_ref(self) -> "BedrockCatalogCreate":
@@ -94,7 +94,7 @@ class BedrockCatalogUpdate(CloudCatalogModelBase):
     model_provider: Literal["bedrock"]
     inference_profile_id: str | None = Field(default=None, min_length=1)
     model_id: str | None = Field(default=None, min_length=1)
-    use_converse: bool = False
+    use_converse: bool = True
 
     @model_validator(mode="after")
     def _require_one_model_ref(self) -> "BedrockCatalogUpdate":
@@ -136,3 +136,44 @@ AgentCatalogUpdate = Annotated[
     | VertexAICatalogUpdate,
     Field(discriminator="model_provider"),
 ]
+
+
+class BedrockCatalogTest(BaseModel):
+    """Request to verify an unsaved Bedrock catalog target."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model_provider: Literal["bedrock"]
+    inference_profile_id: str | None = Field(default=None, min_length=1)
+    model_id: str | None = Field(default=None, min_length=1)
+    use_converse: bool = True
+    workspace_id: UUID | None = None
+
+    @model_validator(mode="after")
+    def _require_one_model_ref(self) -> "BedrockCatalogTest":
+        has_profile = self.inference_profile_id is not None
+        has_model_id = self.model_id is not None
+        if has_profile == has_model_id:
+            raise ValueError("Provide exactly one of inference_profile_id or model_id")
+        return self
+
+
+class BedrockCatalogTestResponse(BaseModel):
+    """Response for Bedrock catalog target verification."""
+
+    success: bool = Field(
+        ...,
+        description="Whether the Bedrock target verification succeeded",
+    )
+    message: str = Field(
+        ...,
+        description="Message describing the verification result",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Error message if verification failed",
+    )
+    details: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Non-sensitive provider details returned during verification",
+    )

--- a/tracecat/agent/catalog/schemas.py
+++ b/tracecat/agent/catalog/schemas.py
@@ -147,7 +147,6 @@ class BedrockCatalogTest(BaseModel):
     inference_profile_id: str | None = Field(default=None, min_length=1)
     model_id: str | None = Field(default=None, min_length=1)
     use_converse: bool = True
-    workspace_id: UUID | None = None
 
     @model_validator(mode="after")
     def _require_one_model_ref(self) -> "BedrockCatalogTest":

--- a/tracecat/agent/catalog/types.py
+++ b/tracecat/agent/catalog/types.py
@@ -1,0 +1,100 @@
+"""Agent catalog type definitions."""
+
+from __future__ import annotations
+
+from typing import Literal, NotRequired, Protocol, TypedDict
+
+
+class BedrockContentBlock(TypedDict):
+    text: str
+
+
+class BedrockMessage(TypedDict):
+    role: Literal["user"]
+    content: list[BedrockContentBlock]
+
+
+class BedrockInferenceConfig(TypedDict):
+    maxTokens: int
+
+
+class AnthropicInvokeContentBlock(TypedDict):
+    type: Literal["text"]
+    text: str
+
+
+class AnthropicInvokeMessage(TypedDict):
+    role: Literal["user"]
+    content: list[AnthropicInvokeContentBlock]
+
+
+class AnthropicInvokePayload(TypedDict):
+    anthropic_version: str
+    max_tokens: int
+    messages: list[AnthropicInvokeMessage]
+
+
+class BedrockInferenceProfileResponse(TypedDict):
+    status: NotRequired[str]
+    inferenceProfileId: NotRequired[str]
+    inferenceProfileArn: NotRequired[str]
+    models: NotRequired[list[dict[str, str]]]
+
+
+class BedrockModelAvailabilityResponse(TypedDict):
+    authorizationStatus: NotRequired[str]
+    entitlementAvailability: NotRequired[str]
+    regionAvailability: NotRequired[str]
+
+
+class BedrockInferenceProfileDetails(TypedDict):
+    target_type: Literal["inference_profile"]
+    model_count: int
+    status: NotRequired[str]
+    inference_profile_id: NotRequired[str]
+    inference_profile_arn: NotRequired[str]
+
+
+class BedrockModelAvailabilityDetails(TypedDict):
+    target_type: Literal["model_id"]
+    authorization_status: NotRequired[str]
+    entitlement_availability: NotRequired[str]
+    region_availability: NotRequired[str]
+
+
+type BedrockVerificationDetails = (
+    BedrockInferenceProfileDetails | BedrockModelAvailabilityDetails
+)
+
+
+class BedrockControlClient(Protocol):
+    async def get_inference_profile(
+        self,
+        *,
+        inferenceProfileIdentifier: str,
+    ) -> BedrockInferenceProfileResponse: ...
+
+    async def get_foundation_model_availability(
+        self,
+        *,
+        modelId: str,
+    ) -> BedrockModelAvailabilityResponse: ...
+
+
+class BedrockRuntimeClient(Protocol):
+    async def converse(
+        self,
+        *,
+        modelId: str,
+        messages: list[BedrockMessage],
+        inferenceConfig: BedrockInferenceConfig,
+    ) -> object: ...
+
+    async def invoke_model(
+        self,
+        *,
+        modelId: str,
+        body: bytes,
+        contentType: str,
+        accept: str,
+    ) -> object: ...

--- a/tracecat/agent/gateway.py
+++ b/tracecat/agent/gateway.py
@@ -185,7 +185,7 @@ async def _resolve_bedrock_runtime_credentials(
             external_id := credentials.get(_AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY)
         ):
             raise ProxyException(
-                message="Bedrock role credentials require a Tracecat-provided workspace External ID.",
+                message="Bedrock role credentials require a Tracecat-provided AWS External ID.",
                 type="config_error",
                 param=None,
                 code=400,
@@ -271,12 +271,9 @@ async def get_provider_credentials(
             if catalog_id is not None:
                 creds = await service.get_catalog_credentials(catalog_id)
             else:
-                creds = await service.get_workspace_provider_credentials(provider)
-                if creds is not None:
-                    creds = await service._augment_runtime_provider_credentials(
-                        provider,
-                        creds,
-                    )
+                creds = await service.get_workspace_runtime_provider_credentials(
+                    provider
+                )
         except ValueError as exc:
             raise ProxyException(
                 message=str(exc),

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -64,6 +64,7 @@ _AZURE_COGNITIVE_SCOPE = "https://cognitiveservices.azure.com/.default"
 _DEFAULT_MODEL_SETTING_KEY = "agent_default_model"
 _DEFAULT_MODEL_CATALOG_ID_SETTING_KEY = "agent_default_model_catalog_id"
 CloudProviderSlug = Literal["bedrock", "azure_openai", "azure_ai", "vertex_ai"]
+RuntimeCredentialScope = Literal["organization", "workspace"]
 
 
 class CloudTargetKey(NamedTuple):
@@ -476,10 +477,34 @@ class AgentManagementService(BaseOrgService):
             return None
 
     async def _augment_runtime_provider_credentials(
-        self, provider: str, credentials: dict[str, str]
+        self,
+        provider: str,
+        credentials: dict[str, str],
+        *,
+        external_id_scope: RuntimeCredentialScope = "organization",
     ) -> dict[str, str]:
         """Augment provider credentials with runtime-only values when required."""
         match provider:
+            case "bedrock":
+                if (
+                    "AWS_ROLE_ARN" not in credentials
+                    or _AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY in credentials
+                ):
+                    return credentials
+                match external_id_scope:
+                    case "workspace" if self.role.workspace_id is not None:
+                        external_id = build_workspace_external_id(
+                            self.role.workspace_id
+                        )
+                    case "workspace":
+                        return credentials
+                    case "organization":
+                        external_id = build_organization_external_id(
+                            self.organization_id
+                        )
+                return credentials | {
+                    _AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY: external_id
+                }
             case "vertex_ai" if "GOOGLE_API_CREDENTIALS" in credentials:
                 return await _resolve_vertex_bearer_token(credentials)
             case "azure_openai" | "azure_ai" if not credentials.get(
@@ -489,39 +514,6 @@ class AgentManagementService(BaseOrgService):
             case _:
                 return credentials
 
-    def _with_bedrock_organization_external_id(
-        self, provider: str, credentials: dict[str, str]
-    ) -> dict[str, str]:
-        """Attach the org-scoped Bedrock AssumeRole external ID when required."""
-        if (
-            provider != "bedrock"
-            or "AWS_ROLE_ARN" not in credentials
-            or _AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY in credentials
-        ):
-            return credentials
-        return credentials | {
-            _AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY: build_organization_external_id(
-                self.organization_id
-            )
-        }
-
-    def _with_bedrock_workspace_external_id(
-        self, provider: str, credentials: dict[str, str]
-    ) -> dict[str, str]:
-        """Attach the workspace-scoped Bedrock AssumeRole external ID when required."""
-        if (
-            provider != "bedrock"
-            or "AWS_ROLE_ARN" not in credentials
-            or _AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY in credentials
-            or self.role.workspace_id is None
-        ):
-            return credentials
-        return credentials | {
-            _AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY: build_workspace_external_id(
-                self.role.workspace_id
-            )
-        }
-
     async def get_runtime_provider_credentials(
         self, provider: str
     ) -> dict[str, str] | None:
@@ -529,10 +521,6 @@ class AgentManagementService(BaseOrgService):
         credentials = await self.get_provider_credentials(provider)
         if credentials is None:
             return None
-        credentials = self._with_bedrock_organization_external_id(
-            provider,
-            credentials,
-        )
         return await self._augment_runtime_provider_credentials(provider, credentials)
 
     async def get_workspace_runtime_provider_credentials(
@@ -542,8 +530,11 @@ class AgentManagementService(BaseOrgService):
         credentials = await self.get_workspace_provider_credentials(provider)
         if credentials is None:
             return None
-        credentials = self._with_bedrock_workspace_external_id(provider, credentials)
-        return await self._augment_runtime_provider_credentials(provider, credentials)
+        return await self._augment_runtime_provider_credentials(
+            provider,
+            credentials,
+            external_id_scope="workspace",
+        )
 
     def _catalog_target_credentials(self, row: AgentCatalog) -> dict[str, str]:
         """Project cloud catalog target metadata into runtime credential keys."""
@@ -600,10 +591,6 @@ class AgentManagementService(BaseOrgService):
         if not target_credentials:
             target_credentials = self._catalog_encrypted_target_credentials(row)
         runtime_credentials = credentials | target_credentials
-        runtime_credentials = self._with_bedrock_organization_external_id(
-            row.model_provider,
-            runtime_credentials,
-        )
         return await self._augment_runtime_provider_credentials(
             row.model_provider,
             runtime_credentials,

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -42,7 +42,10 @@ from tracecat.db.models import (
     Secret,
 )
 from tracecat.exceptions import TracecatAuthorizationError, TracecatNotFoundError
-from tracecat.integrations.aws_assume_role import build_workspace_external_id
+from tracecat.integrations.aws_assume_role import (
+    build_organization_external_id,
+    build_workspace_external_id,
+)
 from tracecat.logger import logger
 from tracecat.secrets import secrets_manager
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
@@ -477,16 +480,6 @@ class AgentManagementService(BaseOrgService):
     ) -> dict[str, str]:
         """Augment provider credentials with runtime-only values when required."""
         match provider:
-            case "bedrock" if (
-                "AWS_ROLE_ARN" in credentials
-                and self.role.workspace_id is not None
-                and _AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY not in credentials
-            ):
-                runtime_credentials = credentials.copy()
-                runtime_credentials[_AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY] = (
-                    build_workspace_external_id(self.role.workspace_id)
-                )
-                return runtime_credentials
             case "vertex_ai" if "GOOGLE_API_CREDENTIALS" in credentials:
                 return await _resolve_vertex_bearer_token(credentials)
             case "azure_openai" | "azure_ai" if not credentials.get(
@@ -496,6 +489,39 @@ class AgentManagementService(BaseOrgService):
             case _:
                 return credentials
 
+    def _with_bedrock_organization_external_id(
+        self, provider: str, credentials: dict[str, str]
+    ) -> dict[str, str]:
+        """Attach the org-scoped Bedrock AssumeRole external ID when required."""
+        if (
+            provider != "bedrock"
+            or "AWS_ROLE_ARN" not in credentials
+            or _AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY in credentials
+        ):
+            return credentials
+        return credentials | {
+            _AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY: build_organization_external_id(
+                self.organization_id
+            )
+        }
+
+    def _with_bedrock_workspace_external_id(
+        self, provider: str, credentials: dict[str, str]
+    ) -> dict[str, str]:
+        """Attach the workspace-scoped Bedrock AssumeRole external ID when required."""
+        if (
+            provider != "bedrock"
+            or "AWS_ROLE_ARN" not in credentials
+            or _AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY in credentials
+            or self.role.workspace_id is None
+        ):
+            return credentials
+        return credentials | {
+            _AWS_ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY: build_workspace_external_id(
+                self.role.workspace_id
+            )
+        }
+
     async def get_runtime_provider_credentials(
         self, provider: str
     ) -> dict[str, str] | None:
@@ -503,6 +529,10 @@ class AgentManagementService(BaseOrgService):
         credentials = await self.get_provider_credentials(provider)
         if credentials is None:
             return None
+        credentials = self._with_bedrock_organization_external_id(
+            provider,
+            credentials,
+        )
         return await self._augment_runtime_provider_credentials(provider, credentials)
 
     async def get_workspace_runtime_provider_credentials(
@@ -512,6 +542,7 @@ class AgentManagementService(BaseOrgService):
         credentials = await self.get_workspace_provider_credentials(provider)
         if credentials is None:
             return None
+        credentials = self._with_bedrock_workspace_external_id(provider, credentials)
         return await self._augment_runtime_provider_credentials(provider, credentials)
 
     def _catalog_target_credentials(self, row: AgentCatalog) -> dict[str, str]:
@@ -569,6 +600,10 @@ class AgentManagementService(BaseOrgService):
         if not target_credentials:
             target_credentials = self._catalog_encrypted_target_credentials(row)
         runtime_credentials = credentials | target_credentials
+        runtime_credentials = self._with_bedrock_organization_external_id(
+            row.model_provider,
+            runtime_credentials,
+        )
         return await self._augment_runtime_provider_credentials(
             row.model_provider,
             runtime_credentials,

--- a/tracecat/integrations/aws_assume_role.py
+++ b/tracecat/integrations/aws_assume_role.py
@@ -22,3 +22,8 @@ def get_tracecat_aws_principal_arn() -> str:
 def build_workspace_external_id(workspace_id: UUID | str) -> str:
     """Build a workspace-scoped External ID for AWS AssumeRole."""
     return str(workspace_id).replace("-", "")
+
+
+def build_organization_external_id(organization_id: UUID | str) -> str:
+    """Build an organization-scoped External ID for AWS AssumeRole."""
+    return str(organization_id).replace("-", "")


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Bedrock connection test so users can verify a model or inference profile before saving. Uses control-plane checks and a runtime ping (Converse is opt-in), and auto-injects org-scoped AWS External IDs for role assumptions.

- New Features
  - Backend: POST `/organization/agent-catalog/bedrock/test` verifies unsaved targets with control-plane checks (profile ACTIVE or model availability) and a runtime ping. Uses `aioboto3`/`aiobotocore` with AWS role (server supplies org-scoped External ID), static keys, or `AWS_BEARER_TOKEN_BEDROCK`. Requires `AWS_REGION` and returns non-sensitive details for inference profiles or model availability.
  - Frontend: Added “Test connection” for Bedrock in Org Settings. Enabled only when exactly one of inference profile ID or model ID is set. Shows spinner and success/failure toasts.
  - Defaults: `use_converse` now defaults to false across create/update/test and in the form. Server injects org-scoped AWS External ID for Bedrock role credentials across provider, catalog, and runtime; workspace-scoped External ID is used only for workspace runtime. Error messages reference “AWS External ID.”

- Refactors
  - Implemented async verification helpers with `aioboto3`/`aiobotocore` and typed SDK interfaces, with clear error mapping and bearer-token support for Bedrock SDK calls.

<sup>Written for commit a392fce84af527615a68eec30c43cf9f6829a856. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2687?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


<img width="648" height="701" alt="image" src="https://github.com/user-attachments/assets/d63ca2d2-8c8a-4757-a4a8-42f860966ddb" />


