### PR TITLE
feat(agent): add DuckDB CLI to sandbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,41 @@ RUN git clone https://github.com/google/nsjail.git /tmp/nsjail && \
 FROM node:22.13.1-slim AS node-bin
 FROM python:3.12-slim-bookworm AS sandbox-rootfs
 
+ARG TARGETARCH
+ARG DUCKDB_VERSION=1.4.3
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl wget jq iputils-ping && rm -rf /var/lib/apt/lists/*
+
+RUN arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    case "${arch}" in \
+        amd64) duckdb_sha256="c479794045d094058d3092e404e696508d6310b5d234a8c1945b745678f09d8d" ;; \
+        arm64) duckdb_sha256="c709eb3efc74a609af4b92bc885c509a1bd21ddfa71ea1e717420d4dd9fc121b" ;; \
+        *) echo "Unsupported DuckDB CLI architecture: ${arch}" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-${arch}.gz" -o /tmp/duckdb.gz && \
+    echo "${duckdb_sha256}  /tmp/duckdb.gz" | sha256sum -c - && \
+    gunzip /tmp/duckdb.gz && \
+    install -m 0755 /tmp/duckdb /usr/local/bin/duckdb.real && \
+    rm -f /tmp/duckdb && \
+    mkdir -p /usr/local/lib/duckdb/extensions /usr/local/share/duckdb && \
+    /usr/local/bin/duckdb.real -c "SET extension_directory = '/usr/local/lib/duckdb/extensions'; INSTALL json; INSTALL postgres; INSTALL httpfs; INSTALL sqlite; INSTALL inet;" && \
+    printf '%s\n' \
+        "SET extension_directory = '/usr/local/lib/duckdb/extensions';" \
+        "LOAD json;" \
+        "LOAD postgres;" \
+        "LOAD httpfs;" \
+        "LOAD sqlite;" \
+        "LOAD inet;" \
+        > /usr/local/share/duckdb/tracecat-init.sql && \
+    printf '%s\n' \
+        '#!/bin/sh' \
+        'exec /usr/local/bin/duckdb.real -init /usr/local/share/duckdb/tracecat-init.sql "$@"' \
+        > /usr/local/bin/duckdb && \
+    chmod 0755 /usr/local/bin/duckdb && \
+    jq --version && \
+    duckdb --version && \
+    test "$(duckdb -csv -noheader -c "SELECT count(*) FROM duckdb_extensions() WHERE extension_name IN ('json', 'postgres_scanner', 'httpfs', 'sqlite_scanner', 'inet') AND installed AND loaded;")" = "5"
 
 COPY --from=ghcr.io/astral-sh/uv:0.9.15 /uv /usr/local/bin/uv
 COPY --from=ghcr.io/astral-sh/uv:0.9.15 /uvx /usr/local/bin/uvx
@@ -59,11 +92,18 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
 
 # Install runtime packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    acl git openssh-client xmlsec1 libmagic1 curl ca-certificates \
+    acl git openssh-client xmlsec1 libmagic1 curl ca-certificates jq \
     libnl-route-3-200 libprotobuf32 libcap2-bin util-linux \
     passt squashfs-tools \
     && apt-get -y upgrade \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=sandbox-rootfs /usr/local/bin/duckdb /usr/local/bin/duckdb
+COPY --from=sandbox-rootfs /usr/local/bin/duckdb.real /usr/local/bin/duckdb.real
+COPY --from=sandbox-rootfs /usr/local/lib/duckdb /usr/local/lib/duckdb
+COPY --from=sandbox-rootfs /usr/local/share/duckdb /usr/local/share/duckdb
+
+RUN jq --version && duckdb --version
 
 # Allow the non-root executor process to invoke mount/umount when the container
 # runtime grants the needed bounding capabilities. Without these file caps,

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,10 @@ ARG DUCKDB_VERSION=1.4.3
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl wget jq iputils-ping && rm -rf /var/lib/apt/lists/*
 
+# This rootfs is shared by run_python and agent sandboxes; CLI additions here
+# are intentionally available to both. DuckDB is not available from Bookworm
+# apt, so install the official release binary, verify it, preinstall extensions,
+# and wrap the CLI to load those extensions on each invocation.
 RUN arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
     case "${arch}" in \
         amd64) duckdb_sha256="c479794045d094058d3092e404e696508d6310b5d234a8c1945b745678f09d8d" ;; \

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -13,6 +13,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     && rm -rf /var/lib/apt/lists/*
 
+# This rootfs is shared by run_python and agent sandboxes; CLI additions here
+# are intentionally available to both. DuckDB is not available from Bookworm
+# apt, so install the official release binary, verify it, preinstall extensions,
+# and wrap the CLI to load those extensions on each invocation.
 RUN arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
     case "${arch}" in \
         amd64) duckdb_sha256="c479794045d094058d3092e404e696508d6310b5d234a8c1945b745678f09d8d" ;; \

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -3,11 +3,45 @@
 
 FROM python:3.12-slim-bookworm
 
+ARG TARGETARCH
+ARG DUCKDB_VERSION=1.4.3
+
 # Install essential packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    jq \
     && rm -rf /var/lib/apt/lists/*
+
+RUN arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    case "${arch}" in \
+        amd64) duckdb_sha256="c479794045d094058d3092e404e696508d6310b5d234a8c1945b745678f09d8d" ;; \
+        arm64) duckdb_sha256="c709eb3efc74a609af4b92bc885c509a1bd21ddfa71ea1e717420d4dd9fc121b" ;; \
+        *) echo "Unsupported DuckDB CLI architecture: ${arch}" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-${arch}.gz" -o /tmp/duckdb.gz && \
+    echo "${duckdb_sha256}  /tmp/duckdb.gz" | sha256sum -c - && \
+    gunzip /tmp/duckdb.gz && \
+    install -m 0755 /tmp/duckdb /usr/local/bin/duckdb.real && \
+    rm -f /tmp/duckdb && \
+    mkdir -p /usr/local/lib/duckdb/extensions /usr/local/share/duckdb && \
+    /usr/local/bin/duckdb.real -c "SET extension_directory = '/usr/local/lib/duckdb/extensions'; INSTALL json; INSTALL postgres; INSTALL httpfs; INSTALL sqlite; INSTALL inet;" && \
+    printf '%s\n' \
+        "SET extension_directory = '/usr/local/lib/duckdb/extensions';" \
+        "LOAD json;" \
+        "LOAD postgres;" \
+        "LOAD httpfs;" \
+        "LOAD sqlite;" \
+        "LOAD inet;" \
+        > /usr/local/share/duckdb/tracecat-init.sql && \
+    printf '%s\n' \
+        '#!/bin/sh' \
+        'exec /usr/local/bin/duckdb.real -init /usr/local/share/duckdb/tracecat-init.sql "$@"' \
+        > /usr/local/bin/duckdb && \
+    chmod 0755 /usr/local/bin/duckdb && \
+    jq --version && \
+    duckdb --version && \
+    test "$(duckdb -csv -noheader -c "SELECT count(*) FROM duckdb_extensions() WHERE extension_name IN ('json', 'postgres_scanner', 'httpfs', 'sqlite_scanner', 'inet') AND installed AND loaded;")" = "5"
 
 # Install uv for fast package management
 COPY --from=ghcr.io/astral-sh/uv:0.9.15 /uv /usr/local/bin/uv

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -257,6 +257,23 @@ class TestClaudeAgentRuntimeRun:
             "Accept-Encoding": "identity",
         }
 
+    def test_system_prompt_documents_duckdb_cli(
+        self, mock_socket_writer: MagicMock
+    ) -> None:
+        """Runtime prompt should document local CLI tools available in shell."""
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer, transport_factory=lambda _: MagicMock()
+        )
+
+        prompt = runtime._build_system_prompt("Preset instructions.")
+
+        assert "<CommandLineTools>" in prompt
+        assert "`duckdb`" in prompt
+        assert "DuckDB CLI" in prompt
+        assert "`postgres`, `httpfs`, `sqlite`, and `inet` extensions" in prompt
+        assert "not a Tracecat action or MCP tool" in prompt
+        assert prompt.endswith("Preset instructions.")
+
     @pytest.mark.anyio
     async def test_sends_done_on_completion(
         self,

--- a/tests/unit/test_agent_sandbox_litellm.py
+++ b/tests/unit/test_agent_sandbox_litellm.py
@@ -90,6 +90,11 @@ class _SkillVisibilityMessage(TypedDict):
     skill_text: str
 
 
+class _DuckDBSmokeMessage(TypedDict):
+    duckdb_extension_count: int
+    duckdb_path: str
+
+
 @dataclass(slots=True)
 class _FakeClaudeOptions:
     env: dict[str, str]
@@ -196,6 +201,26 @@ def _parse_skill_visibility_message(message: object) -> _SkillVisibilityMessage:
     return {
         "skill_path": skill_path,
         "skill_text": skill_text,
+    }
+
+
+def _parse_duckdb_smoke_message(message: object) -> _DuckDBSmokeMessage:
+    if not isinstance(message, dict):
+        raise AssertionError(f"expected dict DuckDB probe, got {type(message)!r}")
+
+    duckdb_path = message.get("duckdb_path")
+    if not isinstance(duckdb_path, str):
+        raise AssertionError(f"expected string duckdb_path, got {duckdb_path!r}")
+
+    extension_count = message.get("duckdb_extension_count")
+    if not isinstance(extension_count, int):
+        raise AssertionError(
+            f"expected int duckdb_extension_count, got {extension_count!r}"
+        )
+
+    return {
+        "duckdb_path": duckdb_path,
+        "duckdb_extension_count": extension_count,
     }
 
 
@@ -624,6 +649,39 @@ class _FakeRuntimeReadingTransport:
         try:
             async for message in transport.read_messages():
                 type(self).messages.append(_parse_skill_visibility_message(message))
+        finally:
+            await transport.close()
+
+
+class _FakeRuntimeReadingDuckDBTransport:
+    instances: list[_FakeRuntimeReadingDuckDBTransport] = []
+    messages: list[_DuckDBSmokeMessage] = []
+
+    def __init__(
+        self,
+        _handler: object,
+        *,
+        transport_factory: Callable[[_FakeClaudeOptions], SandboxedCLITransport],
+        session_home_dir: Path,
+        cwd: Path,
+        cwd_setup_path: Path,
+    ) -> None:
+        self.transport_factory = transport_factory
+        self.session_home_dir = session_home_dir
+        self.cwd = cwd
+        self.cwd_setup_path = cwd_setup_path
+        self.transport: SandboxedCLITransport | None = None
+        type(self).instances.append(self)
+
+    async def run(self, payload: object) -> None:
+        del payload
+        options = _make_fake_claude_options()
+        transport = self.transport_factory(options)
+        self.transport = transport
+        await transport.connect()
+        try:
+            async for message in transport.read_messages():
+                type(self).messages.append(_parse_duckdb_smoke_message(message))
         finally:
             await transport.close()
 
@@ -1209,6 +1267,23 @@ def _run_nsjail_mcp_compression_smoke_from_cli() -> None:
                 tmp_path=tmp_path,
             )
         finally:
+            shutil.rmtree(tmp_path, ignore_errors=True)
+
+    asyncio.run(run())
+
+
+def _run_nsjail_duckdb_smoke_from_cli() -> None:
+    async def run() -> None:
+        monkeypatch = pytest.MonkeyPatch()
+        tmp_path = Path(tempfile.mkdtemp(prefix="tracecat-agent-nsjail-duckdb-"))
+        try:
+            _set_disable_nsjail_mode(monkeypatch, False)
+            await _run_duckdb_cli_available_case(
+                monkeypatch=monkeypatch,
+                tmp_path=tmp_path,
+            )
+        finally:
+            monkeypatch.undo()
             shutil.rmtree(tmp_path, ignore_errors=True)
 
     asyncio.run(run())
@@ -1891,6 +1966,133 @@ async def _run_attached_skills_visible_case(
         )
 
 
+async def _run_duckdb_cli_available_case(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _patch_agent_management_credentials(monkeypatch)
+    _FakeLLMSocketProxy.instances.clear()
+    _FakeRuntimeReadingDuckDBTransport.instances.clear()
+    _FakeRuntimeReadingDuckDBTransport.messages.clear()
+    broker = ClaudeRuntimeBroker()
+    await broker.start()
+
+    async def fake_build_claude_command(self: SandboxedCLITransport) -> list[str]:
+        del self
+        code = "\n".join(
+            [
+                "import json",
+                "import shutil",
+                "import subprocess",
+                "",
+                "duckdb_path = shutil.which('duckdb')",
+                "if duckdb_path is None:",
+                "    raise SystemExit('duckdb CLI not found')",
+                'query = """',
+                "SELECT count(*)",
+                "FROM duckdb_extensions()",
+                "WHERE extension_name IN (",
+                "    'json',",
+                "    'postgres_scanner',",
+                "    'httpfs',",
+                "    'sqlite_scanner',",
+                "    'inet'",
+                ")",
+                "AND installed",
+                "AND loaded;",
+                '"""',
+                "extension_count = subprocess.check_output(",
+                "    [duckdb_path, '-csv', '-noheader', '-c', query],",
+                "    text=True,",
+                ").strip()",
+                "print(",
+                "    json.dumps(",
+                "        {",
+                "            'duckdb_path': duckdb_path,",
+                "            'duckdb_extension_count': int(extension_count),",
+                "        },",
+                "        separators=(',', ':'),",
+                "    ),",
+                "    flush=True,",
+                ")",
+            ]
+        )
+        return ["/usr/local/bin/python3", "-c", code]
+
+    original_create_job_directory = SandboxedAgentExecutor._create_job_directory
+
+    async def fake_create_job_directory(self: SandboxedAgentExecutor) -> Path:
+        job_dir = await original_create_job_directory(self)
+        mcp_socket_path = job_dir / "sockets" / "mcp.sock"
+        mcp_socket_path.touch()
+        monkeypatch.setattr(
+            nsjail_module,
+            "TRACECAT__AGENT_MCP_SOCKET_PATH",
+            mcp_socket_path,
+        )
+        return job_dir
+
+    monkeypatch.setattr(executor_activity, "LoopbackHandler", _FakeLoopbackHandler)
+    monkeypatch.setattr(executor_activity, "LLMSocketProxy", _FakeLLMSocketProxy)
+    monkeypatch.setattr(
+        SandboxedAgentExecutor,
+        "_create_job_directory",
+        fake_create_job_directory,
+    )
+    monkeypatch.setattr(executor_activity, "get_claude_runtime_broker", lambda: broker)
+    monkeypatch.setattr(
+        broker_module,
+        "ClaudeAgentRuntime",
+        _FakeRuntimeReadingDuckDBTransport,
+    )
+    monkeypatch.setattr(
+        transport_module.SandboxedCLITransport,
+        "_build_claude_command",
+        fake_build_claude_command,
+    )
+    monkeypatch.setattr(
+        session_paths_module.tempfile,
+        "gettempdir",
+        lambda: str(tmp_path / "sessions"),
+    )
+    monkeypatch.setattr(
+        executor_activity,
+        "activity",
+        SimpleNamespace(heartbeat=lambda _message: None),
+    )
+    monkeypatch.setattr(
+        executor_activity.AgentSessionService,
+        "with_session",
+        lambda **_kwargs: _FakeAgentSessionService(),
+    )
+
+    try:
+        result = await run_agent_activity(
+            _make_passthrough_executor_input(enable_internet_access=False)
+        )
+    finally:
+        await broker.stop()
+
+    assert result.success is True
+    assert result.error is None
+
+    assert len(_FakeLLMSocketProxy.instances) == 1
+    proxy = _FakeLLMSocketProxy.instances[0]
+    assert proxy.started is True
+    assert proxy.stopped is True
+    assert proxy.request_count == 0
+
+    assert len(_FakeRuntimeReadingDuckDBTransport.instances) == 1
+    runtime = _FakeRuntimeReadingDuckDBTransport.instances[0]
+    assert runtime.transport is not None
+    assert runtime.cwd == Path("/work/claude-project")
+
+    assert _FakeRuntimeReadingDuckDBTransport.messages == [
+        {"duckdb_path": "/usr/local/bin/duckdb", "duckdb_extension_count": 5}
+    ]
+
+
 @pytest.mark.anyio
 async def test_run_agent_activity_makes_attached_skills_visible_in_each_sandbox_mode(
     full_harness_disable_nsjail_mode: bool,
@@ -1906,6 +2108,25 @@ async def test_run_agent_activity_makes_attached_skills_visible_in_each_sandbox_
 
     await _run_attached_skills_visible_case(
         disable_nsjail_mode=full_harness_disable_nsjail_mode,
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+    )
+
+
+@pytest.mark.anyio
+async def test_agent_nsjail_runtime_has_duckdb_cli(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    if not _agent_nsjail_available():
+        _run_nsjail_harness_in_docker_or_skip(
+            cli_flag="--run-nsjail-duckdb-smoke",
+            failure_label="Dockerized nsjail DuckDB smoke fallback failed.",
+        )
+        return
+
+    _set_disable_nsjail_mode(monkeypatch, False)
+    await _run_duckdb_cli_available_case(
         monkeypatch=monkeypatch,
         tmp_path=tmp_path,
     )
@@ -2290,9 +2511,12 @@ if __name__ == "__main__":
         _run_nsjail_skills_smoke_from_cli()
     elif sys.argv[1:] == ["--run-nsjail-mcp-compression-smoke"]:
         _run_nsjail_mcp_compression_smoke_from_cli()
+    elif sys.argv[1:] == ["--run-nsjail-duckdb-smoke"]:
+        _run_nsjail_duckdb_smoke_from_cli()
     else:
         raise SystemExit(
             "Usage: python -m tests.unit.test_agent_sandbox_litellm "
             "[--run-nsjail-harness-smoke|--run-nsjail-pasta-smoke|"
-            "--run-nsjail-skills-smoke|--run-nsjail-mcp-compression-smoke]"
+            "--run-nsjail-skills-smoke|--run-nsjail-mcp-compression-smoke|"
+            "--run-nsjail-duckdb-smoke]"
         )

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -198,6 +198,17 @@ INTERNET_TOOLS = [
     "WebFetch",
 ]
 
+COMMAND_LINE_TOOLS_PROMPT = (
+    "<CommandLineTools>\n"
+    "- `duckdb`: The runtime shell includes the DuckDB CLI. Use it for local "
+    "SQL and tabular data inspection over files such as CSV, JSON, Parquet, "
+    "and DuckDB database files. The CLI is configured with the `json`, "
+    "`postgres`, `httpfs`, `sqlite`, and `inet` extensions for JSON, "
+    "PostgreSQL, HTTP/S3, SQLite, and IP address workflows. This is a local "
+    "command-line capability, not a Tracecat action or MCP tool.\n"
+    "</CommandLineTools>"
+)
+
 # Registry MCP server naming.
 # We canonicalize persisted session history to the hyphen form at the
 # resume boundary so runtime configuration only exposes one logical server.
@@ -984,7 +995,10 @@ class ClaudeAgentRuntime:
         self, instructions: str | None, output_type: str | dict[str, Any] | None = None
     ) -> str:
         """Build the system prompt for the agent."""
-        base = "If asked about your identity, you are a Tracecat automation assistant."
+        base = (
+            "If asked about your identity, you are a Tracecat automation assistant."
+            f"\n\n{COMMAND_LINE_TOOLS_PROMPT}"
+        )
 
         # Only include structured output instruction if output_type is configured (not None)
         if output_type is not None:


### PR DESCRIPTION
## Summary
- Add DuckDB CLI and `jq` to the agent sandbox/root runtime images.
- Preinstall and auto-load common DuckDB extensions: `json`, `postgres`, `httpfs`, `sqlite`, and `inet`.
- Document the DuckDB CLI capability in the Claude runtime system prompt and cover it with a unit test.
- Add a Docker-backed nsjail smoke test that runs `duckdb` from the agent runtime and verifies the extension set is loaded.

## Testing
- `uv run pytest tests/unit/test_agent_runtime.py -k system_prompt_documents_duckdb_cli`
- `uv run ruff check tracecat/agent/runtime/claude_code/runtime.py tests/unit/test_agent_runtime.py`
- `uv run pyright tracecat/agent/runtime/claude_code/runtime.py tests/unit/test_agent_runtime.py`
- `docker build --target sandbox-rootfs -t tracecat-agent-sandbox-rootfs-duckdb-test .`
- `docker build -f docker/sandbox/Dockerfile -t tracecat-standalone-sandbox-duckdb-test docker/sandbox`
- `docker run --rm tracecat-agent-sandbox-rootfs-duckdb-test duckdb -csv -noheader -c "SELECT count(*) FROM duckdb_extensions() WHERE extension_name IN ('json', 'postgres_scanner', 'httpfs', 'sqlite_scanner', 'inet') AND installed AND loaded;"`
- `docker run --rm tracecat-standalone-sandbox-duckdb-test duckdb -csv -noheader -c "SELECT count(*) FROM duckdb_extensions() WHERE extension_name IN ('json', 'postgres_scanner', 'httpfs', 'sqlite_scanner', 'inet') AND installed AND loaded;"`
- `uv run pytest tests/unit/test_agent_sandbox_litellm.py -k duckdb_cli`
- `uv run ruff check tests/unit/test_agent_sandbox_litellm.py`
- `uv run ruff format --check tests/unit/test_agent_sandbox_litellm.py`
- `uv run basedpyright tests/unit/test_agent_sandbox_litellm.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the DuckDB CLI to the agent sandbox and root runtime images with common extensions autoloaded, and documents how it works in the sandbox. Updates the Claude runtime prompt and adds tests, including an nsjail smoke test.

- **New Features**
  - Bundled `duckdb` CLI in sandbox and root images (v1.4.3; `amd64`/`arm64`).
  - Preinstalled and autoloaded extensions: `json`, `postgres`, `httpfs`, `sqlite`, `inet`.
  - Installed `jq` in both images.
  - Documented the CLI in the Claude runtime and repo docs; added a unit test and an nsjail smoke test to verify availability and extensions.

<sup>Written for commit f7982647e3746564801e66a5905484c865f36f12. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2749?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

