### PR TITLE
tests: e2e playwright tests

### DIFF
--- a/.github/workflows/e2e-oss.yml
+++ b/.github/workflows/e2e-oss.yml
@@ -1,0 +1,101 @@
+name: OSS E2E
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 13,22 * * 1-5"
+
+permissions:
+  contents: read
+
+jobs:
+  playwright-oss-smoke:
+    runs-on: blacksmith-8vcpu-ubuntu-2204
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install uv
+        uses: useblacksmith/setup-uv@f4588471335f14dcb60198856207b916701a9e9f # v4
+        with:
+          version: "0.9.7"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python 3.12
+        uses: useblacksmith/setup-python@943b05a7c4ca70c2360391137527a37bee33fb1d # v6
+        with:
+          python-version: "3.12"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Set up Docker builder
+        uses: useblacksmith/setup-docker-builder@78f41686563c732ccc097f7baac2f092f67538f0 # v1
+
+      - name: Disable IPv6
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+
+      - name: Configure environment
+        run: |
+          echo "y
+          localhost
+          n
+          test@tracecat.com" | bash env.sh
+
+      - name: Install dependencies
+        run: |
+          uv sync --locked --group dev
+          pnpm --dir frontend install --frozen-lockfile
+          pnpm --dir frontend exec playwright install --with-deps chromium
+
+      - name: Start Tracecat stack
+        run: |
+          scripts/cluster up -d --single-tenant --seed --default-tier-entitlements custom_registry
+          timeout 300 bash -c 'until curl -fsS http://localhost/api/ready; do sleep 5; done'
+
+      - name: Run OSS E2E smoke suite
+        env:
+          PLAYWRIGHT_BASE_URL: http://localhost
+        run: pnpm --dir frontend test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8 # v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report
+          if-no-files-found: ignore
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8 # v4
+        with:
+          name: playwright-test-results
+          path: frontend/test-results
+          if-no-files-found: ignore
+
+      - name: Show service logs on failure
+        if: failure()
+        run: |
+          scripts/cluster ps
+          scripts/cluster logs api
+          scripts/cluster logs worker
+          scripts/cluster logs executor
+
+      - name: Stop Tracecat stack
+        if: always()
+        run: scripts/cluster down

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -7,6 +7,9 @@ node_modules
 
 # testing
 coverage
+playwright-report
+test-results
+e2e/.auth
 
 # next.js
 .next/

--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -1,0 +1,14 @@
+import { test as setup } from "@playwright/test"
+
+import {
+  signInRequest,
+  TENANT_USER_EMAIL,
+  TENANT_USER_PASSWORD,
+} from "./utils/auth"
+
+const authFile = "e2e/.auth/dev-user.json"
+
+setup("authenticate seeded tenant user", async ({ request }) => {
+  await signInRequest(request, TENANT_USER_EMAIL, TENANT_USER_PASSWORD)
+  await request.storageState({ path: authFile })
+})

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test"
+
+import {
+  createOrganizationInvitation,
+  DEFAULT_E2E_PASSWORD,
+  expectWorkspaceLanding,
+  freshEmail,
+  SUPERUSER_EMAIL,
+  SUPERUSER_PASSWORD,
+  signInWithBasicAuth,
+  TENANT_USER_EMAIL,
+} from "./utils/auth"
+
+test.use({ storageState: { cookies: [], origins: [] } })
+
+test.describe("authentication", () => {
+  test("anonymous visitor can start basic auth", async ({ page }) => {
+    await page.goto("/")
+    await page.getByRole("link", { name: /Sign in/i }).click()
+
+    await expect(page.getByLabel("Email")).toBeVisible()
+    await page.getByLabel("Email").fill(TENANT_USER_EMAIL)
+    await page.getByRole("button", { name: "Continue" }).click()
+
+    await expect(page.getByLabel("Password")).toBeVisible()
+  })
+
+  test("fresh invited user can sign up and land in a workspace", async ({
+    page,
+    request,
+  }, testInfo) => {
+    const email = freshEmail(testInfo.title)
+    const token = await createOrganizationInvitation(request, email)
+    const returnUrl = `/invitations/accept?token=${token}`
+
+    await page.goto(`/sign-up?returnUrl=${encodeURIComponent(returnUrl)}`)
+    await expect(
+      page.getByRole("heading", { name: "Create an account" })
+    ).toBeVisible()
+
+    await page.getByLabel("Email").fill(email)
+    await page.getByLabel("Password").fill(DEFAULT_E2E_PASSWORD)
+    await page.getByRole("button", { name: "Create account" }).click()
+
+    await expectWorkspaceLanding(page)
+  })
+
+  test("seeded superuser can access the admin console", async ({ page }) => {
+    await signInWithBasicAuth(page, SUPERUSER_EMAIL, SUPERUSER_PASSWORD)
+
+    await page.goto("/admin/users")
+    await expect(page.getByRole("heading", { name: "Users" })).toBeVisible()
+    await expect(
+      page.getByText("Manage users and superuser access across the platform.")
+    ).toBeVisible()
+  })
+})

