### PR TITLE
fix(executor): route legacy SDK calls through gateway

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/context.py
+++ b/packages/tracecat-registry/tracecat_registry/context.py
@@ -39,7 +39,6 @@ class RegistryContext:
         wf_exec_id: The full workflow execution ID (for correlation).
         environment: The execution environment (e.g., "default").
         api_url: The Tracecat API URL.
-        action_gateway_socket: Optional local action gateway Unix socket for SDK requests.
         executor_url: The Tracecat executor service URL (sandbox execution).
         token: The executor JWT for authentication.
     """
@@ -52,7 +51,6 @@ class RegistryContext:
     api_url: str = "http://api:8000"
     executor_url: str = "http://executor:8000"
     token: str = ""
-    action_gateway_socket: str | None = field(default=None, kw_only=True)
     # Lazily initialized SDK client
     _client: TracecatClient | None = field(default=None, repr=False)
 
@@ -67,7 +65,6 @@ class RegistryContext:
         - TRACECAT__WF_EXEC_ID: Full workflow execution ID (for correlation)
         - TRACECAT__ENVIRONMENT: Execution environment (default: "default")
         - TRACECAT__API_URL: API URL (default: "http://api:8000")
-        - TRACECAT__ACTION_GATEWAY_SOCKET: Action Gateway socket for internal SDK requests
         - TRACECAT__EXECUTOR_URL: Executor URL (default: "http://executor:8000")
         - TRACECAT__EXECUTOR_TOKEN: JWT token for authentication
 
@@ -95,8 +92,6 @@ class RegistryContext:
             wf_exec_id=os.environ.get("TRACECAT__WF_EXEC_ID"),
             environment=os.environ.get("TRACECAT__ENVIRONMENT", "default"),
             api_url=os.environ.get("TRACECAT__API_URL", "http://api:8000"),
-            action_gateway_socket=os.environ.get("TRACECAT__ACTION_GATEWAY_SOCKET")
-            or None,
             executor_url=os.environ.get(
                 "TRACECAT__EXECUTOR_URL", "http://executor:8000"
             ),
@@ -110,7 +105,6 @@ class RegistryContext:
 
         return TracecatClient(
             api_url=self.api_url,
-            action_gateway_socket=self.action_gateway_socket,
             token=self.token,
             workspace_id=self.workspace_id,
         )

--- a/packages/tracecat-registry/tracecat_registry/sdk/client.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/client.py
@@ -32,7 +32,6 @@ class TracecatClient:
 
     Configuration is read from environment variables:
     - TRACECAT__API_URL: Base URL of the Tracecat API
-    - TRACECAT__ACTION_GATEWAY_SOCKET: Local gateway socket for internal SDK requests
     - TRACECAT__EXECUTOR_TOKEN: JWT token for authentication
     - TRACECAT__WORKSPACE_ID: Current workspace ID (added to requests)
     """
@@ -41,7 +40,6 @@ class TracecatClient:
         self,
         *,
         api_url: str | None = None,
-        action_gateway_socket: str | None = None,
         token: str | None = None,
         workspace_id: str | None = None,
         timeout: float = 120.0,
@@ -50,8 +48,6 @@ class TracecatClient:
 
         Args:
             api_url: Base URL of the Tracecat API. Defaults to TRACECAT__API_URL env var.
-            action_gateway_socket: Optional action gateway Unix socket path for
-                internal SDK requests. Defaults to TRACECAT__ACTION_GATEWAY_SOCKET.
             token: JWT token for authentication. Defaults to TRACECAT__EXECUTOR_TOKEN env var.
             workspace_id: Workspace ID. Defaults to TRACECAT__WORKSPACE_ID env var.
             timeout: Request timeout in seconds.
@@ -59,11 +55,9 @@ class TracecatClient:
         self._api_url = self._normalize_internal_url(
             api_url or os.environ.get("TRACECAT__API_URL", "http://api:8000")
         )
