### PR TITLE
fix(integrations): normalize ARM resource IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,11 @@ just gen-functions
   range-based constraints.
 - Do not bypass commit signing with `--no-gpg-sign` or `--no-verify`. If
   signing is broken, stop and ask the user to fix it.
+- Never copy customer-provided identifiers, URLs, tenant IDs, subscription IDs,
+  workspace names, resource group names, incident IDs, emails, domains, tokens,
+  or other potentially sensitive values into tests, docs, fixtures, snapshots,
+  examples, logs, or committed code. Replace them with clearly synthetic values
+  before writing files, and search for the original strings before committing.
 - Do not assume PostgreSQL superuser access in migrations, queries, or scripts.
 - Never add methods to `tracecat/db/models.py`; keep database models minimal.
 - Use `pnpm` instead of `npm`, and prefer `rg` over slower text-search tools.

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/create_or_update_alert_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/create_or_update_alert_rule.yml
@@ -40,10 +40,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          rule_id: ${{ inputs.rule_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(rule_id):
+              return {
+                  "rule_id": leaf(rule_id),
+              }
     - ref: create_update_rule
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(inputs.rule_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(steps.normalize_ids.result.rule_id) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/delete_alert_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/delete_alert_rule.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          rule_id: ${{ inputs.rule_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(rule_id):
+              return {
+                  "rule_id": leaf(rule_id),
+              }
     - ref: delete_rule
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(inputs.rule_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(steps.normalize_ids.result.rule_id) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/get_alert_rule.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/get_alert_rule.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          rule_id: ${{ inputs.rule_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(rule_id):
+              return {
+                  "rule_id": leaf(rule_id),
+              }
     - ref: get_rule
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(inputs.rule_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRules/${{ FN.url_encode(steps.normalize_ids.result.rule_id) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/get_alert_rule_template.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/alert_rules/get_alert_rule_template.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          alert_rule_template_id: ${{ inputs.alert_rule_template_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(alert_rule_template_id):
+              return {
+                  "alert_rule_template_id": leaf(alert_rule_template_id),
+              }
     - ref: get_template
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRuleTemplates/${{ FN.url_encode(inputs.alert_rule_template_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/alertRuleTemplates/${{ FN.url_encode(steps.normalize_ids.result.alert_rule_template_id) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/create_or_update_bookmark.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/create_or_update_bookmark.yml
@@ -40,10 +40,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          bookmark_id: ${{ inputs.bookmark_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(bookmark_id):
+              return {
+                  "bookmark_id": leaf(bookmark_id),
+              }
     - ref: create_update_bookmark
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(inputs.bookmark_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(steps.normalize_ids.result.bookmark_id) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/delete_bookmark.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/delete_bookmark.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          bookmark_id: ${{ inputs.bookmark_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(bookmark_id):
+              return {
+                  "bookmark_id": leaf(bookmark_id),
+              }
     - ref: delete_bookmark
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(inputs.bookmark_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(steps.normalize_ids.result.bookmark_id) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/get_bookmark.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/bookmarks/get_bookmark.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          bookmark_id: ${{ inputs.bookmark_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(bookmark_id):
+              return {
+                  "bookmark_id": leaf(bookmark_id),
+              }
     - ref: get_bookmark
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(inputs.bookmark_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/bookmarks/${{ FN.url_encode(steps.normalize_ids.result.bookmark_id) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_incident_comment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_incident_comment.yml
@@ -43,10 +43,25 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          incident_id: ${{ inputs.incident_id }}
+          comment_id: ${{ inputs.comment_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(incident_id, comment_id):
+              return {
+                  "incident_id": leaf(incident_id),
+                  "comment_id": leaf(comment_id),
+              }
     - ref: create_comment
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/comments/${{ FN.url_encode(inputs.comment_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(steps.normalize_ids.result.incident_id) }}/comments/${{ FN.url_encode(steps.normalize_ids.result.comment_id) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_or_update_incident.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_or_update_incident.yml
@@ -40,10 +40,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          incident_id: ${{ inputs.incident_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(incident_id):
+              return {
+                  "incident_id": leaf(incident_id),
+              }
     - ref: create_update_incident
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(steps.normalize_ids.result.incident_id) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_or_update_incident_relation.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/create_or_update_incident_relation.yml
@@ -43,10 +43,25 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          incident_id: ${{ inputs.incident_id }}
+          relation_name: ${{ inputs.relation_name }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(incident_id, relation_name):
+              return {
+                  "incident_id": leaf(incident_id),
+                  "relation_name": leaf(relation_name),
+              }
     - ref: create_update_relation
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations/${{ FN.url_encode(inputs.relation_name) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(steps.normalize_ids.result.incident_id) }}/relations/${{ FN.url_encode(steps.normalize_ids.result.relation_name) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          incident_id: ${{ inputs.incident_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(incident_id):
+              return {
+                  "incident_id": leaf(incident_id),
+              }
     - ref: delete_incident
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(steps.normalize_ids.result.incident_id) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident_comment.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident_comment.yml
@@ -40,10 +40,25 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          incident_id: ${{ inputs.incident_id }}
+          comment_id: ${{ inputs.comment_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(incident_id, comment_id):
+              return {
+                  "incident_id": leaf(incident_id),
+                  "comment_id": leaf(comment_id),
+              }
     - ref: delete_comment
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/comments/${{ FN.url_encode(inputs.comment_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(steps.normalize_ids.result.incident_id) }}/comments/${{ FN.url_encode(steps.normalize_ids.result.comment_id) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident_relation.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/delete_incident_relation.yml
@@ -40,10 +40,25 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          incident_id: ${{ inputs.incident_id }}
+          relation_name: ${{ inputs.relation_name }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(incident_id, relation_name):
+              return {
+                  "incident_id": leaf(incident_id),
+                  "relation_name": leaf(relation_name),
+              }
     - ref: delete_relation
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations/${{ FN.url_encode(inputs.relation_name) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(steps.normalize_ids.result.incident_id) }}/relations/${{ FN.url_encode(steps.normalize_ids.result.relation_name) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/get_incident.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/get_incident.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          incident_id: ${{ inputs.incident_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(incident_id):
+              return {
+                  "incident_id": leaf(incident_id),
+              }
     - ref: get_incident
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(steps.normalize_ids.result.incident_id) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/get_incident_relation.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/get_incident_relation.yml
@@ -40,10 +40,25 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          incident_id: ${{ inputs.incident_id }}
+          relation_name: ${{ inputs.relation_name }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(incident_id, relation_name):
+              return {
+                  "incident_id": leaf(incident_id),
+                  "relation_name": leaf(relation_name),
+              }
     - ref: get_relation
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations/${{ FN.url_encode(inputs.relation_name) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(steps.normalize_ids.result.incident_id) }}/relations/${{ FN.url_encode(steps.normalize_ids.result.relation_name) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_alerts.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          incident_id: ${{ inputs.incident_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(incident_id):
+              return {
+                  "incident_id": leaf(incident_id),
+              }
     - ref: list_alerts
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/alerts
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(steps.normalize_ids.result.incident_id) }}/alerts
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_bookmarks.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_bookmarks.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          incident_id: ${{ inputs.incident_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(incident_id):
+              return {
+                  "incident_id": leaf(incident_id),
+              }
     - ref: list_bookmarks
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/bookmarks
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(steps.normalize_ids.result.incident_id) }}/bookmarks
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_comments.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_comments.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          incident_id: ${{ inputs.incident_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(incident_id):
+              return {
+                  "incident_id": leaf(incident_id),
+              }
     - ref: list_comments
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/comments
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(steps.normalize_ids.result.incident_id) }}/comments
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_entities.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_entities.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          incident_id: ${{ inputs.incident_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(incident_id):
+              return {
+                  "incident_id": leaf(incident_id),
+              }
     - ref: list_entities
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/entities
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(steps.normalize_ids.result.incident_id) }}/entities
         method: POST
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_relations.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/incidents/list_incident_relations.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          incident_id: ${{ inputs.incident_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(incident_id):
+              return {
+                  "incident_id": leaf(incident_id),
+              }
     - ref: list_relations
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(inputs.incident_id) }}/relations
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/incidents/${{ FN.url_encode(steps.normalize_ids.result.incident_id) }}/relations
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/create_threat_intelligence_indicator.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/create_threat_intelligence_indicator.yml
@@ -40,10 +40,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          indicator_name: ${{ inputs.indicator_name }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(indicator_name):
+              return {
+                  "indicator_name": leaf(indicator_name),
+              }
     - ref: create_indicator
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(inputs.indicator_name) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(steps.normalize_ids.result.indicator_name) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/delete_threat_intelligence_indicator.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/delete_threat_intelligence_indicator.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          indicator_name: ${{ inputs.indicator_name }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(indicator_name):
+              return {
+                  "indicator_name": leaf(indicator_name),
+              }
     - ref: delete_indicator
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(inputs.indicator_name) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(steps.normalize_ids.result.indicator_name) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/get_threat_intelligence_indicator.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/threat_intelligence/get_threat_intelligence_indicator.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          indicator_name: ${{ inputs.indicator_name }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(indicator_name):
+              return {
+                  "indicator_name": leaf(indicator_name),
+              }
     - ref: get_indicator
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(inputs.indicator_name) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/threatIntelligence/main/indicators/${{ FN.url_encode(steps.normalize_ids.result.indicator_name) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/create_or_update_watchlist.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/create_or_update_watchlist.yml
@@ -40,10 +40,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          watchlist_alias: ${{ inputs.watchlist_alias }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(watchlist_alias):
+              return {
+                  "watchlist_alias": leaf(watchlist_alias),
+              }
     - ref: create_update_watchlist
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(steps.normalize_ids.result.watchlist_alias) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/create_or_update_watchlist_item.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/create_or_update_watchlist_item.yml
@@ -43,10 +43,25 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          watchlist_alias: ${{ inputs.watchlist_alias }}
+          watchlist_item_id: ${{ inputs.watchlist_item_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(watchlist_alias, watchlist_item_id):
+              return {
+                  "watchlist_alias": leaf(watchlist_alias),
+                  "watchlist_item_id": leaf(watchlist_item_id),
+              }
     - ref: create_update_item
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(inputs.watchlist_item_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(steps.normalize_ids.result.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(steps.normalize_ids.result.watchlist_item_id) }}
         method: PUT
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/delete_watchlist.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/delete_watchlist.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          watchlist_alias: ${{ inputs.watchlist_alias }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(watchlist_alias):
+              return {
+                  "watchlist_alias": leaf(watchlist_alias),
+              }
     - ref: delete_watchlist
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(steps.normalize_ids.result.watchlist_alias) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/delete_watchlist_item.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/delete_watchlist_item.yml
@@ -40,10 +40,25 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          watchlist_alias: ${{ inputs.watchlist_alias }}
+          watchlist_item_id: ${{ inputs.watchlist_item_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(watchlist_alias, watchlist_item_id):
+              return {
+                  "watchlist_alias": leaf(watchlist_alias),
+                  "watchlist_item_id": leaf(watchlist_item_id),
+              }
     - ref: delete_item
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(inputs.watchlist_item_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(steps.normalize_ids.result.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(steps.normalize_ids.result.watchlist_item_id) }}
         method: DELETE
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/get_watchlist.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/get_watchlist.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          watchlist_alias: ${{ inputs.watchlist_alias }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(watchlist_alias):
+              return {
+                  "watchlist_alias": leaf(watchlist_alias),
+              }
     - ref: get_watchlist
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(steps.normalize_ids.result.watchlist_alias) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/get_watchlist_item.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/get_watchlist_item.yml
@@ -40,10 +40,25 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          watchlist_alias: ${{ inputs.watchlist_alias }}
+          watchlist_item_id: ${{ inputs.watchlist_item_id }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(watchlist_alias, watchlist_item_id):
+              return {
+                  "watchlist_alias": leaf(watchlist_alias),
+                  "watchlist_item_id": leaf(watchlist_item_id),
+              }
     - ref: get_item
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(inputs.watchlist_item_id) }}
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(steps.normalize_ids.result.watchlist_alias) }}/watchlistItems/${{ FN.url_encode(steps.normalize_ids.result.watchlist_item_id) }}
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/list_watchlist_items.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel/watchlists/list_watchlist_items.yml
@@ -37,10 +37,23 @@ definition:
       description: Base URL for the Azure Management API.
       default: https://management.azure.com
   steps:
+    - ref: normalize_ids
+      action: core.script.run_python
+      args:
+        inputs:
+          watchlist_alias: ${{ inputs.watchlist_alias }}
+        script: |
+          def leaf(value):
+              return str(value).rstrip("/").split("/")[-1]
+
+          def main(watchlist_alias):
+              return {
+                  "watchlist_alias": leaf(watchlist_alias),
+              }
     - ref: list_items
       action: core.http_request
       args:
-        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(inputs.watchlist_alias) }}/watchlistItems
+        url: ${{ inputs.base_url }}/subscriptions/${{ FN.url_encode(inputs.subscription_id) }}/resourceGroups/${{ FN.url_encode(inputs.resource_group_name) }}/providers/Microsoft.OperationalInsights/workspaces/${{ FN.url_encode(inputs.workspace_name) }}/providers/Microsoft.SecurityInsights/watchlists/${{ FN.url_encode(steps.normalize_ids.result.watchlist_alias) }}/watchlistItems
         method: GET
         headers:
           Authorization: Bearer ${{ SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_USER_TOKEN || SECRETS.microsoft_sentinel_oauth.MICROSOFT_SENTINEL_SERVICE_TOKEN }}

--- a/tests/unit/test_microsoft_sentinel_templates.py
+++ b/tests/unit/test_microsoft_sentinel_templates.py
@@ -1,0 +1,113 @@
+from pathlib import Path
+from typing import Any
+
+from tracecat.dsl.schemas import MaterializedTaskResult, TemplateExecutionContext
+from tracecat.expressions.eval import eval_templated_object
+from tracecat.registry.actions.schemas import ActionStep, TemplateAction
+
+TEMPLATE_ROOT = Path(
+    "packages/tracecat-registry/tracecat_registry/templates/tools/microsoft_sentinel"
+)
+
+SUBSCRIPTION_ID = "00000000-1111-2222-3333-444444444444"
+RESOURCE_GROUP_NAME = "example-resource-group"
+WORKSPACE_NAME = "example-workspace"
+INCIDENT_ID = "55555555-6666-7777-8888-999999999999"
+INCIDENT_ARM_ID = (
+    f"/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/{RESOURCE_GROUP_NAME}/"
+    f"providers/Microsoft.OperationalInsights/workspaces/{WORKSPACE_NAME}/"
+    f"providers/Microsoft.SecurityInsights/Incidents/{INCIDENT_ID}"
+)
+
+
+def _load_template(path: str) -> TemplateAction:
+    return TemplateAction.from_yaml(TEMPLATE_ROOT / path)
+
+
+def _step(action: TemplateAction, ref: str) -> ActionStep:
+    return next(step for step in action.definition.steps if step.ref == ref)
+
+
+def _run_python_step(
+    step: ActionStep, context: TemplateExecutionContext
+) -> dict[str, Any]:
+    inputs = eval_templated_object(step.args["inputs"], operand=context)
+    namespace: dict[str, Any] = {}
+    exec(step.args["script"], namespace)  # noqa: S102
+    return namespace["main"](**inputs)
+
+
+def _materialized_result(result: Any) -> MaterializedTaskResult:
+    return {
+        "result": result,
+        "result_typename": type(result).__name__,
+        "error": None,
+        "error_typename": None,
+        "interaction": None,
+        "interaction_id": None,
+        "interaction_type": None,
+    }
+
+
+def _render_http_url(
+    template_path: str,
+    http_ref: str,
+    inputs: dict[str, Any],
+) -> str:
+    action = _load_template(template_path)
+    context = TemplateExecutionContext(inputs=inputs, steps={})
+
+    normalize_step = _step(action, "normalize_ids")
+    normalized = _run_python_step(normalize_step, context)
+    context["steps"]["normalize_ids"] = _materialized_result(normalized)
+
+    http_step = _step(action, http_ref)
+    return eval_templated_object(http_step.args["url"], operand=context)
+
+
+def _sentinel_inputs(incident_id: str) -> dict[str, Any]:
+    return {
+        "base_url": "https://management.azure.com",
+        "subscription_id": SUBSCRIPTION_ID,
+        "resource_group_name": RESOURCE_GROUP_NAME,
+        "workspace_name": WORKSPACE_NAME,
+        "incident_id": incident_id,
+    }
+
+
+def test_get_incident_normalizes_full_arm_id() -> None:
+    url = _render_http_url(
+        "incidents/get_incident.yml",
+        "get_incident",
+        _sentinel_inputs(INCIDENT_ARM_ID),
+    )
+
+    assert url == (
+        f"https://management.azure.com/subscriptions/{SUBSCRIPTION_ID}"
+        f"/resourceGroups/{RESOURCE_GROUP_NAME}"
+        f"/providers/Microsoft.OperationalInsights/workspaces/{WORKSPACE_NAME}"
+        f"/providers/Microsoft.SecurityInsights/incidents/{INCIDENT_ID}"
+    )
+    assert url.count("/subscriptions/") == 1
+
+
+def test_list_incident_comments_normalizes_full_arm_id() -> None:
+    url = _render_http_url(
+        "incidents/list_incident_comments.yml",
+        "list_comments",
+        _sentinel_inputs(INCIDENT_ARM_ID),
+    )
+
+    assert url.endswith(f"/incidents/{INCIDENT_ID}/comments")
+    assert url.count("/subscriptions/") == 1
+
+
+def test_get_incident_keeps_plain_incident_id() -> None:
+    url = _render_http_url(
+        "incidents/get_incident.yml",
+        "get_incident",
+        _sentinel_inputs(INCIDENT_ID),
+    )
+
+    assert url.endswith(f"/incidents/{INCIDENT_ID}")
+    assert url.count("/subscriptions/") == 1


### PR DESCRIPTION
## Summary

- normalize Microsoft Sentinel child resource inputs so full Azure ARM `id` values are reduced to their final resource name before URL construction
- apply the normalization across Sentinel incidents, comments, relations, bookmarks, alert rules, threat indicators, watchlists, and watchlist items
- add template URL regression coverage for the customer ARM incident ID shape and plain incident IDs

## Tests

- `uv run pytest tests/unit/test_microsoft_sentinel_templates.py`
- `uv run pytest tests/registry/test_templates.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- pre-commit hooks during `git commit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Azure ARM resource IDs in Microsoft Sentinel templates to prevent malformed URLs when users pass full ARM paths. Templates now accept either full ARM IDs or simple names and always build correct endpoints.

- **Bug Fixes**
  - Added a `normalize_ids` step that strips ARM paths to the final resource name before URL construction.
  - Applied across incidents, comments, relations, bookmarks, alert rules, alert rule templates, threat intelligence indicators, watchlists, and watchlist items.
  - Added regression tests to cover both full ARM incident IDs and plain IDs, ensuring a single subscription path in rendered URLs.

<sup>Written for commit 349502f682aa87a909cd1a6b9b4a2907c84062da. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2732?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