--- a/frontend/e2e/entitlements.spec.ts
+++ b/frontend/e2e/entitlements.spec.ts
@@ -1,0 +1,97 @@
+import {
+  type APIRequestContext,
+  expect,
+  type TestInfo,
+  test,
+} from "@playwright/test"
+
+import { expectWorkspaceLanding, getWorkspaceId } from "./utils/auth"
+
+type Entitlements = {
+  git_sync: boolean
+  agent_addons: boolean
+}
+
+async function getEntitlements(
+  pageRequest: APIRequestContext
+): Promise<Entitlements> {
+  const response = await pageRequest.get("/api/organization/entitlements")
+  if (!response.ok()) {
+    throw new Error(await response.text())
+  }
+  return (await response.json()) as Entitlements
+}
+
+async function skipIfEntitled(
+  pageRequest: APIRequestContext,
+  testInfo: TestInfo,
+  entitlement: keyof Entitlements
+) {
+  const entitlements = await getEntitlements(pageRequest)
+  if (!entitlements[entitlement]) {
+    return
+  }
+  if (process.env.CI) {
+    expect(
+      entitlements[entitlement],
+      "Run these tests against an OSS entitlement baseline"
+    ).toBe(false)
+  }
+  testInfo.skip(true, `Requires ${entitlement} disabled`)
+}
+
+test.describe("entitlement gates", () => {
+  test("locked sidebar item opens upgrade modal without navigation", async ({
+    page,
+  }, testInfo) => {
+    await skipIfEntitled(page.request, testInfo, "agent_addons")
+
+    await page.goto("/workspaces")
+    await expectWorkspaceLanding(page)
+
+    await expect(async () => {
+      await page.getByRole("button", { name: "Skills" }).click({
+        timeout: 2_000,
+      })
+    }).toPass()
+
+    await expect(
+      page.getByRole("dialog", { name: "Upgrade to unlock this feature" })
+    ).toBeVisible()
+    await expect(page).not.toHaveURL(/\/skills(\/|$|\?)/)
+  })
+
+  test("direct inbox route renders the entitlement empty state", async ({
+    page,
+  }, testInfo) => {
+    await skipIfEntitled(page.request, testInfo, "agent_addons")
+
+    await page.goto("/workspaces")
+    const workspaceId = await getWorkspaceId(page)
+
+    await page.goto(`/workspaces/${workspaceId}/inbox`, {
+      waitUntil: "domcontentloaded",
+    })
+
+    await expect(page.getByText("Enterprise only")).toBeVisible()
+    await expect(
+      page.getByText(
+        "Advanced AI agents (human-in-the-loop and subagents) are only available on enterprise plans."
+      )
+    ).toBeVisible()
+  })
+
+  test("direct Git sync route renders the entitlement empty state", async ({
+    page,
+  }, testInfo) => {
+    await skipIfEntitled(page.request, testInfo, "git_sync")
+
+    await page.goto("/organization/vcs")
+
+    await expect(page.getByRole("heading", { name: "Git sync" })).toBeVisible()
+    await expect(page.getByText("Upgrade required")).toBeVisible()
+    await expect(
+      page.getByText("Git sync is unavailable on your current plan.")
+    ).toBeVisible()
+  })
+})