-        self._action_gateway_socket = (
-            action_gateway_socket
-            or os.environ.get("TRACECAT__ACTION_GATEWAY_SOCKET")
-            or None
-        )
+        self._action_gateway_socket = os.environ.get("TRACECAT__ACTION_GATEWAY_SOCKET")
+        if not self._action_gateway_socket:
+            self._action_gateway_socket = None
 
         self._token = token or os.environ.get("TRACECAT__EXECUTOR_TOKEN", "")
         self._workspace_id = workspace_id or os.environ.get(

--- a/packages/tracecat-registry/tracecat_registry/sdk/client.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/client.py
@@ -40,6 +40,7 @@ class TracecatClient:
         self,
         *,
         api_url: str | None = None,
+        action_gateway_socket: str | None = None,
         token: str | None = None,
         workspace_id: str | None = None,
         timeout: float = 120.0,
@@ -48,6 +49,8 @@ class TracecatClient:
 
         Args:
             api_url: Base URL of the Tracecat API. Defaults to TRACECAT__API_URL env var.
+            action_gateway_socket: Compatibility override for the executor-local
+                gateway socket. Defaults to TRACECAT__ACTION_GATEWAY_SOCKET.
             token: JWT token for authentication. Defaults to TRACECAT__EXECUTOR_TOKEN env var.
             workspace_id: Workspace ID. Defaults to TRACECAT__WORKSPACE_ID env var.
             timeout: Request timeout in seconds.
@@ -55,7 +58,9 @@ class TracecatClient:
         self._api_url = self._normalize_internal_url(
             api_url or os.environ.get("TRACECAT__API_URL", "http://api:8000")
         )
-        self._action_gateway_socket = os.environ.get("TRACECAT__ACTION_GATEWAY_SOCKET")
+        self._action_gateway_socket = action_gateway_socket or os.environ.get(
+            "TRACECAT__ACTION_GATEWAY_SOCKET"
+        )
         if not self._action_gateway_socket:
             self._action_gateway_socket = None
 

--- a/tests/registry/test_context.py
+++ b/tests/registry/test_context.py
@@ -20,15 +20,3 @@ def test_registry_context_preserves_positional_executor_url_token_compat() -> No
     assert context.api_url == "http://api:8000"
     assert context.executor_url == "http://executor:8000"
     assert context.token == "executor-token"
-    assert context.action_gateway_socket is None
-
-
-def test_registry_context_accepts_action_gateway_socket_as_keyword_only() -> None:
-    context = RegistryContext(
-        "workspace-id",
-        "workflow-id",
-        "run-id",
-        action_gateway_socket="/var/run/tracecat/action-gateway.sock",
-    )
-
-    assert context.action_gateway_socket == "/var/run/tracecat/action-gateway.sock"

--- a/tests/registry/test_context.py
+++ b/tests/registry/test_context.py
@@ -4,6 +4,12 @@ from tracecat_registry.context import RegistryContext
 
 
 def test_registry_context_preserves_positional_executor_url_token_compat() -> None:
+    """Adding gateway support must not shift RegistryContext positional slots.
+
+    Registry artifacts can instantiate this dataclass positionally. The gateway
+    socket must stay out of this constructor contract so `executor_url` and
+    `token` keep their historical slots.
+    """
     context = RegistryContext(
         "workspace-id",
         "workflow-id",

--- a/tests/registry/test_tracecat_client.py
+++ b/tests/registry/test_tracecat_client.py
@@ -133,6 +133,69 @@ async def test_empty_action_gateway_socket_env_uses_api_url(
 
 
 @pytest.mark.anyio
+async def test_action_gateway_socket_keyword_is_supported_for_compat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TRACECAT__ACTION_GATEWAY_SOCKET", raising=False)
+    captured: dict[str, Any] = {}
+
+    class FakeTransport:
+        def __init__(self, *, uds: str) -> None:
+            captured["uds"] = uds
+
+    class FakeAsyncClient:
+        def __init__(
+            self,
+            *,
+            transport: FakeTransport | None,
+            timeout: float,
+        ) -> None:
+            captured["transport"] = transport
+            captured["timeout"] = timeout
+
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def request(
+            self,
+            method: str,
+            url: str,
+            *,
+            params: dict[str, Any] | None,
+            json: Any | None,
+            headers: dict[str, str],
+        ) -> httpx.Response:
+            captured["method"] = method
+            captured["url"] = url
+            captured["params"] = params
+            captured["json"] = json
+            captured["headers"] = headers
+            return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(httpx, "AsyncHTTPTransport", FakeTransport)
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    client = TracecatClient(
+        api_url="http://api:8000",
+        action_gateway_socket="/var/run/tracecat/action-gateway.sock",
+        token="executor-token",
+        timeout=12.0,
+    )
+
+    result = await client.get("/cases/case-id")
+
+    assert result == {"ok": True}
+    assert captured["uds"] == "/var/run/tracecat/action-gateway.sock"
+    assert captured["timeout"] == 12.0
+    assert captured["method"] == "GET"
+    assert captured["url"] == "http://tracecat-action-gateway/internal/cases/case-id"
+    assert captured["headers"]["Authorization"] == "Bearer executor-token"
+
+
+@pytest.mark.anyio
 async def test_request_uses_api_url_without_action_gateway(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/registry/test_tracecat_client.py
+++ b/tests/registry/test_tracecat_client.py
@@ -13,6 +13,12 @@ from tracecat_registry.sdk.client import TracecatClient
 async def test_request_uses_action_gateway_unix_socket(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Current SDKs route internal requests through the gateway socket from env.
+
+    This is the normal executor path for freshly loaded SDK code. The client
+    keeps `api_url` unchanged for callers, but selects a UDS transport for the
+    actual request when `TRACECAT__ACTION_GATEWAY_SOCKET` is set.
+    """
     monkeypatch.setenv(
         "TRACECAT__ACTION_GATEWAY_SOCKET",
         "/var/run/tracecat/action-gateway.sock",
@@ -70,6 +76,8 @@ async def test_request_uses_action_gateway_unix_socket(
     assert captured["uds"] == "/var/run/tracecat/action-gateway.sock"
     assert captured["timeout"] == 12.0
     assert captured["method"] == "POST"
+    # With a UDS transport the host is only a placeholder; the path is what the
+    # action gateway FastAPI app receives.
     assert captured["url"] == "http://tracecat-action-gateway/internal/cases/metrics"
     assert captured["json"] == {"case_ids": []}
     assert captured["headers"]["Authorization"] == "Bearer executor-token"
@@ -79,6 +87,11 @@ async def test_request_uses_action_gateway_unix_socket(
 async def test_empty_action_gateway_socket_env_uses_api_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """An empty socket env var is treated as disabled and falls back to API URL.
+
+    This keeps local/dev environments from accidentally constructing an invalid
+    UDS transport when the socket variable is present but blank.
+    """
     monkeypatch.setenv("TRACECAT__ACTION_GATEWAY_SOCKET", "")
     captured: dict[str, Any] = {}
 
@@ -136,6 +149,12 @@ async def test_empty_action_gateway_socket_env_uses_api_url(
 async def test_action_gateway_socket_keyword_is_supported_for_compat(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """The rc-era explicit socket keyword remains a TracecatClient-only alias.
+
+    The keyword is kept for direct SDK callers from the rc line, but it does not
+    flow through `RegistryContext`; transport selection remains private to the
+    client/minimal-runner boundary.
+    """
     monkeypatch.delenv("TRACECAT__ACTION_GATEWAY_SOCKET", raising=False)
     captured: dict[str, Any] = {}
 
@@ -199,6 +218,11 @@ async def test_action_gateway_socket_keyword_is_supported_for_compat(
 async def test_request_uses_api_url_without_action_gateway(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """SDK requests keep using TRACECAT__API_URL when no gateway socket exists.
+
+    This covers non-executor contexts and disabled gateway deployments, where
+    the SDK should behave like the pre-gateway client.
+    """
     monkeypatch.delenv("TRACECAT__ACTION_GATEWAY_SOCKET", raising=False)
     captured: dict[str, Any] = {}
 

--- a/tests/registry/test_tracecat_client.py
+++ b/tests/registry/test_tracecat_client.py
@@ -13,6 +13,10 @@ from tracecat_registry.sdk.client import TracecatClient
 async def test_request_uses_action_gateway_unix_socket(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv(
+        "TRACECAT__ACTION_GATEWAY_SOCKET",
+        "/var/run/tracecat/action-gateway.sock",
+    )
     captured: dict[str, Any] = {}
 
     class FakeTransport:
@@ -56,7 +60,6 @@ async def test_request_uses_action_gateway_unix_socket(
 
     client = TracecatClient(
         api_url="http://api:8000",
-        action_gateway_socket="/var/run/tracecat/action-gateway.sock",
         token="executor-token",
         timeout=12.0,
     )
@@ -172,7 +175,6 @@ async def test_request_uses_api_url_without_action_gateway(
 
     client = TracecatClient(
         api_url="http://api:8000",
-        action_gateway_socket=None,
         token="executor-token",
         timeout=12.0,
     )

--- a/tests/unit/executor/test_minimal_runner_protocol.py
+++ b/tests/unit/executor/test_minimal_runner_protocol.py
@@ -4,6 +4,7 @@ import asyncio
 import io
 import sys
 import types
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from typing import Any
@@ -16,14 +17,25 @@ from pydantic import BaseModel
 
 from tracecat.executor import minimal_runner
 
+# --- Action Gateway compatibility regressions ---
+
 
 def test_action_gateway_sdk_transport_patches_legacy_tracecat_client(
     monkeypatch,
 ) -> None:
+    """Legacy SDK clients are patched to use the executor-local gateway.
+
+    Cached registry artifacts can contain SDKs from before
+    `_request_url_and_transport` existed. Those clients would otherwise keep
+    calling `/internal` over `TRACECAT__API_URL`; the minimal runner shim must
+    replace only their `request()` method and send traffic through the UDS.
+    """
     captured: dict[str, Any] = {}
     sdk_client: Any = types.ModuleType("tracecat_registry.sdk.client")
 
     class LegacyTracecatClient:
+        """Old SDK shape: request exists, gateway transport helper does not."""
+
         def __init__(self) -> None:
             self._timeout = 12.0
 
@@ -78,6 +90,8 @@ def test_action_gateway_sdk_transport_patches_legacy_tracecat_client(
         raise ImportError(name)
 
     sdk_client.TracecatClient = LegacyTracecatClient
+    # The gateway socket is the only signal the minimal runner uses to enable
+    # legacy SDK patching.
     monkeypatch.setattr(
         minimal_runner,
         "_ACTION_GATEWAY_SOCKET",
@@ -98,6 +112,8 @@ def test_action_gateway_sdk_transport_patches_legacy_tracecat_client(
 
     assert result == {"ok": True}
     assert captured["uds"] == "/var/run/tracecat/action-gateway.sock"
+    # The hostname is intentionally synthetic: httpx ignores it when a UDS
+    # transport is supplied, while FastAPI still receives the `/internal` path.
     assert captured["timeout"] == 12.0
     assert captured["method"] == "GET"
     assert captured["url"] == "http://tracecat-action-gateway/internal/cases"
@@ -108,9 +124,17 @@ def test_action_gateway_sdk_transport_patches_legacy_tracecat_client(
 def test_action_gateway_sdk_transport_leaves_current_tracecat_client_unpatched(
     monkeypatch,
 ) -> None:
+    """Current SDK clients keep native request and transport behavior.
+
+    Newer SDKs expose `_request_url_and_transport`, so the minimal runner should
+    not monkeypatch them. This prevents the compatibility shim from overriding
+    the current SDK's own env/keyword handling.
+    """
     sdk_client: Any = types.ModuleType("tracecat_registry.sdk.client")
 
     class CurrentTracecatClient:
+        """Current SDK shape: native gateway transport helper is present."""
+
         def _request_url_and_transport(self) -> None:
             return None
 
@@ -133,6 +157,172 @@ def test_action_gateway_sdk_transport_leaves_current_tracecat_client_unpatched(
     minimal_runner._install_action_gateway_sdk_transport()
 
     assert asyncio.run(CurrentTracecatClient().request()) == "original"
+
+
+def test_run_udf_supports_legacy_registry_context_and_sdk_gateway_transport(
+    monkeypatch,
+) -> None:
+    """Old cached artifacts still run when the executor gateway socket is set.
+
+    This mirrors the EU failure mode: old `RegistryContext` dataclasses do not
+    accept `action_gateway_socket`, and old `TracecatClient` classes do not know
+    how to select the gateway transport. `_run_udf` must keep the socket out of
+    the context constructor while patching SDK requests through the UDS.
+    """
+    captured: dict[str, Any] = {}
+
+    # Build a fake old tracecat_registry package tree so `_run_udf` exercises
+    # the same import boundary it uses for cached registry artifacts.
+    registry_pkg: Any = types.ModuleType("tracecat_registry")
+    registry_pkg.__path__ = []
+    context_module: Any = types.ModuleType("tracecat_registry.context")
+    sdk_pkg: Any = types.ModuleType("tracecat_registry.sdk")
+    sdk_pkg.__path__ = []
+    sdk_client: Any = types.ModuleType("tracecat_registry.sdk.client")
+    internal_pkg: Any = types.ModuleType("tracecat_registry._internal")
+    internal_pkg.__path__ = []
+    secrets_module: Any = types.ModuleType("tracecat_registry._internal.secrets")
+    action_module: Any = types.ModuleType("legacy_action_module")
+
+    @dataclass
+    class LegacyRegistryContext:
+        """Pre-gateway RegistryContext shape.
+
+        This intentionally has the old dataclass fields and no
+        `action_gateway_socket` field. Passing that keyword would raise the
+        same TypeError seen in EU.
+        """
+
+        workspace_id: str
+        workflow_id: str
+        run_id: str
+        wf_exec_id: str | None = None
+        environment: str = "default"
+        api_url: str = "http://api:8000"
+        executor_url: str = "http://executor:8000"
+        token: str = ""
+
+    def set_context(ctx: LegacyRegistryContext) -> None:
+        captured["registry_context"] = ctx
+
+    class LegacyTracecatClient:
+        """Old SDK shape used by pinned registry artifacts."""
+
+        def __init__(self) -> None:
+            self._timeout = 12.0
+
+        def _get_headers(self) -> dict[str, str]:
+            return {"Authorization": "Bearer executor-token"}
+
+        def _handle_error_response(self, response: httpx.Response) -> None:
+            raise AssertionError(response.status_code)
+
+        async def request(self, *_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("legacy SDK request should be patched")
+
+    class FakeTransport:
+        def __init__(self, *, uds: str) -> None:
+            captured["uds"] = uds
+
+    class FakeAsyncClient:
+        def __init__(
+            self,
+            *,
+            transport: FakeTransport,
+            timeout: float,
+        ) -> None:
+            captured["transport"] = transport
+            captured["timeout"] = timeout
+
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def request(
+            self,
+            method: str,
+            url: str,
+            *,
+            params: dict[str, Any] | None,
+            json: Any | None,
+            headers: dict[str, str],
+        ) -> httpx.Response:
+            captured["method"] = method
+            captured["url"] = url
+            captured["params"] = params
+            captured["json"] = json
+            captured["headers"] = headers
+            return httpx.Response(200, json={"ok": True})
+
+    def action() -> Any:
+        # `_run_udf` installs the shim before importing/calling the action, so
+        # this request should be routed through the gateway despite using the
+        # legacy client class.
+        return asyncio.run(
+            LegacyTracecatClient().request(
+                "GET",
+                "/cases",
+                params={"limit": 1},
+            )
+        )
+
+    context_module.RegistryContext = LegacyRegistryContext
+    context_module.set_context = set_context
+    sdk_client.TracecatClient = LegacyTracecatClient
+    secrets_module.set_context = lambda _secret_env: "secret-token"
+    secrets_module.reset_context = lambda _token: None
+    action_module.action = action
+
+    # Make normal imports inside `_run_udf` resolve to the fake old package.
+    for name, module in {
+        "tracecat_registry": registry_pkg,
+        "tracecat_registry.context": context_module,
+        "tracecat_registry.sdk": sdk_pkg,
+        "tracecat_registry.sdk.client": sdk_client,
+        "tracecat_registry._internal": internal_pkg,
+        "tracecat_registry._internal.secrets": secrets_module,
+        "legacy_action_module": action_module,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    # Simulate the executor environment that originally triggered the failure.
+    monkeypatch.setattr(minimal_runner, "_API_URL", "http://api:8000")
+    monkeypatch.setattr(
+        minimal_runner,
+        "_ACTION_GATEWAY_SOCKET",
+        "/var/run/tracecat/action-gateway.sock",
+    )
+    monkeypatch.setenv("TRACECAT__WORKSPACE_ID", "workspace-id")
+    monkeypatch.setenv("TRACECAT__WORKFLOW_ID", "workflow-id")
+    monkeypatch.setenv("TRACECAT__RUN_ID", "run-id")
+    monkeypatch.setenv("TRACECAT__EXECUTOR_TOKEN", "executor-token")
+    monkeypatch.setattr(httpx, "AsyncHTTPTransport", FakeTransport)
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    result = minimal_runner._run_udf(
+        {"module": "legacy_action_module", "name": "action"},
+        {},
+        {},
+    )
+
+    # The result proves both halves of the compatibility path:
+    # - RegistryContext accepted the constructor because no socket kw was passed.
+    # - LegacyTracecatClient.request was patched onto the UDS transport.
+    assert result == {"ok": True}
+    registry_context = captured["registry_context"]
+    assert registry_context == LegacyRegistryContext(
+        workspace_id="workspace-id",
+        workflow_id="workflow-id",
+        run_id="run-id",
+        api_url="http://api:8000",
+        token="executor-token",
+    )
+    assert captured["uds"] == "/var/run/tracecat/action-gateway.sock"
+    assert captured["url"] == "http://tracecat-action-gateway/internal/cases"
+    assert captured["params"] == {"limit": 1}
+    assert captured["headers"]["Authorization"] == "Bearer executor-token"
 
 
 def test_main_minimal_suppresses_action_stdout_and_stderr(monkeypatch) -> None:

--- a/tests/unit/executor/test_minimal_runner_protocol.py
+++ b/tests/unit/executor/test_minimal_runner_protocol.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import io
 import sys
 import types
@@ -8,11 +9,130 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
+import httpx
 import orjson
 import pytest
 from pydantic import BaseModel
 
 from tracecat.executor import minimal_runner
+
+
+def test_action_gateway_sdk_transport_patches_legacy_tracecat_client(
+    monkeypatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    sdk_client: Any = types.ModuleType("tracecat_registry.sdk.client")
+
+    class LegacyTracecatClient:
+        def __init__(self) -> None:
+            self._timeout = 12.0
+
+        def _get_headers(self) -> dict[str, str]:
+            return {"Authorization": "Bearer executor-token"}
+
+        def _handle_error_response(self, response: httpx.Response) -> None:
+            raise AssertionError(response.status_code)
+
+        async def request(self, *_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("original request should be patched")
+
+    class FakeTransport:
+        def __init__(self, *, uds: str) -> None:
+            captured["uds"] = uds
+
+    class FakeAsyncClient:
+        def __init__(
+            self,
+            *,
+            transport: FakeTransport,
+            timeout: float,
+        ) -> None:
+            captured["transport"] = transport
+            captured["timeout"] = timeout
+
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def request(
+            self,
+            method: str,
+            url: str,
+            *,
+            params: dict[str, Any] | None,
+            json: Any | None,
+            headers: dict[str, str],
+        ) -> httpx.Response:
+            captured["method"] = method
+            captured["url"] = url
+            captured["params"] = params
+            captured["json"] = json
+            captured["headers"] = headers
+            return httpx.Response(200, json={"ok": True})
+
+    def import_module(name: str) -> Any:
+        if name == "tracecat_registry.sdk.client":
+            return sdk_client
+        raise ImportError(name)
+
+    sdk_client.TracecatClient = LegacyTracecatClient
+    monkeypatch.setattr(
+        minimal_runner,
+        "_ACTION_GATEWAY_SOCKET",
+        "/var/run/tracecat/action-gateway.sock",
+    )
+    monkeypatch.setattr(minimal_runner.importlib, "import_module", import_module)
+    monkeypatch.setattr(httpx, "AsyncHTTPTransport", FakeTransport)
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    minimal_runner._install_action_gateway_sdk_transport()
+    result = asyncio.run(
+        LegacyTracecatClient().request(
+            "GET",
+            "/cases",
+            params={"limit": 1},
+        )
+    )
+
+    assert result == {"ok": True}
+    assert captured["uds"] == "/var/run/tracecat/action-gateway.sock"
+    assert captured["timeout"] == 12.0
+    assert captured["method"] == "GET"
+    assert captured["url"] == "http://tracecat-action-gateway/internal/cases"
+    assert captured["params"] == {"limit": 1}
+    assert captured["headers"]["Authorization"] == "Bearer executor-token"
+
+
+def test_action_gateway_sdk_transport_leaves_current_tracecat_client_unpatched(
+    monkeypatch,
+) -> None:
+    sdk_client: Any = types.ModuleType("tracecat_registry.sdk.client")
+
+    class CurrentTracecatClient:
+        def _request_url_and_transport(self) -> None:
+            return None
+
+        async def request(self) -> str:
+            return "original"
+
+    def import_module(name: str) -> Any:
+        if name == "tracecat_registry.sdk.client":
+            return sdk_client
+        raise ImportError(name)
+
+    sdk_client.TracecatClient = CurrentTracecatClient
+    monkeypatch.setattr(
+        minimal_runner,
+        "_ACTION_GATEWAY_SOCKET",
+        "/var/run/tracecat/action-gateway.sock",
+    )
+    monkeypatch.setattr(minimal_runner.importlib, "import_module", import_module)
+
+    minimal_runner._install_action_gateway_sdk_transport()
+
+    assert asyncio.run(CurrentTracecatClient().request()) == "original"
 
 
 def test_main_minimal_suppresses_action_stdout_and_stderr(monkeypatch) -> None:

--- a/tracecat/executor/minimal_runner.py
+++ b/tracecat/executor/minimal_runner.py
@@ -65,6 +65,66 @@ _CAPTURED_OUTPUT_CHAR_LIMIT = 8192
 _SUPPRESSED_OUTPUT_PREVIEW_CHAR_LIMIT = 500
 
 
+def _install_action_gateway_sdk_transport() -> None:
+    """Patch legacy registry SDK clients to use the executor gateway socket."""
+    if _ACTION_GATEWAY_SOCKET is None:
+        return
+    socket_path = _ACTION_GATEWAY_SOCKET
+
+    try:
+        import httpx
+
+        sdk_client = importlib.import_module("tracecat_registry.sdk.client")
+    except ImportError:
+        return
+
+    tracecat_client_cls = getattr(sdk_client, "TracecatClient", None)
+    if tracecat_client_cls is None:
+        return
+
+    if hasattr(tracecat_client_cls, "_request_url_and_transport"):
+        return
+
+    if getattr(tracecat_client_cls, "_tracecat_action_gateway_transport", False):
+        return
+
+    async def request(
+        self: Any,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: Any | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
+        request_headers = self._get_headers()
+        if headers:
+            request_headers.update(headers)
+
+        async with httpx.AsyncClient(
+            transport=httpx.AsyncHTTPTransport(uds=socket_path),
+            timeout=getattr(self, "_timeout", 120.0),
+        ) as client:
+            response = await client.request(
+                method,
+                f"http://tracecat-action-gateway/internal{path}",
+                params=params,
+                json=json,
+                headers=request_headers,
+            )
+
+        if not response.is_success:
+            self._handle_error_response(response)
+
+        if not response.content:
+            return None
+
+        return response.json()
+
+    tracecat_client_cls.request = request
+    tracecat_client_cls._tracecat_action_gateway_transport = True
+
+
 class _CappedTextBuffer:
     """Lightweight text buffer with a hard character cap."""
 
@@ -232,12 +292,12 @@ async def _run_udf_async(
     try:
         from tracecat_registry.context import RegistryContext, set_context
 
+        _install_action_gateway_sdk_transport()
         registry_ctx = RegistryContext(
             workspace_id=workspace_id,
             workflow_id=workflow_id,
             run_id=run_id,
             api_url=_API_URL,  # Static, immutable
-            action_gateway_socket=_ACTION_GATEWAY_SOCKET,
             token=executor_token,
         )
         set_context(registry_ctx)
@@ -298,12 +358,12 @@ def _run_udf(
     try:
         from tracecat_registry.context import RegistryContext, set_context
 
+        _install_action_gateway_sdk_transport()
         registry_ctx = RegistryContext(
             workspace_id=os.environ.get("TRACECAT__WORKSPACE_ID", ""),
             workflow_id=os.environ.get("TRACECAT__WORKFLOW_ID", ""),
             run_id=os.environ.get("TRACECAT__RUN_ID", ""),
             api_url=_API_URL,
-            action_gateway_socket=_ACTION_GATEWAY_SOCKET,
             token=os.environ.get("TRACECAT__EXECUTOR_TOKEN", ""),
         )
         set_context(registry_ctx)


### PR DESCRIPTION
## Summary

- keep `RegistryContext` focused on execution identity by removing action gateway socket plumbing
- have current registry SDK clients privately select the action gateway UDS from the executor environment
- patch legacy pinned registry SDK clients inside `minimal_runner` so old workflow locks route SDK calls through the gateway instead of `/internal` on the API service

## Tests

- `uv run pytest tests/unit/executor/test_minimal_runner_protocol.py tests/registry/test_context.py tests/registry/test_tracecat_client.py -q`
- `uv run ruff check tracecat/executor/minimal_runner.py packages/tracecat-registry/tracecat_registry/context.py packages/tracecat-registry/tracecat_registry/sdk/client.py tests/unit/executor/test_minimal_runner_protocol.py tests/registry/test_context.py tests/registry/test_tracecat_client.py`
- `uv run ruff format --check tracecat/executor/minimal_runner.py packages/tracecat-registry/tracecat_registry/context.py packages/tracecat-registry/tracecat_registry/sdk/client.py tests/unit/executor/test_minimal_runner_protocol.py tests/registry/test_context.py tests/registry/test_tracecat_client.py`
- `uv run basedpyright tracecat/executor/minimal_runner.py packages/tracecat-registry/tracecat_registry/context.py packages/tracecat-registry/tracecat_registry/sdk/client.py tests/unit/executor/test_minimal_runner_protocol.py tests/registry/test_context.py tests/registry/test_tracecat_client.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes legacy registry SDK calls through the Action Gateway UDS from the executor to avoid hitting the API `/internal` endpoint and stabilize legacy workflows. Removes gateway plumbing from `RegistryContext`; current SDKs auto-select the socket via env, and the executor shims only legacy clients at runtime.

- **Bug Fixes**
  - In `minimal_runner`, install a transport shim that patches only legacy `TracecatClient` (no `_request_url_and_transport`) to send requests to `http://tracecat-action-gateway/internal/*` over the UDS when `TRACECAT__ACTION_GATEWAY_SOCKET` is set; current clients are untouched.
  - Preserve auth headers and timeouts; treat empty `TRACECAT__ACTION_GATEWAY_SOCKET` as disabled and fall back to the API URL.
  - Keep the `action_gateway_socket` keyword on `TracecatClient` as a compatibility override; add tests for env routing (including empty), keyword support, no-op behavior on current clients, and legacy `RegistryContext`/UDF flows in the executor.

- **Migration**
  - `RegistryContext` no longer accepts `action_gateway_socket`; transport config is removed from context.
  - `TracecatClient` reads `TRACECAT__ACTION_GATEWAY_SOCKET` automatically and still accepts `action_gateway_socket` for backward compatibility. No workflow changes required; ensure the executor sets `TRACECAT__ACTION_GATEWAY_SOCKET`.

<sup>Written for commit a0ea9c5b689dc7a8d52545ed5b1a60ac0fa54771. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2722?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

