### PR TITLE
fix(agent): match Claude session path sanitization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ WORKDIR /app
 # ====================
 FROM base AS development
 
-ENV TMPDIR=/tmp TEMP=/tmp TMP=/tmp
+ENV TMPDIR="/home/apiuser/.cache/tmp" TEMP="/home/apiuser/.cache/tmp" TMP="/home/apiuser/.cache/tmp"
 
 # Set sandbox cache permissions for apiuser
 RUN chown -R 1001:1001 /var/lib/tracecat/sandbox-cache && \

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -45,6 +45,7 @@ from tracecat.agent.runtime.claude_code.runtime import (
     CLAUDE_SDK_MAX_BUFFER_SIZE_BYTES,
     TRUSTED_MCP_BRIDGE_URL,
     ClaudeAgentRuntime,
+    _claude_project_dir_name,
 )
 from tracecat.agent.subagents import AgentSubagentsConfig
 from tracecat.agent.types import AgentConfig
@@ -1856,7 +1857,7 @@ class TestClaudeAgentRuntimeRun:
             session_home_dir
             / ".claude"
             / "projects"
-            / str(runtime_cwd).replace("/", "-")
+            / _claude_project_dir_name(runtime_cwd)
             / "eed8297f-26fb-4e00-905f-a10f0cf20704.jsonl"
         )
         assert session_file.exists()
@@ -2432,6 +2433,79 @@ class TestClaudeAgentRuntimeSessionLineFlushing:
     @staticmethod
     def _line_bytes(line: dict[str, Any]) -> bytes:
         return orjson.dumps(line) + b"\n"
+
+    @pytest.mark.parametrize(
+        "cwd",
+        [
+            Path("/tmp/tracecat-agent-session/claude-project"),
+            Path("/home/apiuser/.cache/tmp/tracecat-agent-session/claude-project"),
+            Path("/work/claude-project"),
+            Path("/tmp/tracecat agent_session/claude.project"),
+            Path("/tmp/tracecat_agent.session+prod@2026/claude project"),
+            Path("/tmp/Tracecat Agent (prod)/claude.project#session"),
+            Path("/tmp/\u7528\u6237/tracecat/claude-project"),
+            Path("/tmp/tracecat/emoji-\U0001f680/claude-project"),
+            Path("/tmp/tracecat/combining-e\u0301/claude-project"),
+            Path("C:/Users/apiuser/AppData/Local/Temp/tracecat-agent/claude-project"),
+            Path(r"C:\Users\apiuser\AppData\Local\Temp\tracecat-agent\claude-project"),
+            Path("/var/folders/zz/abc.def_ghi-jkl/T/tracecat-agent/claude-project"),
+            Path("/" + "very-long.segment_" * 30 + "/claude-project"),
+            Path("/" + "prod path.with_symbols_@2026!" * 18 + "/claude.project"),
+        ],
+    )
+    def test_claude_project_dir_name_matches_sdk_sanitizer(self, cwd: Path) -> None:
+        """Tracecat must derive the same project directory name as Claude."""
+        from claude_agent_sdk._internal.sessions import _sanitize_path
+
+        assert _claude_project_dir_name(cwd) == _sanitize_path(str(cwd))
+
+    @pytest.mark.anyio
+    async def test_emit_new_session_lines_finds_sdk_sanitized_direct_mode_path(
+        self,
+        mock_socket_writer: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Direct mode should find JSONL files under Claude's sanitized cwd."""
+        from claude_agent_sdk._internal.sessions import _sanitize_path
+
+        session_root = (
+            tmp_path / "home" / "apiuser" / ".cache" / "tmp" / "tracecat-agent-session"
+        )
+        session_home_dir = session_root / "claude-home"
+        cwd = session_root / "claude-project"
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            session_home_dir=session_home_dir,
+            cwd=cwd,
+        )
+        sdk_session_id = "eed8297f-26fb-4e00-905f-a10f0cf20704"
+        runtime._sdk_session_id = sdk_session_id
+        line_bytes = self._line_bytes(
+            {
+                "type": "user",
+                "uuid": "prod-direct-line",
+                "message": {"role": "user", "content": "hello"},
+            }
+        )
+        session_file = (
+            session_home_dir
+            / ".claude"
+            / "projects"
+            / _sanitize_path(str(cwd))
+            / f"{sdk_session_id}.jsonl"
+        )
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_bytes(line_bytes)
+
+        await runtime._emit_new_session_lines()
+
+        mock_socket_writer.send_session_line.assert_awaited_once_with(
+            sdk_session_id,
+            line_bytes.rstrip(b"\n").decode("utf-8"),
+            internal=False,
+        )
+        assert runtime._last_seen_byte_offset == len(line_bytes)
 
     @pytest.mark.anyio
     async def test_emit_new_session_lines_tails_by_byte_offset(

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -26,6 +26,7 @@ from claude_agent_sdk.types import (
 )
 
 import tracecat.agent.runtime.claude_code.runtime as runtime_module
+from tracecat.agent.common.exceptions import AgentSandboxValidationError
 from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.socket_io import SocketStreamWriter
 from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
@@ -2449,15 +2450,49 @@ class TestClaudeAgentRuntimeSessionLineFlushing:
             Path("C:/Users/apiuser/AppData/Local/Temp/tracecat-agent/claude-project"),
             Path(r"C:\Users\apiuser\AppData\Local\Temp\tracecat-agent\claude-project"),
             Path("/var/folders/zz/abc.def_ghi-jkl/T/tracecat-agent/claude-project"),
+        ],
+    )
+    def test_claude_project_dir_name_matches_sdk_sanitizer(self, cwd: Path) -> None:
+        """Tracecat must derive the same short-path project directory as Claude."""
+        from claude_agent_sdk._internal.sessions import _sanitize_path
+
+        assert _claude_project_dir_name(cwd) == _sanitize_path(str(cwd))
+
+    @pytest.mark.parametrize(
+        "cwd",
+        [
             Path("/" + "very-long.segment_" * 30 + "/claude-project"),
             Path("/" + "prod path.with_symbols_@2026!" * 18 + "/claude.project"),
         ],
     )
