### PR TITLE
feat: workflow failure alerting metrics

### DIFF
--- a/tests/unit/test_http_metrics_middleware.py
+++ b/tests/unit/test_http_metrics_middleware.py
@@ -38,6 +38,7 @@ def test_http_metrics_middleware_records_normalized_route_and_code() -> None:
     metrics_body = client.get("/metrics").text
 
     assert "http_request_total" in metrics_body
+    assert "http_request_duration_seconds" in metrics_body
     assert 'component="unit-api"' in metrics_body
     assert 'route="/api/items/{item_id}"' in metrics_body
     assert 'route="/api/blocked"' in metrics_body

--- a/tests/unit/test_mcp_metrics_route.py
+++ b/tests/unit/test_mcp_metrics_route.py
@@ -1,0 +1,43 @@
+import importlib
+
+import pytest
+from starlette import status
+from starlette.requests import Request
+
+from tracecat import config
+
+
+def _request(path: str) -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "headers": [],
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("testclient", 50000),
+    }
+    return Request(scope)
+
+
+def _metrics_handler(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(config, "USER_AUTH_SECRET", "test-user-auth-secret")
+    return importlib.import_module("tracecat.mcp.server").metrics
+
+
+@pytest.mark.anyio
+async def test_mcp_metrics_allows_direct_scrape_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = await _metrics_handler(monkeypatch)(_request("/metrics"))
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.anyio
+async def test_mcp_metrics_rejects_public_root_prefixed_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = await _metrics_handler(monkeypatch)(_request("/mcp/metrics"))
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -50,6 +50,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
+from starlette.responses import Response
 from temporalio.client import WorkflowExecutionStatus
 from tracecat_registry import RegistryOAuthSecret, RegistrySecret
 
@@ -2914,7 +2915,10 @@ mcp.add_middleware(
 
 @mcp.custom_route("/metrics", methods=["GET"], include_in_schema=False)
 async def metrics(request: Request):
-    del request
+    # Keep metrics available on the direct in-cluster scrape path, but avoid
+    # exposing them through the public MCP root prefix such as /mcp/metrics.
+    if request.scope.get("path") != "/metrics":
+        return Response(status_code=404)
     return prometheus_metrics_response()
 
 

--- a/tracecat/middleware/metrics.py
+++ b/tracecat/middleware/metrics.py
@@ -1,7 +1,14 @@
+import time
 from collections.abc import Awaitable, Callable
 
 from fastapi import Request
-from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, Counter, generate_latest
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    REGISTRY,
+    Counter,
+    Histogram,
+    generate_latest,
+)
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 from starlette.types import ASGIApp
@@ -29,6 +36,19 @@ HTTP_REQUEST_ERROR_TOTAL = Counter(
     ),
 )
 
+HTTP_REQUEST_DURATION_SECONDS = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request latency for Tracecat services.",
+    labelnames=("component", "route", "method", "code"),
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
+)
+
+WORKFLOW_DISPATCH_FAILURE_TOTAL = Counter(
+    "workflow_dispatch_failure_total",
+    "Workflow starts that failed before Temporal accepted the execution.",
+    labelnames=("trigger_type", "execution_type", "mode"),
+)
+
 _EXCLUDED_METRICS_PATHS = frozenset({"/metrics", "/health", "/ready"})
 
 _TENANT_ERROR_STATUS_CODES = frozenset({400, 401, 403, 422, 429})
@@ -46,6 +66,7 @@ class HTTPMetricsMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         status_code = 500
+        started_at = time.monotonic()
         try:
             response = await call_next(request)
             status_code = response.status_code
@@ -58,6 +79,12 @@ class HTTPMetricsMiddleware(BaseHTTPMiddleware):
                 method=request.method,
                 code=str(status_code),
             ).inc()
+            HTTP_REQUEST_DURATION_SECONDS.labels(
+                component=self.component,
+                route=route,
+                method=request.method,
+                code=str(status_code),
+            ).observe(time.monotonic() - started_at)
 
             if status_code >= 500 or status_code in _TENANT_ERROR_STATUS_CODES:
                 if tenant_labels := _tenant_labels(request):
@@ -75,6 +102,16 @@ class HTTPMetricsMiddleware(BaseHTTPMiddleware):
 def prometheus_metrics_response() -> Response:
     data = generate_latest(REGISTRY)
     return Response(content=data, headers={"Content-Type": str(CONTENT_TYPE_LATEST)})
+
+
+def record_workflow_dispatch_failure(
+    *, trigger_type: str, execution_type: str, mode: str
+) -> None:
+    WORKFLOW_DISPATCH_FAILURE_TOTAL.labels(
+        trigger_type=trigger_type,
+        execution_type=execution_type,
+        mode=mode,
+    ).inc()
 
 
 def _should_skip_request(request: Request) -> bool:

--- a/tracecat/workflow/executions/service.py
+++ b/tracecat/workflow/executions/service.py
@@ -49,6 +49,7 @@ from tracecat.identifiers.workflow import (
     generate_exec_id,
 )
 from tracecat.logger import logger
