### PR TITLE
fix(graph): dedupe edges by handle

### DIFF
--- a/tests/unit/test_view.py
+++ b/tests/unit/test_view.py
@@ -1489,6 +1489,48 @@ def test_from_actions_error_edge():
     assert edge_to_c.source_handle == EdgeType.ERROR
 
 
+def test_from_actions_same_pair_edges_have_distinct_ids() -> None:
+    """Success and error edges for the same action pair must have unique RF IDs."""
+    workflow = MockWorkflow(id=WORKFLOW_UUID)
+    trigger_id = f"trigger-{WORKFLOW_UUID}"
+
+    action_a = MockAction(
+        id=UUID_A,
+        type="udf",
+        title="Action A",
+        upstream_edges=[
+            {"source_id": trigger_id, "source_type": "trigger"},
+        ],
+    )
+    action_b = MockAction(
+        id=UUID_B,
+        type="udf",
+        title="Action B",
+        upstream_edges=[
+            {
+                "source_id": str(UUID_A),
+                "source_type": "udf",
+                "source_handle": "success",
+            },
+            {"source_id": str(UUID_A), "source_type": "udf", "source_handle": "error"},
+        ],
+    )
+
+    graph = RFGraph.from_actions(
+        cast("Workflow", workflow),
+        cast("list[Action]", [action_a, action_b]),
+    )
+
+    edges_by_handle = {edge.source_handle: edge for edge in graph.action_edges()}
+    assert set(edges_by_handle) == {EdgeType.SUCCESS, EdgeType.ERROR}
+    assert edges_by_handle[EdgeType.SUCCESS].id == (
+        f"reactflow__edge-{UUID_A}-{UUID_B}-success"
+    )
+    assert edges_by_handle[EdgeType.ERROR].id == (
+        f"reactflow__edge-{UUID_A}-{UUID_B}-error"
+    )
+
+
 def test_from_actions_empty_graph():
     """Test RFGraph.from_actions with no actions (only trigger)."""
     workflow = MockWorkflow(id=WORKFLOW_UUID)

