### PR TITLE
feat(integrations): add Slack streaming chat templates

### DIFF
--- a/packages/tracecat-registry/pyproject.toml
+++ b/packages/tracecat-registry/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "pymongo==4.8.0",
     "pyyaml==6.0.3",
     "redis[hiredis]==7.1.0",
-    "slack-sdk==3.28.0",
+    "slack-sdk==3.41.0",
     "sqlalchemy>=2.0.0,<3.0.0",
     "tavily-python==0.7.6",
     "tenacity==8.3.0",

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/chat/append_stream.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/chat/append_stream.yml
@@ -1,0 +1,34 @@
+type: action
+definition:
+  title: Append stream
+  description: Append text or chunks to an existing Slack streaming message.
+  display_group: Slack
+  doc_url: https://docs.slack.dev/reference/methods/chat.appendStream/
+  namespace: tools.slack
+  name: append_stream
+  expects:
+    channel:
+      type: str
+      description: ID of the channel containing the streaming message.
+    ts:
+      type: str
+      description: Timestamp of the streaming message.
+    markdown_text:
+      type: str | None
+      description: Markdown-formatted text to append to the stream.
+      default: null
+    chunks:
+      type: list[dict[str, Any]] | None
+      description: Streaming chunks, such as markdown_text, task_update, plan_update, or blocks chunks.
+      default: null
+  steps:
+    - ref: append_stream
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: chat_appendStream
+        params:
+          channel: ${{ inputs.channel }}
+          ts: ${{ inputs.ts }}
+          markdown_text: ${{ inputs.markdown_text }}
+          chunks: ${{ inputs.chunks }}
+  returns: ${{ steps.append_stream.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/chat/post_ephemeral.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/chat/post_ephemeral.yml
@@ -1,0 +1,79 @@
+type: action
+definition:
+  title: Post ephemeral message
+  description: Send an ephemeral Slack message to a user in a channel.
+  display_group: Slack
+  doc_url: https://docs.slack.dev/reference/methods/chat.postEphemeral/
+  namespace: tools.slack
+  name: post_ephemeral
+  expects:
+    channel:
+      type: str
+      description: Channel, private group, or IM channel to send the ephemeral message to.
+    user:
+      type: str
+      description: ID of the user who will receive the ephemeral message.
+    text:
+      type: str | None
+      description: Message text. Used as fallback text when blocks are provided.
+      default: null
+    blocks:
+      type: list[dict[str, Any]] | None
+      description: List of JSON-based blocks.
+      default: null
+    attachments:
+      type: list[dict[str, Any]] | None
+      description: List of JSON-based attachments.
+      default: null
+    markdown_text:
+      type: str | None
+      description: Markdown-formatted message text. Do not use with blocks or text.
+      default: null
+    thread_ts:
+      type: str | None
+      description: Parent message timestamp for posting the ephemeral message in a thread.
+      default: null
+    parse:
+      type: str | None
+      description: How Slack should parse message text.
+      default: null
+    link_names:
+      type: bool
+      description: Whether Slack should find and link channel names and usernames.
+      default: false
+    as_user:
+      type: bool | None
+      description: Legacy option to post the message as the authenticated user.
+      default: null
+    icon_emoji:
+      type: str | None
+      description: Emoji to use as the icon for this message.
+      default: null
+    icon_url:
+      type: str | None
+      description: URL to an image to use as the icon for this message.
+      default: null
+    username:
+      type: str | None
+      description: Bot username to display.
+      default: null
+  steps:
+    - ref: post_ephemeral
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: chat_postEphemeral
+        params:
+          channel: ${{ inputs.channel }}
+          user: ${{ inputs.user }}
+          text: ${{ inputs.text }}
+          blocks: ${{ inputs.blocks }}
+          attachments: ${{ inputs.attachments }}
+          markdown_text: ${{ inputs.markdown_text }}
+          thread_ts: ${{ inputs.thread_ts }}
+          parse: ${{ inputs.parse }}
+          link_names: ${{ inputs.link_names }}
+          as_user: ${{ inputs.as_user }}
+          icon_emoji: ${{ inputs.icon_emoji }}
+          icon_url: ${{ inputs.icon_url }}
+          username: ${{ inputs.username }}
+  returns: ${{ steps.post_ephemeral.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/chat/start_stream.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/chat/start_stream.yml
@@ -1,0 +1,64 @@
+type: action
+definition:
+  title: Start stream
+  description: Start a new Slack streaming message in a thread.
+  display_group: Slack
+  doc_url: https://docs.slack.dev/reference/methods/chat.startStream/
+  namespace: tools.slack
+  name: start_stream
+  expects:
+    channel:
+      type: str
+      description: ID of the channel, private group, or DM for the stream.
+    thread_ts:
+      type: str
+      description: Parent message timestamp to reply to with the stream.
+    markdown_text:
+      type: str | None
+      description: Initial markdown-formatted text for the stream.
+      default: null
+    chunks:
+      type: list[dict[str, Any]] | None
+      description: Initial streaming chunks, such as markdown_text, task_update, plan_update, or blocks chunks.
+      default: null
+    recipient_user_id:
+      type: str | None
+      description: ID of the user receiving the stream. Required by Slack when streaming to channels.
+      default: null
+    recipient_team_id:
+      type: str | None
+      description: ID of the recipient user's team. Required by Slack when streaming to channels.
+      default: null
+    task_display_mode:
+      type: str | None
+      description: How task chunks are displayed. Accepts timeline, plan, or dense.
+      default: null
+    icon_emoji:
+      type: str | None
+      description: Emoji to use as the icon for this message.
+      default: null
+    icon_url:
+      type: str | None
+      description: URL to an image to use as the icon for this message.
+      default: null
+    username:
+      type: str | None
+      description: Bot username to display.
+      default: null
+  steps:
+    - ref: start_stream
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: chat_startStream
+        params:
+          channel: ${{ inputs.channel }}
+          thread_ts: ${{ inputs.thread_ts }}
+          markdown_text: ${{ inputs.markdown_text }}
+          chunks: ${{ inputs.chunks }}
+          recipient_user_id: ${{ inputs.recipient_user_id }}
+          recipient_team_id: ${{ inputs.recipient_team_id }}
+          task_display_mode: ${{ inputs.task_display_mode }}
+          icon_emoji: ${{ inputs.icon_emoji }}
+          icon_url: ${{ inputs.icon_url }}
+          username: ${{ inputs.username }}
+  returns: ${{ steps.start_stream.result }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/chat/stop_stream.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/chat/stop_stream.yml
@@ -1,0 +1,44 @@
+type: action
+definition:
+  title: Stop stream
+  description: Stop and finalize a Slack streaming message.
+  display_group: Slack
+  doc_url: https://docs.slack.dev/reference/methods/chat.stopStream/
+  namespace: tools.slack
+  name: stop_stream
+  expects:
+    channel:
+      type: str
+      description: ID of the channel containing the streaming message.
+    ts:
+      type: str
+      description: Timestamp of the streaming message.
+    markdown_text:
+      type: str | None
+      description: Final markdown-formatted text to append before stopping the stream.
+      default: null
+    chunks:
+      type: list[dict[str, Any]] | None
+      description: Final streaming chunks, such as markdown_text, task_update, plan_update, or blocks chunks.
+      default: null
+    blocks:
+      type: list[dict[str, Any]] | None
+      description: Blocks rendered at the bottom of the finalized message.
+      default: null
+    metadata:
+      type: dict[str, Any] | None
+      description: Slack message metadata with event_type and event_payload fields.
+      default: null
+  steps:
+    - ref: stop_stream
+      action: tools.slack_sdk.call_method
+      args:
+        sdk_method: chat_stopStream
+        params:
+          channel: ${{ inputs.channel }}
+          ts: ${{ inputs.ts }}
+          markdown_text: ${{ inputs.markdown_text }}
+          chunks: ${{ inputs.chunks }}
+          blocks: ${{ inputs.blocks }}
+          metadata: ${{ inputs.metadata }}
+  returns: ${{ steps.stop_stream.result }}

--- a/uv.lock
+++ b/uv.lock
@@ -4113,11 +4113,11 @@ wheels = [
 
 [[package]]
 name = "slack-sdk"
-version = "3.28.0"
+version = "3.41.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bb/d2/a992211856a8ac736d2a927778f1a16ac43cea68744e4ae015c73fbbfac8/slack_sdk-3.28.0.tar.gz", hash = "sha256:e6ece5cb70850492637e002e3b0d26d307939f4a33203b88cb274f7475c9a144", size = 227946, upload-time = "2024-06-10T19:55:40.93Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/35/fc009118a13187dd9731657c60138e5a7c2dea88681a7f04dc406af5da7d/slack_sdk-3.41.0.tar.gz", hash = "sha256:eb61eb12a65bebeca9cb5d36b3f799e836ed2be21b456d15df2627cfe34076ca", size = 250568, upload-time = "2026-03-12T16:10:11.381Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/9c/63a442f9cf8f1911727b1fd02da0d26366d1348895d54b0a98fbe2a17a13/slack_sdk-3.28.0-py2.py3-none-any.whl", hash = "sha256:1a47700ae20566575ce494d1d1b6f594b011d06aad28e3b8e28c052cad1d6c4c", size = 286559, upload-time = "2024-06-10T19:55:37.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/df/2e4be347ff98281b505cc0ccf141408cdd25eb5ca9f3830deb361b2472d3/slack_sdk-3.41.0-py2.py3-none-any.whl", hash = "sha256:bb18dcdfff1413ec448e759cf807ec3324090993d8ab9111c74081623b692a89", size = 313885, upload-time = "2026-03-12T16:10:09.811Z" },
 ]
 
 [[package]]
@@ -4649,7 +4649,7 @@ requires-dist = [
     { name = "pymongo", specifier = "==4.8.0" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "redis", extras = ["hiredis"], specifier = "==7.1.0" },
-    { name = "slack-sdk", specifier = "==3.28.0" },
+    { name = "slack-sdk", specifier = "==3.41.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0,<3.0.0" },
     { name = "tavily-python", specifier = "==0.7.6" },
     { name = "tenacity", specifier = "==8.3.0" },


### PR DESCRIPTION
## Summary

- Add Slack chat templates for `chat.startStream`, `chat.appendStream`, `chat.stopStream`, and `chat.postEphemeral`.
- Bump `slack-sdk` from `3.28.0` to `3.41.0` so the streaming chat SDK methods are available directly.
- Regenerate `uv.lock` for the updated Slack SDK pin.

## Testing

- `uv run pytest tests/registry/test_templates.py`
- `uv run pytest tests/registry/test_templates.py -k chat`

## Notes

- Verified `slack-sdk==3.28.0` exposes `chat_postEphemeral` but not the stream methods.
- Verified `slack-sdk==3.41.0` exposes `chat_startStream`, `chat_appendStream`, `chat_stopStream`, and `chat_postEphemeral`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Slack streaming chat templates to start, append to, and stop a stream, plus send ephemeral messages. Enables native streaming by upgrading `slack-sdk` to 3.41.0.

- **New Features**
  - Added templates: start_stream, append_stream, stop_stream, post_ephemeral.
  - Uses Slack SDK methods: chat_startStream, chat_appendStream, chat_stopStream, chat_postEphemeral.

- **Dependencies**
  - Bumped `slack-sdk` from 3.28.0 to 3.41.0 and regenerated `uv.lock`.

<sup>Written for commit 05bf9c6c827a0224ff6b370a0709eb9381ff4a05. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2730?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

