### PR TITLE
fix(integrations): allow RunReveal MCP OAuth host

### DIFF
--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -11,6 +11,7 @@ This test suite covers MCP integration functionality including:
 import uuid
 from urllib.parse import parse_qs, urlparse
 
+import httpx
 import pytest
 from pydantic import SecretStr, TypeAdapter
 from sqlalchemy import select
@@ -23,9 +24,11 @@ from tracecat.authz.scopes import ADMIN_SCOPES
 from tracecat.db.models import AgentPreset, MCPIntegration, OAuthIntegration
 from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
 from tracecat.integrations.providers.base import (
+    DynamicRegistrationResult,
     MCPAuthProvider,
     OAuthDiscoveryResult,
 )
+from tracecat.integrations.providers.runreveal.mcp import RunRevealMCPProvider
 from tracecat.integrations.providers.sentry.mcp import SentryMCPProvider
 from tracecat.integrations.providers.wiz.mcp import WizMCPProvider
 from tracecat.integrations.schemas import (
@@ -1262,6 +1265,32 @@ class TestMCPIntegrationEdgeCases:
 class TestMCPProviderOAuth:
     """Test MCP OAuth provider behavior and OAuth discovery."""
 
+    def _mock_async_discovery(
+        self, monkeypatch: pytest.MonkeyPatch, discovery_doc: dict[str, object]
+    ) -> None:
+        class FakeAsyncClient:
+            async def __aenter__(self) -> "FakeAsyncClient":
+                return self
+
+            async def __aexit__(self, *args: object) -> None:
+                _ = args
+
+            async def get(self, url: str, *, timeout: float) -> httpx.Response:
+                assert timeout == 10.0
+                assert url == (
+                    "https://api.runreveal.com/.well-known/oauth-authorization-server"
+                )
+                return httpx.Response(
+                    200,
+                    json=discovery_doc,
+                    request=httpx.Request("GET", url),
+                )
+
+        monkeypatch.setattr(
+            "tracecat.integrations.providers.base.httpx.AsyncClient",
+            FakeAsyncClient,
+        )
+
     async def test_wiz_provider_resource_uses_trailing_slash(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1339,6 +1368,70 @@ class TestMCPProviderOAuth:
             getattr(provider.client, "token_endpoint_auth_method", None)
             == "client_secret_post"
         )
+
+    async def test_runreveal_provider_allows_discovered_www_api_oauth_host(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """RunReveal serves MCP and OAuth endpoints from separate fixed hosts."""
+        discovery_doc = {
+            "authorization_endpoint": "https://www-api.runreveal.com/oauth/authorize",
+            "token_endpoint": "https://www-api.runreveal.com/oauth/token",
+            "registration_endpoint": "https://www-api.runreveal.com/oauth/client",
+            "token_endpoint_auth_methods_supported": ["client_secret_post", "none"],
+        }
+        self._mock_async_discovery(monkeypatch, discovery_doc)
+
+        async def fake_register(
+            cls,
+            *,
+            registration_endpoint: str,
+            registration_auth_method: str | None,
+            logger_instance,
+        ) -> DynamicRegistrationResult:
+            _ = cls, logger_instance
+            assert registration_endpoint == "https://www-api.runreveal.com/oauth/client"
+            assert registration_auth_method == "client_secret_post"
+            return DynamicRegistrationResult(
+                client_id="runreveal-client",
+                client_secret="runreveal-secret",
+                auth_method=registration_auth_method,
+            )
+
+        monkeypatch.setattr(
+            RunRevealMCPProvider,
+            "_perform_dynamic_registration_async",
+            classmethod(fake_register),
+        )
+
+        provider = await RunRevealMCPProvider.instantiate()
+
+        assert provider.client_id == "runreveal-client"
+        assert provider.client_secret == "runreveal-secret"
+        assert (
+            provider.authorization_endpoint
+            == "https://www-api.runreveal.com/oauth/authorize"
+        )
+        assert provider.token_endpoint == "https://www-api.runreveal.com/oauth/token"
+        assert provider._registration_endpoint == (
+            "https://www-api.runreveal.com/oauth/client"
+        )
+
+    async def test_runreveal_provider_rejects_unallowed_discovered_oauth_host(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """RunReveal only allows its exact alternate OAuth host."""
+        discovery_doc = {
+            "authorization_endpoint": "https://evil.example/oauth/authorize",
+            "token_endpoint": "https://evil.example/oauth/token",
+            "registration_endpoint": "https://evil.example/oauth/client",
+            "token_endpoint_auth_methods_supported": ["none"],
+        }
+        self._mock_async_discovery(monkeypatch, discovery_doc)
+
+        with pytest.raises(ValueError, match="Could not discover OAuth endpoints"):
+            await RunRevealMCPProvider.instantiate()
 
     async def test_sentry_provider_uses_mcp_resource_path(
         self,

--- a/tracecat/integrations/providers/base.py
+++ b/tracecat/integrations/providers/base.py
@@ -630,6 +630,7 @@ class MCPAuthProvider(AuthorizationCodeOAuthProvider):
     """
 
     mcp_server_uri: ClassVar[str]
+    oauth_endpoint_allowed_hosts: ClassVar[frozenset[str]] = frozenset()
     # Optional fallback endpoints for when discovery fails
     _fallback_auth_endpoint: ClassVar[str | None] = None
     _fallback_token_endpoint: ClassVar[str | None] = None
@@ -727,6 +728,27 @@ class MCPAuthProvider(AuthorizationCodeOAuthProvider):
 
         return f"https://{parsed.netloc}"
 
+    @classmethod
+    def _validate_discovered_oauth_endpoint(
+        cls, endpoint: str, base_domain: str | None
+    ) -> None:
+        """Validate an endpoint from MCP OAuth discovery.
+
+        By default, discovered endpoints must live on the MCP resource server host
+        or its subdomains. Some providers publish their OAuth endpoints on a
+        separate exact host; those providers can opt in with
+        ``oauth_endpoint_allowed_hosts`` without relaxing validation globally.
+        """
+
+        try:
+            validate_oauth_endpoint(endpoint, base_domain)
+        except ValueError:
+            hostname = urlparse(endpoint).hostname
+            if hostname and hostname in cls.oauth_endpoint_allowed_hosts:
+                validate_oauth_endpoint(endpoint)
+                return
+            raise
+
     def _discover_oauth_endpoints(
         self,
         *,
@@ -752,12 +774,14 @@ class MCPAuthProvider(AuthorizationCodeOAuthProvider):
 
                 # Validate discovered endpoints for security
                 base_domain = urlparse(base_url).hostname
-                validate_oauth_endpoint(auth_endpoint, base_domain)
-                validate_oauth_endpoint(token_endpoint, base_domain)
+                self._validate_discovered_oauth_endpoint(auth_endpoint, base_domain)
+                self._validate_discovered_oauth_endpoint(token_endpoint, base_domain)
 
                 registration_endpoint = discovery_doc.get("registration_endpoint")
                 if registration_endpoint:
-                    validate_oauth_endpoint(registration_endpoint, base_domain)
+                    self._validate_discovered_oauth_endpoint(
+                        registration_endpoint, base_domain
+                    )
 
                 self.logger.info(
                     "Discovered OAuth endpoints",
@@ -849,10 +873,12 @@ class MCPAuthProvider(AuthorizationCodeOAuthProvider):
 
             # Validate discovered endpoints for security
             base_domain = urlparse(base_url).hostname
-            validate_oauth_endpoint(authorization_endpoint, base_domain)
-            validate_oauth_endpoint(token_endpoint, base_domain)
+            cls._validate_discovered_oauth_endpoint(authorization_endpoint, base_domain)
+            cls._validate_discovered_oauth_endpoint(token_endpoint, base_domain)
             if registration_endpoint:
-                validate_oauth_endpoint(registration_endpoint, base_domain)
+                cls._validate_discovered_oauth_endpoint(
+                    registration_endpoint, base_domain
+                )
 
             logger_instance.info(
                 "Discovered OAuth endpoints",

--- a/tracecat/integrations/providers/runreveal/mcp.py
+++ b/tracecat/integrations/providers/runreveal/mcp.py
@@ -23,6 +23,12 @@ class RunRevealMCPProvider(MCPAuthProvider):
     # MCP server endpoint - OAuth endpoints discovered automatically
     mcp_server_uri: ClassVar[str] = "https://api.runreveal.com/mcp"
 
+    # RunReveal's MCP resource server is api.runreveal.com, while OAuth endpoints
+    # discovered from it are served from www-api.runreveal.com.
+    oauth_endpoint_allowed_hosts: ClassVar[frozenset[str]] = frozenset(
+        {"www-api.runreveal.com"}
+    )
+
     # No default scopes - authorization server determines based on user/workspace permissions
     scopes: ClassVar[ProviderScopes] = ProviderScopes(default=[])
 


### PR DESCRIPTION
## Summary
- allow MCP providers to opt into exact alternate OAuth endpoint hosts during discovery
- configure RunReveal MCP to accept OAuth endpoints on `www-api.runreveal.com`
- add RunReveal tests for the accepted split-host flow and rejection of unrelated hosts

## Root cause
RunReveal's MCP resource server is `https://api.runreveal.com/mcp`, but its OAuth discovery document returns authorization, token, and registration endpoints under `https://www-api.runreveal.com`. Tracecat's MCP discovery validation only allowed same-host or subdomain OAuth endpoints, so provider instantiation failed before authorization could start.

## Validation
- `uv run pytest tests/unit/test_mcp_integrations.py -k runreveal`
- `uv run ruff check tracecat/integrations/providers tests/unit/test_mcp_integrations.py`
- `uv run ruff format --check tracecat/integrations/providers tests/unit/test_mcp_integrations.py`
- Live RunReveal discovery sanity check resolved `www-api.runreveal.com` endpoints successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OAuth discovery for RunReveal MCP by allowing its OAuth endpoints on `www-api.runreveal.com` while the MCP resource is on `api.runreveal.com`. This unblocks provider instantiation and keeps strict host validation for all other providers.

- **Bug Fixes**
  - Added `oauth_endpoint_allowed_hosts` opt-in to `MCPAuthProvider` and validated discovered endpoints against exact allowed hosts.
  - Allowed `www-api.runreveal.com` in `RunRevealMCPProvider`.
  - Added tests for the split-host success path and for rejecting unrelated hosts.

<sup>Written for commit c39a7fb194ab9aeda5636845da683c4a8d69e92e. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2741?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

