### PR TITLE
fix(sandbox): fail fast on missing gateway socket

### DIFF
--- a/tests/unit/executor/test_run_python_sdk_context.py
+++ b/tests/unit/executor/test_run_python_sdk_context.py
@@ -37,7 +37,11 @@ from tracecat.executor.backends.ephemeral import EphemeralBackend
 from tracecat.executor.schemas import ActionImplementation, ResolvedContext
 from tracecat.identifiers.workflow import ExecutionUUID, WorkflowUUID
 from tracecat.registry.lock.types import RegistryLock
-from tracecat.sandbox import SandboxService, validate_run_python_script
+from tracecat.sandbox import (
+    SandboxExecutionError,
+    SandboxService,
+    validate_run_python_script,
+)
 from tracecat.sandbox.executor import NsjailExecutor
 from tracecat.sandbox.types import SandboxConfig, SandboxResult
 from tracecat.sandbox.unsafe_pid_executor import (
@@ -874,19 +878,18 @@ def test_nsjail_config_mounts_run_python_action_gateway_socket(
     ) in config_text
 
 
-def test_run_python_action_gateway_env_omits_missing_socket(tmp_path: Path) -> None:
+def test_run_python_action_gateway_env_rejects_missing_socket(tmp_path: Path) -> None:
     env_vars = {"CUSTOM_VALUE": "kept"}
 
-    resolved_env = SandboxService._with_action_gateway_socket_env(
-        env_vars,
-        socket_path=tmp_path / "missing-action-gateway.sock",
-    )
-
-    assert resolved_env == {"CUSTOM_VALUE": "kept"}
+    with pytest.raises(SandboxExecutionError, match="socket is unavailable"):
+        SandboxService._with_action_gateway_socket_env(
+            env_vars,
+            socket_path=tmp_path / "missing-action-gateway.sock",
+        )
 
 
 @pytest.mark.anyio
-async def test_run_python_nsjail_omits_missing_action_gateway_socket(
+async def test_run_python_nsjail_rejects_missing_action_gateway_socket(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -895,16 +898,13 @@ async def test_run_python_nsjail_omits_missing_action_gateway_socket(
     monkeypatch.setattr(service, "_nsjail_executor", nsjail_executor)
     monkeypatch.setattr(service, "_is_nsjail_available", lambda: True)
 
-    result = await service.run_python(
-        script="def main():\n    return 1",
-        env_vars={"CUSTOM_VALUE": "kept"},
-        action_gateway_socket=tmp_path / "missing-action-gateway.sock",
-    )
-
-    assert result == {"ok": True}
-    assert nsjail_executor.config is not None
-    assert nsjail_executor.config.action_gateway_socket is None
-    assert nsjail_executor.config.env_vars == {"CUSTOM_VALUE": "kept"}
+    with pytest.raises(SandboxExecutionError, match="socket is unavailable"):
+        await service.run_python(
+            script="def main():\n    return 1",
+            env_vars={"CUSTOM_VALUE": "kept"},
+            action_gateway_socket=tmp_path / "missing-action-gateway.sock",
+        )
+    assert nsjail_executor.config is None
 
 
 def test_nsjail_env_map_prefers_installed_dependencies_over_registry_mounts(

--- a/tests/unit/executor/test_run_python_sdk_context.py
+++ b/tests/unit/executor/test_run_python_sdk_context.py
@@ -39,7 +39,7 @@ from tracecat.identifiers.workflow import ExecutionUUID, WorkflowUUID
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.sandbox import SandboxService, validate_run_python_script
 from tracecat.sandbox.executor import NsjailExecutor
-from tracecat.sandbox.types import SandboxConfig
+from tracecat.sandbox.types import SandboxConfig, SandboxResult
 from tracecat.sandbox.unsafe_pid_executor import (
     SAFE_WRAPPER_SCRIPT as UNSAFE_PID_WRAPPER_SCRIPT,
 )
@@ -87,6 +87,20 @@ class _FakeTracecatClient:
     @property
     def cases(self) -> _FakeCasesClient:
         return _FakeCasesClient()
+
+
+class _CapturingNsjailExecutor:
+    def __init__(self) -> None:
+        self.config: SandboxConfig | None = None
+
+    async def execute(
+        self,
+        _job_dir: Path,
+        config: SandboxConfig,
+        _cache_key: str | None,
+    ) -> SandboxResult:
+        self.config = config
+        return SandboxResult(success=True, output={"ok": True})
 
 
 def _run_wrapper_source(
@@ -843,6 +857,7 @@ def test_nsjail_config_mounts_run_python_action_gateway_socket(
     tmp_path: Path,
 ) -> None:
     action_gateway_socket = tmp_path / "action-gateway.sock"
+    action_gateway_socket.touch()
     sandbox_config = SandboxConfig(
         action_gateway_socket=action_gateway_socket,
     )
@@ -857,6 +872,39 @@ def test_nsjail_config_mounts_run_python_action_gateway_socket(
         f'mount {{ src: "{action_gateway_socket}" '
         f'dst: "{ACTION_GATEWAY_SANDBOX_SOCKET}" is_bind: true rw: false }}'
     ) in config_text
+
+
+def test_run_python_action_gateway_env_omits_missing_socket(tmp_path: Path) -> None:
+    env_vars = {"CUSTOM_VALUE": "kept"}
+
+    resolved_env = SandboxService._with_action_gateway_socket_env(
+        env_vars,
+        socket_path=tmp_path / "missing-action-gateway.sock",
+    )
+
+    assert resolved_env == {"CUSTOM_VALUE": "kept"}
+
+
+@pytest.mark.anyio
+async def test_run_python_nsjail_omits_missing_action_gateway_socket(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    service = SandboxService(cache_dir=str(tmp_path / "sandbox-cache"))
+    nsjail_executor = _CapturingNsjailExecutor()
+    monkeypatch.setattr(service, "_nsjail_executor", nsjail_executor)
+    monkeypatch.setattr(service, "_is_nsjail_available", lambda: True)
+
+    result = await service.run_python(
+        script="def main():\n    return 1",
+        env_vars={"CUSTOM_VALUE": "kept"},
+        action_gateway_socket=tmp_path / "missing-action-gateway.sock",
+    )
+
+    assert result == {"ok": True}
+    assert nsjail_executor.config is not None
+    assert nsjail_executor.config.action_gateway_socket is None
+    assert nsjail_executor.config.env_vars == {"CUSTOM_VALUE": "kept"}
 
 
 def test_nsjail_env_map_prefers_installed_dependencies_over_registry_mounts(

--- a/tracecat/sandbox/service.py
+++ b/tracecat/sandbox/service.py
@@ -122,7 +122,7 @@ class SandboxService:
         env_socket_path: Path | None = None,
     ) -> dict[str, str] | None:
         """Return env vars with Action Gateway socket routing when configured."""
-        resolved_socket_path = SandboxService._resolve_action_gateway_socket(
+        resolved_socket_path = SandboxService._require_action_gateway_socket(
             socket_path
         )
         if resolved_socket_path is None:
@@ -135,10 +135,14 @@ class SandboxService:
         return updated
 
     @staticmethod
-    def _resolve_action_gateway_socket(socket_path: Path | None) -> Path | None:
-        """Return the Action Gateway socket path only when it is available."""
-        if socket_path is None or not socket_path.exists():
+    def _require_action_gateway_socket(socket_path: Path | None) -> Path | None:
+        """Return a configured Action Gateway socket or fail if it is unavailable."""
+        if socket_path is None:
             return None
+        if not socket_path.exists():
+            raise SandboxExecutionError(
+                f"Action Gateway socket is unavailable: {socket_path}"
+            )
         return socket_path
 
     @asynccontextmanager
@@ -355,7 +359,7 @@ class SandboxService:
         """
         if timeout_seconds is None:
             timeout_seconds = TRACECAT__SANDBOX_DEFAULT_TIMEOUT
-        resolved_action_gateway_socket = self._resolve_action_gateway_socket(
+        resolved_action_gateway_socket = self._require_action_gateway_socket(
             action_gateway_socket
         )
 
@@ -448,7 +452,7 @@ class SandboxService:
         """
         if timeout_seconds is None:
             timeout_seconds = TRACECAT__SANDBOX_DEFAULT_TIMEOUT
-        resolved_action_gateway_socket = self._resolve_action_gateway_socket(
+        resolved_action_gateway_socket = self._require_action_gateway_socket(
             action_gateway_socket
         )
 

--- a/tracecat/sandbox/service.py
+++ b/tracecat/sandbox/service.py
@@ -122,12 +122,24 @@ class SandboxService:
         env_socket_path: Path | None = None,
     ) -> dict[str, str] | None:
         """Return env vars with Action Gateway socket routing when configured."""
-        if socket_path is None:
+        resolved_socket_path = SandboxService._resolve_action_gateway_socket(
+            socket_path
+        )
+        if resolved_socket_path is None:
             return env_vars
 
         updated = dict(env_vars or {})
-        updated["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(env_socket_path or socket_path)
+        updated["TRACECAT__ACTION_GATEWAY_SOCKET"] = str(
+            env_socket_path or resolved_socket_path
+        )
         return updated
+
+    @staticmethod
+    def _resolve_action_gateway_socket(socket_path: Path | None) -> Path | None:
+        """Return the Action Gateway socket path only when it is available."""
+        if socket_path is None or not socket_path.exists():
+            return None
+        return socket_path
 
     @asynccontextmanager
     async def _create_job_dir(self) -> AsyncIterator[Path]:
@@ -343,6 +355,9 @@ class SandboxService:
         """
         if timeout_seconds is None:
             timeout_seconds = TRACECAT__SANDBOX_DEFAULT_TIMEOUT
+        resolved_action_gateway_socket = self._resolve_action_gateway_socket(
+            action_gateway_socket
+        )
 
         # Route to appropriate executor based on nsjail availability
         if self._is_nsjail_available():
@@ -356,7 +371,7 @@ class SandboxService:
                 env_vars=env_vars,
                 python_path_dirs=python_path_dirs,
                 workspace_id=workspace_id,
-                action_gateway_socket=action_gateway_socket,
+                action_gateway_socket=resolved_action_gateway_socket,
             )
         else:
             logger.info(
@@ -367,7 +382,7 @@ class SandboxService:
             )
             resolved_env_vars = self._with_action_gateway_socket_env(
                 env_vars,
-                socket_path=action_gateway_socket,
+                socket_path=resolved_action_gateway_socket,
             )
             result = await self.unsafe_pid_executor.execute(
                 script=script,
@@ -433,6 +448,9 @@ class SandboxService:
         """
         if timeout_seconds is None:
             timeout_seconds = TRACECAT__SANDBOX_DEFAULT_TIMEOUT
+        resolved_action_gateway_socket = self._resolve_action_gateway_socket(
+            action_gateway_socket
+        )
 
         async with self._create_job_dir() as job_dir:
             cache_key = None
@@ -469,13 +487,13 @@ class SandboxService:
                 ),
                 env_vars=self._with_action_gateway_socket_env(
                     env_vars,
-                    socket_path=action_gateway_socket,
+                    socket_path=resolved_action_gateway_socket,
                     env_socket_path=RUN_PYTHON_ACTION_GATEWAY_SOCKET,
                 )
                 or {},
                 dependencies=dependencies or [],
                 python_path_dirs=python_path_dirs or [],
-                action_gateway_socket=action_gateway_socket,
+                action_gateway_socket=resolved_action_gateway_socket,
             )
 
             await self._prepare_execution(job_dir, script, inputs)


### PR DESCRIPTION
## Summary
- Fail fast when `run_python` receives a configured Action Gateway socket path that does not exist.
- Keep gateway routing disabled only when no socket path is configured.
- Reuse the validated socket path for both sandbox env injection and nsjail bind mounts.
- Add focused regressions for missing socket failure behavior.

## Rationale
When Action Gateway routing is enabled, executor-owned SDK/action calls are expected to use the gateway socket rather than falling back to direct API routing. A configured-but-missing socket means the executor gateway did not start, was removed, or is misconfigured. Failing before sandbox execution makes that infrastructure problem explicit and avoids silently weakening the gateway-routing invariant.

## Tests
- `uv run pytest tests/unit/executor/test_run_python_sdk_context.py -k "missing_socket or action_gateway_socket"`
- `uv run ruff check tracecat/sandbox/service.py tests/unit/executor/test_run_python_sdk_context.py`
- `uv run ruff format --check tracecat/sandbox/service.py tests/unit/executor/test_run_python_sdk_context.py`
- `uv run pyright tracecat/sandbox/service.py tests/unit/executor/test_run_python_sdk_context.py`
