### PR TITLE
ci: bump blacksmith runners for tests and image builds

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -36,10 +36,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: blacksmith-8vcpu-ubuntu-2404
+          - runner: blacksmith-16vcpu-ubuntu-2404
             platform: linux/amd64
             platform_tag: linux-amd64
-          - runner: blacksmith-8vcpu-ubuntu-2404-arm
+          - runner: blacksmith-16vcpu-ubuntu-2404-arm
             platform: linux/arm64
             platform_tag: linux-arm64
     steps:
@@ -111,7 +111,7 @@ jobs:
         github.triggering_actor || github.actor
       )
     needs: build-and-push-api
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -176,10 +176,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: blacksmith-8vcpu-ubuntu-2404
+          - runner: blacksmith-16vcpu-ubuntu-2404
             platform: linux/amd64
             platform_tag: linux-amd64
-          - runner: blacksmith-8vcpu-ubuntu-2404-arm
+          - runner: blacksmith-16vcpu-ubuntu-2404-arm
             platform: linux/arm64
             platform_tag: linux-arm64
     steps:
@@ -263,7 +263,7 @@ jobs:
         github.triggering_actor || github.actor
       )
     needs: build-and-push-ui
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -92,7 +92,7 @@ jobs:
       )
     needs: ssh-sanity # only start if key check passed
     environment: internal-registry-ci
-    runs-on: blacksmith-8vcpu-ubuntu-2204
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/test-pnpm-build.yml
+++ b/.github/workflows/test-pnpm-build.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   push-ui-to-ghcr-test:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: blacksmith-8vcpu-ubuntu-2204
     timeout-minutes: 10
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -40,7 +40,7 @@ env:
 
 jobs:
   test-custom-registry-install:
-    runs-on: blacksmith-8vcpu-ubuntu-2204
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -64,7 +64,7 @@ jobs:
         run: uv sync --frozen
 
   test-all:
-    runs-on: blacksmith-8vcpu-ubuntu-2204
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     timeout-minutes: 60
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Bumps Blacksmith runner vCPU on CI jobs that can take advantage of more parallelism:

- `test-python.yml` — `test-all` matrix (unit, registry, temporal) and `test-custom-registry-install`: 8 → 16 vCPU. Unit and registry tests run with `pytest -n auto` and are mostly CPU-bound; temporal also runs `-n auto` with Docker services on the same VM.
- `run-integration-tests.yml` — `test-integration`: 8 → 16 vCPU. Runs `pytest -n auto` alongside ~8 Docker services on a single host.
- `build-push-images.yml` — both API and UI publish flows, including amd64 and arm64 matrix legs plus the manifest/merge jobs: 8 → 16 vCPU.
- `test-pnpm-build.yml` — `push-ui-to-ghcr-test`: 4 → 8 vCPU. Frontend Docker build smoke test.

## Test plan

- [ ] On first run, confirm `blacksmith-16vcpu-ubuntu-2404-arm` provisions (the arm leg of `build-push-images.yml`). If it doesn't, fall back to 8 vCPU for that matrix entry.
- [ ] Compare wall-clock duration on `test-all` (unit/registry) and `test-integration` against recent main-branch runs to confirm a meaningful speedup.
- [ ] Spot-check that no job exceeds its existing `timeout-minutes`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase vCPU on Blacksmith runners to speed up CPU‑bound tests and Docker image builds. Most jobs now use 16 vCPU; the UI build smoke test moves from 4 to 8.

- test-python.yml: `test-all` and `test-custom-registry-install` → 16 vCPU (from 8)
- run-integration-tests.yml: `test-integration` → 16 vCPU (from 8)
- build-push-images.yml: API and UI matrix legs (amd64, arm64) and manifest jobs → 16 vCPU (from 8)
- test-pnpm-build.yml: `push-ui-to-ghcr-test` → 8 vCPU (from 4)

<sup>Written for commit f325e60fe8f016f036a65ce35405263166a75022. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

