### PR TITLE
fix: hide Role scopes from repr

### DIFF
--- a/tests/unit/test_role_headers.py
+++ b/tests/unit/test_role_headers.py
@@ -15,6 +15,22 @@ class MockHeaders(dict):
 
 
 class TestRoleToHeaders:
+    def test_role_repr_omits_scopes_without_affecting_serialization(self) -> None:
+        role = Role(
+            type="service",
+            service_id="tracecat-runner",
+            scopes=frozenset({"workflow:read", "cases:write"}),
+        )
+
+        assert "scopes" not in repr(role)
+        assert "scopes" not in str(role)
+        assert role.model_dump()["scopes"] == frozenset(
+            {"workflow:read", "cases:write"}
+        )
+        assert role.to_headers()["x-tracecat-role-scopes"] == (
+            "cases:write,workflow:read"
+        )
+
     def test_to_headers_includes_all_fields(self) -> None:
         workspace_id = uuid4()
         organization_id = uuid4()

--- a/tracecat/auth/types.py
+++ b/tracecat/auth/types.py
@@ -40,7 +40,7 @@ class Role(BaseModel):
     """The service's role name, or None if the role is a user."""
     is_platform_superuser: bool = Field(default=False, frozen=True)
     """Whether this role is currently executing platform-superuser privileges."""
-    scopes: frozenset[str] | None = Field(default=None, frozen=True)
+    scopes: frozenset[str] | None = Field(default=None, frozen=True, repr=False)
     """Effective scopes for this role. None means unresolved/unset."""
 
     @model_validator(mode="after")


### PR DESCRIPTION
## Summary

- Hide `Role.scopes` from the default Pydantic repr/str output to reduce noisy structured logs.
- Add a regression test confirming repr omits scopes while `model_dump()` and role headers still include them.

## Tests

- `uv run pytest tests/unit/test_role_headers.py`
- `uv run ruff check tracecat/auth/types.py tests/unit/test_role_headers.py`
- `uv run ruff format --check tracecat/auth/types.py tests/unit/test_role_headers.py`
- `uv run basedpyright tracecat/auth/types.py tests/unit/test_role_headers.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide `Role.scopes` from the default Pydantic repr/str to reduce noisy structured logs. Added a regression test to confirm repr/str omit scopes while `model_dump()` and `to_headers()` still include them (e.g., `x-tracecat-role-scopes`).

<sup>Written for commit 4f21b91b2253880070edd122629080fda8f77230. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

