### PR TITLE
feat(approvals): delete stale approvals

### DIFF
--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -221,6 +221,8 @@ import type {
   AgentTagsUpdateAgentTagResponse,
   AgentUpdateProviderCredentialsData,
   AgentUpdateProviderCredentialsResponse,
+  ApprovalsDeleteApprovalData,
+  ApprovalsDeleteApprovalResponse,
   ApprovalsSubmitApprovalsData,
   ApprovalsSubmitApprovalsResponse,
   AuthAuthDatabaseLoginData,
@@ -6743,6 +6745,35 @@ export const approvalsSubmitApprovals = (
     },
     body: data.requestBody,
     mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete Approval
+ * Dismiss all pending approvals for a session.
+ *
+ * If the Temporal workflow is alive, deny the approvals so it fails at the
+ * agent step. If the workflow is already gone, delete the approval records
+ * directly. The session itself is left intact in both cases.
+ * @param data The data for the request.
+ * @param data.sessionId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const approvalsDeleteApproval = (
+  data: ApprovalsDeleteApprovalData
+): CancelablePromise<ApprovalsDeleteApprovalResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/workspaces/{workspace_id}/approvals/{session_id}",
+    path: {
+      session_id: data.sessionId,
+      workspace_id: data.workspaceId,
+    },
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -10748,6 +10748,13 @@ export type ApprovalsSubmitApprovalsData = {
 
 export type ApprovalsSubmitApprovalsResponse = void
 
+export type ApprovalsDeleteApprovalData = {
+  sessionId: string
+  workspaceId: string
+}
+
+export type ApprovalsDeleteApprovalResponse = void
+
 export type WatchtowerListWatchtowerAgentsData = {
   agentType?: WatchtowerAgentType | null
   cursor?: string | null
@@ -15734,6 +15741,19 @@ export type $OpenApiTs = {
   "/workspaces/{workspace_id}/approvals/{session_id}": {
     post: {
       req: ApprovalsSubmitApprovalsData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      req: ApprovalsDeleteApprovalData
       res: {
         /**
          * Successful Response

--- a/frontend/src/components/inbox/activity-accordion.tsx
+++ b/frontend/src/components/inbox/activity-accordion.tsx
@@ -64,7 +64,7 @@ interface ActivityAccordionProps {
   selectedId: string | null
   deletingId: string | null
   onSelect: (id: string) => void
-  onDelete: (id: string) => void
+  onDelete?: (id: string) => void
 }
 
 export function ActivityAccordion({
@@ -170,7 +170,11 @@ export function ActivityAccordion({
                       isSelected={selectedId === session.id}
                       isDeleting={deletingId === session.id}
                       onClick={() => onSelect(session.id)}
-                      onDelete={() => onDelete(session.id)}
+                      onDelete={
+                        onDelete && groupKey === "review_required"
+                          ? () => onDelete(session.id)
+                          : undefined
+                      }
                     />
                   ))}
                 </div>

--- a/frontend/src/components/inbox/activity-accordion.tsx
+++ b/frontend/src/components/inbox/activity-accordion.tsx
@@ -62,13 +62,17 @@ const GROUP_ORDER: StatusGroup[] = [
 interface ActivityAccordionProps {
   sessions: InboxSessionItem[]
   selectedId: string | null
+  deletingId: string | null
   onSelect: (id: string) => void
+  onDelete: (id: string) => void
 }
 
 export function ActivityAccordion({
   sessions,
   selectedId,
+  deletingId,
   onSelect,
+  onDelete,
 }: ActivityAccordionProps) {
   // Group sessions by status category
   const groupedSessions = useMemo(() => {
@@ -164,7 +168,9 @@ export function ActivityAccordion({
                       key={session.id}
                       session={session}
                       isSelected={selectedId === session.id}
+                      isDeleting={deletingId === session.id}
                       onClick={() => onSelect(session.id)}
+                      onDelete={() => onDelete(session.id)}
                     />
                   ))}
                 </div>

--- a/frontend/src/components/inbox/activity-item.tsx
+++ b/frontend/src/components/inbox/activity-item.tsx
@@ -6,10 +6,21 @@ import {
   Trash2Icon,
   WorkflowIcon,
 } from "lucide-react"
+import { useState } from "react"
 import {
   EventCreatedAt,
   EventUpdatedAt,
 } from "@/components/cases/cases-feed-event"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { Badge } from "@/components/ui/badge"
 import type { InboxSessionItem } from "@/lib/agents"
 import { cn } from "@/lib/utils"
@@ -75,7 +86,8 @@ export function ActivityItem({
   onClick,
   onDelete,
 }: ActivityItemProps) {
-  // Display name: prefer workflow alias, then parent workflow title, then session title
+  const [confirmOpen, setConfirmOpen] = useState(false)
+
   const displayName =
     session.parent_workflow?.alias ||
     session.parent_workflow?.title ||
@@ -85,61 +97,79 @@ export function ActivityItem({
   const sourceConfig = SOURCE_CONFIGS[sourceType]
   const SourceIcon = sourceConfig.icon
 
-  const handleDelete = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    onDelete?.()
-  }
-
   return (
-    <div
-      className={cn(
-        "-ml-[18px] group/item flex w-[calc(100%+18px)] items-center gap-3 py-2 pl-3 pr-3 transition-colors",
-        "hover:bg-muted/50",
-        isSelected && "bg-muted"
-      )}
-    >
-      <button
-        type="button"
-        onClick={onClick}
-        className="flex min-w-0 flex-1 items-center gap-3 text-left"
-      >
-        {/* Spacer to align with accordion chevron (h-7 w-7) */}
-        <div className="h-7 w-7 shrink-0" />
-
-        {/* Agent name + badge */}
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <span className="truncate text-xs">{displayName}</span>
-          <Badge
-            variant="secondary"
-            className="shrink-0 gap-1 text-[10px] px-1.5 py-0 h-5 font-normal"
-          >
-            <SourceIcon className="size-3" />
-            {sourceConfig.label}
-          </Badge>
-        </div>
-
-        {/* Timestamps */}
-        <div className="flex shrink-0 items-center gap-2">
-          <EventCreatedAt createdAt={session.created_at} />
-          <EventUpdatedAt updatedAt={session.updated_at} />
-        </div>
-      </button>
-
-      {/* Delete button — visible on row hover */}
-      <button
-        type="button"
-        onClick={handleDelete}
-        disabled={isDeleting}
+    <>
+      <div
         className={cn(
-          "flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors",
-          "opacity-0 group-hover/item:opacity-100",
-          "hover:bg-destructive/10 hover:text-destructive",
-          isDeleting && "cursor-not-allowed opacity-50"
+          "-ml-[18px] group/item flex w-[calc(100%+18px)] items-center gap-3 py-2 pl-3 pr-3 transition-colors",
+          "hover:bg-muted/50",
+          isSelected && "bg-muted"
         )}
-        aria-label="Delete approval"
       >
-        <Trash2Icon className="size-3.5" />
-      </button>
-    </div>
+        <button
+          type="button"
+          onClick={onClick}
+          className="flex min-w-0 flex-1 items-center gap-3 text-left"
+        >
+          <div className="h-7 w-7 shrink-0" />
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <span className="truncate text-xs">{displayName}</span>
+            <Badge
+              variant="secondary"
+              className="shrink-0 gap-1 text-[10px] px-1.5 py-0 h-5 font-normal"
+            >
+              <SourceIcon className="size-3" />
+              {sourceConfig.label}
+            </Badge>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <EventCreatedAt createdAt={session.created_at} />
+            <EventUpdatedAt updatedAt={session.updated_at} />
+          </div>
+        </button>
+
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            setConfirmOpen(true)
+          }}
+          disabled={isDeleting}
+          className={cn(
+            "flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors",
+            "opacity-0 group-hover/item:opacity-100",
+            "hover:bg-destructive/10 hover:text-destructive",
+            isDeleting && "cursor-not-allowed opacity-50"
+          )}
+          aria-label="Delete approval"
+        >
+          <Trash2Icon className="size-3.5" />
+        </button>
+      </div>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete approval</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will deny all pending tool calls and remove this approval
+              from the inbox.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                setConfirmOpen(false)
+                onDelete?.()
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   )
 }

--- a/frontend/src/components/inbox/activity-item.tsx
+++ b/frontend/src/components/inbox/activity-item.tsx
@@ -128,23 +128,25 @@ export function ActivityItem({
           </div>
         </button>
 
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
-            setConfirmOpen(true)
-          }}
-          disabled={isDeleting}
-          className={cn(
-            "flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors",
-            "opacity-0 group-hover/item:opacity-100",
-            "hover:bg-destructive/10 hover:text-destructive",
-            isDeleting && "cursor-not-allowed opacity-50"
-          )}
-          aria-label="Delete approval"
-        >
-          <Trash2Icon className="size-3.5" />
-        </button>
+        {onDelete && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              setConfirmOpen(true)
+            }}
+            disabled={isDeleting}
+            className={cn(
+              "flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors",
+              "opacity-0 group-hover/item:opacity-100",
+              "hover:bg-destructive/10 hover:text-destructive",
+              isDeleting && "cursor-not-allowed opacity-50"
+            )}
+            aria-label="Delete approval"
+          >
+            <Trash2Icon className="size-3.5" />
+          </button>
+        )}
       </div>
 
       <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>