-    def test_claude_project_dir_name_matches_sdk_sanitizer(self, cwd: Path) -> None:
-        """Tracecat must derive the same project directory name as Claude."""
-        from claude_agent_sdk._internal.sessions import _sanitize_path
+    def test_claude_project_dir_name_rejects_long_sanitized_paths(
+        self,
+        cwd: Path,
+    ) -> None:
+        """Long paths are rejected instead of guessing Claude's hash suffix."""
+        with pytest.raises(
+            AgentSandboxValidationError,
+            match="runtime cwd is too long",
+        ):
+            _claude_project_dir_name(cwd)
 
-        assert _claude_project_dir_name(cwd) == _sanitize_path(str(cwd))
+    def test_ensure_working_directory_rejects_long_cwd(
+        self,
+        mock_socket_writer: MagicMock,
+    ) -> None:
+        """Runtime setup should fail before Claude writes an ambiguous path."""
+        cwd = Path("/" + "very-long.segment_" * 30 + "/claude-project")
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer,
+            transport_factory=lambda _: MagicMock(),
+            cwd=cwd,
+        )
+
+        with pytest.raises(
+            AgentSandboxValidationError,
+            match="runtime cwd is too long",
+        ):
+            runtime._ensure_working_directory(uuid.uuid4())
 
     @pytest.mark.anyio
     async def test_emit_new_session_lines_finds_sdk_sanitized_direct_mode_path(

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import tempfile
 import uuid
 from collections.abc import AsyncIterator, Callable
@@ -80,6 +81,46 @@ from tracecat.agent.runtime.claude_code.session_lines import (
     is_synthetic_session_line,
 )
 from tracecat.logger import logger
+
+CLAUDE_PROJECT_DIR_MAX_LENGTH = 200
+CLAUDE_PROJECT_DIR_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9]")
+
+
+def _base36(value: int) -> str:
+    if value == 0:
+        return "0"
+    digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+    out: list[str] = []
+    while value > 0:
+        value, digit = divmod(value, 36)
+        out.append(digits[digit])
+    return "".join(reversed(out))
+
+
+def _claude_project_dir_hash(value: str) -> str:
+    """Return Claude's 32-bit signed path hash encoded as base36."""
+    hash_value = 0
+    for char in value:
+        hash_value = ((hash_value << 5) - hash_value + ord(char)) & 0xFFFFFFFF
+        if hash_value >= 0x80000000:
+            hash_value -= 0x100000000
+    return _base36(abs(hash_value))
+
+
+def _claude_project_dir_name(cwd: Path) -> str:
+    """Return the project directory name Claude uses for a runtime cwd.
+
+    This mirrors claude-agent-sdk's private ``_sanitize_path`` helper. Keep the
+    parity test updated if Claude changes how it stores ``~/.claude/projects``.
+    """
+    cwd_str = str(cwd)
+    sanitized = CLAUDE_PROJECT_DIR_SANITIZE_RE.sub("-", cwd_str)
+    if len(sanitized) <= CLAUDE_PROJECT_DIR_MAX_LENGTH:
+        return sanitized
+    return (
+        f"{sanitized[:CLAUDE_PROJECT_DIR_MAX_LENGTH]}-"
+        f"{_claude_project_dir_hash(cwd_str)}"
+    )
 
 
 class RuntimeEventWriter(Protocol):
