### PR TITLE
fix(registry): cap squashfs sync resources

### DIFF
--- a/tests/unit/test_registry_sync_tarball.py
+++ b/tests/unit/test_registry_sync_tarball.py
@@ -101,6 +101,7 @@ def test_create_squashfs_image_makes_mount_root_traversable(
     def fake_subprocess_run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
         staging_dir = Path(cmd[1])
         assert staging_dir.stat().st_mode & 0o777 == 0o755
+        assert cmd[-4:] == ["-processors", "1", "-mem", "200M"]
         image_path.write_bytes(b"squashfs")
         return subprocess.CompletedProcess(cmd, 0, "", "")
 

--- a/tests/unit/test_registry_sync_tarball.py
+++ b/tests/unit/test_registry_sync_tarball.py
@@ -96,12 +96,16 @@ def test_create_squashfs_image_makes_mount_root_traversable(
     monkeypatch.setattr(
         tarball.config, "TRACECAT__REGISTRY_SYNC_SQUASHFS_ENABLED", True
     )
+    monkeypatch.setattr(
+        tarball.config, "TRACECAT__REGISTRY_SYNC_SQUASHFS_PROCESSORS", 2
+    )
+    monkeypatch.setattr(tarball.config, "TRACECAT__REGISTRY_SYNC_SQUASHFS_MEM", "256M")
     monkeypatch.setattr(tarball.shutil, "which", lambda _name: "/usr/bin/mksquashfs")
 
     def fake_subprocess_run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
         staging_dir = Path(cmd[1])
         assert staging_dir.stat().st_mode & 0o777 == 0o755
-        assert cmd[-4:] == ["-processors", "1", "-mem", "200M"]
+        assert cmd[-4:] == ["-processors", "2", "-mem", "256M"]
         image_path.write_bytes(b"squashfs")
         return subprocess.CompletedProcess(cmd, 0, "", "")
 

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -1143,6 +1143,16 @@ TRACECAT__REGISTRY_SYNC_SQUASHFS_ENABLED = os.environ.get(
 ).lower() in ("true", "1")
 """Build SquashFS sidecars for registry tarball venvs when mksquashfs is available."""
 
+TRACECAT__REGISTRY_SYNC_SQUASHFS_PROCESSORS = int(
+    os.environ.get("TRACECAT__REGISTRY_SYNC_SQUASHFS_PROCESSORS") or 1
+)
+"""Number of processors mksquashfs may use for registry SquashFS sidecar builds."""
+
+TRACECAT__REGISTRY_SYNC_SQUASHFS_MEM = os.environ.get(
+    "TRACECAT__REGISTRY_SYNC_SQUASHFS_MEM", "200M"
+)
+"""Memory budget passed to mksquashfs for registry SquashFS sidecar builds."""
+
 TRACECAT__BUILTIN_REGISTRY_SOURCE_PATH = os.environ.get(
     "TRACECAT__BUILTIN_REGISTRY_SOURCE_PATH", "/app/packages/tracecat-registry"
 )

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -1148,8 +1148,8 @@ TRACECAT__REGISTRY_SYNC_SQUASHFS_PROCESSORS = int(
 )
 """Number of processors mksquashfs may use for registry SquashFS sidecar builds."""
 
-TRACECAT__REGISTRY_SYNC_SQUASHFS_MEM = os.environ.get(
-    "TRACECAT__REGISTRY_SYNC_SQUASHFS_MEM", "200M"
+TRACECAT__REGISTRY_SYNC_SQUASHFS_MEM = (
+    os.environ.get("TRACECAT__REGISTRY_SYNC_SQUASHFS_MEM") or "200M"
 )
 """Memory budget passed to mksquashfs for registry SquashFS sidecar builds."""
 

--- a/tracecat/registry/sync/tarball.py
+++ b/tracecat/registry/sync/tarball.py
@@ -176,6 +176,10 @@ def _create_squashfs_image(
             "gzip",
             "-no-xattrs",
             "-all-root",
+            "-processors",
+            str(config.TRACECAT__REGISTRY_SYNC_SQUASHFS_PROCESSORS),
+            "-mem",
+            config.TRACECAT__REGISTRY_SYNC_SQUASHFS_MEM,
         ]
         result = subprocess_run(cmd)
         if result.returncode != 0:


### PR DESCRIPTION
## Summary
- cap `mksquashfs` registry sidecar builds with configurable processor and memory limits
- default the SquashFS build budget to 1 processor / 200M so API startup sync cannot consume the whole pod
- update the unit test to assert the bounded `mksquashfs` invocation
- include the k8s submodule pointer for TracecatHQ/k8s#56, which wires the Helm defaults/env vars

## Related
- TracecatHQ/k8s#56

## Test plan
- `uv run pytest tests/unit/test_registry_sync_tarball.py`
- `uv run ruff check tracecat/config.py tracecat/registry/sync/tarball.py tests/unit/test_registry_sync_tarball.py`
- `uv run basedpyright tracecat/config.py tracecat/registry/sync/tarball.py tests/unit/test_registry_sync_tarball.py`
- `uv run ruff format --check tracecat/config.py tracecat/registry/sync/tarball.py tests/unit/test_registry_sync_tarball.py`
- `helm lint deployments/k8s/helm/tracecat`
- `helm lint deployments/k8s/helm/tracecat -f deployments/k8s/helm/examples/values-ci.yaml`
- `helm template tracecat deployments/k8s/helm/tracecat -f deployments/k8s/helm/examples/values-ci.yaml --set tracecat.registrySync.squashfs.enabled=false --set tracecat.registrySync.squashfs.processors=2 --set tracecat.registrySync.squashfs.memory=256M | rg -n "TRACECAT__REGISTRY_SYNC_(SQUASHFS|BUILTIN)" -A1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps SquashFS sidecar builds during registry sync by limiting `mksquashfs` CPU and memory. Defaults to 1 processor and 200M so API startup sync doesn’t monopolize the pod.

- **Bug Fixes**
  - Add CPU/memory caps via `TRACECAT__REGISTRY_SYNC_SQUASHFS_PROCESSORS` and `TRACECAT__REGISTRY_SYNC_SQUASHFS_MEM` (defaults: 1, 200M; empty `*_MEM` falls back to 200M).
  - Pass `-processors` and `-mem` to `mksquashfs` during sync.
  - Update unit test to assert these flags.

- **Dependencies**
  - Update `deployments/k8s` submodule to pull Helm defaults and env wiring from `TracecatHQ/k8s#56`.

<sup>Written for commit f556045120486e7cddb6180cab8e8aace1eec9a5. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2716?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

