### PR TITLE
fix: readiness not-ready response logging

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -12654,5 +12654,8 @@ export const publicCheckReady =
     return __request(OpenAPI, {
       method: "GET",
       url: "/ready",
+      errors: {
+        503: "API startup or platform registry sync is incomplete.",
+      },
     })
   }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -19062,6 +19062,10 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: ReadinessResponse
+        /**
+         * API startup or platform registry sync is incomplete.
+         */
+        503: ReadinessResponse
       }
     }
   }

--- a/tests/unit/api/test_api_readiness.py
+++ b/tests/unit/api/test_api_readiness.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import tracecat_registry
+from fastapi import Response, status
+
+from tracecat.api.app import app, check_ready
+
+
+@pytest.mark.anyio
+async def test_check_ready_returns_503_response_when_registry_not_synced(mocker):
+    repos_service = mocker.Mock()
+    repos_service.get_repository = AsyncMock(return_value=None)
+    mocker.patch(
+        "tracecat.api.app.PlatformRegistryReposService",
+        return_value=repos_service,
+    )
+    response = Response()
+
+    readiness = await check_ready(response=response, session=AsyncMock())
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert readiness.status == "not_ready"
+    assert readiness.registry.synced is False
+    assert readiness.registry.expected_version == tracecat_registry.__version__
+    assert readiness.registry.current_version is None
+
+
+@pytest.mark.anyio
+async def test_check_ready_returns_200_when_registry_synced(mocker):
+    current_version = SimpleNamespace(version=tracecat_registry.__version__)
+    repository = SimpleNamespace(current_version=current_version)
+    repos_service = mocker.Mock()
+    repos_service.get_repository = AsyncMock(return_value=repository)
+    mocker.patch(
+        "tracecat.api.app.PlatformRegistryReposService",
+        return_value=repos_service,
+    )
+    response = Response()
+
+    readiness = await check_ready(response=response, session=AsyncMock())
+
+    assert response.status_code == status.HTTP_200_OK
+    assert readiness.status == "ready"
+    assert readiness.registry.synced is True
+    assert readiness.registry.expected_version == tracecat_registry.__version__
+    assert readiness.registry.current_version == tracecat_registry.__version__
+
+
+def test_check_ready_documents_not_ready_response():
+    app.openapi_schema = None
+
+    responses = app.openapi()["paths"]["/ready"]["get"]["responses"]
+
+    assert responses["503"]["description"] == (
+        "API startup or platform registry sync is incomplete."
+    )
+    assert responses["503"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/ReadinessResponse"
+    }

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -763,8 +763,17 @@ async def check_health() -> HealthResponse:
     return HealthResponse(status="ok")
 
 
-@app.get("/ready", tags=["public"])
-async def check_ready(session: AsyncDBSession) -> ReadinessResponse:
+@app.get(
+    "/ready",
+    tags=["public"],
+    responses={
+        status.HTTP_503_SERVICE_UNAVAILABLE: {
+            "model": ReadinessResponse,
+            "description": "API startup or platform registry sync is incomplete.",
+        },
+    },
+)
+async def check_ready(response: Response, session: AsyncDBSession) -> ReadinessResponse:
     """Readiness check - returns 200 only after startup and registry sync complete.
 
     Use this endpoint for Docker healthchecks to ensure the API has finished
@@ -793,12 +802,10 @@ async def check_ready(session: AsyncDBSession) -> ReadinessResponse:
 
     # Not ready if registry is not synced
     if not registry_status.synced:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=ReadinessResponse(
-                status="not_ready",
-                registry=registry_status,
-            ).model_dump(),
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return ReadinessResponse(
+            status="not_ready",
+            registry=registry_status,
         )
 
     return ReadinessResponse(


### PR DESCRIPTION
## Summary
- Return `/ready` not-ready states as a normal `ReadinessResponse` with HTTP 503 instead of raising `HTTPException`
- Document the `/ready` 503 response in OpenAPI and regenerate the frontend client
- Add readiness route tests for 503, 200, and schema coverage

## Tests
- `uv run pytest tests/unit/api/test_api_readiness.py`
- `uv run ruff check tracecat/api/app.py tests/unit/api/test_api_readiness.py`
- `uv run ruff format --check tracecat/api/app.py tests/unit/api/test_api_readiness.py`
- `uv run basedpyright --warnings --threads 4 tracecat/api/app.py tests/unit/api/test_api_readiness.py`
- `pnpm -C frontend exec biome check src/client/services.gen.ts src/client/types.gen.ts`
- `just gen-client-ci`
- commit hooks: Python type check, frontend Biome check, frontend type check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the readiness endpoint return a structured `ReadinessResponse` with HTTP 503 when the service isn’t ready, instead of raising an exception. This cleans up logging, documents the 503 in OpenAPI, and updates the generated frontend client to handle it.

- **Bug Fixes**
  - Return 503 with `ReadinessResponse` (no `HTTPException`) to improve not-ready logging.
  - Document the `/ready` 503 response in OpenAPI with description “API startup or platform registry sync is incomplete.”
  - Regenerate frontend client to map 503 errors and include the 503 `ReadinessResponse` type.
  - Add tests covering 503, 200, and OpenAPI schema for `/ready`.

<sup>Written for commit 6fa3089e6df9b038893c64d02f6a3d61ab11cf39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

