### PR TITLE
ci: optimize workflow caching

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -87,6 +87,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=ghcr.io/tracecathq/tracecat,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=ghcr.io/tracecathq/tracecat:buildcache-${{ matrix.platform_tag }}
+          cache-to: type=registry,ref=ghcr.io/tracecathq/tracecat:buildcache-${{ matrix.platform_tag }},mode=max,ignore-error=true
 
       - name: Export digest
         run: |
@@ -239,6 +241,8 @@ jobs:
             NODE_ENV=${{ env.NODE_ENV }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=ghcr.io/tracecathq/tracecat-ui,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=ghcr.io/tracecathq/tracecat-ui:buildcache-${{ matrix.platform_tag }}
+          cache-to: type=registry,ref=ghcr.io/tracecathq/tracecat-ui:buildcache-${{ matrix.platform_tag }},mode=max,ignore-error=true
 
       - name: Export digest
         run: |

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -7,6 +7,8 @@ on:
       - frontend/**
       - tracecat/**
       - packages/**
+      - pyproject.toml
+      - uv.lock
       - .github/workflows/lint-frontend.yml
   pull_request:
     branches: ["main", "staging"]
@@ -14,6 +16,8 @@ on:
       - frontend/**
       - tracecat/**
       - packages/**
+      - pyproject.toml
+      - uv.lock
       - .github/workflows/lint-frontend.yml
 
 permissions:
@@ -31,6 +35,9 @@ jobs:
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: Install Python dependencies
         run: uv sync --no-install-project
@@ -55,6 +62,20 @@ jobs:
         with:
           version: 9
           run_install: false
+
+      - name: Get pnpm store directory
+        working-directory: frontend
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+      - name: Setup pnpm cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-store-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-pnpm-store-
 
       - name: Install frontend dependencies
         working-directory: frontend

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -9,6 +9,7 @@ on:
       - alembic/**
       - tests/**
       - pyproject.toml
+      - uv.lock
       - .github/workflows/lint-python.yml
   pull_request:
     branches: [ "main", "staging" ]
@@ -18,6 +19,7 @@ on:
       - alembic/**
       - tests/**
       - pyproject.toml
+      - uv.lock
       - .github/workflows/lint-python.yml
 
 permissions:
@@ -52,6 +54,9 @@ jobs:
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: uv sync --no-install-project --group lint

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -16,6 +16,10 @@ on:
       - docker-compose.dev.yml
       - docker-compose.local.yml
       - .github/workflows/run-integration-tests.yml
+  schedule:
+    # Full compose coverage is intentionally off the PR critical path.
+    - cron: "17 * * * *"
+  workflow_dispatch:
   pull_request:
     branches: ["main", "staging"]
     paths:
@@ -41,7 +45,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   ssh-sanity:
     if: >-
-      github.event_name == 'push' ||
+      github.event_name != 'pull_request' ||
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository
@@ -87,11 +91,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   test-integration:
     if: >-
-      github.event_name == 'push' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository
-      )
+      github.event_name != 'pull_request'
     needs: ssh-sanity # only start if key check passed
     environment: internal-registry-ci
     runs-on: blacksmith-8vcpu-ubuntu-2204
@@ -218,7 +218,7 @@ jobs:
       - name: Run API-backed temporal tests against compose
         env:
           TRACECAT_TEST_API_MODE: "external"
-          TRACECAT__API_URL: "http://localhost:8000"
+          TRACECAT_TEST_EXTERNAL_API_URL: "http://localhost/api"
           TEMPORAL__CLUSTER_URL: "localhost:7233"
           TRACECAT__DISABLE_NSJAIL: "true"
         run: |

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -116,8 +116,8 @@ jobs:
           sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
           sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Set up Docker builder
+        uses: useblacksmith/setup-docker-builder@78f41686563c732ccc097f7baac2f092f67538f0 # v1
 
       - name: Run environment setup script
         run: |
@@ -126,7 +126,15 @@ jobs:
           n
           test@tracecat.com" | bash env.sh
 
-      - name: Build image and start core Docker services
+      - name: Build CI image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          target: production
+          load: true
+          tags: tracecat-ci:integration-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Start core Docker services
         env:
           TRACECAT__CI_IMAGE_TAG: integration-${{ github.run_id }}-${{ github.run_attempt }}
           TRACECAT__UNSAFE_DISABLE_SM_MASKING: "true"
@@ -138,9 +146,8 @@ jobs:
           set -euo pipefail
 
           compose_files=(-f docker-compose.local.yml -f .github/docker-compose.integration.yml)
-          image="tracecat-ci:${TRACECAT__CI_IMAGE_TAG}"
 
-          # Overlap host dependency setup with the Docker image build and service startup.
+          # Overlap host dependency setup with service startup.
           uv sync --locked --group dev &
           uv_sync_pid=$!
           cleanup_uv_sync() {
@@ -150,7 +157,6 @@ jobs:
           }
           trap cleanup_uv_sync EXIT
 
-          docker buildx build --load --target production -t "$image" .
           docker compose "${compose_files[@]}" up --no-build -d temporal api worker executor postgres_db caddy minio redis
 
           # Wait for services with health checks to become healthy

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -20,21 +20,6 @@ on:
     # Full compose coverage is intentionally off the PR critical path.
     - cron: "17 * * * *"
   workflow_dispatch:
-  pull_request:
-    branches: ["main", "staging"]
-    paths:
-      - tracecat/**
-      - registry/**
-      - tests/integration/**
-      - tests/temporal/**
-      - pyproject.toml
-      - uv.lock
-      - Dockerfile
-      - .github/docker-compose.integration.yml
-      - docker-compose.yml
-      - docker-compose.dev.yml
-      - docker-compose.local.yml
-      - .github/workflows/run-integration-tests.yml
 
 permissions:
   contents: read
@@ -44,12 +29,6 @@ jobs:
   # 1.  LIGHTWEIGHT SSH / INSTALL SMOKE-TEST
   # ──────────────────────────────────────────────────────────────────
   ssh-sanity:
-    if: >-
-      github.event_name != 'pull_request' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository
-      )
     environment: internal-registry-ci
     runs-on: ubuntu-latest
     timeout-minutes: 5 # short fail-fast window
@@ -90,8 +69,6 @@ jobs:
   #     Uses worker-specific task queues from conftest.py for isolation
   # ──────────────────────────────────────────────────────────────────
   test-integration:
-    if: >-
-      github.event_name != 'pull_request'
     needs: ssh-sanity # only start if key check passed
     environment: internal-registry-ci
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -7,6 +7,7 @@ on:
       - tracecat/**
       - registry/**
       - tests/integration/**
+      - tests/temporal/**
       - pyproject.toml
       - uv.lock
       - Dockerfile
@@ -21,6 +22,7 @@ on:
       - tracecat/**
       - registry/**
       - tests/integration/**
+      - tests/temporal/**
       - pyproject.toml
       - uv.lock
       - Dockerfile
@@ -212,6 +214,15 @@ jobs:
           # Worker-specific task queues in conftest.py ensure isolation
           # faulthandler_timeout=300: dump thread state after 5min for extra debugging
           uv run --no-sync pytest tests/integration --ignore=tests/integration/test_pool_integration.py -m "not live_secret" -n auto -ra -v -o faulthandler_timeout=300
+
+      - name: Run API-backed temporal tests against compose
+        env:
+          TRACECAT_TEST_API_MODE: "external"
+          TRACECAT__API_URL: "http://localhost:8000"
+          TEMPORAL__CLUSTER_URL: "localhost:7233"
+          TRACECAT__DISABLE_NSJAIL: "true"
+        run: |
+          uv run --no-sync pytest tests/temporal -m "requires_api and not live_secret" -n auto -ra -v -o faulthandler_timeout=300
 
       - name: Show Docker logs on failure
         if: failure()

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -1,21 +1,6 @@
 name: Integration Tests
 
 on:
-  push:
-    branches: ["main"]
-    paths:
-      - tracecat/**
-      - registry/**
-      - tests/integration/**
-      - tests/temporal/**
-      - pyproject.toml
-      - uv.lock
-      - Dockerfile
-      - .github/docker-compose.integration.yml
-      - docker-compose.yml
-      - docker-compose.dev.yml
-      - docker-compose.local.yml
-      - .github/workflows/run-integration-tests.yml
   schedule:
     # Full compose coverage is intentionally off the PR critical path.
     - cron: "17 * * * *"
@@ -25,10 +10,40 @@ permissions:
   contents: read
 
 jobs:
+  authorize-run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Authorize privileged manual run
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor || github.actor }}
+          TRUSTED_CI_ACTORS_JSON: ${{ vars.TRUSTED_CI_ACTORS_JSON || '[]' }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] || [ "$ACTOR" = "github-actions[bot]" ]; then
+            exit 0
+          fi
+
+          python - <<'PY'
+          import json
+          import os
+          import sys
+
+          trusted_actors = json.loads(os.environ["TRUSTED_CI_ACTORS_JSON"])
+          triggering_actor = os.environ["TRIGGERING_ACTOR"]
+          if triggering_actor not in trusted_actors:
+              print(f"Manual integration run is not trusted for actor: {triggering_actor}", file=sys.stderr)
+              sys.exit(1)
+          PY
+
   # ──────────────────────────────────────────────────────────────────
   # 1.  LIGHTWEIGHT SSH / INSTALL SMOKE-TEST
   # ──────────────────────────────────────────────────────────────────
   ssh-sanity:
+    needs: authorize-run
     environment: internal-registry-ci
     runs-on: ubuntu-latest
     timeout-minutes: 5 # short fail-fast window

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -144,9 +144,10 @@ jobs:
             while true; do
               # Get health status of all services, filter to those with health checks
               # A service is ready when Health is exactly "healthy" (not empty, null, or starting)
-              # Note: docker compose ps --format json outputs JSON Lines (one object per line),
-              # so we use jq -s to slurp them into an array first
-              statuses=$(docker compose -f docker-compose.local.yml -f .github/docker-compose.integration.yml ps --format json | jq -s -r ".[] | select(.Health != null and .Health != \"\") | .Health")
+              statuses=$(
+                docker compose -f docker-compose.local.yml -f .github/docker-compose.integration.yml ps --format json |
+                  jq -r 'if type == "array" then .[] else . end | select(.Health != null and .Health != "") | .Health'
+              )
 
               # Count healthy vs total services with health checks
               total=$(echo "$statuses" | grep -c . || true)

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -2,19 +2,27 @@ name: Integration Tests
 
 on:
   schedule:
-    # Full compose coverage is intentionally off the PR critical path.
-    - cron: "17 * * * *"
+    # GitHub cron is UTC. The plan-run job enforces 10:00-18:00 America/New_York.
+    - cron: "*/30 14-23 * * 1-5"
   workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: integration-tests-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  authorize-run:
+  plan-run:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      should_run: ${{ steps.decision.outputs.should_run }}
+      cache_hit: ${{ steps.decision.outputs.cache_hit }}
     steps:
-      - name: Authorize privileged manual run
+      - name: Check trigger policy
+        id: trigger-policy
         env:
           EVENT_NAME: ${{ github.event_name }}
           ACTOR: ${{ github.actor }}
@@ -23,27 +31,66 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "$EVENT_NAME" != "workflow_dispatch" ] || [ "$ACTOR" = "github-actions[bot]" ]; then
+          echo "candidate=false" >> "$GITHUB_OUTPUT"
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$ACTOR" != "github-actions[bot]" ] &&
+              ! jq -e --arg actor "$TRIGGERING_ACTOR" 'index($actor)' <<< "$TRUSTED_CI_ACTORS_JSON" >/dev/null; then
+              echo "Manual integration run is not trusted for actor: $TRIGGERING_ACTOR" >&2
+              exit 1
+            fi
+            echo "candidate=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          python - <<'PY'
-          import json
-          import os
-          import sys
+          local_dow=$(TZ=America/New_York date +%u)
+          local_hhmm=$(TZ=America/New_York date +%H%M)
+          if [ "$local_dow" -gt 5 ] || [[ "$local_hhmm" < "1000" || "$local_hhmm" > "1800" ]]; then
+            echo "Outside integration window in America/New_York: weekday=$local_dow time=$local_hhmm"
+            exit 0
+          fi
 