--- a/frontend/e2e/utils/auth.ts
+++ b/frontend/e2e/utils/auth.ts
@@ -1,0 +1,154 @@
+import { type APIRequestContext, expect, type Page } from "@playwright/test"
+
+export const TENANT_USER_EMAIL =
+  process.env.E2E_TENANT_EMAIL ?? "dev@tracecat.com"
+export const TENANT_USER_PASSWORD =
+  process.env.E2E_TENANT_PASSWORD ?? "password1234"
+export const SUPERUSER_EMAIL =
+  process.env.E2E_SUPERUSER_EMAIL ?? "test@tracecat.com"
+export const SUPERUSER_PASSWORD =
+  process.env.E2E_SUPERUSER_PASSWORD ?? "password1234"
+export const DEFAULT_E2E_PASSWORD =
+  process.env.E2E_FRESH_USER_PASSWORD ?? "password1234!"
+
+type RoleRead = {
+  id: string
+  slug?: string | null
+}
+
+type RoleList = {
+  items: RoleRead[]
+}
+
+type InvitationRead = {
+  id: string
+}
+
+type InvitationTokenRead = {
+  token: string
+}
+
+/**
+ * Build a unique, deterministic-enough email address for one E2E test run.
+ */
+export function freshEmail(testTitle: string): string {
+  const slug = testTitle
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 32)
+  return `e2e-${slug}-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}@e2e.tracecat.dev`
+}
+
+/**
+ * Sign in through the visible basic-auth UI, including auth discovery.
+ */
+export async function signInWithBasicAuth(
+  page: Page,
+  email: string,
+  password: string
+): Promise<void> {
+  await page.goto("/sign-in")
+  await expect(page.getByLabel("Email")).toBeVisible()
+
+  await page.getByLabel("Email").fill(email)
+  await page.getByRole("button", { name: "Continue" }).click()
+  await expect(page.getByLabel("Password")).toBeVisible()
+
+  await page.getByLabel("Password").fill(password)
+  await page.getByRole("button", { name: "Sign In" }).click()
+  await page.waitForURL(/\/workspaces(\/|$)/)
+}
+
+/**
+ * Authenticate an API request context using the app's basic-auth endpoint.
+ */
+export async function signInRequest(
+  request: APIRequestContext,
+  email: string,
+  password: string
+): Promise<void> {
+  const response = await request.post("/api/auth/login", {
+    form: {
+      username: email,
+      password,
+    },
+  })
+  if (!response.ok()) {
+    throw new Error(await response.text())
+  }
+}
+
+/**
+ * Create an organization invitation and return its raw invitation token.
+ */
+export async function createOrganizationInvitation(
+  request: APIRequestContext,
+  email: string
+): Promise<string> {
+  await signInRequest(request, TENANT_USER_EMAIL, TENANT_USER_PASSWORD)
+
+  const rolesResponse = await request.get("/api/rbac/roles")
+  if (!rolesResponse.ok()) {
+    throw new Error(await rolesResponse.text())
+  }
+  const roles = (await rolesResponse.json()) as RoleList
+  const role =
+    roles.items.find((item) => item.slug === "organization-admin") ??
+    roles.items.find((item) => item.slug === "organization-owner")
+  expect(
+    role,
+    "Expected an organization role for invitation setup"
+  ).toBeTruthy()
+  if (!role) {
+    throw new Error("Expected an organization role for invitation setup")
+  }
+
+  const invitationResponse = await request.post(
+    "/api/organization/invitations",
+    {
+      data: {
+        email,
+        role_id: role.id,
+      },
+    }
+  )
+  if (!invitationResponse.ok()) {
+    throw new Error(await invitationResponse.text())
+  }
+  const invitation = (await invitationResponse.json()) as InvitationRead
+
+  const tokenResponse = await request.get(
+    `/api/organization/invitations/${invitation.id}/token`
+  )
+  if (!tokenResponse.ok()) {
+    throw new Error(await tokenResponse.text())
+  }
+  const token = (await tokenResponse.json()) as InvitationTokenRead
+  return token.token
+}
+
+/**
+ * Wait until the workspace redirect settles on the workflows dashboard.
+ */
+export async function expectWorkspaceLanding(page: Page): Promise<void> {
+  await page.waitForURL(/\/workspaces\/[^/]+(\/workflows)?(\/|$|\?)/)
+  const createNewButton = page.getByRole("button", { name: /Create new/i })
+  if (!(await createNewButton.isVisible())) {
+    await page.getByRole("link", { name: "Workflows" }).click()
+    await page.waitForURL(/\/workspaces\/[^/]+\/workflows(\/|$|\?)/)
+  }
+  await expect(createNewButton).toBeVisible()
+}
+
+/**
+ * Read the active workspace ID from the settled workspace URL.
+ */
+export async function getWorkspaceId(page: Page): Promise<string> {
+  await expectWorkspaceLanding(page)
+  const match = page.url().match(/\/workspaces\/([^/]+)/)
+  expect(match?.[1], "Expected workspace ID in URL").toBeTruthy()
+  return match?.[1] ?? ""
+}

