### PR TITLE
fix(ui): remove duplicate runs sidebar link

### DIFF
--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -146,13 +146,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         visible: canViewWorkflows === true,
       },
       {
-        title: "Runs",
-        url: `${basePath}/runs`,
-        icon: ListVideoIcon,
-        isActive: pathname?.startsWith(`${basePath}/runs`),
-        visible: canViewWorkflows === true,
-      },
-      {
         title: "Cases",
         url: `${basePath}/cases`,
         icon: LayersIcon,


### PR DESCRIPTION
## Summary

This PR removes the duplicate `Runs` entry from the Workspace group in the app sidebar. `Runs` already appears in the Monitor group and points to the same workspace runs route, so keeping both entries made the navigation redundant.

## Cause and effect

The sidebar configuration defined a `Runs` item in both `navWorkspace` and `navMonitor`. Users would see two links to the same `/workspaces/{workspaceId}/runs` destination, which made the grouping less clear and duplicated the monitoring surface in the workspace navigation section.

## Fix

The Workspace group now keeps `Workflows` followed by the rest of the workspace resources, while the Monitor group remains the single place for `Runs`. No route behavior changed.

## Verification

- `git diff --check`
- Commit hooks passed after installing frontend dependencies with `pnpm -C frontend install`, including frontend Biome and TypeScript checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate “Runs” link from the Workspace group in the sidebar. “Runs” now appears only under Monitor; no routes or behavior changed.

<sup>Written for commit cc5a1537346dd40f22e0d7cfe00fb3302153274f. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2723?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

