### PR TITLE
feat(tables): support dropping unique column index

### DIFF
--- a/docs/snippets/mcp-tools.mdx
+++ b/docs/snippets/mcp-tools.mdx
@@ -275,6 +275,12 @@
     <ResponseField name="tables_export_csv" type="tool">
   Export table data as a staged download URL.
     </ResponseField>
+    <ResponseField name="tables_create_column_index" type="tool">
+  Create a unique index on a table column. Only one unique index per table is allowed.
+    </ResponseField>
+    <ResponseField name="tables_drop_column_index" type="tool">
+  Drop the unique index on a table column.
+    </ResponseField>
   </Expandable>
 </ResponseField>
 

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -7780,7 +7780,8 @@ export const $CaseFieldUpdate = {
         },
       ],
       title: "Is Index",
-      description: "Whether the column is an index",
+      description:
+        "True creates a unique index, False drops it, None leaves unchanged.",
     },
     options: {
       anyOf: [
@@ -22211,7 +22212,8 @@ export const $TableColumnUpdate = {
         },
       ],
       title: "Is Index",
-      description: "Whether the column is an index",
+      description:
+        "True creates a unique index, False drops it, None leaves unchanged.",
     },
     options: {
       anyOf: [

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2071,7 +2071,7 @@ export type CaseFieldUpdate = {
    */
   default?: unknown | null
   /**
-   * Whether the column is an index
+   * True creates a unique index, False drops it, None leaves unchanged.
    */
   is_index?: boolean | null
   options?: Array<string> | null
@@ -6713,7 +6713,7 @@ export type TableColumnUpdate = {
    */
   default?: unknown | null
   /**
-   * Whether the column is an index
+   * True creates a unique index, False drops it, None leaves unchanged.
    */
   is_index?: boolean | null
   options?: Array<string> | null

--- a/frontend/src/components/tables/table-view-column-menu.tsx
+++ b/frontend/src/components/tables/table-view-column-menu.tsx
@@ -5,6 +5,7 @@ import {
   CopyIcon,
   DatabaseZapIcon,
   Trash2Icon,
+  UnlinkIcon,
 } from "lucide-react"
 import { useParams } from "next/navigation"
 import { useState } from "react"
@@ -35,7 +36,12 @@ import { useDeleteColumn, useUpdateColumn } from "@/lib/hooks"
 import { SqlTypeCreatableEnum } from "@/lib/tables"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
-type TableViewColumnMenuType = "delete" | "edit" | "set-natural-key" | null
+type TableViewColumnMenuType =
+  | "delete"
+  | "edit"
+  | "set-natural-key"
+  | "drop-natural-key"
+  | null
 
 export function TableViewColumnMenu({ column }: { column: TableColumnRead }) {
   const canUpdateTable = useScopeCheck("table:update")
@@ -75,19 +81,30 @@ export function TableViewColumnMenu({ column }: { column: TableColumnRead }) {
             <CopyIcon className="mr-2 size-3 group-hover/item:text-accent-foreground" />
             Copy name
           </DropdownMenuItem>
-          {canUpdateTable && (
-            <DropdownMenuItem
-              className="py-1 text-xs text-foreground/80"
-              onClick={(e) => {
-                e.stopPropagation()
-                setActiveType("set-natural-key")
-              }}
-              disabled={column.is_index}
-            >
-              <DatabaseZapIcon className="mr-2 size-3 group-hover/item:text-accent-foreground" />
-              {column.is_index ? "Unique index" : "Create unique index"}
-            </DropdownMenuItem>
-          )}
+          {canUpdateTable &&
+            (column.is_index ? (
+              <DropdownMenuItem
+                className="py-1 text-xs text-foreground/80"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setActiveType("drop-natural-key")
+                }}
+              >
+                <UnlinkIcon className="mr-2 size-3 group-hover/item:text-accent-foreground" />
+                Remove unique index
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem
+                className="py-1 text-xs text-foreground/80"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setActiveType("set-natural-key")
+                }}
+              >
+                <DatabaseZapIcon className="mr-2 size-3 group-hover/item:text-accent-foreground" />
+                Create unique index
+              </DropdownMenuItem>
+            ))}
           {canDeleteColumn && (
             <DropdownMenuItem
               className="py-1 text-xs text-destructive"
@@ -112,6 +129,12 @@ export function TableViewColumnMenu({ column }: { column: TableColumnRead }) {
         tableId={tableId}
         column={column}
         open={activeType === "set-natural-key"}
+        onOpenChange={onOpenChange}
+      />
+      <TableColumnDropIndexDialog
+        tableId={tableId}
+        column={column}
+        open={activeType === "drop-natural-key"}
         onOpenChange={onOpenChange}
       />
     </>
@@ -284,7 +307,7 @@ function TableColumnIndexDialog({
             <strong>Requirements:</strong>
             <ul className="mt-2 list-disc pl-5 text-xs">
               <li>All values in the column must be unique</li>
-              <li>This cannot be undone except by recreating the column</li>
+              <li>Only one unique index is allowed per table</li>
             </ul>
           </AlertDialogDescription>
         </AlertDialogHeader>
@@ -305,6 +328,92 @@ function TableColumnIndexDialog({
               <>
                 <DatabaseZapIcon className="mr-2 size-4" />
                 Create unique index
+              </>
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+function TableColumnDropIndexDialog({
+  tableId,
+  column,
+  open,
+  onOpenChange,
+}: {
+  tableId?: string
+  column: TableColumnRead
+  open: boolean
+  onOpenChange: () => void
+}) {
+  const workspaceId = useWorkspaceId()
+  const { updateColumn, updateColumnIsPending } = useUpdateColumn()
+
+  if (!tableId || !workspaceId) {
+    return null
+  }
+
+  const handleDropIndex = async () => {
+    try {
+      await updateColumn({
+        tableId,
+        columnId: column.id,
+        workspaceId,
+        requestBody: { is_index: false },
+      })
+
+      toast({
+        title: "Removed unique index",
+        description: "Column is no longer a unique index.",
+      })
+
+      onOpenChange()
+    } catch (error) {
+      console.error("Error removing unique index:", error)
+    }
+  }
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={() => {
+        if (!updateColumnIsPending) {
+          onOpenChange()
+        }
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove unique index</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to remove the unique index from column{" "}
+            <b>{column.name}</b>?
+            <br />
+            <br />
+            Upsert operations that rely on this column as the conflict key will
+            stop working until a new unique index is created on another column.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={updateColumnIsPending}>
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDropIndex}
+            disabled={updateColumnIsPending}
+            variant="destructive"
+          >
+            {updateColumnIsPending ? (
+              <>
+                <Spinner />
+                Removing...
+              </>
+            ) : (
+              <>
+                <UnlinkIcon className="mr-2 size-4" />
+                Remove unique index
               </>
             )}
           </AlertDialogAction>

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -3138,25 +3138,29 @@ export function useUpdateColumn() {
       )
     },
     onError: (error: TracecatApiError, variables) => {
-      const isIndexOperation =
-        typeof variables.requestBody?.is_index === "boolean"
+      const requestedIsIndex = variables.requestBody?.is_index
+      const isIndexOperation = typeof requestedIsIndex === "boolean"
+      const indexErrorTitle =
+        requestedIsIndex === false
+          ? "Error dropping unique index"
+          : "Error creating unique index"
 
       if (isIndexOperation) {
         // Handle unique index specific errors
         if (error.status === 409) {
           toast({
-            title: "Error creating unique index",
+            title: indexErrorTitle,
             description:
               "Column contains duplicate values. All values must be unique.",
           })
         } else if (error.status === 400) {
           toast({
-            title: "Error creating unique index",
+            title: indexErrorTitle,
             description: String(error.body.detail),
           })
         } else {
           toast({
-            title: "Error creating unique index",
+            title: indexErrorTitle,
             description: error.message || "An unexpected error occurred",
           })
         }

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -3139,7 +3139,7 @@ export function useUpdateColumn() {
     },
     onError: (error: TracecatApiError, variables) => {
       const requestedIsIndex = variables.requestBody?.is_index
-      const isIndexOperation = requestedIsIndex !== undefined
+      const isIndexOperation = typeof requestedIsIndex === "boolean"
       const indexErrorTitle =
         requestedIsIndex === false
           ? "Error removing unique index"

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -3138,29 +3138,25 @@ export function useUpdateColumn() {
       )
     },
     onError: (error: TracecatApiError, variables) => {
-      const requestedIsIndex = variables.requestBody?.is_index
-      const isIndexOperation = typeof requestedIsIndex === "boolean"
-      const indexErrorTitle =
-        requestedIsIndex === false
-          ? "Error removing unique index"
-          : "Error creating unique index"
+      const isIndexOperation =
+        typeof variables.requestBody?.is_index === "boolean"
 
       if (isIndexOperation) {
         // Handle unique index specific errors
         if (error.status === 409) {
           toast({
-            title: indexErrorTitle,
+            title: "Error creating unique index",
             description:
               "Column contains duplicate values. All values must be unique.",
           })
         } else if (error.status === 400) {
           toast({
-            title: indexErrorTitle,
+            title: "Error creating unique index",
             description: String(error.body.detail),
           })
         } else {
           toast({
-            title: indexErrorTitle,
+            title: "Error creating unique index",
             description: error.message || "An unexpected error occurred",
           })
         }

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -3138,25 +3138,29 @@ export function useUpdateColumn() {
       )
     },
     onError: (error: TracecatApiError, variables) => {
-      // Check if this was a unique index operation
-      const isIndexOperation = !!variables.requestBody?.is_index
+      const requestedIsIndex = variables.requestBody?.is_index
+      const isIndexOperation = requestedIsIndex !== undefined
+      const indexErrorTitle =
+        requestedIsIndex === false
+          ? "Error removing unique index"
+          : "Error creating unique index"
 
       if (isIndexOperation) {
         // Handle unique index specific errors
         if (error.status === 409) {
           toast({
-            title: "Error creating unique index",
+            title: indexErrorTitle,
             description:
               "Column contains duplicate values. All values must be unique.",
           })
         } else if (error.status === 400) {
           toast({
-            title: "Error creating unique index",
+            title: indexErrorTitle,
             description: String(error.body.detail),
           })
         } else {
           toast({
-            title: "Error creating unique index",
+            title: indexErrorTitle,
             description: error.message || "An unexpected error occurred",
           })
         }

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -1081,6 +1081,44 @@ class TestTableColumns:
 
         assert "Table cannot have multiple unique indexes" in str(exc_info.value)
 
+    async def test_drop_unique_index_removes_index(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """Test that dropping a unique index removes it from the table."""
+        await tables_service.create_unique_index(table, "name")
+        assert "name" in await tables_service.get_index(table)
+
+        await tables_service.drop_unique_index(table, "name")
+        assert await tables_service.get_index(table) == []
+
+    async def test_drop_unique_index_fails_when_no_index(
+        self, tables_service: TablesService, table: Table
+    ) -> None:
+        """Test that dropping a unique index fails when none exists on the column."""
+        with pytest.raises(ValueError) as exc_info:
+            await tables_service.drop_unique_index(table, "name")
+
+        assert "No unique index exists on column 'name'" in str(exc_info.value)
+
+    async def test_update_column_can_drop_unique_index(
+        self, tables_service: TablesService, table: Table, session: AsyncSession
+    ) -> None:
+        """Calling update_column with is_index=False drops the existing unique index."""
+        await tables_service.create_unique_index(table, "name")
+
+        name_column_id = await session.scalar(
+            select(TableColumn.id).where(
+                TableColumn.table_id == table.id,
+                TableColumn.name == "name",
+            )
+        )
+        assert name_column_id is not None
+        column = await tables_service.get_column(table.id, name_column_id)
+
+        await tables_service.update_column(column, TableColumnUpdate(is_index=False))
+
+        assert await tables_service.get_index(table) == []
+
 
 @pytest.mark.anyio
 class TestTableRows:

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -211,6 +211,7 @@ from tracecat.storage import blob
 from tracecat.tables.enums import SqlType
 from tracecat.tables.schemas import (
     TableColumnCreate,
+    TableColumnUpdate,
     TableCreate,
     TableRowInsert,
     TableUpdate,
@@ -7701,7 +7702,7 @@ async def create_column_index(
         _, role = await _resolve_workspace_role(workspace_id)
         async with TablesService.with_session(role=role) as svc:
             column = await svc.get_column(table_id, column_id)
-            await svc.create_unique_index(column.table, column.name)
+            await svc.update_column(column, TableColumnUpdate(is_index=True))
             return {"status": "ok", "column": column.name}
     except ToolError:
         raise
@@ -7726,7 +7727,7 @@ async def drop_column_index(
         _, role = await _resolve_workspace_role(workspace_id)
         async with TablesService.with_session(role=role) as svc:
             column = await svc.get_column(table_id, column_id)
-            await svc.drop_unique_index(column.table, column.name)
+            await svc.update_column(column, TableColumnUpdate(is_index=False))
             return {"status": "ok", "column": column.name}
     except ToolError:
         raise

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -3877,6 +3877,8 @@ _TOOL_NAMESPACE_BY_NAME: dict[str, str] = {
     "update_table_row": "tables",
     "search_table_rows": "tables",
     "export_csv": "tables",
+    "create_column_index": "tables",
+    "drop_column_index": "tables",
     "list_variables": "variables",
     "get_variable": "variables",
     "list_secrets_metadata": "secrets",
@@ -7683,6 +7685,56 @@ async def export_csv(
     except Exception as e:
         logger.error("Failed to export CSV", error=str(e))
         raise ToolError(f"Failed to export CSV: {e}") from None
+
+
+@mcp.tool()
+async def create_column_index(
+    workspace_id: uuid.UUID,
+    table_id: uuid.UUID,
+    column_id: uuid.UUID,
+) -> dict[str, str]:
+    """Create a unique index on a table column. Only one unique index per table is allowed."""
+
+    try:
+        table_id = _coerce_uuid_arg(table_id, "table_id")
+        column_id = _coerce_uuid_arg(column_id, "column_id")
+        _, role = await _resolve_workspace_role(workspace_id)
+        async with TablesService.with_session(role=role) as svc:
+            column = await svc.get_column(table_id, column_id)
+            await svc.create_unique_index(column.table, column.name)
+            return {"status": "ok", "column": column.name}
+    except ToolError:
+        raise
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to create column index", error=str(e))
+        raise ToolError(f"Failed to create column index: {e}") from None
+
+
+@mcp.tool()
+async def drop_column_index(
+    workspace_id: uuid.UUID,
+    table_id: uuid.UUID,
+    column_id: uuid.UUID,
+) -> dict[str, str]:
+    """Drop the unique index on a table column."""
+
+    try:
+        table_id = _coerce_uuid_arg(table_id, "table_id")
+        column_id = _coerce_uuid_arg(column_id, "column_id")
+        _, role = await _resolve_workspace_role(workspace_id)
+        async with TablesService.with_session(role=role) as svc:
+            column = await svc.get_column(table_id, column_id)
+            await svc.drop_unique_index(column.table, column.name)
+            return {"status": "ok", "column": column.name}
+    except ToolError:
+        raise
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to drop column index", error=str(e))
+        raise ToolError(f"Failed to drop column index: {e}") from None
 
 
 @mcp.tool()

--- a/tracecat/tables/schemas.py
+++ b/tracecat/tables/schemas.py
@@ -112,7 +112,7 @@ class TableColumnUpdate(BaseModel):
     )
     is_index: bool | None = Field(
         default=None,
-        description="Whether the column is an index",
+        description="True creates a unique index, False drops it, None leaves unchanged.",
     )
     options: list[str] | None = Field(default=None)
 

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -627,12 +627,13 @@ class BaseTablesService(BaseWorkspaceService):
                 self._assert_user_column_name_allowed(requested_name)
         full_table_name = self._full_table_name(column.table.name)
         conn = await self.session.connection()
-        is_index = set_fields.pop("is_index", False)
+        is_index = set_fields.pop("is_index", None)
         requested_options = set_fields.pop("options", None)
 
-        # Create index if requested
-        if is_index:
+        if is_index is True:
             await self.create_unique_index(column.table, column.name)
+        elif is_index is False:
+            await self.drop_unique_index(column.table, column.name)
 
         # Handle options for SELECT/MULTI_SELECT columns
         target_type = (
@@ -772,6 +773,38 @@ class BaseTablesService(BaseWorkspaceService):
         )
 
         # Commit the transaction
+        await self.session.flush()
+
+    async def drop_unique_index(self, table: Table, column_name: str) -> None:
+        """Drop the unique index on the specified column."""
+
+        schema_name = self._get_schema_name()
+
+        resolved_column_name = self._resolve_external_column_name(table, column_name)
+        sanitized_column = self._sanitize_identifier(resolved_column_name)
+
+        conn = await self.session.connection()
+
+        def find_index_name(sync_conn: sa.Connection) -> str | None:
+            inspector = sa.inspect(sync_conn)
+            for idx in inspector.get_indexes(table.name, schema=schema_name):
+                cols = idx["column_names"]
+                if (
+                    len(cols) == 1
+                    and isinstance(cols[0], str)
+                    and cols[0] == sanitized_column
+                ):
+                    return idx.get("name")
+            return None
+
+        index_name = await conn.run_sync(find_index_name)
+        if index_name is None:
+            raise ValueError(f"No unique index exists on column '{column_name}'")
+
+        qualified_index = f'"{schema_name}"."{index_name}"'
+
+        await conn.execute(sa.DDL("DROP INDEX %s", (qualified_index,)))
+
         await self.session.flush()
 
     @audit_log(resource_type="table_column", action="delete")

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -790,7 +790,8 @@ class BaseTablesService(BaseWorkspaceService):
             for idx in inspector.get_indexes(table.name, schema=schema_name):
                 cols = idx["column_names"]
                 if (
-                    len(cols) == 1
+                    idx.get("unique") is True
+                    and len(cols) == 1
                     and isinstance(cols[0], str)
                     and cols[0] == sanitized_column
                 ):


### PR DESCRIPTION
## Summary

`TablesService.create_unique_index()` had no inverse — once a column was chosen as a unique index, it was permanent for the lifetime of the table. This adds drop-index semantics across all four surfaces (service, REST, UI, MCP) with the minimum diff.

`TableColumnUpdate.is_index` becomes tri-state:

| `is_index` | Action |
|------------|--------|
| `None` (unset) | No-op |
| `true` | Create unique index (existing) |
| `false` | Drop unique index (new) |

## What's changed

- **Service** (`tracecat/tables/service.py`) — new `drop_unique_index()` that uses the SQLAlchemy inspector to look up the real PG index name, then issues a schema-qualified `DROP INDEX`. Errors with `ValueError` if no index exists on the column (mapped to 400 by the existing router). `update_column()` now dispatches on tri-state `is_index`.
- **Schema** (`tracecat/tables/schemas.py`) — documents the new tri-state in `TableColumnUpdate.is_index` description.
- **REST router** — no code change. The existing PATCH `/tables/{id}/columns/{id}` already maps `ValueError → 400`.
- **MCP** (`tracecat/mcp/server.py`) — two new dedicated tools: `tables_create_column_index` and `tables_drop_column_index`. Closes the column-level gap in the MCP surface (previously column operations were REST-only).
- **UI** (`frontend/src/components/tables/table-view-column-menu.tsx`) — dropdown menu now toggles between "Create unique index" / "Remove unique index" based on `column.is_index`. New `TableColumnDropIndexDialog` warns about upsert impact. `useUpdateColumn` error handling now uses `is_index !== undefined` to categorize both create and drop errors.
- **Tests** — three new unit tests covering drop lifecycle, no-index error, and update_column dispatch.

## Backward-compat note

Today `is_index=false` is a silent no-op (pop default was `False` and the check was truthy). After this change it attempts a drop and returns 400 if no index exists. The frontend only ever sent `true`, so the only observable change is for direct API clients that explicitly sent `false`.

## Test plan

- [x] `uv run pytest tests/unit/test_tables_service.py` — 117 passed (incl. 3 new index tests)
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run basedpyright --warnings --threads 4 tracecat/tables/ tracecat/mcp/server.py`
- [x] `pnpm -C frontend check && pnpm -C frontend run typecheck`
- [ ] Manual REST: PATCH with `{"is_index": true}` → 204; `{"is_index": false}` → 204; second drop → 400 with "No unique index exists..."
- [ ] MCP smoke: `tables_create_column_index` → `tables_drop_column_index` → confirm `tables_get_table` reflects toggling
- [ ] UI smoke: create index via menu → green "Index" badge appears; "Remove unique index" menu item → badge disappears