@@ -466,7 +507,7 @@ class ClaudeAgentRuntime:
 
         if self._cwd is None:
             raise RuntimeError("Runtime working directory is not configured")
-        encoded_cwd = str(self._cwd).replace("/", "-")
+        encoded_cwd = _claude_project_dir_name(self._cwd)
         claude_home_dir = self._session_home_dir or Path.home()
         claude_dir = claude_home_dir / ".claude" / "projects" / encoded_cwd
         return claude_dir / f"{sdk_session_id}.jsonl"

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -86,41 +86,26 @@ CLAUDE_PROJECT_DIR_MAX_LENGTH = 200
 CLAUDE_PROJECT_DIR_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9]")
 
 
-def _base36(value: int) -> str:
-    if value == 0:
-        return "0"
-    digits = "0123456789abcdefghijklmnopqrstuvwxyz"
-    out: list[str] = []
-    while value > 0:
-        value, digit = divmod(value, 36)
-        out.append(digits[digit])
-    return "".join(reversed(out))
-
-
-def _claude_project_dir_hash(value: str) -> str:
-    """Return Claude's 32-bit signed path hash encoded as base36."""
-    hash_value = 0
-    for char in value:
-        hash_value = ((hash_value << 5) - hash_value + ord(char)) & 0xFFFFFFFF
-        if hash_value >= 0x80000000:
-            hash_value -= 0x100000000
-    return _base36(abs(hash_value))
-
-
 def _claude_project_dir_name(cwd: Path) -> str:
     """Return the project directory name Claude uses for a runtime cwd.
 
-    This mirrors claude-agent-sdk's private ``_sanitize_path`` helper. Keep the
-    parity test updated if Claude changes how it stores ``~/.claude/projects``.
+    This mirrors claude-agent-sdk's private ``_sanitize_path`` helper for short
+    paths. Long paths are rejected because Claude CLI and SDK hash suffixes can
+    diverge, which would make session persistence non-deterministic.
     """