--- a/tests/unit/test_workflow_graph_edges.py
+++ b/tests/unit/test_workflow_graph_edges.py
@@ -1,0 +1,358 @@
+"""Tests for workflow graph edge operations.
+
+Covers the dedup contract for `_add_edge` and `_delete_edge`: success and
+error edges between the same source/target pair must coexist independently,
+and deleting one handle must not affect the other.
+
+Regression for https://github.com/TracecatHQ/tracecat/issues/2619.
+"""
+
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.db.models import Action, Workflow, Workspace
+from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.workflow.graph.service import WorkflowGraphService
+from tracecat.workflow.management.schemas import (
+    AddEdgePayload,
+    DeleteEdgePayload,
+    GraphOperation,
+    GraphOperationType,
+)
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+async def workflow_pair(
+    session: AsyncSession,
+    svc_workspace: Workspace,
+) -> AsyncGenerator[tuple[Workflow, Action, Action], None]:
+    """Workflow with a source action A and a target action B, no edges yet."""
+    workflow_id = uuid.uuid4()
+    workflow = Workflow(
+        id=workflow_id,
+        title="Edge Handle Workflow",
+        description="Edge handle regression fixture",
+        status="offline",
+        workspace_id=svc_workspace.id,
+        config={},
+    )
+    session.add(workflow)
+    await session.flush()
+
+    action_a = Action(
+        id=uuid.uuid4(),
+        workspace_id=svc_workspace.id,
+        workflow_id=workflow_id,
+        type="core.http_request",
+        title="Action A",
+        description="Source",
+        inputs="",
+        control_flow={},
+        position_x=0,
+        position_y=0,
+        upstream_edges=[],
+    )
+    action_b = Action(
+        id=uuid.uuid4(),
+        workspace_id=svc_workspace.id,
+        workflow_id=workflow_id,
+        type="core.http_request",
+        title="Action B",
+        description="Target",
+        inputs="",
+        control_flow={},
+        position_x=100,
+        position_y=0,
+        upstream_edges=[],
+    )
+    session.add_all([action_a, action_b])
+    await session.commit()
+    await session.refresh(workflow, ["actions"])
+
+    try:
+        yield workflow, action_a, action_b
+    finally:
+        await session.refresh(workflow, ["actions"])
+        for action in workflow.actions:
+            await session.delete(action)
+        await session.delete(workflow)
+        await session.commit()
+
+
+def _add_edge_op(
+    source_id: uuid.UUID, target_id: uuid.UUID, handle: str
+) -> GraphOperation:
+    return GraphOperation(
+        type=GraphOperationType.ADD_EDGE,
+        payload=AddEdgePayload(
+            source_id=str(source_id),
+            source_type="udf",
+            target_id=target_id,
+            source_handle=handle,  # type: ignore[arg-type]
+        ).model_dump(mode="json"),
+    )
+
+
+def _delete_edge_op(
+    source_id: uuid.UUID, target_id: uuid.UUID, handle: str
+) -> GraphOperation:
+    return GraphOperation(
+        type=GraphOperationType.DELETE_EDGE,
+        payload=DeleteEdgePayload(
+            source_id=str(source_id),
+            source_type="udf",
+            target_id=target_id,
+            source_handle=handle,  # type: ignore[arg-type]
+        ).model_dump(mode="json"),
+    )
+
+
+def _handles_for(action: Action, source_id: uuid.UUID) -> list[str]:
+    return sorted(
+        str(e.get("source_handle", ""))
+        for e in (action.upstream_edges or [])
+        if e.get("source_id") == str(source_id)
+    )
+
+
+def test_edge_dedup_key_udf_defaults_to_success() -> None:
+    """Missing handle on a udf edge canonicalises to 'success'."""
+    assert WorkflowGraphService._edge_dedup_key("a", "udf", None) == (
+        "a",
+        "udf",
+        "success",
+    )
+    assert WorkflowGraphService._edge_dedup_key("a", "udf", "success") == (
+        "a",
+        "udf",
+        "success",
+    )
+    assert WorkflowGraphService._edge_dedup_key("a", "udf", "error") == (
+        "a",
+        "udf",
+        "error",
+    )
+
+
+def test_edge_dedup_key_trigger_ignores_handle() -> None:
+    """Trigger edges have no handle concept."""
+    assert WorkflowGraphService._edge_dedup_key("trigger-x", "trigger", None) == (
+        "trigger-x",
+        "trigger",
+        None,
+    )
+    assert WorkflowGraphService._edge_dedup_key("trigger-x", "trigger", "success") == (
+        "trigger-x",
+        "trigger",
+        None,
+    )
+
+
+@pytest.mark.anyio
+async def test_add_edge_success_then_error_coexist(
+    session: AsyncSession,
+    svc_role: Role,
+    workflow_pair: tuple[Workflow, Action, Action],
+) -> None:
+    """Adding error after success leaves both edges intact (#2619)."""
+    workflow, action_a, action_b = workflow_pair
+    service = WorkflowGraphService(session, role=svc_role)
+
+    await service.apply_operations(
+        WorkflowUUID.new(workflow.id),
+        workflow.graph_version,
+        [_add_edge_op(action_a.id, action_b.id, "success")],
+    )
+    await service.apply_operations(
+        WorkflowUUID.new(workflow.id),
+        workflow.graph_version,
+        [_add_edge_op(action_a.id, action_b.id, "error")],
+    )
+
+    await session.refresh(action_b)
+    assert _handles_for(action_b, action_a.id) == ["error", "success"]
+
+
+@pytest.mark.anyio
+async def test_add_edge_error_then_success_coexist(
+    session: AsyncSession,
+    svc_role: Role,
+    workflow_pair: tuple[Workflow, Action, Action],
+) -> None:
+    """Insertion order does not matter."""
+    workflow, action_a, action_b = workflow_pair
+    service = WorkflowGraphService(session, role=svc_role)
+
+    await service.apply_operations(
+        WorkflowUUID.new(workflow.id),
+        workflow.graph_version,
+        [_add_edge_op(action_a.id, action_b.id, "error")],
+    )
+    await service.apply_operations(
+        WorkflowUUID.new(workflow.id),
+        workflow.graph_version,
+        [_add_edge_op(action_a.id, action_b.id, "success")],
+    )
+
+    await session.refresh(action_b)
+    assert _handles_for(action_b, action_a.id) == ["error", "success"]
+
+
+@pytest.mark.anyio
+async def test_add_edge_same_handle_is_idempotent(
+    session: AsyncSession,
+    svc_role: Role,
+    workflow_pair: tuple[Workflow, Action, Action],
+) -> None:
+    """Re-adding the same handle replaces, never duplicates."""
+    workflow, action_a, action_b = workflow_pair
+    service = WorkflowGraphService(session, role=svc_role)
+
+    await service.apply_operations(
+        WorkflowUUID.new(workflow.id),
+        workflow.graph_version,
+        [_add_edge_op(action_a.id, action_b.id, "success")],
+    )
+    await service.apply_operations(
+        WorkflowUUID.new(workflow.id),
+        workflow.graph_version,
+        [_add_edge_op(action_a.id, action_b.id, "success")],
+    )
+
+    await session.refresh(action_b)
+    assert _handles_for(action_b, action_a.id) == ["success"]
+
+
+@pytest.mark.anyio
+async def test_delete_edge_targets_only_matching_handle(
+    session: AsyncSession,
+    svc_role: Role,
+    workflow_pair: tuple[Workflow, Action, Action],
+) -> None:
+    """Deleting the error edge must leave the success edge intact."""
+    workflow, action_a, action_b = workflow_pair
+    service = WorkflowGraphService(session, role=svc_role)
+
+    await service.apply_operations(
+        WorkflowUUID.new(workflow.id),
+        workflow.graph_version,
+        [
+            _add_edge_op(action_a.id, action_b.id, "success"),
+            _add_edge_op(action_a.id, action_b.id, "error"),
+        ],
+    )
+    await session.refresh(action_b)
+    assert _handles_for(action_b, action_a.id) == ["error", "success"]
+
+    await service.apply_operations(
+        WorkflowUUID.new(workflow.id),
+        workflow.graph_version,
+        [_delete_edge_op(action_a.id, action_b.id, "error")],
+    )
+
+    await session.refresh(action_b)
+    assert _handles_for(action_b, action_a.id) == ["success"]
+
+
+@pytest.mark.anyio
+async def test_delete_edge_other_handle_preserved(
+    session: AsyncSession,
+    svc_role: Role,
+    workflow_pair: tuple[Workflow, Action, Action],
+) -> None:
+    """Deleting success must not also drop error (mirror case)."""
+    workflow, action_a, action_b = workflow_pair
+    service = WorkflowGraphService(session, role=svc_role)
+
+    await service.apply_operations(
+        WorkflowUUID.new(workflow.id),
+        workflow.graph_version,
+        [
+            _add_edge_op(action_a.id, action_b.id, "success"),
+            _add_edge_op(action_a.id, action_b.id, "error"),
+        ],
+    )
+
+    await service.apply_operations(
+        WorkflowUUID.new(workflow.id),
+        workflow.graph_version,
+        [_delete_edge_op(action_a.id, action_b.id, "success")],
+    )
+
+    await session.refresh(action_b)
+    assert _handles_for(action_b, action_a.id) == ["error"]
+
+
+@pytest.mark.anyio
+async def test_trigger_edges_unaffected_by_handle_dedup(
+    session: AsyncSession,
+    svc_role: Role,
+    workflow_pair: tuple[Workflow, Action, Action],
+) -> None:
+    """Trigger edges still dedupe by (source_id, source_type) only."""
+    workflow, _, action_b = workflow_pair
+    service = WorkflowGraphService(session, role=svc_role)
+
+    trigger_id = f"trigger-{workflow.id}"
+    op = GraphOperation(
+        type=GraphOperationType.ADD_EDGE,
+        payload=AddEdgePayload(
+            source_id=trigger_id,
+            source_type="trigger",
+            target_id=action_b.id,
+        ).model_dump(mode="json"),
+    )
+
+    await service.apply_operations(
+        WorkflowUUID.new(workflow.id), workflow.graph_version, [op]
+    )
+    await service.apply_operations(
+        WorkflowUUID.new(workflow.id), workflow.graph_version, [op]
+    )
+
+    await session.refresh(action_b)
+    trigger_edges = [
+        e for e in (action_b.upstream_edges or []) if e.get("source_type") == "trigger"
+    ]
+    assert len(trigger_edges) == 1
+    assert "source_handle" not in trigger_edges[0]
+
+
+@pytest.mark.anyio
+async def test_legacy_edge_without_handle_dedupes_against_success(
+    session: AsyncSession,
+    svc_role: Role,
+    workflow_pair: tuple[Workflow, Action, Action],
+) -> None:
+    """A legacy udf edge missing source_handle is treated as 'success'."""
+    workflow, action_a, action_b = workflow_pair
+
+    # Seed a legacy edge (no source_handle key) directly.
+    action_b.upstream_edges = [{"source_id": str(action_a.id), "source_type": "udf"}]
+    session.add(action_b)
+    await session.commit()
+    await session.refresh(action_b)
+
+    service = WorkflowGraphService(session, role=svc_role)
+    await service.apply_operations(
+        WorkflowUUID.new(workflow.id),
+        workflow.graph_version,
+        [_add_edge_op(action_a.id, action_b.id, "success")],
+    )
+
+    refreshed = await session.execute(select(Action).where(Action.id == action_b.id))
+    target = refreshed.scalar_one()
+    udf_edges = [
+        e
+        for e in (target.upstream_edges or [])
+        if e.get("source_id") == str(action_a.id)
+    ]
+    assert len(udf_edges) == 1
+    assert udf_edges[0]["source_handle"] == "success"

