### PR TITLE
fix(registry): reconcile current startup artifact URI

### DIFF
--- a/tests/unit/test_registry_platform_startup.py
+++ b/tests/unit/test_registry_platform_startup.py
@@ -191,12 +191,22 @@ async def test_startup_sync_skips_when_version_already_current(
         mock_registry.__version__ = "0.1.0"
 
         # Should complete without calling sync
-        with patch(
-            "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
-        ) as mock_sync_service:
+        with (
+            patch(
+                "tracecat.registry.sync.jobs.PlatformRegistrySyncService"
+            ) as mock_sync_service,
+            patch(
+                "tracecat.registry.sync.jobs._schedule_platform_registry_artifact_build"
+            ) as schedule_build,
+        ):
             await _sync_as_leader(session, "0.1.0")
             # Sync service should not be instantiated
             mock_sync_service.assert_not_called()
+            schedule_build.assert_called_once_with(
+                "0.1.0",
+                promote_version_id=version.id,
+                expected_current_version_id=version.id,
+            )
 
 
 @pytest.mark.anyio

--- a/tracecat/registry/sync/jobs.py
+++ b/tracecat/registry/sync/jobs.py
@@ -150,7 +150,11 @@ async def _sync_as_leader(session: AsyncSession, target_version: str) -> None:
                 "Platform registry already at target version",
                 version=target_version,
             )
-            _schedule_platform_registry_artifact_build(target_version)
+            _schedule_platform_registry_artifact_build(
+                target_version,
+                promote_version_id=existing_version.id,
+                expected_current_version_id=existing_version.id,
+            )
             return
 
         # If this repo has versions but no current selection, wait until the


### PR DESCRIPTION
## Summary

- pass the already-current platform registry version id into the background artifact build
- guard the writeback so a delayed artifact repair only updates the version while it remains current
- add a regression assertion for the already-current startup path

## Review context

Addresses the unresolved PR #2753 review comment: https://github.com/TracecatHQ/tracecat/pull/2753#discussion_r3295146510

## Test plan

- `uv run ruff check tracecat/registry/sync/jobs.py tests/unit/test_registry_platform_startup.py`
- `uv run ruff format --check tracecat/registry/sync/jobs.py tests/unit/test_registry_platform_startup.py`
- `uv run basedpyright --warnings tracecat/registry/sync/jobs.py tests/unit/test_registry_platform_startup.py`
- `uv run pytest tests/unit/test_registry_platform_startup.py::test_startup_sync_skips_when_version_already_current tests/unit/test_registry_platform_startup.py::test_promote_after_artifact_build_updates_stored_artifact_uri -q`
