### PR TITLE
refactor(agents): drop pydantic ai runtime in slackbot path

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/schemas.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/schemas.py
@@ -69,6 +69,51 @@ class AgentActionArgs(BaseModel):
     tool_approvals: dict[str, bool] | None = None
 
 
+class SlackbotActionArgs(BaseModel):
+    model_config = _BASE_CONFIG
+
+    # Slack event fields (passed to pre-processing activity)
+    event: dict[str, Any] | None = None
+    prompt: str = ""
+    channel_id: str = ""
+    instructions: str = ""
+    limit_messages: int = 5
+
+    # Agent config
+    model_name: str
+    model_provider: str
+    catalog_id: uuid.UUID | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _unpack_model_selection(cls, values: Any) -> Any:
+        if isinstance(values, dict):
+            values = dict(values)
+            nested = values.get("model")
+            if isinstance(nested, BaseModel):
+                nested = nested.model_dump(mode="python")
+            if not isinstance(nested, dict):
+                return values
+            for key in ("model_name", "model_provider", "catalog_id"):
+                if key in nested:
+                    values[key] = nested[key]
+        return values
+
+    actions: list[str] | None = None
+    model_settings: dict[str, Any] | None = None
+    retries: int = 6
+    max_tool_calls: int = Field(
+        default=15,
+        ge=1,
+        le=config.TRACECAT__AGENT_MAX_TOOL_CALLS,
+    )
+    max_requests: int = Field(
+        default=45,
+        ge=1,
+        le=config.TRACECAT__AGENT_MAX_REQUESTS,
+    )
+
+
 class PresetAgentActionArgs(BaseModel):
     model_config = _BASE_CONFIG
 

--- a/packages/tracecat-registry/tracecat_registry/integrations/agents/slack.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/agents/slack.py
@@ -3,203 +3,16 @@
 1. If no event is provided, the agent will send a message to the channel using the provided prompt.
 2. If an app mention event is provided (assumed to be an non-empty dict), the agent will respond to the app mention in the channel or thread.
 3. If an interaction payload (e.g. for button clicks) is provided (assumed to be a dict with payload field), the agent will respond to the interaction.
