### PR TITLE
feat(registry): deprecated action enforcement

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -17786,6 +17786,18 @@ export const $RegistryActionReadMinimal = {
       $ref: "#/components/schemas/RegistryActionAvailability",
       description: "Availability metadata for this action",
     },
+    deprecated: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Deprecated",
+      description: "Deprecation message if this action is deprecated",
+    },
     action: {
       type: "string",
       title: "Action",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -5466,6 +5466,10 @@ export type RegistryActionReadMinimal = {
    */
   availability?: RegistryActionAvailability
   /**
+   * Deprecation message if this action is deprecated
+   */
+  deprecated?: string | null
+  /**
    * The full action identifier.
    */
   readonly action: string

--- a/frontend/src/components/builder/canvas/canvas-toolbar.tsx
+++ b/frontend/src/components/builder/canvas/canvas-toolbar.tsx
@@ -154,6 +154,10 @@ function isLockedAction(action: RegistryActionReadMinimal): boolean {
   return action.availability?.locked ?? false
 }
 
+function isDeprecatedAction(action: RegistryActionReadMinimal): boolean {
+  return !!action.deprecated
+}
+
 const WORKFLOW_EXTRA_ACTIONS = new Set([
   "core.transform.scatter",
   "core.transform.gather",
@@ -381,6 +385,9 @@ function ToolbarCategoryDropdown({
         setLockedFeatureOpen(true)
         return
       }
+      if (isDeprecatedAction(action)) {
+        return
+      }
       onAddAction(action)
       setOpen(false)
       setSearch("")
@@ -410,15 +417,17 @@ function ToolbarCategoryDropdown({
 
   function renderActionItem(action: RegistryActionReadMinimal) {
     const isLocked = isLockedAction(action)
+    const isDeprecated = isDeprecatedAction(action)
 
-    return (
+    const item = (
       <CommandItem
         key={action.action}
         value={action.action}
         onSelect={() => handleSelect(action)}
         className={cn(
-          "flex w-full cursor-pointer items-center gap-3 py-2",
-          isLocked && "text-muted-foreground"
+          "flex w-full items-center gap-3 py-2",
+          isLocked && "text-muted-foreground",
+          isDeprecated ? "cursor-not-allowed opacity-50" : "cursor-pointer"
         )}
       >
         {renderActionIcon(action)}
@@ -432,6 +441,18 @@ function ToolbarCategoryDropdown({
         </div>
       </CommandItem>
     )
+
+    if (isDeprecated) {
+      return (
+        <Tooltip key={action.action}>
+          <TooltipTrigger asChild>{item}</TooltipTrigger>
+          <TooltipContent side="right" className="max-w-48 text-xs">
+            {action.deprecated}
+          </TooltipContent>
+        </Tooltip>
+      )
+    }
+    return item
   }
 
   return (

--- a/frontend/src/components/builder/canvas/selector-node.tsx
+++ b/frontend/src/components/builder/canvas/selector-node.tsx
@@ -24,6 +24,11 @@ import { Label } from "@/components/ui/label"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
 import {
   useBuilderRegistryActions,
@@ -54,6 +59,10 @@ const SEARCH_KEY_INDEX: Record<(typeof SEARCH_KEYS)[number], number> =
 
 function isLockedAction(action: RegistryActionReadMinimal): boolean {
   return action.availability?.locked ?? false
+}
+
+function isDeprecatedAction(action: RegistryActionReadMinimal): boolean {
+  return !!action.deprecated
 }
 
 type ActionFilterResult = {
@@ -343,6 +352,9 @@ function ActionCommandGroup({
         setLockedFeatureOpen(true)
         return
       }
+      if (isDeprecatedAction(registryAction)) {
+        return
+      }
       if (!workflowId) {
         return
       }
@@ -505,44 +517,38 @@ function ActionCommandGroup({
         {filterResults.map((result) => {
           const { action, actionResult, titleResult } = result
           const isLocked = isLockedAction(action)
+          const isDeprecated = isDeprecatedAction(action)
 
-          if (highlight) {
-            return (
-              <CommandItem
-                key={action.action}
-                className={cn(
-                  "flex w-full items-center gap-3 py-2 text-xs",
-                  isLocked && "text-muted-foreground"
-                )}
-                onSelect={async () => await handleSelect(action)}
-              >
-                {getIcon(action.action, {
-                  className: "size-8 rounded-md border p-1.5",
-                })}
-                <div className="flex min-w-0 flex-1 flex-col">
-                  <span className="truncate text-xs font-medium">
-                    <HighlightedText
-                      result={titleResult}
-                      text={action.default_title ?? action.action}
-                    />
-                  </span>
-                  <span className="truncate text-xs text-muted-foreground">
-                    <HighlightedText
-                      result={actionResult}
-                      text={action.action}
-                    />
-                  </span>
-                </div>
-              </CommandItem>
-            )
-          }
-
-          return (
+          const item = highlight ? (
             <CommandItem
               key={action.action}
               className={cn(
                 "flex w-full items-center gap-3 py-2 text-xs",
-                isLocked && "text-muted-foreground"
+                (isLocked || isDeprecated) && "cursor-not-allowed opacity-50"
+              )}
+              onSelect={async () => await handleSelect(action)}
+            >
+              {getIcon(action.action, {
+                className: "size-8 rounded-md border p-1.5",
+              })}
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate text-xs font-medium">
+                  <HighlightedText
+                    result={titleResult}
+                    text={action.default_title ?? action.action}
+                  />
+                </span>
+                <span className="truncate text-xs text-muted-foreground">
+                  <HighlightedText result={actionResult} text={action.action} />
+                </span>
+              </div>
+            </CommandItem>
+          ) : (
+            <CommandItem
+              key={action.action}
+              className={cn(
+                "flex w-full items-center gap-3 py-2 text-xs",
+                (isLocked || isDeprecated) && "cursor-not-allowed opacity-50"
               )}
               onSelect={async () => await handleSelect(action)}
             >
@@ -559,6 +565,18 @@ function ActionCommandGroup({
               </div>
             </CommandItem>
           )
+
+          if (isDeprecated) {
+            return (
+              <Tooltip key={action.action}>
+                <TooltipTrigger asChild>{item}</TooltipTrigger>
+                <TooltipContent side="right" className="max-w-48 text-xs">
+                  {action.deprecated}
+                </TooltipContent>
+              </Tooltip>
+            )
+          }
+          return item
         })}
       </CommandGroup>
     </>

--- a/tests/unit/api/test_api_registry_actions.py
+++ b/tests/unit/api/test_api_registry_actions.py
@@ -49,6 +49,7 @@ async def test_list_registry_actions_include_locked_returns_availability_metadat
                     default_title="Create task",
                     display_group="Cases",
                     options={"required_entitlements": ["case_addons"]},
+                    deprecated="Use core.cases.create_task_v2 instead.",
                     missing_entitlements=("case_addons",),
                 ),
                 "tracecat_registry",
@@ -64,4 +65,5 @@ async def test_list_registry_actions_include_locked_returns_availability_metadat
         "locked": True,
         "missing_entitlements": ["case_addons"],
     }
+    assert payload[0]["deprecated"] == "Use core.cases.create_task_v2 instead."
     mock_service.list_actions_from_index.assert_awaited_once_with(include_locked=True)

--- a/tests/unit/test_executor_manifest_resolution.py
+++ b/tests/unit/test_executor_manifest_resolution.py
@@ -8,6 +8,7 @@ import pytest
 from tracecat.db.models import RegistryAction, RegistryRepository, RegistryVersion
 from tracecat.dsl.common import create_default_execution_context
 from tracecat.dsl.schemas import ActionStatement, RunActionInput, RunContext
+from tracecat.exceptions import DeprecatedActionError
 from tracecat.executor.schemas import ActionImplementation
 from tracecat.executor.secret_preprocessors import SecretEnvProjection
 from tracecat.executor.service import _prepare_step_context, prepare_resolved_context
@@ -314,3 +315,106 @@ async def test_prepare_resolved_context_includes_projected_secret_masks(
     assert "ASIA_TEMP_KEY" in prepared.resolved_context.secret_projection.mask_values
     assert "temp_secret" in prepared.resolved_context.secret_projection.mask_values
     assert "temp_token" in prepared.resolved_context.secret_projection.mask_values
+
+
+@pytest.mark.anyio
+async def test_prepare_resolved_context_raises_on_deprecated_action(test_role, mocker):
+    """DeprecatedActionError is raised before secrets/vars are fetched."""
+    action_name = "core.echo"
+    wf_id = WorkflowUUID.new_uuid4()
+    run_ctx = RunContext(
+        wf_id=wf_id,
+        wf_exec_id=generate_exec_id(wf_id),
+        wf_run_id=uuid.uuid4(),
+        environment="default",
+        logical_time=datetime.now(UTC),
+    )
+    input = RunActionInput(
+        task=ActionStatement(ref="a", action=action_name, args={}),
+        exec_context=create_default_execution_context(),
+        run_context=run_ctx,
+        registry_lock=RegistryLock(
+            origins={"core-registry": "v1"},
+            actions={action_name: "core-registry"},
+        ),
+    )
+
+    mocker.patch(
+        "tracecat.executor.service.registry_resolver.resolve_action",
+        return_value=ActionImplementation(
+            type="udf",
+            module="manifest.module",
+            name="manifest_fn",
+            deprecated="Use core.transform instead.",
+        ),
+    )
+    # These must NOT be called if we raise before reaching them.
+    mock_secrets = mocker.patch(
+        "tracecat.executor.service.registry_resolver.collect_action_secrets_from_manifest",
+    )
+    mock_get_secrets = mocker.patch(
+        "tracecat.executor.service.secrets_manager.get_action_secrets",
+    )
+
+    with pytest.raises(DeprecatedActionError) as exc_info:
+        await prepare_resolved_context(input=input, role=test_role)
+
+    assert action_name in str(exc_info.value)
+    assert "Use core.transform instead." in str(exc_info.value)
+    mock_secrets.assert_not_called()
+    mock_get_secrets.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_prepare_step_context_raises_on_deprecated_action(test_role, mocker):
+    """DeprecatedActionError is raised from _prepare_step_context for deprecated template steps."""
+    step_action = "core.echo"
+    wf_id = WorkflowUUID.new_uuid4()
+    run_ctx = RunContext(
+        wf_id=wf_id,
+        wf_exec_id=generate_exec_id(wf_id),
+        wf_run_id=uuid.uuid4(),
+        environment="default",
+        logical_time=datetime.now(UTC),
+    )
+    input = RunActionInput(
+        task=ActionStatement(ref="parent", action=step_action, args={}),
+        exec_context=create_default_execution_context(),
+        run_context=run_ctx,
+        registry_lock=RegistryLock(
+            origins={"core-registry": "v1"},
+            actions={step_action: "core-registry"},
+        ),
+    )
+
+    mocker.patch(
+        "tracecat.executor.service.registry_resolver.resolve_action",
+        return_value=ActionImplementation(
+            type="udf",
+            module="manifest.module",
+            name="manifest_fn",
+            deprecated="Use core.transform instead.",
+        ),
+    )
+
+    parent_resolved = SimpleNamespace(
+        secrets={},
+        variables={},
+        workspace_id=str(test_role.workspace_id),
+        workflow_id=str(wf_id),
+        run_id=str(uuid.uuid4()),
+        logical_time=datetime.now(UTC),
+        secret_projection=SecretEnvProjection(env={}, mask_values=set()),
+    )
+
+    with pytest.raises(DeprecatedActionError) as exc_info:
+        await _prepare_step_context(
+            step_action=step_action,
+            evaluated_args={},
+            parent_resolved=parent_resolved,  # type: ignore[arg-type]
+            input=input,
+            role=test_role,
+        )
+
+    assert step_action in str(exc_info.value)
+    assert "Use core.transform instead." in str(exc_info.value)

--- a/tests/unit/test_registry_actions_custom_entitlement.py
+++ b/tests/unit/test_registry_actions_custom_entitlement.py
@@ -21,7 +21,13 @@ from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN
 pytestmark = pytest.mark.usefixtures("db")
 
 
-def _make_manifest(action_names: list[str], *, origin: str) -> dict:
+def _make_manifest(
+    action_names: list[str],
+    *,
+    origin: str,
+    deprecated_actions: dict[str, str] | None = None,
+) -> dict:
+    deprecated_actions = deprecated_actions or {}
     actions: dict[str, dict] = {}
     for action_name in action_names:
         namespace, name = action_name.rsplit(".", 1)
@@ -30,6 +36,7 @@ def _make_manifest(action_names: list[str], *, origin: str) -> dict:
             "name": name,
             "action_type": "udf",
             "description": f"Test action {action_name}",
+            "deprecated": deprecated_actions.get(action_name),
             "interface": {"expects": {}, "returns": None},
             "implementation": {
                 "type": "udf",
@@ -47,6 +54,7 @@ async def _seed_platform_registry(
     origin: str,
     version: str,
     action_names: list[str],
+    deprecated_actions: dict[str, str] | None = None,
 ) -> PlatformRegistryRepository:
     repo = await session.scalar(
         select(PlatformRegistryRepository).where(
@@ -61,7 +69,11 @@ async def _seed_platform_registry(
     registry_version = PlatformRegistryVersion(
         repository_id=repo.id,
         version=version,
-        manifest=_make_manifest(action_names, origin=origin),
+        manifest=_make_manifest(
+            action_names,
+            origin=origin,
+            deprecated_actions=deprecated_actions,
+        ),
         tarball_uri=f"s3://platform/{version}.tar.gz",
     )
     session.add(registry_version)
@@ -80,6 +92,7 @@ async def _seed_platform_registry(
                 action_type="udf",
                 description=f"Platform action {action_name}",
                 options={"include_in_schema": True},
+                deprecated=(deprecated_actions or {}).get(action_name),
             )
         )
     await session.commit()
@@ -93,6 +106,7 @@ async def _seed_org_registry(
     origin: str,
     version: str,
     action_names: list[str],
+    deprecated_actions: dict[str, str] | None = None,
 ) -> RegistryRepository:
     repo = RegistryRepository(
         organization_id=role.organization_id,
@@ -105,7 +119,11 @@ async def _seed_org_registry(
         organization_id=role.organization_id,
         repository_id=repo.id,
         version=version,
-        manifest=_make_manifest(action_names, origin=origin),
+        manifest=_make_manifest(
+            action_names,
+            origin=origin,
+            deprecated_actions=deprecated_actions,
+        ),
         tarball_uri=f"s3://org/{version}.tar.gz",
     )
     session.add(registry_version)
@@ -125,6 +143,7 @@ async def _seed_org_registry(
                 action_type="udf",
                 description=f"Org action {action_name}",
                 options={"include_in_schema": True},
+                deprecated=(deprecated_actions or {}).get(action_name),
             )
         )
     await session.commit()
@@ -166,6 +185,29 @@ async def test_index_list_hides_custom_actions_without_entitlement(
     assert actions_to_origin[shared_action] == DEFAULT_REGISTRY_ORIGIN
     assert custom_only_action not in actions_to_origin
     mock_has_entitlement.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_list_actions_from_index_preserves_deprecated_metadata(
+    svc_role: Role,
+    session: AsyncSession,
+) -> None:
+    action_name = "acme.deprecated.old_action"
+    deprecation_message = "Use acme.deprecated.new_action instead."
+
+    await _seed_platform_registry(
+        session,
+        origin=DEFAULT_REGISTRY_ORIGIN,
+        version="platform-1.0",
+        action_names=[action_name],
+        deprecated_actions={action_name: deprecation_message},
+    )
+
+    service = RegistryActionsService(session, role=svc_role)
+    entries = await service.list_actions_from_index(namespace="acme.deprecated")
+
+    actions = {f"{entry.namespace}.{entry.name}": entry for entry, _ in entries}
+    assert actions[action_name].deprecated == deprecation_message
 
 
 @pytest.mark.anyio

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -802,7 +802,7 @@ class AgentSessionService(BaseWorkspaceService):
         agent_session: AgentSession,
         user_prompt: str,
     ) -> None:
-        """Best-effort auto-title on first prompt via direct PydanticAI call."""
+        """Best-effort auto-title on first prompt via the lightweight LLM client."""
         prompt = user_prompt.strip()
         entity_type = agent_session.entity_type
         old_title = agent_session.title

--- a/tracecat/exceptions.py
+++ b/tracecat/exceptions.py
@@ -127,6 +127,18 @@ class RegistryError(TracecatException):
     """Generic exception raised when a registry error occurs."""
 
 
+class DeprecatedActionError(RegistryError):
+    """Raised when a deprecated registry action is executed.
+
+    Carries the deprecation message so callers can surface migration guidance.
+    """
+
+    def __init__(self, action: str, message: str):
+        super().__init__(f"Action '{action}' is deprecated: {message}")
+        self.action = action
+        self.deprecation_message = message
+
+
 class BuiltinRegistryHasNoSelectionError(RegistryError):
     """Raised when the builtin platform registry has no selected version yet."""
 

--- a/tracecat/executor/registry_resolver.py
+++ b/tracecat/executor/registry_resolver.py
@@ -22,7 +22,11 @@ from tracecat.db.models import (
     RegistryRepository,
     RegistryVersion,
 )
-from tracecat.exceptions import EntitlementRequired, RegistryError
+from tracecat.exceptions import (
+    DeprecatedActionError,
+    EntitlementRequired,
+    RegistryError,
+)
 from tracecat.executor.schemas import ActionImplementation
 from tracecat.identifiers import OrganizationID
 from tracecat.logger import logger
@@ -56,6 +60,7 @@ def _build_impl_index(
                 module=impl.module,
                 name=impl.name,
                 origin=origin,
+                deprecated=manifest_action.deprecated,
             )
         elif impl.type == "template":
             index[action_name] = ActionImplementation(
@@ -65,6 +70,7 @@ def _build_impl_index(
                     mode="json"
                 ),
                 origin=origin,
+                deprecated=manifest_action.deprecated,
             )
         else:
             raise ValueError(f"Unknown implementation type: {impl}")
@@ -392,6 +398,10 @@ async def _collect_secrets_recursive(
             step_manifest_action = step_manifest.actions.get(step_action_name)
             if step_manifest_action is None:
                 continue
+            if step_manifest_action.deprecated:
+                raise DeprecatedActionError(
+                    step_action_name, step_manifest_action.deprecated
+                )
 
             await _collect_secrets_recursive(
                 step_manifest_action, lock, secrets, organization_id

--- a/tracecat/executor/schemas.py
+++ b/tracecat/executor/schemas.py
@@ -130,6 +130,9 @@ class ActionImplementation(BaseModel):
     origin: str | None = None
     """Origin URL for the action's registry (e.g., 'tracecat_registry' or 'git+ssh://...')."""
 
+    deprecated: str | None = None
+    """Deprecation message if this action is deprecated, else None."""
+
 
 class ResolvedContext(BaseModel):
     """Pre-resolved context for untrusted execution mode.

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -38,6 +38,7 @@ from tracecat.dsl.schemas import (
     TemplateExecutionContext,
 )
 from tracecat.exceptions import (
+    DeprecatedActionError,
     ExecutionError,
     LoopExecutionError,
     RegistryValidationError,
@@ -398,6 +399,8 @@ async def _prepare_step_context(
     action_impl = await registry_resolver.resolve_action(
         step_action, input.registry_lock, role.organization_id
     )
+    if action_impl.deprecated:
+        raise DeprecatedActionError(step_action, action_impl.deprecated)
 
     # Mint new executor token for step (required for SDK authentication)
     if role.workspace_id is None:
@@ -660,6 +663,8 @@ async def prepare_resolved_context(
     action_impl = await registry_resolver.resolve_action(
         action_name, input.registry_lock, role.organization_id
     )
+    if action_impl.deprecated:
+        raise DeprecatedActionError(action_name, action_impl.deprecated)
     action_secrets = await registry_resolver.collect_action_secrets_from_manifest(
         action_name, input.registry_lock, role.organization_id
     )

--- a/tracecat/registry/actions/schemas.py
+++ b/tracecat/registry/actions/schemas.py
@@ -219,6 +219,9 @@ class RegistryActionReadMinimal(BaseModel):
         default_factory=RegistryActionAvailability,
         description="Availability metadata for this action",
     )
+    deprecated: str | None = Field(
+        None, description="Deprecation message if this action is deprecated"
+    )
 
     @computed_field(return_type=str)
     @property
@@ -244,6 +247,7 @@ class RegistryActionReadMinimal(BaseModel):
                 locked=bool(index.missing_entitlements),
                 missing_entitlements=list(index.missing_entitlements),
             ),
+            deprecated=index.deprecated,
         )
 
 

--- a/tracecat/registry/actions/service.py
+++ b/tracecat/registry/actions/service.py
@@ -98,6 +98,7 @@ class _IndexSelectRow(NamedTuple):
     default_title: str | None
     display_group: str | None
     options: dict
+    deprecated: str | None
     origin: str
     source: str
 
@@ -276,6 +277,7 @@ class RegistryActionsService(BaseOrgService):
                 RegistryIndex.default_title,
                 RegistryIndex.display_group,
                 RegistryIndex.options,
+                RegistryIndex.deprecated,
                 RegistryRepository.origin,
                 literal("org", type_=String).label("source"),
             )
@@ -304,6 +306,7 @@ class RegistryActionsService(BaseOrgService):
                 PlatformRegistryIndex.default_title,
                 PlatformRegistryIndex.display_group,
                 PlatformRegistryIndex.options,
+                PlatformRegistryIndex.deprecated,
                 PlatformRegistryRepository.origin,
                 literal("platform", type_=String).label("source"),
             )
@@ -387,6 +390,7 @@ class RegistryActionsService(BaseOrgService):
                 default_title=row.default_title,
                 display_group=row.display_group,
                 options=row.options or {},
+                deprecated=row.deprecated,
             )
             entries.append((entry, row.origin))
         return await self._filter_index_entries_by_entitlements(


### PR DESCRIPTION
## Summary by cubic
Block execution of deprecated registry actions and surface a clear deprecation message to guide migrations. This prevents deprecated actions from running in workflows.

- **New Features**
  - Added `DeprecatedActionError` with action name and deprecation message.
  - Plumbed `deprecated` flag from registry manifests into `ActionImplementation`.
  - Enforced at runtime in `_invoke_step`: raise when an action is deprecated.
  - Extended `ActionImplementation` schema with an optional `deprecated` field.

<sup>Written for commit e83b7ac5be8c9cad2e5d5d826a7d786b70efb154. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2704?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

