### PR TITLE
fix(sandbox): route run_python sdk calls through gateway

### DIFF
--- a/tests/unit/executor/test_run_python_sdk_context.py
+++ b/tests/unit/executor/test_run_python_sdk_context.py
@@ -1294,6 +1294,97 @@ async def test_run_python_nsjail_sdk_calls_use_action_gateway_without_network(
     )
 
 
+@pytest.mark.anyio
+async def test_run_python_pid_sdk_calls_use_action_gateway_with_legacy_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Unsafe PID fallback should patch pre-gateway SDK artifacts too."""
+    _set_run_python_nsjail_mode(monkeypatch, disable_nsjail=True)
+    action_gateway_socket = (
+        Path("/tmp") / f"tracecat-run-python-gateway-{uuid.uuid4().hex}.sock"
+    )
+    action_gateway_socket.unlink(missing_ok=True)
+    action_gateway = ActionGateway(socket_path=action_gateway_socket)
+    legacy_registry_root = _write_legacy_registry_sdk(tmp_path / "legacy-registry")
+    fake_runner = _FakeRunPythonRegistryPathRunner(
+        [legacy_registry_root, Path(sysconfig.get_path("purelib")).resolve()]
+    )
+
+    async def _get_tarball_uris(_input: RunActionInput, _role: Role) -> list[str]:
+        return ["s3://tracecat-registry/test/site-packages.tar.gz"]
+
+    monkeypatch.setattr(
+        executor_backend_module,
+        "SandboxService",
+        lambda: SandboxService(cache_dir=str(tmp_path / "sandbox-cache")),
+    )
+    monkeypatch.setattr(
+        executor_backend_module,
+        "get_action_runner",
+        lambda: fake_runner,
+    )
+    monkeypatch.setattr(
+        executor_backend_module.config,
+        "TRACECAT__API_URL",
+        "http://tracecat-api:8000",
+    )
+    monkeypatch.setattr(
+        executor_backend_module.config,
+        "TRACECAT__ACTION_GATEWAY_ENABLED",
+        True,
+    )
+    monkeypatch.setattr(
+        executor_backend_module.config,
+        "TRACECAT__ACTION_GATEWAY_SOCKET",
+        str(action_gateway_socket),
+    )
+
+    backend = DirectBackend()
+    monkeypatch.setattr(backend, "_get_tarball_uris", _get_tarball_uris)
+
+    input_data = _make_run_python_input()
+    resolved_context = _make_run_python_context()
+    resolved_context.evaluated_args.update(
+        {
+            "script": """
+from tracecat_registry import ctx
+
+
+async def main():
+    import os
+
+    return {
+        "gateway": await ctx.client.get("/health"),
+        "socket_path": os.environ.get("TRACECAT__ACTION_GATEWAY_SOCKET"),
+    }
+""",
+            "allow_network": False,
+            "timeout_seconds": 60,
+        }
+    )
+
+    try:
+        await action_gateway.start()
+        result = await backend.execute(
+            input=input_data,
+            role=_make_role(),
+            resolved_context=resolved_context,
+        )
+    finally:
+        await action_gateway.stop()
+        action_gateway_socket.unlink(missing_ok=True)
+
+    assert result.type == "success", result.error
+    assert result.result == {
+        "gateway": {"status": "ok"},
+        "socket_path": str(action_gateway_socket),
+    }
+    assert fake_runner.tarball_uris == [
+        "s3://tracecat-registry/test/site-packages.tar.gz"
+    ]
+
+
 if __name__ == "__main__":
     if sys.argv[1:] == ["--run-nsjail-sdk-context-smoke"]:
         _run_nsjail_sdk_context_smoke_from_cli()

--- a/tests/unit/executor/test_run_python_sdk_context.py
+++ b/tests/unit/executor/test_run_python_sdk_context.py
@@ -29,6 +29,8 @@ from tracecat.dsl.schemas import (
     RunActionInput,
     RunContext,
 )
+from tracecat.executor.action_gateway.config import ACTION_GATEWAY_SANDBOX_SOCKET
+from tracecat.executor.action_gateway.server import ActionGateway
 from tracecat.executor.backends.base import ExecutorBackend
 from tracecat.executor.backends.direct import DirectBackend
 from tracecat.executor.backends.ephemeral import EphemeralBackend
@@ -243,6 +245,29 @@ def main():
 """
 
 
