### PR TITLE
fix(registry): stream tarball venv uploads to S3

### DIFF
--- a/tests/unit/test_registry_sync_tarball.py
+++ b/tests/unit/test_registry_sync_tarball.py
@@ -184,8 +184,8 @@ async def test_upload_tarball_venv_uploads_zstd_sidecar(
     zstd_tarball_path = tmp_path / "site-packages.tar.zst"
     tarball_path.write_bytes(b"gzip")
     zstd_tarball_path.write_bytes(b"zstd")
-    upload_file = mocker.patch(
-        "tracecat.registry.sync.tarball.blob.upload_file",
+    upload_file_from_path = mocker.patch(
+        "tracecat.registry.sync.tarball.blob.upload_file_from_path",
         mocker.AsyncMock(),
     )
 
@@ -200,17 +200,17 @@ async def test_upload_tarball_venv_uploads_zstd_sidecar(
         "s3://tracecat-registry/org/tarball-venvs/tracecat_registry/v1/"
         "site-packages.tar.gz"
     )
-    assert upload_file.await_count == 2
-    upload_file.assert_has_awaits(
+    assert upload_file_from_path.await_count == 2
+    upload_file_from_path.assert_has_awaits(
         [
             mocker.call(
-                content=b"gzip",
+                path=tarball_path,
                 key="org/tarball-venvs/tracecat_registry/v1/site-packages.tar.gz",
                 bucket="tracecat-registry",
                 content_type="application/gzip",
             ),
             mocker.call(
-                content=b"zstd",
+                path=zstd_tarball_path,
                 key="org/tarball-venvs/tracecat_registry/v1/site-packages.tar.zst",
                 bucket="tracecat-registry",
                 content_type="application/zstd",

--- a/tests/unit/test_storage_blob.py
+++ b/tests/unit/test_storage_blob.py
@@ -22,6 +22,7 @@ from tracecat.storage.blob import (
     get_storage_client,
     open_download_stream,
     upload_file,
+    upload_file_from_path,
 )
 
 
@@ -138,6 +139,39 @@ class TestS3Operations:
         mock_client.put_object.assert_called_once()
         kwargs = mock_client.put_object.call_args.kwargs
         assert kwargs == {"Bucket": "bucket", "Key": key, "Body": content}
+
+    @pytest.mark.anyio
+    @patch("tracecat.storage.blob.get_storage_client")
+    async def test_upload_file_from_path_uses_bounded_transfer_config(
+        self,
+        mock_get_client,
+        tmp_path: Path,
+    ):
+        """Path uploads bound queued multipart payloads."""
+        mock_client = AsyncMock()
+        mock_get_client.return_value.__aenter__.return_value = mock_client
+
+        path = tmp_path / "site-packages.tar.gz"
+        path.write_bytes(b"content")
+
+        await upload_file_from_path(
+            path=path,
+            key="registry/site-packages.tar.gz",
+            bucket="tracecat-registry",
+            content_type="application/gzip",
+        )
+
+        mock_client.upload_file.assert_called_once()
+        kwargs = mock_client.upload_file.call_args.kwargs
+        assert kwargs["Filename"] == str(path)
+        assert kwargs["Bucket"] == "tracecat-registry"
+        assert kwargs["Key"] == "registry/site-packages.tar.gz"
+        assert kwargs["ExtraArgs"] == {"ContentType": "application/gzip"}
+        transfer_config = kwargs["Config"]
+        assert transfer_config.multipart_threshold == 8 * 1024 * 1024
+        assert transfer_config.multipart_chunksize == 8 * 1024 * 1024
+        assert transfer_config.max_request_concurrency == 4
+        assert transfer_config.max_io_queue_size == 2
 
     @pytest.mark.anyio
     @patch("tracecat.storage.blob.get_storage_client")

--- a/tracecat/registry/sync/tarball.py
+++ b/tracecat/registry/sync/tarball.py
@@ -609,20 +609,18 @@ async def upload_tarball_venv(
     if not zstd_tarball_path.exists():
         raise FileNotFoundError(f"Zstd tarball file not found: {zstd_tarball_path}")
 
-    # Use asyncio.to_thread to avoid blocking the event loop for large files
-    content = await asyncio.to_thread(tarball_path.read_bytes)
-    zstd_content = await asyncio.to_thread(zstd_tarball_path.read_bytes)
-
-    await blob.upload_file(
-        content=content,
+    # Stream from disk via multipart upload so we don't hold hundreds of MB
+    # of tarball bytes in the API process memory at once.
+    await blob.upload_file_from_path(
+        path=tarball_path,
         key=key,
         bucket=bucket,
         content_type="application/gzip",
     )
 
     zstd_key = _zstd_key_for(key)
-    await blob.upload_file(
-        content=zstd_content,
+    await blob.upload_file_from_path(
+        path=zstd_tarball_path,
         key=zstd_key,
         bucket=bucket,
         content_type="application/zstd",
@@ -634,8 +632,8 @@ async def upload_tarball_venv(
         key=key,
         bucket=bucket,
         s3_uri=s3_uri,
-        size=len(content),
-        zstd_size=len(zstd_content),
+        size=tarball_path.stat().st_size,
+        zstd_size=zstd_tarball_path.stat().st_size,
     )
     return s3_uri
 

--- a/tracecat/storage/blob.py
+++ b/tracecat/storage/blob.py
@@ -350,6 +350,56 @@ async def upload_file(
         raise
 
 
+async def upload_file_from_path(
+    path: Path,
+    key: str,
+    bucket: str,
+    content_type: str | None = None,
+) -> None:
+    """Stream a file from disk to S3 using multipart upload.
+
+    Avoids loading the entire file into memory, which matters for large
+    artifacts like registry venv tarballs.
+
+    Args:
+        path: Local file to upload
+        key: S3 object key
+        bucket: Bucket name (required)
+        content_type: Optional MIME type
+
+    Raises:
+        FileNotFoundError: If `path` does not exist
+        ClientError: If the upload fails
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+
+    extra_args = {"ContentType": content_type} if content_type else None
+
+    try:
+        async with get_storage_client() as s3_client:
+            await s3_client.upload_file(
+                Filename=str(path),
+                Bucket=bucket,
+                Key=key,
+                ExtraArgs=extra_args,
+            )
+            logger.info(
+                "File uploaded successfully",
+                key=key,
+                bucket=bucket,
+                size=path.stat().st_size,
+            )
+    except ClientError as e:
+        logger.error(
+            "Failed to upload file",
+            key=key,
+            bucket=bucket,
+            error=str(e),
+        )
+        raise
+
+
 async def copy_file(
     *,
     source_key: str,

--- a/tracecat/storage/blob.py
+++ b/tracecat/storage/blob.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import aioboto3
 import aiofiles
+from boto3.s3.transfer import TransferConfig
 from botocore.exceptions import ClientError
 
 from tracecat import config
@@ -26,6 +27,9 @@ if TYPE_CHECKING:
 
 
 DEFAULT_DOWNLOAD_CHUNK_SIZE_BYTES = 8 * 1024 * 1024  # 8MB
+DEFAULT_UPLOAD_CHUNK_SIZE_BYTES = 8 * 1024 * 1024  # 8MB
+DEFAULT_UPLOAD_MAX_CONCURRENCY = 4
+DEFAULT_UPLOAD_MAX_IO_QUEUE_SIZE = 2
 
 
 @asynccontextmanager
@@ -375,6 +379,12 @@ async def upload_file_from_path(
         raise FileNotFoundError(f"File not found: {path}")
 
     extra_args = {"ContentType": content_type} if content_type else None
+    transfer_config = TransferConfig(
+        multipart_threshold=DEFAULT_UPLOAD_CHUNK_SIZE_BYTES,
+        multipart_chunksize=DEFAULT_UPLOAD_CHUNK_SIZE_BYTES,
+        max_concurrency=DEFAULT_UPLOAD_MAX_CONCURRENCY,
+        max_io_queue=DEFAULT_UPLOAD_MAX_IO_QUEUE_SIZE,
+    )
 
     try:
         async with get_storage_client() as s3_client:
@@ -383,6 +393,7 @@ async def upload_file_from_path(
                 Bucket=bucket,
                 Key=key,
                 ExtraArgs=extra_args,
+                Config=transfer_config,
             )
             logger.info(
                 "File uploaded successfully",


### PR DESCRIPTION
## Summary
- Stream the gzip + zstd registry venv tarballs directly off disk via `aioboto3`'s multipart `upload_file` instead of `path.read_bytes()` + `put_object`.
- Adds a `tracecat.storage.blob.upload_file_from_path` helper for path-based S3 uploads.

## Why
After #2691 added the zstd sidecar, `upload_tarball_venv` was reading both archives fully into memory before uploading (~333 MB gzip + ~304 MB zstd for our registry today). On the eu-west-1 cluster the API pod sits at a 1 Gi limit and started OOMKilling in a loop right after the helm rev-77 rollout — captured here:

```
Last State:     Terminated
  Reason:       OOMKilled
  Exit Code:    137
```

Streaming from disk drops the peak footprint of this upload path from ~640 MB to roughly the multipart chunk size, which should be enough to keep the API under its current limit while the rest of the zstd rollout proceeds.

## Test plan
- [x] `uv run ruff check` / `ruff format --check` on touched files
- [x] `uv run basedpyright --warnings` on touched files
- [x] `uv run pytest tests/unit/test_registry_sync_tarball.py tests/unit/test_action_runner.py tests/unit/test_registry_sync_runner.py` (37 passed)
- [ ] Deploy to eu-west-1 and confirm API pod no longer OOMKills during registry sync

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stream registry venv tarball uploads from disk to S3 to reduce peak memory and stop API OOMKills during registry sync. Uses `aioboto3` multipart `upload_file` via a new `upload_file_from_path` helper with bounded buffering.

- **Bug Fixes**
  - Replace in-memory uploads with `upload_file_from_path` streaming from disk.
  - Bound multipart buffering using `TransferConfig` (8MB chunks, 4 concurrency, IO queue 2).
  - Use `stat()` for gzip/zstd sizes instead of `len(bytes)`.
  - Add tests for `upload_file_from_path` args and transfer config.

<sup>Written for commit 3f894bd7cb5cf13cb1b51fed00f819b5e878af03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

