### PR TITLE
fix(agents): collapse duplicate Authorization headers in MCP discovery

### DIFF
--- a/tests/unit/test_agent_mcp_user_client.py
+++ b/tests/unit/test_agent_mcp_user_client.py
@@ -1,7 +1,8 @@
 import pytest
+from fastmcp.client.transports import StreamableHttpTransport
 
 from tracecat.agent.common.types import MCPHttpServerConfig, MCPToolDefinition
-from tracecat.agent.mcp.user_client import UserMCPClient
+from tracecat.agent.mcp.user_client import UserMCPClient, _create_transport
 
 
 def _mcp_server(name: str) -> MCPHttpServerConfig:
@@ -69,3 +70,57 @@ async def test_discover_tools_fails_closed_in_strict_mode(
         match="Failed to discover tools from user MCP server 'broken'",
     ):
         await client.discover_tools(fail_on_error=True)
+
+
+# Regression: fastmcp's StreamableHttpTransport.connect_session merges any
+# inbound `authorization` header (from get_http_headers) with the transport's
+# configured headers using `inbound | self.headers`. If our headers use a
+# different case for the Authorization key, both end up in the outgoing
+# request and httpx joins their values with ", " — Cloudflare 400s the
+# malformed header. Normalize keys to lowercase so the dict union collapses
+# the two entries and our configured value always wins.
+
+
+def test_create_transport_lowercases_authorization_so_inbound_jwt_cannot_stack() -> (
+    None
+):
+    """fastmcp does `inbound_lowercase_headers | transport.headers`.
+
+    If our key is "Authorization" (uppercase A), the union keeps both
+    `authorization` (the inbound forwarded JWT) and `Authorization` (ours),
+    and httpx serializes them as `<jwt>, <our-token>`. Lowercasing our keys
+    ensures the union collapses to a single `authorization` entry whose
+    value is ours.
+    """
+    transport = _create_transport(
+        url="https://mcp.example.com/mcp",
+        transport_type="http",
+        headers={"Authorization": "Bearer real-token"},
+        timeout=None,
+    )
+    assert isinstance(transport, StreamableHttpTransport)
+    assert "Authorization" not in transport.headers
+    assert transport.headers.get("authorization") == "Bearer real-token"
+
+
+def test_create_transport_lowercased_headers_survive_inbound_merge() -> None:
+    """Simulate fastmcp.connect_session's merge to lock the contract.
+
+    fastmcp computes: `get_http_headers(include={'authorization'}) | self.headers`.
+    With our lowercase normalization, an inbound forwarded JWT must not
+    survive that merge — our configured Notion bearer must win.
+    """
+    transport = _create_transport(
+        url="https://mcp.example.com/mcp",
+        transport_type="http",
+        headers={"Authorization": "Bearer notion-real"},
+        timeout=None,
+    )
+    assert isinstance(transport, StreamableHttpTransport)
+
+    simulated_inbound = {"authorization": "Bearer tracecat-inbound-jwt"}
+    merged = simulated_inbound | transport.headers
+
+    assert merged.get("authorization") == "Bearer notion-real"
+    auth_keys = [k for k in merged if k.lower() == "authorization"]
+    assert auth_keys == ["authorization"]

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -29,6 +29,11 @@ def _create_transport(
     timeout: int | None = None,
 ) -> StreamableHttpTransport | SSETransport:
     """Create the appropriate transport for the MCP server."""
+    # FastMCP forwards inbound authorization as lowercase from request context.
+    # Normalize configured headers so outbound auth overrides it instead of
+    # producing duplicate Authorization headers with different casing.
+    if headers is not None:
+        headers = {name.lower(): value for name, value in headers.items()}
     if transport_type == "sse":
         return SSETransport(url=url, headers=headers, sse_read_timeout=timeout)
     # Default to HTTP (Streamable HTTP transport)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes duplicate Authorization headers during MCP discovery by lowercasing configured header keys so the `fastmcp` merge collapses to a single `authorization` using our token. Prevents malformed headers that caused 400s behind Cloudflare.

- **Bug Fixes**
  - Normalize headers in `_create_transport` to lowercase before creating the transport.
  - Ensure outbound `authorization` overrides inbound forwarded JWT from `fastmcp`.
  - Add regression tests to verify no mixed-case duplicates and correct merge behavior.

<sup>Written for commit 49d1a61f497a0c0c5460084bbe986bbbb0209a72. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2717?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