-    cwd_str = str(cwd)
-    sanitized = CLAUDE_PROJECT_DIR_SANITIZE_RE.sub("-", cwd_str)
-    if len(sanitized) <= CLAUDE_PROJECT_DIR_MAX_LENGTH:
-        return sanitized
-    return (
-        f"{sanitized[:CLAUDE_PROJECT_DIR_MAX_LENGTH]}-"
-        f"{_claude_project_dir_hash(cwd_str)}"
-    )
+    sanitized = CLAUDE_PROJECT_DIR_SANITIZE_RE.sub("-", str(cwd))
+    if len(sanitized) > CLAUDE_PROJECT_DIR_MAX_LENGTH:
+        raise AgentSandboxValidationError(
+            "Claude runtime cwd is too long for deterministic session persistence: "
+            f"sanitized path length {len(sanitized)} exceeds "
+            f"{CLAUDE_PROJECT_DIR_MAX_LENGTH}. Shorten TMPDIR or the runtime cwd."
+        )
+    return sanitized
+
+
+def _validate_claude_project_dir_name(cwd: Path) -> None:
+    """Validate that Claude can persist sessions under the runtime cwd."""
+    _claude_project_dir_name(cwd)
 
 
 class RuntimeEventWriter(Protocol):
@@ -1092,6 +1077,7 @@ class ClaudeAgentRuntime:
         """Create the stable Claude cwd used for session resume."""
         if self._cwd is None:
             self._cwd = Path(tempfile.gettempdir()) / f"tracecat-agent-{session_id}"
+        _validate_claude_project_dir_name(self._cwd)
         cwd_setup_path = self._cwd_setup_path or self._cwd
         cwd_setup_path.mkdir(parents=True, exist_ok=True)
 

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -103,8 +103,8 @@ def _claude_project_dir_name(cwd: Path) -> str:
     return sanitized
 
 
-def _validate_claude_project_dir_name(cwd: Path) -> None:
-    """Validate that Claude can persist sessions under the runtime cwd."""
+def _ensure_supported_claude_project_dir_name(cwd: Path) -> None:
+    """Ensure Claude can persist sessions under the runtime cwd."""
     _claude_project_dir_name(cwd)
 
 
@@ -1077,7 +1077,7 @@ class ClaudeAgentRuntime:
         """Create the stable Claude cwd used for session resume."""
         if self._cwd is None:
             self._cwd = Path(tempfile.gettempdir()) / f"tracecat-agent-{session_id}"
-        _validate_claude_project_dir_name(self._cwd)
+        _ensure_supported_claude_project_dir_name(self._cwd)
         cwd_setup_path = self._cwd_setup_path or self._cwd
         cwd_setup_path.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- Derive Claude session JSONL paths with a local Tracecat helper that mirrors Claude's project-directory sanitizer, including non-alphanumeric replacement and long-path hash suffixes.
- Add parity coverage against the pinned Claude SDK sanitizer plus an emit regression for direct-mode `.cache/tmp` session roots.
- Align the development Docker target TMPDIR/TEMP/TMP values with production so direct-mode dev runs exercise the same temp path shape.

## Testing
- `uv run pytest tests/unit/test_agent_runtime.py::TestClaudeAgentRuntimeSessionLineFlushing`
- `uv run ruff check tracecat/agent/runtime/claude_code/runtime.py tests/unit/test_agent_runtime.py`
- `uv run ruff format --check tracecat/agent/runtime/claude_code/runtime.py tests/unit/test_agent_runtime.py`
- `uv run basedpyright tracecat/agent/runtime/claude_code/runtime.py tests/unit/test_agent_runtime.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Match Claude’s session path sanitization and validate cwd length so the agent reads/writes JSONL files under the same `~/.claude/projects` directory. Fixes missed session line emission in direct mode and prevents non-deterministic paths.

- **Bug Fixes**
  - Added `_claude_project_dir_name` mirroring `claude_agent_sdk` sanitizer for short paths (non-alphanumeric to `-`) and rejecting sanitized paths over 200 chars with `AgentSandboxValidationError`.
  - Switched `_get_session_file_path` to use the sanitizer and validated cwd in `_ensure_working_directory`; added parity tests (POSIX/Windows, Unicode), long-path rejection, and a direct-mode test that tails JSONL under the sanitized cwd.
  - Set `TMPDIR`, `TEMP`, and `TMP` in the dev Docker target to `/home/apiuser/.cache/tmp` to match production.

<sup>Written for commit 5a23d2817c47ad3b2f1c7f757de26da8c7c759a0. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2705?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

