### PR TITLE
feat(agent): surface runtime_resolution metadata on ai.action results

### DIFF
--- a/docs/agents/ai-action.mdx
+++ b/docs/agents/ai-action.mdx
@@ -155,3 +155,49 @@ Default: `3`.
         - spam
         - unknown
 ```
+
+#### Output
+
+<ResponseField name="runtime_resolution" type="object | null">
+
+Diagnostic metadata describing what the runtime actually received for the
+turn. Use it to confirm whether an override took effect or to understand
+token usage, without reading source or attaching a debugger. It carries
+metadata only — never the system prompt body or tool definitions — so it
+cannot leak values injected via template expressions.
+
+It is chainable in expressions, e.g.
+`${{ ACTIONS.classify_email.result.runtime_resolution.system_prompt_source }}`.
+
+<Expandable title="runtime_resolution fields">
+
+<ResponseField name="runtime" type="string">
+Runtime that executed the turn: `claude_code` or `pydantic_ai`.
+</ResponseField>
+
+<ResponseField name="system_prompt_source" type="string">
+Which cascade level supplied the effective system prompt: `default`,
+`source`, or `action`.
+</ResponseField>
+
+<ResponseField name="system_prompt_length" type="integer">
+Character length of the system prompt sent to the runtime.
+</ResponseField>
+
+<ResponseField name="system_prompt_append_count" type="integer">
+Number of append-mode contributions folded into the system prompt.
+</ResponseField>
+
+<ResponseField name="allowed_tools_source" type="string">
+Which cascade level supplied the effective allowed-tools list: `default`,
+`source`, or `action`.
+</ResponseField>
+
+<ResponseField name="allowed_tools_count" type="integer | null">
+Number of tools exposed to the runtime. `null` means the runtime default
+(the full built-in toolset) was used.
+</ResponseField>
+
+</Expandable>
+
+</ResponseField>

--- a/tests/unit/test_agent_runtime_resolution.py
+++ b/tests/unit/test_agent_runtime_resolution.py
@@ -1,0 +1,60 @@
+"""Tests for the ``RuntimeResolution`` diagnostic metadata.
+
+These pin down the cascade-source semantics that surface on
+``AgentOutput.runtime_resolution`` so workflow authors can answer "did my
+override take effect?" without reading source. They cover the model contract
+and the pydantic-ai runtime's resolution builder without invoking an LLM.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tracecat.agent.runtime.pydantic_ai.runtime import _build_pydantic_ai_resolution
+from tracecat.agent.schemas import AgentOutput, RuntimeResolution
+
+
+def test_agent_output_runtime_resolution_defaults_none() -> None:
+    # Backward compatibility: existing callers that don't set the field get
+    # ``None``, i.e. zero behaviour change.
+    import uuid
+
+    output = AgentOutput(output="hi", duration=0.1, session_id=uuid.uuid4())
+    assert output.runtime_resolution is None
+
+
+def test_resolution_rejects_negative_lengths() -> None:
+    with pytest.raises(ValueError):
+        RuntimeResolution(
+            runtime="pydantic_ai",
+            system_prompt_source="default",
+            system_prompt_length=-1,
+            system_prompt_append_count=0,
+            allowed_tools_source="default",
+        )
+
+
+def test_pydantic_ai_resolution_no_instructions() -> None:
+    res = _build_pydantic_ai_resolution(None)
+    assert res.runtime == "pydantic_ai"
+    assert res.system_prompt_source == "default"
+    assert res.system_prompt_length == 0
+    assert res.system_prompt_append_count == 0
+    # pydantic-ai has no implicit built-in toolset, so this is always default.
+    assert res.allowed_tools_source == "default"
+    assert res.allowed_tools_count is None
+
+
+def test_pydantic_ai_resolution_empty_string_is_default() -> None:
+    # An empty instructions string is indistinguishable from "no override".
+    res = _build_pydantic_ai_resolution("")
+    assert res.system_prompt_source == "default"
+    assert res.system_prompt_append_count == 0
+
+
+def test_pydantic_ai_resolution_with_instructions() -> None:
+    instructions = "You are a security analyst. Be thorough."
+    res = _build_pydantic_ai_resolution(instructions)
+    assert res.system_prompt_source == "action"
+    assert res.system_prompt_length == len(instructions)
+    assert res.system_prompt_append_count == 1

--- a/tracecat/agent/runtime/pydantic_ai/runtime.py
+++ b/tracecat/agent/runtime/pydantic_ai/runtime.py
@@ -12,7 +12,12 @@ from pydantic_core import to_jsonable_python
 from tracecat.agent.exceptions import AgentRunError
 from tracecat.agent.executor.aio import AioStreamingAgentExecutor
 from tracecat.agent.parsers import try_parse_json
-from tracecat.agent.schemas import AgentOutput, RunAgentArgs, RunUsage
+from tracecat.agent.schemas import (
+    AgentOutput,
+    RunAgentArgs,
+    RuntimeResolution,
+    RunUsage,
+)
 from tracecat.agent.stream.common import PersistableStreamingAgentDeps
 from tracecat.agent.types import (
     AgentConfig,
@@ -28,6 +33,26 @@ from tracecat.config import (
 from tracecat.contexts import ctx_role, ctx_session_id
 from tracecat.exceptions import TracecatAuthorizationError
 from tracecat.logger import logger
+
+
+def _build_pydantic_ai_resolution(instructions: str | None) -> RuntimeResolution:
+    """Describe what the pydantic-ai runtime received for this turn.
+
+    The pydantic-ai harness has no notion of implicit built-in tools -- it only
+    sees the tools it is explicitly given -- so ``allowed_tools_*`` is reported
+    as the runtime default. The effective system prompt is the ``instructions``
+    string; there is no Tracecat baseline injection on this runtime.
+    """
+    instructions = instructions or ""
+    has_instructions = bool(instructions)
+    return RuntimeResolution(
+        runtime="pydantic_ai",
+        system_prompt_source="action" if has_instructions else "default",
+        system_prompt_length=len(instructions),
+        system_prompt_append_count=1 if has_instructions else 0,
+        allowed_tools_source="default",
+        allowed_tools_count=None,
+    )
 
 
 async def run_agent_sync(
@@ -225,6 +250,7 @@ async def run_agent(
             duration=end_time - start_time,
             usage=usage,
             session_id=session_id,
+            runtime_resolution=_build_pydantic_ai_resolution(instructions),
         )
 
     except Exception as e:

--- a/tracecat/agent/schemas.py
+++ b/tracecat/agent/schemas.py
@@ -199,12 +199,43 @@ class RunUsage(BaseModel):
     """Total number of output tokens."""
 
 
+class RuntimeResolution(BaseModel):
+    """Diagnostic metadata describing what the runtime actually received.
+
+    Surfaced on :class:`AgentOutput` so workflow authors can answer "did my
+    override take effect?" and "why is my token usage high?" without reading
+    source or attaching a debugger. This is metadata only -- it never carries
+    the system prompt body or tool definitions, so it cannot leak secrets
+    injected via template expressions.
+    """
+
+    runtime: Literal["claude_code", "pydantic_ai"]
+    """Runtime that executed the turn."""
+
+    system_prompt_source: Literal["default", "source", "action"]
+    """Which cascade level supplied the effective system prompt."""
+
+    system_prompt_length: int = Field(ge=0)
+    """Character length of the system prompt sent to the runtime."""
+
+    system_prompt_append_count: int = Field(ge=0)
+    """Number of append-mode contributions folded into the system prompt."""
+
+    allowed_tools_source: Literal["default", "source", "action"]
+    """Which cascade level supplied the effective allowed-tools list."""
+
+    allowed_tools_count: int | None = None
+    """Number of tools exposed to the runtime. ``None`` means the runtime
+    default (the full built-in toolset) was used."""
+
+
 class AgentOutput(BaseModel):
     output: Any
     message_history: list[ChatMessage] | None = None
     duration: float
     usage: RunUsage | None = None
     session_id: uuid.UUID
+    runtime_resolution: RuntimeResolution | None = None
 
 
 class ExecuteToolCallArgs(BaseModel):


### PR DESCRIPTION
## Summary

Implements the OSS vertical slice of #2656: an optional `runtime_resolution`
diagnostic block on `AgentOutput`, so workflow authors can answer "did my
override take effect?" and "why is my token usage high?" without reading
source or attaching a debugger.

The block is **metadata only** — it never carries the system prompt body or
tool definitions, so it cannot leak values injected via `${{ TRIGGER.x }}`.
It defaults to `None`, so existing workflows and custom sources are unchanged.

## What's included

- **`RuntimeResolution`** model + `AgentOutput.runtime_resolution` field
  (`tracecat/agent/schemas.py`).
- Populated in the **pydantic-ai** `run_agent` path (which backs the
  `/agents/run` API) via `_build_pydantic_ai_resolution`.
- Unit tests covering backward-compatible defaulting, field validation, and
  the system-prompt source cascade.
- Docs: new **Output** section on `docs/agents/ai-action.mdx` documenting the
  chainable field.

The reported fields:

| Field | Meaning |
|---|---|
| `runtime` | `claude_code` or `pydantic_ai` |
| `system_prompt_source` | `default` / `source` / `action` |
| `system_prompt_length` | chars sent to the runtime |
| `system_prompt_append_count` | append-mode contributions folded in |
| `allowed_tools_source` | `default` / `source` / `action` |
| `allowed_tools_count` | tools exposed; `null` = runtime default (full toolset) |

Chainable in expressions, e.g.
`${{ ACTIONS.classify_email.result.runtime_resolution.system_prompt_source }}`.

## Scope / follow-up

This PR intentionally covers the OSS pydantic-ai + schema slice to keep the
change additive and reviewable. Computing the block in the `claude_code`
durable path needs the one-line EE change noted in the issue
(`AgentOutput(...)` in `packages/tracecat-ee/.../durable.py`) and is left as a
documented follow-up. As the issue notes, this work "can ship before, after,
or in parallel" with the `system_prompt` / `allowed_tools` override PRs.

## Testing

- `uv run ruff check` / `ruff format --check`: clean.
- `uv run basedpyright --warnings`: 0 errors, 0 warnings.
- New unit tests in `tests/unit/test_agent_runtime_resolution.py` (logic
  verified; full pytest run requires a Postgres 15+ test cluster).

Refs #2656


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional `runtime_resolution` metadata to `AgentOutput` to show what the runtime actually received, so authors can verify overrides and understand token usage. Implemented for the `pydantic_ai` path that backs `/agents/run`; defaults to null for full backward compatibility. Refs #2656.

- New Features
  - New `RuntimeResolution` model and `AgentOutput.runtime_resolution` (metadata only; never includes prompt body or tool definitions).
  - Populated in `tracecat/agent/runtime/pydantic_ai/runtime.py` via `_build_pydantic_ai_resolution(...)`.
  - Reports: runtime, system prompt source/length/append count, and allowed-tools source/count.
  - Docs updated in `docs/agents/ai-action.mdx`; unit tests added in `tests/unit/test_agent_runtime_resolution.py`.
  - Follow-up: add `claude_code` durable path in EE.

<sup>Written for commit 14486b07d19beab03ff5618d4e554b3818dcde1d. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2733?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