--- a/frontend/e2e/workspace.spec.ts
+++ b/frontend/e2e/workspace.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test"
+
+import { expectWorkspaceLanding } from "./utils/auth"
+
+test.describe("workspace first run", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/workspaces")
+    await expectWorkspaceLanding(page)
+  })
+
+  test("core OSS workspace navigation is visible", async ({ page }) => {
+    for (const item of [
+      "Workflows",
+      "Cases",
+      "Variables",
+      "Credentials",
+      "Integrations",
+      "Actions",
+    ]) {
+      await expect(
+        page.locator('[data-sidebar="menu-button"]').filter({ hasText: item })
+      ).toBeVisible()
+    }
+  })
+
+  test("user can create a workflow and load the builder", async ({ page }) => {
+    await page.getByRole("button", { name: /Create new/i }).click()
+    await page
+      .getByRole("menuitem")
+      .filter({ hasText: "Start from scratch" })
+      .click()
+
+    await page.waitForURL(/\/workspaces\/[^/]+\/workflows\/[^/]+$/)
+    await expect(page.getByText("Workflow trigger")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Publish" })).toBeVisible()
+  })
+})

--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -12,7 +12,7 @@ module.exports = {
       },
     ],
   },
-  testPathIgnorePatterns: ["/node_modules/", "/.next/"],
+  testPathIgnorePatterns: ["/node_modules/", "/.next/", "/e2e/"],
   transformIgnorePatterns: ["node_modules/(?!(yaml)/)"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,8 @@
     "start": "next start",
     "typecheck": "tsc --noEmit --incremental",
     "test": "jest",
+    "test:e2e": "playwright test",
+    "test:e2e:report": "playwright show-report",
     "generate-client": "openapi-ts --input ${TRACECAT__PUBLIC_API_URL:-http://localhost/api}/openapi.json --output ./src/client --client axios",
     "generate-client-ci": "uv run --directory .. scripts/openapi/generate_openapi.py /tmp/tracecat-openapi.json && openapi-ts --input /tmp/tracecat-openapi.json --output ./src/client --client axios && rm /tmp/tracecat-openapi.json",
     "upgrade:next": "pnpm add next@14 react@18 react-dom@18 && pnpm add -D eslint-config-next@14 eslint@8"
@@ -137,6 +139,7 @@
     "@biomejs/cli-darwin-arm64": "^2.2.4",
     "@hey-api/openapi-ts": "^0.48.3",
     "@hookform/devtools": "^4.4.0",
+    "@playwright/test": "1.58.2",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query-devtools": "^5.90.2",
     "@testing-library/jest-dom": "^6.8.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from "@playwright/test"
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost"
+const authFile = "e2e/.auth/dev-user.json"
+const browserChannel = process.env.PLAYWRIGHT_BROWSER_CHANNEL
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: process.env.CI ? "retain-on-failure" : "off",
+  },
+  projects: [
+    {
+      name: "setup",
+      testMatch: /.*\.setup\.ts/,
+    },
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        ...(browserChannel ? { channel: browserChannel } : {}),
+        storageState: authFile,
+      },
+      dependencies: ["setup"],
+      testIgnore: /.*\.setup\.ts/,
+    },
+  ],
+})

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -282,13 +282,13 @@ importers:
         version: 5.1.6
       next:
         specifier: 15.5.18
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2)
+        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2)
       next-runtime-env:
         specifier: ^3.3.0
-        version: 3.3.0(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2))(react@18.3.1)
+        version: 3.3.0(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2))(react@18.3.1)
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.2.1(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       papaparse:
         specifier: ^5.5.3
         version: 5.5.3
@@ -380,6 +380,9 @@ importers:
       '@hookform/devtools':
         specifier: ^4.4.0
         version: 4.4.0(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@playwright/test':
+        specifier: 1.58.2
+        version: 1.58.2
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@3.4.17)
@@ -1705,6 +1708,11 @@ packages:
   '@parcel/watcher@2.5.1':
     resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
     engines: {node: '>= 10.0.0'}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@posthog/core@1.2.2':
     resolution: {integrity: sha512-f16Ozx6LIigRG+HsJdt+7kgSxZTHeX5f1JlCGKI1lXcvlZgfsCR338FuMI2QRYXGl+jg/vYFzGOTQBxl90lnBg==}
@@ -3965,6 +3973,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5056,6 +5069,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -7291,6 +7314,10 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.1
       '@parcel/watcher-win32-x64': 2.5.1
     optional: true
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
 
   '@posthog/core@1.2.2': {}
 
@@ -9714,6 +9741,9 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -11086,18 +11116,18 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-runtime-env@3.3.0(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2))(react@18.3.1):
+  next-runtime-env@3.3.0(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2))(react@18.3.1):
     dependencies:
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2)
       react: 18.3.1
 
