### PR TITLE
docs: use SentinelOne Purple MCP link for actions

### DIFF
--- a/docs/tools/sentinel_one.mdx
+++ b/docs/tools/sentinel_one.mdx
@@ -10,7 +10,7 @@ Action ID: `tools.sentinel_one.abort_scan`
 
 Abort a running scan on SentinelOne agents.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -40,7 +40,7 @@ Action ID: `tools.sentinel_one.disable_agent`
 
 Disable a SentinelOne agent.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -78,7 +78,7 @@ Action ID: `tools.sentinel_one.enable_agent`
 
 Enable a SentinelOne agent.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -116,7 +116,7 @@ Action ID: `tools.sentinel_one.initiate_scan`
 
 Initiate a scan on SentinelOne agents.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -146,7 +146,7 @@ Action ID: `tools.sentinel_one.disconnect_device`
 
 Disconnect a SentinelOne agent from the network.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -176,7 +176,7 @@ Action ID: `tools.sentinel_one.list_agent_ids`
 
 Get a simple list of SentinelOne agent IDs.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -208,7 +208,7 @@ Action ID: `tools.sentinel_one.list_alerts`
 
 Query for SentinelOne alerts.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -260,7 +260,7 @@ Action ID: `tools.sentinel_one.list_threats`
 
 Query for SentinelOne threats.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -312,7 +312,7 @@ Action ID: `tools.sentinel_one.lookup_agent_account_id`
 
 Find all SentinelOne agents in a specific account.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -350,7 +350,7 @@ Action ID: `tools.sentinel_one.lookup_agent_email`
 
 Find all SentinelOne agents associated with a user email address.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -388,7 +388,7 @@ Action ID: `tools.sentinel_one.lookup_agent_hash`
 
 Find all SentinelOne agents that have encountered threats with a specific file hash.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -426,7 +426,7 @@ Action ID: `tools.sentinel_one.lookup_agent_groupid`
 
 Find all SentinelOne agents in a specific group.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -464,7 +464,7 @@ Action ID: `tools.sentinel_one.lookup_agent_hostname`
 
 Find all SentinelOne agents by hostname/computer name.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -502,7 +502,7 @@ Action ID: `tools.sentinel_one.lookup_agent_ip`
 
 Find all SentinelOne agents by IP address (external IP, network interface, or gateway).
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -540,7 +540,7 @@ Action ID: `tools.sentinel_one.lookup_agent_mac_address`
 
 Find all SentinelOne agents by MAC address (network interface physical address or gateway MAC).
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -586,7 +586,7 @@ Action ID: `tools.sentinel_one.lookup_agent_machine_type`
 
 Find all SentinelOne agents filtered by machine type (laptop, desktop, server, etc.).
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -632,7 +632,7 @@ Action ID: `tools.sentinel_one.lookup_agent_os`
 
 Find all SentinelOne agents filtered by operating system type, name, revision, and version information.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 
@@ -694,7 +694,7 @@ Action ID: `tools.sentinel_one.connect_to_network`
 
 Connect a SentinelOne agent to the network.
 
-Reference: [https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a](https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a)
+Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
 
 ### Secrets
 

--- a/docs/tools/sentinel_one.mdx
+++ b/docs/tools/sentinel_one.mdx
@@ -10,7 +10,7 @@ Action ID: `tools.sentinel_one.abort_scan`
 
 Abort a running scan on SentinelOne agents.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -40,7 +40,7 @@ Action ID: `tools.sentinel_one.disable_agent`
 
 Disable a SentinelOne agent.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -78,7 +78,7 @@ Action ID: `tools.sentinel_one.enable_agent`
 
 Enable a SentinelOne agent.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -116,7 +116,7 @@ Action ID: `tools.sentinel_one.initiate_scan`
 
 Initiate a scan on SentinelOne agents.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -146,7 +146,7 @@ Action ID: `tools.sentinel_one.disconnect_device`
 
 Disconnect a SentinelOne agent from the network.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -176,7 +176,7 @@ Action ID: `tools.sentinel_one.list_agent_ids`
 
 Get a simple list of SentinelOne agent IDs.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -208,7 +208,7 @@ Action ID: `tools.sentinel_one.list_alerts`
 
 Query for SentinelOne alerts.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -260,7 +260,7 @@ Action ID: `tools.sentinel_one.list_threats`
 
 Query for SentinelOne threats.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -312,7 +312,7 @@ Action ID: `tools.sentinel_one.lookup_agent_account_id`
 
 Find all SentinelOne agents in a specific account.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -350,7 +350,7 @@ Action ID: `tools.sentinel_one.lookup_agent_email`
 
 Find all SentinelOne agents associated with a user email address.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -388,7 +388,7 @@ Action ID: `tools.sentinel_one.lookup_agent_hash`
 
 Find all SentinelOne agents that have encountered threats with a specific file hash.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -426,7 +426,7 @@ Action ID: `tools.sentinel_one.lookup_agent_groupid`
 
 Find all SentinelOne agents in a specific group.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -464,7 +464,7 @@ Action ID: `tools.sentinel_one.lookup_agent_hostname`
 
 Find all SentinelOne agents by hostname/computer name.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -502,7 +502,7 @@ Action ID: `tools.sentinel_one.lookup_agent_ip`
 
 Find all SentinelOne agents by IP address (external IP, network interface, or gateway).
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -540,7 +540,7 @@ Action ID: `tools.sentinel_one.lookup_agent_mac_address`
 
 Find all SentinelOne agents by MAC address (network interface physical address or gateway MAC).
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -586,7 +586,7 @@ Action ID: `tools.sentinel_one.lookup_agent_machine_type`
 
 Find all SentinelOne agents filtered by machine type (laptop, desktop, server, etc.).
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -632,7 +632,7 @@ Action ID: `tools.sentinel_one.lookup_agent_os`
 
 Find all SentinelOne agents filtered by operating system type, name, revision, and version information.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 