-
-For deduplication, we use the SlackApiError: {'ok': False, 'error': 'already_reacted'} as a heuristic.
 """
 
-import orjson
-from tracecat_registry.integrations.agents.prompts.slackbot import (
-    SlackAppMentionPrompts,
-    SlackInteractionPrompts,
-    SlackNoEventPrompts,
-    SlackPrompts,
-)
-from tracecat_registry.integrations.slack_sdk import call_method, slack_secret
-from tracecat_registry.sdk.agents import run_agent
+from typing import Annotated, Any
+
+from typing_extensions import Doc
 
 from tracecat_registry import registry
-from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
+from tracecat_registry._internal.exceptions import ActionIsInterfaceError
 from tracecat_registry.fields import ActionType, AgentModel, ModelSelection, TextArea
-from pydantic import BaseModel
-from typing_extensions import Doc
-from typing import Annotated, Any
-from slack_sdk.errors import SlackApiError
-
-
-async def _ack_event(channel_id: str, ts: str):
-    try:
-        await call_method(
-            sdk_method="reactions_add",
-            params={"channel": channel_id, "timestamp": ts, "name": "eyes"},
-        )
-    except SlackApiError as e:
-        if e.response.get("error") == "already_reacted":
-            raise ValueError(
-                "Another agent has already reacted to this message. Please wait for them to finish."
-            )
-        else:
-            raise e
-
-
-async def _notify_error(channel_id: str, thread_ts: str | None, ts: str | None):
-    # Remove the eyes emoji
-    if ts:
-        await call_method(
-            sdk_method="reactions_remove",
-            params={"channel": channel_id, "timestamp": ts, "name": "eyes"},
-        )
-
-    if ts:
-        # Add the warning emoji
-        await call_method(
-            sdk_method="reactions_add",
-            params={"channel": channel_id, "timestamp": ts, "name": "warning"},
-        )
-
-    await call_method(
-        sdk_method="chat_postMessage",
-        params={
-            "channel": channel_id,
-            "text": "I'm having trouble responding to your message. Please try again.",
-            "thread_ts": thread_ts,
-        },
-    )
-
-
-async def _remove_ack(channel_id: str, ts: str):
-    await call_method(
-        sdk_method="reactions_remove",
-        params={"channel": channel_id, "timestamp": ts, "name": "eyes"},
-    )
-
-
-class AppMentionEvent(BaseModel):
-    channel_id: str
-    thread_ts: str
-    ts: str
-    messages: list[dict[str, Any]]
-    user_id: str | None = None
-
-
-async def _handle_app_mention(
-    event: dict[str, Any], limit_messages: int
-) -> AppMentionEvent:
-    # App mention event
-    try:
-        event_body = event["event"]
-        ts = event_body["ts"]
-        thread_ts = event_body.get("thread_ts")
-        channel_id = event_body["channel"]
-        user_id = event_body.get("user")
-    except KeyError as exc:
-        raise ValueError("Expected 'ts', 'thread_ts', and 'channel' in event.") from exc
-
-    # Add "eyes" emoji to the app mention message
-    await _ack_event(channel_id, ts)
-
-    if thread_ts:
-        # If in thread, list message replies
-        response = await call_method(
-            sdk_method="conversations_replies",
-            params={
-                "channel": channel_id,
-                "ts": thread_ts,
-                "limit": limit_messages,
-            },
-        )
-        messages = response.get("messages", [])
-    else:
-        # If in channel, list conversation history
-        response = await call_method(
-            sdk_method="conversations_history",
-            params={"channel": channel_id, "limit": limit_messages},
-        )
-        messages = response.get("messages", [])
-        # Set thread_ts to the latest message
-        thread_ts = ts
-    return AppMentionEvent(
-        messages=messages,
-        thread_ts=thread_ts,
-        ts=ts,
-        channel_id=channel_id,
-        user_id=user_id,
-    )
-
-
-class InteractionPayloadEvent(BaseModel):
-    channel_id: str
-    thread_ts: str
-    ts: str
-    messages: list[dict[str, Any]]
-    actions: list[dict[str, Any]]
-    user_id: str | None = None
-    callback_id: str | None = None
-    response_url: str
-
-
-async def _handle_interaction_payload(
-    event: dict[str, Any], limit_messages: int
-) -> InteractionPayloadEvent:
-    try:
-        payload = orjson.loads(event["payload"])
-        container = payload["container"]
-        channel_id = container["channel_id"]
-        ts = container["message_ts"]
-        thread_ts = container.get("thread_ts", ts)
-        actions = payload["actions"]
-        callback_id = payload.get("callback_id")
-        user_id = payload.get("user", {}).get("id")
-        response_url = payload.get("response_url")
-        if not response_url and payload.get("response_urls"):
-            # Use the first response URL if multiple are provided
-            response_url = payload["response_urls"][0].get("response_url")
-    except KeyError as exc:
-        raise ValueError(
-            "Expected 'container', 'message_ts', and 'actions' in payload."
-        ) from exc
-
-    if not channel_id or not ts:
-        raise ValueError("Interaction payload is missing channel or message timestamp.")
-
-    if not response_url:
-        raise ValueError(
-            "Interaction payload is missing response_url for post_response tool."
-        )
-
-    # Add "eyes" emoji to the interaction payload message
-    await _ack_event(channel_id, ts)
-
-    if thread_ts:
-        # If in thread, list message replies
-        response = await call_method(
-            sdk_method="conversations_replies",
-            params={
-                "channel": channel_id,
-                "ts": thread_ts,
-                "limit": limit_messages,
-            },
-        )
-        messages = response.get("messages", [])
-    else:
-        # If in channel, list conversation history
-        response = await call_method(
-            sdk_method="conversations_history",
-            params={"channel": channel_id, "limit": limit_messages},
-        )
-        messages = response.get("messages", [])
-        # Set thread_ts to the latest message
-        thread_ts = ts
-
-    return InteractionPayloadEvent(
-        thread_ts=thread_ts,
-        ts=ts,
-        channel_id=channel_id,
-        messages=messages,
-        actions=actions,
-        user_id=user_id,
-        callback_id=callback_id,
-        response_url=response_url,
-    )
+from tracecat_registry.integrations.slack_sdk import slack_secret
 
 
 @registry.register(
@@ -208,7 +21,7 @@ async def _handle_interaction_payload(
     display_group="AI",
     doc_url="https://docs.slack.dev/reference/events/app_mention/",
     namespace="ai",
-    secrets=[*PYDANTIC_AI_REGISTRY_SECRETS, slack_secret],
+    secrets=[slack_secret],
 )
 async def slackbot(
     event: Annotated[
@@ -250,77 +63,4 @@ async def slackbot(
         int, Doc("Max number of messages to look back in the conversation.")
     ] = 5,
 ) -> Any:
-    if limit_messages > 20:
-        raise ValueError("Cannot look back more than 20 messages in a conversation.")
-
-    bot_actions = [
-        "tools.slack.post_message",
-        "tools.slack.update_message",
-        "tools.slack_sdk.post_response",
-    ]
-    if actions:
-        bot_actions = list(set([*actions, *bot_actions]))
-
-    ts = None
-    thread_ts = None
-
-    prompts: SlackPrompts
-
-    if event and ("event" in event or "payload" in event):
-        if event.get("event", {}).get("type") == "app_mention":
-            slackbot_event = await _handle_app_mention(event, limit_messages)
-            channel_id = slackbot_event.channel_id
-            thread_ts = slackbot_event.thread_ts
-            ts = slackbot_event.ts
-            prompts = SlackAppMentionPrompts(
-                channel_id=channel_id,
-                response_instructions=instructions,
-                messages=slackbot_event.messages,
-                thread_ts=thread_ts,
-                trigger_ts=ts,
-                trigger_user_id=slackbot_event.user_id,
-            )
-        elif "payload" in event:
-            slackbot_event = await _handle_interaction_payload(event, limit_messages)
-            channel_id = slackbot_event.channel_id
-            thread_ts = slackbot_event.thread_ts
-            ts = slackbot_event.ts
-            prompts = SlackInteractionPrompts(
-                channel_id=channel_id,
-                response_instructions=instructions,
-                messages=slackbot_event.messages,
-                thread_ts=thread_ts,
-                trigger_ts=ts,
-                actions=slackbot_event.actions,
-                acting_user_id=slackbot_event.user_id,
-                callback_id=slackbot_event.callback_id,
-                response_url=slackbot_event.response_url,
-            )
-        else:
-            raise ValueError("Unsupported Slack event type.")
-    else:
-        prompts = SlackNoEventPrompts(
-            channel_id=channel_id,
-            response_instructions=instructions,
-            initial_prompt=prompt,
-        )
-
-    try:
-        response = await run_agent(
-            user_prompt=prompts.user_prompt,
-            model_name=model.model_name,
-            model_provider=model.model_provider,
-            catalog_id=model.catalog_id,
-            actions=bot_actions,
-            instructions=prompts.instructions,
-            model_settings=model_settings,
-            retries=retries,
-        )
-    except Exception as e:
-        # Send unexpected error message to Slack with the thread_ts
-        await _notify_error(channel_id, thread_ts, ts)
-        raise e
-    else:
-        if ts:
-            await _remove_ack(channel_id, ts)
-    return response
+    raise ActionIsInterfaceError()

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -6,16 +6,24 @@ from collections.abc import Callable, Coroutine, Mapping
 from typing import Any, cast
 
 import dateparser
+import orjson
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from slack_sdk.errors import SlackApiError
+from slack_sdk.web.async_client import AsyncWebClient
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
-from tracecat_ee.agent.schemas import AgentActionArgs, PresetAgentActionArgs
+from tracecat_ee.agent.schemas import (
+    AgentActionArgs,
+    PresetAgentActionArgs,
+    SlackbotActionArgs,
+)
 
 from tracecat import config
 from tracecat.agent.common.types import MCPServerConfig
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.auth.types import Role
 from tracecat.common import is_iterable
+from tracecat.contexts import ctx_role
 from tracecat.dsl.common import (
     MAX_LOOP_ITERATIONS,
     DSLInput,
@@ -52,6 +60,8 @@ from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.integrations.mcp_validation import MCPValidationError
 from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
+from tracecat.secrets.service import SecretsService
 from tracecat.storage.collection import (
     materialize_collection_values,
     store_collection,
@@ -180,6 +190,39 @@ class BuildPresetAgentArgsActivityInput(BaseModel):
     role: Role
     task_environment: str | None
     default_environment: str
+
+
+class BuildSlackbotArgsActivityInput(BaseModel):
+    args: dict[str, Any]
+    operand: ExecutionContext
+    role: Role
+    task_environment: str | None
+    default_environment: str
+
+
+class SlackbotPrepareActivityInput(BaseModel):
+    role: Role
+    event: dict[str, Any] | None
+    prompt: str
+    channel_id: str
+    instructions: str
+    limit_messages: int
+
+
+class SlackbotPrepareActivityResult(BaseModel):
+    user_prompt: str
+    instructions: str
+    channel_id: str
+    ts: str | None
+    thread_ts: str | None
+
+
+class SlackbotPostProcessingActivityInput(BaseModel):
+    role: Role
+    channel_id: str
+    ts: str | None
+    thread_ts: str | None
+    success: bool
 
 
 class EvaluateTemplatedObjectActivityInput(BaseModel):
@@ -713,6 +756,336 @@ class DSLActivities:
             eval_templated_object, args, operand=materialized
         )
         return PresetAgentActionArgs(**evaled_args)
+
+    @staticmethod
+    @activity.defn
+    async def build_slackbot_args_activity(
+        input: BuildSlackbotArgsActivityInput,
+    ) -> SlackbotActionArgs:
+        """Resolve and evaluate templated slackbot action args. No I/O."""
+        ctx_role.set(input.role)
+        operand = input.operand
+        materialized = await materialize_context(operand)
+        environment = await asyncio.to_thread(
+            _resolve_environment,
+            input.task_environment,
+            input.default_environment,
+            materialized,
+        )
+        collected = await asyncio.to_thread(collect_expressions, input.args)
+        if collected.variables:
+            workspace_variables = await get_workspace_variables(
+                variable_exprs=collected.variables,
+                environment=environment,
+                role=input.role,
+            )
+            if workspace_variables:
+                operand["VARS"] = workspace_variables
+                materialized = await materialize_context(operand)
+        args = _strip_string_values(input.args)
+        evaled_args = await asyncio.to_thread(
+            eval_templated_object, args, operand=materialized
+        )
+        return SlackbotActionArgs(**evaled_args)
+
+    @staticmethod
+    @activity.defn
+    async def slackbot_prepare_activity(
+        input: SlackbotPrepareActivityInput,
+    ) -> SlackbotPrepareActivityResult:
+        """Ack the Slack event, fetch thread/channel history, build prompts.
+
+        All Slack I/O side effects happen here. Returns the resolved
+        user_prompt and instructions (via Slack*Prompts) plus cleanup context.
+        """
+        ctx_role.set(input.role)
+        async with SecretsService.with_session(role=input.role) as secrets_svc:
+            secret = await secrets_svc.get_secret_by_name(
+                "slack", DEFAULT_SECRETS_ENVIRONMENT
+            )
+            kv = {
+                k.key: k.value.get_secret_value()
+                for k in secrets_svc.decrypt_keys(secret.encrypted_keys)
+            }
+        client = AsyncWebClient(token=kv["SLACK_BOT_TOKEN"])
+
+        event = input.event
+        channel_id = input.channel_id
+        limit_messages = input.limit_messages
+        ts: str | None = None
+        thread_ts: str | None = None
+
+        import textwrap
+        from datetime import UTC, datetime
+
+        import yaml
+
+        def _ts_to_dt(ts: str | None) -> str:
+            if not ts:
+                return "unknown"
+            try:
+                return datetime.fromtimestamp(float(ts), tz=UTC).isoformat()
+            except (TypeError, ValueError):
+                return "unknown"
+
+        def _format_messages(msgs: list[dict]) -> str:
+            lines = []
+            for m in msgs:
+                ts_iso = _ts_to_dt(m.get("ts"))
+                user = (
+                    m.get("user") or m.get("username") or m.get("bot_id") or "unknown"
+                )
+                text = m.get("text") or ""
+                line = f"{user} [{ts_iso}]: {text}".strip()
+                if line:
+                    lines.append(line)
+            return "\n".join(reversed(lines))
+
+        now = datetime.now(tz=UTC).isoformat()
+        user_prompt: str
+        instructions: str
+
+        if event and ("event" in event or "payload" in event):
+            if event.get("event", {}).get("type") == "app_mention":
+                event_body = event["event"]
+                ts = event_body["ts"]
+                thread_ts = event_body.get("thread_ts")
+                channel_id = event_body["channel"]
+                trigger_user = event_body.get("user") or "unknown"
+                try:
+                    await client.api_call(
+                        "reactions.add",
+                        params={"channel": channel_id, "timestamp": ts, "name": "eyes"},
+                    )
+                except SlackApiError as e:
+                    if e.response.get("error") == "already_reacted":
+                        raise ApplicationError(
+                            "Another agent has already reacted to this message.",
+                            non_retryable=True,
+                        ) from e
+                    raise
+                if thread_ts:
+                    resp = await client.api_call(
+                        "conversations.replies",
+                        params={
+                            "channel": channel_id,
+                            "ts": thread_ts,
+                            "limit": limit_messages,
+                        },
+                    )
+                else:
+                    resp = await client.api_call(
+                        "conversations.history",
+                        params={"channel": channel_id, "limit": limit_messages},
+                    )
+                    thread_ts = ts
+                messages = resp.get("messages", [])
+                user_prompt = _format_messages(messages)
+                instructions = textwrap.dedent(f"""
+                    You are an expert Slackbot responding to a user who mentioned you in channel <ChannelID>{channel_id}</ChannelID>.
+                    The conversation transcript is attached for context.
+
+                    Steps:
+                    1. Review the transcript to understand the situation and the latest app mention that triggered you at <TriggerTS>{_ts_to_dt(ts)}</TriggerTS>.
+                    2. Check if you're already responded to the most recent message in the thread. If you have, stop and summarize what you've posted as the final agent output.
+                    3. Formulate a concise, helpful reply that resolves the user's request.
+                    4. Call `tools.slack.post_message` exactly once with `channel` set to `{channel_id}` and `thread_ts` set to `{thread_ts}` so your reply stays in the thread.
+                    5. Immediately after the tool call, output the single token `DONE` as your final assistant message (not via a Slack tool) and halt.
+
+                    <ThreadTS>{thread_ts}</ThreadTS>
+                    <TriggerTS>{_ts_to_dt(ts)}</TriggerTS>
+                    <MentionedUser>{trigger_user}</MentionedUser>
+                    <TimeRightNow>{now}</TimeRightNow>
+
+                    <IMPORTANT>
+                    - Respond only once and stop immediately after the tool call.
+                    - Address the newest user message directly; do not repeat earlier bot output or loop on prior prompts.
+                    - Keep the tone friendly, confident, and appropriately brief.
+                    - After posting, do not call any other tools; the `DONE` message ends the run.
+                    </IMPORTANT>
+
+                    <TaggingUsers>
+                    You can tag users in the channel by using their user ID in the format `<@some-user-id>`.
+                    </TaggingUsers>
+
+                    <instructions>
+                    {input.instructions}
+                    </instructions>
+                """)
+
+            elif "payload" in event:
+                payload = orjson.loads(event["payload"])
+                container = payload["container"]
+                channel_id = container["channel_id"]
+                ts = container["message_ts"]
+                thread_ts = container.get("thread_ts", ts)
+                response_url = payload.get("response_url") or (
+                    payload.get("response_urls", [{}])[0].get("response_url", "")
+                )
+                acting_user = payload.get("user", {}).get("id") or "unknown"
+                callback = payload.get("callback_id") or "n/a"
+                actions = payload.get("actions", [])
+                actions_yaml = yaml.safe_dump(actions, sort_keys=False).strip()
+                try:
+                    await client.api_call(
+                        "reactions.add",
+                        params={"channel": channel_id, "timestamp": ts, "name": "eyes"},
+                    )
+                except SlackApiError as e:
+                    if e.response.get("error") == "already_reacted":
+                        raise ApplicationError(
+                            "Another agent has already reacted to this message.",
+                            non_retryable=True,
+                        ) from e
+                    raise
+                if thread_ts:
+                    resp = await client.api_call(
+                        "conversations.replies",
+                        params={
+                            "channel": channel_id,
+                            "ts": thread_ts,
+                            "limit": limit_messages,
+                        },
+                    )
+                else:
+                    resp = await client.api_call(
+                        "conversations.history",
+                        params={"channel": channel_id, "limit": limit_messages},
+                    )
+                    thread_ts = ts
+                messages = resp.get("messages", [])
+                user_prompt = _format_messages(messages)
+                instructions = textwrap.dedent(f"""
+                    You are handling a Slack interaction payload inside channel <ChannelID>{channel_id}</ChannelID>.
+                    The current conversation context and action summary are provided.
+
+                    Steps:
+                    1. Review the transcript and payload details to understand what the user needs.
+                    2. Check if you've already responded to the most recent message in the thread. If you have, stop and summarize what you've posted as the final agent output.
+                    3. Use `tools.slack_sdk.post_response` once to update the interactive message via <ResponseURL>{response_url}</ResponseURL>. Set `replace_original` to true. Update the message to show who performed the action and what action they took.
+                    4. After updating the interactive message, call `tools.slack.post_message` exactly once with `thread_ts` set to `{thread_ts}` and `channel` set to `{channel_id}` to provide a follow-up response that explains:
+                       - Who did what (reference the acting user and their specific action)
+                       - What happens next (clear next steps or outcomes)
+                    5. Immediately after the confirmation reply, output the literal word `DONE` as your final assistant message (not via Slack) to finish the run.
+
+                    <ThreadTS>{thread_ts}</ThreadTS>
+                    <TriggerTS>{_ts_to_dt(ts)}</TriggerTS>
+                    <CallbackID>{callback}</CallbackID>
+                    <ActingUser>{acting_user}</ActingUser>
+                    <TimeRightNow>{now}</TimeRightNow>
+
+                    Interaction actions:
+                    ```yaml
+                    {actions_yaml}
+                    ```
+
+                    <IMPORTANT>
+                    - Maintain the order: update the interactive message first, then post exactly one confirmation reply in the thread.
+                    - Do not call `tools.slack.update_message` unless the injected instructions explicitly require it.
+                    - Stop immediately after the confirmation reply and emit the standalone `DONE` message to close the run.
+                    </IMPORTANT>
+
+                    <TaggingUsers>
+                    You can tag users in the channel by using their user ID in the format `<@some-user-id>`.
+                    </TaggingUsers>
+
+                    <instructions>
+                    {input.instructions}
+                    </instructions>
+                """)
+            else:
+                raise ApplicationError(
+                    "Unsupported Slack event type.", non_retryable=True
+                )
+        else:
+            user_prompt = input.prompt
+            instructions = textwrap.dedent(f"""
+                You are an expert Slackbot preparing a proactive update for channel <ChannelID>{channel_id}</ChannelID>.
+
+                Steps:
+                1. Study the planning instructions block.
+                2. Check if you're already responded to the most recent message in the thread. If you have, stop and summarize what you've posted as the final agent output.
+                3. Compose exactly one Slack message that satisfies those instructions.
+                4. Call `tools.slack.post_message` once with `channel` set to `{channel_id}` and do not provide `thread_ts`.
+                5. Immediately after the tool call, end the run by emitting the literal word `DONE` as your final assistant message (do not send it to Slack).
+
+                <TimeRightNow>{now}</TimeRightNow>
+
+                <IMPORTANT>
+                - Post only once; after the tool call, stop.
+                - Do not fabricate additional context beyond what the instructions provide.
+                - Keep the tone clear, professional, and tailored to the audience described.
+                - Never call any additional tools after you've posted once; the closing `DONE` text completes the run.
+                </IMPORTANT>
+
+                <TaggingUsers>
+                You can tag users in the channel by using their user ID in the format `<@some-user-id>`.
+                </TaggingUsers>
+
+                <instructions>
+                {input.instructions}
+                </instructions>
+            """)
+
+        return SlackbotPrepareActivityResult(
+            user_prompt=user_prompt,
+            instructions=instructions,
+            channel_id=channel_id,
+            ts=ts,
+            thread_ts=thread_ts,
+        )
+
+    @staticmethod
+    @activity.defn
+    async def slackbot_finalize_activity(
+        input: SlackbotPostProcessingActivityInput,
+    ) -> None:
+        """Remove the ack reaction and optionally post an error notification."""
+        ctx_role.set(input.role)
+        async with SecretsService.with_session(role=input.role) as secrets_svc:
+            secret = await secrets_svc.get_secret_by_name(
+                "slack", DEFAULT_SECRETS_ENVIRONMENT
+            )
+            kv = {
+                k.key: k.value.get_secret_value()
+                for k in secrets_svc.decrypt_keys(secret.encrypted_keys)
+            }
+        client = AsyncWebClient(token=kv["SLACK_BOT_TOKEN"])
+
+        if input.ts:
+            try:
+                await client.api_call(
+                    "reactions.remove",
+                    params={
+                        "channel": input.channel_id,
+                        "timestamp": input.ts,
+                        "name": "eyes",
+                    },
+                )
+            except Exception:
+                pass
+
+        if not input.success:
+            if input.ts:
+                try:
+                    await client.api_call(
+                        "reactions.add",
+                        params={
+                            "channel": input.channel_id,
+                            "timestamp": input.ts,
+                            "name": "warning",
+                        },
+                    )
+                except Exception:
+                    pass
+            await client.api_call(
+                "chat.postMessage",
+                params={
+                    "channel": input.channel_id,
+                    "text": "I'm having trouble responding to your message. Please try again.",
+                    "thread_ts": input.thread_ts,
+                },
+            )
 
     @staticmethod
     @activity.defn

--- a/tracecat/dsl/enums.py
+++ b/tracecat/dsl/enums.py
@@ -10,6 +10,7 @@ class PlatformAction(StrEnum):
     AI_AGENT = "ai.agent"
     AI_PRESET_AGENT = "ai.preset_agent"
     AI_ACTION = "ai.action"
+    AI_SLACKBOT = "ai.slackbot"
     RUN_PYTHON = "core.script.run_python"
 
     @classmethod
@@ -18,6 +19,7 @@ class PlatformAction(StrEnum):
             cls.AI_AGENT,
             cls.AI_PRESET_AGENT,
             cls.AI_ACTION,
+            cls.AI_SLACKBOT,
         )
 
     @classmethod
@@ -32,6 +34,7 @@ class PlatformAction(StrEnum):
                 cls.AI_AGENT,
                 cls.AI_PRESET_AGENT,
                 cls.AI_ACTION,
+                cls.AI_SLACKBOT,
                 cls.RUN_PYTHON,
             )
         )

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -54,10 +54,13 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.action import (
         BuildAgentArgsActivityInput,
         BuildPresetAgentArgsActivityInput,
+        BuildSlackbotArgsActivityInput,
         DSLActivities,
         EvaluateTemplatedObjectActivityInput,
         NormalizeTriggerInputsActivityInputs,
         PrepareSubflowActivityInput,
+        SlackbotPostProcessingActivityInput,
+        SlackbotPrepareActivityInput,
         SynchronizeCollectionObjectActivityInput,
     )
     from tracecat.dsl.common import (
@@ -836,6 +839,108 @@ class DSLWorkflow:
                 return False
             current = nested
 
+    async def _execute_slackbot(
+        self,
+        task: ActionStatement,
+        agent_operand: Any,
+        stream_id: StreamID | None,
+    ) -> Any:
+        slackbot_args = await workflow.execute_activity(
+            DSLActivities.build_slackbot_args_activity,
+            arg=BuildSlackbotArgsActivityInput(
+                args=dict(task.args),
+                operand=agent_operand,
+                role=self.role,
+                task_environment=task.environment,
+                default_environment=self.run_context.environment,
+            ),
+            start_to_close_timeout=timedelta(seconds=60),
+            retry_policy=RETRY_POLICIES["activity:fail_fast"],
+        )
+        pre = await workflow.execute_activity(
+            DSLActivities.slackbot_prepare_activity,
+            arg=SlackbotPrepareActivityInput(
+                role=self.role,
+                event=slackbot_args.event,
+                prompt=slackbot_args.prompt,
+                channel_id=slackbot_args.channel_id,
+                instructions=slackbot_args.instructions,
+                limit_messages=slackbot_args.limit_messages,
+            ),
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=RETRY_POLICIES["activity:fail_fast"],
+        )
+        wf_info = workflow.info()
+        child_search_attributes = _build_agent_child_search_attributes(
+            wf_info, task.ref
+        )
+        session_id = workflow.uuid4()
+        default_bot_actions = [
+            "tools.slack.post_message",
+            "tools.slack.update_message",
+            "tools.slack_sdk.post_response",
+        ]
+        bot_actions = default_bot_actions + [
+            a for a in (slackbot_args.actions or []) if a not in default_bot_actions
+        ]
+        arg = AgentWorkflowArgs(
+            role=self.role,
+            agent_args=RunAgentArgs(
+                user_prompt=pre.user_prompt,
+                session_id=session_id,
+                config=AgentConfig(
+                    model_name=slackbot_args.model_name,
+                    model_provider=slackbot_args.model_provider,
+                    catalog_id=slackbot_args.catalog_id,
+                    instructions=pre.instructions,
+                    actions=bot_actions,
+                    model_settings=slackbot_args.model_settings,
+                    retries=slackbot_args.retries,
+                ),
+                max_requests=slackbot_args.max_requests,
+                max_tool_calls=slackbot_args.max_tool_calls,
+            ),
+            title=self.dsl.title,
+            entity_type=AgentSessionEntity.WORKFLOW,
+            entity_id=self.run_context.wf_id,
+        )
+        finalize_input = SlackbotPostProcessingActivityInput(
+            role=self.role,
+            channel_id=pre.channel_id,
+            ts=pre.ts,
+            thread_ts=pre.thread_ts,
+            success=True,
+        )
+        try:
+            result = await workflow.execute_child_workflow(
+                DurableAgentWorkflow.run,
+                arg=arg,
+                id=AgentWorkflowID(session_id),
+                retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+                task_queue=config.TRACECAT__AGENT_QUEUE,
+                execution_timeout=wf_info.execution_timeout,
+                task_timeout=wf_info.task_timeout,
+                search_attributes=child_search_attributes,
+                memo=AgentActionMemo(
+                    action_ref=task.ref,
+                    action_title=task.title,
+                    stream_id=stream_id or ROOT_STREAM,
+                    mask_output=task.mask_output,
+                ).model_dump(),
+            )
+        except Exception:
+            finalize_input = finalize_input.model_copy(update={"success": False})
+            raise
+        finally:
+            if pre.ts:
+                await workflow.execute_activity(
+                    DSLActivities.slackbot_finalize_activity,
+                    arg=finalize_input,
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                )
+        return result
+
     @maybe_interactive
     async def _execute_task(self, task: ActionStatement) -> TaskResult:
         """Purely execute a task and manage the results.
