### PR TITLE
docs: update Helm chart registry access

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Sandboxed-by-default with [`nsjail`](https://github.com/google/nsjail) and run o
 This repo is available under the [AGPL-3.0 license](https://github.com/TracecatHQ/tracecat/blob/main/LICENSE) with the following exceptions:
 
 - `packages/tracecat-ee` directory is under Tracecat's paid EE (Enterprise Edition) license.
-- `deployments/k8s` is a git submodule under the source available [PolyForm Shield License](https://polyformproject.org/licenses/shield/1.0.0/). It contains the Tracecat Helm chart and EKS deployment templates for internal use only, and its chart releases are published from that repo to public ECR.
+- `deployments/k8s` is a git submodule under the source available [PolyForm Shield License](https://polyformproject.org/licenses/shield/1.0.0/). It contains the Tracecat Helm chart and EKS deployment templates for internal use only. The Helm chart is distributed as a private OCI artifact hosted in AWS ECR.
 - Any code that gates `ee` features across the repo
 
 Code that fall under the above exceptions must not be redistributed, sold, or otherwise commercialized without permission.

--- a/docs/self-hosting/kubernetes.mdx
+++ b/docs/self-hosting/kubernetes.mdx
@@ -4,8 +4,8 @@ description: "Deploy self-hosted Tracecat to Kubernetes with the OCI Helm chart:
 ---
 
 <Info>
-  The Tracecat Helm chart is distributed as an OCI artifact hosted in AWS ECR.
-  Contact the Tracecat team at [founders@tracecat.com](mailto:founders@tracecat.com) or via [Discord](https://discord.com/invite/H4XZwsYzY4) for access to the registry for evaluations and internal use.
+  The Tracecat Helm chart is distributed as a private OCI artifact hosted in AWS ECR.
+  Please contact [customer success](https://cal.com/team/tracecat) for access for evaluations or internal enterprise use.
 </Info>
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

- Clarifies that the Tracecat Helm chart is distributed as a private OCI artifact hosted in AWS ECR.
- Replaces the previous founders/Discord registry access path with the customer success booking link.
- Updates the README so it no longer says chart releases are published to public ECR.

## Testing

- `git diff --check -- README.md docs/self-hosting/kubernetes.mdx`
- Pre-commit hooks during `git commit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that the Tracecat Helm chart is a private OCI artifact hosted in AWS ECR and is not published to public ECR. Updates registry access guidance to use the customer success booking link instead of founders/Discord.

<sup>Written for commit b6d0f84de458983e7e557fe1368460c3550a9d7b. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2748?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