+def _registry_ctx_gateway_smoke_script() -> str:
+    return """
+from tracecat_registry import ctx
+
+
+async def main():
+    import os
+    import urllib.request
+
+    try:
+        urllib.request.urlopen("https://example.com", timeout=2)
+        outbound_status = "allowed"
+    except Exception as exc:
+        outbound_status = f"blocked: {type(exc).__name__}"
+
+    return {
+        "gateway": await ctx.client.get("/health"),
+        "socket_path": os.environ.get("TRACECAT__ACTION_GATEWAY_SOCKET"),
+        "outbound_status": outbound_status,
+    }
+"""
+
+
 def _registry_ctx_env_vars() -> dict[str, str]:
     return {
         "TRACECAT__API_URL": "http://api.test:8000",
@@ -283,6 +308,129 @@ def _registry_python_path_dirs() -> list[Path]:
     registry_source_root = Path(tracecat_registry.__file__).resolve().parents[1]
     purelib = Path(sysconfig.get_path("purelib")).resolve()
     return [registry_source_root, purelib]
+
+
+def _write_legacy_registry_sdk(root: Path) -> Path:
+    """Write a minimal pre-gateway tracecat_registry package for nsjail tests."""
+    package_dir = root / "tracecat_registry"
+    sdk_dir = package_dir / "sdk"
+    sdk_dir.mkdir(parents=True)
+
+    (package_dir / "__init__.py").write_text("from . import ctx\n")
+    (sdk_dir / "__init__.py").write_text("")
+    (package_dir / "ctx.py").write_text(
+        """
+from tracecat_registry.context import get_context
+
+
+def __getattr__(name):
+    if name == "client":
+        return get_context().client
+    raise AttributeError(name)
+"""
+    )
+    (package_dir / "context.py").write_text(
+        """
+import os
+
+
+_context = None
+
+
+class RegistryContext:
+    def __init__(self, *, api_url, token, workspace_id):
+        self.api_url = api_url
+        self.token = token
+        self.workspace_id = workspace_id
+
+    @classmethod
+    def from_env(cls):
+        return cls(
+            workspace_id=os.environ["TRACECAT__WORKSPACE_ID"],
+            api_url=os.environ.get("TRACECAT__API_URL", "http://api:8000"),
+            token=os.environ.get("TRACECAT__EXECUTOR_TOKEN", ""),
+        )
+
+    @property
+    def client(self):
+        from tracecat_registry.sdk.client import TracecatClient
+
+        return TracecatClient(
+            api_url=self.api_url,
+            token=self.token,
+            workspace_id=self.workspace_id,
+        )
+
+
+def get_context():
+    if _context is None:
+        raise RuntimeError("No registry context is set")
+    return _context
+
+
+def set_context(ctx):
+    global _context
+    _context = ctx
+
+
+def init_context_from_env():
+    ctx = RegistryContext.from_env()
+    set_context(ctx)
+    return ctx
+"""
+    )
+    (sdk_dir / "client.py").write_text(
+        """
+import os
+
+import httpx
+
+
+class TracecatClient:
+    def __init__(
+        self,
+        *,
+        api_url=None,
+        token=None,
+        workspace_id=None,
+        timeout=120.0,
+    ):
+        self._api_url = (api_url or os.environ.get("TRACECAT__API_URL", "http://api:8000")).rstrip("/") + "/internal"
+        self._token = token or os.environ.get("TRACECAT__EXECUTOR_TOKEN", "")
+        self._timeout = timeout
+
+    def _get_headers(self):
+        headers = {"Content-Type": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+        return headers
+
+    def _handle_error_response(self, response):
+        response.raise_for_status()
+
+    async def request(self, method, path, *, params=None, json=None, headers=None):
+        request_headers = self._get_headers()
+        if headers:
+            request_headers.update(headers)
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.request(
+                method,
+                f"{self._api_url}{path}",
+                params=params,
+                json=json,
+                headers=request_headers,
+            )
+        if not response.is_success:
+            self._handle_error_response(response)
+        if not response.content:
+            return None
+        return response.json()
+
+    async def get(self, path, *, params=None, headers=None):
+        return await self.request("GET", path, params=params, headers=headers)
+"""
+    )
+    return root
 
 
 async def _run_sandbox_registry_ctx_smoke(
@@ -337,6 +485,11 @@ async def _run_backend_registry_ctx_smoke(
         "TRACECAT__API_URL",
         "http://api.test:8000",
     )
+    monkeypatch.setattr(
+        executor_backend_module.config,
+        "TRACECAT__ACTION_GATEWAY_ENABLED",
+        False,
+    )
 
     input_data = _make_run_python_input()
     resolved_context = _make_run_python_context()
@@ -368,6 +521,75 @@ async def _run_backend_registry_ctx_smoke(
     return result.result
 
 
+async def _run_backend_registry_ctx_gateway_smoke(
+    *,
+    backend: ExecutorBackend,
+    monkeypatch: pytest.MonkeyPatch,
+    cache_dir: Path,
+    action_gateway_socket: Path,
+    registry_paths: list[Path],
+) -> dict[str, Any]:
+    """Run a real SDK request through run_python's nsjail Action Gateway mount."""
+    fake_runner = _FakeRunPythonRegistryPathRunner(registry_paths)
+
+    async def _get_tarball_uris(_input: RunActionInput, _role: Role) -> list[str]:
+        return ["s3://tracecat-registry/test/site-packages.tar.gz"]
+
+    monkeypatch.setattr(
+        executor_backend_module,
+        "SandboxService",
+        lambda: SandboxService(cache_dir=str(cache_dir)),
+    )
+    monkeypatch.setattr(backend, "_get_tarball_uris", _get_tarball_uris)
+    monkeypatch.setattr(
+        executor_backend_module,
+        "get_action_runner",
+        lambda: fake_runner,
+    )
+    monkeypatch.setattr(
+        executor_backend_module.config,
+        "TRACECAT__API_URL",
+        "http://tracecat-api:8000",
+    )
+    monkeypatch.setattr(
+        executor_backend_module.config,
+        "TRACECAT__ACTION_GATEWAY_ENABLED",
+        True,
+    )
+    monkeypatch.setattr(
+        executor_backend_module.config,
+        "TRACECAT__ACTION_GATEWAY_SOCKET",
+        str(action_gateway_socket),
+    )
+
+    input_data = _make_run_python_input()
+    resolved_context = _make_run_python_context()
+    resolved_context.evaluated_args.update(
+        {
+            "script": _registry_ctx_gateway_smoke_script(),
+            "allow_network": False,
+            "timeout_seconds": 60,
+        }
+    )
+
+    result = await backend.execute(
+        input=input_data,
+        role=_make_role(),
+        resolved_context=resolved_context,
+    )
+
+    assert result.type == "success"
+    assert result.result == {
+        "gateway": {"status": "ok"},
+        "socket_path": str(ACTION_GATEWAY_SANDBOX_SOCKET),
+        "outbound_status": "blocked: URLError",
+    }
+    assert fake_runner.tarball_uris == [
+        "s3://tracecat-registry/test/site-packages.tar.gz"
+    ]
+    return result.result
+
+
 async def _run_backend_registry_ctx_smoke_matrix(
     *,
     monkeypatch: pytest.MonkeyPatch,
@@ -382,7 +604,46 @@ async def _run_backend_registry_ctx_smoke_matrix(
         assert isinstance(result, dict)
 
 
-def _run_nsjail_sdk_context_harness_in_docker_or_skip() -> None:
+async def _run_backend_registry_ctx_gateway_smoke_matrix(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    cache_dir: Path,
+) -> None:
+    action_gateway_socket = cache_dir / "action-gateway.sock"
+    monkeypatch.setattr(
+        executor_backend_module.config,
+        "TRACECAT__ACTION_GATEWAY_ENABLED",
+        True,
+    )
+    action_gateway = ActionGateway(socket_path=action_gateway_socket)
+    await action_gateway.start()
+    legacy_registry_root = _write_legacy_registry_sdk(cache_dir / "legacy-registry")
+
+    try:
+        registry_path_cases = [
+            _registry_python_path_dirs(),
+            [legacy_registry_root, Path(sysconfig.get_path("purelib")).resolve()],
+        ]
+        for index, registry_paths in enumerate(registry_path_cases):
+            result = await _run_backend_registry_ctx_gateway_smoke(
+                backend=DirectBackend(),
+                monkeypatch=monkeypatch,
+                cache_dir=cache_dir / f"sandbox-cache-{index}",
+                action_gateway_socket=action_gateway_socket,
+                registry_paths=registry_paths,
+            )
+            assert isinstance(result, dict)
+    finally:
+        await action_gateway.stop()
+
+
+def _run_nsjail_harness_in_docker_or_skip(
+    *,
+    cli_arg: str,
+    override_prefix: str,
+    timeout: int,
+    failure_message: str,
+) -> None:
     if os.environ.get("TRACECAT__RUN_PYTHON_NSJAIL_DOCKER_FALLBACK_CHILD") == "1":
         pytest.skip("run_python nsjail unavailable inside Docker fallback child")
     if not _docker_nsjail_fallback_enabled():
@@ -412,7 +673,7 @@ def _run_nsjail_sdk_context_harness_in_docker_or_skip() -> None:
     compose_env.setdefault("TRACECAT__APP_ENV", "development")
     tests_mount = f"{repo_root / 'tests'}:/app/tests:ro"
     fd, override_name = tempfile.mkstemp(
-        prefix="tracecat-run-python-nsjail-test-",
+        prefix=override_prefix,
         suffix=".yml",
     )
     os.close(fd)
@@ -460,13 +721,13 @@ def _run_nsjail_sdk_context_harness_in_docker_or_skip() -> None:
                 "api",
                 "-lc",
                 "uv run python -m tests.unit.executor.test_run_python_sdk_context "
-                "--run-nsjail-sdk-context-smoke",
+                f"{cli_arg}",
             ],
             cwd=repo_root,
             env=compose_env,
             capture_output=True,
             text=True,
-            timeout=180,
+            timeout=timeout,
             check=False,
         )
     finally:
@@ -474,9 +735,26 @@ def _run_nsjail_sdk_context_harness_in_docker_or_skip() -> None:
 
     if result.returncode != 0:
         pytest.fail(
-            "Dockerized run_python nsjail SDK-context fallback failed."
-            f"\n\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+            f"{failure_message}\n\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
         )
+
+
+def _run_nsjail_sdk_context_harness_in_docker_or_skip() -> None:
+    _run_nsjail_harness_in_docker_or_skip(
+        cli_arg="--run-nsjail-sdk-context-smoke",
+        override_prefix="tracecat-run-python-nsjail-test-",
+        timeout=180,
+        failure_message="Dockerized run_python nsjail SDK-context fallback failed.",
+    )
+
+
+def _run_nsjail_sdk_gateway_harness_in_docker_or_skip() -> None:
+    _run_nsjail_harness_in_docker_or_skip(
+        cli_arg="--run-nsjail-sdk-gateway-smoke",
+        override_prefix="tracecat-run-python-nsjail-gateway-test-",
+        timeout=240,
+        failure_message="Dockerized run_python nsjail SDK-gateway fallback failed.",
+    )
 
 
 def _run_nsjail_sdk_context_smoke_from_cli() -> None:
@@ -488,6 +766,23 @@ def _run_nsjail_sdk_context_smoke_from_cli() -> None:
             await _run_backend_registry_ctx_smoke_matrix(
                 monkeypatch=monkeypatch,
                 cache_dir=tmp_path / "sandbox-cache",
+            )
+        finally:
+            monkeypatch.undo()
+            shutil.rmtree(tmp_path, ignore_errors=True)
+
+    asyncio.run(run())
+
+
+def _run_nsjail_sdk_gateway_smoke_from_cli() -> None:
+    async def run() -> None:
+        monkeypatch = pytest.MonkeyPatch()
+        tmp_path = Path(tempfile.mkdtemp(prefix="tracecat-run-python-gateway-"))
+        try:
+            _set_run_python_nsjail_mode(monkeypatch, disable_nsjail=False)
+            await _run_backend_registry_ctx_gateway_smoke_matrix(
+                monkeypatch=monkeypatch,
+                cache_dir=tmp_path,
             )
         finally:
             monkeypatch.undo()
@@ -541,6 +836,26 @@ def test_nsjail_config_mounts_registry_paths_under_pythonpath_root(
     ) in config_text
     assert (
         f'mount {{ src: "{dependency_path}" dst: "/pythonpath/1" is_bind: true rw: false }}'
+    ) in config_text
+
+
+def test_nsjail_config_mounts_run_python_action_gateway_socket(
+    tmp_path: Path,
+) -> None:
+    action_gateway_socket = tmp_path / "action-gateway.sock"
+    sandbox_config = SandboxConfig(
+        action_gateway_socket=action_gateway_socket,
+    )
+
+    config_text = NsjailExecutor(rootfs_path=str(tmp_path))._build_config(
+        tmp_path,
+        "execute",
+        sandbox_config,
+    )
+
+    assert (
+        f'mount {{ src: "{action_gateway_socket}" '
+        f'dst: "{ACTION_GATEWAY_SANDBOX_SOCKET}" is_bind: true rw: false }}'
     ) in config_text
 
 
@@ -955,11 +1270,37 @@ async def test_run_python_nsjail_can_import_registry_ctx_with_registry_paths(
     )
 
 
+@pytest.mark.anyio
+async def test_run_python_nsjail_sdk_calls_use_action_gateway_without_network(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """SDK calls should use the internal gateway while outbound network is off.
+
+    This mirrors cloud `core.script.run_python` execution: user egress remains
+    disabled by default, but `tracecat_registry.ctx` calls are internal platform
+    calls and should route through the worker-owned Unix socket. The matrix also
+    uses a minimal pre-gateway registry package to catch cached legacy artifacts
+    whose `TracecatClient` does not natively read the gateway socket env var.
+    """
+    if not _run_python_nsjail_available():
+        _run_nsjail_sdk_gateway_harness_in_docker_or_skip()
+        return
+
+    _set_run_python_nsjail_mode(monkeypatch, disable_nsjail=False)
+    await _run_backend_registry_ctx_gateway_smoke_matrix(
+        monkeypatch=monkeypatch,
+        cache_dir=tmp_path,
+    )
+
+
 if __name__ == "__main__":
     if sys.argv[1:] == ["--run-nsjail-sdk-context-smoke"]:
         _run_nsjail_sdk_context_smoke_from_cli()
+    elif sys.argv[1:] == ["--run-nsjail-sdk-gateway-smoke"]:
+        _run_nsjail_sdk_gateway_smoke_from_cli()
     else:
         raise SystemExit(
             "Usage: python -m tests.unit.executor.test_run_python_sdk_context "
-            "[--run-nsjail-sdk-context-smoke]"
+            "[--run-nsjail-sdk-context-smoke|--run-nsjail-sdk-gateway-smoke]"
         )

--- a/tracecat/executor/backends/base.py
+++ b/tracecat/executor/backends/base.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 from tracecat import config
 from tracecat.dsl.enums import PlatformAction
+from tracecat.executor.action_gateway.config import action_gateway_socket_path
 from tracecat.executor.action_runner import get_action_runner
 from tracecat.executor.schemas import (
     ExecutorActionErrorInfo,
@@ -146,6 +147,7 @@ class ExecutorBackend(ABC):
                 env_vars=env_vars,
                 python_path_dirs=registry_paths,
                 workspace_id=resolved_context.workspace_id,
+                action_gateway_socket=action_gateway_socket_path(),
             )
             return ExecutorResultSuccess(result=result)
         except (

--- a/tracecat/sandbox/executor.py
+++ b/tracecat/sandbox/executor.py
@@ -26,6 +26,9 @@ from tracecat.sandbox.networking import (
 from tracecat.sandbox.seccomp import build_untrusted_seccomp_policy
 from tracecat.sandbox.types import ResourceLimits, SandboxConfig, SandboxResult
 
+RUN_PYTHON_ACTION_GATEWAY_SOCKET = Path("/var/run/tracecat/action-gateway.sock")
+"""Path visible inside run_python nsjail for executor-owned SDK calls."""
+
 
 @dataclass
 class ActionSandboxConfig:
@@ -208,6 +211,8 @@ class NsjailExecutor:
             _validate_path(python_path_dir, f"python_path_dir_{i}")
         if cache_key:
             _validate_cache_key(cache_key)
+        if config.action_gateway_socket is not None:
+            _validate_path(config.action_gateway_socket, "action_gateway_socket")
 
         # Determine if network should be enabled
         # - Install phase: always enabled for package downloads
@@ -322,6 +327,16 @@ class NsjailExecutor:
             lines.append(
                 f'mount {{ src: "{job_dir}" dst: "/work" is_bind: true rw: true }}'
             )
+            if config.action_gateway_socket is not None:
+                lines.extend(
+                    [
+                        "",
+                        "# Action Gateway socket for internal Tracecat SDK calls",
+                        f'mount {{ src: "{config.action_gateway_socket}" '
+                        f'dst: "{RUN_PYTHON_ACTION_GATEWAY_SOCKET}" '
+                        "is_bind: true rw: false }",
+                    ]
+                )
 
         # Resource limits
         lines.extend(

--- a/tracecat/sandbox/service.py
+++ b/tracecat/sandbox/service.py
@@ -24,7 +24,7 @@ from tracecat.sandbox.exceptions import (
     PackageInstallError,
     SandboxExecutionError,
 )
-from tracecat.sandbox.executor import NsjailExecutor
+from tracecat.sandbox.executor import RUN_PYTHON_ACTION_GATEWAY_SOCKET, NsjailExecutor
 from tracecat.sandbox.types import ResourceLimits, SandboxConfig
 from tracecat.sandbox.unsafe_pid_executor import UnsafePidExecutor
 from tracecat.sandbox.wrapper import INSTALL_SCRIPT, WRAPPER_SCRIPT
@@ -113,6 +113,21 @@ class SandboxService:
         if self._unsafe_pid_executor is None:
             self._unsafe_pid_executor = UnsafePidExecutor(cache_dir=str(self.cache_dir))
         return self._unsafe_pid_executor
+
+    @staticmethod
+    def _with_action_gateway_socket_env(
+        env_vars: dict[str, str] | None,
+        *,
+        socket_path: Path | None,
+        env_socket_path: Path | None = None,
+    ) -> dict[str, str] | None:
+        """Return env vars with Action Gateway socket routing when configured."""
+        if socket_path is None:
+            return env_vars
+
+        updated = dict(env_vars or {})
+        updated["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(env_socket_path or socket_path)
+        return updated
 
     @asynccontextmanager
     async def _create_job_dir(self) -> AsyncIterator[Path]:
@@ -293,6 +308,7 @@ class SandboxService:
         env_vars: dict[str, str] | None = None,
         python_path_dirs: list[Path] | None = None,
         workspace_id: str | None = None,
+        action_gateway_socket: Path | None = None,
     ) -> Any:
         """Execute a Python script in a sandbox.
 
@@ -313,6 +329,9 @@ class SandboxService:
             workspace_id: Optional workspace ID for multi-tenant cache isolation.
                 When provided, package caches are scoped to the workspace,
                 preventing cross-workspace package poisoning attacks.
+            action_gateway_socket: Optional host-side action gateway Unix socket.
+                Internal Tracecat SDK calls use this socket even when outbound
+                network access is disabled.
 
         Returns:
             The return value of the script's main function.
@@ -337,6 +356,7 @@ class SandboxService:
                 env_vars=env_vars,
                 python_path_dirs=python_path_dirs,
                 workspace_id=workspace_id,
+                action_gateway_socket=action_gateway_socket,
             )
         else:
             logger.info(
@@ -351,7 +371,10 @@ class SandboxService:
                 dependencies=dependencies,
                 timeout_seconds=timeout_seconds,
                 allow_network=allow_network,
-                env_vars=env_vars,
+                env_vars=self._with_action_gateway_socket_env(
+                    env_vars,
+                    socket_path=action_gateway_socket,
+                ),
                 python_path_dirs=python_path_dirs,
                 workspace_id=workspace_id,
             )
@@ -378,6 +401,7 @@ class SandboxService:
         env_vars: dict[str, str] | None = None,
         python_path_dirs: list[Path] | None = None,
         workspace_id: str | None = None,
+        action_gateway_socket: Path | None = None,
     ) -> Any:
         """Execute a Python script using the nsjail sandbox.
 
@@ -396,6 +420,7 @@ class SandboxService:
             env_vars: Environment variables to set in the sandbox.
             python_path_dirs: Read-only Python path roots to expose to the sandbox.
             workspace_id: Optional workspace ID for multi-tenant cache isolation.
+            action_gateway_socket: Optional host-side action gateway Unix socket.
 
         Returns:
             The return value of the script's main function.
@@ -441,9 +466,15 @@ class SandboxService:
                     timeout_seconds=timeout_seconds,
                     memory_mb=TRACECAT__SANDBOX_DEFAULT_MEMORY_MB,
                 ),
-                env_vars=env_vars or {},
+                env_vars=self._with_action_gateway_socket_env(
+                    env_vars,
+                    socket_path=action_gateway_socket,
+                    env_socket_path=RUN_PYTHON_ACTION_GATEWAY_SOCKET,
+                )
+                or {},
                 dependencies=dependencies or [],
                 python_path_dirs=python_path_dirs or [],
+                action_gateway_socket=action_gateway_socket,
             )
 
             await self._prepare_execution(job_dir, script, inputs)

--- a/tracecat/sandbox/service.py
+++ b/tracecat/sandbox/service.py
@@ -365,16 +365,17 @@ class SandboxService:
                 "For full OS-level isolation, set TRACECAT__DISABLE_NSJAIL=false "
                 "and ensure nsjail is installed with the sandbox rootfs."
             )
+            resolved_env_vars = self._with_action_gateway_socket_env(
+                env_vars,
+                socket_path=action_gateway_socket,
+            )
             result = await self.unsafe_pid_executor.execute(
                 script=script,
                 inputs=inputs,
                 dependencies=dependencies,
                 timeout_seconds=timeout_seconds,
                 allow_network=allow_network,
-                env_vars=self._with_action_gateway_socket_env(
-                    env_vars,
-                    socket_path=action_gateway_socket,
-                ),
+                env_vars=resolved_env_vars,
                 python_path_dirs=python_path_dirs,
                 workspace_id=workspace_id,
             )

--- a/tracecat/sandbox/types.py
+++ b/tracecat/sandbox/types.py
@@ -36,6 +36,8 @@ class SandboxConfig:
         env_vars: Environment variables to inject into the sandbox.
         dependencies: Python packages to install before execution.
         python_path_dirs: Host directories to mount read-only and add to PYTHONPATH.
+        action_gateway_socket: Optional host-side action gateway Unix socket to
+            bind into nsjail for internal Tracecat SDK calls.
     """
 
     network_enabled: bool = False
@@ -43,6 +45,7 @@ class SandboxConfig:
     env_vars: dict[str, str] = field(default_factory=dict)
     dependencies: list[str] = field(default_factory=list)
     python_path_dirs: list[Path] = field(default_factory=list)
+    action_gateway_socket: Path | None = None
 
 
 @dataclass

--- a/tracecat/sandbox/unsafe_pid_executor.py
+++ b/tracecat/sandbox/unsafe_pid_executor.py
@@ -36,13 +36,74 @@ module_logger = logging.getLogger(__name__)
 
 SAFE_WRAPPER_SCRIPT = '''
 import asyncio
+import importlib
 import inspect
 import json
+import os
 import sys
 import traceback
 from pathlib import Path
 
+def _install_action_gateway_sdk_transport():
+    socket_path = os.environ.get("TRACECAT__ACTION_GATEWAY_SOCKET")
+    if not socket_path:
+        return
+
+    try:
+        import httpx
+
+        sdk_client = importlib.import_module("tracecat_registry.sdk.client")
+    except ImportError:
+        return
+
+    tracecat_client_cls = getattr(sdk_client, "TracecatClient", None)
+    if tracecat_client_cls is None:
+        return
+
+    if hasattr(tracecat_client_cls, "_request_url_and_transport"):
+        return
+
+    if getattr(tracecat_client_cls, "_tracecat_action_gateway_transport", False):
+        return
+
+    async def request(
+        self,
+        method,
+        path,
+        *,
+        params=None,
+        json=None,
+        headers=None,
+    ):
+        request_headers = self._get_headers()
+        if headers:
+            request_headers.update(headers)
+
+        async with httpx.AsyncClient(
+            transport=httpx.AsyncHTTPTransport(uds=socket_path),
+            timeout=getattr(self, "_timeout", 120.0),
+        ) as client:
+            response = await client.request(
+                method,
+                "http://tracecat-action-gateway/internal" + path,
+                params=params,
+                json=json,
+                headers=request_headers,
+            )
+
+        if not response.is_success:
+            self._handle_error_response(response)
+
+        if not response.content:
+            return None
+
+        return response.json()
+
+    tracecat_client_cls.request = request
+    tracecat_client_cls._tracecat_action_gateway_transport = True
+
 def _init_tracecat_context():
+    _install_action_gateway_sdk_transport()
     try:
         from tracecat_registry.context import init_context_from_env
     except ImportError:

--- a/tracecat/sandbox/wrapper.py
+++ b/tracecat/sandbox/wrapper.py
@@ -11,13 +11,74 @@ The wrapper script is executed inside the nsjail sandbox and handles:
 # to be written to the job directory before execution
 WRAPPER_SCRIPT = '''
 import asyncio
+import importlib
 import inspect
 import json
+import os
 import sys
 import traceback
 from pathlib import Path
 
+def _install_action_gateway_sdk_transport():
+    socket_path = os.environ.get("TRACECAT__ACTION_GATEWAY_SOCKET")
+    if not socket_path:
+        return
+
+    try:
+        import httpx
+
+        sdk_client = importlib.import_module("tracecat_registry.sdk.client")
+    except ImportError:
+        return
+
+    tracecat_client_cls = getattr(sdk_client, "TracecatClient", None)
+    if tracecat_client_cls is None:
+        return
+
+    if hasattr(tracecat_client_cls, "_request_url_and_transport"):
+        return
+
+    if getattr(tracecat_client_cls, "_tracecat_action_gateway_transport", False):
+        return
+
+    async def request(
+        self,
+        method,
+        path,
+        *,
+        params=None,
+        json=None,
+        headers=None,
+    ):
+        request_headers = self._get_headers()
+        if headers:
+            request_headers.update(headers)
+
+        async with httpx.AsyncClient(
+            transport=httpx.AsyncHTTPTransport(uds=socket_path),
+            timeout=getattr(self, "_timeout", 120.0),
+        ) as client:
+            response = await client.request(
+                method,
+                f"http://tracecat-action-gateway/internal{path}",
+                params=params,
+                json=json,
+                headers=request_headers,
+            )
+
+        if not response.is_success:
+            self._handle_error_response(response)
+
+        if not response.content:
+            return None
+
+        return response.json()
+
+    tracecat_client_cls.request = request
+    tracecat_client_cls._tracecat_action_gateway_transport = True
+
 def _init_tracecat_context():
+    _install_action_gateway_sdk_transport()
     try:
         from tracecat_registry.context import init_context_from_env
     except ImportError:


### PR DESCRIPTION
## Summary

- route `core.script.run_python` registry SDK calls through the executor Action Gateway socket when nsjail network access is disabled
- mount the worker-owned Action Gateway socket into the run_python nsjail and expose it via `TRACECAT__ACTION_GATEWAY_SOCKET`
- patch legacy cached registry SDK clients in the run_python wrapper so older artifacts use the gateway transport too
- add a Docker/nsjail regression covering `ctx.client` calls with `allow_network=False`, including a legacy SDK fixture

## Network semantics

- `allow_network` still controls generic outbound egress from the run_python nsjail: when false, the jail keeps an isolated network namespace without pasta/userspace networking.
- By design, Tracecat SDK calls can still reach the executor-owned Action Gateway over the mounted Unix socket. That path is platform-internal API access, not arbitrary internet egress.

## Backward compatibility

- Before this change, `core.script.run_python` had no separate internal API transport. SDK calls used normal HTTP to `TRACECAT__API_URL`, so with nsjail network disabled they failed along with other outbound requests.
- This change adds the missing internal capability: when the Action Gateway is enabled, SDK calls use the mounted Unix socket while generic egress remains controlled by `allow_network`.
- Existing scripts without SDK calls are unchanged; scripts that already set `allow_network=True` keep the same general network behavior; scripts using SDK calls with `allow_network=False` move from unsupported/failing to supported internal platform access.
- If the Action Gateway is disabled or unavailable, the socket env/mount is omitted and the SDK falls back to the previous API URL path.
- Cached legacy registry SDK artifacts are covered by the wrapper shim, so older package trees can use the gateway transport without being rebuilt first.

## Validation

- `uv run pytest tests/unit/executor/test_run_python_sdk_context.py -q`
- `uv run ruff check tracecat/sandbox/types.py tracecat/sandbox/executor.py tracecat/sandbox/service.py tracecat/sandbox/wrapper.py tracecat/executor/backends/base.py tests/unit/executor/test_run_python_sdk_context.py`
- `uv run basedpyright tracecat/sandbox/types.py tracecat/sandbox/executor.py tracecat/sandbox/service.py tracecat/sandbox/wrapper.py tracecat/executor/backends/base.py tests/unit/executor/test_run_python_sdk_context.py`
- local cluster smoke: ephemeral backend + nsjail enabled, `ctx.cases.list_cases()` routed via `GET /internal/cases` through Action Gateway with HTTP 200

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `core.script.run_python` SDK calls through the internal Action Gateway when nsjail network is off, so `ctx.client` works without outbound egress. Also adds PID fallback support and legacy SDK shims so gateway routing works across both sandbox modes.

- **Bug Fixes**
  - Mounts the Action Gateway socket into nsjail at `/var/run/tracecat/action-gateway.sock` and exposes `TRACECAT__ACTION_GATEWAY_SOCKET`.
  - Resolves the socket env to the sandbox path in nsjail and the host path in the unsafe PID executor.
  - Patches both run_python wrappers (nsjail and PID) to shim legacy `tracecat_registry` clients to use `httpx` UDS when the env var is set.
  - Wires the socket path from the executor (`action_gateway_socket_path()`) through `SandboxService`/`SandboxConfig`, and adds tests for gateway routing with `allow_network=False`, the nsjail mount, a Docker gateway harness, and a PID fallback test with a legacy SDK.

<sup>Written for commit 3be05de81c9fb2892de7a2b0d0478e722a358928. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2740?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

