### PR TITLE
fix: preserve date-like action input strings

### DIFF
--- a/tests/unit/test_dsl_common.py
+++ b/tests/unit/test_dsl_common.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
 
+from tracecat.dsl.common import build_action_statements_from_actions
 from tracecat.dsl.view import (
     RFEdge,
     RFGraph,
@@ -12,6 +16,8 @@ from tracecat.dsl.view import (
     UDFNode,
     UDFNodeData,
 )
+from tracecat.expressions.expectations import create_expectation_model
+from tracecat.registry.actions.schemas import TemplateAction
 
 
 def _make_trigger_node(trigger_id: str | None = None) -> TriggerNode:
@@ -126,3 +132,41 @@ class TestRFGraphNormalizeActionIds:
         assert len(action_nodes) == 2
         node_ids = {n.id for n in action_nodes}
         assert node_ids == {action1_uuid, action2_uuid}
+
+
+def test_build_action_statements_preserves_sentinel_date_like_api_version() -> None:
+    """Date-like string inputs should stay strings for template arg validation."""
+    template = TemplateAction.from_yaml(
+        Path(
+            "packages/tracecat-registry/tracecat_registry/templates/tools/"
+            "microsoft_sentinel/incidents/get_incident.yml"
+        )
+    )
+    expectation_model = create_expectation_model(template.definition.expects)
+    action = cast(
+        Any,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            ref="get_incident",
+            type=template.definition.action,
+            inputs="""
+subscription_id: sub-123
+resource_group_name: rg
+workspace_name: workspace
+incident_id: incident-123
+api_version: 2025-09-01
+base_url: https://management.azure.com
+""",
+            control_flow={},
+            upstream_edges=[],
+            is_interactive=False,
+            interaction=None,
+        ),
+    )
+
+    statements = build_action_statements_from_actions([action])
+
+    assert len(statements) == 1
+    assert statements[0].args["api_version"] == "2025-09-01"
+    validated_args = expectation_model.model_validate(statements[0].args)
+    assert validated_args.model_dump()["api_version"] == "2025-09-01"

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -80,22 +80,19 @@ from tracecat.workflow.executions.enums import (
     TriggerType,
 )
 
-_YAML_TIMESTAMP_TAG = "tag:yaml.org,2002:timestamp"
-
-
-class _ActionInputsSafeLoader(yaml.SafeLoader):
-    """Safe YAML loader that keeps date-like action input scalars as strings."""
-
-
-_ActionInputsSafeLoader.yaml_implicit_resolvers = {
-    char: [resolver for resolver in resolvers if resolver[0] != _YAML_TIMESTAMP_TAG]
-    for char, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
-}
-
 
 def _load_action_inputs_yaml(inputs: str) -> Any:
     """Parse persisted action inputs without coercing date-like strings."""
-    return yaml.load(inputs, Loader=_ActionInputsSafeLoader)
+    yaml_timestamp_tag = "tag:yaml.org,2002:timestamp"
+
+    class ActionInputsSafeLoader(yaml.SafeLoader):
+        """Safe YAML loader that keeps date-like action input scalars as strings."""
+
+    ActionInputsSafeLoader.yaml_implicit_resolvers = {
+        char: [resolver for resolver in resolvers if resolver[0] != yaml_timestamp_tag]
+        for char, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+    }
+    return yaml.load(inputs, Loader=ActionInputsSafeLoader)
 
 
 _memo_payload_converter = PydanticPayloadConverter()

--- a/tracecat/dsl/common.py
+++ b/tracecat/dsl/common.py
@@ -80,6 +80,24 @@ from tracecat.workflow.executions.enums import (
     TriggerType,
 )
 
+_YAML_TIMESTAMP_TAG = "tag:yaml.org,2002:timestamp"
+
+
+class _ActionInputsSafeLoader(yaml.SafeLoader):
+    """Safe YAML loader that keeps date-like action input scalars as strings."""
+
+
+_ActionInputsSafeLoader.yaml_implicit_resolvers = {
+    char: [resolver for resolver in resolvers if resolver[0] != _YAML_TIMESTAMP_TAG]
+    for char, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+
+
+def _load_action_inputs_yaml(inputs: str) -> Any:
+    """Parse persisted action inputs without coercing date-like strings."""
+    return yaml.load(inputs, Loader=_ActionInputsSafeLoader)
+
+
 _memo_payload_converter = PydanticPayloadConverter()
 
 
@@ -1310,7 +1328,7 @@ def build_action_statements_from_actions(
         dependencies = sorted(dependencies)
 
         control_flow = ActionControlFlow.model_validate(action.control_flow)
-        args = yaml.safe_load(action.inputs) or {}
+        args = _load_action_inputs_yaml(action.inputs) or {}
         interaction = (
             ActionInteractionValidator.validate_python(action.interaction)
             if action.is_interactive and action.interaction


### PR DESCRIPTION
Verified fix works in local dev with microsoft sentinel get_incident

## Summary
- Parse persisted action input YAML with a SafeLoader variant that disables implicit timestamp coercion.
- Keep date-like string inputs such as Microsoft Sentinel `api_version: 2025-09-01` as strings before template arg validation.
- Add a regression test using the Microsoft Sentinel `get_incident` template schema.

## Testing
- `uv run pytest tests/unit/test_dsl_common.py -q`
- `uv run ruff check tracecat/dsl/common.py tests/unit/test_dsl_common.py`
- `uv run ruff format --check tracecat/dsl/common.py tests/unit/test_dsl_common.py`
- `uv run basedpyright tracecat/dsl/common.py tests/unit/test_dsl_common.py`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve date-like strings in action input YAML so values like Microsoft Sentinel `api_version: 2025-09-01` are not coerced to timestamps. Keeps these values as strings during action statement build and validation.

- **Bug Fixes**
  - Parse persisted action inputs with a SafeLoader variant that disables implicit timestamp resolution.
  - Ensure date-like fields (e.g., `api_version`) remain strings through template arg validation.
  - Add a regression test using the Microsoft Sentinel `get_incident` template.

- **Refactors**
  - Encapsulated YAML parsing in `_load_action_inputs_yaml` and replaced direct `yaml.safe_load` usage when building action statements.

<sup>Written for commit 0846228c37ac353043994bea11843b5feb6375ab. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2725?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



