### PR TITLE
ci: disable action doc link checks

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -67,34 +67,6 @@ jobs:
           env -u UV_SYSTEM_PYTHON uv pip install --python .venv/bin/python .
           .venv/bin/python -c "import custom_actions"
 
-  test-action-doc-links:
-    runs-on: blacksmith-8vcpu-ubuntu-2204
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Install uv
-        uses: useblacksmith/setup-uv@f4588471335f14dcb60198856207b916701a9e9f # v4
-        with:
-          version: "0.9.7"
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-
-      - name: Set up Python 3.12
-        uses: useblacksmith/setup-python@943b05a7c4ca70c2360391137527a37bee33fb1d # v6
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: uv sync --frozen
-
-      - name: Check action documentation links
-        env:
-          TRACECAT_TEST_ACTION_DOC_LINKS: "1"
-        run: uv run pytest scripts/tests/test_action_doc_links.py -ra
-
   test-all:
     runs-on: blacksmith-8vcpu-ubuntu-2204
     timeout-minutes: 60

--- a/scripts/tests/test_action_doc_links.py
+++ b/scripts/tests/test_action_doc_links.py
@@ -11,6 +11,8 @@ import pytest
 
 from tracecat.registry.repository import Repository
 
+pytestmark = pytest.mark.skip(reason="action documentation link checks are disabled")
+
 
 def _action_doc_urls() -> dict[str, tuple[str, ...]]:
     repo = Repository()


### PR DESCRIPTION
## Summary

- Remove the dedicated `test-action-doc-links` job from the Python CI workflow.
- Add a module-level skip to `scripts/tests/test_action_doc_links.py` so the action documentation link checks are disabled when invoked directly.

## Validation

- `uv run pytest scripts/tests/test_action_doc_links.py -q` reports 3 skipped tests.
- `git diff --check` passes.
- Commit hooks passed during `git commit`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable action documentation link checks in CI to reduce build time and avoid flaky failures. Removes the `test-action-doc-links` job and adds a module-level skip so these tests are always skipped.

- Removed the `test-action-doc-links` job from `.github/workflows/test-python.yml`.
- Added `pytestmark = pytest.mark.skip(...)` in `scripts/tests/test_action_doc_links.py`.

<sup>Written for commit 19702f075740bf18e46bd52a01fff078db1cb26d. Summary will update on new commits. <a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2756?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

