### PR TITLE
fix(agent): request identity encoding from MCP bridge

### DIFF
--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -248,6 +248,15 @@ def test_get_litellm_route_model_prefixes_provider_route(
 class TestClaudeAgentRuntimeRun:
     """Tests for ClaudeAgentRuntime.run()."""
 
+    def test_trusted_mcp_bridge_disables_response_compression(self) -> None:
+        """The MCP SDK parses bridge responses itself, so request plain JSON."""
+        server_config = ClaudeAgentRuntime._trusted_mcp_server_config("test-jwt-token")
+
+        assert server_config.get("headers") == {
+            "Authorization": "Bearer test-jwt-token",
+            "Accept-Encoding": "identity",
+        }
+
     @pytest.mark.anyio
     async def test_sends_done_on_completion(
         self,
@@ -832,7 +841,10 @@ class TestClaudeAgentRuntimeRun:
         assert mcp_servers["tracecat-registry"] == {
             "type": "http",
             "url": TRUSTED_MCP_BRIDGE_URL,
-            "headers": {"Authorization": "Bearer test-jwt-token"},
+            "headers": {
+                "Authorization": "Bearer test-jwt-token",
+                "Accept-Encoding": "identity",
+            },
         }
         assert "tracecat_registry" not in mcp_servers
 
@@ -884,7 +896,10 @@ class TestClaudeAgentRuntimeRun:
             "tracecat-registry": {
                 "type": "http",
                 "url": TRUSTED_MCP_BRIDGE_URL,
-                "headers": {"Authorization": "Bearer test-jwt-token"},
+                "headers": {
+                    "Authorization": "Bearer test-jwt-token",
+                    "Accept-Encoding": "identity",
+                },
             },
             "local-tools": {
                 "type": "stdio",
@@ -1171,7 +1186,10 @@ class TestClaudeAgentRuntimeRun:
             "tracecat-registry": {
                 "type": "http",
                 "url": TRUSTED_MCP_BRIDGE_URL,
-                "headers": {"Authorization": "Bearer test-jwt-token"},
+                "headers": {
+                    "Authorization": "Bearer test-jwt-token",
+                    "Accept-Encoding": "identity",
+                },
             }
         }
         agent_def = options.agents["analyst"]
@@ -1181,7 +1199,10 @@ class TestClaudeAgentRuntimeRun:
                 "tracecat-registry-analyst": {
                     "type": "http",
                     "url": TRUSTED_MCP_BRIDGE_URL,
-                    "headers": {"Authorization": "Bearer child-mcp-token"},
+                    "headers": {
+                        "Authorization": "Bearer child-mcp-token",
+                        "Accept-Encoding": "identity",
+                    },
                 }
             },
             {

--- a/tests/unit/test_agent_sandbox_litellm.py
+++ b/tests/unit/test_agent_sandbox_litellm.py
@@ -392,6 +392,134 @@ class _FakeLLMSocketProxy:
         await writer.wait_closed()
 
 
+class _FakeCompressedMCPUnixSocketProxy:
+    def __init__(self, socket_path: Path) -> None:
+        self.socket_path = socket_path
+        self.requests: list[dict[str, object]] = []
+        self.started = False
+        self.stopped = False
+        self._server: asyncio.Server | None = None
+
+    async def start(self) -> None:
+        self.socket_path.parent.mkdir(parents=True, exist_ok=True)
+        with contextlib.suppress(FileNotFoundError):
+            self.socket_path.unlink()
+        self._server = await asyncio.start_unix_server(
+            self._handle_connection,
+            path=str(self.socket_path),
+        )
+        self.started = True
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+        with contextlib.suppress(FileNotFoundError):
+            self.socket_path.unlink()
+        self.stopped = True
+
+    async def _handle_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        headers_data = b""
+        while True:
+            line = await reader.readline()
+            if not line:
+                return
+            headers_data += line
+            if line == b"\r\n":
+                break
+
+        headers: dict[str, str] = {}
+        content_length = 0
+        for raw_line in headers_data.split(b"\r\n"):
+            if b":" not in raw_line:
+                continue
+            name, value = raw_line.split(b":", 1)
+            header_name = name.decode("latin1").strip().lower()
+            header_value = value.decode("latin1").strip()
+            headers[header_name] = header_value
+            if header_name == "content-length":
+                content_length = int(header_value)
+
+        body_bytes = b""
+        if content_length:
+            body_bytes = await reader.readexactly(content_length)
+
+        request_body: dict[str, object] | None = None
+        with contextlib.suppress(json.JSONDecodeError):
+            decoded = json.loads(body_bytes.decode("utf-8"))
+            if isinstance(decoded, dict):
+                request_body = decoded
+
+        accept_encoding = headers.get("accept-encoding", "")
+        self.requests.append(
+            {
+                "accept_encoding": accept_encoding,
+                "body": request_body,
+            }
+        )
+
+        if request_body is not None and "id" not in request_body:
+            writer.write(
+                b"HTTP/1.1 202 Accepted\r\n"
+                b"Content-Length: 0\r\n"
+                b"Connection: close\r\n"
+                b"\r\n"
+            )
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+            return
+
+        if accept_encoding.strip().lower() != "identity":
+            body = b"(\xb5/\xfdd\x88\x04%compressed-jsonrpc"
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Encoding: zstd\r\n"
+                + f"Content-Length: {len(body)}\r\n".encode()
+                + b"Connection: close\r\n"
+                + b"\r\n"
+                + body
+            )
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+            return
+
+        request_id = request_body.get("id") if request_body is not None else None
+        body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {
+                        "name": "tracecat-test-mcp",
+                        "version": "1.0.0",
+                    },
+                },
+            },
+            separators=(",", ":"),
+        ).encode()
+        writer.write(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: application/json\r\n"
+            + f"Content-Length: {len(body)}\r\n".encode()
+            + b"Connection: close\r\n"
+            + b"\r\n"
+            + body
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+
 class _FakeAgentManagementService:
     async def get_catalog_credentials(self, _catalog_id: uuid.UUID) -> dict[str, str]:
         return {"CUSTOM_MODEL_PROVIDER_API_KEY": "sk-test"}
@@ -648,6 +776,267 @@ async def _run_full_claude_harness_runtime_case(
     assert stream_sink.done_count == 1
 
 
+async def _run_mcp_compression_initialize_case(
+    *,
+    disable_nsjail_mode: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    expect_success: bool,
+) -> AgentExecutorResult:
+    _patch_agent_management_credentials(monkeypatch)
+    _FakeLLMSocketProxy.instances.clear()
+    broker = ClaudeRuntimeBroker()
+    await broker.start()
+    stream_sink = _InMemoryStreamSink()
+    job_dir = Path(tempfile.mkdtemp(prefix="tcaj-mcp-compression-", dir="/tmp"))
+    session_root = Path(tempfile.mkdtemp(prefix="tcaj-mcp-sessions-", dir="/tmp"))
+    mcp_proxy: _FakeCompressedMCPUnixSocketProxy | None = None
+
+    async def fake_create_job_directory(self: SandboxedAgentExecutor) -> Path:
+        del self
+        nonlocal mcp_proxy
+        socket_dir = job_dir / "sockets"
+        socket_dir.mkdir(parents=True)
+        mcp_proxy = _FakeCompressedMCPUnixSocketProxy(socket_dir / "mcp.sock")
+        await mcp_proxy.start()
+        monkeypatch.setattr(
+            nsjail_module,
+            "TRACECAT__AGENT_MCP_SOCKET_PATH",
+            mcp_proxy.socket_path,
+        )
+        return job_dir
+
+    async def fake_initialize_stream_sink(self: LoopbackHandler) -> _InMemoryStreamSink:
+        del self
+        return stream_sink
+
+    async def fake_persist_session_line(
+        self: LoopbackHandler,
+        sdk_session_id: str,
+        session_line: str,
+        *,
+        internal: bool = False,
+    ) -> None:
+        del self, sdk_session_id, session_line, internal
+
+    async def fake_build_claude_command(self: SandboxedCLITransport) -> list[str]:
+        python_bin = sys.executable if disable_nsjail_mode else "/usr/local/bin/python3"
+        mcp_servers = self._options.mcp_servers
+        if not isinstance(mcp_servers, dict):
+            raise AssertionError("expected trusted MCP server config")
+        server_config = mcp_servers["tracecat-registry"]
+        if not isinstance(server_config, dict):
+            raise AssertionError("expected trusted MCP server dict config")
+        http_server_config = cast(dict[str, object], server_config)
+        url = http_server_config.get("url")
+        headers = http_server_config.get("headers", {})
+        if not isinstance(url, str) or not isinstance(headers, dict):
+            raise AssertionError("expected HTTP MCP URL and headers")
+        code = "\n".join(
+            [
+                "import json, sys, time, urllib.request",
+                f"MCP_URL = {url!r}",
+                f"MCP_HEADERS = {json.dumps(headers)!r}",
+                "",
+                "def initialize_mcp():",
+                "    headers = json.loads(MCP_HEADERS)",
+                "    headers.setdefault('Accept-Encoding', 'gzip, deflate, br, zstd')",
+                "    headers['Content-Type'] = 'application/json'",
+                "    body = json.dumps({",
+                "        'jsonrpc': '2.0',",
+                "        'id': 1,",
+                "        'method': 'initialize',",
+                "        'params': {",
+                "            'protocolVersion': '2025-11-25',",
+                "            'capabilities': {},",
+                "            'clientInfo': {'name': 'tracecat-test', 'version': '1.0.0'},",
+                "        },",
+                "    }).encode()",
+                "    request = urllib.request.Request(",
+                "        MCP_URL,",
+                "        data=body,",
+                "        headers=headers,",
+                "        method='POST',",
+                "    )",
+                "    response_body = urllib.request.urlopen(request, timeout=2).read()",
+                "    json.loads(response_body)",
+                "",
+                "def emit(payload):",
+                "    print(json.dumps(payload), flush=True)",
+                "",
+                "control_line = sys.stdin.readline()",
+                "control = json.loads(control_line)",
+                "request_id = control['request_id']",
+                "try:",
+                "    initialize_mcp()",
+                "except Exception as exc:",
+                "    print('Error parsing JSON response', file=sys.stderr, flush=True)",
+                "    print(f'Invalid JSON: {exc}', file=sys.stderr, flush=True)",
+                "    time.sleep(2)",
+                "    raise SystemExit(0)",
+                "emit({",
+                "    'type': 'control_response',",
+                "    'response': {",
+                "        'request_id': request_id,",
+                "        'subtype': 'initialize',",
+                "        'response': {'supported_commands': []},",
+                "    },",
+                "})",
+                "sys.stdin.readline()",
+                "emit({",
+                "    'type': 'result',",
+                "    'subtype': 'success',",
+                "    'duration_ms': 1,",
+                "    'duration_api_ms': 1,",
+                "    'is_error': False,",
+                "    'num_turns': 1,",
+                "    'session_id': 'sdk-session-compression-smoke',",
+                "    'result': 'mcp initialized',",
+                "    'usage': {'input_tokens': 1, 'output_tokens': 1},",
+                "})",
+            ]
+        )
+        return [python_bin, "-c", code]
+
+    from claude_agent_sdk._internal.query import Query
+
+    original_send_control_request = Query._send_control_request
+
+    async def fast_send_control_request(
+        self: Query,
+        request: dict[str, Any],
+        timeout: float = 60.0,
+    ) -> dict[str, Any]:
+        if request.get("subtype") == "initialize":
+            timeout = 1.0
+        return await original_send_control_request(self, request, timeout=timeout)
+
+    executor_input = _make_passthrough_executor_input(
+        enable_internet_access=False
+    ).model_copy(
+        update={
+            "allowed_actions": {
+                "core.http_request": MCPToolDefinition(
+                    name="core.http_request",
+                    description="Make an HTTP request",
+                    parameters_json_schema={
+                        "type": "object",
+                        "properties": {},
+                    },
+                )
+            }
+        }
+    )
+
+    monkeypatch.setattr(executor_activity, "LLMSocketProxy", _FakeLLMSocketProxy)
+    monkeypatch.setattr(
+        SandboxedAgentExecutor,
+        "_create_job_directory",
+        fake_create_job_directory,
+    )
+    monkeypatch.setattr(
+        LoopbackHandler,
+        "_initialize_stream_sink",
+        fake_initialize_stream_sink,
+    )
+    monkeypatch.setattr(
+        LoopbackHandler,
+        "_persist_session_line",
+        fake_persist_session_line,
+    )
+    monkeypatch.setattr(executor_activity, "get_claude_runtime_broker", lambda: broker)
+    monkeypatch.setattr(
+        transport_module.SandboxedCLITransport,
+        "_build_claude_command",
+        fake_build_claude_command,
+    )
+    monkeypatch.setattr(Query, "_send_control_request", fast_send_control_request)
+    monkeypatch.setattr(
+        session_paths_module.tempfile,
+        "gettempdir",
+        lambda: str(session_root),
+    )
+    monkeypatch.setattr(
+        executor_activity,
+        "activity",
+        SimpleNamespace(heartbeat=lambda _message: None),
+    )
+    monkeypatch.setattr(
+        executor_activity.AgentSessionService,
+        "with_session",
+        lambda **_kwargs: _FakeAgentSessionService(),
+    )
+
+    try:
+        result = await run_agent_activity(executor_input)
+    finally:
+        await broker.stop()
+        if mcp_proxy is not None:
+            await mcp_proxy.stop()
+        shutil.rmtree(job_dir, ignore_errors=True)
+        shutil.rmtree(session_root, ignore_errors=True)
+
+    assert mcp_proxy is not None
+    assert mcp_proxy.started is True
+    assert mcp_proxy.stopped is True
+    assert mcp_proxy.requests
+
+    if expect_success:
+        assert result.success is True
+        assert result.error is None
+        assert result.output == "mcp initialized"
+        assert any(
+            request["accept_encoding"] == "identity" for request in mcp_proxy.requests
+        )
+        assert stream_sink.errors == []
+        assert stream_sink.done_count == 1
+    else:
+        assert result.success is False
+        assert result.error == "Unexpected error: Control request timeout: initialize"
+        assert all(
+            request["accept_encoding"] != "identity" for request in mcp_proxy.requests
+        )
+
+    return result
+
+
+async def _run_mcp_compression_initialize_repro_case(
+    *,
+    disable_nsjail_mode: bool,
+    tmp_path: Path,
+) -> None:
+    with pytest.MonkeyPatch.context() as legacy_monkeypatch:
+        _set_disable_nsjail_mode(legacy_monkeypatch, disable_nsjail_mode)
+
+        def legacy_trusted_mcp_server_config(auth_token: str) -> dict[str, object]:
+            return {
+                "type": "http",
+                "url": runtime_module.TRUSTED_MCP_BRIDGE_URL,
+                "headers": {"Authorization": f"Bearer {auth_token}"},
+            }
+
+        legacy_monkeypatch.setattr(
+            runtime_module.ClaudeAgentRuntime,
+            "_trusted_mcp_server_config",
+            staticmethod(legacy_trusted_mcp_server_config),
+        )
+        await _run_mcp_compression_initialize_case(
+            disable_nsjail_mode=disable_nsjail_mode,
+            monkeypatch=legacy_monkeypatch,
+            tmp_path=tmp_path / "legacy",
+            expect_success=False,
+        )
+
+    with pytest.MonkeyPatch.context() as fixed_monkeypatch:
+        _set_disable_nsjail_mode(fixed_monkeypatch, disable_nsjail_mode)
+        await _run_mcp_compression_initialize_case(
+            disable_nsjail_mode=disable_nsjail_mode,
+            monkeypatch=fixed_monkeypatch,
+            tmp_path=tmp_path / "fixed",
+            expect_success=True,
+        )
+
+
 def _run_nsjail_harness_in_docker_or_skip(
     *,
     cli_flag: str = "--run-nsjail-harness-smoke",
@@ -806,6 +1195,20 @@ def _run_nsjail_skills_smoke_from_cli() -> None:
             )
         finally:
             monkeypatch.undo()
+            shutil.rmtree(tmp_path, ignore_errors=True)
+
+    asyncio.run(run())
+
+
+def _run_nsjail_mcp_compression_smoke_from_cli() -> None:
+    async def run() -> None:
+        tmp_path = Path(tempfile.mkdtemp(prefix="tracecat-agent-nsjail-mcp-"))
+        try:
+            await _run_mcp_compression_initialize_repro_case(
+                disable_nsjail_mode=False,
+                tmp_path=tmp_path,
+            )
+        finally:
             shutil.rmtree(tmp_path, ignore_errors=True)
 
     asyncio.run(run())
@@ -1550,6 +1953,24 @@ async def test_run_agent_activity_spawns_full_claude_harness_runtime_with_pasta_
 
 
 @pytest.mark.anyio
+async def test_run_agent_activity_reproduces_mcp_compression_initialize_timeout_in_each_sandbox_mode(
+    full_harness_disable_nsjail_mode: bool,
+    tmp_path: Path,
+) -> None:
+    if not full_harness_disable_nsjail_mode and not _agent_nsjail_available():
+        _run_nsjail_harness_in_docker_or_skip(
+            cli_flag="--run-nsjail-mcp-compression-smoke",
+            failure_label="Dockerized nsjail MCP compression smoke fallback failed.",
+        )
+        return
+
+    await _run_mcp_compression_initialize_repro_case(
+        disable_nsjail_mode=full_harness_disable_nsjail_mode,
+        tmp_path=tmp_path,
+    )
+
+
+@pytest.mark.anyio
 async def test_executor_always_starts_llm_socket_proxy(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1867,9 +2288,11 @@ if __name__ == "__main__":
         _run_nsjail_pasta_smoke_from_cli()
     elif sys.argv[1:] == ["--run-nsjail-skills-smoke"]:
         _run_nsjail_skills_smoke_from_cli()
+    elif sys.argv[1:] == ["--run-nsjail-mcp-compression-smoke"]:
+        _run_nsjail_mcp_compression_smoke_from_cli()
     else:
         raise SystemExit(
             "Usage: python -m tests.unit.test_agent_sandbox_litellm "
             "[--run-nsjail-harness-smoke|--run-nsjail-pasta-smoke|"
-            "--run-nsjail-skills-smoke]"
+            "--run-nsjail-skills-smoke|--run-nsjail-mcp-compression-smoke]"
         )

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -310,7 +310,10 @@ class ClaudeAgentRuntime:
         return {
             "type": "http",
             "url": TRUSTED_MCP_BRIDGE_URL,
-            "headers": {"Authorization": f"Bearer {auth_token}"},
+            "headers": {
+                "Authorization": f"Bearer {auth_token}",
+                "Accept-Encoding": "identity",
+            },
         }
 
     @staticmethod


### PR DESCRIPTION
## Summary

- request `Accept-Encoding: identity` for Tracecat's trusted MCP bridge config used by Claude agents
- cover root-agent and subagent MCP bridge configs in existing runtime tests
- add a Docker/nsjail reproduction that proves compressed MCP initialize responses can surface as `Unexpected error: Control request timeout: initialize`

## Evidence

The production executor logs showed the MCP streamable HTTP client failing to parse bytes beginning with `28 b5 2f fd`, the zstd magic prefix, immediately before the SDK surfaced `Control request timeout: initialize`.

The new regression test runs the real `run_agent_activity` path with `SandboxedCLITransport` in both direct and nsjail modes. It first monkeypatches the trusted MCP bridge config back to the legacy headers and asserts the exact outer error:

```text
Unexpected error: Control request timeout: initialize
```

Then it runs the fixed config and asserts the fake jailed Claude command receives plain JSON from the bridge and completes successfully.

## Tests

- `uv run pytest tests/unit/test_agent_runtime.py::TestClaudeAgentRuntimeRun::test_trusted_mcp_bridge_disables_response_compression tests/unit/test_agent_runtime.py::TestClaudeAgentRuntimeRun::test_canonicalizes_registry_mcp_alias_on_resume tests/unit/test_agent_runtime.py::TestClaudeAgentRuntimeRun::test_root_agent_preserves_attached_stdio_mcp_servers tests/unit/test_agent_runtime.py::TestClaudeAgentRuntimeRun::test_explicit_subagents_get_root_style_agent_definitions 'tests/unit/test_agent_sandbox_litellm.py::test_run_agent_activity_reproduces_mcp_compression_initialize_timeout_in_each_sandbox_mode'`
- `uv run ruff check tracecat/agent/runtime/claude_code/runtime.py tests/unit/test_agent_runtime.py tests/unit/test_agent_sandbox_litellm.py`
- `uv run ruff format --check tracecat/agent/runtime/claude_code/runtime.py tests/unit/test_agent_runtime.py tests/unit/test_agent_sandbox_litellm.py`
- `uv run basedpyright tracecat/agent/runtime/claude_code/runtime.py tests/unit/test_agent_runtime.py tests/unit/test_agent_sandbox_litellm.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force `Accept-Encoding: identity` for the trusted MCP bridge used by Claude agents to ensure plain JSON responses. Fixes initialize failures where compressed (zstd) responses led to “Control request timeout: initialize”.

- **Bug Fixes**
  - Add `Accept-Encoding: identity` to trusted MCP bridge headers for root and subagent configs.
  - Extend unit tests to assert the header on all trusted MCP bridge configs.
  - Add a regression harness with a fake MCP socket that returns zstd when not requesting identity; reproduces the timeout with legacy headers and passes with the fix in both direct and nsjail modes. Includes `--run-nsjail-mcp-compression-smoke` CLI support.

<sup>Written for commit 3ec3a20dcc58a112946a8a18f8ecbe70fcb15235. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2728?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