-          trusted_actors = json.loads(os.environ["TRUSTED_CI_ACTORS_JSON"])
-          triggering_actor = os.environ["TRIGGERING_ACTOR"]
-          if triggering_actor not in trusted_actors:
-              print(f"Manual integration run is not trusted for actor: {triggering_actor}", file=sys.stderr)
-              sys.exit(1)
-          PY
+          echo "candidate=true" >> "$GITHUB_OUTPUT"
+
+      - name: Check prior successful integration for this commit
+        id: integration-success
+        if: steps.trigger-policy.outputs.candidate == 'true'
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .integration-success
+          key: integration-tests-success-v1-${{ github.sha }}
+          lookup-only: true
+
+      - name: Decide whether integration should run
+        id: decision
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CANDIDATE: ${{ steps.trigger-policy.outputs.candidate }}
+          CACHE_HIT: ${{ steps.integration-success.outputs.cache-hit || 'false' }}
+        run: |
+          set -euo pipefail
+
+          echo "cache_hit=$CACHE_HIT" >> "$GITHUB_OUTPUT"
+
+          if [ "$CANDIDATE" != "true" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$EVENT_NAME" = "schedule" ] && [ "$CACHE_HIT" = "true" ]; then
+            echo "Integration already passed for this commit; skipping scheduled run."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
 
   # ──────────────────────────────────────────────────────────────────
   # 1.  LIGHTWEIGHT SSH / INSTALL SMOKE-TEST
   # ──────────────────────────────────────────────────────────────────
   ssh-sanity:
-    needs: authorize-run
+    needs: plan-run
+    if: needs.plan-run.outputs.should_run == 'true'
     environment: internal-registry-ci
     runs-on: ubuntu-latest
     timeout-minutes: 5 # short fail-fast window
@@ -84,7 +131,8 @@ jobs:
   #     Uses worker-specific task queues from conftest.py for isolation
   # ──────────────────────────────────────────────────────────────────
   test-integration:
-    needs: ssh-sanity # only start if key check passed
+    needs: [plan-run, ssh-sanity] # only start if key check passed
+    if: needs.plan-run.outputs.should_run == 'true' && needs.ssh-sanity.result == 'success'
     environment: internal-registry-ci
     runs-on: blacksmith-8vcpu-ubuntu-2204
     timeout-minutes: 30
@@ -161,7 +209,7 @@ jobs:
               # A service is ready when Health is exactly "healthy" (not empty, null, or starting)
               statuses=$(
                 docker compose -f docker-compose.local.yml -f .github/docker-compose.integration.yml ps --format json |
-                  jq -r 'if type == "array" then .[] else . end | select(.Health != null and .Health != "") | .Health'
+                  jq -r "if type == \"array\" then .[] else . end | select(.Health != null and .Health != \"\") | .Health"
               )
 
               # Count healthy vs total services with health checks
@@ -255,3 +303,16 @@ jobs:
           TRACECAT__CI_IMAGE_TAG: integration-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           docker compose -f docker-compose.local.yml -f .github/docker-compose.integration.yml down -v
+
+      - name: Create integration success marker
+        if: success() && needs.plan-run.outputs.cache_hit != 'true'
+        run: |
+          mkdir -p .integration-success
+          printf '%s\n' "$GITHUB_SHA" > .integration-success/head-sha
+
+      - name: Save integration success marker
+        if: success() && needs.plan-run.outputs.cache_hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .integration-success
+          key: integration-tests-success-v1-${{ github.sha }}

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -38,15 +38,15 @@ jobs:
         working-directory: frontend
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+          echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-store-${{ hashFiles('frontend/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-${{ runner.arch }}-pnpm-store-
 
       - name: Install dependencies
         working-directory: frontend

--- a/.github/workflows/test-pnpm-build.yml
+++ b/.github/workflows/test-pnpm-build.yml
@@ -30,13 +30,8 @@ jobs:
           sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
           sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-        with:
-          version: v0.23.0
+      - name: Set up Docker builder
+        uses: useblacksmith/setup-docker-builder@78f41686563c732ccc097f7baac2f092f67538f0 # v1
 
       - name: Extract Docker metadata
         id: meta
@@ -50,7 +45,7 @@ jobs:
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
 
-      - name: Build and push Docker image
+      - name: Build Docker image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           NEXT_PUBLIC_API_URL: http://localhost:8000
@@ -70,5 +65,3 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -123,7 +123,7 @@ jobs:
           trap cleanup_uv_sync EXIT
 
           if [ "${{ matrix.test_group }}" = "temporal" ]; then
-            services=(temporal api postgres_db minio redis)
+            services=(temporal postgres_db minio redis)
             cat > /tmp/tracecat-ci-postgres.yml <<'YAML'
           services:
             postgres_db:
@@ -162,6 +162,50 @@ jobs:
           wait "$uv_sync_pid"
           trap - EXIT
 
+      - name: Register Temporal search attributes
+        if: matrix.test_group == 'temporal'
+        run: |
+          set -euo pipefail
+
+          attrs=(
+            TracecatTriggerType
+            TracecatTriggeredByUserId
+            TracecatWorkspaceId
+            TracecatAlias
+            TracecatCorrelationId
+            TracecatExecutionType
+          )
+
+          add_args=()
+          for attr in "${attrs[@]}"; do
+            add_args+=(--name "$attr" --type Keyword)
+          done
+
+          docker compose -f docker-compose.dev.yml exec -T temporal \
+            tctl --address temporal:7233 --namespace default --auto_confirm \
+            admin cluster add-search-attributes "${add_args[@]}"
+
+          for _ in {1..30}; do
+            output=$(docker compose -f docker-compose.dev.yml exec -T temporal \
+              tctl --address temporal:7233 --namespace default \
+              admin cluster get-search-attributes --print_json true)
+            missing=()
+            for attr in "${attrs[@]}"; do
+              if [[ "$output" != *"$attr"* ]]; then
+                missing+=("$attr")
+              fi
+            done
+            if [ "${#missing[@]}" -eq 0 ]; then
+              echo "Temporal search attributes registered"
+              exit 0
+            fi
+            echo "Waiting for Temporal search attributes: ${missing[*]}"
+            sleep 2
+          done
+
+          echo "Timed out waiting for Temporal search attributes: ${missing[*]}"
+          exit 1
+
       - name: Run tests
         env:
           TRACECAT__SYSTEM_PATH: "/usr/local/bin:/usr/bin:/bin"
@@ -178,6 +222,7 @@ jobs:
           elif [ "${{ matrix.test_group }}" = "temporal" ]; then
             # Temporal tests run with compression enabled and parallelization
             # Worker-specific task queues in conftest.py enable safe parallel execution
+            TRACECAT_TEST_API_MODE=inprocess \
             TRACECAT__CONTEXT_COMPRESSION_ENABLED=true \
             TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB=0 \
             uv run pytest tests/temporal -m "not live_secret" -n auto -ra -o faulthandler_timeout=300
@@ -203,10 +248,4 @@ jobs:
           if [ "${{ matrix.test_group }}" = "temporal" ]; then
             echo "=== Temporal Logs ==="
             docker compose -f docker-compose.dev.yml logs temporal --tail=200
-
-            echo "=== Migrations Logs ==="
-            docker compose -f docker-compose.dev.yml logs migrations --tail=200
-
-            echo "=== API Logs ==="
-            docker compose -f docker-compose.dev.yml logs api --tail=200
           fi

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -123,7 +123,7 @@ jobs:
           trap cleanup_uv_sync EXIT
 
           if [ "${{ matrix.test_group }}" = "temporal" ]; then
-            services=(temporal postgres_db minio redis)
+            services=(temporal api postgres_db minio redis)
             cat > /tmp/tracecat-ci-postgres.yml <<'YAML'
           services:
             postgres_db:
@@ -161,50 +161,6 @@ jobs:
           echo "Waiting for Python environment sync..."
           wait "$uv_sync_pid"
           trap - EXIT
-
-      - name: Register Temporal search attributes
-        if: matrix.test_group == 'temporal'
-        run: |
-          set -euo pipefail
-
-          attrs=(
-            TracecatTriggerType
-            TracecatTriggeredByUserId
-            TracecatWorkspaceId
-            TracecatAlias
-            TracecatCorrelationId
-            TracecatExecutionType
-          )
-
-          add_args=()
-          for attr in "${attrs[@]}"; do
-            add_args+=(--name "$attr" --type Keyword)
-          done
-
-          docker compose -f docker-compose.dev.yml exec -T temporal \
-            tctl --address temporal:7233 --namespace default --auto_confirm \
-            admin cluster add-search-attributes "${add_args[@]}"
-
-          for _ in {1..30}; do
-            output=$(docker compose -f docker-compose.dev.yml exec -T temporal \
-              tctl --address temporal:7233 --namespace default \
-              admin cluster get-search-attributes --print_json true)
-            missing=()
-            for attr in "${attrs[@]}"; do
-              if [[ "$output" != *"$attr"* ]]; then
-                missing+=("$attr")
-              fi
-            done
-            if [ "${#missing[@]}" -eq 0 ]; then
-              echo "Temporal search attributes registered"
-              exit 0
-            fi
-            echo "Waiting for Temporal search attributes: ${missing[*]}"
-            sleep 2
-          done
-
-          echo "Timed out waiting for Temporal search attributes: ${missing[*]}"
-          exit 1
 
       - name: Run tests
         env:
@@ -247,4 +203,10 @@ jobs:
           if [ "${{ matrix.test_group }}" = "temporal" ]; then
             echo "=== Temporal Logs ==="
             docker compose -f docker-compose.dev.yml logs temporal --tail=200
+
+            echo "=== Migrations Logs ==="
+            docker compose -f docker-compose.dev.yml logs migrations --tail=200
+
+            echo "=== API Logs ==="
+            docker compose -f docker-compose.dev.yml logs api --tail=200
           fi

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -155,9 +155,6 @@ jobs:
             sleep 5
           done
 
-          echo "Creating storage buckets..."
-          docker compose "${compose_files[@]}" exec -T minio mc mb --ignore-existing local/tracecat-attachments
-
           echo "Waiting for Python environment sync..."
           wait "$uv_sync_pid"
           trap - EXIT

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Register Temporal search attributes
         if: matrix.test_group == 'temporal'
         env:
-          TEMPORAL__CLUSTER_URL: "http://localhost:7233"
+          TEMPORAL__CLUSTER_URL: "localhost:7233"
           TEMPORAL__CLUSTER_NAMESPACE: "default"
         run: |
           uv run python - <<'PY'

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -170,6 +170,7 @@ jobs:
         run: |
           uv run python - <<'PY'
           import asyncio
+          import time
 
           from temporalio.api.workflowservice.v1 import GetSearchAttributesRequest
 
@@ -189,14 +190,20 @@ jobs:
           async def main() -> None:
               await add_temporal_search_attributes()
               client = await get_temporal_client()
-              attrs = await client.workflow_service.get_search_attributes(
-                  GetSearchAttributesRequest()
-              )
-              missing = REQUIRED_ATTRS - set(attrs.keys)
-              if missing:
-                  raise RuntimeError(
-                      f"Temporal search attributes were not registered: {sorted(missing)}"
+              deadline = time.monotonic() + 60
+              while True:
+                  attrs = await client.workflow_service.get_search_attributes(
+                      GetSearchAttributesRequest()
                   )
+                  missing = REQUIRED_ATTRS - set(attrs.keys)
+                  if not missing:
+                      return
+                  if time.monotonic() >= deadline:
+                      raise RuntimeError(
+                          "Temporal search attributes were not registered: "
+                          f"{sorted(missing)}"
+                      )
+                  await asyncio.sleep(2)
 
           asyncio.run(main())
           PY

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -182,7 +182,7 @@ jobs:
           done
 
           docker compose -f docker-compose.dev.yml exec -T temporal \
-            tctl --address temporal:7233 --namespace default \
+            tctl --address temporal:7233 --namespace default --auto_confirm \
             admin cluster add-search-attributes "${add_args[@]}"
 
           for _ in {1..30}; do

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -62,7 +62,10 @@ jobs:
 
       - name: Install dependencies
         working-directory: custom-integrations-starter-kit
-        run: uv sync --no-dev
+        run: |
+          uv venv
+          uv pip install .
+          .venv/bin/python -c "import custom_actions"
 
   test-all:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: custom-integrations-starter-kit
-        run: uv sync --frozen
+        run: uv sync
 
   test-all:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -164,49 +164,47 @@ jobs:
 
       - name: Register Temporal search attributes
         if: matrix.test_group == 'temporal'
-        env:
-          TEMPORAL__CLUSTER_URL: "localhost:7233"
-          TEMPORAL__CLUSTER_NAMESPACE: "default"
         run: |
-          uv run python - <<'PY'
-          import asyncio
-          import time
+          set -euo pipefail
 
-          from temporalio.api.workflowservice.v1 import GetSearchAttributesRequest
+          attrs=(
+            TracecatTriggerType
+            TracecatTriggeredByUserId
+            TracecatWorkspaceId
+            TracecatAlias
+            TracecatCorrelationId
+            TracecatExecutionType
+          )
 
-          from tracecat.api.common import add_temporal_search_attributes
-          from tracecat.dsl.client import get_temporal_client
-          from tracecat.workflow.executions.enums import TemporalSearchAttr
+          add_args=()
+          for attr in "${attrs[@]}"; do
+            add_args+=(--name "$attr" --type Keyword)
+          done
 
-          REQUIRED_ATTRS = {
-              TemporalSearchAttr.TRIGGER_TYPE.value,
-              TemporalSearchAttr.TRIGGERED_BY_USER_ID.value,
-              TemporalSearchAttr.WORKSPACE_ID.value,
-              TemporalSearchAttr.ALIAS.value,
-              TemporalSearchAttr.CORRELATION_ID.value,
-              TemporalSearchAttr.EXECUTION_TYPE.value,
-          }
+          docker compose -f docker-compose.dev.yml exec -T temporal \
+            tctl --address temporal:7233 --namespace default \
+            admin cluster add-search-attributes "${add_args[@]}"
 
-          async def main() -> None:
-              await add_temporal_search_attributes()
-              client = await get_temporal_client()
-              deadline = time.monotonic() + 60
-              while True:
-                  attrs = await client.workflow_service.get_search_attributes(
-                      GetSearchAttributesRequest()
-                  )
-                  missing = REQUIRED_ATTRS - set(attrs.keys)
-                  if not missing:
-                      return
-                  if time.monotonic() >= deadline:
-                      raise RuntimeError(
-                          "Temporal search attributes were not registered: "
-                          f"{sorted(missing)}"
-                      )
-                  await asyncio.sleep(2)
+          for _ in {1..30}; do
+            output=$(docker compose -f docker-compose.dev.yml exec -T temporal \
+              tctl --address temporal:7233 --namespace default \
+              admin cluster get-search-attributes --print_json true)
+            missing=()
+            for attr in "${attrs[@]}"; do
+              if [[ "$output" != *"$attr"* ]]; then
+                missing+=("$attr")
+              fi
+            done
+            if [ "${#missing[@]}" -eq 0 ]; then
+              echo "Temporal search attributes registered"
+              exit 0
+            fi
+            echo "Waiting for Temporal search attributes: ${missing[*]}"
+            sleep 2
+          done
 
-          asyncio.run(main())
-          PY
+          echo "Timed out waiting for Temporal search attributes: ${missing[*]}"
+          exit 1
 
       - name: Run tests
         env:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -11,10 +11,9 @@ on:
       - packages/tracecat-registry/**
       - pyproject.toml
       - uv.lock
-      - Dockerfile
-      - docker-compose.yml
       - docker-compose.dev.yml
-      - docker-compose.local.yml
+      - .env.example
+      - env.sh
       - .github/workflows/test-python.yml
   pull_request:
     branches: ["main", "staging"]
@@ -26,10 +25,9 @@ on:
       - packages/tracecat-registry/**
       - pyproject.toml
       - uv.lock
-      - Dockerfile
-      - docker-compose.yml
       - docker-compose.dev.yml
-      - docker-compose.local.yml
+      - .env.example
+      - env.sh
       - .github/workflows/test-python.yml
 
 permissions:
@@ -49,6 +47,10 @@ jobs:
         uses: useblacksmith/setup-uv@f4588471335f14dcb60198856207b916701a9e9f # v4
         with:
           version: "0.9.7"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: Set up Python 3.12
         uses: useblacksmith/setup-python@943b05a7c4ca70c2360391137527a37bee33fb1d # v6
@@ -56,11 +58,10 @@ jobs:
           python-version: "3.12"
 
       - name: Clone custom registry starter
-        run: |
-          git clone https://github.com/TracecatHQ/custom-integrations-starter-kit
-          cd custom-integrations-starter-kit
+        run: git clone https://github.com/TracecatHQ/custom-integrations-starter-kit
 
       - name: Install dependencies
+        working-directory: custom-integrations-starter-kit
         run: uv sync --frozen
 
   test-all:
@@ -81,7 +82,9 @@ jobs:
         with:
           version: "0.9.7"
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: Set up Python 3.12
         uses: useblacksmith/setup-python@943b05a7c4ca70c2360391137527a37bee33fb1d # v6
@@ -93,9 +96,6 @@ jobs:
           sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
           sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
       - name: Run environment setup script
         run: |
           echo "y
@@ -103,14 +103,24 @@ jobs:
           n
           test@tracecat.com" | bash env.sh
 
-      - name: Start core Docker services
-        env:
-          COMPOSE_BAKE: "true"
-          TRACECAT__UNSAFE_DISABLE_SM_MASKING: "true"
+      - name: Start core Docker services and install dependencies
         run: |
+          set -euo pipefail
+
           compose_files=(-f docker-compose.dev.yml)
+          services=(postgres_db minio redis)
+
+          uv sync --frozen &
+          uv_sync_pid=$!
+          cleanup_uv_sync() {
+            if kill -0 "$uv_sync_pid" 2>/dev/null; then
+              kill "$uv_sync_pid" 2>/dev/null || true
+            fi
+          }
+          trap cleanup_uv_sync EXIT
 
           if [ "${{ matrix.test_group }}" = "temporal" ]; then
+            services=(temporal postgres_db minio redis)
             cat > /tmp/tracecat-ci-postgres.yml <<'YAML'
           services:
             postgres_db:
@@ -119,10 +129,35 @@ jobs:
             compose_files+=(-f /tmp/tracecat-ci-postgres.yml)
           fi
 
-          docker compose "${compose_files[@]}" up -d temporal api postgres_db caddy minio
+          docker compose "${compose_files[@]}" up -d "${services[@]}"
 
-      - name: Install dependencies
-        run: uv sync --frozen
+          echo "Waiting for services to become healthy..."
+          deadline=$((SECONDS + 300))
+          while true; do
+            statuses=$(docker compose "${compose_files[@]}" ps --format json | jq -s -r ".[] | select(.Health != null and .Health != \"\") | .Health")
+            total=$(echo "$statuses" | grep -c . || true)
+            healthy=$(echo "$statuses" | grep -c "^healthy$" || true)
+
+            if [ "$total" -eq 0 ]; then
+              echo "No services with health checks found yet, waiting..."
+            elif [ "$healthy" -lt "$total" ]; then
+              echo "Waiting for services to be healthy ($healthy/$total ready)..."
+            else
+              echo "All $total services with health checks are healthy"
+              break
+            fi
+
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "Timed out waiting for Docker services to become healthy"
+              docker compose "${compose_files[@]}" ps
+              exit 124
+            fi
+            sleep 5
+          done
+
+          echo "Waiting for Python environment sync..."
+          wait "$uv_sync_pid"
+          trap - EXIT
 
       - name: Run tests
         env:
@@ -153,14 +188,16 @@ jobs:
           echo "=== Docker Service Status ==="
           docker compose -f docker-compose.dev.yml ps
 
-          echo "=== Temporal Logs ==="
-          docker compose -f docker-compose.dev.yml logs temporal --tail=200
-
-          echo "=== Migrations Logs ==="
-          docker compose -f docker-compose.dev.yml logs migrations --tail=200
-
-          echo "=== API Logs ==="
-          docker compose -f docker-compose.dev.yml logs api --tail=200
-
           echo "=== Postgres Logs ==="
           docker compose -f docker-compose.dev.yml logs postgres_db --tail=200
+
+          echo "=== MinIO Logs ==="
+          docker compose -f docker-compose.dev.yml logs minio --tail=200
+
+          echo "=== Redis Logs ==="
+          docker compose -f docker-compose.dev.yml logs redis --tail=200
+
+          if [ "${{ matrix.test_group }}" = "temporal" ]; then
+            echo "=== Temporal Logs ==="
+            docker compose -f docker-compose.dev.yml logs temporal --tail=200
+          fi

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -162,6 +162,45 @@ jobs:
           wait "$uv_sync_pid"
           trap - EXIT
 
+      - name: Register Temporal search attributes
+        if: matrix.test_group == 'temporal'
+        env:
+          TEMPORAL__CLUSTER_URL: "http://localhost:7233"
+          TEMPORAL__CLUSTER_NAMESPACE: "default"
+        run: |
+          uv run python - <<'PY'
+          import asyncio
+
+          from temporalio.api.workflowservice.v1 import GetSearchAttributesRequest
+
+          from tracecat.api.common import add_temporal_search_attributes
+          from tracecat.dsl.client import get_temporal_client
+          from tracecat.workflow.executions.enums import TemporalSearchAttr
+
+          REQUIRED_ATTRS = {
+              TemporalSearchAttr.TRIGGER_TYPE.value,
+              TemporalSearchAttr.TRIGGERED_BY_USER_ID.value,
+              TemporalSearchAttr.WORKSPACE_ID.value,
+              TemporalSearchAttr.ALIAS.value,
+              TemporalSearchAttr.CORRELATION_ID.value,
+              TemporalSearchAttr.EXECUTION_TYPE.value,
+          }
+
+          async def main() -> None:
+              await add_temporal_search_attributes()
+              client = await get_temporal_client()
+              attrs = await client.workflow_service.get_search_attributes(
+                  GetSearchAttributesRequest()
+              )
+              missing = REQUIRED_ATTRS - set(attrs.keys)
+              if missing:
+                  raise RuntimeError(
+                      f"Temporal search attributes were not registered: {sorted(missing)}"
+                  )
+
+          asyncio.run(main())
+          PY
+
       - name: Run tests
         env:
           TRACECAT__SYSTEM_PATH: "/usr/local/bin:/usr/bin:/bin"

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -225,7 +225,14 @@ jobs:
             TRACECAT_TEST_API_MODE=inprocess \
             TRACECAT__CONTEXT_COMPRESSION_ENABLED=true \
             TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB=0 \
-            uv run pytest tests/temporal -m "not live_secret" -n auto -ra -o faulthandler_timeout=300
+            uv run pytest tests/temporal -m "not live_secret and not requires_api" -n auto -ra -o faulthandler_timeout=300
+
+            # API-backed temporal tests start a local API process against the
+            # test DB. Run them serially to avoid startup races under xdist.
+            TRACECAT_TEST_API_MODE=inprocess \
+            TRACECAT__CONTEXT_COMPRESSION_ENABLED=true \
+            TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB=0 \
+            uv run pytest tests/temporal -m "requires_api and not live_secret" -ra -o faulthandler_timeout=300
           else
             uv run pytest tests/${{ matrix.test_group }} -m "not live_secret" -n auto -ra -o faulthandler_timeout=300
           fi

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: custom-integrations-starter-kit
-        run: uv sync
+        run: uv sync --no-dev
 
   test-all:
     runs-on: blacksmith-8vcpu-ubuntu-2204
@@ -154,6 +154,9 @@ jobs:
             fi
             sleep 5
           done
+
+          echo "Creating storage buckets..."
+          docker compose "${compose_files[@]}" exec -T minio mc mb --ignore-existing local/tracecat-attachments
 
           echo "Waiting for Python environment sync..."
           wait "$uv_sync_pid"

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -137,7 +137,10 @@ jobs:
           echo "Waiting for services to become healthy..."
           deadline=$((SECONDS + 300))
           while true; do
-            statuses=$(docker compose "${compose_files[@]}" ps --format json | jq -s -r ".[] | select(.Health != null and .Health != \"\") | .Health")
+            statuses=$(
+              docker compose "${compose_files[@]}" ps --format json |
+                jq -r 'if type == "array" then .[] else . end | select(.Health != null and .Health != "") | .Health'
+            )
             total=$(echo "$statuses" | grep -c . || true)
             healthy=$(echo "$statuses" | grep -c "^healthy$" || true)
 

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -64,7 +64,7 @@ jobs:
         working-directory: custom-integrations-starter-kit
         run: |
           uv venv
-          uv pip install .
+          env -u UV_SYSTEM_PYTHON uv pip install --python .venv/bin/python .
           .venv/bin/python -c "import custom_actions"
 
   test-all:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,7 @@ markers = [
     "live_secret: marks tests that require real environment-backed third-party secrets",
     "ollama: mark tests that require Ollama",
     "temporal: marks tests that require Temporal server",
+    "requires_api: marks tests that require a live Tracecat API endpoint",
     "regression: marks regression tests",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1576,12 +1576,13 @@ def minio_server():
 
 @pytest.fixture(scope="session", autouse=True)
 def workflow_bucket(minio_server, env_sandbox):
-    """Create the workflow bucket for result externalization and reset object storage.
+    """Create test storage buckets and reset object storage.
 
     This fixture:
     1. Creates the bucket used by S3ObjectStorage for StoredObject externalization
-    2. Reloads the blob module to pick up the test config
-    3. Resets the object storage singleton so it uses S3ObjectStorage
+    2. Creates API-owned buckets that are needed when tests run without API startup
+    3. Reloads the blob module to pick up the test config
+    4. Resets the object storage singleton so it uses S3ObjectStorage
 
     Session-scoped and autouse to ensure all tests use S3-backed object storage.
     Depends on env_sandbox to ensure config is set before we create the bucket.
@@ -1592,7 +1593,6 @@ def workflow_bucket(minio_server, env_sandbox):
     # Reload blob module to pick up MinIO config
     importlib.reload(blob)
 
-    # Create workflow bucket if it doesn't exist
     access_key, secret_key = _minio_credentials()
     client = Minio(
         f"localhost:{MINIO_PORT}",
@@ -1600,13 +1600,20 @@ def workflow_bucket(minio_server, env_sandbox):
         secret_key=secret_key,
         secure=False,
     )
-    try:
-        if not client.bucket_exists(MINIO_WORKFLOW_BUCKET):
-            client.make_bucket(MINIO_WORKFLOW_BUCKET)
-            logger.info(f"Created workflow bucket: {MINIO_WORKFLOW_BUCKET}")
-    except S3Error as e:
-        if e.code != "BucketAlreadyOwnedByYou":
-            raise
+    bucket_names = {
+        config.TRACECAT__BLOB_STORAGE_BUCKET_ATTACHMENTS,
+        config.TRACECAT__BLOB_STORAGE_BUCKET_REGISTRY,
+        config.TRACECAT__BLOB_STORAGE_BUCKET_SKILLS,
+        config.TRACECAT__BLOB_STORAGE_BUCKET_WORKFLOW,
+    }
+    for bucket_name in sorted(bucket_names):
+        try:
+            if not client.bucket_exists(bucket_name):
+                client.make_bucket(bucket_name)
+                logger.info(f"Created MinIO bucket: {bucket_name}")
+        except S3Error as e:
+            if e.code != "BucketAlreadyOwnedByYou":
+                raise
 
     # Reset object storage singleton so it picks up the test config (S3ObjectStorage)
     object_module.reset_object_storage()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1304,7 +1304,10 @@ def inprocess_api_server(
 
 
 @pytest.fixture(autouse=True)
-def api_server_for_requires_api_tests(request: pytest.FixtureRequest) -> None:
+def api_server_for_requires_api_tests(
+    request: pytest.FixtureRequest,
+    monkeysession: pytest.MonkeyPatch,
+) -> None:
     """Select the API harness for tests marked ``requires_api``.
 
     PR CI uses an in-process uvicorn server to keep behavioral coverage without
@@ -1317,6 +1320,9 @@ def api_server_for_requires_api_tests(request: pytest.FixtureRequest) -> None:
     if mode == "inprocess":
         request.getfixturevalue("inprocess_api_server")
     elif mode == "external":
+        if api_url := os.environ.get("TRACECAT_TEST_EXTERNAL_API_URL"):
+            monkeysession.setattr(config, "TRACECAT__API_URL", api_url)
+            monkeysession.setenv("TRACECAT__API_URL", api_url)
         return
     else:
         pytest.fail(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@ import asyncio
 import importlib
 import os
 import socket
-import threading
+import subprocess
+import sys
+import tempfile
 import time
 import urllib.request
 import uuid
@@ -1236,9 +1238,11 @@ def inprocess_api_server(
     redis_server: None,
     monkeysession: pytest.MonkeyPatch,
 ) -> Iterator[str]:
-    """Run the real Tracecat API on localhost without building the Docker image."""
-    import uvicorn
+    """Run the real Tracecat API on localhost without building the Docker image.
 
+    The API runs in a separate local process instead of a thread so SQLAlchemy's
+    async engine/pool is never shared across the pytest and Uvicorn event loops.
+    """
     port = _get_free_tcp_port()
     api_url = f"http://127.0.0.1:{port}"
     monkeysession.setattr(config, "TRACECAT__API_URL", api_url)
@@ -1246,36 +1250,57 @@ def inprocess_api_server(
     monkeysession.setattr(config, "TRACECAT__PUBLIC_API_URL", f"{api_url}/api")
     monkeysession.setenv("TRACECAT__PUBLIC_API_URL", f"{api_url}/api")
 
-    # Import after env_sandbox overrides so the module-level FastAPI app sees the
-    # same config as the tests. The decorated health/internal routes live there.
-    from tracecat.api.app import app as api_app
+    api_env = os.environ.copy()
+    api_env["TRACECAT__API_URL"] = api_url
+    api_env["TRACECAT__PUBLIC_API_URL"] = f"{api_url}/api"
 
-    server = uvicorn.Server(
-        uvicorn.Config(
-            api_app,
-            host="127.0.0.1",
-            port=port,
-            log_level="warning",
-            access_log=False,
-        )
+    log_file = tempfile.NamedTemporaryFile(
+        mode="w+",
+        prefix=f"tracecat-api-{WORKER_ID}-",
+        suffix=".log",
+        delete=True,
     )
-    thread = threading.Thread(
-        target=server.run,
-        name=f"tracecat-inprocess-api-{WORKER_ID}",
-        daemon=True,
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "tracecat.api.app:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--log-level",
+            "warning",
+            "--no-access-log",
+        ],
+        env=api_env,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        text=True,
     )
-    thread.start()
     try:
         _wait_for_http_ok(f"{api_url}/health")
-    except Exception:
-        server.should_exit = True
-        thread.join(timeout=10)
-        raise
-
-    yield api_url
-
-    server.should_exit = True
-    thread.join(timeout=10)
+        yield api_url
+    except Exception as exc:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+        log_file.seek(0)
+        logs = log_file.read()[-4000:]
+        raise RuntimeError(f"Tracecat API test server failed. Logs:\n{logs}") from exc
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=10)
+        log_file.close()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
 import asyncio
 import importlib
 import os
+import socket
+import threading
 import time
+import urllib.request
 import uuid
 from collections.abc import AsyncGenerator, Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor
@@ -144,6 +147,26 @@ def _lock_test_db_setup(conn: Any, db_uri: str) -> None:
         text("SELECT pg_advisory_xact_lock(hashtext(:lock_key)::bigint)"),
         {"lock_key": f"tests:db-setup:{db_name}"},
     )
+
+
+def _get_free_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_http_ok(url: str, *, timeout: float = 45.0) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=1.0) as response:
+                if 200 <= response.getcode() < 300:
+                    return
+        except Exception as exc:
+            last_error = exc
+        time.sleep(0.2)
+    raise RuntimeError(f"Timed out waiting for {url}: {last_error}")
 
 
 PG_PORT = int(os.environ.get("PG_PORT", "5432"))
@@ -1203,6 +1226,78 @@ def env_sandbox(monkeysession: pytest.MonkeyPatch):
 
     yield
     logger.info("Environment variables cleaned up")
+
+
+@pytest.fixture(scope="session")
+def inprocess_api_server(
+    env_sandbox: None,
+    default_org: None,
+    workflow_bucket: None,
+    redis_server: None,
+    monkeysession: pytest.MonkeyPatch,
+) -> Iterator[str]:
+    """Run the real Tracecat API on localhost without building the Docker image."""
+    import uvicorn
+
+    port = _get_free_tcp_port()
+    api_url = f"http://127.0.0.1:{port}"
+    monkeysession.setattr(config, "TRACECAT__API_URL", api_url)
+    monkeysession.setenv("TRACECAT__API_URL", api_url)
+    monkeysession.setattr(config, "TRACECAT__PUBLIC_API_URL", f"{api_url}/api")
+    monkeysession.setenv("TRACECAT__PUBLIC_API_URL", f"{api_url}/api")
+
+    # Import after env_sandbox overrides so the module-level FastAPI app sees the
+    # same config as the tests. The decorated health/internal routes live there.
+    from tracecat.api.app import app as api_app
+
+    server = uvicorn.Server(
+        uvicorn.Config(
+            api_app,
+            host="127.0.0.1",
+            port=port,
+            log_level="warning",
+            access_log=False,
+        )
+    )
+    thread = threading.Thread(
+        target=server.run,
+        name=f"tracecat-inprocess-api-{WORKER_ID}",
+        daemon=True,
+    )
+    thread.start()
+    try:
+        _wait_for_http_ok(f"{api_url}/health")
+    except Exception:
+        server.should_exit = True
+        thread.join(timeout=10)
+        raise
+
+    yield api_url
+
+    server.should_exit = True
+    thread.join(timeout=10)
+
+
+@pytest.fixture(autouse=True)
+def api_server_for_requires_api_tests(request: pytest.FixtureRequest) -> None:
+    """Select the API harness for tests marked ``requires_api``.
+
+    PR CI uses an in-process uvicorn server to keep behavioral coverage without
+    building the API image. Full integration jobs keep using the external API.
+    """
+    if request.node.get_closest_marker("requires_api") is None:
+        return
+
+    mode = os.environ.get("TRACECAT_TEST_API_MODE", "external")
+    if mode == "inprocess":
+        request.getfixturevalue("inprocess_api_server")
+    elif mode == "external":
+        return
+    else:
+        pytest.fail(
+            "TRACECAT_TEST_API_MODE must be either 'inprocess' or 'external', "
+            f"got {mode!r}"
+        )
 
 
 @pytest.fixture(scope="session")

--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -3815,6 +3815,7 @@ async def test_workflow_error_handler_invalid_handler_fail_no_match(
 
 @pytest.mark.anyio
 @pytest.mark.integration
+@pytest.mark.requires_api
 async def test_workflow_lookup_table_success(
     test_role: Role,
     temporal_client: Client,
@@ -3877,6 +3878,7 @@ async def test_workflow_lookup_table_success(
 
 @pytest.mark.anyio
 @pytest.mark.integration
+@pytest.mark.requires_api
 async def test_workflow_lookup_table_missing_value(
     test_role: Role,
     temporal_client: Client,
@@ -3942,6 +3944,7 @@ async def test_workflow_lookup_table_missing_value(
 
 @pytest.mark.anyio
 @pytest.mark.integration
+@pytest.mark.requires_api
 async def test_workflow_insert_table_row_success(
     test_role: Role,
     temporal_client: Client,
@@ -4016,6 +4019,7 @@ async def test_workflow_insert_table_row_success(
 
 @pytest.mark.anyio
 @pytest.mark.integration
+@pytest.mark.requires_api
 async def test_workflow_table_actions_in_loop(
     test_role: Role,
     temporal_client: Client,


### PR DESCRIPTION
## Summary

- optimizes CI dependency and image caching with explicit `uv`/`pnpm` cache keys, Blacksmith sticky Docker builders, and registry-backed Docker layer caches for published API/UI images
- keeps Python PR CI focused on fast dependency services by avoiding app image builds, starting only the services each test group needs, and running Temporal API-backed tests through the local API harness
- moves full compose integration off the PR/main-push critical path; it now runs on trusted manual dispatch or every 30 minutes during 10:00-18:00 America/New_York on weekdays, and scheduled runs skip once the current commit has already passed integration

## Testing

- `uv run ruff check`
- workflow YAML parse for all changed workflows
- Bash syntax checks for edited workflow shell blocks
- `git diff --check origin/main...HEAD`
- commit hooks on the workflow-only commits

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up CI and shrinks caches using a sticky Docker builder, registry-backed layer caches, and explicit `uv`/`pnpm` caching. Full integration runs on schedule/manual only with a trusted-actor gate and business-hours window; Python splits Temporal tests to use a local `uvicorn` API and runs API-backed cases serially.

- **Refactors**
  - CI builds/caching: use `useblacksmith/setup-docker-builder`; add per-platform registry layer caches for `tracecat`/`tracecat-ui`; enable `uv` cache keyed on `pyproject.toml`/`uv.lock`; share OS/arch-keyed `pnpm` store across jobs.
  - Integration tests: scheduled + manual only; trusted-actor authorization; enforce 10:00–18:00 America/New_York window and skip scheduled runs if the commit already passed; build CI image with `docker/build-push-action@v6` (load), start only needed services, robust health waits; run API-backed Temporal tests against compose in a separate step.
  - Python tests: skip app image builds; parallel `uv sync`; start only dependencies; auto-select API via `TRACECAT_TEST_API_MODE` + `requires_api`; run a local API in a separate process with `uvicorn`; register Temporal search attributes via `tctl` with readiness waits; run API-backed Temporal tests serially.

- **Bug Fixes**
  - Starter kit smoke test: install into an isolated venv with `uv pip install .` (no dev deps) and verify import.
  - Temporal: register and wait for required search attributes via `tctl`; gate API-dependent tests behind `requires_api`.
  - Compose health check: normalize parsing to handle both JSON array and JSON Lines outputs.
  - MinIO: auto-create API-owned buckets when tests run without the API.

<sup>Written for commit 055c7243cf2d241b8d847986b8894207e4f3749b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


