### PR TITLE
fix(executor): allow squashfs module autoload

### DIFF
--- a/tests/unit/test_registry_artifacts.py
+++ b/tests/unit/test_registry_artifacts.py
@@ -191,6 +191,31 @@ class TestRegistryArtifactCache:
         assert artifact.uri == "s3://bucket/path/site-packages.tar.gz"
         assert artifact.format == RegistryArtifactFormat.TAR_GZ
 
+    def test_can_try_squashfs_does_not_require_preloaded_filesystem(
+        self, temp_cache_dir
+    ):
+        """Attempt SquashFS even when the kernel module is not registered yet."""
+        cache = RegistryArtifactCache(temp_cache_dir)
+
+        with (
+            patch(
+                "tracecat.executor.registry_artifacts.shutil.which",
+                return_value="/usr/bin/mount",
+            ),
+            patch(
+                "tracecat.executor.registry_artifacts.config.TRACECAT__EXECUTOR_REGISTRY_SQUASHFS_ENABLED",
+                True,
+            ),
+            patch("tracecat.executor.registry_artifacts.Path") as path_cls,
+        ):
+            filesystems_path = path_cls.return_value
+            filesystems_path.exists.return_value = True
+            filesystems_path.read_text.return_value = "nodev\tproc\nnodev\ttmpfs\n"
+
+            assert cache._can_try_squashfs() is True
+
+        filesystems_path.read_text.assert_not_called()
+
     @pytest.mark.anyio
     async def test_resolve_preferred_artifact_skips_non_registry_tarballs(
         self, temp_cache_dir

--- a/tracecat/executor/registry_artifacts.py
+++ b/tracecat/executor/registry_artifacts.py
@@ -91,23 +91,6 @@ def _tarball_suffix(artifact: RegistryArtifact) -> str:
     raise ValueError(f"Unsupported tarball artifact format: {artifact.format}")
 
 
-def _kernel_supports_squashfs() -> bool:
-    """Return whether the kernel advertises SquashFS filesystem support."""
-    filesystems_path = Path("/proc/filesystems")
-    if not filesystems_path.exists():
-        return True
-
-    try:
-        return any(
-            split_line[-1] == "squashfs"
-            for line in filesystems_path.read_text().splitlines()
-            if (split_line := line.split())
-        )
-    except OSError:
-        logger.debug("Could not inspect kernel filesystems")
-        return True
-
-
 class RegistryArtifactCache:
     """Materializes registry artifacts into executor-local Python paths."""
 
@@ -271,11 +254,13 @@ class RegistryArtifactCache:
 
     def _can_try_squashfs(self) -> bool:
         """Return whether this process should attempt SquashFS registry mounts."""
+        # /proc/filesystems only lists currently registered filesystems. On EKS
+        # AL2023, SquashFS may be available as a loadable module and appear only
+        # after the first successful mount attempt.
         return (
             config.TRACECAT__EXECUTOR_REGISTRY_SQUASHFS_ENABLED
             and not self._squashfs_mount_disabled
             and shutil.which("mount") is not None
-            and _kernel_supports_squashfs()
         )
 
     async def _materialize_squashfs(


### PR DESCRIPTION
## Summary

- allow executor SquashFS materialization to try the mount directly instead of requiring `squashfs` to already appear in `/proc/filesystems`
- keep the existing fallback path when SquashFS mount fails
- add regression coverage for loadable kernel modules that are not registered before the first mount attempt

## Testing

- `uv run pytest tests/unit/test_registry_artifacts.py`
- `uv run ruff check tracecat/executor/registry_artifacts.py tests/unit/test_registry_artifacts.py`
- `uv run ruff format --check tracecat/executor/registry_artifacts.py tests/unit/test_registry_artifacts.py`
- `uv run basedpyright tracecat/executor/registry_artifacts.py tests/unit/test_registry_artifacts.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable SquashFS registry mounts to auto-load the kernel module by attempting the mount even when `squashfs` isn’t listed in `/proc/filesystems`. Keeps the gzip fallback and adds a regression test.

- **Bug Fixes**
  - Removed `_kernel_supports_squashfs` check; attempt SquashFS when enabled and `mount` is available.
  - Preserved fallback to tarball materialization on mount failure.
  - Added unit test to ensure SquashFS is tried without a preloaded filesystem entry.

<sup>Written for commit e9aa2d9b010810283a896d9c65e244636af0aed0. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2719?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