--- a/frontend/src/components/inbox/activity-item.tsx
+++ b/frontend/src/components/inbox/activity-item.tsx
@@ -3,6 +3,7 @@ import {
   FlaskConicalIcon,
   LayersIcon,
   MessageSquareIcon,
+  Trash2Icon,
   WorkflowIcon,
 } from "lucide-react"
 import {
@@ -16,7 +17,9 @@ import { cn } from "@/lib/utils"
 interface ActivityItemProps {
   session: InboxSessionItem
   isSelected: boolean
+  isDeleting?: boolean
   onClick: () => void
+  onDelete?: () => void
 }
 
 type SourceType = "workflow" | "case" | "chat" | "test" | "assistant"
@@ -68,7 +71,9 @@ function getSourceType(entityType: string): SourceType {
 export function ActivityItem({
   session,
   isSelected,
+  isDeleting,
   onClick,
+  onDelete,
 }: ActivityItemProps) {
   // Display name: prefer workflow alias, then parent workflow title, then session title
   const displayName =
@@ -80,37 +85,61 @@ export function ActivityItem({
   const sourceConfig = SOURCE_CONFIGS[sourceType]
   const SourceIcon = sourceConfig.icon
 
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onDelete?.()
+  }
+
   return (
-    <button
-      type="button"
-      onClick={onClick}
+    <div
       className={cn(
-        // Use negative margins to extend hover to full width
-        "-ml-[18px] flex w-[calc(100%+18px)] items-center gap-3 py-2 pl-3 pr-3 text-left transition-colors",
+        "-ml-[18px] group/item flex w-[calc(100%+18px)] items-center gap-3 py-2 pl-3 pr-3 transition-colors",
         "hover:bg-muted/50",
         isSelected && "bg-muted"
       )}
     >
-      {/* Spacer to align with accordion chevron (h-7 w-7) */}
-      <div className="h-7 w-7 shrink-0" />
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex min-w-0 flex-1 items-center gap-3 text-left"
+      >
+        {/* Spacer to align with accordion chevron (h-7 w-7) */}
+        <div className="h-7 w-7 shrink-0" />
 
-      {/* Agent name + badge */}
-      <div className="flex min-w-0 flex-1 items-center gap-2">
-        <span className="truncate text-xs">{displayName}</span>
-        <Badge
-          variant="secondary"
-          className="shrink-0 gap-1 text-[10px] px-1.5 py-0 h-5 font-normal"
-        >
-          <SourceIcon className="size-3" />
-          {sourceConfig.label}
-        </Badge>
-      </div>
+        {/* Agent name + badge */}
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <span className="truncate text-xs">{displayName}</span>
+          <Badge
+            variant="secondary"
+            className="shrink-0 gap-1 text-[10px] px-1.5 py-0 h-5 font-normal"
+          >
+            <SourceIcon className="size-3" />
+            {sourceConfig.label}
+          </Badge>
+        </div>
 
-      {/* Timestamps */}
-      <div className="flex shrink-0 items-center gap-2">
-        <EventCreatedAt createdAt={session.created_at} />
-        <EventUpdatedAt updatedAt={session.updated_at} />
-      </div>
-    </button>
+        {/* Timestamps */}
+        <div className="flex shrink-0 items-center gap-2">
+          <EventCreatedAt createdAt={session.created_at} />
+          <EventUpdatedAt updatedAt={session.updated_at} />
+        </div>
+      </button>
+
+      {/* Delete button — visible on row hover */}
+      <button
+        type="button"
+        onClick={handleDelete}
+        disabled={isDeleting}
+        className={cn(
+          "flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors",
+          "opacity-0 group-hover/item:opacity-100",
+          "hover:bg-destructive/10 hover:text-destructive",
+          isDeleting && "cursor-not-allowed opacity-50"
+        )}
+        aria-label="Delete approval"
+      >
+        <Trash2Icon className="size-3.5" />
+      </button>
+    </div>
   )
 }

--- a/frontend/src/components/inbox/index.tsx
+++ b/frontend/src/components/inbox/index.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { useInboxChat } from "@/app/workspaces/[workspaceId]/inbox/layout"
 import type { AgentSessionEntity } from "@/client"
 import { CenteredSpinner } from "@/components/loading/spinner"
@@ -42,8 +42,18 @@ export function ActivityLayout({
   onCreatedAfterChange,
 }: ActivityLayoutProps) {
   const { setSelectedSession, setChatOpen, registerOnClose } = useInboxChat()
-  const { mutateAsync: deleteApproval, variables: deletingId } =
-    useDeleteApproval()
+  const {
+    mutateAsync: deleteApproval,
+    variables,
+    isPending: isDeletePending,
+  } = useDeleteApproval()
+  const deletingId = isDeletePending ? (variables ?? null) : null
+
+  // Always reflects the current selectedId without closing over a stale value.
+  const selectedIdRef = useRef(selectedId)
+  useEffect(() => {
+    selectedIdRef.current = selectedId
+  }, [selectedId])
 
   // Sync selected session with layout context
   const selectedSession = sessions.find((s) => s.id === selectedId) ?? null
@@ -65,7 +75,7 @@ export function ActivityLayout({
   const handleDeleteItem = async (id: string) => {
     try {
       await deleteApproval(id)
-      if (selectedId === id) {
+      if (selectedIdRef.current === id) {
         onSelect(null)
       }
     } catch {

--- a/frontend/src/components/inbox/index.tsx
+++ b/frontend/src/components/inbox/index.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react"
 import { useInboxChat } from "@/app/workspaces/[workspaceId]/inbox/layout"
 import type { AgentSessionEntity } from "@/client"
+import { useScopeCheck } from "@/components/auth/scope-guard"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { toast } from "@/components/ui/use-toast"
 import {
@@ -42,6 +43,7 @@ export function ActivityLayout({
   onCreatedAfterChange,
 }: ActivityLayoutProps) {
   const { setSelectedSession, setChatOpen, registerOnClose } = useInboxChat()
+  const canDeleteApproval = useScopeCheck("agent:delete")
   const {
     mutateAsync: deleteApproval,
     variables,
@@ -153,7 +155,7 @@ export function ActivityLayout({
           selectedId={selectedId}
           deletingId={deletingId ?? null}
           onSelect={handleSelectItem}
-          onDelete={handleDeleteItem}
+          onDelete={canDeleteApproval ? handleDeleteItem : undefined}
         />
       </div>
     </div>

--- a/frontend/src/components/inbox/index.tsx
+++ b/frontend/src/components/inbox/index.tsx
@@ -4,7 +4,12 @@ import { useEffect } from "react"
 import { useInboxChat } from "@/app/workspaces/[workspaceId]/inbox/layout"
 import type { AgentSessionEntity } from "@/client"
 import { CenteredSpinner } from "@/components/loading/spinner"
-import type { DateFilterValue, UseInboxFilters } from "@/hooks/use-inbox"
+import { toast } from "@/components/ui/use-toast"
+import {
+  type DateFilterValue,
+  type UseInboxFilters,
+  useDeleteApproval,
+} from "@/hooks/use-inbox"
 import type { InboxSessionItem } from "@/lib/agents"
 import { ActivityAccordion } from "./activity-accordion"
 import { InboxHeader } from "./inbox-header"
@@ -37,6 +42,8 @@ export function ActivityLayout({
   onCreatedAfterChange,
 }: ActivityLayoutProps) {
   const { setSelectedSession, setChatOpen, registerOnClose } = useInboxChat()
+  const { mutateAsync: deleteApproval, variables: deletingId } =
+    useDeleteApproval()
 
   // Sync selected session with layout context
   const selectedSession = sessions.find((s) => s.id === selectedId) ?? null
@@ -53,6 +60,21 @@ export function ActivityLayout({
 
   const handleSelectItem = (id: string) => {
     onSelect(id)
+  }
+
+  const handleDeleteItem = async (id: string) => {
+    try {
+      await deleteApproval(id)
+      if (selectedId === id) {
+        onSelect(null)
+      }
+    } catch {
+      toast({
+        title: "Failed to delete approval",
+        description: "Could not delete this approval. Please try again.",
+        variant: "destructive",
+      })
+    }
   }
 
   if (isLoading) {
@@ -119,7 +141,9 @@ export function ActivityLayout({
         <ActivityAccordion
           sessions={sessions}
           selectedId={selectedId}
+          deletingId={deletingId ?? null}
           onSelect={handleSelectItem}
+          onDelete={handleDeleteItem}
         />
       </div>
     </div>

--- a/frontend/src/hooks/use-inbox.ts
+++ b/frontend/src/hooks/use-inbox.ts
@@ -1,9 +1,15 @@
 "use client"
 
-import { type Query, useQuery } from "@tanstack/react-query"
+import {
+  type Query,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import {
   type AgentSessionEntity,
+  approvalsDeleteApproval,
   type InboxItemRead,
   type InboxItemStatus,
   type InboxListItemsResponse,
@@ -362,4 +368,17 @@ export function useInbox(options: UseInboxOptions = {}): UseInboxResult {
     setUpdatedAfter,
     setCreatedAfter,
   }
+}
+
+export function useDeleteApproval() {
+  const workspaceId = useWorkspaceId()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (sessionId: string) =>
+      approvalsDeleteApproval({ sessionId, workspaceId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["inbox-items"] })
+    },
+  })
 }

--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
@@ -72,6 +72,7 @@ def _to_approval_decisions(approvals: ApprovalMap) -> list[ApprovalDecision]:
 
 
 @router.post("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+@require_scope("agent:update")
 async def submit_approvals(
     *,
     role: WorkspaceUserRouteRole,
@@ -151,7 +152,7 @@ async def submit_approvals(
 
 
 @router.delete("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
-@require_scope("agent:execute")
+@require_scope("agent:delete")
 async def delete_approval(
     *,
     role: WorkspaceUserRouteRole,
@@ -203,10 +204,13 @@ async def delete_approval(
             session_id,
             ContinueRunRequest(decisions=decisions, source="inbox"),
         )
+        return
     except Exception:
         logger.warning(
-            "Workflow handle dead or unavailable; deleting approval records directly",
+            "run_turn failed; deleting approval records directly",
             session_id=str(session_id),
+            exc_info=True,
         )
-        for approval in pending:
-            await approval_service.delete_approval(approval)
+
+    for approval in pending:
+        await approval_service.delete_approval(approval)

--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
@@ -6,14 +6,16 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.types import ToolApproved, ToolDenied
 from tracecat.auth.dependencies import WorkspaceUserRouteRole
+from tracecat.authz.controls import require_scope
 from tracecat.chat.schemas import ApprovalDecision, ContinueRunRequest
 from tracecat.db.engine import get_async_session
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.logger import logger
-from tracecat_ee.agent.approvals.service import ApprovalMap
+from tracecat_ee.agent.approvals.service import ApprovalMap, ApprovalService
 
 router = APIRouter(prefix="/approvals", tags=["approvals"])
 
@@ -146,3 +148,65 @@ async def submit_approvals(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to submit approvals",
         ) from exc
+
+
+@router.delete("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+@require_scope("agent:execute")
+async def delete_approval(
+    *,
+    role: WorkspaceUserRouteRole,
+    session_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+) -> None:
+    """Dismiss all pending approvals for a session.
+
+    If the Temporal workflow is alive, deny the approvals so it fails at the
+    agent step. If the workflow is already gone, delete the approval records
+    directly. The session itself is left intact in both cases.
+    """
+    workspace_id = role.workspace_id
+    if workspace_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Workspace access required",
+        )
+
+    session_service = AgentSessionService(session, role)
+    approval_service = ApprovalService(session=session, role=role)
+
+    agent_session = await session_service.get_session(session_id)
+    if agent_session is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Agent session not found",
+        )
+
+    pending = [
+        a
+        for a in await approval_service.list_approvals_for_session(session_id)
+        if a.status == ApprovalStatus.PENDING
+    ]
+
+    if not pending:
+        return
+
+    decisions = [
+        ApprovalDecision(
+            tool_call_id=a.tool_call_id,
+            action="deny",
+            reason="Dismissed from approvals inbox",
+        )
+        for a in pending
+    ]
+    try:
+        await session_service.run_turn(
+            session_id,
+            ContinueRunRequest(decisions=decisions, source="inbox"),
+        )
+    except Exception:
+        logger.warning(
+            "Workflow handle dead or unavailable; deleting approval records directly",
+            session_id=str(session_id),
+        )
+        for approval in pending:
+            await approval_service.delete_approval(approval)

--- a/tests/unit/test_approvals_delete.py
+++ b/tests/unit/test_approvals_delete.py
@@ -1,0 +1,191 @@
+"""Tests for DELETE /approvals/{session_id} (delete_approval endpoint)."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from tracecat_ee.agent.approvals.router import delete_approval
+
+from tracecat.agent.approvals.enums import ApprovalStatus
+from tracecat.auth.types import Role
+
+
+def _execute_role(workspace_id: uuid.UUID) -> Role:
+    return Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute"}),
+    )
+
+
+def _approval_stub(tool_call_id: str, status: ApprovalStatus) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        tool_call_id=tool_call_id,
+        status=status,
+    )
+
+
+@pytest.mark.anyio
+async def test_delete_approval_denies_pending_via_run_turn() -> None:
+    """Workflow alive: pending approvals are denied via run_turn, session is kept."""
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    pending = _approval_stub("tool_call_1", ApprovalStatus.PENDING)
+    already_resolved = _approval_stub("tool_call_2", ApprovalStatus.APPROVED)
+    session_stub = SimpleNamespace(id=session_id)
+
+    fake_session_svc = SimpleNamespace(
+        get_session=AsyncMock(return_value=session_stub),
+        run_turn=AsyncMock(return_value=None),
+    )
+    fake_approval_svc = SimpleNamespace(
+        list_approvals_for_session=AsyncMock(return_value=[pending, already_resolved]),
+        delete_approval=AsyncMock(return_value=None),
+    )
+
+    with (
+        patch(
+            "tracecat_ee.agent.approvals.router.AgentSessionService",
+            return_value=fake_session_svc,
+        ),
+        patch(
+            "tracecat_ee.agent.approvals.router.ApprovalService",
+            return_value=fake_approval_svc,
+        ),
+    ):
+        raw = cast(Any, delete_approval).__wrapped__
+        await raw(
+            role=_execute_role(workspace_id),
+            session_id=session_id,
+            session=AsyncMock(),
+        )
+
+    # Only the pending approval goes into the deny decisions
+    decisions = fake_session_svc.run_turn.call_args.args[1].decisions
+    assert len(decisions) == 1
+    assert decisions[0].tool_call_id == "tool_call_1"
+    assert decisions[0].action == "deny"
+
+    # Session is not deleted, approval records are not directly deleted
+    fake_approval_svc.delete_approval.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_delete_approval_deletes_records_when_workflow_dead() -> None:
+    """Workflow dead: run_turn fails, approval records are deleted directly."""
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    pending = _approval_stub("tool_call_1", ApprovalStatus.PENDING)
+    session_stub = SimpleNamespace(id=session_id)
+
+    fake_session_svc = SimpleNamespace(
+        get_session=AsyncMock(return_value=session_stub),
+        run_turn=AsyncMock(side_effect=RuntimeError("Temporal workflow not found")),
+    )
+    fake_approval_svc = SimpleNamespace(
+        list_approvals_for_session=AsyncMock(return_value=[pending]),
+        delete_approval=AsyncMock(return_value=None),
+    )
+
+    with (
+        patch(
+            "tracecat_ee.agent.approvals.router.AgentSessionService",
+            return_value=fake_session_svc,
+        ),
+        patch(
+            "tracecat_ee.agent.approvals.router.ApprovalService",
+            return_value=fake_approval_svc,
+        ),
+    ):
+        raw = cast(Any, delete_approval).__wrapped__
+        await raw(
+            role=_execute_role(workspace_id),
+            session_id=session_id,
+            session=AsyncMock(),
+        )
+
+    fake_session_svc.run_turn.assert_awaited_once()
+    # Falls back to direct approval record deletion
+    fake_approval_svc.delete_approval.assert_awaited_once_with(pending)
+
+
+@pytest.mark.anyio
+async def test_delete_approval_no_op_when_no_pending() -> None:
+    """No pending approvals: returns immediately without calling run_turn or delete."""
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    session_stub = SimpleNamespace(id=session_id)
+
+    fake_session_svc = SimpleNamespace(
+        get_session=AsyncMock(return_value=session_stub),
+        run_turn=AsyncMock(return_value=None),
+    )
+    fake_approval_svc = SimpleNamespace(
+        list_approvals_for_session=AsyncMock(return_value=[]),
+        delete_approval=AsyncMock(return_value=None),
+    )
+
+    with (
+        patch(
+            "tracecat_ee.agent.approvals.router.AgentSessionService",
+            return_value=fake_session_svc,
+        ),
+        patch(
+            "tracecat_ee.agent.approvals.router.ApprovalService",
+            return_value=fake_approval_svc,
+        ),
+    ):
+        raw = cast(Any, delete_approval).__wrapped__
+        await raw(
+            role=_execute_role(workspace_id),
+            session_id=session_id,
+            session=AsyncMock(),
+        )
+
+    fake_session_svc.run_turn.assert_not_awaited()
+    fake_approval_svc.delete_approval.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_delete_approval_returns_404_when_session_not_found() -> None:
+    """Missing session returns 404 without touching approvals."""
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+
+    fake_session_svc = SimpleNamespace(
+        get_session=AsyncMock(return_value=None),
+        run_turn=AsyncMock(return_value=None),
+    )
+    fake_approval_svc = SimpleNamespace(
+        list_approvals_for_session=AsyncMock(return_value=[]),
+        delete_approval=AsyncMock(return_value=None),
+    )
+
+    with (
+        patch(
+            "tracecat_ee.agent.approvals.router.AgentSessionService",
+            return_value=fake_session_svc,
+        ),
+        patch(
+            "tracecat_ee.agent.approvals.router.ApprovalService",
+            return_value=fake_approval_svc,
+        ),
+    ):
+        raw = cast(Any, delete_approval).__wrapped__
+        with pytest.raises(HTTPException) as exc_info:
+            await raw(
+                role=_execute_role(workspace_id),
+                session_id=session_id,
+                session=AsyncMock(),
+            )
+
+    assert exc_info.value.status_code == 404
+    fake_approval_svc.list_approvals_for_session.assert_not_awaited()


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a “Delete approval” action to the inbox with a backend endpoint to dismiss all pending approvals for a session. It cleans up stale approvals by denying live workflows or deleting orphaned records, keeps sessions intact, and is gated by `agent:delete`.

- **New Features**
  - Backend: `DELETE /workspaces/{workspace_id}/approvals/{session_id}` returns 204 and requires `agent:delete`. Denies pending tool calls via `run_turn`; on failure, deletes approval records. Enforces `agent:update` on `POST /approvals/{session_id}`.
  - Frontend: Trash button is shown only for “Review required” items and only to users with `agent:delete`. Shows a confirmation dialog, disables while deleting, clears selection if the deleted item was open, and shows an error toast on failure.
  - Hooks/API: `approvalsDeleteApproval` client and `useDeleteApproval` mutation that invalidates `inbox-items` on success.
  - Tests: Coverage for denying via `run_turn`, fallback deletion when the workflow is dead, no-op when nothing is pending, and 404 when the session is missing.

<sup>Written for commit 07f619f8a7587ab23c0a6ed45290a2d59d1bb5c4. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2714?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

https://github.com/user-attachments/assets/6bafdf1d-c890-4b49-a21a-9f397cacf2d1



