### PR TITLE
fix(agents): eagerly init stream_cursor for ai.* actions

### DIFF
--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -715,6 +715,9 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
         async def append(self, event: Any) -> None:
             del event
 
+        async def reset_for_new_turn(self) -> None:
+            return None
+
     async def fake_agent_stream_new(
         *,
         session_id: uuid.UUID,
@@ -1463,6 +1466,9 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
     class _FakeStream:
         async def append(self, event: Any) -> None:
             del event
+
+        async def reset_for_new_turn(self) -> None:
+            return None
 
     async def fake_agent_stream_new(
         *,

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -214,6 +214,20 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
                 session_id=input.session_id,
             )
 
+        # Initialize the Redis stream cursor so GET /stream returns events
+        # instead of 204. Chat sessions do this in send_message before the
+        # SSE response starts; workflow-based ai.* sessions must do it here,
+        # before the executor activity runs, so the frontend can connect as
+        # soon as it sees the session ID in the workflow history.
+        # Skip for require_existing (approval continuations) — they resume
+        # mid-stream and must not clear the existing Redis buffer.
+        if not input.require_existing and input.role.workspace_id is not None:
+            stream = await AgentStream.new(
+                session_id=input.session_id,
+                workspace_id=input.role.workspace_id,
+            )
+            await stream.reset_for_new_turn()
+
         return CreateSessionResult(session_id=input.session_id, success=True)
 
     except ApplicationError:


### PR DESCRIPTION
## Problem

`#2637` introduced 204 as a "no stream" signal. Chat sessions eagerly set a cursor before streaming — workflow `ai.*` sessions never did.

**204 on completion is still correct** — cursor is cleared after stream ends, Vercel SDK stops, completed session renders via static `session.events`.