-  next-themes@0.2.1(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-themes@0.2.1(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2):
+  next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.93.2):
     dependencies:
       '@next/env': 15.5.18
       '@swc/helpers': 0.5.15
@@ -11116,6 +11146,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 15.5.18
       '@next/swc-win32-x64-msvc': 15.5.18
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.58.2
       sass: 1.93.2
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -11284,6 +11315,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 

--- a/frontend/src/app/workspaces/layout.tsx
+++ b/frontend/src/app/workspaces/layout.tsx
@@ -48,7 +48,6 @@ export default function WorkspaceLayout({
   children: React.ReactNode
 }) {
   const router = useRouter()
-  const { user, userIsLoading } = useAuth()
   const {
     workspaces,
     workspacesLoading,
@@ -120,20 +119,10 @@ export default function WorkspaceLayout({
     workspacesLoading,
   ])
 
-  useEffect(() => {
-    if (!hasNoOrgMemberships || userIsLoading || !user?.isSuperuser) {
-      return
-    }
-    router.replace("/admin")
-  }, [hasNoOrgMemberships, router, user?.isSuperuser, userIsLoading])
-
   if (workspacesLoading) {
     return <CenteredSpinner />
   }
   if (hasNoOrgMemberships) {
-    if (userIsLoading || user?.isSuperuser) {
-      return <CenteredSpinner />
-    }
     return <NoOrganizationAccess />
   }
   if (workspacesError || !workspaces) {

--- a/frontend/tests/auth-ui-matrix.test.tsx
+++ b/frontend/tests/auth-ui-matrix.test.tsx
@@ -432,7 +432,7 @@ describe("Auth UI matrix", () => {
     })
   })
 
-  it("redirects superusers with no organization memberships to admin", async () => {
+  it("keeps superusers with no organization memberships on the help screen", () => {
     mockUser = { email: "admin@example.com", isSuperuser: true }
     mockWorkspacesError = getNoOrgMembershipsError()
 
@@ -442,12 +442,8 @@ describe("Auth UI matrix", () => {
       </WorkspaceLayout>
     )
 
-    await waitFor(() => {
-      expect(mockRouterReplace).toHaveBeenCalledWith("/admin")
-    })
-    expect(
-      screen.queryByText("No organization access yet")
-    ).not.toBeInTheDocument()
+    expect(screen.getByText("No organization access yet")).toBeInTheDocument()
+    expect(mockRouterReplace).not.toHaveBeenCalledWith("/admin")
   })
 
   it("keeps regular users with no organization memberships on the help screen", () => {

--- a/justfile
+++ b/justfile
@@ -22,6 +22,15 @@ test-file file:
 test-k keyword:
 	uv run pytest tests/unit -k "{{keyword}}" -n auto -x
 
+# Run frontend Playwright E2E tests against PLAYWRIGHT_BASE_URL (default http://localhost)
+test-e2e *args:
+	#!/usr/bin/env sh
+	set -e
+	if [ -z "${CI:-}" ] && [ -z "${PLAYWRIGHT_BROWSER_CHANNEL+x}" ]; then
+		export PLAYWRIGHT_BROWSER_CHANNEL=chrome
+	fi
+	pnpm -C frontend exec playwright test --workers="${PLAYWRIGHT_WORKERS:-1}" {{args}}
+
 # Run backend benchmarks inside Docker (required for nsjail on macOS)
 bench *args:
 	docker run --rm \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Playwright E2E tests and CI to validate auth, workspace navigation, and entitlement gates in the OSS stack. Also updates superuser behavior when no organization memberships exist.

- **New Features**
  - Introduced Playwright E2E suite (`@playwright/test`) with setup auth, auth flows, entitlement gates, and workspace smoke tests.
  - Added OSS E2E GitHub Action (`.github/workflows/e2e-oss.yml`) to boot the local stack, run smoke tests on schedule/dispatch, and upload reports.
  - Added helper utilities for API login, invitations, and workspace navigation; configured storage state and base URL in `playwright.config.ts`.
  - New scripts: `pnpm test:e2e`, `pnpm test:e2e:report`, and `just test-e2e`; updated `.gitignore` and Jest to exclude `/e2e`.

- **Bug Fixes**
  - Superusers without organization memberships no longer auto-redirect to `/admin`; they remain on the help screen.

<sup>Written for commit 78cc76ce1ad726d2e375b0e7fb256c24c841e89a. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2736?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

