### PR TITLE
fix(registry): preserve RegistryContext positional args

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/context.py
+++ b/packages/tracecat-registry/tracecat_registry/context.py
@@ -50,9 +50,9 @@ class RegistryContext:
     wf_exec_id: str | None = None
     environment: str = "default"
     api_url: str = "http://api:8000"
-    action_gateway_socket: str | None = None
     executor_url: str = "http://executor:8000"
     token: str = ""
+    action_gateway_socket: str | None = field(default=None, kw_only=True)
     # Lazily initialized SDK client
     _client: TracecatClient | None = field(default=None, repr=False)
 

--- a/tests/registry/test_context.py
+++ b/tests/registry/test_context.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from tracecat_registry.context import RegistryContext
+
+
+def test_registry_context_preserves_positional_executor_url_token_compat() -> None:
+    context = RegistryContext(
+        "workspace-id",
+        "workflow-id",
+        "run-id",
+        "workflow-exec-id",
+        "prod",
+        "http://api:8000",
+        "http://executor:8000",
+        "executor-token",
+    )
+
+    assert context.wf_exec_id == "workflow-exec-id"
+    assert context.environment == "prod"
+    assert context.api_url == "http://api:8000"
+    assert context.executor_url == "http://executor:8000"
+    assert context.token == "executor-token"
+    assert context.action_gateway_socket is None
+
+
+def test_registry_context_accepts_action_gateway_socket_as_keyword_only() -> None:
+    context = RegistryContext(
+        "workspace-id",
+        "workflow-id",
+        "run-id",
+        action_gateway_socket="/var/run/tracecat/action-gateway.sock",
+    )
+
+    assert context.action_gateway_socket == "/var/run/tracecat/action-gateway.sock"


### PR DESCRIPTION
## Summary
- Keep the new RegistryContext action gateway socket keyword-only so the existing positional executor_url/token arguments keep their meaning.
- Add regression coverage for the old positional constructor shape and the new keyword-only socket argument.

## Tests
- uv run pytest tests/registry/test_context.py
- uv run ruff check packages/tracecat-registry/tracecat_registry/context.py tests/registry/test_context.py

Note: commit hooks passed with SKIP=gen-client because this fresh worktree did not have frontend node_modules/openapi-ts installed and this change does not affect the OpenAPI schema.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `RegistryContext` positional arguments by making `action_gateway_socket` keyword-only, so `executor_url` and `token` keep their original positions. Adds regression tests for the old positional constructor and the new keyword-only socket.

<sup>Written for commit 37a2e592ec16ec21e91cc7ca2e263ab43f8be56a. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2720?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

