### PR TITLE
feat(admin): add registry artifact backfill control

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -17891,6 +17891,42 @@ export const $RegistryActionValidationErrorInfo = {
   title: "RegistryActionValidationErrorInfo",
 } as const
 
+export const $RegistryArtifactsBackfillStartRequest = {
+  properties: {
+    version_ids: {
+      items: {
+        type: "string",
+        format: "uuid",
+      },
+      type: "array",
+      minItems: 1,
+      title: "Version Ids",
+    },
+  },
+  type: "object",
+  required: ["version_ids"],
+  title: "RegistryArtifactsBackfillStartRequest",
+  description:
+    "Request to start an artifact backfill workflow for selected versions.",
+} as const
+
+export const $RegistryArtifactsBackfillStartResponse = {
+  properties: {
+    workflow_id: {
+      type: "string",
+      title: "Workflow Id",
+    },
+    requested_count: {
+      type: "integer",
+      title: "Requested Count",
+    },
+  },
+  type: "object",
+  required: ["workflow_id", "requested_count"],
+  title: "RegistryArtifactsBackfillStartResponse",
+  description: "Response after scheduling an artifact backfill workflow.",
+} as const
+
 export const $RegistryLock = {
   properties: {
     origins: {
@@ -29926,6 +29962,26 @@ export const $tracecat__admin__registry__schemas__RegistryVersionRead = {
       type: "string",
       format: "date-time",
       title: "Created At",
+    },
+    is_current: {
+      type: "boolean",
+      title: "Is Current",
+      default: false,
+    },
+    artifacts_ready: {
+      type: "boolean",
+      title: "Artifacts Ready",
+      default: false,
+    },
+    workflow_definition_count: {
+      type: "integer",
+      title: "Workflow Definition Count",
+      default: 0,
+    },
+    in_use: {
+      type: "boolean",
+      title: "In Use",
+      default: false,
     },
   },
   type: "object",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -73,6 +73,8 @@ import type {
   AdminRegistryListRegistryVersionsResponse,
   AdminRegistryPromoteRegistryVersionData,
   AdminRegistryPromoteRegistryVersionResponse,
+  AdminRegistryStartRegistryArtifactsBackfillData,
+  AdminRegistryStartRegistryArtifactsBackfillResponse,
   AdminRegistrySyncAllRepositoriesData,
   AdminRegistrySyncAllRepositoriesResponse,
   AdminRegistrySyncRepositoryData,
@@ -7815,6 +7817,28 @@ export const adminRegistryListRegistryVersions = (
       repository_id: data.repositoryId,
       limit: data.limit,
     },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Start Registry Artifacts Backfill
+ * Start a workflow to backfill artifacts for selected versions.
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns RegistryArtifactsBackfillStartResponse Successful Response
+ * @throws ApiError
+ */
+export const adminRegistryStartRegistryArtifactsBackfill = (
+  data: AdminRegistryStartRegistryArtifactsBackfillData
+): CancelablePromise<AdminRegistryStartRegistryArtifactsBackfillResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/admin/registry/versions/artifacts/backfill",
+    body: data.requestBody,
+    mediaType: "application/json",
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -5504,6 +5504,21 @@ export type RegistryActionValidationErrorInfo = {
 }
 
 /**
+ * Request to start an artifact backfill workflow for selected versions.
+ */
+export type RegistryArtifactsBackfillStartRequest = {
+  version_ids: Array<string>
+}
+
+/**
+ * Response after scheduling an artifact backfill workflow.
+ */
+export type RegistryArtifactsBackfillStartResponse = {
+  workflow_id: string
+  requested_count: number
+}
+
+/**
  * Registry version lock with action-level bindings for O(1) resolution.
  *
  * Attributes:
@@ -8885,6 +8900,10 @@ export type tracecat__admin__registry__schemas__RegistryVersionRead = {
   commit_sha: string | null
   tarball_uri: string | null
   created_at: string
+  is_current?: boolean
+  artifacts_ready?: boolean
+  workflow_definition_count?: number
+  in_use?: boolean
 }
 
 export type tracecat__organization__schemas__OrgDomainRead = {
@@ -11067,6 +11086,13 @@ export type AdminRegistryListRegistryVersionsData = {
 
 export type AdminRegistryListRegistryVersionsResponse =
   Array<tracecat__admin__registry__schemas__RegistryVersionRead>
+
+export type AdminRegistryStartRegistryArtifactsBackfillData = {
+  requestBody: RegistryArtifactsBackfillStartRequest
+}
+
+export type AdminRegistryStartRegistryArtifactsBackfillResponse =
+  RegistryArtifactsBackfillStartResponse
 
 export type AdminRegistryPromoteRegistryVersionData = {
   repositoryId: string
@@ -16365,6 +16391,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: Array<tracecat__admin__registry__schemas__RegistryVersionRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/admin/registry/versions/artifacts/backfill": {
+    post: {
+      req: AdminRegistryStartRegistryArtifactsBackfillData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: RegistryArtifactsBackfillStartResponse
         /**
          * Validation Error
          */

--- a/frontend/src/components/admin/platform-registry-versions-table.tsx
+++ b/frontend/src/components/admin/platform-registry-versions-table.tsx
@@ -130,6 +130,7 @@ export function PlatformRegistryVersionsTable() {
       </div>
       <DataTable
         data={versions ?? []}
+        getRowId={(version) => version.id}
         initialSortingState={[{ id: "created_at", desc: true }]}
         columns={[
           {

--- a/frontend/src/components/admin/platform-registry-versions-table.tsx
+++ b/frontend/src/components/admin/platform-registry-versions-table.tsx
@@ -1,7 +1,8 @@
 "use client"
 
+import type { Row } from "@tanstack/react-table"
 import { CheckIcon, RefreshCwIcon } from "lucide-react"
-import { useState } from "react"
+import { useCallback, useState } from "react"
 import type { tracecat__admin__registry__schemas__RegistryVersionRead } from "@/client"
 import {
   DataTable,
@@ -36,6 +37,24 @@ export function PlatformRegistryVersionsTable() {
     backfillArtifacts,
     backfillArtifactsPending,
   } = useAdminRegistrySync()
+
+  const handleSelectionChange = useCallback(
+    (rows: Row<RegistryVersionRead>[]) => {
+      const nextVersions = rows.map((row) => row.original)
+      setSelectedVersions((currentVersions) => {
+        if (
+          currentVersions.length === nextVersions.length &&
+          currentVersions.every(
+            (version, index) => version.id === nextVersions[index]?.id
+          )
+        ) {
+          return currentVersions
+        }
+        return nextVersions
+      })
+    },
+    []
+  )
 
   const handlePromote = async (version: RegistryVersionRead) => {
     setPromotingId(version.id)
@@ -316,9 +335,7 @@ export function PlatformRegistryVersionsTable() {
         ]}
         toolbarProps={defaultToolbarProps}
         showSelectedRows
-        onSelectionChange={(rows) =>
-          setSelectedVersions(rows.map((row) => row.original))
-        }
+        onSelectionChange={handleSelectionChange}
         clearSelectionTrigger={clearSelectionTrigger}
       />
     </div>

--- a/frontend/src/components/admin/platform-registry-versions-table.tsx
+++ b/frontend/src/components/admin/platform-registry-versions-table.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CheckIcon } from "lucide-react"
+import { CheckIcon, RefreshCwIcon } from "lucide-react"
 import { useState } from "react"
 import type { tracecat__admin__registry__schemas__RegistryVersionRead } from "@/client"
 import {
@@ -8,7 +8,9 @@ import {
   DataTableColumnHeader,
   type DataTableToolbarProps,
 } from "@/components/data-table"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { toast } from "@/components/ui/use-toast"
 import {
   useAdminRegistryStatus,
@@ -22,9 +24,18 @@ type RegistryVersionRead =
 
 export function PlatformRegistryVersionsTable() {
   const [promotingId, setPromotingId] = useState<string | null>(null)
+  const [selectedVersions, setSelectedVersions] = useState<
+    RegistryVersionRead[]
+  >([])
+  const [clearSelectionTrigger, setClearSelectionTrigger] = useState(0)
   const { versions, isLoading } = useAdminRegistryVersions()
   const { status } = useAdminRegistryStatus()
-  const { promoteVersion, promotePending } = useAdminRegistrySync()
+  const {
+    promoteVersion,
+    promotePending,
+    backfillArtifacts,
+    backfillArtifactsPending,
+  } = useAdminRegistrySync()
 
   const handlePromote = async (version: RegistryVersionRead) => {
     setPromotingId(version.id)
@@ -49,145 +60,268 @@ export function PlatformRegistryVersionsTable() {
     }
   }
 
-  // Create a map of repository_id to current_version_id from status
-  const currentVersionMap = new Map<string, string | null | undefined>()
-  status?.repositories?.forEach((repo) => {
-    currentVersionMap.set(repo.id, repo.current_version_id)
-  })
+  const handleBackfillSelected = async () => {
+    if (selectedVersions.length === 0) return
+
+    try {
+      const result = await backfillArtifacts({
+        version_ids: selectedVersions.map((version) => version.id),
+      })
+      toast({
+        title: "Artifact backfill started",
+        description: `Workflow ${result.workflow_id} queued ${result.requested_count} version${result.requested_count === 1 ? "" : "s"}.`,
+      })
+      setSelectedVersions([])
+      setClearSelectionTrigger((value) => value + 1)
+    } catch (error) {
+      console.error("Failed to start artifact backfill", error)
+      toast({
+        title: "Failed to start artifact backfill",
+        description: "Please try again.",
+        variant: "destructive",
+      })
+    }
+  }
+
+  const selectedMissingCount = selectedVersions.filter(
+    (version) => !(version.artifacts_ready ?? false)
+  ).length
 
   if (isLoading) {
     return <div className="text-muted-foreground">Loading versions...</div>
   }
 
   return (
-    <DataTable
-      data={versions ?? []}
-      initialSortingState={[{ id: "created_at", desc: true }]}
-      columns={[
-        {
-          accessorKey: "version",
-          header: ({ column }) => (
-            <DataTableColumnHeader
-              className="text-xs"
-              column={column}
-              title="Version"
-            />
-          ),
-          cell: ({ row }) => {
-            const version = row.original
-            const isCurrent =
-              currentVersionMap.get(version.repository_id) === version.id
-            return (
-              <div className="flex items-center gap-2">
-                <span className="text-xs font-mono">{version.version}</span>
-                {isCurrent && (
-                  <span className="flex items-center">
-                    <span className="sr-only">Current</span>
-                    <span
-                      aria-hidden="true"
-                      className="flex size-1.5 rounded-full bg-[hsl(var(--success)/0.55)]"
-                    />
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-xs text-muted-foreground">
+          {selectedVersions.length > 0
+            ? `${selectedVersions.length} selected, ${selectedMissingCount} missing artifacts`
+            : "No versions selected"}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleBackfillSelected}
+          disabled={selectedVersions.length === 0 || backfillArtifactsPending}
+        >
+          <RefreshCwIcon className="mr-1 size-3" />
+          {backfillArtifactsPending ? "Starting..." : "Backfill artifacts"}
+        </Button>
+      </div>
+      <DataTable
+        data={versions ?? []}
+        initialSortingState={[{ id: "created_at", desc: true }]}
+        columns={[
+          {
+            id: "select",
+            header: ({ table }) => (
+              <Checkbox
+                aria-label="Select visible versions"
+                checked={
+                  table.getIsAllPageRowsSelected()
+                    ? true
+                    : table.getIsSomePageRowsSelected()
+                      ? "indeterminate"
+                      : false
+                }
+                onCheckedChange={(value) =>
+                  table.toggleAllPageRowsSelected(!!value)
+                }
+              />
+            ),
+            cell: ({ row }) => (
+              <Checkbox
+                aria-label={`Select version ${row.original.version}`}
+                checked={row.getIsSelected()}
+                onCheckedChange={(value) => row.toggleSelected(!!value)}
+                onClick={(event) => event.stopPropagation()}
+              />
+            ),
+            enableSorting: false,
+            enableHiding: false,
+          },
+          {
+            accessorKey: "version",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Version"
+              />
+            ),
+            cell: ({ row }) => {
+              const version = row.original
+              return (
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-mono">{version.version}</span>
+                  {(version.is_current ?? false) && (
+                    <span className="flex items-center">
+                      <span className="sr-only">Current</span>
+                      <span
+                        aria-hidden="true"
+                        className="flex size-1.5 rounded-full bg-[hsl(var(--success)/0.55)]"
+                      />
+                    </span>
+                  )}
+                </div>
+              )
+            },
+            enableSorting: true,
+            enableHiding: false,
+          },
+          {
+            accessorKey: "repository_id",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Repository"
+              />
+            ),
+            cell: ({ row }) => {
+              const repoId = row.getValue<string>("repository_id")
+              const repo = status?.repositories?.find((r) => r.id === repoId)
+              return (
+                <div className="text-xs text-muted-foreground">
+                  {repo?.name ?? repoId.substring(0, 8)}
+                </div>
+              )
+            },
+            enableSorting: true,
+            enableHiding: false,
+          },
+          {
+            accessorKey: "commit_sha",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Commit"
+              />
+            ),
+            cell: ({ row }) => (
+              <code className="text-xs text-muted-foreground">
+                {row.getValue<string | null>("commit_sha")?.substring(0, 7) ??
+                  "-"}
+              </code>
+            ),
+            enableSorting: false,
+            enableHiding: true,
+          },
+          {
+            accessorKey: "artifacts_ready",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Artifacts"
+              />
+            ),
+            cell: ({ row }) => {
+              const version = row.original
+              return (
+                <Badge
+                  variant={
+                    (version.artifacts_ready ?? false) ? "secondary" : "outline"
+                  }
+                  className="font-normal"
+                >
+                  {(version.artifacts_ready ?? false) ? "Ready" : "Missing"}
+                </Badge>
+              )
+            },
+            enableSorting: true,
+            enableHiding: false,
+          },
+          {
+            accessorKey: "in_use",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Usage"
+              />
+            ),
+            cell: ({ row }) => {
+              const version = row.original
+              return (
+                <div className="flex items-center gap-2">
+                  <Badge
+                    variant={
+                      (version.in_use ?? false) ? "secondary" : "outline"
+                    }
+                    className="font-normal"
+                  >
+                    {(version.in_use ?? false) ? "In use" : "Unused"}
+                  </Badge>
+                  <span className="text-xs text-muted-foreground">
+                    {version.workflow_definition_count ?? 0} defs
                   </span>
-                )}
-              </div>
-            )
+                </div>
+              )
+            },
+            enableSorting: true,
+            enableHiding: false,
           },
-          enableSorting: true,
-          enableHiding: false,
-        },
-        {
-          accessorKey: "repository_id",
-          header: ({ column }) => (
-            <DataTableColumnHeader
-              className="text-xs"
-              column={column}
-              title="Repository"
-            />
-          ),
-          cell: ({ row }) => {
-            const repoId = row.getValue<string>("repository_id")
-            const repo = status?.repositories?.find((r) => r.id === repoId)
-            return (
-              <div className="text-xs text-muted-foreground">
-                {repo?.name ?? repoId.substring(0, 8)}
-              </div>
-            )
+          {
+            accessorKey: "created_at",
+            header: ({ column }) => (
+              <DataTableColumnHeader
+                className="text-xs"
+                column={column}
+                title="Created"
+              />
+            ),
+            cell: ({ row }) => {
+              const createdAt = row.getValue<string>("created_at")
+              const date = new Date(createdAt)
+              return (
+                <div className="text-xs text-muted-foreground">
+                  {getRelativeTime(date)}
+                </div>
+              )
+            },
+            enableSorting: true,
+            enableHiding: false,
           },
-          enableSorting: true,
-          enableHiding: false,
-        },
-        {
-          accessorKey: "commit_sha",
-          header: ({ column }) => (
-            <DataTableColumnHeader
-              className="text-xs"
-              column={column}
-              title="Commit"
-            />
-          ),
-          cell: ({ row }) => (
-            <code className="text-xs text-muted-foreground">
-              {row.getValue<string | null>("commit_sha")?.substring(0, 7) ??
-                "-"}
-            </code>
-          ),
-          enableSorting: false,
-          enableHiding: true,
-        },
-        {
-          accessorKey: "created_at",
-          header: ({ column }) => (
-            <DataTableColumnHeader
-              className="text-xs"
-              column={column}
-              title="Created"
-            />
-          ),
-          cell: ({ row }) => {
-            const createdAt = row.getValue<string>("created_at")
-            const date = new Date(createdAt)
-            return (
-              <div className="text-xs text-muted-foreground">
-                {getRelativeTime(date)}
-              </div>
-            )
-          },
-          enableSorting: true,
-          enableHiding: false,
-        },
-        {
-          id: "actions",
-          enableHiding: false,
-          cell: ({ row }) => {
-            const version = row.original
-            const isCurrent =
-              currentVersionMap.get(version.repository_id) === version.id
-            const isPromoting = promotingId === version.id && promotePending
+          {
+            id: "actions",
+            enableHiding: false,
+            cell: ({ row }) => {
+              const version = row.original
+              const isPromoting = promotingId === version.id && promotePending
 
-            if (isCurrent) return null
+              if (version.is_current ?? false) return null
 
-            return (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => handlePromote(version)}
-                disabled={isPromoting}
-              >
-                {isPromoting ? (
-                  "Promoting..."
-                ) : (
-                  <>
-                    <CheckIcon className="mr-1 size-3" />
-                    Promote
-                  </>
-                )}
-              </Button>
-            )
+              return (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handlePromote(version)}
+                  disabled={isPromoting}
+                >
+                  {isPromoting ? (
+                    "Promoting..."
+                  ) : (
+                    <>
+                      <CheckIcon className="mr-1 size-3" />
+                      Promote
+                    </>
+                  )}
+                </Button>
+              )
+            },
           },
-        },
-      ]}
-      toolbarProps={defaultToolbarProps}
-    />
+        ]}
+        toolbarProps={defaultToolbarProps}
+        showSelectedRows
+        onSelectionChange={(rows) =>
+          setSelectedVersions(rows.map((row) => row.original))
+        }
+        clearSelectionTrigger={clearSelectionTrigger}
+      />
+    </div>
   )
 }
 

--- a/frontend/src/components/data-table/table.tsx
+++ b/frontend/src/components/data-table/table.tsx
@@ -56,6 +56,7 @@ export type TableCol<TData> = {
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
   data?: TData[]
+  getRowId?: (originalRow: TData, index: number, parent?: Row<TData>) => string
   onClickRow?: (row: Row<TData>) => () => void
   getRowHref?: (row: Row<TData>) => string | undefined
   toolbarProps?: DataTableToolbarProps<TData>
@@ -77,6 +78,7 @@ interface DataTableProps<TData, TValue> {
 export function DataTable<TData, TValue>({
   columns,
   data,
+  getRowId,
   onClickRow,
   getRowHref,
   toolbarProps,
@@ -148,6 +150,7 @@ export function DataTable<TData, TValue>({
       },
     },
     enableRowSelection: true,
+    getRowId,
     onRowSelectionChange: setRowSelection,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -47,6 +47,7 @@ import {
   adminRegistryGetRegistryStatus,
   adminRegistryListRegistryVersions,
   adminRegistryPromoteRegistryVersion,
+  adminRegistryStartRegistryArtifactsBackfill,
   adminRegistrySyncAllRepositories,
   adminRegistrySyncRepository,
   adminRevokeOrganizationInvitation,
@@ -66,6 +67,8 @@ import {
   type tracecat_ee__admin__organizations__schemas__OrgRead as OrgRead,
   type OrgUpdate,
   type PlatformRegistrySettingsUpdate,
+  type RegistryArtifactsBackfillStartRequest,
+  type RegistryArtifactsBackfillStartResponse,
   type TierCreate,
   type TierRead,
   type TierUpdate,
@@ -759,6 +762,21 @@ export function useAdminRegistrySync() {
       },
     })
 
+  const {
+    mutateAsync: backfillArtifacts,
+    isPending: backfillArtifactsPending,
+  } = useMutation<
+    RegistryArtifactsBackfillStartResponse,
+    Error,
+    RegistryArtifactsBackfillStartRequest
+  >({
+    mutationFn: (data) =>
+      adminRegistryStartRegistryArtifactsBackfill({ requestBody: data }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "registry"] })
+    },
+  })
+
   return {
     syncAllRepositories,
     syncAllPending,
@@ -766,6 +784,8 @@ export function useAdminRegistrySync() {
     syncPending,
     promoteVersion,
     promotePending,
+    backfillArtifacts,
+    backfillArtifactsPending,
   }
 }
 

--- a/tests/unit/api/test_api_admin_registry.py
+++ b/tests/unit/api/test_api_admin_registry.py
@@ -19,6 +19,7 @@ from tracecat.admin.registry.schemas import (
     RepositorySyncResult,
 )
 from tracecat.auth.types import Role
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 
 
 @pytest.mark.anyio
@@ -135,6 +136,53 @@ async def test_start_registry_artifacts_backfill_success(
     assert data["requested_count"] == 1
     request = mock_svc.start_artifacts_backfill.call_args.args[0]
     assert request.version_ids == [version_id]
+
+
+@pytest.mark.anyio
+async def test_start_registry_artifacts_backfill_missing_version(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    version_id = uuid.uuid4()
+
+    with patch.object(registry_router_module, "AdminRegistryService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.start_artifacts_backfill.side_effect = TracecatNotFoundError(
+            f"Registry versions not found: {version_id}"
+        )
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            "/admin/registry/versions/artifacts/backfill",
+            json={"version_ids": [str(version_id)]},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == f"Registry versions not found: {version_id}"
+
+
+@pytest.mark.anyio
+async def test_start_registry_artifacts_backfill_version_without_tarball(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    version_id = uuid.uuid4()
+
+    with patch.object(registry_router_module, "AdminRegistryService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.start_artifacts_backfill.side_effect = TracecatValidationError(
+            f"Registry versions do not have tarballs: {version_id}"
+        )
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            "/admin/registry/versions/artifacts/backfill",
+            json={"version_ids": [str(version_id)]},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        response.json()["detail"]
+        == f"Registry versions do not have tarballs: {version_id}"
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_admin_registry.py
+++ b/tests/unit/api/test_api_admin_registry.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 import tracecat.admin.registry.router as registry_router_module
 from tracecat.admin.registry.schemas import (
+    RegistryArtifactsBackfillStartResponse,
     RegistryStatusResponse,
     RegistrySyncResponse,
     RegistryVersionPromoteResponse,
@@ -106,6 +107,34 @@ async def test_list_registry_versions_success(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json()[0]["version"] == "1.0.0"
+
+
+@pytest.mark.anyio
+async def test_start_registry_artifacts_backfill_success(
+    client: TestClient, test_admin_role: Role
+) -> None:
+    version_id = uuid.uuid4()
+    payload = RegistryArtifactsBackfillStartResponse(
+        workflow_id="registry-artifacts-backfill-20240101000000-abcd1234",
+        requested_count=1,
+    )
+
+    with patch.object(registry_router_module, "AdminRegistryService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.start_artifacts_backfill.return_value = payload
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            "/admin/registry/versions/artifacts/backfill",
+            json={"version_ids": [str(version_id)]},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["workflow_id"] == payload.workflow_id
+    assert data["requested_count"] == 1
+    request = mock_svc.start_artifacts_backfill.call_args.args[0]
+    assert request.version_ids == [version_id]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_admin_registry_service.py
+++ b/tests/unit/test_admin_registry_service.py
@@ -1,0 +1,111 @@
+"""Tests for admin registry service behavior."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.admin.registry.service import AdminRegistryService
+from tracecat.auth.types import PlatformRole
+from tracecat.db.models import (
+    PlatformRegistryRepository,
+    PlatformRegistryVersion,
+    Workflow,
+    WorkflowDefinition,
+    Workspace,
+)
+
+pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.fixture
+def platform_role() -> PlatformRole:
+    return PlatformRole(
+        type="user",
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+    )
+
+
+@pytest.mark.anyio
+async def test_list_versions_includes_artifact_and_usage_status(
+    session: AsyncSession,
+    svc_workspace: Workspace,
+    platform_role: PlatformRole,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = PlatformRegistryRepository(origin="tracecat_registry")
+    session.add(repo)
+    await session.flush()
+
+    version_in_definition = PlatformRegistryVersion(
+        repository_id=repo.id,
+        version="1.0.0",
+        manifest={"schema_version": "1.0", "actions": {}},
+        tarball_uri="s3://registry-artifacts/platform/v1/site-packages.tar.gz",
+    )
+    current_version = PlatformRegistryVersion(
+        repository_id=repo.id,
+        version="2.0.0",
+        manifest={"schema_version": "1.0", "actions": {}},
+        tarball_uri="s3://registry-artifacts/platform/v2/site-packages.tar.gz",
+    )
+    session.add_all([version_in_definition, current_version])
+    await session.flush()
+
+    repo.current_version_id = current_version.id
+    session.add(repo)
+
+    workflow = Workflow(
+        workspace_id=svc_workspace.id,
+        title="Workflow using old registry version",
+        description="",
+    )
+    session.add(workflow)
+    await session.flush()
+
+    session.add(
+        WorkflowDefinition(
+            workflow_id=workflow.id,
+            workspace_id=svc_workspace.id,
+            version=1,
+            content={},
+            registry_lock={
+                "origins": {"tracecat_registry": "1.0.0"},
+                "actions": {},
+            },
+        )
+    )
+    await session.commit()
+
+    async def fake_artifacts_ready(
+        _service: AdminRegistryService,
+        tarball_uri: str | None,
+    ) -> bool:
+        if tarball_uri is None:
+            return False
+        return "v2" in tarball_uri
+
+    monkeypatch.setattr(
+        AdminRegistryService,
+        "_artifacts_ready",
+        fake_artifacts_ready,
+    )
+
+    service = AdminRegistryService(session, platform_role)
+    versions = await service.list_versions(limit=10)
+    versions_by_number = {version.version: version for version in versions}
+
+    old_version = versions_by_number["1.0.0"]
+    assert old_version.workflow_definition_count == 1
+    assert old_version.in_use is True
+    assert old_version.is_current is False
+    assert old_version.artifacts_ready is False
+
+    new_version = versions_by_number["2.0.0"]
+    assert new_version.workflow_definition_count == 0
+    assert new_version.in_use is True
+    assert new_version.is_current is True
+    assert new_version.artifacts_ready is True

--- a/tests/unit/test_admin_registry_service.py
+++ b/tests/unit/test_admin_registry_service.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import uuid
+from datetime import timedelta
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat.admin.registry.schemas import RegistryArtifactsBackfillStartRequest
 from tracecat.admin.registry.service import AdminRegistryService
 from tracecat.auth.types import PlatformRole
 from tracecat.db.models import (
@@ -78,6 +81,25 @@ async def test_list_versions_includes_artifact_and_usage_status(
             },
         )
     )
+    malformed_lock_workflow = Workflow(
+        workspace_id=svc_workspace.id,
+        title="Workflow with malformed registry lock",
+        description="",
+    )
+    session.add(malformed_lock_workflow)
+    await session.flush()
+    session.add(
+        WorkflowDefinition(
+            workflow_id=malformed_lock_workflow.id,
+            workspace_id=svc_workspace.id,
+            version=1,
+            content={},
+            registry_lock={
+                "origins": ["tracecat_registry"],
+                "actions": {},
+            },
+        )
+    )
     await session.commit()
 
     async def fake_artifacts_ready(
@@ -109,3 +131,49 @@ async def test_list_versions_includes_artifact_and_usage_status(
     assert new_version.in_use is True
     assert new_version.is_current is True
     assert new_version.artifacts_ready is True
+
+
+@pytest.mark.anyio
+async def test_start_artifacts_backfill_scales_workflow_timeout(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = PlatformRegistryRepository(origin="tracecat_registry")
+    session.add(repo)
+    await session.flush()
+
+    versions = [
+        PlatformRegistryVersion(
+            repository_id=repo.id,
+            version=f"1.0.{idx}",
+            manifest={"schema_version": "1.0", "actions": {}},
+            tarball_uri=f"s3://registry-artifacts/platform/v{idx}/site-packages.tar.gz",
+        )
+        for idx in range(3)
+    ]
+    session.add_all(versions)
+    await session.commit()
+
+    fake_client = AsyncMock()
+
+    async def fake_get_temporal_client() -> AsyncMock:
+        return fake_client
+
+    monkeypatch.setattr(
+        "tracecat.dsl.client.get_temporal_client",
+        fake_get_temporal_client,
+    )
+
+    service = AdminRegistryService(session, platform_role)
+    response = await service.start_artifacts_backfill(
+        RegistryArtifactsBackfillStartRequest(
+            version_ids=[version.id for version in versions],
+        )
+    )
+
+    assert response.requested_count == 3
+    fake_client.start_workflow.assert_awaited_once()
+    assert fake_client.start_workflow.await_args.kwargs[
+        "execution_timeout"
+    ] == timedelta(minutes=135)

--- a/tests/unit/test_admin_registry_service.py
+++ b/tests/unit/test_admin_registry_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import timedelta
+from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -19,6 +20,7 @@ from tracecat.db.models import (
     WorkflowDefinition,
     Workspace,
 )
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 
 pytestmark = pytest.mark.usefixtures("db")
 
@@ -177,3 +179,51 @@ async def test_start_artifacts_backfill_scales_workflow_timeout(
     assert fake_client.start_workflow.await_args.kwargs[
         "execution_timeout"
     ] == timedelta(minutes=135)
+
+
+@pytest.mark.anyio
+async def test_start_artifacts_backfill_missing_version_raises_not_found(
+    session: AsyncSession,
+    platform_role: PlatformRole,
+) -> None:
+    service = AdminRegistryService(session, platform_role)
+    missing_version_id = uuid.uuid4()
+
+    with pytest.raises(TracecatNotFoundError, match="Registry versions not found"):
+        await service.start_artifacts_backfill(
+            RegistryArtifactsBackfillStartRequest(version_ids=[missing_version_id])
+        )
+
+
+@pytest.mark.anyio
+async def test_start_artifacts_backfill_version_without_tarball_raises_validation(
+    platform_role: PlatformRole,
+) -> None:
+    version_id = uuid.uuid4()
+    version = PlatformRegistryVersion(
+        repository_id=uuid.uuid4(),
+        version="1.0.0",
+        manifest={"schema_version": "1.0", "actions": {}},
+        tarball_uri="s3://registry-artifacts/platform/v1/site-packages.tar.gz",
+    )
+    object.__setattr__(version, "id", version_id)
+    object.__setattr__(version, "tarball_uri", None)
+
+    class FakeScalars:
+        def all(self) -> list[PlatformRegistryVersion]:
+            return [version]
+
+    class FakeResult:
+        def scalars(self) -> FakeScalars:
+            return FakeScalars()
+
+    session = AsyncMock(spec=AsyncSession)
+    session.execute.return_value = FakeResult()
+
+    service = AdminRegistryService(cast(AsyncSession, session), platform_role)
+    with pytest.raises(
+        TracecatValidationError, match="Registry versions do not have tarballs"
+    ):
+        await service.start_artifacts_backfill(
+            RegistryArtifactsBackfillStartRequest(version_ids=[version_id])
+        )

--- a/tests/unit/test_admin_registry_service.py
+++ b/tests/unit/test_admin_registry_service.py
@@ -71,17 +71,29 @@ async def test_list_versions_includes_artifact_and_usage_status(
     session.add(workflow)
     await session.flush()
 
-    session.add(
-        WorkflowDefinition(
-            workflow_id=workflow.id,
-            workspace_id=svc_workspace.id,
-            version=1,
-            content={},
-            registry_lock={
-                "origins": {"tracecat_registry": "1.0.0"},
-                "actions": {},
-            },
-        )
+    session.add_all(
+        [
+            WorkflowDefinition(
+                workflow_id=workflow.id,
+                workspace_id=svc_workspace.id,
+                version=1,
+                content={},
+                registry_lock={
+                    "origins": {"tracecat_registry": "1.0.0"},
+                    "actions": {},
+                },
+            ),
+            WorkflowDefinition(
+                workflow_id=workflow.id,
+                workspace_id=svc_workspace.id,
+                version=2,
+                content={},
+                registry_lock={
+                    "origins": {"tracecat_registry": "2.0.0"},
+                    "actions": {},
+                },
+            ),
+        ]
     )
     malformed_lock_workflow = Workflow(
         workspace_id=svc_workspace.id,
@@ -123,13 +135,13 @@ async def test_list_versions_includes_artifact_and_usage_status(
     versions_by_number = {version.version: version for version in versions}
 
     old_version = versions_by_number["1.0.0"]
-    assert old_version.workflow_definition_count == 1
-    assert old_version.in_use is True
+    assert old_version.workflow_definition_count == 0
+    assert old_version.in_use is False
     assert old_version.is_current is False
     assert old_version.artifacts_ready is False
 
     new_version = versions_by_number["2.0.0"]
-    assert new_version.workflow_definition_count == 0
+    assert new_version.workflow_definition_count == 1
     assert new_version.in_use is True
     assert new_version.is_current is True
     assert new_version.artifacts_ready is True

--- a/tests/unit/test_registry_sync_tarball.py
+++ b/tests/unit/test_registry_sync_tarball.py
@@ -12,6 +12,63 @@ from tracecat.registry.sync import tarball
 from tracecat.registry.sync.tarball import upload_tarball_venv
 
 
+def test_squashfs_sidecar_key_helpers() -> None:
+    uri = (
+        "s3://registry-artifacts/platform/tarball-venvs/test/1.0.0/site-packages.tar.gz"
+    )
+
+    assert tarball.parse_s3_uri(uri) == (
+        "registry-artifacts",
+        "platform/tarball-venvs/test/1.0.0/site-packages.tar.gz",
+    )
+    assert (
+        tarball.get_squashfs_sidecar_key(
+            "platform/tarball-venvs/test/1.0.0/site-packages.tar.gz"
+        )
+        == "platform/tarball-venvs/test/1.0.0/site-packages.squashfs"
+    )
+
+
+@pytest.mark.anyio
+async def test_build_squashfs_sidecar_from_tarball_uses_existing_tarball_contents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package_dir = tmp_path / "package"
+    package_dir.mkdir()
+    (package_dir / "module.py").write_text("VALUE = 1\n")
+
+    tarball_path = tmp_path / "site-packages.tar.gz"
+    with tarfile.open(tarball_path, "w:gz") as archive:
+        archive.add(package_dir / "module.py", arcname="module.py")
+
+    squashfs_path = tmp_path / "site-packages.squashfs"
+
+    def fake_create_squashfs(
+        path: Path,
+        entries: list[tuple[Path, str]],
+        *,
+        preserve_symlinks: bool = True,
+    ) -> bool:
+        assert preserve_symlinks is True
+        assert [(entry_path.name, arcname) for entry_path, arcname in entries] == [
+            ("module.py", "module.py")
+        ]
+        path.write_bytes(b"squashfs")
+        return True
+
+    monkeypatch.setattr(tarball, "_create_squashfs_image", fake_create_squashfs)
+
+    created = await tarball.build_squashfs_sidecar_from_tarball(
+        tarball_path=tarball_path,
+        squashfs_path=squashfs_path,
+        work_dir=tmp_path / "extract",
+    )
+
+    assert created is True
+    assert squashfs_path.read_bytes() == b"squashfs"
+
+
 def test_get_installed_site_packages_paths_includes_platlib(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_registry_sync_workflow.py
+++ b/tests/unit/test_registry_sync_workflow.py
@@ -167,3 +167,29 @@ async def test_backfill_registry_artifacts_activity_creates_sidecar(
     assert uploaded["key"] == "platform/tarball-venvs/test/1.0.0/site-packages.squashfs"
     assert uploaded["bucket"] == "registry-artifacts"
     assert uploaded["content_type"] == "application/vnd.squashfs"
+
+
+@pytest.mark.anyio
+async def test_backfill_registry_artifacts_activity_reraises_unexpected_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_file_exists(*, key: str, bucket: str) -> bool:
+        del key, bucket
+        raise RuntimeError("storage unavailable")
+
+    monkeypatch.setattr(
+        "tracecat.registry.sync.workflow.blob.file_exists",
+        fake_file_exists,
+    )
+
+    with pytest.raises(RuntimeError, match="storage unavailable"):
+        await backfill_registry_artifacts_activity(
+            RegistryArtifactsBackfillItem(
+                version_id=uuid4(),
+                version="1.0.0",
+                tarball_uri=(
+                    "s3://registry-artifacts/platform/tarball-venvs/test/1.0.0/"
+                    "site-packages.tar.gz"
+                ),
+            )
+        )

--- a/tests/unit/test_registry_sync_workflow.py
+++ b/tests/unit/test_registry_sync_workflow.py
@@ -3,19 +3,24 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from uuid import uuid4
 
 import pytest
-from temporalio.exceptions import ApplicationError
+from temporalio.exceptions import ActivityError, ApplicationError
 
 from tracecat.registry.actions.enums import TemplateActionValidationErrorType
 from tracecat.registry.actions.schemas import RegistryActionValidationErrorInfo
 from tracecat.registry.sync.runner import RegistrySyncValidationError
 from tracecat.registry.sync.schemas import (
     RegistryArtifactsBackfillItem,
+    RegistryArtifactsBackfillItemResult,
+    RegistryArtifactsBackfillRequest,
     RegistrySyncRequest,
 )
 from tracecat.registry.sync.workflow import (
+    RegistryArtifactsBackfillWorkflow,
     backfill_registry_artifacts_activity,
     sync_registry_activity,
 )
@@ -193,3 +198,72 @@ async def test_backfill_registry_artifacts_activity_reraises_unexpected_errors(
                 ),
             )
         )
+
+
+@pytest.mark.anyio
+async def test_backfill_workflow_continues_after_item_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed_version_id = uuid4()
+    next_version_id = uuid4()
+
+    async def fake_execute_activity(
+        _activity: Any,
+        item: RegistryArtifactsBackfillItem,
+        **_kwargs: Any,
+    ) -> RegistryArtifactsBackfillItemResult:
+        if item.version_id == failed_version_id:
+            try:
+                raise RuntimeError("corrupt tarball")
+            except RuntimeError as exc:
+                raise ActivityError(
+                    "Activity task failed",
+                    scheduled_event_id=1,
+                    started_event_id=2,
+                    identity="test",
+                    activity_type="backfill_registry_artifacts_activity",
+                    activity_id="activity-id",
+                    retry_state=None,
+                ) from exc
+        return RegistryArtifactsBackfillItemResult(
+            version_id=item.version_id,
+            status="created",
+        )
+
+    monkeypatch.setattr(
+        "tracecat.registry.sync.workflow.workflow.execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        "tracecat.registry.sync.workflow.workflow.logger",
+        SimpleNamespace(
+            info=lambda *_args, **_kwargs: None,
+            warning=lambda *_args, **_kwargs: None,
+        ),
+    )
+
+    result = await RegistryArtifactsBackfillWorkflow().run(
+        RegistryArtifactsBackfillRequest(
+            items=[
+                RegistryArtifactsBackfillItem(
+                    version_id=failed_version_id,
+                    version="1.0.0",
+                    tarball_uri="s3://registry-artifacts/platform/v1/site-packages.tar.gz",
+                ),
+                RegistryArtifactsBackfillItem(
+                    version_id=next_version_id,
+                    version="2.0.0",
+                    tarball_uri="s3://registry-artifacts/platform/v2/site-packages.tar.gz",
+                ),
+            ],
+        )
+    )
+
+    assert result.requested_count == 2
+    assert [item.version_id for item in result.results] == [
+        failed_version_id,
+        next_version_id,
+    ]
+    assert result.results[0].status == "failed"
+    assert result.results[0].error == "RuntimeError: corrupt tarball"
+    assert result.results[1].status == "created"

--- a/tests/unit/test_registry_sync_workflow.py
+++ b/tests/unit/test_registry_sync_workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -10,8 +11,14 @@ from temporalio.exceptions import ApplicationError
 from tracecat.registry.actions.enums import TemplateActionValidationErrorType
 from tracecat.registry.actions.schemas import RegistryActionValidationErrorInfo
 from tracecat.registry.sync.runner import RegistrySyncValidationError
-from tracecat.registry.sync.schemas import RegistrySyncRequest
-from tracecat.registry.sync.workflow import sync_registry_activity
+from tracecat.registry.sync.schemas import (
+    RegistryArtifactsBackfillItem,
+    RegistrySyncRequest,
+)
+from tracecat.registry.sync.workflow import (
+    backfill_registry_artifacts_activity,
+    sync_registry_activity,
+)
 
 
 @pytest.mark.anyio
@@ -49,3 +56,114 @@ async def test_sync_registry_activity_raises_validation_application_error(
 
     with pytest.raises(ApplicationError, match="Registry sync validation failed"):
         await sync_registry_activity(request)
+
+
+@pytest.mark.anyio
+async def test_backfill_registry_artifacts_activity_skips_existing_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_file_exists(*, key: str, bucket: str) -> bool:
+        assert bucket == "registry-artifacts"
+        assert key == "platform/tarball-venvs/test/1.0.0/site-packages.squashfs"
+        return True
+
+    monkeypatch.setattr(
+        "tracecat.registry.sync.workflow.blob.file_exists",
+        fake_file_exists,
+    )
+
+    version_id = uuid4()
+    result = await backfill_registry_artifacts_activity(
+        RegistryArtifactsBackfillItem(
+            version_id=version_id,
+            version="1.0.0",
+            tarball_uri=(
+                "s3://registry-artifacts/platform/tarball-venvs/test/1.0.0/"
+                "site-packages.tar.gz"
+            ),
+        )
+    )
+
+    assert result.status == "exists"
+    assert result.version_id == version_id
+
+
+@pytest.mark.anyio
+async def test_backfill_registry_artifacts_activity_creates_sidecar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    uploaded: dict[str, object] = {}
+
+    async def fake_file_exists(*, key: str, bucket: str) -> bool:
+        assert key.endswith("site-packages.squashfs")
+        assert bucket == "registry-artifacts"
+        return False
+
+    async def fake_download_tarball_venv(
+        *,
+        key: str,
+        bucket: str,
+        output_path: Path,
+    ) -> Path:
+        assert key.endswith("site-packages.tar.gz")
+        assert bucket == "registry-artifacts"
+        return output_path
+
+    async def fake_build_squashfs_sidecar_from_tarball(
+        *,
+        tarball_path: Path,
+        squashfs_path: Path,
+        work_dir: Path,
+    ) -> bool:
+        assert tarball_path.name == "site-packages.tar.gz"
+        assert work_dir.name == "extract"
+        squashfs_path.write_bytes(b"squashfs")
+        return True
+
+    async def fake_upload_file_from_path(
+        *,
+        path: Path,
+        key: str,
+        bucket: str,
+        content_type: str | None,
+    ) -> None:
+        kwargs = {
+            "path": path,
+            "key": key,
+            "bucket": bucket,
+            "content_type": content_type,
+        }
+        uploaded.update(kwargs)
+
+    monkeypatch.setattr(
+        "tracecat.registry.sync.workflow.blob.file_exists",
+        fake_file_exists,
+    )
+    monkeypatch.setattr(
+        "tracecat.registry.sync.workflow.download_tarball_venv",
+        fake_download_tarball_venv,
+    )
+    monkeypatch.setattr(
+        "tracecat.registry.sync.workflow.build_squashfs_sidecar_from_tarball",
+        fake_build_squashfs_sidecar_from_tarball,
+    )
+    monkeypatch.setattr(
+        "tracecat.registry.sync.workflow.blob.upload_file_from_path",
+        fake_upload_file_from_path,
+    )
+
+    result = await backfill_registry_artifacts_activity(
+        RegistryArtifactsBackfillItem(
+            version_id=uuid4(),
+            version="1.0.0",
+            tarball_uri=(
+                "s3://registry-artifacts/platform/tarball-venvs/test/1.0.0/"
+                "site-packages.tar.gz"
+            ),
+        )
+    )
+
+    assert result.status == "created"
+    assert uploaded["key"] == "platform/tarball-venvs/test/1.0.0/site-packages.squashfs"
+    assert uploaded["bucket"] == "registry-artifacts"
+    assert uploaded["content_type"] == "application/vnd.squashfs"

--- a/tracecat/admin/registry/router.py
+++ b/tracecat/admin/registry/router.py
@@ -8,6 +8,8 @@ from fastapi import APIRouter, HTTPException, Query, status
 
 from tracecat import config
 from tracecat.admin.registry.schemas import (
+    RegistryArtifactsBackfillStartRequest,
+    RegistryArtifactsBackfillStartResponse,
     RegistryStatusResponse,
     RegistrySyncResponse,
     RegistryVersionPromoteResponse,
@@ -98,6 +100,25 @@ async def list_registry_versions(
     """List registry versions with optional filtering."""
     service = AdminRegistryService(session, role)
     return list(await service.list_versions(repository_id=repository_id, limit=limit))
+
+
+@router.post(
+    "/versions/artifacts/backfill",
+    response_model=RegistryArtifactsBackfillStartResponse,
+)
+async def start_registry_artifacts_backfill(
+    role: SuperuserRole,
+    session: AsyncDBSessionBypass,
+    params: RegistryArtifactsBackfillStartRequest,
+) -> RegistryArtifactsBackfillStartResponse:
+    """Start a workflow to backfill artifacts for selected versions."""
+    service = AdminRegistryService(session, role)
+    try:
+        return await service.start_artifacts_backfill(params)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from e
 
 
 @router.post(

--- a/tracecat/admin/registry/router.py
+++ b/tracecat/admin/registry/router.py
@@ -18,6 +18,7 @@ from tracecat.admin.registry.schemas import (
 from tracecat.admin.registry.service import AdminRegistryService
 from tracecat.auth.credentials import SuperuserRole
 from tracecat.db.dependencies import AsyncDBSessionBypass
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.registry.repositories.schemas import (
     RegistryRepositoryRead,
     RegistryRepositoryReadMinimal,
@@ -115,7 +116,9 @@ async def start_registry_artifacts_backfill(
     service = AdminRegistryService(session, role)
     try:
         return await service.start_artifacts_backfill(params)
-    except ValueError as e:
+    except TracecatNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except TracecatValidationError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
         ) from e

--- a/tracecat/admin/registry/schemas.py
+++ b/tracecat/admin/registry/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class RepositorySyncResult(BaseModel):
@@ -55,6 +55,10 @@ class RegistryVersionRead(BaseModel):
     commit_sha: str | None
     tarball_uri: str | None
     created_at: datetime
+    is_current: bool = False
+    artifacts_ready: bool = False
+    workflow_definition_count: int = 0
+    in_use: bool = False
 
     model_config = {"from_attributes": True}
 
@@ -67,3 +71,16 @@ class RegistryVersionPromoteResponse(BaseModel):
     previous_version_id: uuid.UUID | None
     current_version_id: uuid.UUID
     version: str
+
+
+class RegistryArtifactsBackfillStartRequest(BaseModel):
+    """Request to start an artifact backfill workflow for selected versions."""
+
+    version_ids: list[uuid.UUID] = Field(..., min_length=1)
+
+
+class RegistryArtifactsBackfillStartResponse(BaseModel):
+    """Response after scheduling an artifact backfill workflow."""
+
+    workflow_id: str
+    requested_count: int

--- a/tracecat/admin/registry/service.py
+++ b/tracecat/admin/registry/service.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import Sequence
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, ClassVar
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 
 from tracecat import config
 from tracecat.admin.registry.schemas import (
+    RegistryArtifactsBackfillStartRequest,
+    RegistryArtifactsBackfillStartResponse,
     RegistryStatusResponse,
     RegistrySyncResponse,
     RegistryVersionPromoteResponse,
@@ -37,9 +40,18 @@ from tracecat.registry.repositories.schemas import (
     RegistryRepositoryReadMinimal,
 )
 from tracecat.registry.sync.platform_service import PlatformRegistrySyncService
+from tracecat.registry.sync.schemas import (
+    RegistryArtifactsBackfillItem,
+    RegistryArtifactsBackfillRequest,
+)
+from tracecat.registry.sync.tarball import (
+    get_squashfs_sidecar_key,
+    parse_s3_uri,
+)
 from tracecat.registry.versions.schemas import RegistryVersionManifest
 from tracecat.registry.versions.service import PlatformRegistryVersionsService
 from tracecat.service import BasePlatformService
+from tracecat.storage import blob
 
 if TYPE_CHECKING:
     from tracecat_ee.admin.settings.service import AdminSettingsService
@@ -363,7 +375,14 @@ class AdminRegistryService(BasePlatformService):
         limit: int = 50,
     ) -> Sequence[RegistryVersionRead]:
         """List registry versions."""
-        stmt = select(PlatformRegistryVersion)
+        stmt = select(
+            PlatformRegistryVersion,
+            PlatformRegistryRepository.origin,
+            PlatformRegistryRepository.current_version_id,
+        ).join(
+            PlatformRegistryRepository,
+            PlatformRegistryVersion.repository_id == PlatformRegistryRepository.id,
+        )
         if repository_id:
             stmt = stmt.where(PlatformRegistryVersion.repository_id == repository_id)
         stmt = stmt.order_by(
@@ -372,7 +391,173 @@ class AdminRegistryService(BasePlatformService):
         ).limit(limit)
 
         result = await self.session.execute(stmt)
-        return [RegistryVersionRead.model_validate(v) for v in result.scalars().all()]
+        rows = result.all()
+        usage_counts = await self._workflow_definition_usage_counts(
+            [(origin, version.version) for version, origin, _ in rows]
+        )
+        artifact_statuses = await asyncio.gather(
+            *[self._artifacts_ready(version.tarball_uri) for version, _, _ in rows]
+        )
+
+        versions: list[RegistryVersionRead] = []
+        for (version, origin, current_version_id), artifacts_ready in zip(
+            rows, artifact_statuses, strict=True
+        ):
+            workflow_definition_count = usage_counts.get((origin, version.version), 0)
+            is_current = version.id == current_version_id
+            versions.append(
+                RegistryVersionRead(
+                    id=version.id,
+                    repository_id=version.repository_id,
+                    version=version.version,
+                    commit_sha=version.commit_sha,
+                    tarball_uri=version.tarball_uri,
+                    created_at=version.created_at,
+                    is_current=is_current,
+                    artifacts_ready=artifacts_ready,
+                    workflow_definition_count=workflow_definition_count,
+                    in_use=is_current or workflow_definition_count > 0,
+                )
+            )
+        return versions
+
+    async def _workflow_definition_usage_counts(
+        self,
+        pairs: Sequence[tuple[str, str]],
+    ) -> dict[tuple[str, str], int]:
+        """Count workflow definitions pinned to each origin/version pair."""
+        unique_pairs = list(dict.fromkeys(pairs))
+        if not unique_pairs:
+            return {}
+
+        values_sql: list[str] = []
+        params: dict[str, str] = {}
+        for idx, (origin, version) in enumerate(unique_pairs):
+            origin_param = f"origin_{idx}"
+            version_param = f"version_{idx}"
+            values_sql.append(f"(:{origin_param}, :{version_param})")
+            params[origin_param] = origin
+            params[version_param] = version
+
+        stmt = text(
+            f"""
+            WITH requested(origin, registry_version) AS (
+                VALUES {", ".join(values_sql)}
+            )
+            SELECT
+                lock_entry.origin AS origin,
+                lock_entry.registry_version AS registry_version,
+                count(*)::int AS definition_count
+            FROM workflow_definition AS wd
+            JOIN LATERAL jsonb_each_text(
+                wd.registry_lock -> 'origins'
+            ) AS lock_entry(origin, registry_version) ON true
+            JOIN requested AS requested_pair
+              ON requested_pair.origin = lock_entry.origin
+             AND requested_pair.registry_version = lock_entry.registry_version
+            WHERE wd.registry_lock IS NOT NULL
+              AND jsonb_typeof(wd.registry_lock -> 'origins') = 'object'
+            GROUP BY lock_entry.origin, lock_entry.registry_version
+            """
+        )
+        result = await self.session.execute(stmt, params)
+        counts: dict[tuple[str, str], int] = {}
+        for row in result:
+            mapping = row._mapping
+            counts[
+                (
+                    str(mapping["origin"]),
+                    str(mapping["registry_version"]),
+                )
+            ] = int(mapping["definition_count"])
+        return counts
+
+    async def _artifacts_ready(
+        self,
+        tarball_uri: str | None,
+    ) -> bool:
+        """Return whether the optimized artifacts for a registry version exist."""
+        if tarball_uri is None:
+            return False
+
+        try:
+            bucket, tarball_key = parse_s3_uri(tarball_uri)
+            artifact_key = get_squashfs_sidecar_key(tarball_key)
+            return await blob.file_exists(key=artifact_key, bucket=bucket)
+        except ValueError:
+            self.logger.warning(
+                "Registry version has invalid tarball URI",
+                tarball_uri=tarball_uri,
+            )
+        except Exception as exc:
+            self.logger.warning(
+                "Failed to check registry artifacts",
+                tarball_uri=tarball_uri,
+                error=str(exc),
+            )
+        return False
+
+    async def start_artifacts_backfill(
+        self,
+        params: RegistryArtifactsBackfillStartRequest,
+    ) -> RegistryArtifactsBackfillStartResponse:
+        """Start a Temporal workflow to backfill registry artifacts."""
+        from tracecat.dsl.client import get_temporal_client
+        from tracecat.registry.sync.workflow import RegistryArtifactsBackfillWorkflow
+
+        version_ids = list(dict.fromkeys(params.version_ids))
+        stmt = select(PlatformRegistryVersion).where(
+            PlatformRegistryVersion.id.in_(version_ids)
+        )
+        result = await self.session.execute(stmt)
+        versions = list(result.scalars().all())
+
+        found_ids = {version.id for version in versions}
+        missing_ids = [
+            version_id for version_id in version_ids if version_id not in found_ids
+        ]
+        if missing_ids:
+            raise ValueError(
+                "Registry versions not found: "
+                + ", ".join(str(version_id) for version_id in missing_ids)
+            )
+
+        missing_tarballs = [
+            version.id for version in versions if version.tarball_uri is None
+        ]
+        if missing_tarballs:
+            raise ValueError(
+                "Registry versions do not have tarballs: "
+                + ", ".join(str(version_id) for version_id in missing_tarballs)
+            )
+
+        request = RegistryArtifactsBackfillRequest(
+            items=[
+                RegistryArtifactsBackfillItem(
+                    version_id=version.id,
+                    version=version.version,
+                    tarball_uri=version.tarball_uri,
+                )
+                for version in versions
+                if version.tarball_uri is not None
+            ],
+        )
+        workflow_id = (
+            "registry-artifacts-backfill-"
+            f"{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:8]}"
+        )
+        client = await get_temporal_client()
+        await client.start_workflow(
+            RegistryArtifactsBackfillWorkflow.run,
+            request,
+            id=workflow_id,
+            task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+            execution_timeout=timedelta(hours=2),
+        )
+        return RegistryArtifactsBackfillStartResponse(
+            workflow_id=workflow_id,
+            requested_count=len(request.items),
+        )
 
     async def promote_version(
         self,

--- a/tracecat/admin/registry/service.py
+++ b/tracecat/admin/registry/service.py
@@ -8,7 +8,18 @@ from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, ClassVar
 
-from sqlalchemy import select, text
+from sqlalchemy import (
+    String,
+    and_,
+    case,
+    column,
+    func,
+    literal,
+    select,
+    true,
+    values,
+)
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import IntegrityError
 
 from tracecat import config
@@ -26,6 +37,7 @@ from tracecat.db.models import (
     PlatformRegistryIndex,
     PlatformRegistryRepository,
     PlatformRegistryVersion,
+    WorkflowDefinition,
 )
 from tracecat.parse import safe_url
 from tracecat.registry.actions.schemas import RegistryActionRead
@@ -430,37 +442,45 @@ class AdminRegistryService(BasePlatformService):
         if not unique_pairs:
             return {}
 
-        values_sql: list[str] = []
-        params: dict[str, str] = {}
-        for idx, (origin, version) in enumerate(unique_pairs):
-            origin_param = f"origin_{idx}"
-            version_param = f"version_{idx}"
-            values_sql.append(f"(:{origin_param}, :{version_param})")
-            params[origin_param] = origin
-            params[version_param] = version
-
-        stmt = text(
-            f"""
-            WITH requested(origin, registry_version) AS (
-                VALUES {", ".join(values_sql)}
+        requested_pairs = (
+            values(
+                column("origin", String),
+                column("registry_version", String),
+                name="requested_pair",
             )
-            SELECT
-                lock_entry.origin AS origin,
-                lock_entry.registry_version AS registry_version,
-                count(*)::int AS definition_count
-            FROM workflow_definition AS wd
-            JOIN LATERAL jsonb_each_text(
-                wd.registry_lock -> 'origins'
-            ) AS lock_entry(origin, registry_version) ON true
-            JOIN requested AS requested_pair
-              ON requested_pair.origin = lock_entry.origin
-             AND requested_pair.registry_version = lock_entry.registry_version
-            WHERE wd.registry_lock IS NOT NULL
-              AND jsonb_typeof(wd.registry_lock -> 'origins') = 'object'
-            GROUP BY lock_entry.origin, lock_entry.registry_version
-            """
+            .data(unique_pairs)
+            .alias("requested_pair")
         )
-        result = await self.session.execute(stmt, params)
+        origins = WorkflowDefinition.registry_lock["origins"]
+        lock_origins = case(
+            (func.jsonb_typeof(origins) == "object", origins),
+            else_=literal({}, type_=JSONB),
+        )
+        lock_entry = (
+            func.jsonb_each_text(lock_origins)
+            .table_valued("key", "value")
+            .lateral("lock_entry")
+        )
+
+        stmt = (
+            select(
+                lock_entry.c.key.label("origin"),
+                lock_entry.c.value.label("registry_version"),
+                func.count().label("definition_count"),
+            )
+            .select_from(WorkflowDefinition)
+            .join(lock_entry, true())
+            .join(
+                requested_pairs,
+                and_(
+                    requested_pairs.c.origin == lock_entry.c.key,
+                    requested_pairs.c.registry_version == lock_entry.c.value,
+                ),
+            )
+            .where(WorkflowDefinition.registry_lock.is_not(None))
+            .group_by(lock_entry.c.key, lock_entry.c.value)
+        )
+        result = await self.session.execute(stmt)
         counts: dict[tuple[str, str], int] = {}
         for row in result:
             mapping = row._mapping
@@ -547,12 +567,13 @@ class AdminRegistryService(BasePlatformService):
             f"{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:8]}"
         )
         client = await get_temporal_client()
+        execution_timeout = timedelta(minutes=max(120, 45 * len(request.items)))
         await client.start_workflow(
             RegistryArtifactsBackfillWorkflow.run,
             request,
             id=workflow_id,
             task_queue=config.TRACECAT__EXECUTOR_QUEUE,
-            execution_timeout=timedelta(hours=2),
+            execution_timeout=execution_timeout,
         )
         return RegistryArtifactsBackfillStartResponse(
             workflow_id=workflow_id,

--- a/tracecat/admin/registry/service.py
+++ b/tracecat/admin/registry/service.py
@@ -39,6 +39,7 @@ from tracecat.db.models import (
     PlatformRegistryVersion,
     WorkflowDefinition,
 )
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.parse import safe_url
 from tracecat.registry.actions.schemas import RegistryActionRead
 from tracecat.registry.actions.types import IndexEntry
@@ -537,7 +538,7 @@ class AdminRegistryService(BasePlatformService):
             version_id for version_id in version_ids if version_id not in found_ids
         ]
         if missing_ids:
-            raise ValueError(
+            raise TracecatNotFoundError(
                 "Registry versions not found: "
                 + ", ".join(str(version_id) for version_id in missing_ids)
             )
@@ -546,7 +547,7 @@ class AdminRegistryService(BasePlatformService):
             version.id for version in versions if version.tarball_uri is None
         ]
         if missing_tarballs:
-            raise ValueError(
+            raise TracecatValidationError(
                 "Registry versions do not have tarballs: "
                 + ", ".join(str(version_id) for version_id in missing_tarballs)
             )

--- a/tracecat/admin/registry/service.py
+++ b/tracecat/admin/registry/service.py
@@ -9,17 +9,10 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, ClassVar
 
 from sqlalchemy import (
-    String,
     and_,
-    case,
-    column,
     func,
-    literal,
     select,
-    true,
-    values,
 )
-from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import IntegrityError
 
 from tracecat import config
@@ -388,35 +381,103 @@ class AdminRegistryService(BasePlatformService):
         limit: int = 50,
     ) -> Sequence[RegistryVersionRead]:
         """List registry versions."""
-        stmt = select(
-            PlatformRegistryVersion,
-            PlatformRegistryRepository.origin,
-            PlatformRegistryRepository.current_version_id,
+        latest_definition_version = (
+            select(
+                WorkflowDefinition.workflow_id,
+                func.max(WorkflowDefinition.version).label("latest_version"),
+            )
+            .where(WorkflowDefinition.workflow_id.is_not(None))
+            .group_by(WorkflowDefinition.workflow_id)
+            .subquery()
+        )
+        latest_definition = (
+            select(
+                WorkflowDefinition.id.label("definition_id"),
+                WorkflowDefinition.registry_lock.label("registry_lock"),
+            )
+            .join(
+                latest_definition_version,
+                and_(
+                    WorkflowDefinition.workflow_id
+                    == latest_definition_version.c.workflow_id,
+                    WorkflowDefinition.version
+                    == latest_definition_version.c.latest_version,
+                ),
+            )
+            .subquery()
+        )
+        workflow_definition_count = func.count(latest_definition.c.definition_id).label(
+            "workflow_definition_count"
+        )
+        version_page = select(
+            PlatformRegistryVersion.surrogate_id.label("version_surrogate_id"),
+            PlatformRegistryRepository.origin.label("origin"),
+            PlatformRegistryRepository.current_version_id.label("current_version_id"),
         ).join(
             PlatformRegistryRepository,
             PlatformRegistryVersion.repository_id == PlatformRegistryRepository.id,
         )
         if repository_id:
-            stmt = stmt.where(PlatformRegistryVersion.repository_id == repository_id)
-        stmt = stmt.order_by(
+            version_page = version_page.where(
+                PlatformRegistryVersion.repository_id == repository_id
+            )
+        version_page = (
+            version_page.order_by(
+                PlatformRegistryVersion.created_at.desc(),
+                PlatformRegistryVersion.id.desc(),
+            )
+            .limit(limit)
+            .subquery()
+        )
+
+        stmt = (
+            select(
+                PlatformRegistryVersion,
+                version_page.c.origin,
+                version_page.c.current_version_id,
+                workflow_definition_count,
+            )
+            .join(
+                version_page,
+                PlatformRegistryVersion.surrogate_id
+                == version_page.c.version_surrogate_id,
+            )
+            .outerjoin(
+                latest_definition,
+                and_(
+                    latest_definition.c.registry_lock.is_not(None),
+                    func.jsonb_extract_path_text(
+                        latest_definition.c.registry_lock,
+                        "origins",
+                        version_page.c.origin,
+                    )
+                    == PlatformRegistryVersion.version,
+                ),
+            )
+        )
+        stmt = stmt.group_by(
+            PlatformRegistryVersion.surrogate_id,
+            version_page.c.origin,
+            version_page.c.current_version_id,
+        ).order_by(
             PlatformRegistryVersion.created_at.desc(),
             PlatformRegistryVersion.id.desc(),
-        ).limit(limit)
+        )
 
         result = await self.session.execute(stmt)
         rows = result.all()
-        usage_counts = await self._workflow_definition_usage_counts(
-            [(origin, version.version) for version, origin, _ in rows]
-        )
         artifact_statuses = await asyncio.gather(
-            *[self._artifacts_ready(version.tarball_uri) for version, _, _ in rows]
+            *[self._artifacts_ready(version.tarball_uri) for version, _, _, _ in rows]
         )
 
         versions: list[RegistryVersionRead] = []
-        for (version, origin, current_version_id), artifacts_ready in zip(
-            rows, artifact_statuses, strict=True
-        ):
-            workflow_definition_count = usage_counts.get((origin, version.version), 0)
+        for (
+            version,
+            _origin,
+            current_version_id,
+            definition_count,
+        ), artifacts_ready in zip(rows, artifact_statuses, strict=True):
+            count = int(definition_count)
             is_current = version.id == current_version_id
             versions.append(
                 RegistryVersionRead(
@@ -428,70 +489,11 @@ class AdminRegistryService(BasePlatformService):
                     created_at=version.created_at,
                     is_current=is_current,
                     artifacts_ready=artifacts_ready,
-                    workflow_definition_count=workflow_definition_count,
-                    in_use=is_current or workflow_definition_count > 0,
+                    workflow_definition_count=count,
+                    in_use=is_current or count > 0,
                 )
             )
         return versions
-
-    async def _workflow_definition_usage_counts(
-        self,
-        pairs: Sequence[tuple[str, str]],
-    ) -> dict[tuple[str, str], int]:
-        """Count workflow definitions pinned to each origin/version pair."""
-        unique_pairs = list(dict.fromkeys(pairs))
-        if not unique_pairs:
-            return {}
-
-        requested_pairs = (
-            values(
-                column("origin", String),
-                column("registry_version", String),
-                name="requested_pair",
-            )
-            .data(unique_pairs)
-            .alias("requested_pair")
-        )
-        origins = WorkflowDefinition.registry_lock["origins"]
-        lock_origins = case(
-            (func.jsonb_typeof(origins) == "object", origins),
-            else_=literal({}, type_=JSONB),
-        )
-        lock_entry = (
-            func.jsonb_each_text(lock_origins)
-            .table_valued("key", "value")
-            .lateral("lock_entry")
-        )
-
-        stmt = (
-            select(
-                lock_entry.c.key.label("origin"),
-                lock_entry.c.value.label("registry_version"),
-                func.count().label("definition_count"),
-            )
-            .select_from(WorkflowDefinition)
-            .join(lock_entry, true())
-            .join(
-                requested_pairs,
-                and_(
-                    requested_pairs.c.origin == lock_entry.c.key,
-                    requested_pairs.c.registry_version == lock_entry.c.value,
-                ),
-            )
-            .where(WorkflowDefinition.registry_lock.is_not(None))
-            .group_by(lock_entry.c.key, lock_entry.c.value)
-        )
-        result = await self.session.execute(stmt)
-        counts: dict[tuple[str, str], int] = {}
-        for row in result:
-            mapping = row._mapping
-            counts[
-                (
-                    str(mapping["origin"]),
-                    str(mapping["registry_version"]),
-                )
-            ] = int(mapping["definition_count"])
-        return counts
 
     async def _artifacts_ready(
         self,

--- a/tracecat/executor/worker.py
+++ b/tracecat/executor/worker.py
@@ -63,6 +63,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from tracecat.logger import logger
     from tracecat.registry.sync.workflow import (
+        RegistryArtifactsBackfillWorkflow,
         RegistrySyncActivities,
         RegistrySyncWorkflow,
     )
@@ -139,7 +140,7 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
         ]
 
         # Collect all workflows
-        workflows = [RegistrySyncWorkflow]
+        workflows = [RegistrySyncWorkflow, RegistryArtifactsBackfillWorkflow]
 
         logger.debug(
             "Activities loaded",

--- a/tracecat/registry/sync/schemas.py
+++ b/tracecat/registry/sync/schemas.py
@@ -114,3 +114,34 @@ class RegistrySyncResult(BaseModel):
         default_factory=dict,
         description="Map of action name to validation errors",
     )
+
+
+class RegistryArtifactsBackfillItem(BaseModel):
+    """Registry version whose artifacts should be backfilled."""
+
+    version_id: UUID = Field(..., description="Database registry version ID")
+    version: str = Field(..., description="Registry version string")
+    tarball_uri: str = Field(..., description="S3 URI of the existing tarball venv")
+
+
+class RegistryArtifactsBackfillRequest(BaseModel):
+    """Request for backfilling registry version artifacts."""
+
+    items: list[RegistryArtifactsBackfillItem] = Field(
+        ..., min_length=1, description="Registry versions to backfill"
+    )
+
+
+class RegistryArtifactsBackfillItemResult(BaseModel):
+    """Result for one registry version artifact backfill."""
+
+    version_id: UUID
+    status: Literal["created", "exists", "skipped", "failed"]
+    error: str | None = None
+
+
+class RegistryArtifactsBackfillResult(BaseModel):
+    """Result from a registry artifact backfill workflow."""
+
+    requested_count: int
+    results: list[RegistryArtifactsBackfillItemResult]

--- a/tracecat/registry/sync/tarball.py
+++ b/tracecat/registry/sync/tarball.py
@@ -20,6 +20,7 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 import aiofiles
 import tracecat_registry
@@ -61,6 +62,19 @@ def _squashfs_key_for(key: str) -> str:
     if key.endswith(".tar.gz"):
         return key.removesuffix(".tar.gz") + ".squashfs"
     return f"{key}.squashfs"
+
+
+def parse_s3_uri(uri: str) -> tuple[str, str]:
+    """Parse an S3 URI into bucket and key."""
+    parsed = urlparse(uri)
+    if parsed.scheme != "s3" or not parsed.netloc or not parsed.path.strip("/"):
+        raise ValueError(f"Invalid S3 URI: {uri}")
+    return parsed.netloc, parsed.path.lstrip("/")
+
+
+def get_squashfs_sidecar_key(tarball_key: str) -> str:
+    """Return the sibling SquashFS key for a tarball S3 key."""
+    return _squashfs_key_for(tarball_key)
 
 
 def _compute_file_hash(file_path: Path) -> str:
@@ -685,6 +699,34 @@ async def build_builtin_registry_tarball_venv(
 
     package_path = get_builtin_registry_source_path()
     return await build_tarball_venv_from_path(package_path, output_dir)
+
+
+async def build_squashfs_sidecar_from_tarball(
+    *,
+    tarball_path: Path,
+    squashfs_path: Path,
+    work_dir: Path,
+) -> bool:
+    """Build a SquashFS sidecar from an existing site-packages tarball."""
+
+    def _build_sidecar() -> bool:
+        if not tarball_path.exists():
+            raise FileNotFoundError(f"Tarball file not found: {tarball_path}")
+
+        extracted_dir = work_dir / "site-packages"
+        extracted_dir.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(tarball_path, "r:gz") as tar:
+            tar.extractall(path=extracted_dir, filter="data")
+
+        entries = [(item, item.name) for item in extracted_dir.iterdir()]
+        _create_squashfs_sidecar(
+            squashfs_path,
+            entries,
+            preserve_symlinks=True,
+        )
+        return squashfs_path.exists()
+
+    return await asyncio.to_thread(_build_sidecar)
 
 
 def get_tarball_venv_s3_key(

--- a/tracecat/registry/sync/workflow.py
+++ b/tracecat/registry/sync/workflow.py
@@ -278,18 +278,14 @@ async def backfill_registry_artifacts_activity(
             version_id=item.version_id,
             status="created",
         )
-    except Exception as exc:
+    except Exception:
         logger.exception(
             "Failed to backfill registry artifacts",
             version_id=str(item.version_id),
             version=item.version,
             tarball_uri=item.tarball_uri,
         )
-        return RegistryArtifactsBackfillItemResult(
-            version_id=item.version_id,
-            status="failed",
-            error=f"{type(exc).__name__}: {exc}",
-        )
+        raise
 
 
 class RegistrySyncActivities:

--- a/tracecat/registry/sync/workflow.py
+++ b/tracecat/registry/sync/workflow.py
@@ -28,18 +28,33 @@ from __future__ import annotations
 from datetime import timedelta
 
 from temporalio import activity, workflow
+from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
 
 with workflow.unsafe.imports_passed_through():
+    import tempfile
+    from pathlib import Path
+
     from tracecat.logger import logger
     from tracecat.registry.sync.runner import (
         RegistrySyncRunner,
         RegistrySyncValidationError,
     )
     from tracecat.registry.sync.schemas import (
+        RegistryArtifactsBackfillItem,
+        RegistryArtifactsBackfillItemResult,
+        RegistryArtifactsBackfillRequest,
+        RegistryArtifactsBackfillResult,
         RegistrySyncRequest,
         RegistrySyncResult,
     )
+    from tracecat.registry.sync.tarball import (
+        build_squashfs_sidecar_from_tarball,
+        download_tarball_venv,
+        get_squashfs_sidecar_key,
+        parse_s3_uri,
+    )
+    from tracecat.storage import blob
 
 
 @workflow.defn
@@ -86,6 +101,46 @@ class RegistrySyncWorkflow:
         )
 
         return result
+
+
+@workflow.defn
+class RegistryArtifactsBackfillWorkflow:
+    """Backfill artifacts for existing registry versions."""
+
+    @workflow.run
+    async def run(
+        self,
+        request: RegistryArtifactsBackfillRequest,
+    ) -> RegistryArtifactsBackfillResult:
+        """Build missing artifacts for selected registry versions."""
+        workflow.logger.info(
+            "Starting RegistryArtifactsBackfillWorkflow",
+            requested_count=len(request.items),
+        )
+
+        results: list[RegistryArtifactsBackfillItemResult] = []
+        for item in request.items:
+            result = await workflow.execute_activity(
+                backfill_registry_artifacts_activity,
+                item,
+                start_to_close_timeout=timedelta(minutes=20),
+                retry_policy=RetryPolicy(
+                    maximum_attempts=2,
+                    initial_interval=timedelta(seconds=5),
+                ),
+            )
+            results.append(result)
+
+        workflow.logger.info(
+            "RegistryArtifactsBackfillWorkflow completed",
+            requested_count=len(request.items),
+            created_count=sum(1 for result in results if result.status == "created"),
+            failed_count=sum(1 for result in results if result.status == "failed"),
+        )
+        return RegistryArtifactsBackfillResult(
+            requested_count=len(request.items),
+            results=results,
+        )
 
 
 @activity.defn
@@ -156,6 +211,87 @@ async def sync_registry_activity(request: RegistrySyncRequest) -> RegistrySyncRe
     return result
 
 
+@activity.defn
+async def backfill_registry_artifacts_activity(
+    item: RegistryArtifactsBackfillItem,
+) -> RegistryArtifactsBackfillItemResult:
+    """Build and upload missing artifacts for an existing registry tarball."""
+    try:
+        bucket, tarball_key = parse_s3_uri(item.tarball_uri)
+        squashfs_key = get_squashfs_sidecar_key(tarball_key)
+        artifact_uri = f"s3://{bucket}/{squashfs_key}"
+
+        if await blob.file_exists(key=squashfs_key, bucket=bucket):
+            logger.info(
+                "Registry artifacts already exist",
+                version_id=str(item.version_id),
+                version=item.version,
+                artifact_uri=artifact_uri,
+            )
+            return RegistryArtifactsBackfillItemResult(
+                version_id=item.version_id,
+                status="exists",
+            )
+
+        with tempfile.TemporaryDirectory(
+            prefix="tracecat_registry_artifacts_backfill_"
+        ) as temp_dir:
+            work_dir = Path(temp_dir)
+            tarball_path = work_dir / "site-packages.tar.gz"
+            squashfs_path = work_dir / "site-packages.squashfs"
+            await download_tarball_venv(
+                key=tarball_key,
+                bucket=bucket,
+                output_path=tarball_path,
+            )
+            created = await build_squashfs_sidecar_from_tarball(
+                tarball_path=tarball_path,
+                squashfs_path=squashfs_path,
+                work_dir=work_dir / "extract",
+            )
+            if not created:
+                logger.info(
+                    "Registry artifact backfill skipped",
+                    version_id=str(item.version_id),
+                    version=item.version,
+                )
+                return RegistryArtifactsBackfillItemResult(
+                    version_id=item.version_id,
+                    status="skipped",
+                    error="Artifact build is disabled or the builder is unavailable.",
+                )
+
+            await blob.upload_file_from_path(
+                path=squashfs_path,
+                key=squashfs_key,
+                bucket=bucket,
+                content_type="application/vnd.squashfs",
+            )
+
+        logger.info(
+            "Registry artifacts backfilled",
+            version_id=str(item.version_id),
+            version=item.version,
+            artifact_uri=artifact_uri,
+        )
+        return RegistryArtifactsBackfillItemResult(
+            version_id=item.version_id,
+            status="created",
+        )
+    except Exception as exc:
+        logger.exception(
+            "Failed to backfill registry artifacts",
+            version_id=str(item.version_id),
+            version=item.version,
+            tarball_uri=item.tarball_uri,
+        )
+        return RegistryArtifactsBackfillItemResult(
+            version_id=item.version_id,
+            status="failed",
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+
 class RegistrySyncActivities:
     """Container for registry sync activities.
 
@@ -166,4 +302,4 @@ class RegistrySyncActivities:
     @classmethod
     def get_activities(cls) -> list:
         """Return all registry sync activities for worker registration."""
-        return [sync_registry_activity]
+        return [sync_registry_activity, backfill_registry_artifacts_activity]

--- a/tracecat/registry/sync/workflow.py
+++ b/tracecat/registry/sync/workflow.py
@@ -29,7 +29,7 @@ from datetime import timedelta
 
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
-from temporalio.exceptions import ApplicationError
+from temporalio.exceptions import ActivityError, ApplicationError
 
 with workflow.unsafe.imports_passed_through():
     import tempfile
@@ -120,15 +120,31 @@ class RegistryArtifactsBackfillWorkflow:
 
         results: list[RegistryArtifactsBackfillItemResult] = []
         for item in request.items:
-            result = await workflow.execute_activity(
-                backfill_registry_artifacts_activity,
-                item,
-                start_to_close_timeout=timedelta(minutes=20),
-                retry_policy=RetryPolicy(
-                    maximum_attempts=2,
-                    initial_interval=timedelta(seconds=5),
-                ),
-            )
+            try:
+                result = await workflow.execute_activity(
+                    backfill_registry_artifacts_activity,
+                    item,
+                    start_to_close_timeout=timedelta(minutes=20),
+                    retry_policy=RetryPolicy(
+                        maximum_attempts=2,
+                        initial_interval=timedelta(seconds=5),
+                    ),
+                )
+            except ActivityError as exc:
+                workflow.logger.warning(
+                    "Registry artifact backfill item failed",
+                    version_id=str(item.version_id),
+                    version=item.version,
+                    tarball_uri=item.tarball_uri,
+                    error=str(exc.cause or exc),
+                )
+                result = RegistryArtifactsBackfillItemResult(
+                    version_id=item.version_id,
+                    status="failed",
+                    error=f"{type(exc.cause).__name__}: {exc.cause}"
+                    if exc.cause
+                    else str(exc),
+                )
             results.append(result)
 
         workflow.logger.info(


### PR DESCRIPTION
## Summary
- add admin API metadata for platform registry version artifact readiness and workflow-definition usage
- add a Temporal backfill workflow/activity that materializes optimized artifacts from each selected version's stored tarball
- add multi-select artifact backfill controls and usage indicators on the admin platform registry versions table

## Notes
- Backfill rebuilds from the existing tarball rather than re-running registry sync, so older versions are materialized from their pinned artifacts instead of current source.
- The usage indicator counts pinned workflow definitions from `workflow_definition.registry_lock` and marks current versions as in use.
- This PR intentionally does not persist a new `content_hash` column; that can stay a follow-up if we need dedupe or version fast-forward semantics.

## Testing
- `just gen-client-ci`
- `uv run pytest tests/unit/api/test_api_admin_registry.py tests/unit/test_admin_registry_service.py tests/unit/test_registry_sync_workflow.py tests/unit/test_registry_sync_tarball.py`
- `uv run basedpyright tracecat/admin/registry/schemas.py tracecat/admin/registry/router.py tracecat/admin/registry/service.py tracecat/registry/sync/schemas.py tracecat/registry/sync/workflow.py tracecat/registry/sync/tarball.py tracecat/executor/worker.py tests/unit/api/test_api_admin_registry.py tests/unit/test_admin_registry_service.py tests/unit/test_registry_sync_workflow.py tests/unit/test_registry_sync_tarball.py`
- `uv run ruff check tracecat/admin/registry/schemas.py tracecat/admin/registry/router.py tracecat/admin/registry/service.py tracecat/registry/sync/schemas.py tracecat/registry/sync/workflow.py tracecat/registry/sync/tarball.py tracecat/executor/worker.py tests/unit/api/test_api_admin_registry.py tests/unit/test_admin_registry_service.py tests/unit/test_registry_sync_workflow.py tests/unit/test_registry_sync_tarball.py`
- `uv run ruff format --check tracecat/admin/registry/schemas.py tracecat/admin/registry/router.py tracecat/admin/registry/service.py tracecat/registry/sync/schemas.py tracecat/registry/sync/workflow.py tracecat/registry/sync/tarball.py tracecat/executor/worker.py tests/unit/api/test_api_admin_registry.py tests/unit/test_admin_registry_service.py tests/unit/test_registry_sync_workflow.py tests/unit/test_registry_sync_tarball.py`
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`
- pre-commit hooks during amend
