### PR TITLE
fix: extend dev seed readiness timeout

### DIFF
--- a/scripts/cluster
+++ b/scripts/cluster
@@ -1163,10 +1163,10 @@ fi
 # Function to seed a tenant dev user after cluster starts
 seed_dev_user() {
     local api_url="http://localhost:${PUBLIC_APP_PORT}/api"
-    local max_attempts=60
+    local max_attempts=150
     local attempt=1
 
-    echo "[dev-seed] Waiting for API to be ready..."
+    echo "[dev-seed] Waiting for API to be ready (up to 5 minutes)..."
     while [[ $attempt -le $max_attempts ]]; do
         # Use /ready endpoint which checks full startup completion (not /health which returns immediately)
         local status_code
@@ -1180,7 +1180,7 @@ seed_dev_user() {
     done
 
     if [[ $attempt -gt $max_attempts ]]; then
-        echo "[dev-seed] Warning: API did not become ready in time, skipping dev seed"
+        echo "[dev-seed] Warning: API did not become ready within 5 minutes, skipping dev seed"
         return 1
     fi
 


### PR DESCRIPTION
## Summary

- Increase the dev cluster seed readiness wait from 2 minutes to 5 minutes.
- Update dev-seed status messages to report the 5-minute wait budget.

## Testing

- `bash -n scripts/cluster`
- `shellcheck -x scripts/cluster`
- `uv run ruff check .`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase dev-seed API readiness wait in `scripts/cluster` from 2 to 5 minutes to reduce flakiness on slower startups. Updated log messages to reflect the 5-minute wait window.

<sup>Written for commit 15fc83c3f33091501c8423ce8fad5767cf88d70a. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2744?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

