### PR TITLE
fix(agent): align agent executor drain timeout

### DIFF
--- a/tests/unit/test_worker_activity_registration.py
+++ b/tests/unit/test_worker_activity_registration.py
@@ -156,13 +156,18 @@ async def test_agent_executor_worker_treats_empty_numeric_env_vars_as_defaults(
         "TRACECAT__AGENT_EXECUTOR_QUEUE",
         "test-agent-executor-queue",
     )
+    monkeypatch.setattr(
+        executor_worker.config,
+        "TRACECAT__AGENT_EXECUTOR_GRACEFUL_SHUTDOWN_TIMEOUT",
+        1860,
+    )
     await executor_worker.main(shutdown_event=shutdown_event)
 
     assert captured == {
         "task_queue": "test-agent-executor-queue",
         "max_concurrent_activities": 1,
         "threadpool_max_workers": 100,
-        "graceful_shutdown_timeout": timedelta(minutes=5),
+        "graceful_shutdown_timeout": timedelta(seconds=1860),
     }
 
 

--- a/tracecat/agent/executor_worker.py
+++ b/tracecat/agent/executor_worker.py
@@ -97,7 +97,9 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
                 max_concurrent_activities=max_concurrent,
                 disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
                 activity_executor=executor,
-                graceful_shutdown_timeout=timedelta(minutes=5),
+                graceful_shutdown_timeout=timedelta(
+                    seconds=config.TRACECAT__AGENT_EXECUTOR_GRACEFUL_SHUTDOWN_TIMEOUT
+                ),
             ):
                 logger.info("AgentExecutorWorker started, ctrl+c to exit")
                 await shutdown_event.wait()

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -687,6 +687,17 @@ TRACECAT__AGENT_SANDBOX_TIMEOUT = int(
 )
 """Default timeout for agent sandbox execution in seconds (30 minutes)."""
 
+TRACECAT__AGENT_EXECUTOR_GRACEFUL_SHUTDOWN_TIMEOUT = int(
+    os.environ.get("TRACECAT__AGENT_EXECUTOR_GRACEFUL_SHUTDOWN_TIMEOUT")
+    or (TRACECAT__AGENT_SANDBOX_TIMEOUT + 60)
+)
+"""Agent executor worker drain timeout in seconds.
+
+Defaults to the agent sandbox timeout plus a small buffer so planned worker
+shutdowns can let active agent activities finish instead of interrupting the
+sandbox.
+"""
+
 TRACECAT__AGENT_SANDBOX_MEMORY_MB = int(
     os.environ.get("TRACECAT__AGENT_SANDBOX_MEMORY_MB") or 4096
 )


### PR DESCRIPTION
## Summary
- Add a configurable agent executor graceful shutdown timeout.
- Default the worker drain window to the sandbox timeout plus 60 seconds.
- Assert the agent executor worker passes the configured drain timeout into Temporal's `Worker`.

## Context
The agent executor worker previously used a hardcoded 5 minute `graceful_shutdown_timeout`, while agent sandbox activity execution can run for 30 minutes by default. This meant planned worker shutdown could interrupt an otherwise valid long-running agent activity before the activity's own timeout.

This PR aligns the Temporal worker drain timeout with the sandbox timeout so planned shutdowns can drain active agent activities instead of forcing early interruption.

## Follow-up
The standalone Kubernetes chart is tracked through the `deployments/k8s` submodule and already has unrelated local changes in this checkout, so this PR does not change chart values. A companion chart update may be needed so the pod termination grace period is at least as long as the worker drain timeout.

## Validation
- `uv run pytest tests/unit/test_worker_activity_registration.py`
- `uv run ruff check tests/unit/test_worker_activity_registration.py tracecat/config.py tracecat/agent/executor_worker.py`
- `uv run ruff format --check tests/unit/test_worker_activity_registration.py tracecat/config.py tracecat/agent/executor_worker.py`
- `uv run basedpyright tests/unit/test_worker_activity_registration.py tracecat/config.py tracecat/agent/executor_worker.py`
- `git diff --check -- tests/unit/test_worker_activity_registration.py tracecat/agent/executor_worker.py tracecat/config.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the agent executor drain timeout with the sandbox timeout so planned shutdowns drain long-running activities instead of aborting them. Adds a configurable `TRACECAT__AGENT_EXECUTOR_GRACEFUL_SHUTDOWN_TIMEOUT` that defaults to sandbox timeout + 60s.

- **Bug Fixes**
  - Pass the configured drain timeout to the `Temporal` `Worker` in the agent executor.
  - Default drain timeout to `TRACECAT__AGENT_SANDBOX_TIMEOUT + 60` seconds; override via `TRACECAT__AGENT_EXECUTOR_GRACEFUL_SHUTDOWN_TIMEOUT`.
  - Added a unit test to verify the timeout is propagated.

- **Migration**
  - If running on Kubernetes, set pod `terminationGracePeriodSeconds` to at least the configured drain timeout.

<sup>Written for commit 74af4ac4ad247866dbc224a903f73ae800561237. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2743?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

