### PR TITLE
feat(executor): route action SDK calls through gateway

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,11 @@
 	"python.testing.pytestArgs": ["tests"],
 	"python.testing.unittestEnabled": false,
 	"python.testing.pytestEnabled": true,
-	"python.analysis.extraPaths": ["./registry"],
+	"python.analysis.extraPaths": [
+		"./packages/tracecat-registry",
+		"./packages/tracecat-admin",
+		"./packages/tracecat-ee"
+	],
 	"biome.configurationPath": "./frontend/biome.json",
 	"biome.enabled": true,
 	"biome.lsp.bin": "./frontend/node_modules/.bin/biome",

--- a/packages/tracecat-registry/pyproject.toml
+++ b/packages/tracecat-registry/pyproject.toml
@@ -70,6 +70,9 @@ pattern = '^__pep440_version__ = "(?P<version>[^"]+)"'
 strict = true
 ignore_missing_imports = true
 
+[tool.pyrefly]
+search-path = ["."]
+
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true

--- a/packages/tracecat-registry/tracecat_registry/context.py
+++ b/packages/tracecat-registry/tracecat_registry/context.py
@@ -39,6 +39,7 @@ class RegistryContext:
         wf_exec_id: The full workflow execution ID (for correlation).
         environment: The execution environment (e.g., "default").
         api_url: The Tracecat API URL.
+        action_gateway_socket: Optional local action gateway Unix socket for SDK requests.
         executor_url: The Tracecat executor service URL (sandbox execution).
         token: The executor JWT for authentication.
     """
@@ -49,6 +50,7 @@ class RegistryContext:
     wf_exec_id: str | None = None
     environment: str = "default"
     api_url: str = "http://api:8000"
+    action_gateway_socket: str | None = None
     executor_url: str = "http://executor:8000"
     token: str = ""
     # Lazily initialized SDK client
@@ -65,6 +67,7 @@ class RegistryContext:
         - TRACECAT__WF_EXEC_ID: Full workflow execution ID (for correlation)
         - TRACECAT__ENVIRONMENT: Execution environment (default: "default")
         - TRACECAT__API_URL: API URL (default: "http://api:8000")
+        - TRACECAT__ACTION_GATEWAY_SOCKET: Action Gateway socket for internal SDK requests
         - TRACECAT__EXECUTOR_URL: Executor URL (default: "http://executor:8000")
         - TRACECAT__EXECUTOR_TOKEN: JWT token for authentication
 
@@ -92,6 +95,8 @@ class RegistryContext:
             wf_exec_id=os.environ.get("TRACECAT__WF_EXEC_ID"),
             environment=os.environ.get("TRACECAT__ENVIRONMENT", "default"),
             api_url=os.environ.get("TRACECAT__API_URL", "http://api:8000"),
+            action_gateway_socket=os.environ.get("TRACECAT__ACTION_GATEWAY_SOCKET")
+            or None,
             executor_url=os.environ.get(
                 "TRACECAT__EXECUTOR_URL", "http://executor:8000"
             ),
@@ -105,6 +110,7 @@ class RegistryContext:
 
         return TracecatClient(
             api_url=self.api_url,
+            action_gateway_socket=self.action_gateway_socket,
             token=self.token,
             workspace_id=self.workspace_id,
         )

--- a/packages/tracecat-registry/tracecat_registry/sdk/client.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/client.py
@@ -32,6 +32,7 @@ class TracecatClient:
 
     Configuration is read from environment variables:
     - TRACECAT__API_URL: Base URL of the Tracecat API
+    - TRACECAT__ACTION_GATEWAY_SOCKET: Local gateway socket for internal SDK requests
     - TRACECAT__EXECUTOR_TOKEN: JWT token for authentication
     - TRACECAT__WORKSPACE_ID: Current workspace ID (added to requests)
     """
@@ -40,6 +41,7 @@ class TracecatClient:
         self,
         *,
         api_url: str | None = None,
+        action_gateway_socket: str | None = None,
         token: str | None = None,
         workspace_id: str | None = None,
         timeout: float = 120.0,
@@ -48,15 +50,18 @@ class TracecatClient:
 
         Args:
             api_url: Base URL of the Tracecat API. Defaults to TRACECAT__API_URL env var.
+            action_gateway_socket: Optional action gateway Unix socket path for
+                internal SDK requests. Defaults to TRACECAT__ACTION_GATEWAY_SOCKET.
             token: JWT token for authentication. Defaults to TRACECAT__EXECUTOR_TOKEN env var.
             workspace_id: Workspace ID. Defaults to TRACECAT__WORKSPACE_ID env var.
             timeout: Request timeout in seconds.
         """
-        base_url = api_url or os.environ.get("TRACECAT__API_URL", "http://api:8000")
-        # Ensure /internal suffix is present
-        if not base_url.endswith("/internal"):
-            base_url = base_url.rstrip("/") + "/internal"
-        self._api_url = base_url
+        self._api_url = self._normalize_internal_url(
+            api_url or os.environ.get("TRACECAT__API_URL", "http://api:8000")
+        )
+        self._action_gateway_socket = action_gateway_socket or os.environ.get(
+            "TRACECAT__ACTION_GATEWAY_SOCKET"
+        )
 
         self._token = token or os.environ.get("TRACECAT__EXECUTOR_TOKEN", "")
         self._workspace_id = workspace_id or os.environ.get(
@@ -72,10 +77,29 @@ class TracecatClient:
         self._variables: VariablesClient | None = None
         self._workflows: WorkflowsClient | None = None
 
+    @staticmethod
+    def _normalize_internal_url(base_url: str) -> str:
+        """Normalize a base URL so SDK paths resolve under /internal."""
+        if base_url.endswith("/internal"):
+            return base_url
+        return base_url.rstrip("/") + "/internal"
+
     @property
     def api_url(self) -> str:
         """Base URL of the Tracecat API."""
         return self._api_url
+
+    def _request_url_and_transport(
+        self,
+        path: str,
+    ) -> tuple[str, httpx.AsyncHTTPTransport | None]:
+        """Return the target URL and transport for an internal SDK request."""
+        if self._action_gateway_socket is None:
+            return f"{self._api_url}{path}", None
+        return (
+            f"http://tracecat-action-gateway/internal{path}",
+            httpx.AsyncHTTPTransport(uds=self._action_gateway_socket),
+        )
 
     @property
     def workspace_id(self) -> str:
@@ -202,12 +226,15 @@ class TracecatClient:
             TracecatValidationError: For 400/422 responses
             TracecatAPIError: For other error responses
         """
-        url = f"{self._api_url}{path}"
+        url, transport = self._request_url_and_transport(path)
         request_headers = self._get_headers()
         if headers:
             request_headers.update(headers)
 