+from tracecat.middleware.metrics import record_workflow_dispatch_failure
 from tracecat.pagination import CursorPaginationParams
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage.collection import (
@@ -238,15 +239,28 @@ class WorkflowExecutionsService:
         client = await get_temporal_client()
         return WorkflowExecutionsService(client=client, role=role)
 
-    def _handle_background_task_exception(self, task: asyncio.Task[Any]) -> None:
+    def _handle_background_task_exception(
+        self,
+        task: asyncio.Task[Any],
+        *,
+        trigger_type: TriggerType,
+        execution_type: ExecutionType,
+    ) -> None:
         """Handle exceptions from background workflow execution tasks."""
         if task.cancelled():
             return
         exc = task.exception()
         if exc is not None:
+            record_workflow_dispatch_failure(
+                trigger_type=trigger_type.value,
+                execution_type=execution_type.value,
+                mode="background",
+            )
             self.logger.error(
                 "Workflow dispatch task failed",
                 exception=str(exc),
+                trigger_type=trigger_type,
+                execution_type=execution_type,
             )
 
     def handle(
@@ -1385,7 +1399,13 @@ class WorkflowExecutionsService:
             execution_type=ExecutionType.PUBLISHED,
         )
         task = asyncio.ensure_future(coro)
-        task.add_done_callback(self._handle_background_task_exception)
+        task.add_done_callback(
+            lambda task: self._handle_background_task_exception(
+                task,
+                trigger_type=trigger_type,
+                execution_type=ExecutionType.PUBLISHED,
+            )
+        )
         return WorkflowExecutionCreateResponse(
             message="Workflow execution started",
             wf_id=wf_id,
@@ -1409,17 +1429,25 @@ class WorkflowExecutionsService:
         if wf_exec_id is None:
             wf_exec_id = generate_exec_id(wf_id)
 
-        await self._start_workflow(
-            dsl=dsl,
-            wf_id=wf_id,
-            wf_exec_id=wf_exec_id,
-            trigger_inputs=payload,
-            trigger_type=trigger_type,
-            execution_type=ExecutionType.PUBLISHED,
-            time_anchor=time_anchor,
-            registry_lock=registry_lock,
-            memo=memo,
-        )
+        try:
+            await self._start_workflow(
+                dsl=dsl,
+                wf_id=wf_id,
+                wf_exec_id=wf_exec_id,
+                trigger_inputs=payload,
+                trigger_type=trigger_type,
+                execution_type=ExecutionType.PUBLISHED,
+                time_anchor=time_anchor,
+                registry_lock=registry_lock,
+                memo=memo,
+            )
+        except Exception:
+            record_workflow_dispatch_failure(
+                trigger_type=trigger_type.value,
+                execution_type=ExecutionType.PUBLISHED.value,
+                mode="wait_for_start",
+            )
+            raise
 
         return WorkflowExecutionCreateResponse(
             message="Workflow execution started",
@@ -1454,7 +1482,13 @@ class WorkflowExecutionsService:
             execution_type=ExecutionType.DRAFT,
         )
         task = asyncio.ensure_future(coro)
-        task.add_done_callback(self._handle_background_task_exception)
+        task.add_done_callback(
+            lambda task: self._handle_background_task_exception(
+                task,
+                trigger_type=trigger_type,
+                execution_type=ExecutionType.DRAFT,
+            )
+        )
         return WorkflowExecutionCreateResponse(
             message="Draft workflow execution started",
             wf_id=wf_id,
@@ -1477,16 +1511,24 @@ class WorkflowExecutionsService:
         if wf_exec_id is None:
             wf_exec_id = generate_exec_id(wf_id)
 
-        await self._start_workflow(
-            dsl=dsl,
-            wf_id=wf_id,
-            wf_exec_id=wf_exec_id,
-            trigger_inputs=payload,
-            trigger_type=trigger_type,
-            execution_type=ExecutionType.DRAFT,
-            time_anchor=time_anchor,
-            registry_lock=registry_lock,
-        )
+        try:
+            await self._start_workflow(
+                dsl=dsl,
+                wf_id=wf_id,
+                wf_exec_id=wf_exec_id,
+                trigger_inputs=payload,
+                trigger_type=trigger_type,
+                execution_type=ExecutionType.DRAFT,
+                time_anchor=time_anchor,
+                registry_lock=registry_lock,
+            )
+        except Exception:
+            record_workflow_dispatch_failure(
+                trigger_type=trigger_type.value,
+                execution_type=ExecutionType.DRAFT.value,
+                mode="wait_for_start",
+            )
+            raise
 
         return WorkflowExecutionCreateResponse(
             message="Draft workflow execution started",


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Prometheus metrics for HTTP request latency and workflow dispatch failures. This enables alerting on slow API responses and failed starts before Temporal accepts a run.

- **New Features**
  - Added `http_request_duration_seconds` histogram with `component`, `route`, `method`, `code` labels.
  - Added `workflow_dispatch_failure_total` counter with `trigger_type`, `execution_type`, `mode` labels.
  - Recorded dispatch failures in both background and `wait_for_start` paths via `record_workflow_dispatch_failure()`.
  - Updated unit test to assert presence of the duration metric.

<sup>Written for commit fb2583bbb9e7499cb44a7f26082f5b1e2f842d06. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2754?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

