### PR TITLE
fix(saml): make accept_invitation_for_user idempotent with upserts

### DIFF
--- a/tracecat/auth/saml.py
+++ b/tracecat/auth/saml.py
@@ -96,6 +96,7 @@ from tracecat.identifiers import OrganizationID
 from tracecat.invitations.enums import InvitationStatus
 from tracecat.logger import logger
 from tracecat.organization.domains import normalize_domain
+from tracecat.organization.service import accept_invitation_for_user
 from tracecat.settings.service import get_setting
 
 router = APIRouter(prefix="/auth/saml", tags=["auth"])
@@ -926,6 +927,33 @@ async def sso_acs(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Authentication failed",
         )
+
+    # Accept a pending org invitation so the user receives the role the inviter
+    # intended. This is idempotent: if single-tenant defaults already created an
+    # organization-member assignment (e.g. SSO auto-provisioning ran first), the
+    # upsert in accept_invitation_for_user upgrades the role to invitation.role_id.
+    if pending_invitation is not None:
+        try:
+            await accept_invitation_for_user(
+                db_session,
+                user_id=user.id,  # pyright: ignore[reportArgumentType]
+                token=pending_invitation.token,
+            )
+            logger.info(
+                "Accepted pending org invitation during SAML login",
+                user_id=str(user.id),
+                email=email,
+                org_id=str(organization_id),
+                role_id=str(pending_invitation.role_id),
+            )
+        except Exception:
+            await db_session.rollback()
+            logger.warning(
+                "Failed to accept org invitation during SAML login",
+                user_id=str(user.id),
+                email=email,
+                exc_info=True,
+            )
 
     # Ensure user can access this organization.
     membership_stmt = select(OrganizationMembership).where(

--- a/tracecat/organization/service.py
+++ b/tracecat/organization/service.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import and_, cast, func, select, update
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import contains_eager, selectinload
 
@@ -141,21 +142,54 @@ async def accept_invitation_for_user(
             # Shouldn't reach here, but handle gracefully
             raise TracecatAuthorizationError("Invitation is no longer valid")
 
-        # Create membership (still needed for org membership existence checks)
-        membership = OrganizationMembership(
-            user_id=user_id,
-            organization_id=invitation.organization_id,
+        # Upsert membership — idempotent if single-tenant defaults already ran.
+        membership_stmt = (
+            pg_insert(OrganizationMembership)
+            .values(
+                user_id=user_id,
+                organization_id=invitation.organization_id,
+            )
+            .on_conflict_do_nothing(
+                index_elements=[
+                    OrganizationMembership.user_id,
+                    OrganizationMembership.organization_id,
+                ]
+            )
+            .returning(OrganizationMembership)
         )
-        session.add(membership)
+        membership_result = await session.execute(membership_stmt)
+        membership = membership_result.scalar_one_or_none()
+        if membership is None:
+            # Row already existed; fetch it.
+            existing = await session.execute(
+                select(OrganizationMembership).where(
+                    OrganizationMembership.user_id == user_id,
+                    OrganizationMembership.organization_id
+                    == invitation.organization_id,
+                )
+            )
+            membership = existing.scalar_one()
 
-        # Create RBAC role assignment from invitation's role_id
-        assignment = UserRoleAssignment(
-            organization_id=invitation.organization_id,
-            user_id=user_id,
-            workspace_id=None,
-            role_id=invitation.role_id,
+        # Upsert the org-wide role assignment to the invitation's role.
+        # Uses on_conflict_do_update so a pre-existing organization-member row
+        # (written by single-tenant defaults during SSO auto-provisioning) is
+        # upgraded to the role the invitation granted.
+        assignment_stmt = (
+            pg_insert(UserRoleAssignment)
+            .values(
+                organization_id=invitation.organization_id,
+                user_id=user_id,
+                workspace_id=None,
+                role_id=invitation.role_id,
+            )
+            .on_conflict_do_update(
+                index_elements=[UserRoleAssignment.user_id],
+                index_where=UserRoleAssignment.workspace_id.is_(None),
+                set_={"role_id": invitation.role_id},
+                where=UserRoleAssignment.organization_id == invitation.organization_id,
+            )
         )
-        session.add(assignment)
+        await session.execute(assignment_stmt)
 
         await session.commit()
         await session.refresh(membership)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make org invitation acceptance idempotent and run it during SAML login so invited roles apply even if SSO auto-provisioning already created membership.

- **Bug Fixes**
  - Use PostgreSQL upsert for `OrganizationMembership` and fetch the existing row on conflict to avoid duplicates.
  - Upsert `UserRoleAssignment` for the org-wide role (`workspace_id` is null); on conflict, update `role_id` within the same organization to upgrade existing assignments.
  - In SAML ACS, call `accept_invitation_for_user` to auto-accept pending invites on login; commit on success, rollback and log on error.

<sup>Written for commit 787b65926d23ed5dfad553266200b341376e3248. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

