### PR TITLE
security(mcp): drop destructive case delete tools

### DIFF
--- a/docs/snippets/mcp-tools.mdx
+++ b/docs/snippets/mcp-tools.mdx
@@ -164,9 +164,6 @@
     <ResponseField name="cases_update_case" type="tool">
   Update a case. Only provided fields are changed.
     </ResponseField>
-    <ResponseField name="cases_delete_case" type="tool">
-  Delete a case.
-    </ResponseField>
     <ResponseField name="cases_list_case_comments" type="tool">
   List all comments for a case.
     </ResponseField>
@@ -193,9 +190,6 @@
     </ResponseField>
     <ResponseField name="cases_update_case_task" type="tool">
   Update a case task. Only provided fields are changed.
-    </ResponseField>
-    <ResponseField name="cases_delete_case_task" type="tool">
-  Delete a case task.
     </ResponseField>
     <ResponseField name="cases_run_case_task" type="tool">
   Run the workflow associated with a case task.
@@ -242,9 +236,6 @@
     </ResponseField>
     <ResponseField name="cases_update_case_field" type="tool">
   Update a case field definition.
-    </ResponseField>
-    <ResponseField name="cases_delete_case_field" type="tool">
-  Delete a case field definition.
     </ResponseField>
   </Expandable>
 </ResponseField>

--- a/scripts/tests/test_action_doc_links.py
+++ b/scripts/tests/test_action_doc_links.py
@@ -64,7 +64,9 @@ async def _check_url(
 ) -> tuple[int | None, str | None]:
     async with semaphore:
         try:
-            response = await client.get(url, follow_redirects=True)
+            response = await client.head(url, follow_redirects=True)
+            if response.status_code in {405, 501}:
+                response = await client.get(url, follow_redirects=True)
         except httpx.HTTPError as exc:
             return None, f"{type(exc).__name__}: {exc}"
         return response.status_code, None

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -3715,34 +3715,6 @@ async def test_update_case_field_parses_type_and_options(monkeypatch):
     assert "updated successfully" in payload["message"]
 
 
-@pytest.mark.anyio
-async def test_delete_case_field(monkeypatch):
-    async def _resolve(_workspace_id):
-        return uuid.uuid4(), SimpleNamespace()
-
-    captured: dict[str, Any] = {}
-
-    async def _delete_field(field_id):
-        captured["field_id"] = field_id
-
-    field_service = SimpleNamespace(delete_field=_delete_field)
-
-    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(
-        mcp_server,
-        "CaseFieldsService",
-        SimpleNamespace(with_session=lambda role: _AsyncContext(field_service)),
-    )
-
-    result = await _tool(mcp_server.delete_case_field)(
-        workspace_id=str(uuid.uuid4()),
-        field_id="severity_band",
-    )
-    payload = _payload(result)
-    assert captured["field_id"] == "severity_band"
-    assert "deleted successfully" in payload["message"]
-
-
 # ---------------------------------------------------------------------------
 # Case CRUD tests
 # ---------------------------------------------------------------------------
@@ -4173,63 +4145,6 @@ async def test_update_case_not_found(monkeypatch):
             workspace_id=str(uuid.uuid4()),
             case_id=str(uuid.uuid4()),
             summary="Won't work",
-        )
-
-
-@pytest.mark.anyio
-async def test_delete_case(monkeypatch):
-    async def _resolve(_workspace_id):
-        return uuid.uuid4(), SimpleNamespace()
-
-    case_id = uuid.uuid4()
-    case = SimpleNamespace(id=case_id)
-    deleted = []
-
-    async def _get_case(parsed_id, **kwargs):
-        return case
-
-    async def _delete_case(c):
-        deleted.append(c.id)
-
-    cases_service = SimpleNamespace(get_case=_get_case, delete_case=_delete_case)
-
-    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(
-        mcp_server,
-        "CasesService",
-        SimpleNamespace(with_session=lambda role: _AsyncContext(cases_service)),
-    )
-
-    result = await _tool(mcp_server.delete_case)(
-        workspace_id=str(uuid.uuid4()),
-        case_id=str(case_id),
-    )
-    payload = _payload(result)
-    assert "deleted successfully" in payload["message"]
-    assert deleted == [case_id]
-
-
-@pytest.mark.anyio
-async def test_delete_case_not_found(monkeypatch):
-    async def _resolve(_workspace_id):
-        return uuid.uuid4(), SimpleNamespace()
-
-    async def _get_case(parsed_id, **kwargs):
-        return None
-
-    cases_service = SimpleNamespace(get_case=_get_case)
-
-    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(
-        mcp_server,
-        "CasesService",
-        SimpleNamespace(with_session=lambda role: _AsyncContext(cases_service)),
-    )
-
-    with pytest.raises(ToolError, match="not found"):
-        await _tool(mcp_server.delete_case)(
-            workspace_id=str(uuid.uuid4()),
-            case_id=str(uuid.uuid4()),
         )
 
 
