### PR TITLE
fix(api): bound internal route workloads

### DIFF
--- a/tests/unit/api/test_api_internal_cases.py
+++ b/tests/unit/api/test_api_internal_cases.py
@@ -6,8 +6,10 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
+from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.cases import internal_router as internal_cases_router
+from tracecat.cases.durations.schemas import CaseDurationMetric
 from tracecat.cases.enums import CaseEventType, CasePriority, CaseSeverity, CaseStatus
 from tracecat.cases.rows.schemas import CaseTableRowRead
 from tracecat.cases.schemas import (
@@ -99,6 +101,7 @@ async def test_internal_get_case_include_rows_hydrates_rows(
         mock_service.fields = AsyncMock()
         mock_service.fields.get_fields.return_value = {}
         mock_service.fields.list_fields.return_value = []
+        mock_service.fields.get_field_schema.return_value = {}
         mock_service_cls.return_value = mock_service
 
         response = client.get(
@@ -114,6 +117,9 @@ async def test_internal_get_case_include_rows_hydrates_rows(
     assert len(data["rows"]) == 1
     assert data["rows"][0]["id"] == str(row.id)
     assert mock_list_rows.await_count == 1
+    mock_service.get_case.assert_awaited_once_with(
+        mock_internal_case.id, track_view=False
+    )
 
 
 @pytest.mark.anyio
@@ -142,6 +148,7 @@ async def test_internal_update_case_include_rows_hydrates_rows(
         mock_service.fields = AsyncMock()
         mock_service.fields.get_fields.return_value = {}
         mock_service.fields.list_fields.return_value = []
+        mock_service.fields.get_field_schema.return_value = {}
         mock_service_cls.return_value = mock_service
 
         response = client.patch(
@@ -343,6 +350,42 @@ async def test_internal_list_comment_threads_success(
         assert data[0]["comment"]["content"] == "Comment deleted"
         assert data[0]["comment"]["is_deleted"] is True
         assert data[0]["reply_count"] == 1
+        mock_comments_service.list_comment_threads.assert_awaited_once_with(
+            mock_internal_case,
+            limit=config.TRACECAT__LIMIT_CASE_COMMENTS_DEFAULT,
+        )
+
+
+@pytest.mark.anyio
+async def test_internal_list_comments_applies_default_limit(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_internal_case: Case,
+) -> None:
+    with (
+        patch.object(internal_cases_router, "CasesService") as mock_cases_service_cls,
+        patch.object(
+            internal_cases_router, "CaseCommentsService"
+        ) as mock_comments_service_cls,
+    ):
+        mock_cases_service = AsyncMock()
+        mock_cases_service.get_case.return_value = mock_internal_case
+        mock_cases_service_cls.return_value = mock_cases_service
+
+        mock_comments_service = AsyncMock()
+        mock_comments_service.list_comments.return_value = []
+        mock_comments_service_cls.return_value = mock_comments_service
+
+        response = client.get(
+            f"/internal/cases/{mock_internal_case.id}/comments",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_comments_service.list_comments.assert_awaited_once_with(
+        mock_internal_case,
+        limit=config.TRACECAT__LIMIT_CASE_COMMENTS_DEFAULT,
+    )
 
 
 @pytest.mark.anyio
@@ -503,6 +546,88 @@ async def test_internal_list_case_events_includes_comment_activity(
     data = response.json()
     assert data["events"][0]["type"] == "comment_created"
     assert data["events"][0]["comment_id"] == str(comment_id)
+
+
+@pytest.mark.anyio
+async def test_internal_case_metrics_uses_batch_context_loaders(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_internal_case: Case,
+) -> None:
+    metric = CaseDurationMetric(
+        timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        value=12.0,
+        duration_name="Time to Triage",
+        duration_slug="time_to_triage",
+        case_priority=mock_internal_case.priority.value,
+        case_severity=mock_internal_case.severity.value,
+        case_status=mock_internal_case.status.value,
+        case_id=str(mock_internal_case.id),
+        case_short_id=mock_internal_case.short_id,
+    )
+    with (
+        patch.object(internal_cases_router, "CasesService") as mock_service_cls,
+        patch.object(
+            internal_cases_router, "CaseDurationService"
+        ) as mock_duration_service_cls,
+        patch.object(
+            internal_cases_router,
+            "_list_case_dropdown_values_by_case",
+            new=AsyncMock(return_value={mock_internal_case.id: []}),
+        ) as mock_list_dropdowns,
+    ):
+        mock_service = AsyncMock()
+        mock_service.get_cases.return_value = [mock_internal_case]
+        mock_service.fields = AsyncMock()
+        mock_service.fields.list_fields.return_value = []
+        mock_service.fields.get_field_schema.return_value = {}
+        mock_service.fields.batch_get_fields.return_value = {mock_internal_case.id: {}}
+        mock_service_cls.return_value = mock_service
+
+        mock_duration_service = AsyncMock()
+        mock_duration_service.compute_time_series.return_value = [metric]
+        mock_duration_service_cls.return_value = mock_duration_service
+
+        response = client.post(
+            "/internal/cases/metrics",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"case_ids": [str(mock_internal_case.id)]},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data[0]["case_id"] == str(mock_internal_case.id)
+    mock_service.get_cases.assert_awaited_once_with([mock_internal_case.id])
+    mock_service.get_case.assert_not_awaited()
+    mock_service.fields.batch_get_fields.assert_awaited_once_with(
+        case_ids=[mock_internal_case.id],
+        field_ids=[],
+    )
+    mock_duration_service.compute_time_series.assert_awaited_once_with(
+        [mock_internal_case]
+    )
+    dropdown_args = mock_list_dropdowns.await_args
+    assert dropdown_args is not None
+    assert dropdown_args.kwargs["case_ids"] == [mock_internal_case.id]
+
+
+@pytest.mark.anyio
+async def test_internal_case_metrics_rejects_oversized_batches(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    response = client.post(
+        "/internal/cases/metrics",
+        params={"workspace_id": str(test_admin_role.workspace_id)},
+        json={
+            "case_ids": [
+                str(uuid.uuid4())
+                for _ in range(config.TRACECAT__LIMIT_CASE_METRICS_MAX + 1)
+            ]
+        },
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_internal_tables.py
+++ b/tests/unit/api/test_api_internal_tables.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
+from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.db.models import Table, Workspace
 from tracecat.tables import internal_router as internal_tables_router
@@ -68,3 +69,29 @@ async def test_internal_update_table_row_invalid_integer_value_returns_400(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["detail"] == "Invalid integer value: '1.5'"
+
+
+@pytest.mark.anyio
+async def test_internal_lookup_rows_applies_default_limit(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    with patch.object(internal_tables_router, "TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.lookup_rows.return_value = []
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            f"/internal/tables/{mock_table.name}/lookup",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"columns": ["email"], "values": ["alice@example.com"]},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_svc.lookup_rows.assert_awaited_once_with(
+        mock_table.name,
+        columns=["email"],
+        values=["alice@example.com"],
+        limit=config.TRACECAT__LIMIT_TABLE_LOOKUP_DEFAULT,
+    )

--- a/tests/unit/test_case_comments_service.py
+++ b/tests/unit/test_case_comments_service.py
@@ -525,6 +525,9 @@ class TestCaseCommentsService:
         comments = await case_comments_service.list_comments(test_case)
         assert len(comments) == 3
 
+        limited_comments = await case_comments_service.list_comments(test_case, limit=2)
+        assert len(limited_comments) == 2
+
         # Check that all our comments are in the list
         comment_ids = {comment.id for comment in comments}
         assert comment1.id in comment_ids

--- a/tests/unit/test_tables_service.py
+++ b/tests/unit/test_tables_service.py
@@ -1332,6 +1332,27 @@ class TestTableRows:
         assert len(results) == 1
         assert results[0]["id"] == inserted["id"]
 
+    async def test_lookup_rows_applies_default_limit(
+        self,
+        tables_service: TablesService,
+        table: Table,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """lookup_rows should remain bounded when no explicit limit is provided."""
+        monkeypatch.setattr(config, "TRACECAT__LIMIT_TABLE_LOOKUP_DEFAULT", 2)
+
+        for age in (50, 60, 70):
+            await tables_service.insert_row(
+                table, TableRowInsert(data={"name": "Charlie", "age": age})
+            )
+
+        results = await tables_service.lookup_rows(
+            table_name=table.name, columns=["name"], values=["Charlie"]
+        )
+
+        assert len(results) == 2
+        assert [result["age"] for result in results] == [50, 60]
+
     async def test_exists_rows_allows_system_id_column(
         self, tables_service: TablesService, table: Table
     ) -> None:

--- a/tracecat/cases/attachments/internal_router.py
+++ b/tracecat/cases/attachments/internal_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import uuid
 
@@ -87,7 +88,9 @@ async def create_attachment(
         )
 
     try:
-        content = base64.b64decode(params.content_base64, validate=True)
+        content = await asyncio.to_thread(
+            base64.b64decode, params.content_base64, validate=True
+        )
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -214,8 +217,9 @@ async def download_attachment_content(
             detail=str(e),
         ) from e
 
+    encoded_content = await asyncio.to_thread(base64.b64encode, content)
     return {
-        "content_base64": base64.b64encode(content).decode("utf-8"),
+        "content_base64": encoded_content.decode("utf-8"),
         "file_name": filename,
         "content_type": content_type,
     }

--- a/tracecat/cases/attachments/service.py
+++ b/tracecat/cases/attachments/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import uuid
 from collections.abc import Sequence
@@ -270,14 +271,15 @@ class CaseAttachmentService(BaseWorkspaceService):
         )
         # Strip "Content-Type" from the declared MIME type
         declared_mime_type = params.content_type.split(";")[0].strip()
-        validation_result = validator.validate_file(
+        validation_result = await asyncio.to_thread(
+            validator.validate_file,
             content=params.content,
             filename=params.file_name,
             declared_mime_type=declared_mime_type,
         )
 
         # Compute content hash for deduplication and integrity
-        sha256 = self._compute_sha256(params.content)
+        sha256 = await asyncio.to_thread(self._compute_sha256, params.content)
 
         # Determine uploader ID (may be None for workflow/service uploads)
         creator_id: uuid.UUID | None = (
@@ -421,7 +423,9 @@ class CaseAttachmentService(BaseWorkspaceService):
             )
 
             # Verify integrity
-            self._verify_integrity(content, attachment.file.sha256)
+            await asyncio.to_thread(
+                self._verify_integrity, content, attachment.file.sha256
+            )
 
             return content, attachment.file.name, attachment.file.content_type
         except FileNotFoundError as e:

--- a/tracecat/cases/dropdowns/service.py
+++ b/tracecat/cases/dropdowns/service.py
@@ -365,20 +365,50 @@ class CaseDropdownValuesService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         rows = result.scalars().all()
 
-        return [
-            CaseDropdownValueRead(
-                id=row.id,
-                definition_id=row.definition_id,
-                definition_ref=row.definition.ref,
-                definition_name=row.definition.name,
-                option_id=row.option.id if row.option else None,
-                option_label=row.option.label if row.option else None,
-                option_ref=row.option.ref if row.option else None,
-                option_icon_name=row.option.icon_name if row.option else None,
-                option_color=row.option.color if row.option else None,
+        return [self._serialize_value(row) for row in rows]
+
+    @requires_entitlement(Entitlement.CASE_ADDONS)
+    async def list_values_for_cases(
+        self, case_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, list[CaseDropdownValueRead]]:
+        """Batch list dropdown values for workspace-scoped cases."""
+        unique_case_ids = list(dict.fromkeys(case_ids))
+        if not unique_case_ids:
+            return {}
+
+        stmt = (
+            select(CaseDropdownValue)
+            .join(Case, Case.id == CaseDropdownValue.case_id)
+            .where(
+                Case.workspace_id == self.workspace_id,
+                CaseDropdownValue.case_id.in_(unique_case_ids),
             )
-            for row in rows
-        ]
+            .options(
+                selectinload(CaseDropdownValue.definition).selectinload(
+                    CaseDropdownDefinition.options
+                ),
+                selectinload(CaseDropdownValue.option),
+            )
+        )
+        result = await self.session.execute(stmt)
+        grouped = {case_id: [] for case_id in unique_case_ids}
+        for row in result.scalars().all():
+            grouped.setdefault(row.case_id, []).append(self._serialize_value(row))
+        return grouped
+
+    @staticmethod
+    def _serialize_value(row: CaseDropdownValue) -> CaseDropdownValueRead:
+        return CaseDropdownValueRead(
+            id=row.id,
+            definition_id=row.definition_id,
+            definition_ref=row.definition.ref,
+            definition_name=row.definition.name,
+            option_id=row.option.id if row.option else None,
+            option_label=row.option.label if row.option else None,
+            option_ref=row.option.ref if row.option else None,
+            option_icon_name=row.option.icon_name if row.option else None,
+            option_color=row.option.color if row.option else None,
+        )
 
     async def _set_value(
         self,

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Sequence
 from datetime import datetime
 from typing import Any, Literal, NoReturn
 
 from fastapi import APIRouter, HTTPException, Query
+from pydantic import Field
 from sqlalchemy.exc import DBAPIError, NoResultFound
 from starlette.status import (
     HTTP_200_OK,
@@ -97,6 +99,22 @@ async def _list_case_dropdown_values(
     if not await dropdown_service.has_entitlement(Entitlement.CASE_ADDONS):
         return []
     return await dropdown_service.list_values_for_case(case_id)
+
+
+async def _list_case_dropdown_values_by_case(
+    *,
+    session: AsyncDBSession,
+    role: ExecutorWorkspaceRole,
+    case_ids: Sequence[uuid.UUID],
+) -> dict[uuid.UUID, list[CaseDropdownValueRead]]:
+    unique_case_ids = list(dict.fromkeys(case_ids))
+    if not unique_case_ids:
+        return {}
+
+    dropdown_service = CaseDropdownValuesService(session, role)
+    if not await dropdown_service.has_entitlement(Entitlement.CASE_ADDONS):
+        return {case_id: [] for case_id in unique_case_ids}
+    return await dropdown_service.list_values_for_cases(unique_case_ids)
 
 
 async def _list_case_rows(
@@ -373,7 +391,7 @@ async def get_case(
     include_rows: bool = Query(False, description="Include linked table rows"),
 ) -> CaseRead:
     service = CasesService(session, role)
-    case = await service.get_case(case_id, track_view=True)
+    case = await service.get_case(case_id, track_view=False)
     if case is None:
         raise HTTPException(
             status_code=HTTP_404_NOT_FOUND,
@@ -587,6 +605,12 @@ async def list_comments(
     role: ExecutorWorkspaceRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
+    limit: int = Query(
+        config.TRACECAT__LIMIT_CASE_COMMENTS_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CASE_COMMENTS_MAX,
+        description="Maximum comments to return",
+    ),
 ) -> list[CaseCommentRead]:
     service = CasesService(session, role)
     case = await service.get_case(case_id)
@@ -596,7 +620,7 @@ async def list_comments(
             detail=f"Case with ID {case_id} not found",
         )
     comments_svc = CaseCommentsService(session, role)
-    return await comments_svc.list_comments(case)
+    return await comments_svc.list_comments(case, limit=limit)
 
 
 @router.get("/{case_id}/comments/threads", status_code=HTTP_200_OK)
@@ -606,6 +630,12 @@ async def list_comment_threads(
     role: ExecutorWorkspaceRole,
     session: AsyncDBSession,
     case_id: uuid.UUID,
+    limit: int = Query(
+        config.TRACECAT__LIMIT_CASE_COMMENTS_DEFAULT,
+        ge=config.TRACECAT__LIMIT_MIN,
+        le=config.TRACECAT__LIMIT_CASE_COMMENTS_MAX,
+        description="Maximum comments to return before grouping threads",
+    ),
 ) -> list[CaseCommentThreadRead]:
     service = CasesService(session, role)
     case = await service.get_case(case_id)
@@ -615,7 +645,7 @@ async def list_comment_threads(
             detail=f"Case with ID {case_id} not found",
         )
     comments_svc = CaseCommentsService(session, role)
-    return await comments_svc.list_comment_threads(case)
+    return await comments_svc.list_comment_threads(case, limit=limit)
 
 
 @router.post("/{case_id}/comments", status_code=HTTP_201_CREATED)
@@ -822,7 +852,9 @@ async def list_events_with_users(
 class CaseMetricsRequest(Schema):
     """Request body for case metrics."""
 
-    case_ids: list[uuid.UUID]
+    case_ids: list[uuid.UUID] = Field(
+        max_length=config.TRACECAT__LIMIT_CASE_METRICS_MAX,
+    )
 
 
 @duration_router.post("/metrics", status_code=HTTP_200_OK)
@@ -839,6 +871,7 @@ async def get_case_metrics(
 
     cases_service = CasesService(session, role)
     duration_service = CaseDurationService(session, role)
+    requested_case_ids = list(dict.fromkeys(params.case_ids))
 
     field_definitions = await cases_service.fields.list_fields()
     field_schema = await cases_service.fields.get_field_schema()
@@ -847,19 +880,34 @@ async def get_case_metrics(
         for defn in field_definitions
     ]
 
-    cases = []
+    cases = await cases_service.get_cases(requested_case_ids)
+    cases_by_id = {case.id: case for case in cases}
+    missing_case_ids = [
+        case_id for case_id in requested_case_ids if case_id not in cases_by_id
+    ]
+    if missing_case_ids:
+        missing_case_id = missing_case_ids[0]
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"Case with ID {missing_case_id} not found",
+        )
+
+    cases = [cases_by_id[case_id] for case_id in requested_case_ids]
+    fields_by_case = await cases_service.fields.batch_get_fields(
+        case_ids=[case.id for case in cases],
+        field_ids=[field.id for field in field_templates],
+    )
+    dropdown_values_by_case = await _list_case_dropdown_values_by_case(
+        session=session,
+        role=role,
+        case_ids=[case.id for case in cases],
+    )
+
     case_context: dict[
         str, tuple[list[dict[str, Any]], list[CaseTagRead], list[CaseDropdownValueRead]]
     ] = {}
-    for case_id in params.case_ids:
-        case = await cases_service.get_case(case_id)
-        if case is None:
-            raise HTTPException(
-                status_code=HTTP_404_NOT_FOUND,
-                detail=f"Case with ID {case_id} not found",
-            )
-
-        fields = await cases_service.fields.get_fields(case) or {}
+    for case in cases:
+        fields = fields_by_case.get(case.id, {})
         field_reads = [
             CaseFieldRead(
                 **f.model_dump(),
@@ -871,12 +919,9 @@ async def get_case_metrics(
         tag_reads = [
             CaseTagRead.model_validate(tag, from_attributes=True) for tag in case.tags
         ]
-        dropdown_reads = await _list_case_dropdown_values(
-            session=session, role=role, case_id=case.id
-        )
+        dropdown_reads = dropdown_values_by_case.get(case.id, [])
 
         case_context[str(case.id)] = (field_dicts, tag_reads, dropdown_reads)
-        cases.append(case)
 
     metrics = await duration_service.compute_time_series(cases)
     enriched_metrics: list[CaseDurationMetric] = []

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -834,6 +834,28 @@ class CasesService(BaseWorkspaceService):
 
         return case
 
+    async def get_cases(self, case_ids: Sequence[uuid.UUID]) -> list[Case]:
+        """Get multiple workspace-scoped cases while preserving request order."""
+        if not case_ids:
+            return []
+
+        unique_case_ids = list(dict.fromkeys(case_ids))
+        statement = (
+            select(Case)
+            .where(
+                Case.workspace_id == self.workspace_id,
+                Case.id.in_(unique_case_ids),
+            )
+            .options(selectinload(Case.tags))
+        )
+        result = await self.session.execute(statement)
+        cases_by_id = {case.id: case for case in result.scalars().all()}
+        return [
+            case
+            for case_id in unique_case_ids
+            if (case := cases_by_id.get(case_id)) is not None
+        ]
+
     @require_scope("case:create")
     @audit_log(resource_type="case", action="create")
     async def create_case(self, params: CaseCreate) -> Case:
@@ -1869,6 +1891,7 @@ class CaseCommentsService(BaseWorkspaceService):
         *,
         case_id: uuid.UUID,
         thread_root_id: uuid.UUID | None = None,
+        limit: int | None = None,
     ) -> list[tuple[CaseComment, User | None]]:
         """List case comments with user information."""
         predicates: list[ColumnElement[bool]] = [CaseComment.case_id == case_id]
@@ -1886,19 +1909,25 @@ class CaseCommentsService(BaseWorkspaceService):
             .where(*predicates)
             .order_by(CaseComment.created_at, CaseComment.surrogate_id)
         )
+        if limit is not None:
+            statement = statement.limit(limit)
         result = await self.session.execute(statement)
         rows = result.tuples().all()
         return typing_cast(list[tuple[CaseComment, User | None]], rows)
 
-    async def list_comments(self, case: Case) -> list[CaseCommentRead]:
+    async def list_comments(
+        self, case: Case, *, limit: int | None = None
+    ) -> list[CaseCommentRead]:
         """List all comments for a case as a flat compatibility view."""
-        rows = await self._list_comment_rows(case_id=case.id)
+        rows = await self._list_comment_rows(case_id=case.id, limit=limit)
         return [self.serialize_comment(comment, user=user) for comment, user in rows]
 
-    async def list_comment_threads(self, case: Case) -> list[CaseCommentThreadRead]:
+    async def list_comment_threads(
+        self, case: Case, *, limit: int | None = None
+    ) -> list[CaseCommentThreadRead]:
         """List comments grouped by top-level thread."""
         await self._require_replies_entitlement()
-        rows = await self._list_comment_rows(case_id=case.id)
+        rows = await self._list_comment_rows(case_id=case.id, limit=limit)
         threads_by_id: dict[uuid.UUID, CaseCommentThreadRead] = {}
         ordered_threads: list[CaseCommentThreadRead] = []
 

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -859,11 +859,23 @@ TRACECAT__LIMIT_WORKFLOW_EXECUTIONS_MAX = 1000
 TRACECAT__LIMIT_TABLE_SEARCH_DEFAULT = min(100, TRACECAT__LIMIT_CURSOR_MAX)
 """Default page size for internal table search."""
 
+TRACECAT__LIMIT_TABLE_LOOKUP_DEFAULT = min(100, TRACECAT__LIMIT_CURSOR_MAX)
+"""Default row count for internal table lookup."""
+
 TRACECAT__LIMIT_TABLE_DOWNLOAD_MAX = 1000
 """Maximum row count for internal table downloads."""
 
 TRACECAT__LIMIT_TABLE_DOWNLOAD_DEFAULT = TRACECAT__LIMIT_TABLE_DOWNLOAD_MAX
 """Default row count for internal table download."""
+
+TRACECAT__LIMIT_CASE_COMMENTS_DEFAULT = min(100, TRACECAT__LIMIT_CURSOR_MAX)
+"""Default row count for internal case comment list endpoints."""
+
+TRACECAT__LIMIT_CASE_COMMENTS_MAX = TRACECAT__LIMIT_CURSOR_MAX
+"""Maximum row count for internal case comment list endpoints."""
+
+TRACECAT__LIMIT_CASE_METRICS_MAX = TRACECAT__LIMIT_CURSOR_MAX
+"""Maximum number of cases accepted by the internal case metrics endpoint."""
 
 # === Context Compression === #
 TRACECAT__CONTEXT_COMPRESSION_ENABLED = os.environ.get(

--- a/tracecat/tables/internal_router.py
+++ b/tracecat/tables/internal_router.py
@@ -47,8 +47,8 @@ class TableCreateRequest(BaseModel):
 class TableLookupRequest(BaseModel):
     columns: list[str]
     values: list[Any]
-    limit: int | None = Field(
-        default=None,
+    limit: int = Field(
+        default=config.TRACECAT__LIMIT_TABLE_LOOKUP_DEFAULT,
         ge=config.TRACECAT__LIMIT_MIN,
         le=config.TRACECAT__LIMIT_CURSOR_MAX,
     )
@@ -186,7 +186,7 @@ async def lookup_rows(
     params: TableLookupRequest,
 ) -> list[dict[str, Any]]:
     """Lookup rows matching column/value pairs."""
-    if params.limit is not None and params.limit > config.TRACECAT__LIMIT_CURSOR_MAX:
+    if params.limit > config.TRACECAT__LIMIT_CURSOR_MAX:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(

--- a/tracecat/tables/service.py
+++ b/tracecat/tables/service.py
@@ -1114,8 +1114,10 @@ class BaseTablesService(BaseWorkspaceService):
 
         table = await self.get_table_by_name(table_name)
         schema_name = self._get_schema_name()
-        table = await self.get_table_by_name(table_name)
         sanitized_table_name = self._sanitize_identifier(table.name)
+        row_limit = (
+            limit if limit is not None else config.TRACECAT__LIMIT_TABLE_LOOKUP_DEFAULT
+        )
 
         resolved_columns = [
             self._resolve_external_column_name(table, column_name)
@@ -1133,9 +1135,8 @@ class BaseTablesService(BaseWorkspaceService):
                     *[col == value for col, value in zip(cols, values, strict=True)]
                 )
             )
+            .limit(row_limit)
         )
-        if limit is not None:
-            stmt = stmt.limit(limit)
         txn_cm = (
             self.session.begin_nested()
             if self.session.in_transaction()


### PR DESCRIPTION
## Summary

- Add default/max bounds to hot `/internal` table lookup, case comments, and case metrics routes.
- Stop internal case reads from recording case-view events.
- Batch case metrics context loading for cases, custom fields, and dropdown values.
- Move attachment base64, file validation, hashing, and integrity checks off the async event loop.

## Tests

- `uv run pytest tests/unit/api/test_api_internal_cases.py tests/unit/api/test_api_internal_tables.py -q`
- `uv run pytest tests/unit/test_case_comments_service.py::TestCaseCommentsService::test_list_comments tests/unit/test_tables_service.py::TestTableRows::test_lookup_rows_applies_default_limit tests/unit/test_tables_service.py::TestTableRows::test_lookup_row_multiple tests/unit/test_case_attachments_service.py::test_create_list_download_delete_attachment -q`
- `uv run ruff check tracecat/config.py tracecat/tables/internal_router.py tracecat/tables/service.py tracecat/cases/internal_router.py tracecat/cases/service.py tracecat/cases/dropdowns/service.py tracecat/cases/attachments/internal_router.py tracecat/cases/attachments/service.py tests/unit/api/test_api_internal_tables.py tests/unit/api/test_api_internal_cases.py tests/unit/test_case_comments_service.py tests/unit/test_tables_service.py`
- `uv run ruff format --check tracecat/config.py tracecat/tables/internal_router.py tracecat/tables/service.py tracecat/cases/internal_router.py tracecat/cases/service.py tracecat/cases/dropdowns/service.py tracecat/cases/attachments/internal_router.py tracecat/cases/attachments/service.py tests/unit/api/test_api_internal_tables.py tests/unit/api/test_api_internal_cases.py tests/unit/test_case_comments_service.py tests/unit/test_tables_service.py`
- `uv run basedpyright tracecat/config.py tracecat/tables/internal_router.py tracecat/tables/service.py tracecat/cases/internal_router.py tracecat/cases/service.py tracecat/cases/dropdowns/service.py tracecat/cases/attachments/internal_router.py tracecat/cases/attachments/service.py tests/unit/api/test_api_internal_tables.py tests/unit/api/test_api_internal_cases.py tests/unit/test_case_comments_service.py tests/unit/test_tables_service.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound internal API workloads with sane defaults and max limits, batched case metrics context loading, and moved blocking attachment work off the event loop to improve stability and latency. Internal case reads no longer record case-view events.

- **Refactors**
  - Added bounded defaults/max in `tracecat.config` and applied them to table lookup, case comments, and case metrics.
  - Batched case metrics context: use `CasesService.get_cases`, `fields.batch_get_fields`, and dropdown batch loading to remove N+1 DB calls.
  - Offloaded attachment base64 work, file validation, hashing, and integrity checks via `asyncio.to_thread`.
  - Internal `get_case` now sets `track_view=False` to avoid view-side effects.

- **Bug Fixes**
  - Enforced limits and validation across table lookup, comments, and metrics; apply defaults when omitted and return 422 for oversized metrics batches.

<sup>Written for commit 2b83671a91abd2bcb57132247cbf0e8cd9f45935. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2712?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