@@ -694,7 +694,7 @@ Action ID: `tools.sentinel_one.connect_to_network`
 
 Connect a SentinelOne agent to the network.
 
-Reference: [https://github.com/sentinel-official/sentinel-python-sdk](https://github.com/sentinel-official/sentinel-python-sdk)
+Reference: [https://github.com/Sentinel-One/purple-mcp](https://github.com/Sentinel-One/purple-mcp)
 
 ### Secrets
 

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/abort_scan.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/abort_scan.yml
@@ -3,7 +3,7 @@ definition:
   title: Abort scan
   description: Abort a running scan on SentinelOne agents.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: abort_scan
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/abort_scan.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/abort_scan.yml
@@ -3,7 +3,7 @@ definition:
   title: Abort scan
   description: Abort a running scan on SentinelOne agents.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: abort_scan
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/disable_agent.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/disable_agent.yml
@@ -3,7 +3,7 @@ definition:
   title: Disable agent
   description: Disable a SentinelOne agent.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: disable_agent
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/disable_agent.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/disable_agent.yml
@@ -3,7 +3,7 @@ definition:
   title: Disable agent
   description: Disable a SentinelOne agent.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: disable_agent
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/enable_agent.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/enable_agent.yml
@@ -3,7 +3,7 @@ definition:
   title: Enable agent
   description: Enable a SentinelOne agent.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: enable_agent
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/enable_agent.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/enable_agent.yml
@@ -3,7 +3,7 @@ definition:
   title: Enable agent
   description: Enable a SentinelOne agent.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: enable_agent
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/initiate_scan.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/initiate_scan.yml
@@ -3,7 +3,7 @@ definition:
   title: Initiate scan
   description: Initiate a scan on SentinelOne agents.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: initiate_scan
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/initiate_scan.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/initiate_scan.yml
@@ -3,7 +3,7 @@ definition:
   title: Initiate scan
   description: Initiate a scan on SentinelOne agents.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: initiate_scan
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/isolate_endpoint.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/isolate_endpoint.yml
@@ -3,7 +3,7 @@ definition:
   title: Isolate endpoint
   description: Disconnect a SentinelOne agent from the network.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: disconnect_device
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/isolate_endpoint.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/isolate_endpoint.yml
@@ -3,7 +3,7 @@ definition:
   title: Isolate endpoint
   description: Disconnect a SentinelOne agent from the network.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: disconnect_device
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/list_agent_ids.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/list_agent_ids.yml
@@ -3,7 +3,7 @@ definition:
   title: List agent IDs
   description: Get a simple list of SentinelOne agent IDs.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: list_agent_ids
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/list_agent_ids.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/list_agent_ids.yml
@@ -3,7 +3,7 @@ definition:
   title: List agent IDs
   description: Get a simple list of SentinelOne agent IDs.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: list_agent_ids
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/list_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/list_alerts.yml
@@ -3,7 +3,7 @@ definition:
   title: List alerts
   description: Query for SentinelOne alerts.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: list_alerts
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/list_alerts.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/list_alerts.yml
@@ -3,7 +3,7 @@ definition:
   title: List alerts
   description: Query for SentinelOne alerts.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: list_alerts
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/list_threats.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/list_threats.yml
@@ -3,7 +3,7 @@ definition:
   title: List threats
   description: Query for SentinelOne threats.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: list_threats
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/list_threats.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/list_threats.yml
@@ -3,7 +3,7 @@ definition:
   title: List threats
   description: Query for SentinelOne threats.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: list_threats
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_account_id.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_account_id.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by account ID
   description: Find all SentinelOne agents in a specific account.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: lookup_agent_account_id
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_account_id.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_account_id.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by account ID
   description: Find all SentinelOne agents in a specific account.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: lookup_agent_account_id
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_email.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_email.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by email
   description: Find all SentinelOne agents associated with a user email address.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: lookup_agent_email
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_email.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_email.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by email
   description: Find all SentinelOne agents associated with a user email address.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: lookup_agent_email
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_groupid.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_groupid.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by group ID
   description: Find all SentinelOne agents in a specific group.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: lookup_agent_groupid
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_groupid.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_groupid.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by group ID
   description: Find all SentinelOne agents in a specific group.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: lookup_agent_groupid
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_hash.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_hash.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by file hash
   description: Find all SentinelOne agents that have encountered threats with a specific file hash.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: lookup_agent_hash
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_hash.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_hash.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by file hash
   description: Find all SentinelOne agents that have encountered threats with a specific file hash.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: lookup_agent_hash
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_hostname.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_hostname.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by hostname
   description: Find all SentinelOne agents by hostname/computer name.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: lookup_agent_hostname
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_hostname.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_hostname.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by hostname
   description: Find all SentinelOne agents by hostname/computer name.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: lookup_agent_hostname
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_ip.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_ip.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by IP address
   description: Find all SentinelOne agents by IP address (external IP, network interface, or gateway).
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: lookup_agent_ip
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_ip.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_ip.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by IP address
   description: Find all SentinelOne agents by IP address (external IP, network interface, or gateway).
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: lookup_agent_ip
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_mac_address.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_mac_address.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by MAC address
   description: Find all SentinelOne agents by MAC address (network interface physical address or gateway MAC).
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: lookup_agent_mac_address
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_mac_address.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_mac_address.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by MAC address
   description: Find all SentinelOne agents by MAC address (network interface physical address or gateway MAC).
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: lookup_agent_mac_address
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_machine_type.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_machine_type.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by machine type
   description: Find all SentinelOne agents filtered by machine type (laptop, desktop, server, etc.).
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: lookup_agent_machine_type
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_machine_type.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_machine_type.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by machine type
   description: Find all SentinelOne agents filtered by machine type (laptop, desktop, server, etc.).
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: lookup_agent_machine_type
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_os.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_os.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by operating system
   description: Find all SentinelOne agents filtered by operating system type, name, revision, and version information.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: lookup_agent_os
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_os.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/lookup_agent_os.yml
@@ -3,7 +3,7 @@ definition:
   title: Lookup agents by operating system
   description: Find all SentinelOne agents filtered by operating system type, name, revision, and version information.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: lookup_agent_os
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/unisolate_endpoint.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/unisolate_endpoint.yml
@@ -3,7 +3,7 @@ definition:
   title: Unisolate endpoint
   description: Connect a SentinelOne agent to the network.
   display_group: SentinelOne
-  doc_url: https://www.postman.com/api-evangelist/workspace/sentinelone/documentation/35240-8314fa61-90b8-405a-a1fa-c695b640a11a
+  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
   namespace: tools.sentinel_one
   name: connect_to_network
   secrets:

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/unisolate_endpoint.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/sentinel_one/unisolate_endpoint.yml
@@ -3,7 +3,7 @@ definition:
   title: Unisolate endpoint
   description: Connect a SentinelOne agent to the network.
   display_group: SentinelOne
-  doc_url: https://github.com/sentinel-official/sentinel-python-sdk
+  doc_url: https://github.com/Sentinel-One/purple-mcp
   namespace: tools.sentinel_one
   name: connect_to_network
   secrets:


### PR DESCRIPTION
## Summary

- Replace SentinelOne action documentation URLs that pointed at a public Postman mirror with SentinelOne's `Sentinel-One/purple-mcp` repository.
- Regenerate the SentinelOne tool docs so the rendered references match the registry templates.

## Validation

- `git pull origin main` reported `Already up to date.` before committing from the follow-up branch.
- `curl -sSL -o /dev/null -w "%{http_code} %{url_effective}\n" https://github.com/Sentinel-One/purple-mcp` returned `200`.
- `uv run pytest scripts/tests/test_action_doc_links.py -ra`
- `TRACECAT_TEST_ACTION_DOC_LINKS=1 uv run pytest scripts/tests/test_action_doc_links.py -ra`
- pre-commit hooks during `git commit`, including YAML validation, Gitleaks, and generated frontend client check.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced SentinelOne action docs links with the official SentinelOne Python SDK and regenerated the tool docs. This keeps the registry templates and rendered docs in sync.

- **Refactors**
  - Updated `doc_url` for all SentinelOne actions to `https://github.com/sentinel-official/sentinel-python-sdk`.
  - Regenerated `docs/tools/sentinel_one.mdx` to reflect the new references.

<sup>Written for commit 3a83deb7c3521a8afd0a2ade9a8107cc474be410. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2737?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->