@@ -4848,42 +4763,6 @@ async def test_update_case_task_wrong_case(monkeypatch):
             task_id=str(task_id),
             status="completed",
         )
-
-
-@pytest.mark.anyio
-async def test_delete_case_task(monkeypatch):
-    async def _resolve(_workspace_id):
-        return uuid.uuid4(), SimpleNamespace()
-
-    case_id = uuid.uuid4()
-    task_id = uuid.uuid4()
-    deleted = []
-
-    existing_task = SimpleNamespace(id=task_id, case_id=case_id)
-
-    async def _get_task(parsed_task_id):
-        return existing_task
-
-    async def _delete_task(parsed_task_id):
-        deleted.append(parsed_task_id)
-
-    task_service = SimpleNamespace(get_task=_get_task, delete_task=_delete_task)
-
-    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(
-        mcp_server,
-        "CaseTasksService",
-        SimpleNamespace(with_session=lambda role: _AsyncContext(task_service)),
-    )
-
-    result = await _tool(mcp_server.delete_case_task)(
-        workspace_id=str(uuid.uuid4()),
-        case_id=str(case_id),
-        task_id=str(task_id),
-    )
-    payload = _payload(result)
-    assert "deleted successfully" in payload["message"]
-    assert deleted == [task_id]
 
 
 @pytest.mark.anyio
@@ -6262,6 +6141,17 @@ def test_workflow_file_tools_removed():
         "prepare_workflow_file_upload",
         "create_workflow_from_uploaded_file",
         "update_workflow_from_uploaded_file",
+    }
+    assert removed_tools.isdisjoint(mcp_server._TOOL_NAMESPACE_BY_NAME)
+    for tool_name in removed_tools:
+        assert not hasattr(mcp_server, tool_name)
+
+
+def test_destructive_case_tools_removed():
+    removed_tools = {
+        "delete_case",
+        "delete_case_task",
+        "delete_case_field",
     }
     assert removed_tools.isdisjoint(mcp_server._TOOL_NAMESPACE_BY_NAME)
     for tool_name in removed_tools:

--- a/tracecat/mcp/README.md
+++ b/tracecat/mcp/README.md
@@ -84,7 +84,6 @@ truncation metadata under `truncation.collections`.
 - `list_case_fields(workspace_id, limit=20, cursor=None)` returns field objects with `id`, `type`, `description`, `nullable`, `default`, `reserved`, `options`, and optional `kind`
 - `create_case_field(workspace_id, name, type, kind=None, options=None)` where `kind` is create-only; valid values are `LONG_TEXT` with `type=TEXT` and `URL` with `type=JSONB`
 - `update_case_field(workspace_id, field_id, name=None, type=None, options=None)`