--- a/tests/unit/test_workflow_graph_edges.py
+++ b/tests/unit/test_workflow_graph_edges.py
@@ -9,6 +9,7 @@ Regression for https://github.com/TracecatHQ/tracecat/issues/2619.
 
 import uuid
 from collections.abc import AsyncGenerator
+from typing import Literal
 
 import pytest
 from sqlalchemy import select
@@ -17,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat.auth.types import Role
 from tracecat.db.models import Action, Workflow, Workspace
 from tracecat.identifiers.workflow import WorkflowUUID
-from tracecat.workflow.graph.service import WorkflowGraphService
+from tracecat.workflow.graph.service import EdgeDedupKey, WorkflowGraphService
 from tracecat.workflow.management.schemas import (
     AddEdgePayload,
     DeleteEdgePayload,
@@ -26,6 +27,8 @@ from tracecat.workflow.management.schemas import (
 )
 
 pytestmark = pytest.mark.usefixtures("db")
+
+type EdgeHandle = Literal["success", "error"]
 
 
 @pytest.fixture
@@ -87,7 +90,7 @@ async def workflow_pair(
 
 
 def _add_edge_op(
-    source_id: uuid.UUID, target_id: uuid.UUID, handle: str
+    source_id: uuid.UUID, target_id: uuid.UUID, handle: EdgeHandle
 ) -> GraphOperation:
     return GraphOperation(
         type=GraphOperationType.ADD_EDGE,
@@ -95,13 +98,13 @@ def _add_edge_op(
             source_id=str(source_id),
             source_type="udf",
             target_id=target_id,
-            source_handle=handle,  # type: ignore[arg-type]
+            source_handle=handle,
         ).model_dump(mode="json"),
     )
 
 
 def _delete_edge_op(
-    source_id: uuid.UUID, target_id: uuid.UUID, handle: str
+    source_id: uuid.UUID, target_id: uuid.UUID, handle: EdgeHandle
 ) -> GraphOperation:
     return GraphOperation(
         type=GraphOperationType.DELETE_EDGE,
@@ -109,7 +112,7 @@ def _delete_edge_op(
             source_id=str(source_id),
             source_type="udf",
             target_id=target_id,
-            source_handle=handle,  # type: ignore[arg-type]
+            source_handle=handle,
         ).model_dump(mode="json"),
     )
 
@@ -124,34 +127,28 @@ def _handles_for(action: Action, source_id: uuid.UUID) -> list[str]:
 
 def test_edge_dedup_key_udf_defaults_to_success() -> None:
     """Missing handle on a udf edge canonicalises to 'success'."""
-    assert WorkflowGraphService._edge_dedup_key("a", "udf", None) == (
-        "a",
-        "udf",
-        "success",
+    assert WorkflowGraphService._edge_dedup_key("a", "udf", None) == EdgeDedupKey(
+        "a", "udf", "success"
     )
-    assert WorkflowGraphService._edge_dedup_key("a", "udf", "success") == (
-        "a",
-        "udf",
-        "success",
+    assert WorkflowGraphService._edge_dedup_key("a", "udf", "success") == EdgeDedupKey(
+        "a", "udf", "success"
     )
-    assert WorkflowGraphService._edge_dedup_key("a", "udf", "error") == (
-        "a",
-        "udf",
-        "error",
+    assert WorkflowGraphService._edge_dedup_key("a", "udf", "error") == EdgeDedupKey(
+        "a", "udf", "error"
     )
 
 
 def test_edge_dedup_key_trigger_ignores_handle() -> None:
     """Trigger edges have no handle concept."""
-    assert WorkflowGraphService._edge_dedup_key("trigger-x", "trigger", None) == (
+    assert WorkflowGraphService._edge_dedup_key(
+        "trigger-x", "trigger", None
+    ) == EdgeDedupKey(
         "trigger-x",
         "trigger",
         None,
     )
     assert WorkflowGraphService._edge_dedup_key("trigger-x", "trigger", "success") == (
-        "trigger-x",
-        "trigger",
-        None,
+        EdgeDedupKey("trigger-x", "trigger", None)
     )
 
 

--- a/tracecat/dsl/view.py
+++ b/tracecat/dsl/view.py
@@ -118,9 +118,14 @@ class RFEdge(TSObject):
 
     @model_validator(mode="before")
     def generate_id(cls, values: dict[str, Any]) -> dict[str, Any]:
-        """Generate the ID as a concatenation of source and target with a prefix."""
+        """Generate the ID from the React Flow edge identity."""
         if (source := values.get("source")) and (target := values.get("target")):
-            values["id"] = "-".join(("reactflow__edge", str(source), str(target)))
+            edge_id_parts = ["reactflow__edge", str(source), str(target)]
+            if source_handle := values.get("source_handle") or values.get(
+                "sourceHandle"
+            ):
+                edge_id_parts.append(str(source_handle))
+            values["id"] = "-".join(edge_id_parts)
         return values
 
 

--- a/tracecat/workflow/graph/service.py
+++ b/tracecat/workflow/graph/service.py
@@ -3,7 +3,8 @@
 Implements the canonical graph API with optimistic concurrency.
 """
 
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 from fastapi import HTTPException, status
 from sqlalchemy import column, delete, func, literal, select, update
@@ -27,6 +28,16 @@ from tracecat.workflow.management.schemas import (
     UpdateTriggerPositionPayload,
     UpdateViewportPayload,
 )
+
+type EdgeSourceType = Literal["trigger", "udf"]
+type EdgeHandle = Literal["success", "error"]
+
+
+@dataclass(frozen=True, slots=True)
+class EdgeDedupKey:
+    source_id: str
+    source_type: EdgeSourceType
+    source_handle: EdgeHandle | None
 
 
 class WorkflowGraphService(BaseWorkspaceService):
@@ -293,8 +304,10 @@ class WorkflowGraphService(BaseWorkspaceService):
 
     @staticmethod
     def _edge_dedup_key(
-        source_id: str, source_type: str, source_handle: str | None
-    ) -> tuple[str, str, str | None]:
+        source_id: str,
+        source_type: EdgeSourceType,
+        source_handle: EdgeHandle | None,
+    ) -> EdgeDedupKey:
         """Canonical key used to dedupe upstream edges.
 
         Trigger edges have no handle; udf edges with a missing handle are
@@ -302,8 +315,34 @@ class WorkflowGraphService(BaseWorkspaceService):
         correctly against newly-written edges.
         """
         if source_type == "udf":
-            return (source_id, source_type, source_handle or "success")
-        return (source_id, source_type, None)
+            return EdgeDedupKey(source_id, source_type, source_handle or "success")
+        return EdgeDedupKey(source_id, source_type, None)
+
+    @classmethod
+    def _stored_edge_dedup_key(cls, edge: dict[str, Any]) -> EdgeDedupKey | None:
+        source_id = edge.get("source_id")
+        if not isinstance(source_id, str):
+            return None
+
+        source_type: EdgeSourceType
+        match edge.get("source_type"):
+            case "trigger":
+                source_type = "trigger"
+            case "udf":
+                source_type = "udf"
+            case _:
+                source_type = "trigger" if source_id.startswith("trigger-") else "udf"
+
+        source_handle: EdgeHandle | None
+        match edge.get("source_handle"):
+            case "success":
+                source_handle = "success"
+            case "error":
+                source_handle = "error"
+            case _:
+                source_handle = None
+
+        return cls._edge_dedup_key(source_id, source_type, source_handle)
 
     async def _add_edge(self, workflow: Workflow, payload: AddEdgePayload) -> None:
         """Add an edge between two nodes.
@@ -354,19 +393,10 @@ class WorkflowGraphService(BaseWorkspaceService):
             "source_type": payload.source_type,
         }
         if payload.source_type == "udf":
-            new_edge["source_handle"] = new_key[2]
+            new_edge["source_handle"] = new_key.source_handle
 
         edges = target_action.upstream_edges or []
-        filtered_edges = [
-            e
-            for e in edges
-            if self._edge_dedup_key(
-                str(e.get("source_id", "")),
-                str(e.get("source_type", "")),
-                e.get("source_handle"),
-            )
-            != new_key
-        ]
+        filtered_edges = [e for e in edges if self._stored_edge_dedup_key(e) != new_key]
         filtered_edges.append(new_edge)
 
         target_action.upstream_edges = filtered_edges
@@ -398,14 +428,7 @@ class WorkflowGraphService(BaseWorkspaceService):
 
         edges = target_action.upstream_edges or []
         target_action.upstream_edges = [
-            e
-            for e in edges
-            if self._edge_dedup_key(
-                str(e.get("source_id", "")),
-                str(e.get("source_type", "")),
-                e.get("source_handle"),
-            )
-            != target_key
+            e for e in edges if self._stored_edge_dedup_key(e) != target_key
         ]
         self.session.add(target_action)
 

--- a/tracecat/workflow/graph/service.py
+++ b/tracecat/workflow/graph/service.py
@@ -291,11 +291,26 @@ class WorkflowGraphService(BaseWorkspaceService):
         )
         await self.session.execute(delete_stmt)
 
+    @staticmethod
+    def _edge_dedup_key(
+        source_id: str, source_type: str, source_handle: str | None
+    ) -> tuple[str, str, str | None]:
+        """Canonical key used to dedupe upstream edges.
+
+        Trigger edges have no handle; udf edges with a missing handle are
+        treated as the implicit "success" default so legacy data dedupes
+        correctly against newly-written edges.
+        """
+        if source_type == "udf":
+            return (source_id, source_type, source_handle or "success")
+        return (source_id, source_type, None)
+
     async def _add_edge(self, workflow: Workflow, payload: AddEdgePayload) -> None:
         """Add an edge between two nodes.
 
         Supports both trigger and action sources. Validates source exists.
-        Normalizes duplicates (only one edge per source_id + source_type).
+        Dedupes by (source_id, source_type, source_handle) so success and
+        error edges between the same pair can coexist.
         """
         # Validate source based on type
         if payload.source_type == "udf":
@@ -329,23 +344,28 @@ class WorkflowGraphService(BaseWorkspaceService):
         if target_action is None:
             raise ValueError(f"Target action {payload.target_id} not found")
 
+        new_key = self._edge_dedup_key(
+            payload.source_id, payload.source_type, payload.source_handle
+        )
+
         # Build the new edge
         new_edge: dict[str, Any] = {
             "source_id": payload.source_id,
             "source_type": payload.source_type,
         }
         if payload.source_type == "udf":
-            new_edge["source_handle"] = payload.source_handle or "success"
+            new_edge["source_handle"] = new_key[2]
 
-        # Filter out existing edge with same source_id + source_type, then add new one
         edges = target_action.upstream_edges or []
         filtered_edges = [
             e
             for e in edges
-            if not (
-                e.get("source_id") == payload.source_id
-                and e.get("source_type") == payload.source_type
+            if self._edge_dedup_key(
+                str(e.get("source_id", "")),
+                str(e.get("source_type", "")),
+                e.get("source_handle"),
             )
+            != new_key
         ]
         filtered_edges.append(new_edge)
 
@@ -355,7 +375,11 @@ class WorkflowGraphService(BaseWorkspaceService):
     async def _delete_edge(
         self, workflow: Workflow, payload: DeleteEdgePayload
     ) -> None:
-        """Delete an edge between two nodes."""
+        """Delete an edge between two nodes.
+
+        Matches on (source_id, source_type, source_handle) so deleting one
+        handle leaves the other intact when both exist for the same pair.
+        """
         # Get target action
         target_result = await self.session.execute(
             select(Action).where(
@@ -368,15 +392,20 @@ class WorkflowGraphService(BaseWorkspaceService):
         if target_action is None:
             raise ValueError(f"Target action {payload.target_id} not found")
 
-        # Remove edge from target's upstream_edges by matching source_id + source_type
+        target_key = self._edge_dedup_key(
+            payload.source_id, payload.source_type, payload.source_handle
+        )
+
         edges = target_action.upstream_edges or []
         target_action.upstream_edges = [
             e
             for e in edges
-            if not (
-                e.get("source_id") == payload.source_id
-                and e.get("source_type") == payload.source_type
+            if self._edge_dedup_key(
+                str(e.get("source_id", "")),
+                str(e.get("source_type", "")),
+                e.get("source_handle"),
             )
+            != target_key
         ]
         self.session.add(target_action)
 


### PR DESCRIPTION
## Summary

Fixes the workflow canvas edge dedupe bug where adding both success and error edges from the same source action to the same target action drops one of them.

This keeps PR #2710's behavior and tightens the implementation with a dedicated `EdgeDedupKey` value object plus typed edge-handle helpers, so add/delete edge operations compare the full logical edge identity.

Supersedes #2710.
Fixes #2619.

## Changes

- Dedupe UDF edges by source id, source type, and normalized source handle.
- Keep trigger edges handle-less and deduped by source id/source type only.
- Treat legacy UDF edges without `source_handle` as implicit `success`.
- Preserve malformed stored edges without a valid `source_id` instead of matching them via an empty-string sentinel.
- Add DB-backed regression coverage for success/error coexistence, deletion, trigger behavior, and legacy success edges.

## Verification

```bash
uv run pytest tests/unit/test_workflow_graph_edges.py tests/unit/test_workflow_graph_reconciliation.py tests/unit/api/test_api_workflow_graph.py
uv run ruff check tracecat/workflow/graph/service.py tests/unit/test_workflow_graph_edges.py
uv run ruff format --check tracecat/workflow/graph/service.py tests/unit/test_workflow_graph_edges.py
uv run basedpyright tracecat/workflow/graph/service.py tests/unit/test_workflow_graph_edges.py
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes graph edge deduping so success and error edges between the same source and target no longer overwrite each other, and deletes now target the specific handle. React Flow edge IDs now include the handle so both edges render and persist distinctly, fixing #2619.

- **Bug Fixes**
  - Dedupes by (source_id, source_type, source_handle) via an `EdgeDedupKey`.
  - React Flow edge IDs now include the handle, making success/error edges unique.
  - UDF edges missing a handle default to "success"; trigger edges ignore handles.
  - Preserves malformed stored edges without a valid `source_id`.
  - Adds tests for RF ID uniqueness plus DB-backed coverage for coexistence, deletion, trigger behavior, and legacy success edges.

<sup>Written for commit 65f97bd455525ca5fc2688fffcaf20b58184fd8b. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2711?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