-        async with httpx.AsyncClient(timeout=self._timeout) as client:
+        async with httpx.AsyncClient(
+            transport=transport,
+            timeout=self._timeout,
+        ) as client:
             response = await client.request(
                 method,
                 url,

--- a/packages/tracecat-registry/tracecat_registry/sdk/client.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/client.py
@@ -59,8 +59,10 @@ class TracecatClient:
         self._api_url = self._normalize_internal_url(
             api_url or os.environ.get("TRACECAT__API_URL", "http://api:8000")
         )
-        self._action_gateway_socket = action_gateway_socket or os.environ.get(
-            "TRACECAT__ACTION_GATEWAY_SOCKET"
+        self._action_gateway_socket = (
+            action_gateway_socket
+            or os.environ.get("TRACECAT__ACTION_GATEWAY_SOCKET")
+            or None
         )
 
         self._token = token or os.environ.get("TRACECAT__EXECUTOR_TOKEN", "")

--- a/tests/registry/test_tracecat_client.py
+++ b/tests/registry/test_tracecat_client.py
@@ -73,6 +73,63 @@ async def test_request_uses_action_gateway_unix_socket(
 
 
 @pytest.mark.anyio
+async def test_empty_action_gateway_socket_env_uses_api_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TRACECAT__ACTION_GATEWAY_SOCKET", "")
+    captured: dict[str, Any] = {}
+
+    class FakeAsyncClient:
+        def __init__(
+            self,
+            *,
+            transport: object | None,
+            timeout: float,
+        ) -> None:
+            captured["transport"] = transport
+            captured["timeout"] = timeout
+
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def request(
+            self,
+            method: str,
+            url: str,
+            *,
+            params: dict[str, Any] | None,
+            json: Any | None,
+            headers: dict[str, str],
+        ) -> httpx.Response:
+            captured["method"] = method
+            captured["url"] = url
+            captured["params"] = params
+            captured["json"] = json
+            captured["headers"] = headers
+            return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    client = TracecatClient(
+        api_url="http://api:8000",
+        token="executor-token",
+        timeout=12.0,
+    )
+
+    result = await client.get("/cases/case-id")
+
+    assert result == {"ok": True}
+    assert captured["transport"] is None
+    assert captured["timeout"] == 12.0
+    assert captured["method"] == "GET"
+    assert captured["url"] == "http://api:8000/internal/cases/case-id"
+    assert captured["headers"]["Authorization"] == "Bearer executor-token"
+
+
+@pytest.mark.anyio
 async def test_request_uses_api_url_without_action_gateway(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/registry/test_tracecat_client.py
+++ b/tests/registry/test_tracecat_client.py
@@ -1,0 +1,130 @@
+"""Tests for the base Tracecat SDK client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from tracecat_registry.sdk.client import TracecatClient
+
+
+@pytest.mark.anyio
+async def test_request_uses_action_gateway_unix_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeTransport:
+        def __init__(self, *, uds: str) -> None:
+            captured["uds"] = uds
+
+    class FakeAsyncClient:
+        def __init__(
+            self,
+            *,
+            transport: FakeTransport | None,
+            timeout: float,
+        ) -> None:
+            captured["transport"] = transport
+            captured["timeout"] = timeout
+
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def request(
+            self,
+            method: str,
+            url: str,
+            *,
+            params: dict[str, Any] | None,
+            json: Any | None,
+            headers: dict[str, str],
+        ) -> httpx.Response:
+            captured["method"] = method
+            captured["url"] = url
+            captured["params"] = params
+            captured["json"] = json
+            captured["headers"] = headers
+            return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(httpx, "AsyncHTTPTransport", FakeTransport)
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    client = TracecatClient(
+        api_url="http://api:8000",
+        action_gateway_socket="/var/run/tracecat/action-gateway.sock",
+        token="executor-token",
+        timeout=12.0,
+    )
+
+    result = await client.post("/cases/metrics", json={"case_ids": []})
+
+    assert result == {"ok": True}
+    assert captured["uds"] == "/var/run/tracecat/action-gateway.sock"
+    assert captured["timeout"] == 12.0
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://tracecat-action-gateway/internal/cases/metrics"
+    assert captured["json"] == {"case_ids": []}
+    assert captured["headers"]["Authorization"] == "Bearer executor-token"
+
+
+@pytest.mark.anyio
+async def test_request_uses_api_url_without_action_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TRACECAT__ACTION_GATEWAY_SOCKET", raising=False)
+    captured: dict[str, Any] = {}
+
+    class FakeAsyncClient:
+        def __init__(
+            self,
+            *,
+            transport: object | None,
+            timeout: float,
+        ) -> None:
+            captured["transport"] = transport
+            captured["timeout"] = timeout
+
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def request(
+            self,
+            method: str,
+            url: str,
+            *,
+            params: dict[str, Any] | None,
+            json: Any | None,
+            headers: dict[str, str],
+        ) -> httpx.Response:
+            captured["method"] = method
+            captured["url"] = url
+            captured["params"] = params
+            captured["json"] = json
+            captured["headers"] = headers
+            return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    client = TracecatClient(
+        api_url="http://api:8000",
+        action_gateway_socket=None,
+        token="executor-token",
+        timeout=12.0,
+    )
+
+    result = await client.get("/cases/case-id")
+
+    assert result == {"ok": True}
+    assert captured["transport"] is None
+    assert captured["timeout"] == 12.0
+    assert captured["method"] == "GET"
+    assert captured["url"] == "http://api:8000/internal/cases/case-id"
+    assert captured["headers"]["Authorization"] == "Bearer executor-token"

--- a/tests/unit/test_action_gateway_app.py
+++ b/tests/unit/test_action_gateway_app.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
 
-from tracecat.executor.action_gateway.app import create_app
+from tracecat.executor.action_gateway.app import (
+    create_app,
+    validation_exception_handler,
+)
 
 
 def _route_keys(app: FastAPI) -> set[tuple[str, str]]:
@@ -35,3 +40,29 @@ def test_action_gateway_mounts_internal_routes() -> None:
     assert not any(
         path.startswith("/internal/capabilities") for path, _ in gateway_routes
     )
+
+
+def test_action_gateway_validation_errors_are_json_safe() -> None:
+    app = FastAPI()
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+
+    async def boom() -> None:
+        raise RequestValidationError(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("body", "field"),
+                    "msg": "Value error, bad value",
+                    "input": "x",
+                    "ctx": {"error": ValueError("bad value")},
+                }
+            ]
+        )
+
+    app.add_api_route("/boom", boom, methods=["GET"])
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/boom")
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["ctx"]["error"] == "bad value"

--- a/tests/unit/test_action_gateway_app.py
+++ b/tests/unit/test_action_gateway_app.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+from tracecat.executor.action_gateway.app import create_app
+from tracecat.logger import logger
+
+
+def _route_keys(app: FastAPI) -> set[tuple[str, str]]:
+    return {
+        (route.path, method)
+        for route in app.routes
+        if isinstance(route, APIRoute)
+        for method in route.methods
+    }
+
+
+def _internal_route_keys(app: FastAPI) -> set[tuple[str, str]]:
+    return {
+        route_key
+        for route_key in _route_keys(app)
+        if route_key[0].startswith("/internal")
+    }
+
+
+@contextmanager
+def _capture_logs(*, level: str) -> Iterator[list[Any]]:
+    records: list[Any] = []
+    sink_id = logger.add(
+        lambda message: records.append(message.record),
+        level=level,
+    )
+    try:
+        yield records
+    finally:
+        logger.remove(sink_id)
+
+
+def test_action_gateway_mounts_internal_routes() -> None:
+    from tracecat.api.app import create_app as create_api_app
+
+    api_routes = _internal_route_keys(create_api_app())
+    app = create_app()
+    gateway_routes = _internal_route_keys(app)
+
+    assert api_routes <= gateway_routes
+    assert ("/internal/health", "GET") in gateway_routes
+    assert not any(
+        path.startswith("/internal/capabilities") for path, _ in gateway_routes
+    )
+
+
+def test_action_gateway_logs_request_completion() -> None:
+    app = create_app()
+    with _capture_logs(level="DEBUG") as records:
+        with TestClient(app) as client:
+            response = client.get("/internal/health?probe=1")
+
+    assert response.status_code == 200
+    record = next(
+        record
+        for record in records
+        if record["message"] == "Action Gateway request completed"
+    )
+    assert record["extra"]["method"] == "GET"
+    assert record["extra"]["uri"] == "/internal/health?probe=1"
+    assert record["extra"]["status_code"] == 200
+    assert record["extra"]["elapsed_ms"] >= 0
+    assert "request_size_bytes" in record["extra"]

--- a/tests/unit/test_action_gateway_app.py
+++ b/tests/unit/test_action_gateway_app.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
-from typing import Any
-
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
-from fastapi.testclient import TestClient
 
 from tracecat.executor.action_gateway.app import create_app
-from tracecat.logger import logger
 
 
 def _route_keys(app: FastAPI) -> set[tuple[str, str]]:
@@ -29,19 +23,6 @@ def _internal_route_keys(app: FastAPI) -> set[tuple[str, str]]:
     }
 
 
-@contextmanager
-def _capture_logs(*, level: str) -> Iterator[list[Any]]:
-    records: list[Any] = []
-    sink_id = logger.add(
-        lambda message: records.append(message.record),
-        level=level,
-    )
-    try:
-        yield records
-    finally:
-        logger.remove(sink_id)
-
-
 def test_action_gateway_mounts_internal_routes() -> None:
     from tracecat.api.app import create_app as create_api_app
 
@@ -54,22 +35,3 @@ def test_action_gateway_mounts_internal_routes() -> None:
     assert not any(
         path.startswith("/internal/capabilities") for path, _ in gateway_routes
     )
-
-
-def test_action_gateway_logs_request_completion() -> None:
-    app = create_app()
-    with _capture_logs(level="DEBUG") as records:
-        with TestClient(app) as client:
-            response = client.get("/internal/health?probe=1")
-
-    assert response.status_code == 200
-    record = next(
-        record
-        for record in records
-        if record["message"] == "Action Gateway request completed"
-    )
-    assert record["extra"]["method"] == "GET"
-    assert record["extra"]["uri"] == "/internal/health?probe=1"
-    assert record["extra"]["status_code"] == 200
-    assert record["extra"]["elapsed_ms"] >= 0
-    assert "request_size_bytes" in record["extra"]

--- a/tests/unit/test_action_gateway_app.py
+++ b/tests/unit/test_action_gateway_app.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import pytest
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
+from tracecat.executor.action_gateway import app as action_gateway_app
 from tracecat.executor.action_gateway.app import (
     create_app,
+    request_logging_middleware,
     validation_exception_handler,
 )
 
@@ -40,6 +43,42 @@ def test_action_gateway_mounts_internal_routes() -> None:
     assert not any(
         path.startswith("/internal/capabilities") for path, _ in gateway_routes
     )
+
+
+def test_action_gateway_request_log_omits_query_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records: list[tuple[str, dict[str, object]]] = []
+
+    def fake_info(message: str, **kwargs: object) -> None:
+        records.append((message, kwargs))
+
+    app = FastAPI()
+    app.middleware("http")(request_logging_middleware)
+
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    app.add_api_route("/internal/health", health, methods=["GET"])
+
+    monkeypatch.setattr(action_gateway_app.logger, "info", fake_info)
+
+    with TestClient(app) as client:
+        response = client.get("/internal/health?token=secret")
+
+    assert response.status_code == 200
+    assert records == [
+        (
+            "Action Gateway request",
+            {
+                "method": "GET",
+                "path": "/internal/health",
+                "status_code": 200,
+                "elapsed_ms": records[0][1]["elapsed_ms"],
+            },
+        )
+    ]
+    assert "token" not in str(records[0][1])
 
 
 def test_action_gateway_validation_errors_are_json_safe() -> None:

--- a/tests/unit/test_action_runner.py
+++ b/tests/unit/test_action_runner.py
@@ -16,6 +16,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import orjson
 import pytest
 
 from tracecat import config
@@ -378,8 +379,6 @@ class TestActionRunner:
         runner = ActionRunner(cache_dir=temp_cache_dir)
         base_dir = temp_cache_dir / "base"
         base_dir.mkdir()
-
-        import orjson
 
         monkeypatch.setattr(
             action_runner.config, "TRACECAT__ACTION_GATEWAY_ENABLED", True

--- a/tests/unit/test_action_runner.py
+++ b/tests/unit/test_action_runner.py
@@ -367,6 +367,78 @@ class TestActionRunner:
         assert captured_env["TRACECAT__EXECUTOR_TOKEN"] == "test-executor-token"
 
     @pytest.mark.anyio
+    async def test_execute_action_sets_action_gateway_env_when_enabled(
+        self,
+        temp_cache_dir,
+        mock_run_action_input,
+        mock_role,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Action gateway mode injects the local socket path into action SDK env."""
+        runner = ActionRunner(cache_dir=temp_cache_dir)
+        base_dir = temp_cache_dir / "base"
+        base_dir.mkdir()
+
+        import orjson
+
+        monkeypatch.setattr(
+            action_runner.config, "TRACECAT__ACTION_GATEWAY_ENABLED", True
+        )
+        monkeypatch.setattr(
+            action_runner.config,
+            "TRACECAT__ACTION_GATEWAY_SOCKET",
+            "/var/run/tracecat/action-gateway.sock",
+        )
+
+        success_response = orjson.dumps({"success": True, "result": {"data": "test"}})
+        captured_env: dict[str, str] = {}
+
+        resolved_context = ResolvedContext(
+            secrets={},
+            variables={},
+            action_impl=ActionImplementation(
+                type="udf",
+                action_name="core.table.search_rows",
+                module="tracecat_registry.core.table",
+                name="search_rows",
+            ),
+            evaluated_args={"table": "customers"},
+            workspace_id=str(mock_role.workspace_id),
+            workflow_id=str(mock_run_action_input.run_context.wf_id),
+            run_id=str(mock_run_action_input.run_context.wf_run_id),
+            executor_token="test-executor-token",
+        )
+
+        async def create_subprocess_exec_side_effect(*args, **kwargs):  # noqa: ARG001
+            env = kwargs.get("env")
+            assert isinstance(env, dict)
+            captured_env.update(env)
+
+            mock_proc = AsyncMock()
+            mock_proc.returncode = 0
+            mock_proc.communicate = AsyncMock(return_value=(success_response, b""))
+            return mock_proc
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=create_subprocess_exec_side_effect,
+        ):
+            result = await runner._execute_direct(
+                input=mock_run_action_input,
+                role=mock_role,
+                registry_paths=[base_dir],
+                secret_projection=_empty_secret_projection(),
+                timeout=10.0,
+                resolved_context=resolved_context,
+            )
+
+        assert result == {"data": "test"}
+        assert (
+            captured_env["TRACECAT__ACTION_GATEWAY_SOCKET"]
+            == "/var/run/tracecat/action-gateway.sock"
+        )
+
+    @pytest.mark.anyio
     async def test_execute_action_disables_new_privileges_for_direct_subprocess(
         self,
         temp_cache_dir,

--- a/tests/unit/test_action_runner.py
+++ b/tests/unit/test_action_runner.py
@@ -519,6 +519,7 @@ class TestActionRunner:
 
         with _mock_tracecat_api_server("test-executor-token") as (api_url, state):
             monkeypatch.setattr(config, "TRACECAT__API_URL", api_url)
+            monkeypatch.setattr(config, "TRACECAT__ACTION_GATEWAY_ENABLED", False)
             result = await runner._execute_direct(
                 input=mock_run_action_input,
                 role=mock_role,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import importlib
+
 import pytest
 
+import tracecat.config as tracecat_config
 from tracecat.config import bound_env
 
 
@@ -45,6 +48,23 @@ def test_bound_env_uses_default_for_empty_string(
     result = bound_env("TEST_BOUND_ENV", 10, lower=8)
 
     assert result == 10
+
+
+def test_action_gateway_socket_uses_default_for_empty_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    try:
+        with monkeypatch.context() as env:
+            env.setenv("TRACECAT__ACTION_GATEWAY_SOCKET", "")
+
+            reloaded_config = importlib.reload(tracecat_config)
+
+            assert (
+                reloaded_config.TRACECAT__ACTION_GATEWAY_SOCKET
+                == "/var/run/tracecat/action-gateway.sock"
+            )
+    finally:
+        importlib.reload(tracecat_config)
 
 
 def test_bound_env_rejects_invalid_numeric_value(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -67,6 +67,26 @@ def test_action_gateway_socket_uses_default_for_empty_string(
         importlib.reload(tracecat_config)
 
 
+def test_action_gateway_enabled_defaults_true_and_allows_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    try:
+        with monkeypatch.context() as env:
+            env.delenv("TRACECAT__ACTION_GATEWAY_ENABLED", raising=False)
+            reloaded_config = importlib.reload(tracecat_config)
+            assert reloaded_config.TRACECAT__ACTION_GATEWAY_ENABLED is True
+
+            env.setenv("TRACECAT__ACTION_GATEWAY_ENABLED", "")
+            reloaded_config = importlib.reload(tracecat_config)
+            assert reloaded_config.TRACECAT__ACTION_GATEWAY_ENABLED is True
+
+            env.setenv("TRACECAT__ACTION_GATEWAY_ENABLED", "false")
+            reloaded_config = importlib.reload(tracecat_config)
+            assert reloaded_config.TRACECAT__ACTION_GATEWAY_ENABLED is False
+    finally:
+        importlib.reload(tracecat_config)
+
+
 def test_bound_env_rejects_invalid_numeric_value(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_executor_sandbox_nsjail.py
+++ b/tests/unit/test_executor_sandbox_nsjail.py
@@ -24,6 +24,8 @@ from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.dsl.common import create_default_execution_context
 from tracecat.dsl.schemas import ActionStatement, RunActionInput, RunContext
+from tracecat.executor.action_gateway.config import ACTION_GATEWAY_SANDBOX_SOCKET
+from tracecat.executor.action_gateway.server import ActionGateway
 from tracecat.executor.action_runner import ActionRunner
 from tracecat.executor.registry_artifacts import (
     RegistryArtifactFormat,
@@ -47,6 +49,7 @@ class SmokeCase(StrEnum):
     DIRECT = "direct"
     NSJAIL_GZ = "nsjail-gz"
     NSJAIL_SQUASHFS = "nsjail-squashfs"
+    NSJAIL_GATEWAY = "nsjail-gateway"
 
     @property
     def force_sandbox(self) -> bool:
@@ -284,6 +287,59 @@ def _write_registry_artifact_source(source_dir: Path) -> None:
     )
 
 
+def _write_gateway_artifact_source(source_dir: Path) -> None:
+    source_dir.mkdir(parents=True)
+    (source_dir / "registry_artifact_smoke_action.py").write_text(
+        "\n".join(
+            [
+                "import json",
+                "import os",
+                "import socket",
+                "",
+                "",
+                "def _gateway_health() -> dict:",
+                '    socket_path = os.environ["TRACECAT__ACTION_GATEWAY_SOCKET"]',
+                "    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)",
+                "    client.settimeout(5)",
+                "    try:",
+                "        client.connect(socket_path)",
+                "        request = (",
+                '            b"GET /internal/health HTTP/1.1\\r\\n"',
+                '            b"Host: tracecat-action-gateway\\r\\n"',
+                '            b"Connection: close\\r\\n\\r\\n"',
+                "        )",
+                "        client.sendall(request)",
+                "        chunks = []",
+                "        while True:",
+                "            chunk = client.recv(4096)",
+                "            if not chunk:",
+                "                break",
+                "            chunks.append(chunk)",
+                "    finally:",
+                "        client.close()",
+                "",
+                '    raw = b"".join(chunks).decode("utf-8")',
+                '    headers, body = raw.split("\\r\\n\\r\\n", 1)',
+                '    status_line = headers.split("\\r\\n", 1)[0]',
+                '    status_code = int(status_line.split(" ", 2)[1])',
+                "    return {",
+                '        "status_code": status_code,',
+                '        "body": json.loads(body),',
+                '        "socket_path": socket_path,',
+                "    }",
+                "",
+                "",
+                "def run(value: str) -> dict:",
+                "    return {",
+                '        "value": value,',
+                '        "gateway": _gateway_health(),',
+                "    }",
+                "",
+            ]
+        )
+    )
+
+
 def _add_source_dir_to_tar(tar: tarfile.TarFile, source_dir: Path) -> None:
     for path in sorted(source_dir.iterdir()):
         tar.add(path, arcname=path.name)
@@ -343,12 +399,23 @@ async def _run_executor_action_smoke_case(
     monkeypatch.setattr(config, "TRACECAT__EXECUTOR_SANDBOX_ENABLED", True)
     monkeypatch.setattr(config, "TRACECAT__EXECUTOR_REGISTRY_SQUASHFS_ENABLED", True)
     monkeypatch.setattr(config, "TRACECAT__EXECUTOR_CLIENT_TIMEOUT", 30.0)
+    monkeypatch.setattr(config, "TRACECAT__ACTION_GATEWAY_ENABLED", False)
+    if smoke_case is SmokeCase.NSJAIL_GATEWAY:
+        monkeypatch.setattr(config, "TRACECAT__ACTION_GATEWAY_ENABLED", True)
+        monkeypatch.setattr(
+            config,
+            "TRACECAT__ACTION_GATEWAY_SOCKET",
+            str(tmp_path / "action-gateway.sock"),
+        )
 
     source_dir = tmp_path / "site-packages"
     tar_gz_path = tmp_path / "site-packages.tar.gz"
     squashfs_path = tmp_path / "site-packages.squashfs"
     cache_dir = tmp_path / "registry-cache"
-    _write_registry_artifact_source(source_dir)
+    if smoke_case is SmokeCase.NSJAIL_GATEWAY:
+        _write_gateway_artifact_source(source_dir)
+    else:
+        _write_registry_artifact_source(source_dir)
     _build_tar_gz(source_dir, tar_gz_path)
     if smoke_case == SmokeCase.NSJAIL_SQUASHFS:
         _build_squashfs_image(source_dir, squashfs_path)
@@ -380,8 +447,13 @@ async def _run_executor_action_smoke_case(
         input=action_input,
         role=role,
     )
+    action_gateway: ActionGateway | None = None
 
     try:
+        if smoke_case is SmokeCase.NSJAIL_GATEWAY:
+            action_gateway = ActionGateway()
+            await action_gateway.start()
+
         with (
             patch.object(runner.registry_artifacts, "_sidecar_exists", sidecar_exists),
             patch.object(
@@ -404,6 +476,15 @@ async def _run_executor_action_smoke_case(
 
         assert isinstance(result, dict)
         assert result["value"] == "from-registry-artifact"
+        if smoke_case is SmokeCase.NSJAIL_GATEWAY:
+            assert result["gateway"] == {
+                "status_code": 200,
+                "body": {"status": "ok"},
+                "socket_path": str(ACTION_GATEWAY_SANDBOX_SOCKET),
+            }
+            assert tarball_dir.exists()
+            return
+
         assert result["marker"] == "registry-artifact"
         if smoke_case == SmokeCase.DIRECT:
             assert tarball_dir.exists()
@@ -416,6 +497,8 @@ async def _run_executor_action_smoke_case(
             else:
                 assert tarball_dir.exists()
     finally:
+        if action_gateway is not None:
+            await action_gateway.stop()
         _unmount_if_needed(mount_dir)
 
 
@@ -425,6 +508,7 @@ async def _run_executor_action_smoke_case(
         pytest.param(SmokeCase.DIRECT, id=SmokeCase.DIRECT.value),
         pytest.param(SmokeCase.NSJAIL_GZ, id=SmokeCase.NSJAIL_GZ.value),
         pytest.param(SmokeCase.NSJAIL_SQUASHFS, id=SmokeCase.NSJAIL_SQUASHFS.value),
+        pytest.param(SmokeCase.NSJAIL_GATEWAY, id=SmokeCase.NSJAIL_GATEWAY.value),
     ],
 )
 @pytest.mark.anyio

--- a/tests/unit/test_nsjail_seccomp.py
+++ b/tests/unit/test_nsjail_seccomp.py
@@ -93,3 +93,20 @@ def test_worker_pool_config_includes_seccomp_policy(tmp_path: Path):
     )
 
     _assert_seccomp_config(config_text)
+
+
+def test_worker_pool_config_mounts_action_gateway_socket(tmp_path: Path):
+    """Warm nsjail workers should mount the action gateway socket when enabled."""
+    pool = WorkerPool()
+    action_gateway_socket = tmp_path / "action-gateway.sock"
+
+    config_text = pool._build_nsjail_config(
+        worker_id=1,
+        work_dir=tmp_path / "work",
+        action_gateway_socket=action_gateway_socket,
+    )
+
+    assert (
+        f'mount {{ src: "{action_gateway_socket}" dst: "/var/run/tracecat/action-gateway.sock" '
+        "is_bind: true rw: false }"
+    ) in config_text

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -18,6 +18,7 @@ from tracecat.registry.repository import Repository
 
 
 @pytest.mark.anyio
+@pytest.mark.usefixtures("registry_version_with_manifest")
 async def test_list_registry_actions(test_role):
     """Test that list_actions_from_index returns actions."""
     async with RegistryActionsService.with_session(test_role) as service:
@@ -53,6 +54,7 @@ async def test_registry_actions_filtered_by_entitlements(test_role, monkeypatch)
 
 
 @pytest.mark.anyio
+@pytest.mark.usefixtures("registry_version_with_manifest")
 async def test_registry_actions_include_locked_marks_missing_entitlements(
     test_role, monkeypatch
 ):
@@ -76,6 +78,7 @@ async def test_registry_actions_include_locked_marks_missing_entitlements(
 
 
 @pytest.mark.anyio
+@pytest.mark.usefixtures("registry_version_with_manifest")
 async def test_registry_actions_include_locked_shows_agent_preset_crud(
     test_role,
     monkeypatch,

--- a/tests/unit/test_sandbox_networking.py
+++ b/tests/unit/test_sandbox_networking.py
@@ -165,3 +165,25 @@ def test_action_sandbox_config_enables_pasta(tmp_path: Path) -> None:
     assert f'src: "{tmp_path}/job/resolv.conf"' in config_text
     assert 'src: "/proc"' not in config_text
     assert 'dst: "/proc" fstype: "proc"' in config_text
+
+
+def test_action_sandbox_config_mounts_action_gateway_socket(tmp_path: Path) -> None:
+    executor = NsjailExecutor(rootfs_path=str(tmp_path / "rootfs"))
+    action_gateway_socket = tmp_path / "action-gateway.sock"
+
+    config_text = executor._build_action_config(
+        job_dir=tmp_path / "job",
+        config=ActionSandboxConfig(
+            registry_paths=[tmp_path / "registry"],
+            tracecat_app_dir=tmp_path / "app",
+            action_gateway_socket=action_gateway_socket,
+            action_gateway_socket_mount_path=Path(
+                "/var/run/tracecat/action-gateway.sock"
+            ),
+        ),
+    )
+
+    assert (
+        f'mount {{ src: "{action_gateway_socket}" dst: "/var/run/tracecat/action-gateway.sock" '
+        "is_bind: true rw: false }"
+    ) in config_text

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -622,6 +622,18 @@ TRACECAT__EXECUTOR_CLIENT_TIMEOUT = float(
 )
 """Default timeout in seconds for executor client operations (default: 300s)."""
 
+# === Action Gateway === #
+TRACECAT__ACTION_GATEWAY_ENABLED = os.environ.get(
+    "TRACECAT__ACTION_GATEWAY_ENABLED", "false"
+).lower() in ("true", "1")
+"""Enable the executor-local action gateway for action SDK calls."""
+
+TRACECAT__ACTION_GATEWAY_SOCKET = os.environ.get(
+    "TRACECAT__ACTION_GATEWAY_SOCKET",
+    "/var/run/tracecat/action-gateway.sock",
+)
+"""Unix socket path for the executor-local action gateway."""
+
 # === Action Executor Sandbox === #
 TRACECAT__EXECUTOR_SANDBOX_ENABLED = os.environ.get(
     "TRACECAT__EXECUTOR_SANDBOX_ENABLED", "false"

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -628,9 +628,9 @@ TRACECAT__ACTION_GATEWAY_ENABLED = os.environ.get(
 ).lower() in ("true", "1")
 """Enable the executor-local action gateway for action SDK calls."""
 
-TRACECAT__ACTION_GATEWAY_SOCKET = os.environ.get(
-    "TRACECAT__ACTION_GATEWAY_SOCKET",
-    "/var/run/tracecat/action-gateway.sock",
+TRACECAT__ACTION_GATEWAY_SOCKET = (
+    os.environ.get("TRACECAT__ACTION_GATEWAY_SOCKET")
+    or "/var/run/tracecat/action-gateway.sock"
 )
 """Unix socket path for the executor-local action gateway."""
 

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -623,8 +623,8 @@ TRACECAT__EXECUTOR_CLIENT_TIMEOUT = float(
 """Default timeout in seconds for executor client operations (default: 300s)."""
 
 # === Action Gateway === #
-TRACECAT__ACTION_GATEWAY_ENABLED = os.environ.get(
-    "TRACECAT__ACTION_GATEWAY_ENABLED", "false"
+TRACECAT__ACTION_GATEWAY_ENABLED = (
+    os.environ.get("TRACECAT__ACTION_GATEWAY_ENABLED") or "true"
 ).lower() in ("true", "1")
 """Enable the executor-local action gateway for action SDK calls."""
 

--- a/tracecat/executor/action_gateway/__init__.py
+++ b/tracecat/executor/action_gateway/__init__.py
@@ -1,0 +1,1 @@
+"""Executor-local action gateway."""

--- a/tracecat/executor/action_gateway/app.py
+++ b/tracecat/executor/action_gateway/app.py
@@ -1,0 +1,266 @@
+"""Action gateway FastAPI application."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from fastapi import APIRouter, FastAPI, Request, Response, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import ORJSONResponse
+
+from tracecat.contexts import ctx_role, ctx_run
+from tracecat.logger import logger
+
+router = APIRouter(
+    prefix="/internal",
+    tags=["action-gateway"],
+    include_in_schema=False,
+)
+
+
+def _request_size_bytes(request: Request) -> int | None:
+    """Parse the request size from Content-Length when the client sends it."""
+    content_length = request.headers.get("content-length")
+    if content_length is None:
+        return None
+    try:
+        return int(content_length)
+    except ValueError:
+        return None
+
+
+def _request_uri(request: Request) -> str:
+    """Return the raw request URI path plus query string."""
+    if request.url.query:
+        return f"{request.url.path}?{request.url.query}"
+    return request.url.path
+
+
+def _runtime_log_context() -> dict[str, Any]:
+    """Collect request-scoped runtime identifiers when dependencies set them."""
+    role = ctx_role.get()
+    run = ctx_run.get()
+    context: dict[str, Any] = {}
+    if role is not None:
+        context["role_type"] = role.type
+        context["service_id"] = role.service_id
+        if role.workspace_id is not None:
+            context["workspace_id"] = str(role.workspace_id)
+        if role.organization_id is not None:
+            context["organization_id"] = str(role.organization_id)
+    if run is not None:
+        context["workflow_id"] = str(run.wf_id)
+        context["workflow_run_id"] = str(run.wf_run_id)
+        context["workflow_execution_id"] = str(run.wf_exec_id)
+        context["environment"] = run.environment
+    return context
+
+
+def _log_request(
+    *,
+    request: Request,
+    started_at: float,
+    request_size: int | None,
+    response: Response | None = None,
+    error: Exception | None = None,
+) -> None:
+    """Log a completed or failed action gateway request."""
+    elapsed_ms = round((time.perf_counter() - started_at) * 1000, 2)
+    status_code = response.status_code if response is not None else 500
+    log_context = {
+        "method": request.method,
+        "uri": _request_uri(request),
+        "status_code": status_code,
+        "elapsed_ms": elapsed_ms,
+        "request_size_bytes": request_size,
+        **_runtime_log_context(),
+    }
+
+    if error is not None:
+        logger.opt(exception=error).error(
+            "Action Gateway request failed",
+            **log_context,
+        )
+        return
+
+    if status_code >= 500:
+        logger.error("Action Gateway request completed", **log_context)
+    elif status_code >= 400:
+        logger.warning("Action Gateway request completed", **log_context)
+    else:
+        logger.debug("Action Gateway request completed", **log_context)
+
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+def validation_exception_handler(request: Request, exc: Exception) -> Response:
+    """Handle validation errors for action gateway-served internal routes."""
+    errors = exc.errors() if isinstance(exc, RequestValidationError) else str(exc)
+    logger.error(
+        "Action Gateway validation error",
+        method=request.method,
+        path=request.url.path,
+        errors=errors,
+    )
+    return ORJSONResponse(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        content={"detail": errors},
+    )
+
+
+def entitlement_exception_handler(request: Request, exc: Exception) -> Response:
+    """Handle entitlement errors for action gateway-served internal routes."""
+    detail = getattr(exc, "detail", None)
+    logger.warning(
+        "Action Gateway entitlement required",
+        path=request.url.path,
+        detail=detail,
+    )
+    return ORJSONResponse(
+        status_code=status.HTTP_403_FORBIDDEN,
+        content={
+            "type": "EntitlementRequired",
+            "message": str(exc),
+            "detail": detail,
+        },
+    )
+
+
+def scope_denied_exception_handler(request: Request, exc: Exception) -> Response:
+    """Handle scope errors for action gateway-served internal routes."""
+    required_scopes = getattr(exc, "required_scopes", ())
+    missing_scopes = getattr(exc, "missing_scopes", ())
+    logger.warning(
+        "Action Gateway scope denied",
+        required_scopes=required_scopes,
+        missing_scopes=missing_scopes,
+        path=request.url.path,
+        role=ctx_role.get(),
+    )
+    return ORJSONResponse(
+        status_code=status.HTTP_403_FORBIDDEN,
+        content={
+            "error": {
+                "code": "insufficient_scope",
+                "message": str(exc),
+                "required_scopes": required_scopes,
+                "missing_scopes": missing_scopes,
+            }
+        },
+    )
+
+
+async def _log_requests(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
+    """Log action gateway requests after routing has produced a response."""
+    started_at = time.perf_counter()
+    request_size = _request_size_bytes(request)
+    response: Response | None = None
+    error: Exception | None = None
+    try:
+        response = await call_next(request)
+        return response
+    except Exception as exc:
+        error = exc
+        _log_request(
+            request=request,
+            started_at=started_at,
+            request_size=request_size,
+            error=exc,
+        )
+        raise
+    finally:
+        if error is None:
+            _log_request(
+                request=request,
+                started_at=started_at,
+                request_size=request_size,
+                response=response,
+            )
+
+
+def _include_internal_routers(app: FastAPI) -> None:
+    """Mount the API's executor-facing internal routers onto the action gateway."""
+    from tracecat.agent.internal_router import router as internal_agent_router
+    from tracecat.agent.preset.internal_router import (
+        router as internal_agent_preset_router,
+    )
+    from tracecat.cases.attachments.internal_router import (
+        router as internal_case_attachments_router,
+    )
+    from tracecat.cases.internal_router import (
+        comments_router as internal_comments_router,
+    )
+    from tracecat.cases.internal_router import router as internal_cases_router
+    from tracecat.cases.rows.internal_router import router as internal_case_rows_router
+    from tracecat.cases.tag_definitions.internal_router import (
+        router as internal_case_tag_definitions_router,
+    )
+    from tracecat.cases.tags.internal_router import router as internal_case_tags_router
+    from tracecat.deduplicate.internal_router import (
+        router as internal_deduplicate_router,
+    )
+    from tracecat.tables.internal_router import router as internal_tables_router
+    from tracecat.variables.internal_router import router as internal_variables_router
+    from tracecat.workflow.executions.internal_router import (
+        router as internal_workflows_router,
+    )
+
+    app.include_router(internal_agent_router)
+    app.include_router(internal_agent_preset_router)
+    app.include_router(internal_case_attachments_router)
+    app.include_router(internal_cases_router)
+    app.include_router(internal_deduplicate_router)
+    app.include_router(internal_case_rows_router)
+    app.include_router(internal_comments_router)
+    app.include_router(internal_case_tags_router)
+    app.include_router(internal_case_tag_definitions_router)
+    app.include_router(internal_tables_router)
+    app.include_router(internal_variables_router)
+    app.include_router(internal_workflows_router)
+
+
+def _add_exception_handlers(app: FastAPI) -> None:
+    """Install API-compatible exception handlers on the action gateway."""
+    from fastapi import HTTPException
+
+    from tracecat.api.common import (
+        generic_exception_handler,
+        http_exception_handler,
+        tracecat_exception_handler,
+    )
+    from tracecat.exceptions import (
+        EntitlementRequired,
+        ScopeDeniedError,
+        TracecatException,
+    )
+
+    app.add_exception_handler(Exception, generic_exception_handler)
+    app.add_exception_handler(TracecatException, tracecat_exception_handler)
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    app.add_exception_handler(EntitlementRequired, entitlement_exception_handler)
+    app.add_exception_handler(ScopeDeniedError, scope_denied_exception_handler)
+    app.add_exception_handler(HTTPException, http_exception_handler)
+
+
+def create_app(**kwargs) -> FastAPI:
+    """Create the executor-local action gateway app."""
+    app = FastAPI(
+        title="Tracecat Action Gateway",
+        version="0",
+        default_response_class=ORJSONResponse,
+        **kwargs,
+    )
+
+    app.middleware("http")(_log_requests)
+    app.include_router(router)
+    _include_internal_routers(app)
+    _add_exception_handlers(app)
+    return app

--- a/tracecat/executor/action_gateway/app.py
+++ b/tracecat/executor/action_gateway/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, FastAPI, Request, Response, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import ORJSONResponse
+from pydantic_core import to_jsonable_python
 
 from tracecat.contexts import ctx_role
 from tracecat.logger import logger
@@ -23,7 +24,11 @@ async def health() -> dict[str, str]:
 
 def validation_exception_handler(request: Request, exc: Exception) -> Response:
     """Handle validation errors for action gateway-served internal routes."""
-    errors = exc.errors() if isinstance(exc, RequestValidationError) else str(exc)
+    errors = (
+        to_jsonable_python(exc.errors(), fallback=str)
+        if isinstance(exc, RequestValidationError)
+        else str(exc)
+    )
     logger.error(
         "Action Gateway validation error",
         method=request.method,

--- a/tracecat/executor/action_gateway/app.py
+++ b/tracecat/executor/action_gateway/app.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import time
+from collections.abc import Awaitable, Callable
+
 from fastapi import APIRouter, FastAPI, Request, Response, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import ORJSONResponse
@@ -20,6 +23,27 @@ router = APIRouter(
 @router.get("/health")
 async def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+async def request_logging_middleware(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
+    """Log action gateway requests without query strings."""
+    started_at = time.perf_counter()
+    response: Response | None = None
+    try:
+        response = await call_next(request)
+        return response
+    finally:
+        status_code = response.status_code if response is not None else 500
+        logger.info(
+            "Action Gateway request",
+            method=request.method,
+            path=request.url.path,
+            status_code=status_code,
+            elapsed_ms=round((time.perf_counter() - started_at) * 1000, 2),
+        )
 
 
 def validation_exception_handler(request: Request, exc: Exception) -> Response:
@@ -156,6 +180,7 @@ def create_app(**kwargs) -> FastAPI:
         **kwargs,
     )
 
+    app.middleware("http")(request_logging_middleware)
     app.include_router(router)
     _include_internal_routers(app)
     _add_exception_handlers(app)

--- a/tracecat/executor/action_gateway/app.py
+++ b/tracecat/executor/action_gateway/app.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-import time
-from collections.abc import Awaitable, Callable
-from typing import Any
-
 from fastapi import APIRouter, FastAPI, Request, Response, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import ORJSONResponse
 
-from tracecat.contexts import ctx_role, ctx_run
+from tracecat.contexts import ctx_role
 from tracecat.logger import logger
 
 router = APIRouter(
@@ -18,79 +14,6 @@ router = APIRouter(
     tags=["action-gateway"],
     include_in_schema=False,
 )
-
-
-def _request_size_bytes(request: Request) -> int | None:
-    """Parse the request size from Content-Length when the client sends it."""
-    content_length = request.headers.get("content-length")
-    if content_length is None:
-        return None
-    try:
-        return int(content_length)
-    except ValueError:
-        return None
-
-
-def _request_uri(request: Request) -> str:
-    """Return the raw request URI path plus query string."""
-    if request.url.query:
-        return f"{request.url.path}?{request.url.query}"
-    return request.url.path
-
-
-def _runtime_log_context() -> dict[str, Any]:
-    """Collect request-scoped runtime identifiers when dependencies set them."""
-    role = ctx_role.get()
-    run = ctx_run.get()
-    context: dict[str, Any] = {}
-    if role is not None:
-        context["role_type"] = role.type
-        context["service_id"] = role.service_id
-        if role.workspace_id is not None:
-            context["workspace_id"] = str(role.workspace_id)
-        if role.organization_id is not None:
-            context["organization_id"] = str(role.organization_id)
-    if run is not None:
-        context["workflow_id"] = str(run.wf_id)
-        context["workflow_run_id"] = str(run.wf_run_id)
-        context["workflow_execution_id"] = str(run.wf_exec_id)
-        context["environment"] = run.environment
-    return context
-
-
-def _log_request(
-    *,
-    request: Request,
-    started_at: float,
-    request_size: int | None,
-    response: Response | None = None,
-    error: Exception | None = None,
-) -> None:
-    """Log a completed or failed action gateway request."""
-    elapsed_ms = round((time.perf_counter() - started_at) * 1000, 2)
-    status_code = response.status_code if response is not None else 500
-    log_context = {
-        "method": request.method,
-        "uri": _request_uri(request),
-        "status_code": status_code,
-        "elapsed_ms": elapsed_ms,
-        "request_size_bytes": request_size,
-        **_runtime_log_context(),
-    }
-
-    if error is not None:
-        logger.opt(exception=error).error(
-            "Action Gateway request failed",
-            **log_context,
-        )
-        return
-
-    if status_code >= 500:
-        logger.error("Action Gateway request completed", **log_context)
-    elif status_code >= 400:
-        logger.warning("Action Gateway request completed", **log_context)
-    else:
-        logger.debug("Action Gateway request completed", **log_context)
 
 
 @router.get("/health")
@@ -153,37 +76,6 @@ def scope_denied_exception_handler(request: Request, exc: Exception) -> Response
             }
         },
     )
-
-
-async def _log_requests(
-    request: Request,
-    call_next: Callable[[Request], Awaitable[Response]],
-) -> Response:
-    """Log action gateway requests after routing has produced a response."""
-    started_at = time.perf_counter()
-    request_size = _request_size_bytes(request)
-    response: Response | None = None
-    error: Exception | None = None
-    try:
-        response = await call_next(request)
-        return response
-    except Exception as exc:
-        error = exc
-        _log_request(
-            request=request,
-            started_at=started_at,
-            request_size=request_size,
-            error=exc,
-        )
-        raise
-    finally:
-        if error is None:
-            _log_request(
-                request=request,
-                started_at=started_at,
-                request_size=request_size,
-                response=response,
-            )
 
 
 def _include_internal_routers(app: FastAPI) -> None:
@@ -259,7 +151,6 @@ def create_app(**kwargs) -> FastAPI:
         **kwargs,
     )
 
-    app.middleware("http")(_log_requests)
     app.include_router(router)
     _include_internal_routers(app)
     _add_exception_handlers(app)

--- a/tracecat/executor/action_gateway/config.py
+++ b/tracecat/executor/action_gateway/config.py
@@ -1,0 +1,17 @@
+"""Action gateway configuration helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tracecat import config
+
+ACTION_GATEWAY_SANDBOX_SOCKET = Path("/var/run/tracecat/action-gateway.sock")
+"""Path actions use inside nsjail after the host action gateway socket is mounted."""
+
+
+def action_gateway_socket_path() -> Path | None:
+    """Return the host-side action gateway Unix socket path when enabled."""
+    if not config.TRACECAT__ACTION_GATEWAY_ENABLED:
+        return None
+    return Path(config.TRACECAT__ACTION_GATEWAY_SOCKET)

--- a/tracecat/executor/action_gateway/server.py
+++ b/tracecat/executor/action_gateway/server.py
@@ -1,0 +1,89 @@
+"""Worker-owned lifecycle for the executor-local action gateway."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any
+
+from tracecat import config
+from tracecat.executor.action_gateway.app import create_app
+from tracecat.executor.action_gateway.config import action_gateway_socket_path
+from tracecat.logger import logger
+
+
+class ActionGateway:
+    """Executor-local gateway for action SDK calls backed by a Unix socket."""
+
+    def __init__(self, *, socket_path: Path | None = None) -> None:
+        self._configured_socket_path = socket_path
+        self._server: Any | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._socket_path: Path | None = None
+
+    async def start(self) -> None:
+        """Start the action gateway when enabled for this executor process."""
+        if not config.TRACECAT__ACTION_GATEWAY_ENABLED:
+            return
+        if self._task is not None:
+            return
+
+        import uvicorn
+
+        socket_path = self._configured_socket_path or action_gateway_socket_path()
+        if socket_path is None:
+            return
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+        socket_path.unlink(missing_ok=True)
+
+        uvicorn_config = uvicorn.Config(
+            create_app(),
+            uds=str(socket_path),
+            log_level="warning",
+            lifespan="on",
+        )
+        server = uvicorn.Server(uvicorn_config)
+        self._server = server
+        self._socket_path = socket_path
+        self._task = asyncio.create_task(server.serve())
+
+        for _ in range(50):
+            if server.started and socket_path.exists():
+                os.chmod(socket_path, 0o600)
+                logger.info(
+                    "Action Gateway started",
+                    socket_path=str(socket_path),
+                )
+                return
+            if self._task.done():
+                await self._task
+            await asyncio.sleep(0.1)
+
+        await self.stop()
+        raise RuntimeError("Action Gateway did not start within 5s")
+
+    async def stop(self) -> None:
+        """Stop the action gateway if it was started."""
+        server = self._server
+        socket_path = self._socket_path
+        task = self._task
+        self._server = None
+        self._socket_path = None
+        self._task = None
+        if task is None:
+            return
+
+        if server is not None and hasattr(server, "should_exit"):
+            server.should_exit = True
+        try:
+            await asyncio.wait_for(task, timeout=5)
+        except TimeoutError:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        if socket_path is not None:
+            socket_path.unlink(missing_ok=True)
+        logger.info("Action Gateway stopped")

--- a/tracecat/executor/action_runner.py
+++ b/tracecat/executor/action_runner.py
@@ -30,6 +30,10 @@ from pydantic_core import to_json
 
 from tracecat import config
 from tracecat.auth.executor_tokens import mint_executor_token
+from tracecat.executor.action_gateway.config import (
+    ACTION_GATEWAY_SANDBOX_SOCKET,
+    action_gateway_socket_path,
+)
 from tracecat.executor.registry_artifacts import RegistryArtifactCache
 from tracecat.executor.schemas import (
     ExecutorActionErrorInfo,
@@ -302,6 +306,13 @@ class ActionRunner:
             sandbox_env["TRACECAT__RUN_ID"] = str(input.run_context.wf_run_id)
             sandbox_env["TRACECAT__WF_EXEC_ID"] = str(input.run_context.wf_exec_id)
             sandbox_env["TRACECAT__ENVIRONMENT"] = input.run_context.environment
+            action_gateway_socket = action_gateway_socket_path()
+            if action_gateway_socket is not None:
+                sandbox_env["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(
+                    ACTION_GATEWAY_SANDBOX_SOCKET
+                )
+            else:
+                sandbox_env.pop("TRACECAT__ACTION_GATEWAY_SOCKET", None)
 
             # Mint an executor token for SDK calls
             if role.workspace_id is None:
@@ -326,6 +337,8 @@ class ActionRunner:
                 tracecat_app_dir=_get_tracecat_app_dir(),
                 site_packages_dir=_get_site_packages_dir(),
                 env_vars=sandbox_env,
+                action_gateway_socket=action_gateway_socket,
+                action_gateway_socket_mount_path=ACTION_GATEWAY_SANDBOX_SOCKET,
                 resources=ResourceLimits(
                     memory_mb=config.TRACECAT__SANDBOX_DEFAULT_MEMORY_MB,
                     timeout_seconds=int(timeout),
@@ -419,6 +432,10 @@ class ActionRunner:
             env["TRACECAT__WF_EXEC_ID"] = str(input.run_context.wf_exec_id)
             env["TRACECAT__ENVIRONMENT"] = input.run_context.environment
             env["TRACECAT__EXECUTOR_TOKEN"] = resolved_context.executor_token
+            if socket_path := action_gateway_socket_path():
+                env["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(socket_path)
+            else:
+                env.pop("TRACECAT__ACTION_GATEWAY_SOCKET", None)
 
         # Build PYTHONPATH with multiple registry paths (deterministic order)
         pythonpath_parts = [str(p) for p in registry_paths if p.exists()]

--- a/tracecat/executor/backends/pool/pool.py
+++ b/tracecat/executor/backends/pool/pool.py
@@ -52,6 +52,10 @@ import orjson
 from pydantic import TypeAdapter
 
 from tracecat import config
+from tracecat.executor.action_gateway.config import (
+    ACTION_GATEWAY_SANDBOX_SOCKET,
+    action_gateway_socket_path,
+)
 from tracecat.executor.schemas import ExecutorResult, ResolvedContext
 from tracecat.executor.secret_preprocessors import project_secret_env
 from tracecat.logger import logger
@@ -275,16 +279,17 @@ class WorkerPool:
         env["TRACECAT_WORKER_ID"] = str(worker_id)
         env["PYTHONDONTWRITEBYTECODE"] = "1"
         env["PYTHONUNBUFFERED"] = "1"
+        action_gateway_socket = action_gateway_socket_path()
 
         if config.TRACECAT__DISABLE_NSJAIL:
             # Direct subprocess mode (no sandbox)
             proc = await self._spawn_direct_worker(
-                worker_id, work_dir, socket_path, env
+                worker_id, work_dir, socket_path, env, action_gateway_socket
             )
         else:
             # Sandboxed mode with nsjail
             proc = await self._spawn_nsjail_worker(
-                worker_id, work_dir, socket_path, env
+                worker_id, work_dir, socket_path, env, action_gateway_socket
             )
 
         # Wait for socket to appear (indicates worker is ready)
@@ -329,12 +334,17 @@ class WorkerPool:
         work_dir: Path,
         socket_path: Path,
         env: dict[str, str],
+        action_gateway_socket: Path | None,
     ) -> asyncio.subprocess.Process:
         """Spawn worker as direct subprocess (no nsjail sandbox)."""
         import sys
 
         # Socket path is the actual host path
         env["TRACECAT_WORKER_SOCKET"] = str(socket_path)
+        if action_gateway_socket is not None:
+            env["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(action_gateway_socket)
+        else:
+            env.pop("TRACECAT__ACTION_GATEWAY_SOCKET", None)
 
         cmd = [
             sys.executable,
@@ -359,13 +369,20 @@ class WorkerPool:
         work_dir: Path,
         socket_path: Path,
         env: dict[str, str],
+        action_gateway_socket: Path | None,
     ) -> asyncio.subprocess.Process:
         """Spawn worker inside nsjail sandbox."""
         # Socket path inside sandbox
         env["TRACECAT_WORKER_SOCKET"] = "/work/task.sock"
+        if action_gateway_socket is not None:
+            env["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(ACTION_GATEWAY_SANDBOX_SOCKET)
+        else:
+            env.pop("TRACECAT__ACTION_GATEWAY_SOCKET", None)
 
         # Build nsjail config
-        nsjail_config = self._build_nsjail_config(worker_id, work_dir)
+        nsjail_config = self._build_nsjail_config(
+            worker_id, work_dir, action_gateway_socket=action_gateway_socket
+        )
         config_path = work_dir.parent / "nsjail.cfg"
         config_path.write_text(nsjail_config)
 
@@ -396,6 +413,11 @@ class WorkerPool:
             "TRACECAT_WORKER_ID",
             "--env",
             "TRACECAT_WORKER_SOCKET",
+            *(
+                ["--env", "TRACECAT__ACTION_GATEWAY_SOCKET"]
+                if "TRACECAT__ACTION_GATEWAY_SOCKET" in env
+                else []
+            ),
             # Set PYTHONPATH explicitly for the sandbox Python
             "--env",
             f"PYTHONPATH={pythonpath}",
@@ -421,7 +443,13 @@ class WorkerPool:
             env=env,
         )
 
-    def _build_nsjail_config(self, worker_id: int, work_dir: Path) -> str:
+    def _build_nsjail_config(
+        self,
+        worker_id: int,
+        work_dir: Path,
+        *,
+        action_gateway_socket: Path | None = None,
+    ) -> str:
         """Build nsjail configuration for a persistent worker."""
         rootfs = config.TRACECAT__SANDBOX_ROOTFS_PATH
         tracecat_app = "/app"  # Where tracecat is installed in container
@@ -512,6 +540,15 @@ class WorkerPool:
                 f'mount {{ src: "{work_dir}" dst: "/work" is_bind: true rw: true }}',
             ]
         )
+
+        if action_gateway_socket is not None:
+            config_lines.extend(
+                [
+                    "",
+                    "# Action Gateway socket for SDK calls",
+                    f'mount {{ src: "{action_gateway_socket}" dst: "{ACTION_GATEWAY_SANDBOX_SOCKET}" is_bind: true rw: false }}',
+                ]
+            )
 
         # Dev and proc
         config_lines.extend(

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -60,6 +60,7 @@ except ImportError:
 
 # Static config (read once at module load, immutable)
 _API_URL = os.environ.get("TRACECAT__API_URL", "http://api:8000")
+_ACTION_GATEWAY_SOCKET = os.environ.get("TRACECAT__ACTION_GATEWAY_SOCKET") or None
 _CAPTURED_OUTPUT_CHAR_LIMIT = 8192
 _SUPPRESSED_OUTPUT_PREVIEW_CHAR_LIMIT = 500
 
@@ -236,6 +237,7 @@ async def _run_udf_async(
             workflow_id=workflow_id,
             run_id=run_id,
             api_url=_API_URL,  # Static, immutable
+            action_gateway_socket=_ACTION_GATEWAY_SOCKET,
             token=executor_token,
         )
         set_context(registry_ctx)
@@ -301,6 +303,7 @@ def _run_udf(
             workflow_id=os.environ.get("TRACECAT__WORKFLOW_ID", ""),
             run_id=os.environ.get("TRACECAT__RUN_ID", ""),
             api_url=_API_URL,
+            action_gateway_socket=_ACTION_GATEWAY_SOCKET,
             token=os.environ.get("TRACECAT__EXECUTOR_TOKEN", ""),
         )
         set_context(registry_ctx)

--- a/tracecat/executor/worker.py
+++ b/tracecat/executor/worker.py
@@ -56,6 +56,7 @@ with workflow.unsafe.imports_passed_through():
 
     from tracecat import config
     from tracecat.dsl.client import get_temporal_client
+    from tracecat.executor.action_gateway.server import ActionGateway
     from tracecat.executor.activities import ExecutorActivities
     from tracecat.executor.backends import (
         initialize_executor_backend,
@@ -118,11 +119,16 @@ async def main() -> None:
         threadpool_max_workers=threadpool_max_workers,
         executor_backend=config.TRACECAT__EXECUTOR_BACKEND,
     )
-
-    # Initialize the executor backend before accepting tasks
-    await initialize_executor_backend()
+    action_gateway = ActionGateway()
 
     try:
+        # Start the local action gateway before sandbox workers are spawned so its
+        # socket path is available in their immutable process environment.
+        await action_gateway.start()
+
+        # Initialize the executor backend before accepting tasks
+        await initialize_executor_backend()
+
         client = await get_temporal_client()
 
         # Collect all activities from executor and registry sync
@@ -169,6 +175,7 @@ async def main() -> None:
     finally:
         logger.info("Shutting down executor backend")
         await shutdown_executor_backend()
+        await action_gateway.stop()
 
 
 def _signal_handler(sig: int, _frame: object) -> None:

--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -40,6 +40,9 @@ class ActionSandboxConfig:
         tracecat_app_dir: Directory containing tracecat package (not mounted in untrusted mode).
         site_packages_dir: Directory containing Python site-packages (not mounted in untrusted mode).
         env_vars: Environment variables to inject (SDK context, NOT DB credentials).
+        action_gateway_socket: Optional host-side action gateway Unix socket to bind
+            into the sandbox for SDK calls.
+        action_gateway_socket_mount_path: Socket path visible inside the sandbox.
         resources: Resource limits for the sandbox.
         timeout_seconds: Maximum execution time in seconds.
     """
@@ -48,6 +51,10 @@ class ActionSandboxConfig:
     tracecat_app_dir: Path
     site_packages_dir: Path | None = None
     env_vars: dict[str, str] = field(default_factory=dict)
+    action_gateway_socket: Path | None = None
+    action_gateway_socket_mount_path: Path = Path(
+        "/var/run/tracecat/action-gateway.sock"
+    )
     resources: ResourceLimits = field(default_factory=ResourceLimits)
     timeout_seconds: float = 300
 
@@ -633,6 +640,12 @@ class NsjailExecutor:
         _validate_path(config.tracecat_app_dir, "tracecat_app_dir")
         if config.site_packages_dir:
             _validate_path(config.site_packages_dir, "site_packages_dir")
+        if config.action_gateway_socket is not None:
+            _validate_path(config.action_gateway_socket, "action_gateway_socket")
+            _validate_path(
+                config.action_gateway_socket_mount_path,
+                "action_gateway_socket_mount_path",
+            )
 
         lines = [
             'name: "action_sandbox"',
@@ -705,6 +718,15 @@ class NsjailExecutor:
                 lines.append(
                     f'mount {{ src: "{registry_path}" dst: "/packages/{i}" is_bind: true rw: false }}'
                 )
+
+        if config.action_gateway_socket is not None:
+            lines.extend(
+                [
+                    "",
+                    "# Action Gateway socket for SDK calls",
+                    f'mount {{ src: "{config.action_gateway_socket}" dst: "{config.action_gateway_socket_mount_path}" is_bind: true rw: false }}',
+                ]
+            )
 
         # NOTE: /app and /site-packages are NOT mounted in untrusted mode
         # Untrusted mode uses minimal_runner.py copied to /work, no tracecat imports


### PR DESCRIPTION
## Summary

- add an executor-local Action Gateway served over a Unix domain socket for action SDK requests
- route registry SDK clients through the gateway when `TRACECAT__ACTION_GATEWAY_SOCKET` is present
- enable the Action Gateway by default while keeping `TRACECAT__ACTION_GATEWAY_ENABLED=false` as the rollback switch
- plumb the gateway socket into direct, worker-pool, and nsjail sandbox execution paths
- add regression coverage for gateway routing, route mounting, and sandbox socket mounts

## Rollout safety

- this is additive at the API surface: the existing API-served `/internal/*` routes are still mounted and continue to work during rollout
- new executors use the local Action Gateway path by default, while old or mixed-version executors can keep calling the API `/internal/*` routes directly
- if the gateway path has an operational issue, operators can disable it with `TRACECAT__ACTION_GATEWAY_ENABLED=false` without reverting the image

## Tests

- `uv run pytest tests/unit/test_action_gateway_app.py tests/registry/test_tracecat_client.py tests/unit/test_action_runner.py tests/unit/test_nsjail_seccomp.py tests/unit/test_sandbox_networking.py`
- `uv run pytest tests/unit/test_config.py tests/unit/test_action_runner.py tests/unit/test_action_gateway_app.py tests/registry/test_tracecat_client.py -q`
- `uv run pytest tests/unit/test_registry.py::test_list_registry_actions tests/unit/test_registry.py::test_registry_actions_include_locked_marks_missing_entitlements tests/unit/test_registry.py::test_registry_actions_include_locked_shows_agent_preset_crud -q`
- `uv run pytest -n 2 tests/unit/test_registry.py::test_list_registry_actions tests/unit/test_registry.py::test_registry_actions_include_locked_marks_missing_entitlements tests/unit/test_registry.py::test_registry_actions_include_locked_shows_agent_preset_crud -q`
- `uv run ruff check tracecat/config.py tests/unit/test_config.py tests/unit/test_action_runner.py`
- `uv run ruff format --check tracecat/config.py tests/unit/test_config.py tests/unit/test_action_runner.py`
- `uv run basedpyright tracecat/config.py tests/unit/test_config.py tests/unit/test_action_runner.py`