-- `delete_case_field(workspace_id, field_id)`
 
 Case field and table `type` values are:
 - `TEXT`

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -3846,7 +3846,6 @@ _TOOL_NAMESPACE_BY_NAME: dict[str, str] = {
     "get_case": "cases",
     "create_case": "cases",
     "update_case": "cases",
-    "delete_case": "cases",
     "list_case_comments": "cases",
     "list_case_comment_threads": "cases",
     "create_case_comment": "cases",
@@ -3856,7 +3855,6 @@ _TOOL_NAMESPACE_BY_NAME: dict[str, str] = {
     "get_case_task": "cases",
     "create_case_task": "cases",
     "update_case_task": "cases",
-    "delete_case_task": "cases",
     "run_case_task": "cases",
     "list_case_events": "cases",
     "list_case_tags": "cases",
@@ -3869,7 +3867,6 @@ _TOOL_NAMESPACE_BY_NAME: dict[str, str] = {
     "list_case_fields": "cases",
     "create_case_field": "cases",
     "update_case_field": "cases",
-    "delete_case_field": "cases",
     "list_tables": "tables",
     "create_table": "tables",
     "get_table": "tables",
@@ -6326,37 +6323,6 @@ async def update_case(
         raise ToolError(f"Failed to update case: {e}") from None
 
 
-@mcp.tool()
-async def delete_case(
-    workspace_id: uuid.UUID, case_id: uuid.UUID
-) -> MCPMessageResponse:
-    """Delete a case.
-
-    Args:
-        workspace_id: The workspace ID.
-        case_id: Case UUID.
-
-    Returns a confirmation message.
-    """
-
-    try:
-        case_id = _coerce_uuid_arg(case_id, "case_id")
-        _, role = await _resolve_workspace_role(workspace_id)
-        async with CasesService.with_session(role=role) as svc:
-            case = await svc.get_case(case_id)
-            if case is None:
-                raise ToolError(f"Case {case_id!r} not found")
-            await svc.delete_case(case)
-            return MCPMessageResponse(message=f"Case {case_id} deleted successfully")
-    except ToolError:
-        raise
-    except ValueError as e:
-        raise ToolError(str(e)) from e
-    except Exception as e:
-        logger.error("Failed to delete case", error=str(e))
-        raise ToolError(f"Failed to delete case: {e}") from None
-
-
 # ---------------------------------------------------------------------------
 # Case Comments
 # ---------------------------------------------------------------------------
@@ -6771,43 +6737,6 @@ async def update_case_task(
     except Exception as e:
         logger.error("Failed to update case task", error=str(e))
         raise ToolError(f"Failed to update case task: {e}") from None
-
-
-@mcp.tool()
-async def delete_case_task(
-    workspace_id: uuid.UUID,
-    case_id: uuid.UUID,
-    task_id: uuid.UUID,
-) -> MCPMessageResponse:
-    """Delete a case task.
-
-    Args:
-        workspace_id: The workspace ID.
-        case_id: Case UUID (must match the task's parent case).
-        task_id: Task UUID.
-
-    Returns a confirmation message.
-    """
-
-    try:
-        case_id = _coerce_uuid_arg(case_id, "case_id")
-        task_id = _coerce_uuid_arg(task_id, "task_id")
-        _, role = await _resolve_workspace_role(workspace_id)
-        async with CaseTasksService.with_session(role=role) as svc:
-            existing = await svc.get_task(task_id)
-            if existing.case_id != case_id:
-                raise ToolError("Task not found in the specified case")
-            await svc.delete_task(task_id)
-            return MCPMessageResponse(message=f"Task {task_id} deleted successfully")
-    except ToolError:
-        raise
-    except TracecatNotFoundError as e:
-        raise ToolError(str(e)) from e
-    except ValueError as e:
-        raise ToolError(str(e)) from e
-    except Exception as e:
-        logger.error("Failed to delete case task", error=str(e))
-        raise ToolError(f"Failed to delete case task: {e}") from None
 
 
 @mcp.tool()
@@ -7357,33 +7286,6 @@ async def update_case_field(
     except Exception as e:
         logger.error("Failed to update case field", error=str(e))
         raise ToolError(f"Failed to update case field: {e}") from None
-
-
-@mcp.tool()
-async def delete_case_field(
-    workspace_id: uuid.UUID, field_id: str
-) -> MCPMessageResponse:
-    """Delete a case field definition.
-
-    Args:
-        workspace_id: The workspace ID.
-        field_id: Existing field id from `list_case_fields` (field name, not UUID).
-
-    Returns a confirmation message.
-    """
-
-    try:
-        _, role = await _resolve_workspace_role(workspace_id)
-        async with CaseFieldsService.with_session(role=role) as svc:
-            await svc.delete_field(field_id)
-            return MCPMessageResponse(
-                message=f"Case field {field_id} deleted successfully"
-            )
-    except ValueError as e:
-        raise ToolError(str(e)) from e
-    except Exception as e:
-        logger.error("Failed to delete case field", error=str(e))
-        raise ToolError(f"Failed to delete case field: {e}") from None
 
 
 @mcp.tool()

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -2833,7 +2833,7 @@ inputs, results, and errors. This is essential for diagnosing failed runs.
 Action names like `core.http_request` are for use *inside* workflow YAML definitions \
 (in the `action:` field of a workflow action step). They are NOT MCP tool names. \
 To manage cases directly, use the MCP tools `create_case`, `list_cases`, `get_case`, \
-`update_case`, and `delete_case`. Similarly, use `create_workflow` (not \
+and `update_case`. Similarly, use `create_workflow` (not \
 `core.workflow.execute`) to create workflows via MCP.
 
 ## Tag and case field argument rules


### PR DESCRIPTION
## Summary

- Remove `cases_delete_case`, `cases_delete_case_task`, and `cases_delete_case_field` from the Tracecat MCP tool surface.
- Regenerate the public MCP tools snippet so docs no longer advertise those tools.
- Replace direct MCP delete-tool unit tests with a regression assertion that the destructive case tools stay unregistered.
- Make the live action-doc-link checker use `HEAD` before falling back to `GET`, avoiding heavyweight docs downloads that caused Splunk Help timeouts in CI.

## Validation

- `uv run pytest tests/unit/test_mcp_server.py -k "removed or case_task or case_field or case" -q`
- `uv run ruff check tracecat/mcp/server.py tests/unit/test_mcp_server.py`
- `TRACECAT_TEST_ACTION_DOC_LINKS=1 uv run pytest scripts/tests/test_action_doc_links.py -q`
- `uv run ruff check scripts/tests/test_action_doc_links.py`
- Commit hooks: Ruff, Python type check, frontend client generation, MCP docs generation, and secret scan passed.