@@ -1158,6 +1263,13 @@ class DSLWorkflow:
                             stream_id=stream_id or ROOT_STREAM,
                             mask_output=task.mask_output,
                         ).model_dump(),
+                    )
+                case PlatformAction.AI_SLACKBOT:
+                    self.logger.debug("Executing Slackbot agent", task=task)
+                    agent_operand = self._build_action_context(task, stream_id)
+                    self._set_logical_time_context()
+                    action_result = await self._execute_slackbot(
+                        task, agent_operand, stream_id
                     )
                 case _:
                     # Below this point, we're executing the task


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced the Slackbot agent’s pydantic-ai registry path with a durable DSL-based workflow and activities. The registry action is now an interface; all Slack I/O, prompts, and execution run in the DSL engine.

- **Refactors**
  - Added `ai.slackbot` to platform actions; marked as streamable and interface.
  - Registry `slackbot` now raises `ActionIsInterfaceError`; removed pydantic-ai runtime and `PYDANTIC_AI_REGISTRY_SECRETS`.
  - Introduced `SlackbotActionArgs` to resolve templated inputs and model selection.
  - New Temporal activities: build args, prepare (ack event, fetch history, build prompts for app_mention/interaction/no-event), and finalize (remove ack, add warning, post error message).
  - Slack execution runs via `DurableAgentWorkflow` with default tools: `tools.slack.post_message`, `tools.slack.update_message`, `tools.slack_sdk.post_response`.
  - Secrets pulled via `SecretsService` using the `slack` secret (`SLACK_BOT_TOKEN`); uses `slack_sdk` client.
  - Improved dedup and failure handling: treats `already_reacted` as non-retryable; posts a warning and user-facing error on failure.

<sup>Written for commit d34b75975fb5e1b6aa31b10746e2d05ca8de7355. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

