### PR TITLE
feat(integrations): add catalog-backed connections

### DIFF
--- a/alembic/versions/b7e1c9f2a3d4_consolidated_integrations_phase_1.py
+++ b/alembic/versions/b7e1c9f2a3d4_consolidated_integrations_phase_1.py
@@ -1,0 +1,87 @@
+"""consolidated integrations catalog
+
+Revision ID: b7e1c9f2a3d4
+Revises: a3d7c9e8b4f2
+Create Date: 2026-05-25 21:00:00.000000
+
+Adds the consolidated Integrations catalog model: an integration catalog table.
+
+Additive only -- no existing tables are dropped. Secret, OAuthIntegration,
+WorkspaceOAuthProvider, and MCPIntegration storage continue to drive credential
+and MCP behavior.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b7e1c9f2a3d4"
+down_revision: str | None = "a3d7c9e8b4f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+INTEGRATION_SOURCE_VALUES = ("platform", "workspace")
+
+
+def upgrade() -> None:
+    # --- enums ---------------------------------------------------------
+    sa.Enum(*INTEGRATION_SOURCE_VALUES, name="integrationsource").create(op.get_bind())
+
+    # --- integration ---------------------------------------------------
+    op.create_table(
+        "integration",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("workspace_id", sa.UUID(), nullable=True),
+        sa.Column("namespace", sa.String(), nullable=False),
+        sa.Column("display_name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("icon_url", sa.String(), nullable=True),
+        sa.Column(
+            "source",
+            postgresql.ENUM(
+                *INTEGRATION_SOURCE_VALUES,
+                name="integrationsource",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspace.id"],
+            name=op.f("fk_integration_workspace_id_workspace"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_integration")),
+        sa.UniqueConstraint(
+            "workspace_id",
+            "namespace",
+            name="uq_integration_workspace_namespace",
+        ),
+    )
+    op.create_index(op.f("ix_integration_id"), "integration", ["id"], unique=True)
+    op.create_index("ix_integration_namespace", "integration", ["namespace"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_integration_namespace", table_name="integration")
+    op.drop_index(op.f("ix_integration_id"), table_name="integration")
+    op.drop_table("integration")
+
+    sa.Enum(name="integrationsource").drop(op.get_bind())

--- a/alembic/versions/c8f2d1e4a5b6_backfill_secret_namespaces_into_integrations.py
+++ b/alembic/versions/c8f2d1e4a5b6_backfill_secret_namespaces_into_integrations.py
@@ -1,0 +1,66 @@
+"""backfill secret namespaces into integrations
+
+Revision ID: c8f2d1e4a5b6
+Revises: b7e1c9f2a3d4
+Create Date: 2026-05-25 23:00:00.000000
+
+For secret names that don't already have an Integration row, a workspace-scoped
+``Integration`` is created on demand so the Integrations catalog can project
+legacy static credentials without moving credential storage.
+
+Additive only -- the legacy ``secret`` table remains the source of truth for
+static/API-key credentials.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c8f2d1e4a5b6"
+down_revision: str | None = "b7e1c9f2a3d4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Backfill workspace-scoped Integration rows for every Secret name that
+    # doesn't already have a catalog entry. Source=workspace so we can tell
+    # these apart from the platform-seeded providers.
+    op.execute(
+        """
+        INSERT INTO integration (
+            id, workspace_id, namespace, display_name, description,
+            source, created_at, updated_at
+        )
+        SELECT
+            gen_random_uuid(),
+            s.workspace_id,
+            s.name,
+            INITCAP(REPLACE(s.name, '_', ' ')),
+            'Backfilled from legacy credential.',
+            'workspace',
+            NOW(),
+            NOW()
+        FROM (
+            SELECT DISTINCT workspace_id, name
+            FROM secret
+        ) AS s
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM integration i
+            WHERE i.namespace = s.name
+              AND (
+                i.workspace_id IS NULL
+                OR i.workspace_id = s.workspace_id
+              )
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    # This migration only adds catalog rows for pre-existing secret names.
+    # Leave them in place on downgrade; deleting them could hide credentials
+    # from the catalog after a downgrade/upgrade loop.
+    pass

--- a/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/integrations/page.tsx
@@ -1,643 +1,261 @@
 "use client"
 
-import { ChevronRight, Loader2, RotateCcw, SquareAsterisk } from "lucide-react"
+import { Star, UserSquare } from "lucide-react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import type { IntegrationStatus, OAuthGrantType } from "@/client"
+import { useCallback, useMemo, useState } from "react"
+import type { CatalogIntegrationRead } from "@/client"
 import { useScopeCheck } from "@/components/auth/scope-guard"
-import { ConfirmDestructiveDialog } from "@/components/confirm-destructive-dialog"
-import { ProviderIcon } from "@/components/icons"
 import {
-  type ConnectionFilter,
-  IntegrationsHeader,
-  type IntegrationTypeFilter,
-} from "@/components/integrations/integrations-header"
-import { OAuthIntegrationDetailsDialog } from "@/components/integrations/oauth-integration-details-dialog"
-import { OAuthIntegrationDialog } from "@/components/integrations/oauth-integration-dialog"
+  CatalogHeader,
+  type CatalogHeaderPillOption,
+} from "@/components/catalog/catalog-header"
+import { CatalogCard } from "@/components/integrations/catalog-card"
+import { IntegrationDetailPanel } from "@/components/integrations/integration-detail-panel"
 import { CenteredSpinner } from "@/components/loading/spinner"
-import { Button } from "@/components/ui/button"
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible"
-import {
-  Item,
-  ItemActions,
-  ItemContent,
-  ItemMedia,
-  ItemTitle,
-} from "@/components/ui/item"
-import { ScrollArea } from "@/components/ui/scroll-area"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
-import {
-  useConnectProvider,
-  useDisconnectProvider,
-  useTestProvider,
-} from "@/hooks/use-integration-actions"
-import { useIntegrations } from "@/lib/hooks"
-import { isMcpProvider } from "@/lib/integrations"
-import { cn } from "@/lib/utils"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { useListIntegrationCatalog } from "@/lib/hooks/integrations-catalog"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
-type IntegrationItem = {
-  type: "oauth"
-  id: string
-  name: string
-  description: string
-  enabled: boolean
-  integration_status: IntegrationStatus
-  grant_type: OAuthGrantType
-  requires_config: boolean
-}
+type CatalogPillFilter = "built_by_me"
+type CatalogCardIntent = "connect" | "configure" | "open"
 
-const displayStatus = (status: IntegrationStatus) =>
-  status === "configured" ? "not_configured" : status
-
-type IntegrationSectionType = "oauth" | "custom_oauth"
-
-const integrationTypeLabels = {
-  oauth: "OAuth",
-  custom_oauth: "Custom OAuth",
-} as const
-
-const integrationSectionOrder: IntegrationSectionType[] = [
-  "oauth",
-  "custom_oauth",
+const PILL_FILTERS: Array<CatalogHeaderPillOption<CatalogPillFilter>> = [
+  { value: "built_by_me", label: "Built by me", icon: UserSquare },
 ]
 
-const integrationSectionTitles: Record<IntegrationSectionType, string> = {
-  oauth: "OAuth",
-  custom_oauth: "Custom OAuth",
+const POPULAR_NAMESPACES = new Set([
+  "github",
+  "slack",
+  "google_gmail",
+  "google_drive",
+  "microsoft_graph",
+  "servicenow",
+])
+
+const INTEGRATION_ID_PARAM = "integrationId"
+
+function matchesFilters(
+  integration: CatalogIntegrationRead,
+  activeFilters: CatalogPillFilter[]
+): boolean {
+  if (activeFilters.length === 0) return true
+  return activeFilters.every((filter) => {
+    switch (filter) {
+      case "built_by_me":
+        return integration.source === "workspace"
+      default:
+        return true
+    }
+  })
 }
 
-function getIntegrationStatus(item: IntegrationItem): IntegrationStatus {
-  return displayStatus(item.integration_status)
-}
+function catalogCardState(integration: CatalogIntegrationRead): {
+  ctaIntent: CatalogCardIntent
+  isConnected: boolean
+} {
+  const authOptions = integration.auth_options ?? []
+  const isConnected = authOptions.some(
+    (option) => option.status === "connected"
+  )
+  const needsConfiguration = authOptions.some(
+    (option) =>
+      option.requires_config === true && option.status === "not_configured"
+  )
+  const hasReadyConnectableOption = authOptions.some(
+    (option) =>
+      option.enabled !== false &&
+      (option.auth_method === "static_kv" ||
+        (option.auth_method === "oauth_auth_code" &&
+          !(
+            option.requires_config === true &&
+            option.status === "not_configured"
+          )))
+  )
 
-function getIntegrationDisplayType(
-  item: IntegrationItem
-): IntegrationSectionType {
-  if (item.id.startsWith("custom_")) {
-    return "custom_oauth"
+  if (!isConnected && hasReadyConnectableOption) {
+    return { ctaIntent: "connect", isConnected }
   }
-  return item.type
+  if (needsConfiguration) {
+    return {
+      ctaIntent: "configure",
+      isConnected,
+    }
+  }
+  return { ctaIntent: "open", isConnected }
 }
 
 export default function IntegrationsPage() {
   const workspaceId = useWorkspaceId()
-  const canReadIntegrations = useScopeCheck("integration:read")
-  const canUpdateIntegrations = useScopeCheck("integration:update")
-  const canMutateIntegrations = canUpdateIntegrations === true
   const router = useRouter()
   const searchParams = useSearchParams()
+  const canRead = useScopeCheck("integration:read")
+
   const [searchQuery, setSearchQuery] = useState("")
-  const [typeFilters, setTypeFilters] = useState<IntegrationTypeFilter[]>([])
-  const [connectionFilter, setConnectionFilter] =
-    useState<ConnectionFilter>("all")
-  const [activeOAuthProvider, setActiveOAuthProvider] = useState<{
-    providerId: string
-    grantType: OAuthGrantType
-  } | null>(null)
-  const [detailsProvider, setDetailsProvider] = useState<{
-    providerId: string
-    grantType: OAuthGrantType
-  } | null>(null)
-  const [disconnectTarget, setDisconnectTarget] = useState<{
-    providerId: string
-    grantType: OAuthGrantType
-    name: string
-  } | null>(null)
-  const [expandedSections, setExpandedSections] = useState<
-    Record<IntegrationSectionType, boolean>
-  >({
-    oauth: false,
-    custom_oauth: false,
-  })
-  const lastHandledConnectRef = useRef<string | null>(null)
+  const [activeFilters, setActiveFilters] = useState<CatalogPillFilter[]>([])
 
-  const { providers, providersIsLoading, providersError } =
-    useIntegrations(workspaceId)
+  const { catalog, catalogIsLoading, catalogError } = useListIntegrationCatalog(
+    workspaceId,
+    {
+      search: searchQuery || null,
+    }
+  )
 
-  function handleTypeFilterToggle(filter: IntegrationTypeFilter) {
-    setTypeFilters((prev) =>
+  const togglePillFilter = useCallback((filter: CatalogPillFilter) => {
+    setActiveFilters((prev) =>
       prev.includes(filter)
         ? prev.filter((value) => value !== filter)
         : [...prev, filter]
     )
-  }
+  }, [])
 
-  const connectProviderMutation = useConnectProvider(workspaceId)
-  const disconnectProviderMutation = useDisconnectProvider(workspaceId)
-  const testConnectionMutation = useTestProvider(workspaceId)
+  const filteredCatalog = useMemo(() => {
+    if (!catalog) return []
+    return catalog
+      .filter((integration) => matchesFilters(integration, activeFilters))
+      .sort((a, b) => a.display_name.localeCompare(b.display_name))
+  }, [catalog, activeFilters])
 
-  const allIntegrations = useMemo<IntegrationItem[]>(() => {
-    return (
-      providers
-        ?.filter((provider) => !isMcpProvider(provider.id))
-        .map<IntegrationItem>((provider) => ({
-          type: "oauth" as const,
-          id: provider.id,
-          name: provider.name,
-          description: provider.description,
-          enabled: provider.enabled,
-          integration_status: provider.integration_status,
-          grant_type: provider.grant_type,
-          requires_config: provider.requires_config,
-        })) ?? []
-    )
-  }, [providers])
-
-  const filteredIntegrations = useMemo(() => {
-    const q = searchQuery.toLowerCase()
-    const filtered = allIntegrations.filter((item) => {
-      const matchesSearch =
-        item.name.toLowerCase().includes(q) ||
-        (item.description ?? "").toLowerCase().includes(q)
-      const matchesType =
-        typeFilters.length === 0 ||
-        typeFilters.some((filter) => {
-          if (filter === "custom_oauth") {
-            return item.id.startsWith("custom_")
-          }
-          return item.type === filter
-        })
-      const status = getIntegrationStatus(item)
-      const matchesConnection =
-        connectionFilter === "all"
-          ? true
-          : connectionFilter === "connected"
-            ? status === "connected"
-            : status !== "connected"
-
-      return matchesSearch && matchesType && matchesConnection
-    })
-
-    return [...filtered].sort((a, b) => {
-      const aStatus = getIntegrationStatus(a)
-      const bStatus = getIntegrationStatus(b)
-
-      const statusOrder: Record<IntegrationStatus, number> = {
-        connected: 0,
-        not_configured: 1,
-        configured: 1,
-      }
-
-      const aOrder = statusOrder[aStatus] ?? 1
-      const bOrder = statusOrder[bStatus] ?? 1
-
-      if (aOrder !== bOrder) {
-        return aOrder - bOrder
-      }
-
-      if (a.enabled !== b.enabled) {
-        return a.enabled ? -1 : 1
-      }
-
-      return a.name.localeCompare(b.name)
-    })
-  }, [allIntegrations, connectionFilter, searchQuery, typeFilters])
-
-  const sectionedIntegrations = useMemo(() => {
-    const groupedIntegrations: Record<
-      IntegrationSectionType,
-      IntegrationItem[]
-    > = {
-      oauth: [],
-      custom_oauth: [],
+  const { popular, rest } = useMemo(() => {
+    const showPopular = searchQuery.trim() === "" && activeFilters.length === 0
+    if (!showPopular) {
+      return { popular: [] as CatalogIntegrationRead[], rest: filteredCatalog }
     }
-
-    for (const item of filteredIntegrations) {
-      groupedIntegrations[getIntegrationDisplayType(item)].push(item)
+    const popularList: CatalogIntegrationRead[] = []
+    const restList: CatalogIntegrationRead[] = []
+    for (const integration of filteredCatalog) {
+      if (POPULAR_NAMESPACES.has(integration.namespace)) {
+        popularList.push(integration)
+      } else {
+        restList.push(integration)
+      }
     }
+    return { popular: popularList, rest: restList }
+  }, [filteredCatalog, searchQuery, activeFilters])
 
-    return integrationSectionOrder
-      .map((sectionType) => ({
-        sectionType,
-        title: integrationSectionTitles[sectionType],
-        items: groupedIntegrations[sectionType],
-      }))
-      .filter(
-        (section) =>
-          section.items.length > 0 || section.sectionType === "custom_oauth"
-      )
-  }, [filteredIntegrations])
+  const selectedIntegrationId = searchParams?.get(INTEGRATION_ID_PARAM) ?? null
 
-  const connectParam = searchParams?.get("connect")
-  const connectGrantType = searchParams?.get(
-    "grant_type"
-  ) as OAuthGrantType | null
-
-  useEffect(() => {
-    if (!connectParam) {
-      lastHandledConnectRef.current = null
-    }
-  }, [connectParam])
-
-  const clearConnectParams = useCallback(() => {
-    const params = new URLSearchParams(searchParams?.toString() || "")
-    params.delete("connect")
-    params.delete("grant_type")
-    const query = params.toString()
-    router.replace(
-      `/workspaces/${workspaceId}/integrations${query ? `?${query}` : ""}`
-    )
-  }, [router, searchParams, workspaceId])
-
-  const setConnectParams = useCallback(
-    (providerId: string, grantType: OAuthGrantType) => {
+  const updateSelection = useCallback(
+    (next: string | null) => {
       const params = new URLSearchParams(searchParams?.toString() || "")
-      params.set("connect", providerId)
-      params.set("grant_type", grantType)
+      if (next) {
+        params.set(INTEGRATION_ID_PARAM, next)
+      } else {
+        params.delete(INTEGRATION_ID_PARAM)
+      }
+      const query = params.toString()
       router.replace(
-        `/workspaces/${workspaceId}/integrations?${params.toString()}`
+        `/workspaces/${workspaceId}/integrations${query ? `?${query}` : ""}`
       )
     },
     [router, searchParams, workspaceId]
   )
 
-  const handleOpenOAuthModal = useCallback(
-    (providerId: string, grantType: OAuthGrantType) => {
-      setActiveOAuthProvider({ providerId, grantType })
-      setConnectParams(providerId, grantType)
-    },
-    [setConnectParams]
-  )
-
-  const handleOAuthDialogOpenChange = useCallback(
-    (nextOpen: boolean) => {
-      if (!nextOpen) {
-        setActiveOAuthProvider(null)
-        clearConnectParams()
-      }
-    },
-    [clearConnectParams]
-  )
-
-  const handleDirectConnect = useCallback(
-    (providerId: string, grantType: OAuthGrantType) => {
-      if (grantType === "authorization_code") {
-        connectProviderMutation.mutate({ providerId })
-      } else {
-        testConnectionMutation.mutate({ providerId, grantType })
-      }
-    },
-    [connectProviderMutation, testConnectionMutation]
-  )
-
-  useEffect(() => {
-    if (!canMutateIntegrations) {
-      return
-    }
-    if (!connectParam || !providers) {
-      return
-    }
-
-    const handleKey = `${connectParam}:${connectGrantType ?? ""}`
-    if (lastHandledConnectRef.current === handleKey) {
-      return
-    }
-
-    const provider = providers.find(
-      (item) =>
-        item.id === connectParam &&
-        (connectGrantType == null || item.grant_type === connectGrantType)
+  if (canRead !== true) {
+    return (
+      <div className="flex h-full items-center justify-center p-6">
+        <Alert className="max-w-md">
+          <AlertTitle>Access denied</AlertTitle>
+          <AlertDescription>
+            You do not have permission to view integrations.
+          </AlertDescription>
+        </Alert>
+      </div>
     )
-    if (!provider) {
-      lastHandledConnectRef.current = handleKey
-      return
-    }
-
-    lastHandledConnectRef.current = handleKey
-
-    if (provider.requires_config) {
-      handleOpenOAuthModal(provider.id, provider.grant_type)
-      return
-    }
-
-    handleDirectConnect(provider.id, provider.grant_type)
-    clearConnectParams()
-  }, [
-    canMutateIntegrations,
-    clearConnectParams,
-    connectGrantType,
-    connectParam,
-    handleDirectConnect,
-    handleOpenOAuthModal,
-    providers,
-  ])
-
-  const handleReconnect = useCallback(
-    (providerId: string, grantType: OAuthGrantType) => {
-      handleDirectConnect(providerId, grantType)
-    },
-    [handleDirectConnect]
-  )
-
-  if (
-    canReadIntegrations === undefined ||
-    canUpdateIntegrations === undefined ||
-    providersIsLoading
-  ) {
-    return <CenteredSpinner />
-  }
-
-  if (!canReadIntegrations) {
-    return null
-  }
-  if (providersError) {
-    return <div>Error: {providersError.message}</div>
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <IntegrationsHeader
+    <div className="flex h-full flex-col">
+      <CatalogHeader<CatalogPillFilter>
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
-        typeFilters={typeFilters}
-        onTypeFilterToggle={handleTypeFilterToggle}
-        connectionFilter={connectionFilter}
-        onConnectionFilterChange={setConnectionFilter}
-        displayIntegrationCount={filteredIntegrations.length}
+        searchPlaceholder="Search integrations..."
+        pillFilters={PILL_FILTERS}
+        activePillFilters={activeFilters}
+        onPillFilterToggle={togglePillFilter}
+        displayCount={filteredCatalog.length}
+        countLabel="integrations"
       />
 
-      {/* Integrations List */}
-      <ScrollArea className="flex-1 min-h-0 [&>[data-radix-scroll-area-viewport]]:[scrollbar-width:none] [&>[data-radix-scroll-area-viewport]::-webkit-scrollbar]:hidden [&>[data-orientation=vertical]]:!hidden [&>[data-orientation=horizontal]]:!hidden">
-        <div className="w-full pb-10">
-          {sectionedIntegrations.map((section) => {
-            const isExpanded = expandedSections[section.sectionType] ?? false
-            return (
-              <Collapsible
-                key={section.sectionType}
-                className="border-b border-border/50"
-                open={isExpanded}
-                onOpenChange={(nextOpen) =>
-                  setExpandedSections((prev) => ({
-                    ...prev,
-                    [section.sectionType]: nextOpen,
-                  }))
-                }
-              >
-                <div>
-                  <CollapsibleTrigger asChild>
-                    <button
-                      type="button"
-                      className="flex w-full items-center gap-1 py-1.5 pl-[10px] pr-3 text-left transition-colors hover:bg-muted/50 data-[state=open]:bg-primary/5 dark:data-[state=open]:bg-primary/10 [&[data-state=open]_.chevron]:rotate-90"
-                    >
-                      <div className="flex h-7 w-7 shrink-0 items-center justify-center">
-                        <ChevronRight className="chevron size-4 text-muted-foreground transition-transform duration-200" />
-                      </div>
-                      <div className="flex items-center gap-1.5">
-                        <span className="text-xs font-medium">
-                          {section.title}
-                        </span>
-                        <span className="text-xs text-muted-foreground">
-                          {section.items.length}
-                        </span>
-                      </div>
-                    </button>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <div className="divide-y divide-border/50">
-                      {section.items.map((item) => {
-                        const status = getIntegrationStatus(item)
-                        const isConnected =
-                          item.integration_status === "connected"
-                        const isConfigured = status === "connected"
-                        const isClickable =
-                          isConnected ||
-                          (canMutateIntegrations &&
-                            item.requires_config &&
-                            item.enabled)
-                        const isDisabled = !item.enabled
-                        const showConnect =
-                          canMutateIntegrations && !isConnected
-                        const showDisconnect =
-                          canMutateIntegrations && isConnected
-                        const isConnecting =
-                          (connectProviderMutation.isPending &&
-                            connectProviderMutation.variables?.providerId ===
-                              item.id) ||
-                          (testConnectionMutation.isPending &&
-                            testConnectionMutation.variables?.providerId ===
-                              item.id)
-                        const isDisconnecting =
-                          disconnectProviderMutation.isPending &&
-                          disconnectProviderMutation.variables?.providerId ===
-                            item.id
-                        const displayType = getIntegrationDisplayType(item)
-                        const typeLabel = integrationTypeLabels[displayType]
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        <div className="mx-auto flex max-w-6xl flex-col gap-6">
+          <p className="text-sm text-muted-foreground">
+            Browse and connect integrations available to this workspace.
+          </p>
 
-                        return (
-                          <Item
-                            key={`${item.id}-${item.grant_type}`}
-                            variant="default"
-                            size="sm"
-                            className={cn(
-                              "w-full flex-nowrap rounded-none border-none px-3 py-1.5 text-left transition-colors hover:bg-muted/50",
-                              isClickable && "cursor-pointer",
-                              !isClickable && "cursor-default"
-                            )}
-                            onClick={() => {
-                              if (isConnected) {
-                                setDetailsProvider({
-                                  providerId: item.id,
-                                  grantType: item.grant_type,
-                                })
-                                return
-                              }
-                              if (item.requires_config && item.enabled) {
-                                if (!canMutateIntegrations) {
-                                  return
-                                }
-                                handleOpenOAuthModal(item.id, item.grant_type)
-                              }
-                            }}
-                          >
-                            <ItemMedia className="translate-y-0 self-center">
-                              <ProviderIcon
-                                providerId={item.id}
-                                className="size-6 rounded"
-                              />
-                            </ItemMedia>
-                            <ItemContent className="min-w-0 gap-0">
-                              <ItemTitle className="flex w-full min-w-0 items-center gap-2 text-xs">
-                                <TooltipProvider>
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <span className="min-w-0 truncate">
-                                        {item.name}
-                                      </span>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                      <p>{item.name}</p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </TooltipProvider>
-                                <span className="text-xs text-muted-foreground">
-                                  {typeLabel}
-                                </span>
-                              </ItemTitle>
-                            </ItemContent>
-                            <ItemActions className="ml-auto flex shrink-0 items-center gap-1.5 pl-3">
-                              {isConfigured ? (
-                                <TooltipProvider>
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <span className="flex h-6 w-6 items-center justify-center">
-                                        <SquareAsterisk className="icon-success size-3.5" />
-                                      </span>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                      <p>Configured</p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </TooltipProvider>
-                              ) : null}
-                              {isConnected && canMutateIntegrations && (
-                                <TooltipProvider>
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        className="h-6 w-6"
-                                        aria-label={`Reconnect ${item.name}`}
-                                        onClick={(event) => {
-                                          event.stopPropagation()
-                                          handleReconnect(
-                                            item.id,
-                                            item.grant_type
-                                          )
-                                        }}
-                                        disabled={isDisabled || isConnecting}
-                                      >
-                                        <RotateCcw className="size-3.5" />
-                                      </Button>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                      <p>Reconnect</p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </TooltipProvider>
-                              )}
-                              {showConnect && (
-                                <>
-                                  <Button
-                                    variant="outline"
-                                    size="sm"
-                                    className="h-6 border-input bg-white px-2.5 text-[11px] text-foreground hover:bg-muted"
-                                    onClick={(event) => {
-                                      event.stopPropagation()
-                                      if (item.requires_config) {
-                                        handleOpenOAuthModal(
-                                          item.id,
-                                          item.grant_type
-                                        )
-                                        return
-                                      }
-                                      handleDirectConnect(
-                                        item.id,
-                                        item.grant_type
-                                      )
-                                    }}
-                                    disabled={isDisabled || isConnecting}
-                                  >
-                                    {isConnecting ? (
-                                      <Loader2 className="mr-1.5 size-3 animate-spin" />
-                                    ) : null}
-                                    Connect
-                                  </Button>
-                                </>
-                              )}
-                              {showDisconnect && (
-                                <Button
-                                  variant="outline"
-                                  size="sm"
-                                  className="h-6 border-input bg-white px-2.5 text-[11px] text-foreground hover:border-destructive hover:bg-destructive hover:text-destructive-foreground"
-                                  onClick={(event) => {
-                                    event.stopPropagation()
-                                    setDisconnectTarget({
-                                      providerId: item.id,
-                                      grantType: item.grant_type,
-                                      name: item.name,
-                                    })
-                                  }}
-                                  disabled={isDisabled || isDisconnecting}
-                                >
-                                  Disconnect
-                                </Button>
-                              )}
-                            </ItemActions>
-                          </Item>
-                        )
-                      })}
-                    </div>
-                  </CollapsibleContent>
-                </div>
-              </Collapsible>
-            )
-          })}
-        </div>
-        {filteredIntegrations.length === 0 && (
-          <div className="py-12 text-center">
-            <p className="text-sm text-muted-foreground">
-              No integrations found matching your criteria.
-            </p>
-          </div>
-        )}
-      </ScrollArea>
-      {activeOAuthProvider && (
-        <OAuthIntegrationDialog
-          open={Boolean(activeOAuthProvider)}
-          onOpenChange={handleOAuthDialogOpenChange}
-          providerId={activeOAuthProvider.providerId}
-          grantType={activeOAuthProvider.grantType}
-        />
-      )}
-      {detailsProvider && (
-        <OAuthIntegrationDetailsDialog
-          open={Boolean(detailsProvider)}
-          onOpenChange={(nextOpen) => {
-            if (!nextOpen) {
-              setDetailsProvider(null)
-            }
-          }}
-          providerId={detailsProvider.providerId}
-          grantType={detailsProvider.grantType}
-          canUpdate={canMutateIntegrations}
-        />
-      )}
-      <ConfirmDestructiveDialog
-        open={disconnectTarget !== null}
-        onOpenChange={(next) => {
-          if (!next) setDisconnectTarget(null)
-        }}
-        confirmPhrase={disconnectTarget?.name ?? ""}
-        title="Disconnect integration"
-        description={
-          disconnectTarget ? (
+          {catalogError ? (
+            <Alert variant="destructive">
+              <AlertTitle>Failed to load integrations</AlertTitle>
+              <AlertDescription>
+                {String(catalogError.body?.detail ?? catalogError.message)}
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
+          {catalogIsLoading ? (
+            <CenteredSpinner />
+          ) : (
             <>
-              Are you sure you want to disconnect from{" "}
-              <span className="font-medium">{disconnectTarget.name}</span>?
+              {popular.length > 0 ? (
+                <section className="space-y-3">
+                  <div className="flex items-center gap-2">
+                    <Star className="size-4 text-amber-500" />
+                    <h2 className="text-sm font-semibold text-foreground">
+                      Popular in workspace
+                    </h2>
+                  </div>
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                    {popular.map((integration) => {
+                      const cardState = catalogCardState(integration)
+                      return (
+                        <CatalogCard
+                          key={integration.id}
+                          integration={integration}
+                          ctaIntent={cardState.ctaIntent}
+                          isConnected={cardState.isConnected}
+                          onSelect={() => updateSelection(integration.id)}
+                        />
+                      )
+                    })}
+                  </div>
+                </section>
+              ) : null}
+
+              <section className="space-y-3">
+                {popular.length > 0 ? (
+                  <h2 className="text-sm font-semibold text-foreground">
+                    All integrations
+                  </h2>
+                ) : null}
+                {rest.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    No integrations match your filters.
+                  </p>
+                ) : (
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                    {rest.map((integration) => {
+                      const cardState = catalogCardState(integration)
+                      return (
+                        <CatalogCard
+                          key={integration.id}
+                          integration={integration}
+                          ctaIntent={cardState.ctaIntent}
+                          isConnected={cardState.isConnected}
+                          onSelect={() => updateSelection(integration.id)}
+                        />
+                      )
+                    })}
+                  </div>
+                )}
+              </section>
             </>
-          ) : null
-        }
-        confirmLabel="Disconnect"
-        isPending={disconnectProviderMutation.isPending}
-        onConfirm={async () => {
-          if (!disconnectTarget) return
-          await disconnectProviderMutation.mutateAsync({
-            providerId: disconnectTarget.providerId,
-            grantType: disconnectTarget.grantType,
-          })
-          setDisconnectTarget(null)
-        }}
+          )}
+        </div>
+      </div>
+
+      <IntegrationDetailPanel
+        workspaceId={workspaceId}
+        integrationId={selectedIntegrationId}
+        onClose={() => updateSelection(null)}
       />
     </div>
   )

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -8838,6 +8838,433 @@ export const $CaseViewedEventRead = {
   description: "Event for when a case is viewed.",
 } as const
 
+export const $CatalogAuthOption = {
+  properties: {
+    auth_method: {
+      $ref: "#/components/schemas/ConnectionAuthMethod",
+    },
+    label: {
+      type: "string",
+      title: "Label",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    provider_id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Provider Id",
+    },
+    grant_type: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/OAuthGrantType",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    requires_config: {
+      type: "boolean",
+      title: "Requires Config",
+      default: false,
+    },
+    enabled: {
+      type: "boolean",
+      title: "Enabled",
+      default: true,
+    },
+    status: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/IntegrationStatus",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    fields: {
+      items: {
+        $ref: "#/components/schemas/CatalogCredentialField",
+      },
+      type: "array",
+      title: "Fields",
+    },
+  },
+  type: "object",
+  required: ["auth_method", "label"],
+  title: "CatalogAuthOption",
+  description: "Supported authentication path for a catalog integration.",
+} as const
+
+export const $CatalogConnectionRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    integration_id: {
+      type: "string",
+      format: "uuid",
+      title: "Integration Id",
+    },
+    workspace_id: {
+      type: "string",
+      format: "uuid",
+      title: "Workspace Id",
+    },
+    user_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "User Id",
+    },
+    auth_method: {
+      $ref: "#/components/schemas/ConnectionAuthMethod",
+    },
+    label: {
+      type: "string",
+      title: "Label",
+    },
+    expires_at: {
+      anyOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Expires At",
+    },
+    scope: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Scope",
+    },
+    metadata_: {
+      additionalProperties: true,
+      type: "object",
+      title: "Metadata",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+    is_expired: {
+      type: "boolean",
+      title: "Is Expired",
+      default: false,
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "integration_id",
+    "workspace_id",
+    "user_id",
+    "auth_method",
+    "label",
+    "expires_at",
+    "scope",
+    "created_at",
+    "updated_at",
+  ],
+  title: "CatalogConnectionRead",
+  description: "A user/workspace authenticated binding to an integration.",
+} as const
+
+export const $CatalogCredentialField = {
+  properties: {
+    key: {
+      type: "string",
+      title: "Key",
+    },
+    label: {
+      type: "string",
+      title: "Label",
+    },
+    required: {
+      type: "boolean",
+      title: "Required",
+      default: true,
+    },
+    secret: {
+      type: "boolean",
+      title: "Secret",
+      default: true,
+    },
+    multiline: {
+      type: "boolean",
+      title: "Multiline",
+      default: false,
+    },
+    placeholder: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Placeholder",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+  },
+  type: "object",
+  required: ["key", "label"],
+  title: "CatalogCredentialField",
+  description:
+    "Credential field required by a static/auth configuration option.",
+} as const
+
+export const $CatalogIntegrationDetail = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    workspace_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Workspace Id",
+    },
+    namespace: {
+      type: "string",
+      title: "Namespace",
+    },
+    display_name: {
+      type: "string",
+      title: "Display Name",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    icon_url: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Icon Url",
+    },
+    source: {
+      $ref: "#/components/schemas/IntegrationSource",
+    },
+    auth_options: {
+      items: {
+        $ref: "#/components/schemas/CatalogAuthOption",
+      },
+      type: "array",
+      title: "Auth Options",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+    connections: {
+      items: {
+        $ref: "#/components/schemas/CatalogConnectionRead",
+      },
+      type: "array",
+      title: "Connections",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "workspace_id",
+    "namespace",
+    "display_name",
+    "source",
+    "created_at",
+    "updated_at",
+  ],
+  title: "CatalogIntegrationDetail",
+  description: "Integration row enriched with related connections.",
+} as const
+
+export const $CatalogIntegrationRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    workspace_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Workspace Id",
+    },
+    namespace: {
+      type: "string",
+      title: "Namespace",
+    },
+    display_name: {
+      type: "string",
+      title: "Display Name",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+    icon_url: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Icon Url",
+    },
+    source: {
+      $ref: "#/components/schemas/IntegrationSource",
+    },
+    auth_options: {
+      items: {
+        $ref: "#/components/schemas/CatalogAuthOption",
+      },
+      type: "array",
+      title: "Auth Options",
+    },
+    created_at: {
+      type: "string",
+      format: "date-time",
+      title: "Created At",
+    },
+    updated_at: {
+      type: "string",
+      format: "date-time",
+      title: "Updated At",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "workspace_id",
+    "namespace",
+    "display_name",
+    "source",
+    "created_at",
+    "updated_at",
+  ],
+  title: "CatalogIntegrationRead",
+  description: "Catalog row for an integration.",
+} as const
+
+export const $CatalogStaticKVConnectionCreate = {
+  properties: {
+    auth_method: {
+      $ref: "#/components/schemas/ConnectionAuthMethod",
+      default: "static_kv",
+    },
+    environment: {
+      type: "string",
+      title: "Environment",
+      default: "default",
+    },
+    keys: {
+      additionalProperties: {
+        type: "string",
+      },
+      type: "object",
+      title: "Keys",
+    },
+  },
+  type: "object",
+  required: ["keys"],
+  title: "CatalogStaticKVConnectionCreate",
+  description: "Connection backed by an arbitrary key-value blob.",
+} as const
+
 export const $ChannelType = {
   type: "string",
   enum: ["slack"],
@@ -9827,6 +10254,18 @@ export const $CommentUpdatedEventRead = {
   required: ["comment_id", "thread_root_id", "created_at"],
   title: "CommentUpdatedEventRead",
   description: "Event for when a top-level comment is updated.",
+} as const
+
+export const $ConnectionAuthMethod = {
+  type: "string",
+  enum: [
+    "oauth_auth_code",
+    "oauth_client_credentials",
+    "service_account",
+    "static_kv",
+  ],
+  title: "ConnectionAuthMethod",
+  description: "Auth method for catalog connection projections.",
 } as const
 
 export const $ContinueRunRequest = {
@@ -14128,6 +14567,13 @@ export const $IntegrationReadMinimal = {
   required: ["id", "provider_id", "status", "is_expired"],
   title: "IntegrationReadMinimal",
   description: "Response model for user integration.",
+} as const
+
+export const $IntegrationSource = {
+  type: "string",
+  enum: ["platform", "workspace"],
+  title: "IntegrationSource",
+  description: "Origin of a catalog integration.",
 } as const
 
 export const $IntegrationStatus = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -414,6 +414,16 @@ import type {
   InboxGetPendingCountResponse,
   InboxListItemsData,
   InboxListItemsResponse,
+  IntegrationsCatalogCreateConnectionData,
+  IntegrationsCatalogCreateConnectionResponse,
+  IntegrationsCatalogDeleteConnectionData,
+  IntegrationsCatalogDeleteConnectionResponse,
+  IntegrationsCatalogGetCatalogEntryData,
+  IntegrationsCatalogGetCatalogEntryResponse,
+  IntegrationsCatalogListCatalogData,
+  IntegrationsCatalogListCatalogResponse,
+  IntegrationsCatalogListConnectionsData,
+  IntegrationsCatalogListConnectionsResponse,
   IntegrationsConnectProviderData,
   IntegrationsConnectProviderResponse,
   IntegrationsDeleteIntegrationData,
@@ -11085,6 +11095,139 @@ export const integrationsOauthCallback = (
     query: {
       code: data.code,
       state: data.state,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Catalog
+ * List integrations visible to this workspace.
+ *
+ * Includes platform-shipped (``workspace_id IS NULL``) rows plus
+ * workspace-authored rows for the caller's workspace.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.source
+ * @param data.search
+ * @returns CatalogIntegrationRead Successful Response
+ * @throws ApiError
+ */
+export const integrationsCatalogListCatalog = (
+  data: IntegrationsCatalogListCatalogData
+): CancelablePromise<IntegrationsCatalogListCatalogResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/integrations/catalog",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    query: {
+      source: data.source,
+      search: data.search,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Get Catalog Entry
+ * Get an integration with its connections.
+ * @param data The data for the request.
+ * @param data.integrationId
+ * @param data.workspaceId
+ * @returns CatalogIntegrationDetail Successful Response
+ * @throws ApiError
+ */
+export const integrationsCatalogGetCatalogEntry = (
+  data: IntegrationsCatalogGetCatalogEntryData
+): CancelablePromise<IntegrationsCatalogGetCatalogEntryResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/integrations/catalog/{integration_id}",
+    path: {
+      integration_id: data.integrationId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Connections
+ * @param data The data for the request.
+ * @param data.integrationId
+ * @param data.workspaceId
+ * @returns CatalogConnectionRead Successful Response
+ * @throws ApiError
+ */
+export const integrationsCatalogListConnections = (
+  data: IntegrationsCatalogListConnectionsData
+): CancelablePromise<IntegrationsCatalogListConnectionsResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/integrations/catalog/{integration_id}/connections",
+    path: {
+      integration_id: data.integrationId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Create Connection
+ * Create a static key-value connection for registry credentials.
+ * @param data The data for the request.
+ * @param data.integrationId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns CatalogConnectionRead Successful Response
+ * @throws ApiError
+ */
+export const integrationsCatalogCreateConnection = (
+  data: IntegrationsCatalogCreateConnectionData
+): CancelablePromise<IntegrationsCatalogCreateConnectionResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/integrations/catalog/{integration_id}/connections",
+    path: {
+      integration_id: data.integrationId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete Connection
+ * @param data The data for the request.
+ * @param data.connectionId
+ * @param data.workspaceId
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const integrationsCatalogDeleteConnection = (
+  data: IntegrationsCatalogDeleteConnectionData
+): CancelablePromise<IntegrationsCatalogDeleteConnectionResponse> => {
+  return __request(OpenAPI, {
+    method: "DELETE",
+    url: "/workspaces/{workspace_id}/integrations/connections/{connection_id}",
+    path: {
+      connection_id: data.connectionId,
+      workspace_id: data.workspaceId,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2332,6 +2332,98 @@ export type CaseViewedEventRead = {
 }
 
 /**
+ * Supported authentication path for a catalog integration.
+ */
+export type CatalogAuthOption = {
+  auth_method: ConnectionAuthMethod
+  label: string
+  description?: string | null
+  provider_id?: string | null
+  grant_type?: OAuthGrantType | null
+  requires_config?: boolean
+  enabled?: boolean
+  status?: IntegrationStatus | null
+  fields?: Array<CatalogCredentialField>
+}
+
+/**
+ * A user/workspace authenticated binding to an integration.
+ */
+export type CatalogConnectionRead = {
+  id: string
+  integration_id: string
+  workspace_id: string
+  user_id: string | null
+  auth_method: ConnectionAuthMethod
+  label: string
+  expires_at: string | null
+  scope: string | null
+  metadata_?: {
+    [key: string]: unknown
+  }
+  created_at: string
+  updated_at: string
+  is_expired?: boolean
+}
+
+/**
+ * Credential field required by a static/auth configuration option.
+ */
+export type CatalogCredentialField = {
+  key: string
+  label: string
+  required?: boolean
+  secret?: boolean
+  multiline?: boolean
+  placeholder?: string | null
+  description?: string | null
+}
+
+/**
+ * Integration row enriched with related connections.
+ */
+export type CatalogIntegrationDetail = {
+  id: string
+  workspace_id: string | null
+  namespace: string
+  display_name: string
+  description?: string | null
+  icon_url?: string | null
+  source: IntegrationSource
+  auth_options?: Array<CatalogAuthOption>
+  created_at: string
+  updated_at: string
+  connections?: Array<CatalogConnectionRead>
+}
+
+/**
+ * Catalog row for an integration.
+ */
+export type CatalogIntegrationRead = {
+  id: string
+  workspace_id: string | null
+  namespace: string
+  display_name: string
+  description?: string | null
+  icon_url?: string | null
+  source: IntegrationSource
+  auth_options?: Array<CatalogAuthOption>
+  created_at: string
+  updated_at: string
+}
+
+/**
+ * Connection backed by an arbitrary key-value blob.
+ */
+export type CatalogStaticKVConnectionCreate = {
+  auth_method?: ConnectionAuthMethod
+  environment?: string
+  keys: {
+    [key: string]: string
+  }
+}
+
+/**
  * Supported external channel types.
  */
 export type ChannelType = "slack"
@@ -2739,6 +2831,15 @@ export type CommentUpdatedEventRead = {
    */
   created_at: string
 }
+
+/**
+ * Auth method for catalog connection projections.
+ */
+export type ConnectionAuthMethod =
+  | "oauth_auth_code"
+  | "oauth_client_credentials"
+  | "service_account"
+  | "static_kv"
 
 /**
  * Payload to continue a CE run after collecting approvals.
@@ -4339,6 +4440,11 @@ export type IntegrationReadMinimal = {
   status: IntegrationStatus
   is_expired: boolean
 }
+
+/**
+ * Origin of a catalog integration.
+ */
+export type IntegrationSource = "platform" | "workspace"
 
 /**
  * Status of an integration.
@@ -12189,6 +12295,46 @@ export type IntegrationsOauthCallbackData = {
 
 export type IntegrationsOauthCallbackResponse = IntegrationOAuthCallback
 
+export type IntegrationsCatalogListCatalogData = {
+  search?: string | null
+  source?: IntegrationSource | null
+  workspaceId: string
+}
+
+export type IntegrationsCatalogListCatalogResponse =
+  Array<CatalogIntegrationRead>
+
+export type IntegrationsCatalogGetCatalogEntryData = {
+  integrationId: string
+  workspaceId: string
+}
+
+export type IntegrationsCatalogGetCatalogEntryResponse =
+  CatalogIntegrationDetail
+
+export type IntegrationsCatalogListConnectionsData = {
+  integrationId: string
+  workspaceId: string
+}
+
+export type IntegrationsCatalogListConnectionsResponse =
+  Array<CatalogConnectionRead>
+
+export type IntegrationsCatalogCreateConnectionData = {
+  integrationId: string
+  requestBody: CatalogStaticKVConnectionCreate
+  workspaceId: string
+}
+
+export type IntegrationsCatalogCreateConnectionResponse = CatalogConnectionRead
+
+export type IntegrationsCatalogDeleteConnectionData = {
+  connectionId: string
+  workspaceId: string
+}
+
+export type IntegrationsCatalogDeleteConnectionResponse = void
+
 export type IntegrationsListIntegrationsData = {
   workspaceId: string
 }
@@ -18122,6 +18268,79 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: IntegrationOAuthCallback
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/integrations/catalog": {
+    get: {
+      req: IntegrationsCatalogListCatalogData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<CatalogIntegrationRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/integrations/catalog/{integration_id}": {
+    get: {
+      req: IntegrationsCatalogGetCatalogEntryData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: CatalogIntegrationDetail
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/integrations/catalog/{integration_id}/connections": {
+    get: {
+      req: IntegrationsCatalogListConnectionsData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<CatalogConnectionRead>
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    post: {
+      req: IntegrationsCatalogCreateConnectionData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: CatalogConnectionRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/integrations/connections/{connection_id}": {
+    delete: {
+      req: IntegrationsCatalogDeleteConnectionData
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
         /**
          * Validation Error
          */

--- a/frontend/src/components/integrations/catalog-card.tsx
+++ b/frontend/src/components/integrations/catalog-card.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import type { CatalogIntegrationRead } from "@/client"
+import { ProviderIcon } from "@/components/icons"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+
+type CtaIntent = "connect" | "configure" | "open"
+
+interface CatalogCardProps {
+  integration: CatalogIntegrationRead
+  ctaIntent?: CtaIntent
+  isConnected?: boolean
+  onSelect: () => void
+}
+
+const ctaLabels: Record<CtaIntent, string> = {
+  connect: "Connect",
+  configure: "Configure",
+  open: "Open",
+}
+
+function catalogStatusLabel(
+  integration: CatalogIntegrationRead,
+  isConnected: boolean
+): string | null {
+  if (isConnected) return "Connected"
+  if (integration.source === "workspace") return "Built by me"
+  return null
+}
+
+export function CatalogCard({
+  integration,
+  ctaIntent = "open",
+  isConnected = false,
+  onSelect,
+}: CatalogCardProps) {
+  const statusLabel = catalogStatusLabel(integration, isConnected)
+
+  return (
+    <Card
+      className="flex h-full min-h-[120px] cursor-pointer flex-col gap-2.5 border bg-card p-4 shadow-none transition-colors hover:border-foreground/30"
+      onClick={onSelect}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <ProviderIcon
+          providerId={integration.namespace}
+          className="size-9 shrink-0"
+        />
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 px-3 text-xs font-medium"
+          onClick={(event) => {
+            event.stopPropagation()
+            onSelect()
+          }}
+        >
+          {ctaLabels[ctaIntent]}
+        </Button>
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-1">
+        <div className="flex min-w-0 items-baseline gap-2">
+          <h3 className="truncate text-sm font-semibold leading-5 text-foreground">
+            {integration.display_name}
+          </h3>
+          {statusLabel ? (
+            <span className="shrink-0 text-xs text-muted-foreground">
+              {statusLabel}
+            </span>
+          ) : null}
+        </div>
+        <p className="line-clamp-2 text-sm leading-5 text-muted-foreground">
+          {integration.description ?? "No description"}
+        </p>
+      </div>
+    </Card>
+  )
+}

--- a/frontend/src/components/integrations/configure-dialog.tsx
+++ b/frontend/src/components/integrations/configure-dialog.tsx
@@ -1,0 +1,575 @@
+"use client"
+
+import { Check, ChevronDown, ChevronRight, Copy, Loader2 } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import type { CatalogAuthOption } from "@/client"
+import { MultiTagCommandInput } from "@/components/tags-input"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { toast } from "@/components/ui/use-toast"
+import {
+  useDeleteProviderAuthConfig,
+  useProviderAuthConfig,
+  useTestProviderAuthConnection,
+  useUpdateProviderAuthConfig,
+} from "@/lib/hooks/integrations-catalog"
+import { cn } from "@/lib/utils"
+
+interface ConfigureDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workspaceId: string
+  integrationId: string
+  displayName: string
+  authOptions: CatalogAuthOption[]
+  defaultAuthOption?: CatalogAuthOption | null
+}
+
+function optionKey(option: CatalogAuthOption): string {
+  return [
+    option.auth_method,
+    option.provider_id ?? "unknown",
+    option.grant_type ?? "none",
+  ].join(":")
+}
+
+function isConfigurableOption(option: CatalogAuthOption): boolean {
+  return Boolean(
+    option.enabled !== false &&
+      option.provider_id &&
+      option.grant_type &&
+      option.requires_config
+  )
+}
+
+function optionStatusLabel(option: CatalogAuthOption): string | null {
+  if (option.status === "connected") {
+    return "Connected"
+  }
+  if (option.status === "configured") {
+    return "Configured"
+  }
+  return null
+}
+
+function fallbackRedirectUrl(): string {
+  if (typeof window === "undefined") {
+    return "/integrations/callback"
+  }
+  return `${window.location.origin}/integrations/callback`
+}
+
+export function ConfigureDialog({
+  open,
+  onOpenChange,
+  workspaceId,
+  integrationId,
+  displayName,
+  authOptions,
+  defaultAuthOption,
+}: ConfigureDialogProps) {
+  const configurableOptions = useMemo(
+    () => authOptions.filter(isConfigurableOption),
+    [authOptions]
+  )
+  const defaultKey = useMemo(() => {
+    const preferred = defaultAuthOption
+      ? configurableOptions.find(
+          (option) => optionKey(option) === optionKey(defaultAuthOption)
+        )
+      : null
+    const fallback = preferred ?? configurableOptions[0]
+    return fallback ? optionKey(fallback) : ""
+  }, [configurableOptions, defaultAuthOption])
+  const [selectedKey, setSelectedKey] = useState(defaultKey)
+
+  useEffect(() => {
+    if (open) {
+      setSelectedKey(defaultKey)
+    }
+  }, [defaultKey, open])
+
+  const selectedOption =
+    configurableOptions.find((option) => optionKey(option) === selectedKey) ??
+    configurableOptions[0]
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Configure {displayName}</DialogTitle>
+          <DialogDescription>
+            Save the provider credentials used by this workspace.
+          </DialogDescription>
+        </DialogHeader>
+        {configurableOptions.length === 0 || !selectedOption ? (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              This integration does not require workspace configuration.
+            </p>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Close
+              </Button>
+            </DialogFooter>
+          </div>
+        ) : configurableOptions.length === 1 ? (
+          <ProviderConfigForm
+            key={optionKey(selectedOption)}
+            open={open}
+            workspaceId={workspaceId}
+            integrationId={integrationId}
+            authOption={selectedOption}
+            onClose={() => onOpenChange(false)}
+          />
+        ) : (
+          <div className="space-y-4">
+            <div className="grid gap-2">
+              {configurableOptions.map((option) => {
+                const key = optionKey(option)
+                const selected = selectedKey === key
+                const statusLabel = optionStatusLabel(option)
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    className={cn(
+                      "flex items-start gap-3 rounded-md border px-3 py-2 text-left transition-colors",
+                      selected
+                        ? "border-foreground/50 bg-muted/40"
+                        : "border-border hover:border-foreground/30 hover:bg-muted/20"
+                    )}
+                    onClick={() => setSelectedKey(key)}
+                    aria-pressed={selected}
+                  >
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-sm font-medium leading-5">
+                        {option.label}
+                      </span>
+                      {option.description ? (
+                        <span className="line-clamp-2 text-xs text-muted-foreground">
+                          {option.description}
+                        </span>
+                      ) : null}
+                    </span>
+                    {statusLabel ? (
+                      <span
+                        className={cn(
+                          "mt-0.5 rounded border px-1.5 py-0.5 text-[10px] font-medium",
+                          option.status === "connected" ||
+                            option.status === "configured"
+                            ? "border-emerald-400/50 bg-emerald-500/10 text-emerald-700"
+                            : "border-border bg-muted/40 text-muted-foreground"
+                        )}
+                      >
+                        {statusLabel}
+                      </span>
+                    ) : null}
+                  </button>
+                )
+              })}
+            </div>
+            <ProviderConfigForm
+              key={optionKey(selectedOption)}
+              open={open}
+              workspaceId={workspaceId}
+              integrationId={integrationId}
+              authOption={selectedOption}
+              onClose={() => onOpenChange(false)}
+            />
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ProviderConfigForm({
+  open,
+  workspaceId,
+  integrationId,
+  authOption,
+  onClose,
+}: {
+  open: boolean
+  workspaceId: string
+  integrationId: string
+  authOption: CatalogAuthOption
+  onClose: () => void
+}) {
+  const providerId = authOption.provider_id!
+  const grantType = authOption.grant_type!
+  const isServiceAccount = authOption.auth_method === "service_account"
+  const canTest =
+    authOption.auth_method === "oauth_client_credentials" || isServiceAccount
+  const { provider, providerIsLoading, integration, integrationIsLoading } =
+    useProviderAuthConfig(workspaceId, authOption, open)
+  const { updateProviderAuthConfig, updateProviderAuthConfigIsPending } =
+    useUpdateProviderAuthConfig({
+      workspaceId,
+      integrationId,
+      providerId,
+      grantType,
+    })
+  const { deleteProviderAuthConfig, deleteProviderAuthConfigIsPending } =
+    useDeleteProviderAuthConfig({
+      workspaceId,
+      integrationId,
+      providerId,
+      grantType,
+    })
+  const { testProviderAuthConnection, testProviderAuthConnectionIsPending } =
+    useTestProviderAuthConnection({
+      workspaceId,
+      integrationId,
+      providerId,
+      grantType,
+    })
+
+  const [clientId, setClientId] = useState("")
+  const [clientSecret, setClientSecret] = useState("")
+  const [serviceAccountJson, setServiceAccountJson] = useState("")
+  const [scopes, setScopes] = useState<string[]>([])
+  const [authEndpoint, setAuthEndpoint] = useState("")
+  const [tokenEndpoint, setTokenEndpoint] = useState("")
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState(false)
+
+  useEffect(() => {
+    setClientId("")
+    setClientSecret("")
+    setServiceAccountJson("")
+    setScopes(integration?.requested_scopes ?? provider?.scopes.default ?? [])
+    setAuthEndpoint(
+      integration?.authorization_endpoint ??
+        provider?.default_authorization_endpoint ??
+        ""
+    )
+    setTokenEndpoint(
+      integration?.token_endpoint ?? provider?.default_token_endpoint ?? ""
+    )
+    setAdvancedOpen(false)
+  }, [authOption, integration, provider])
+
+  const redirectUrl = provider?.redirect_uri ?? fallbackRedirectUrl()
+  const hasExistingConfig = Boolean(integration)
+  const hasStoredClientId = Boolean(integration?.client_id)
+  const canSave = isServiceAccount
+    ? hasExistingConfig || Boolean(serviceAccountJson.trim())
+    : hasExistingConfig ||
+      (Boolean(clientId.trim()) && Boolean(clientSecret.trim()))
+
+  const save = async () => {
+    let nextClientId = clientId.trim() || null
+    let nextClientSecret = clientSecret.trim() || null
+
+    if (isServiceAccount) {
+      const trimmedJson = serviceAccountJson.trim()
+      nextClientId = null
+      nextClientSecret = trimmedJson || null
+      if (trimmedJson) {
+        const derived = deriveServiceAccountClientId(trimmedJson)
+        if (!derived) return
+        nextClientId = derived
+      }
+    }
+
+    await updateProviderAuthConfig({
+      client_id: nextClientId,
+      client_secret: nextClientSecret,
+      scopes,
+      authorization_endpoint: authEndpoint.trim() || null,
+      token_endpoint: tokenEndpoint.trim() || null,
+    })
+    setClientId("")
+    setClientSecret("")
+    setServiceAccountJson("")
+  }
+
+  const confirmDelete = async () => {
+    setPendingDelete(false)
+    await deleteProviderAuthConfig()
+    onClose()
+  }
+
+  if (providerIsLoading || integrationIsLoading) {
+    return (
+      <div className="flex h-32 items-center justify-center">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {authOption.auth_method === "oauth_auth_code" ? (
+        <RedirectUrlRow url={redirectUrl} />
+      ) : null}
+
+      <div className="space-y-1.5">
+        <Label>Scopes</Label>
+        <MultiTagCommandInput
+          value={scopes}
+          onChange={setScopes}
+          placeholder="Add scope and press Enter"
+          searchKeys={["value"]}
+          allowCustomTags
+          disableSuggestions
+        />
+      </div>
+
+      {isServiceAccount ? (
+        <div className="space-y-1.5">
+          <Label htmlFor="service-account-json">
+            Service account JSON
+            {hasExistingConfig ? (
+              <span className="ml-2 text-xs text-muted-foreground">
+                (saved - leave blank to keep)
+              </span>
+            ) : null}
+          </Label>
+          <Textarea
+            id="service-account-json"
+            rows={8}
+            className="font-mono text-xs"
+            placeholder='{"type": "service_account", ...}'
+            value={serviceAccountJson}
+            onChange={(event) => setServiceAccountJson(event.target.value)}
+          />
+        </div>
+      ) : (
+        <>
+          <div className="space-y-1.5">
+            <Label htmlFor="client-id">
+              Client ID
+              {hasStoredClientId ? (
+                <span className="ml-2 text-xs text-muted-foreground">
+                  (saved - leave blank to keep)
+                </span>
+              ) : null}
+            </Label>
+            <Input
+              id="client-id"
+              placeholder={hasStoredClientId ? "Saved client ID" : "Client ID"}
+              value={clientId}
+              onChange={(event) => setClientId(event.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="client-secret">
+              Client secret
+              {hasExistingConfig ? (
+                <span className="ml-2 text-xs text-muted-foreground">
+                  (saved - leave blank to keep)
+                </span>
+              ) : null}
+            </Label>
+            <Input
+              id="client-secret"
+              type="password"
+              placeholder={hasExistingConfig ? "Saved secret" : "Client secret"}
+              value={clientSecret}
+              onChange={(event) => setClientSecret(event.target.value)}
+            />
+          </div>
+        </>
+      )}
+
+      <button
+        type="button"
+        className="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground"
+        onClick={() => setAdvancedOpen((prev) => !prev)}
+      >
+        {advancedOpen ? (
+          <ChevronDown className="size-3.5" />
+        ) : (
+          <ChevronRight className="size-3.5" />
+        )}
+        Advanced endpoint overrides
+      </button>
+
+      {advancedOpen ? (
+        <div className="space-y-3 rounded-md border bg-muted/20 p-3">
+          {authOption.auth_method === "oauth_auth_code" ? (
+            <div className="space-y-1.5">
+              <Label htmlFor="auth-endpoint">Authorization URL</Label>
+              <Input
+                id="auth-endpoint"
+                placeholder="https://example.com/oauth/authorize"
+                value={authEndpoint}
+                onChange={(event) => setAuthEndpoint(event.target.value)}
+              />
+            </div>
+          ) : null}
+          <div className="space-y-1.5">
+            <Label htmlFor="token-endpoint">Token URL</Label>
+            <Input
+              id="token-endpoint"
+              placeholder="https://example.com/oauth/token"
+              value={tokenEndpoint}
+              onChange={(event) => setTokenEndpoint(event.target.value)}
+            />
+          </div>
+        </div>
+      ) : null}
+
+      <DialogFooter className="gap-2 sm:justify-between">
+        {hasExistingConfig ? (
+          <Button
+            variant="ghost"
+            className="text-destructive hover:text-destructive"
+            disabled={deleteProviderAuthConfigIsPending}
+            onClick={() => setPendingDelete(true)}
+          >
+            Remove configuration
+          </Button>
+        ) : (
+          <span />
+        )}
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={onClose}>
+            Close
+          </Button>
+          {canTest ? (
+            <Button
+              variant="outline"
+              disabled={
+                !hasExistingConfig ||
+                updateProviderAuthConfigIsPending ||
+                testProviderAuthConnectionIsPending
+              }
+              onClick={() => testProviderAuthConnection()}
+            >
+              {testProviderAuthConnectionIsPending ? (
+                <Loader2 className="mr-2 size-4 animate-spin" />
+              ) : null}
+              Test
+            </Button>
+          ) : null}
+          <Button
+            onClick={save}
+            disabled={!canSave || updateProviderAuthConfigIsPending}
+          >
+            {updateProviderAuthConfigIsPending ? (
+              <Loader2 className="mr-2 size-4 animate-spin" />
+            ) : null}
+            Save configuration
+          </Button>
+        </div>
+      </DialogFooter>
+
+      <AlertDialog open={pendingDelete} onOpenChange={setPendingDelete}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove configuration?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the saved provider credentials. Existing connections
+              keep working until they expire, then users will need to reconnect.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={confirmDelete}
+            >
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}
+
+function deriveServiceAccountClientId(json: string): string | null {
+  try {
+    const parsed = JSON.parse(json) as unknown
+    if (!parsed || typeof parsed !== "object") {
+      throw new Error("Service account JSON must be an object.")
+    }
+    const record = parsed as Record<string, unknown>
+    const clientEmail = record.client_email
+    if (typeof clientEmail === "string" && clientEmail.trim()) {
+      return clientEmail.trim()
+    }
+    const clientId = record.client_id
+    if (typeof clientId === "string" && clientId.trim()) {
+      return clientId.trim()
+    }
+  } catch {
+    toast({
+      title: "Invalid JSON",
+      description: "Paste a valid service account JSON key.",
+      variant: "destructive",
+    })
+    return null
+  }
+
+  toast({
+    title: "Missing service account identity",
+    description: "Service account JSON must include client_email or client_id.",
+    variant: "destructive",
+  })
+  return null
+}
+
+function RedirectUrlRow({ url }: { url: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* noop */
+    }
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <Label>Redirect URL</Label>
+      <div className="flex items-center gap-2 rounded-md border bg-muted/30 px-2 py-1.5 text-xs">
+        <code className="flex-1 truncate font-mono text-foreground/80">
+          {url}
+        </code>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="size-7 shrink-0"
+          onClick={copy}
+          aria-label="Copy redirect URL"
+        >
+          {copied ? (
+            <Check className="size-3.5" />
+          ) : (
+            <Copy className="size-3.5" />
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/integrations/connect-dialog.tsx
+++ b/frontend/src/components/integrations/connect-dialog.tsx
@@ -1,0 +1,658 @@
+"use client"
+
+import { useMutation } from "@tanstack/react-query"
+import { KeyRound, Loader2, Lock, Plus, Trash2, Wrench } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import type { CatalogAuthOption, CatalogCredentialField } from "@/client"
+import { integrationsConnectProvider } from "@/client"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { toast } from "@/components/ui/use-toast"
+import type { TracecatApiError } from "@/lib/errors"
+import { useCreateConnection } from "@/lib/hooks/integrations-catalog"
+import { cn } from "@/lib/utils"
+
+interface ConnectDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workspaceId: string
+  integrationId: string
+  namespace: string
+  displayName: string
+  authOptions: CatalogAuthOption[]
+  defaultAuthMethod?: CatalogAuthOption["auth_method"]
+  onConfigure?: (option: CatalogAuthOption) => void
+}
+
+function optionKey(option: CatalogAuthOption): string {
+  return [
+    option.auth_method,
+    option.provider_id ?? "static",
+    option.grant_type ?? "none",
+  ].join(":")
+}
+
+function isVisibleAuthOption(option: CatalogAuthOption): boolean {
+  return (
+    option.enabled !== false &&
+    (option.auth_method === "oauth_auth_code" ||
+      option.auth_method === "oauth_client_credentials" ||
+      option.auth_method === "service_account" ||
+      option.auth_method === "static_kv")
+  )
+}
+
+function isBlockedByMissingConfig(option: CatalogAuthOption): boolean {
+  return option.requires_config === true && option.status === "not_configured"
+}
+
+function isActionableAuthOption(option: CatalogAuthOption): boolean {
+  if (option.auth_method === "static_kv") {
+    return true
+  }
+  if (option.auth_method === "oauth_auth_code") {
+    return !isBlockedByMissingConfig(option)
+  }
+  return option.status === "connected" || option.status === "configured"
+}
+
+function authOptionOrder(option: CatalogAuthOption): number {
+  if (isActionableAuthOption(option)) {
+    return 0
+  }
+  if (isBlockedByMissingConfig(option)) {
+    return 1
+  }
+  return 2
+}
+
+function AuthOptionIcon({ option }: { option: CatalogAuthOption }) {
+  if (option.auth_method.startsWith("oauth")) {
+    return <Lock className="size-3.5" />
+  }
+  return <KeyRound className="size-3.5" />
+}
+
+function optionStatusLabel(option: CatalogAuthOption): string | null {
+  if (option.requires_config === true && option.status === "not_configured") {
+    return null
+  }
+  if (option.status === "connected") {
+    return "Connected"
+  }
+  if (option.status === "configured") {
+    return "Configured"
+  }
+  return null
+}
+
+function AuthOptionStatusBadge({ option }: { option: CatalogAuthOption }) {
+  const label = optionStatusLabel(option)
+  if (!label) return null
+
+  const connected = option.status === "connected"
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "h-5 shrink-0 px-1.5 text-[10px] font-medium",
+        connected && "border-emerald-400/50 bg-emerald-500/10 text-emerald-700"
+      )}
+    >
+      {label}
+    </Badge>
+  )
+}
+
+export function ConnectDialog({
+  open,
+  onOpenChange,
+  workspaceId,
+  integrationId,
+  namespace,
+  displayName,
+  authOptions,
+  defaultAuthMethod,
+  onConfigure,
+}: ConnectDialogProps) {
+  const visibleOptions = useMemo(
+    () =>
+      [...authOptions]
+        .filter(isVisibleAuthOption)
+        .sort((a, b) => authOptionOrder(a) - authOptionOrder(b)),
+    [authOptions]
+  )
+  const defaultKey = useMemo(() => {
+    if (visibleOptions.length === 0) {
+      return ""
+    }
+    const preferred = visibleOptions.find(
+      (option) => option.auth_method === defaultAuthMethod
+    )
+    const actionable = visibleOptions.find(isActionableAuthOption)
+    return optionKey(preferred ?? actionable ?? visibleOptions[0])
+  }, [visibleOptions, defaultAuthMethod])
+  const [selectedKey, setSelectedKey] = useState(defaultKey)
+
+  useEffect(() => {
+    if (open) {
+      setSelectedKey(defaultKey)
+    }
+  }, [defaultKey, open])
+
+  const selectedOption =
+    visibleOptions.find((option) => optionKey(option) === selectedKey) ??
+    visibleOptions[0]
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Connect {displayName}</DialogTitle>
+          <DialogDescription>
+            Choose an authentication method supported by this integration.
+          </DialogDescription>
+        </DialogHeader>
+
+        {visibleOptions.length === 0 || !selectedOption ? (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              This integration does not expose a user connection flow.
+            </p>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Close
+              </Button>
+            </DialogFooter>
+          </div>
+        ) : visibleOptions.length === 1 ? (
+          <ConnectOptionPanel
+            option={selectedOption}
+            workspaceId={workspaceId}
+            integrationId={integrationId}
+            namespace={namespace}
+            displayName={displayName}
+            onConfigure={onConfigure}
+            onSuccess={() => onOpenChange(false)}
+          />
+        ) : (
+          <div className="space-y-4">
+            <div className="grid gap-2">
+              {visibleOptions.map((option) => {
+                const key = optionKey(option)
+                const selected = key === selectedKey
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    className={cn(
+                      "flex items-start gap-3 rounded-md border px-3 py-2 text-left transition-colors",
+                      selected
+                        ? "border-foreground/50 bg-muted/40"
+                        : "border-border hover:border-foreground/30 hover:bg-muted/20"
+                    )}
+                    onClick={() => setSelectedKey(key)}
+                    aria-pressed={selected}
+                  >
+                    <span className="mt-0.5 text-muted-foreground">
+                      <AuthOptionIcon option={option} />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-sm font-medium leading-5">
+                        {option.label}
+                      </span>
+                      {option.description ? (
+                        <span className="line-clamp-2 text-xs text-muted-foreground">
+                          {option.description}
+                        </span>
+                      ) : null}
+                    </span>
+                    <AuthOptionStatusBadge option={option} />
+                  </button>
+                )
+              })}
+            </div>
+            <ConnectOptionPanel
+              option={selectedOption}
+              workspaceId={workspaceId}
+              integrationId={integrationId}
+              namespace={namespace}
+              displayName={displayName}
+              onConfigure={onConfigure}
+              onSuccess={() => onOpenChange(false)}
+            />
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ConnectOptionPanel({
+  option,
+  workspaceId,
+  integrationId,
+  namespace,
+  displayName,
+  onConfigure,
+  onSuccess,
+}: {
+  option: CatalogAuthOption
+  workspaceId: string
+  integrationId: string
+  namespace: string
+  displayName: string
+  onConfigure?: (option: CatalogAuthOption) => void
+  onSuccess: () => void
+}) {
+  if (option.auth_method === "oauth_auth_code") {
+    return (
+      <OAuthOptionPanel
+        option={option}
+        workspaceId={workspaceId}
+        namespace={namespace}
+        displayName={displayName}
+        onConfigure={onConfigure}
+        onSuccess={onSuccess}
+      />
+    )
+  }
+  if (option.auth_method === "static_kv") {
+    return (
+      <StaticKVOptionPanel
+        option={option}
+        workspaceId={workspaceId}
+        integrationId={integrationId}
+        onSuccess={onSuccess}
+      />
+    )
+  }
+  return (
+    <ProviderConfigOptionPanel
+      option={option}
+      displayName={displayName}
+      onConfigure={onConfigure}
+    />
+  )
+}
+
+function ProviderConfigOptionPanel({
+  option,
+  displayName,
+  onConfigure,
+}: {
+  option: CatalogAuthOption
+  displayName: string
+  onConfigure?: (option: CatalogAuthOption) => void
+}) {
+  const needsConfiguration =
+    option.requires_config === true && option.status === "not_configured"
+  return (
+    <div className="space-y-3">
+      {option.description ? (
+        <p className="text-sm text-muted-foreground">{option.description}</p>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          This method uses workspace-level credentials for {displayName}.
+        </p>
+      )}
+      <DialogFooter>
+        <Button
+          onClick={() => onConfigure?.(option)}
+          disabled={!onConfigure}
+          className="gap-2"
+        >
+          <Wrench className="size-4" />
+          {needsConfiguration ? "Configure" : "Edit configuration"}
+        </Button>
+      </DialogFooter>
+    </div>
+  )
+}
+
+function OAuthOptionPanel({
+  option,
+  workspaceId,
+  namespace,
+  displayName,
+  onConfigure,
+  onSuccess,
+}: {
+  option: CatalogAuthOption
+  workspaceId: string
+  namespace: string
+  displayName: string
+  onConfigure?: (option: CatalogAuthOption) => void
+  onSuccess: () => void
+}) {
+  const providerId = option.provider_id ?? namespace
+  const needsConfiguration =
+    option.requires_config === true && option.status === "not_configured"
+  const { mutate, isPending } = useMutation({
+    mutationFn: async () =>
+      await integrationsConnectProvider({
+        workspaceId,
+        providerId,
+      }),
+    onSuccess: (result) => {
+      onSuccess()
+      window.location.href = result.auth_url
+    },
+    onError: (error: TracecatApiError) => {
+      toast({
+        title: "Failed to start OAuth",
+        description: String(error.body?.detail ?? error.message),
+        variant: "destructive",
+      })
+    },
+  })
+
+  return (
+    <div className="space-y-3">
+      {option.description ? (
+        <p className="text-sm text-muted-foreground">{option.description}</p>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          You will be redirected to {displayName} to authorize access.
+        </p>
+      )}
+      <DialogFooter>
+        {needsConfiguration ? (
+          <Button
+            onClick={() => onConfigure?.(option)}
+            disabled={!onConfigure}
+            className="gap-2"
+          >
+            <Wrench className="size-4" />
+            Configure
+          </Button>
+        ) : (
+          <Button onClick={() => mutate()} disabled={isPending}>
+            {isPending ? (
+              <Loader2 className="mr-2 size-4 animate-spin" />
+            ) : (
+              <Lock className="mr-2 size-4" />
+            )}
+            Continue to {displayName}
+          </Button>
+        )}
+      </DialogFooter>
+    </div>
+  )
+}
+
+function StaticKVOptionPanel({
+  option,
+  workspaceId,
+  integrationId,
+  onSuccess,
+}: {
+  option: CatalogAuthOption
+  workspaceId: string
+  integrationId: string
+  onSuccess: () => void
+}) {
+  const fields = option.fields ?? []
+  const [environment, setEnvironment] = useState("default")
+  const [values, setValues] = useState<Record<string, string>>({})
+  const [extraKeys, setExtraKeys] = useState<
+    Array<{ id: number; key: string; value: string }>
+  >([])
+  const { createConnection, createConnectionIsPending } = useCreateConnection(
+    workspaceId,
+    integrationId
+  )
+
+  useEffect(() => {
+    setEnvironment("default")
+    setValues({})
+    setExtraKeys([])
+  }, [option])
+
+  const submit = async () => {
+    const missing = fields.filter(
+      (field) => field.required !== false && !values[field.key]?.trim()
+    )
+    if (missing.length > 0) {
+      toast({
+        title: "Missing credential fields",
+        description: missing.map((field) => field.label).join(", "),
+        variant: "destructive",
+      })
+      return
+    }
+
+    const declaredKeys = Object.fromEntries(
+      fields
+        .map((field) => [field.key, values[field.key]?.trim() ?? ""] as const)
+        .filter(([, value]) => value.length > 0)
+    )
+    const completeExtraKeys = extraKeys
+      .map((item) => ({
+        key: item.key.trim(),
+        value: item.value.trim(),
+      }))
+      .filter((item) => item.key.length > 0 || item.value.length > 0)
+    const incompleteExtraKey = completeExtraKeys.find(
+      (item) => item.key.length === 0 || item.value.length === 0
+    )
+    if (incompleteExtraKey) {
+      toast({
+        title: "Incomplete credential key",
+        description: "Additional keys require both a key and a value.",
+        variant: "destructive",
+      })
+      return
+    }
+    const declaredFieldKeys = new Set(fields.map((field) => field.key))
+    const duplicateKey = completeExtraKeys.find(
+      (item, index) =>
+        declaredFieldKeys.has(item.key) ||
+        completeExtraKeys.findIndex((other) => other.key === item.key) !== index
+    )
+    if (duplicateKey) {
+      toast({
+        title: "Duplicate credential key",
+        description: `${duplicateKey.key} is already defined.`,
+        variant: "destructive",
+      })
+      return
+    }
+
+    const keys = {
+      ...declaredKeys,
+      ...Object.fromEntries(
+        completeExtraKeys.map((item) => [item.key, item.value] as const)
+      ),
+    }
+    if (Object.keys(keys).length === 0) {
+      toast({
+        title: "No credential keys",
+        description: "Add at least one credential key before saving.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    await createConnection({
+      auth_method: "static_kv",
+      environment: environment.trim() || "default",
+      keys,
+    })
+    setEnvironment("default")
+    setValues({})
+    setExtraKeys([])
+    onSuccess()
+  }
+
+  return (
+    <div className="space-y-3">
+      {option.description ? (
+        <p className="text-sm text-muted-foreground">{option.description}</p>
+      ) : null}
+      <div className="space-y-1.5">
+        <Label htmlFor={`${optionKey(option)}-environment`}>Environment</Label>
+        <Input
+          id={`${optionKey(option)}-environment`}
+          placeholder="default"
+          value={environment}
+          onChange={(event) => setEnvironment(event.target.value)}
+        />
+        <p className="text-[11px] text-muted-foreground">
+          Workflows use this environment to select the right credentials.
+        </p>
+      </div>
+      {fields.map((field) => (
+        <CredentialFieldInput
+          key={field.key}
+          field={field}
+          value={values[field.key] ?? ""}
+          inputId={`${optionKey(option)}-${field.key}`}
+          onChange={(value) =>
+            setValues((prev) => ({ ...prev, [field.key]: value }))
+          }
+        />
+      ))}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-2">
+          <Label>Additional keys</Label>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1.5 px-2 text-xs"
+            onClick={() =>
+              setExtraKeys((prev) => [
+                ...prev,
+                { id: Date.now() + Math.random(), key: "", value: "" },
+              ])
+            }
+          >
+            <Plus className="size-3.5" />
+            Add key
+          </Button>
+        </div>
+        {extraKeys.length > 0 ? (
+          <div className="flex flex-col gap-2">
+            {extraKeys.map((item) => (
+              <div key={item.id} className="flex items-center gap-2">
+                <Input
+                  placeholder="Key"
+                  value={item.key}
+                  onChange={(event) =>
+                    setExtraKeys((prev) =>
+                      prev.map((prevItem) =>
+                        prevItem.id === item.id
+                          ? { ...prevItem, key: event.target.value }
+                          : prevItem
+                      )
+                    )
+                  }
+                />
+                <Input
+                  type="password"
+                  placeholder="Value"
+                  value={item.value}
+                  onChange={(event) =>
+                    setExtraKeys((prev) =>
+                      prev.map((prevItem) =>
+                        prevItem.id === item.id
+                          ? { ...prevItem, value: event.target.value }
+                          : prevItem
+                      )
+                    )
+                  }
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-8 shrink-0"
+                  onClick={() =>
+                    setExtraKeys((prev) =>
+                      prev.filter((prevItem) => prevItem.id !== item.id)
+                    )
+                  }
+                  aria-label={`Remove additional key ${item.key || "row"}`}
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-[11px] text-muted-foreground">
+            Add optional keys that are not part of the default template.
+          </p>
+        )}
+      </div>
+      <DialogFooter>
+        <Button
+          onClick={submit}
+          disabled={
+            (fields.length === 0 && extraKeys.length === 0) ||
+            createConnectionIsPending
+          }
+        >
+          {createConnectionIsPending ? (
+            <Loader2 className="mr-2 size-4 animate-spin" />
+          ) : null}
+          Save connection
+        </Button>
+      </DialogFooter>
+    </div>
+  )
+}
+
+function CredentialFieldInput({
+  field,
+  value,
+  inputId,
+  onChange,
+}: {
+  field: CatalogCredentialField
+  value: string
+  inputId: string
+  onChange: (value: string) => void
+}) {
+  const label =
+    field.required === false ? `${field.label} (optional)` : field.label
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={inputId}>{label}</Label>
+      {field.multiline ? (
+        <Textarea
+          id={inputId}
+          rows={8}
+          className="font-mono text-xs"
+          placeholder={field.placeholder ?? field.key}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      ) : (
+        <Input
+          id={inputId}
+          type={field.secret === false ? "text" : "password"}
+          placeholder={field.placeholder ?? field.key}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      )}
+      {field.description ? (
+        <p className="text-[11px] text-muted-foreground">{field.description}</p>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/components/integrations/integration-detail-panel.tsx
+++ b/frontend/src/components/integrations/integration-detail-panel.tsx
@@ -1,0 +1,361 @@
+"use client"
+
+import { formatDistanceToNowStrict } from "date-fns"
+import { Plug, Trash2, Wrench } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import type {
+  CatalogAuthOption,
+  CatalogConnectionRead,
+  CatalogIntegrationDetail,
+} from "@/client"
+import { ProviderIcon } from "@/components/icons"
+import { ConfigureDialog } from "@/components/integrations/configure-dialog"
+import { ConnectDialog } from "@/components/integrations/connect-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  useDeleteConnection,
+  useIntegrationDetail,
+} from "@/lib/hooks/integrations-catalog"
+
+interface IntegrationDetailPanelProps {
+  workspaceId: string
+  integrationId: string | null
+  onClose: () => void
+}
+
+export function IntegrationDetailPanel({
+  workspaceId,
+  integrationId,
+  onClose,
+}: IntegrationDetailPanelProps) {
+  const open = Boolean(integrationId)
+  const { integration, integrationIsLoading } = useIntegrationDetail(
+    workspaceId,
+    integrationId
+  )
+  const [lastIntegration, setLastIntegration] =
+    useState<CatalogIntegrationDetail | null>(null)
+  const renderedIntegration = integration ?? (open ? null : lastIntegration)
+
+  useEffect(() => {
+    if (integration) {
+      setLastIntegration(integration)
+    }
+  }, [integration])
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose()
+      }}
+    >
+      <DialogContent className="min-h-[220px] w-[calc(100vw-2rem)] max-w-2xl gap-4 p-0 data-[state=closed]:zoom-out-100 data-[state=open]:zoom-in-100 sm:w-full">
+        {integrationIsLoading || !renderedIntegration ? (
+          <IntegrationDetailSkeleton />
+        ) : (
+          <IntegrationDetailContent
+            key={renderedIntegration.id}
+            integration={renderedIntegration}
+            workspaceId={workspaceId}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function IntegrationDetailSkeleton() {
+  return (
+    <>
+      <DialogHeader className="px-6 pt-6">
+        <DialogTitle className="sr-only">Loading integration</DialogTitle>
+        <div className="flex items-start gap-3">
+          <Skeleton className="size-11 shrink-0" />
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-3 w-72 max-w-full" />
+          </div>
+          <Skeleton className="h-7 w-24 shrink-0" />
+        </div>
+      </DialogHeader>
+
+      <div className="flex max-h-[60vh] min-h-[116px] flex-col gap-3 overflow-y-auto px-6 pb-6">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-7 w-28" />
+        </div>
+        <Skeleton className="h-12 w-full" />
+      </div>
+    </>
+  )
+}
+
+interface IntegrationDetailContentProps {
+  integration: CatalogIntegrationDetail
+  workspaceId: string
+}
+
+function isConnectableOption(option: CatalogAuthOption): boolean {
+  return (
+    option.enabled !== false &&
+    (option.auth_method === "oauth_auth_code" ||
+      option.auth_method === "static_kv")
+  )
+}
+
+function isConfigurableOption(option: CatalogAuthOption): boolean {
+  return Boolean(
+    option.enabled !== false &&
+      option.provider_id &&
+      option.grant_type &&
+      option.requires_config
+  )
+}
+
+function authMethodLabel(
+  authMethod: CatalogConnectionRead["auth_method"]
+): string {
+  switch (authMethod) {
+    case "oauth_auth_code":
+      return "OAuth"
+    case "oauth_client_credentials":
+      return "Client credentials"
+    case "service_account":
+      return "Service account"
+    case "static_kv":
+      return "Static credentials"
+    default:
+      return authMethod
+  }
+}
+
+function IntegrationDetailContent({
+  integration,
+  workspaceId,
+}: IntegrationDetailContentProps) {
+  const [connectOpen, setConnectOpen] = useState(false)
+  const [configureOpen, setConfigureOpen] = useState(false)
+  const [configureOption, setConfigureOption] =
+    useState<CatalogAuthOption | null>(null)
+  const isWorkspaceBuilt = integration.source === "workspace"
+  const authOptions = integration.auth_options ?? []
+  const connectableOptions = authOptions.filter(isConnectableOption)
+  const configurableOptions = authOptions.filter(isConfigurableOption)
+  const missingConfigOption =
+    configurableOptions.find((option) => option.status === "not_configured") ??
+    null
+  const openConfigure = (option?: CatalogAuthOption | null) => {
+    setConfigureOption(
+      option ?? missingConfigOption ?? configurableOptions[0] ?? null
+    )
+    setConfigureOpen(true)
+  }
+
+  return (
+    <>
+      <DialogHeader className="px-6 pt-6">
+        <div className="flex items-start gap-3">
+          <ProviderIcon
+            providerId={integration.namespace}
+            className="size-11 shrink-0"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <DialogTitle className="truncate text-lg leading-tight">
+                {integration.display_name}
+              </DialogTitle>
+              {isWorkspaceBuilt ? (
+                <Badge variant="secondary" className="h-5 px-1.5 text-[10px]">
+                  Built by me
+                </Badge>
+              ) : null}
+            </div>
+            <DialogDescription className="mt-1 text-xs">
+              {integration.description ?? "No description"}
+            </DialogDescription>
+          </div>
+          {configurableOptions.length > 0 ? (
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 shrink-0 gap-1.5 px-2.5 text-xs"
+              onClick={() => openConfigure()}
+            >
+              <Wrench className="size-3.5" />
+              Configure
+            </Button>
+          ) : null}
+        </div>
+      </DialogHeader>
+
+      <div className="max-h-[60vh] min-h-[116px] space-y-5 overflow-y-auto px-6 pb-6">
+        <ConnectionsSection
+          workspaceId={workspaceId}
+          integrationId={integration.id}
+          connections={integration.connections ?? []}
+          canAddConnection={connectableOptions.length > 0}
+          canConfigure={configurableOptions.length > 0}
+          onAddConnection={() => setConnectOpen(true)}
+        />
+      </div>
+
+      <ConnectDialog
+        open={connectOpen}
+        onOpenChange={setConnectOpen}
+        workspaceId={workspaceId}
+        integrationId={integration.id}
+        namespace={integration.namespace}
+        displayName={integration.display_name}
+        authOptions={authOptions}
+        onConfigure={(option) => {
+          setConnectOpen(false)
+          openConfigure(option)
+        }}
+      />
+
+      <ConfigureDialog
+        open={configureOpen}
+        onOpenChange={setConfigureOpen}
+        workspaceId={workspaceId}
+        integrationId={integration.id}
+        displayName={integration.display_name}
+        authOptions={authOptions}
+        defaultAuthOption={configureOption}
+      />
+    </>
+  )
+}
+
+function ConnectionsSection({
+  workspaceId,
+  integrationId,
+  connections,
+  canAddConnection,
+  canConfigure,
+  onAddConnection,
+}: {
+  workspaceId: string
+  integrationId: string
+  connections: CatalogConnectionRead[]
+  canAddConnection: boolean
+  canConfigure: boolean
+  onAddConnection: () => void
+}) {
+  const { deleteConnection, deleteConnectionIsPending } = useDeleteConnection(
+    workspaceId,
+    integrationId
+  )
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Plug className="size-4 text-muted-foreground" />
+          <h3 className="text-sm font-semibold">Connections</h3>
+          <Badge variant="outline" className="h-4 px-1.5 text-[10px]">
+            {connections.length}
+          </Badge>
+        </div>
+        {canAddConnection ? (
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 px-2.5 text-xs"
+            onClick={onAddConnection}
+          >
+            Add connection
+          </Button>
+        ) : null}
+      </div>
+      {connections.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          {canAddConnection
+            ? "No connections yet. Add a connection to authenticate this integration."
+            : canConfigure
+              ? "Use Configure to finish credential setup for this integration."
+              : "No separate connection is required for this integration."}
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {connections.map((connection) => (
+            <ConnectionRow
+              key={connection.id}
+              connection={connection}
+              onDelete={() => deleteConnection(connection.id)}
+              isDeleting={deleteConnectionIsPending}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+function ConnectionRow({
+  connection,
+  onDelete,
+  isDeleting,
+}: {
+  connection: CatalogConnectionRead
+  onDelete: () => void
+  isDeleting: boolean
+}) {
+  const lastUpdated = useMemo(() => {
+    if (!connection.updated_at) return null
+    try {
+      return formatDistanceToNowStrict(new Date(connection.updated_at), {
+        addSuffix: true,
+      })
+    } catch {
+      return null
+    }
+  }, [connection.updated_at])
+
+  return (
+    <li className="flex items-center justify-between gap-3 rounded-md border bg-muted/20 px-3 py-2">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium">
+            {connection.label}
+          </span>
+          <Badge variant="outline" className="h-4 px-1.5 text-[10px]">
+            {authMethodLabel(connection.auth_method)}
+          </Badge>
+          {connection.is_expired ? (
+            <Badge
+              variant="outline"
+              className="h-4 gap-1 border-destructive/40 bg-destructive/10 px-1.5 text-[10px] text-destructive"
+            >
+              Expired
+            </Badge>
+          ) : null}
+        </div>
+        {lastUpdated ? (
+          <p className="text-[11px] text-muted-foreground">
+            Updated {lastUpdated}
+          </p>
+        ) : null}
+      </div>
+      <Button
+        size="icon"
+        variant="ghost"
+        className="size-7 shrink-0 text-muted-foreground hover:text-destructive"
+        disabled={isDeleting}
+        onClick={onDelete}
+        aria-label={`Remove connection ${connection.label}`}
+      >
+        <Trash2 className="size-4" />
+      </Button>
+    </li>
+  )
+}

--- a/frontend/src/lib/hooks/integrations-catalog.ts
+++ b/frontend/src/lib/hooks/integrations-catalog.ts
@@ -1,0 +1,481 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import type {
+  CatalogAuthOption,
+  CatalogConnectionRead,
+  CatalogIntegrationDetail,
+  CatalogIntegrationRead,
+  CatalogStaticKVConnectionCreate,
+  IntegrationRead,
+  IntegrationSource,
+  IntegrationTestConnectionResponse,
+  IntegrationUpdate,
+  OAuthGrantType,
+  ProviderRead,
+} from "@/client"
+import {
+  integrationsCatalogCreateConnection,
+  integrationsCatalogDeleteConnection,
+  integrationsCatalogGetCatalogEntry,
+  integrationsCatalogListCatalog,
+  integrationsCatalogListConnections,
+  integrationsDeleteIntegration,
+  integrationsGetIntegration,
+  integrationsTestConnection,
+  integrationsUpdateIntegration,
+  providersGetProvider,
+} from "@/client"
+import { toast } from "@/components/ui/use-toast"
+import { retryHandler, type TracecatApiError } from "@/lib/errors"
+
+const CATALOG_LIST_KEY = "integrations-catalog"
+const CATALOG_DETAIL_KEY = "integrations-catalog-detail"
+const CATALOG_CONNECTIONS_KEY = "integrations-catalog-connections"
+
+export type CatalogConnectionCreatePayload = CatalogStaticKVConnectionCreate & {
+  auth_method: "static_kv"
+}
+
+export interface UseListIntegrationCatalogOptions {
+  source?: IntegrationSource | null
+  search?: string | null
+}
+
+export function useListIntegrationCatalog(
+  workspaceId: string,
+  options: UseListIntegrationCatalogOptions = {}
+) {
+  const { source = null, search = null } = options
+  const {
+    data: catalog,
+    isLoading: catalogIsLoading,
+    error: catalogError,
+  } = useQuery<CatalogIntegrationRead[], TracecatApiError>({
+    queryKey: [CATALOG_LIST_KEY, workspaceId, source, search],
+    queryFn: async () =>
+      await integrationsCatalogListCatalog({
+        workspaceId,
+        source,
+        search,
+      }),
+    enabled: Boolean(workspaceId),
+    staleTime: 30 * 1000,
+    refetchOnWindowFocus: false,
+  })
+
+  return { catalog, catalogIsLoading, catalogError }
+}
+
+export function useIntegrationDetail(
+  workspaceId: string,
+  integrationId: string | null | undefined
+) {
+  const {
+    data: integration,
+    isLoading: integrationIsLoading,
+    error: integrationError,
+  } = useQuery<CatalogIntegrationDetail, TracecatApiError>({
+    queryKey: [CATALOG_DETAIL_KEY, workspaceId, integrationId],
+    queryFn: async () =>
+      await integrationsCatalogGetCatalogEntry({
+        workspaceId,
+        integrationId: integrationId!,
+      }),
+    enabled: Boolean(workspaceId && integrationId),
+    staleTime: 15 * 1000,
+    refetchOnWindowFocus: false,
+  })
+
+  return { integration, integrationIsLoading, integrationError }
+}
+
+function invalidateCatalogQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  workspaceId: string,
+  integrationId?: string | null
+) {
+  queryClient.invalidateQueries({ queryKey: [CATALOG_LIST_KEY, workspaceId] })
+  if (integrationId) {
+    queryClient.invalidateQueries({
+      queryKey: [CATALOG_DETAIL_KEY, workspaceId, integrationId],
+    })
+  }
+}
+
+function invalidateProviderAuthQueries({
+  queryClient,
+  workspaceId,
+  integrationId,
+  providerId,
+  grantType,
+}: {
+  queryClient: ReturnType<typeof useQueryClient>
+  workspaceId: string
+  integrationId?: string | null
+  providerId: string
+  grantType: OAuthGrantType
+}) {
+  invalidateCatalogQueries(queryClient, workspaceId, integrationId)
+  queryClient.invalidateQueries({
+    queryKey: ["integration", providerId, workspaceId, grantType],
+  })
+  queryClient.invalidateQueries({
+    queryKey: ["provider-schema", providerId, workspaceId, grantType],
+  })
+  queryClient.invalidateQueries({
+    queryKey: ["providers", workspaceId],
+  })
+}
+
+export function useListConnections(
+  workspaceId: string,
+  integrationId: string | null | undefined
+) {
+  const {
+    data: connections,
+    isLoading: connectionsIsLoading,
+    error: connectionsError,
+  } = useQuery<CatalogConnectionRead[], TracecatApiError>({
+    queryKey: [CATALOG_CONNECTIONS_KEY, workspaceId, integrationId],
+    queryFn: async () =>
+      await integrationsCatalogListConnections({
+        workspaceId,
+        integrationId: integrationId!,
+      }),
+    enabled: Boolean(workspaceId && integrationId),
+    staleTime: 15 * 1000,
+    refetchOnWindowFocus: false,
+  })
+
+  return { connections, connectionsIsLoading, connectionsError }
+}
+
+export function useCreateConnection(
+  workspaceId: string,
+  integrationId: string
+) {
+  const queryClient = useQueryClient()
+
+  const {
+    mutateAsync: createConnection,
+    isPending: createConnectionIsPending,
+    error: createConnectionError,
+  } = useMutation({
+    mutationFn: async (params: CatalogConnectionCreatePayload) =>
+      await integrationsCatalogCreateConnection({
+        workspaceId,
+        integrationId,
+        requestBody: params,
+      }),
+    onSuccess: (connection) => {
+      queryClient.invalidateQueries({
+        queryKey: [CATALOG_CONNECTIONS_KEY, workspaceId, integrationId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: [CATALOG_DETAIL_KEY, workspaceId, integrationId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: [CATALOG_LIST_KEY, workspaceId],
+      })
+      toast({
+        title: "Connection added",
+        description: connection.label,
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      console.error("Failed to create connection:", error)
+      toast({
+        title: "Failed to add connection",
+        description: `${error.body?.detail || error.message}`,
+        variant: "destructive",
+      })
+    },
+  })
+
+  return {
+    createConnection,
+    createConnectionIsPending,
+    createConnectionError,
+  }
+}
+
+export function useProviderAuthConfig(
+  workspaceId: string,
+  authOption: CatalogAuthOption | null | undefined,
+  enabled: boolean
+) {
+  const providerId = authOption?.provider_id ?? null
+  const grantType = authOption?.grant_type ?? null
+  const hasConfiguredProvider = authOption?.status !== "not_configured"
+
+  const {
+    data: provider,
+    isLoading: providerIsLoading,
+    error: providerError,
+  } = useQuery<ProviderRead, TracecatApiError>({
+    queryKey: ["provider-schema", providerId, workspaceId, grantType],
+    queryFn: async () =>
+      await providersGetProvider({
+        providerId: providerId!,
+        workspaceId,
+        grantType: grantType!,
+      }),
+    enabled: Boolean(enabled && workspaceId && providerId && grantType),
+    retry: retryHandler,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  })
+
+  const {
+    data: integration,
+    isLoading: integrationIsLoading,
+    error: integrationError,
+  } = useQuery<IntegrationRead | null, TracecatApiError>({
+    queryKey: ["integration", providerId, workspaceId, grantType],
+    queryFn: async () => {
+      try {
+        return await integrationsGetIntegration({
+          providerId: providerId!,
+          workspaceId,
+          grantType: grantType!,
+        })
+      } catch (error) {
+        if ((error as TracecatApiError).status === 404) {
+          return null
+        }
+        throw error
+      }
+    },
+    enabled: Boolean(
+      enabled && hasConfiguredProvider && workspaceId && providerId && grantType
+    ),
+    retry: retryHandler,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  })
+
+  return {
+    provider,
+    providerIsLoading,
+    providerError,
+    integration,
+    integrationIsLoading,
+    integrationError,
+  }
+}
+
+export function useUpdateProviderAuthConfig({
+  workspaceId,
+  integrationId,
+  providerId,
+  grantType,
+}: {
+  workspaceId: string
+  integrationId: string
+  providerId: string
+  grantType: OAuthGrantType
+}) {
+  const queryClient = useQueryClient()
+
+  const {
+    mutateAsync: updateProviderAuthConfig,
+    isPending: updateProviderAuthConfigIsPending,
+    error: updateProviderAuthConfigError,
+  } = useMutation({
+    mutationFn: async (params: Omit<IntegrationUpdate, "grant_type">) =>
+      await integrationsUpdateIntegration({
+        workspaceId,
+        providerId,
+        grantType,
+        requestBody: {
+          ...params,
+          grant_type: grantType,
+        },
+      }),
+    onSuccess: () => {
+      invalidateProviderAuthQueries({
+        queryClient,
+        workspaceId,
+        integrationId,
+        providerId,
+        grantType,
+      })
+      toast({ title: "Configuration saved" })
+    },
+    onError: (error: TracecatApiError) => {
+      console.error("Failed to save provider configuration:", error)
+      toast({
+        title: "Failed to save configuration",
+        description: `${error.body?.detail || error.message}`,
+        variant: "destructive",
+      })
+    },
+  })
+
+  return {
+    updateProviderAuthConfig,
+    updateProviderAuthConfigIsPending,
+    updateProviderAuthConfigError,
+  }
+}
+
+export function useDeleteProviderAuthConfig({
+  workspaceId,
+  integrationId,
+  providerId,
+  grantType,
+}: {
+  workspaceId: string
+  integrationId: string
+  providerId: string
+  grantType: OAuthGrantType
+}) {
+  const queryClient = useQueryClient()
+
+  const {
+    mutateAsync: deleteProviderAuthConfig,
+    isPending: deleteProviderAuthConfigIsPending,
+    error: deleteProviderAuthConfigError,
+  } = useMutation({
+    mutationFn: async () =>
+      await integrationsDeleteIntegration({
+        workspaceId,
+        providerId,
+        grantType,
+      }),
+    onSuccess: () => {
+      invalidateProviderAuthQueries({
+        queryClient,
+        workspaceId,
+        integrationId,
+        providerId,
+        grantType,
+      })
+      toast({ title: "Configuration removed" })
+    },
+    onError: (error: TracecatApiError) => {
+      console.error("Failed to remove provider configuration:", error)
+      toast({
+        title: "Failed to remove configuration",
+        description: `${error.body?.detail || error.message}`,
+        variant: "destructive",
+      })
+    },
+  })
+
+  return {
+    deleteProviderAuthConfig,
+    deleteProviderAuthConfigIsPending,
+    deleteProviderAuthConfigError,
+  }
+}
+
+export function useTestProviderAuthConnection({
+  workspaceId,
+  integrationId,
+  providerId,
+  grantType,
+}: {
+  workspaceId: string
+  integrationId: string
+  providerId: string
+  grantType: OAuthGrantType
+}) {
+  const queryClient = useQueryClient()
+
+  const {
+    mutateAsync: testProviderAuthConnection,
+    isPending: testProviderAuthConnectionIsPending,
+    error: testProviderAuthConnectionError,
+  } = useMutation<IntegrationTestConnectionResponse, TracecatApiError>({
+    mutationFn: async () =>
+      await integrationsTestConnection({
+        workspaceId,
+        providerId,
+      }),
+    onSuccess: (result) => {
+      invalidateProviderAuthQueries({
+        queryClient,
+        workspaceId,
+        integrationId,
+        providerId,
+        grantType,
+      })
+      if (result.success) {
+        toast({
+          title: "Connection successful",
+          description: result.message,
+        })
+      } else {
+        toast({
+          title: "Connection failed",
+          description: result.error || result.message,
+          variant: "destructive",
+        })
+      }
+    },
+    onError: (error: TracecatApiError) => {
+      console.error("Failed to test provider connection:", error)
+      toast({
+        title: "Test failed",
+        description: `${error.body?.detail || error.message}`,
+        variant: "destructive",
+      })
+    },
+  })
+
+  return {
+    testProviderAuthConnection,
+    testProviderAuthConnectionIsPending,
+    testProviderAuthConnectionError,
+  }
+}
+
+export function useDeleteConnection(
+  workspaceId: string,
+  integrationId: string | null
+) {
+  const queryClient = useQueryClient()
+
+  const {
+    mutateAsync: deleteConnection,
+    isPending: deleteConnectionIsPending,
+    error: deleteConnectionError,
+  } = useMutation({
+    mutationFn: async (connectionId: string) =>
+      await integrationsCatalogDeleteConnection({
+        workspaceId,
+        connectionId,
+      }),
+    onSuccess: () => {
+      if (integrationId) {
+        queryClient.invalidateQueries({
+          queryKey: [CATALOG_CONNECTIONS_KEY, workspaceId, integrationId],
+        })
+        queryClient.invalidateQueries({
+          queryKey: [CATALOG_DETAIL_KEY, workspaceId, integrationId],
+        })
+      } else {
+        queryClient.invalidateQueries({
+          queryKey: [CATALOG_CONNECTIONS_KEY, workspaceId],
+        })
+      }
+      toast({ title: "Connection removed" })
+    },
+    onError: (error: TracecatApiError) => {
+      console.error("Failed to delete connection:", error)
+      toast({
+        title: "Failed to remove connection",
+        description: `${error.body?.detail || error.message}`,
+        variant: "destructive",
+      })
+    },
+  })
+
+  return {
+    deleteConnection,
+    deleteConnectionIsPending,
+    deleteConnectionError,
+  }
+}

--- a/packages/tracecat-admin/tracecat_admin/cli.py
+++ b/packages/tracecat-admin/tracecat_admin/cli.py
@@ -13,6 +13,7 @@ from tracecat_admin import __version__
 from tracecat_admin.commands import (
     admin,
     auth,
+    integrations,
     migrate,
     orgs,
     registry,
@@ -65,6 +66,9 @@ app.add_typer(registry.app, name="registry", help="Registry management commands.
 app.add_typer(settings.app, name="settings", help="Platform settings commands.")
 app.add_typer(migrate.app, name="migrate", help="Database migration commands.")
 app.add_typer(tiers.app, name="tiers", help="Tier management commands.")
+app.add_typer(
+    integrations.app, name="integrations", help="Integration catalog commands."
+)
 
 
 if __name__ == "__main__":

--- a/packages/tracecat-admin/tracecat_admin/commands/integrations.py
+++ b/packages/tracecat-admin/tracecat_admin/commands/integrations.py
@@ -1,0 +1,54 @@
+"""Integration catalog admin commands."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+import typer
+
+from tracecat_admin.output import print_error, print_success
+
+app = typer.Typer(no_args_is_help=True)
+
+
+def async_command[F: Callable[..., Any]](func: F) -> F:
+    """Decorator to run async functions in typer commands."""
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return asyncio.run(func(*args, **kwargs))
+
+    return wrapper  # type: ignore[return-value]
+
+
+@app.command("seed")
+@async_command
+async def seed() -> None:
+    """Seed the platform integration catalog from the provider registry.
+
+    Idempotent — running again upserts metadata for known namespaces
+    without duplicating. MCP servers are intentionally excluded; they
+    are managed on the MCP page with their own backing table.
+    """
+    try:
+        from tracecat.db.engine import get_async_session_context_manager
+        from tracecat.integrations.catalog.seed import seed_platform_integrations
+    except ImportError as exc:
+        print_error(
+            "Failed to import tracecat. Run this command in an environment that "
+            f"has the tracecat package installed: {exc}"
+        )
+        raise typer.Exit(1) from exc
+
+    try:
+        async with get_async_session_context_manager() as session:
+            created = await seed_platform_integrations(session)
+            await session.commit()
+    except Exception as exc:  # noqa: BLE001 - surface any failure to operator
+        print_error(f"Seed failed: {exc}")
+        raise typer.Exit(1) from exc
+
+    print_success(f"Seeded {created} platform integration(s).")

--- a/tests/unit/test_integrations_catalog_auth.py
+++ b/tests/unit/test_integrations_catalog_auth.py
@@ -1,0 +1,305 @@
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import SecretStr
+from sqlalchemy import select
+
+from tracecat.db.models import Integration, OAuthIntegration, Secret
+from tracecat.integrations.catalog.schemas import (
+    CatalogAuthOption,
+    CatalogCredentialField,
+    CatalogStaticKVConnectionCreate,
+)
+from tracecat.integrations.catalog.service import (
+    ConnectionsService,
+    IntegrationCatalogService,
+    _record_secret_fields,
+    _validate_static_kv_fields,
+)
+from tracecat.integrations.enums import (
+    ConnectionAuthMethod,
+    IntegrationSource,
+    OAuthGrantType,
+)
+from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
+from tracecat.secrets.schemas import SecretKeyValue
+from tracecat.secrets.service import SecretsService
+
+
+def test_record_secret_fields_uses_declared_registry_keys() -> None:
+    fields_by_name: dict[str, list[CatalogCredentialField]] = {}
+
+    _record_secret_fields(
+        fields_by_name,
+        {
+            "name": "abuseipdb",
+            "keys": ["ABUSEIPDB_API_KEY"],
+            "optional_keys": ["ABUSEIPDB_BASE_URL"],
+        },
+    )
+
+    fields = fields_by_name["abuseipdb"]
+    assert [(field.key, field.required) for field in fields] == [
+        ("ABUSEIPDB_API_KEY", True),
+        ("ABUSEIPDB_BASE_URL", False),
+    ]
+    assert [field.label for field in fields] == [
+        "Abuseipdb API key",
+        "Abuseipdb base URL",
+    ]
+
+
+def test_record_secret_fields_skips_oauth_secrets() -> None:
+    fields_by_name: dict[str, list[CatalogCredentialField]] = {}
+
+    _record_secret_fields(
+        fields_by_name,
+        {
+            "type": "oauth",
+            "provider_id": "slack",
+            "grant_type": "authorization_code",
+        },
+    )
+
+    assert fields_by_name == {}
+
+
+def test_record_secret_fields_promotes_duplicate_optional_key_to_required() -> None:
+    fields_by_name: dict[str, list[CatalogCredentialField]] = {}
+
+    _record_secret_fields(
+        fields_by_name,
+        {"name": "jira", "optional_keys": ["JIRA_API_TOKEN"]},
+    )
+    _record_secret_fields(
+        fields_by_name,
+        {"name": "jira", "keys": ["JIRA_API_TOKEN"]},
+    )
+
+    [field] = fields_by_name["jira"]
+    assert field.key == "JIRA_API_TOKEN"
+    assert field.required is True
+
+
+def test_validate_static_kv_fields_requires_declared_keys_and_allows_extra_keys() -> (
+    None
+):
+    option = CatalogAuthOption(
+        auth_method=ConnectionAuthMethod.STATIC_KV,
+        label="API key",
+        fields=fields_by_name_from_secret(
+            {"name": "abuseipdb", "keys": ["ABUSEIPDB_API_KEY"]}
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Missing required credential fields"):
+        _validate_static_kv_fields(option, {})
+
+    _validate_static_kv_fields(
+        option,
+        {"ABUSEIPDB_API_KEY": "secret", "EXTRA_HEADER": "extra"},
+    )
+
+
+@pytest.mark.anyio
+async def test_workspace_integration_does_not_inherit_platform_provider_options(
+    session, svc_role
+) -> None:
+    service = IntegrationCatalogService(session, role=svc_role)
+    service._static_fields_for_secret = cast(Any, AsyncMock(return_value=[]))
+    integration = Integration(
+        workspace_id=svc_role.workspace_id,
+        namespace="github",
+        display_name="GitHub",
+        source=IntegrationSource.WORKSPACE,
+    )
+
+    assert await service.auth_options_for(integration) == []
+
+
+@pytest.mark.anyio
+async def test_platform_integration_exposes_provider_options(session, svc_role) -> None:
+    service = IntegrationCatalogService(session, role=svc_role)
+    service._static_fields_for_secret = cast(Any, AsyncMock(return_value=[]))
+    integration = Integration(
+        workspace_id=None,
+        namespace="github",
+        display_name="GitHub",
+        source=IntegrationSource.PLATFORM,
+    )
+
+    options = await service.auth_options_for(integration)
+
+    assert [(option.auth_method, option.provider_id) for option in options] == [
+        (ConnectionAuthMethod.OAUTH_AUTH_CODE, "github")
+    ]
+
+
+@pytest.mark.anyio
+async def test_static_secrets_are_projected_as_connection_summaries(
+    session, svc_role
+) -> None:
+    integration = Integration(
+        workspace_id=None,
+        namespace="virustotal",
+        display_name="VirusTotal",
+        source=IntegrationSource.PLATFORM,
+    )
+    secret = Secret(
+        workspace_id=svc_role.workspace_id,
+        name="virustotal",
+        type="custom",
+        encrypted_keys=SecretsService(session, role=svc_role).encrypt_keys(
+            [SecretKeyValue(key="VIRUSTOTAL_API_KEY", value=SecretStr("secret"))]
+        ),
+        environment=DEFAULT_SECRETS_ENVIRONMENT,
+    )
+    session.add_all([integration, secret])
+    await session.flush()
+
+    connections = await ConnectionsService(
+        session, role=svc_role
+    ).list_connection_summaries(integration)
+
+    assert len(connections) == 1
+    assert connections[0].id == secret.id
+    assert connections[0].integration_id == integration.id
+    assert connections[0].auth_method == ConnectionAuthMethod.STATIC_KV
+    assert connections[0].metadata["source"] == "secret"
+
+
+@pytest.mark.anyio
+async def test_create_static_connection_writes_secret_source_of_truth(
+    session, svc_role
+) -> None:
+    integration = Integration(
+        workspace_id=None,
+        namespace="abuseipdb",
+        display_name="AbuseIPDB",
+        source=IntegrationSource.PLATFORM,
+    )
+    session.add(integration)
+    await session.flush()
+
+    connection = await ConnectionsService(session, role=svc_role).create_connection(
+        integration,
+        CatalogStaticKVConnectionCreate(
+            keys={"ABUSEIPDB_API_KEY": "test-api-key"},
+        ),
+    )
+    await session.flush()
+
+    secret = (
+        await session.execute(
+            select(Secret).where(
+                Secret.workspace_id == svc_role.workspace_id,
+                Secret.name == "abuseipdb",
+                Secret.environment == DEFAULT_SECRETS_ENVIRONMENT,
+            )
+        )
+    ).scalar_one()
+    decrypted = {
+        kv.key: kv.value.get_secret_value()
+        for kv in SecretsService(session, role=svc_role).decrypt_keys(
+            secret.encrypted_keys
+        )
+    }
+
+    assert connection.id == secret.id
+    assert connection.metadata["source"] == "secret"
+    assert decrypted == {"ABUSEIPDB_API_KEY": "test-api-key"}
+
+
+@pytest.mark.anyio
+async def test_create_static_connection_writes_requested_environment(
+    session, svc_role
+) -> None:
+    integration = Integration(
+        workspace_id=None,
+        namespace="virustotal",
+        display_name="VirusTotal",
+        source=IntegrationSource.PLATFORM,
+    )
+    session.add(integration)
+    await session.flush()
+
+    connection = await ConnectionsService(session, role=svc_role).create_connection(
+        integration,
+        CatalogStaticKVConnectionCreate(
+            environment="production",
+            keys={"VIRUSTOTAL_API_KEY": "test-api-key"},
+        ),
+    )
+    await session.flush()
+
+    secret = (
+        await session.execute(
+            select(Secret).where(
+                Secret.workspace_id == svc_role.workspace_id,
+                Secret.name == "virustotal",
+                Secret.environment == "production",
+            )
+        )
+    ).scalar_one()
+
+    assert connection.id == secret.id
+    assert connection.label == "production"
+    assert connection.metadata["environment"] == "production"
+
+
+@pytest.mark.anyio
+async def test_oauth_integrations_are_projected_as_connection_summaries(
+    session, svc_role
+) -> None:
+    integration = Integration(
+        workspace_id=None,
+        namespace="github",
+        display_name="GitHub",
+        source=IntegrationSource.PLATFORM,
+    )
+    session.add(integration)
+    await session.flush()
+
+    session.add_all(
+        [
+            OAuthIntegration(
+                workspace_id=svc_role.workspace_id,
+                user_id=None,
+                provider_id="github",
+                grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+                encrypted_access_token=b"access-token",
+                encrypted_client_id=b"client-id",
+                encrypted_client_secret=b"client-secret",
+            ),
+            OAuthIntegration(
+                workspace_id=svc_role.workspace_id,
+                user_id=None,
+                provider_id="github",
+                grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+                encrypted_access_token=b"",
+                encrypted_client_id=b"admin-client-id",
+                encrypted_client_secret=b"admin-client-secret",
+            ),
+        ]
+    )
+    await session.flush()
+
+    connections = await ConnectionsService(
+        session, role=svc_role
+    ).list_connection_summaries(integration)
+
+    assert len(connections) == 1
+    assert connections[0].integration_id == integration.id
+    assert connections[0].auth_method == ConnectionAuthMethod.OAUTH_AUTH_CODE
+    assert connections[0].metadata["source"] == "oauth_integration"
+
+
+def fields_by_name_from_secret(
+    secret: dict[str, object],
+) -> list[CatalogCredentialField]:
+    fields_by_name: dict[str, list[CatalogCredentialField]] = {}
+    _record_secret_fields(fields_by_name, secret)
+    name = secret["name"]
+    assert isinstance(name, str)
+    return fields_by_name[name]

--- a/tests/unit/test_validation_service_secrets.py
+++ b/tests/unit/test_validation_service_secrets.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from pydantic import SecretStr
+from tracecat_registry import RegistrySecret
+
+from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
+from tracecat.secrets.schemas import SecretKeyValue, SecretSearch
+from tracecat.validation.service import validate_single_secret
+
+
+class FakeSecretsService:
+    def __init__(self, *, search_results: list[Any]):
+        self.search_results = search_results
+        self.search_params: SecretSearch | None = None
+
+    async def get_secret_by_name(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("validation should use search_secrets")
+
+    async def search_secrets(self, params: SecretSearch) -> list[Any]:
+        self.search_params = params
+        return self.search_results
+
+    def decrypt_keys(self, encrypted_keys: bytes) -> list[SecretKeyValue]:
+        assert encrypted_keys == b"encrypted"
+        return [
+            SecretKeyValue(
+                key="VIRUSTOTAL_API_KEY",
+                value=SecretStr("test-value"),
+            )
+        ]
+
+
+@pytest.mark.anyio
+async def test_validate_single_secret_accepts_searched_secret() -> None:
+    service = FakeSecretsService(
+        search_results=[type("SecretView", (), {"encrypted_keys": b"encrypted"})()]
+    )
+    checked: set[str] = set()
+
+    results = await validate_single_secret(
+        cast(Any, service),
+        checked,
+        DEFAULT_SECRETS_ENVIRONMENT,
+        RegistrySecret(name="virustotal", keys=["VIRUSTOTAL_API_KEY"]),
+    )
+
+    assert results == []
+    assert checked == {"virustotal"}
+    assert service.search_params == SecretSearch(
+        names={"virustotal"}, environment=DEFAULT_SECRETS_ENVIRONMENT
+    )
+
+
+@pytest.mark.anyio
+async def test_validate_single_secret_reports_missing_searched_secret() -> None:
+    service = FakeSecretsService(search_results=[])
+    checked: set[str] = set()
+
+    results = await validate_single_secret(
+        cast(Any, service),
+        checked,
+        DEFAULT_SECRETS_ENVIRONMENT,
+        RegistrySecret(name="virustotal", keys=["VIRUSTOTAL_API_KEY"]),
+    )
+
+    assert len(results) == 1
+    assert "missing in the secrets manager" in results[0].msg
+    assert results[0].detail is not None
+    assert results[0].detail["secret_name"] == "virustotal"
+    assert checked == {"virustotal"}
+
+
+@pytest.mark.anyio
+async def test_validate_single_secret_reports_duplicate_searched_secret() -> None:
+    duplicate = type("SecretView", (), {"encrypted_keys": b"encrypted"})()
+    service = FakeSecretsService(search_results=[duplicate, duplicate])
+
+    results = await validate_single_secret(
+        cast(Any, service),
+        set(),
+        DEFAULT_SECRETS_ENVIRONMENT,
+        RegistrySecret(name="virustotal", keys=["VIRUSTOTAL_API_KEY"]),
+    )
+
+    assert len(results) == 1
+    assert "Multiple secrets found" in results[0].msg

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -124,6 +124,9 @@ from tracecat.exceptions import EntitlementRequired, ScopeDeniedError, TracecatE
 from tracecat.feature_flags import FlagLike, is_feature_enabled
 from tracecat.feature_flags.router import router as feature_flags_router
 from tracecat.inbox.router import router as inbox_router
+from tracecat.integrations.catalog.router import (
+    catalog_router as integrations_catalog_router,
+)
 from tracecat.integrations.router import (
     integrations_router,
     mcp_router,
@@ -556,6 +559,7 @@ def create_app(**kwargs) -> FastAPI:
     _include_workspace_scoped_router(app, case_durations_router)
     _include_workspace_scoped_router(app, workflow_folders_router)
     app.include_router(integrations_oauth_router)
+    _include_workspace_scoped_router(app, integrations_catalog_router)
     _include_workspace_scoped_router(app, integrations_router)
     _include_workspace_scoped_router(app, providers_router)
     _include_workspace_scoped_router(app, mcp_router)

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -65,7 +65,12 @@ from tracecat.identifiers import (
     action,
 )
 from tracecat.identifiers.workflow import WorkflowUUID
-from tracecat.integrations.enums import IntegrationStatus, MCPAuthType, OAuthGrantType
+from tracecat.integrations.enums import (
+    IntegrationSource,
+    IntegrationStatus,
+    MCPAuthType,
+    OAuthGrantType,
+)
 from tracecat.interactions.enums import InteractionStatus, InteractionType
 from tracecat.invitations.enums import InvitationStatus
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
@@ -507,6 +512,11 @@ class Workspace(OrganizationModel):
     )
     oauth_providers: Mapped[list[WorkspaceOAuthProvider]] = relationship(
         "WorkspaceOAuthProvider",
+        back_populates="workspace",
+        cascade="all, delete",
+    )
+    integration_catalog: Mapped[list[Integration]] = relationship(
+        "Integration",
         back_populates="workspace",
         cascade="all, delete",
     )
@@ -4645,6 +4655,82 @@ class OAuthStateDB(TimestampMixin, Base):
     # Relationships
     workspace: Mapped[Workspace] = relationship()
     user: Mapped[User] = relationship()
+
+
+# ============================================================================
+# Consolidated Integrations model (revamp-integrations branch)
+#
+# This table backs the Integrations catalog. Credentials remain in their
+# existing source-of-truth tables and are projected through the catalog API:
+# static credentials in Secret, OAuth credentials in OAuthIntegration, MCP
+# servers in MCPIntegration.
+# ============================================================================
+
+
+class Integration(TimestampMixin, Base):
+    """Catalog entry for an integration.
+
+    One row per platform-shipped action/API connector (Slack, GitHub, ...)
+    or per workspace-authored action/API connector. `workspace_id` is NULL
+    for platform-shipped rows. `namespace` follows the registry convention
+    (e.g. "slack", "virustotal", "workspace.<slug>").
+    """
+
+    __tablename__ = "integration"
+    __table_args__ = (
+        UniqueConstraint(
+            "workspace_id",
+            "namespace",
+            name="uq_integration_workspace_namespace",
+        ),
+        Index("ix_integration_namespace", "namespace"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID,
+        default=uuid.uuid4,
+        primary_key=True,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    workspace_id: Mapped[WorkspaceID | None] = mapped_column(
+        UUID,
+        ForeignKey("workspace.id", ondelete="CASCADE"),
+        nullable=True,
+        doc="NULL = platform-shipped, available across all workspaces.",
+    )
+    namespace: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        doc="Stable identifier; matches RegistryAction.namespace where applicable.",
+    )
+    display_name: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+    )
+    description: Mapped[str | None] = mapped_column(
+        String,
+        nullable=True,
+    )
+    icon_url: Mapped[str | None] = mapped_column(
+        String,
+        nullable=True,
+    )
+    source: Mapped[IntegrationSource] = mapped_column(
+        Enum(
+            IntegrationSource,
+            name="integrationsource",
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+        ),
+        nullable=False,
+        default=IntegrationSource.PLATFORM,
+    )
+
+    workspace: Mapped[Workspace | None] = relationship(
+        "Workspace",
+        back_populates="integration_catalog",
+    )
 
 
 class Chat(WorkspaceModel):

--- a/tracecat/integrations/catalog/__init__.py
+++ b/tracecat/integrations/catalog/__init__.py
@@ -1,0 +1,6 @@
+"""Consolidated integrations catalog.
+
+This subpackage holds the Integration catalog and connection-shaped API
+surfaces used by the integrations page. Static credentials, OAuth provider
+configuration, and MCP server storage remain in their existing tables.
+"""

--- a/tracecat/integrations/catalog/router.py
+++ b/tracecat/integrations/catalog/router.py
@@ -1,0 +1,163 @@
+"""FastAPI routes for the consolidated integrations catalog."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from tracecat.auth.dependencies import WorkspaceUserRouteRole
+from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import TracecatNotFoundError
+from tracecat.integrations.catalog.schemas import (
+    CatalogConnectionRead,
+    CatalogIntegrationDetail,
+    CatalogIntegrationRead,
+    CatalogStaticKVConnectionCreate,
+)
+from tracecat.integrations.catalog.service import (
+    ConnectionsService,
+    IntegrationCatalogService,
+)
+from tracecat.integrations.enums import IntegrationSource
+
+# Mounted under /integrations to keep the URL surface unified. Paths are
+# disjoint from the legacy router endpoints, which use {provider_id}
+# directly under /integrations.
+catalog_router = APIRouter(prefix="/integrations", tags=["integrations-catalog"])
+
+
+# ----------------------------------------------------------------------
+# Catalog (Integration table)
+# ----------------------------------------------------------------------
+
+
+@catalog_router.get("/catalog", response_model=list[CatalogIntegrationRead])
+async def list_catalog(
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+    source: IntegrationSource | None = Query(default=None),
+    search: str | None = Query(default=None, max_length=128),
+) -> list[CatalogIntegrationRead]:
+    """List integrations visible to this workspace.
+
+    Includes platform-shipped (``workspace_id IS NULL``) rows plus
+    workspace-authored rows for the caller's workspace.
+    """
+    service = IntegrationCatalogService(session, role=role)
+    rows = await service.list_integrations(
+        source=source,
+        search=search,
+    )
+    return [await service.to_read_schema(row) for row in rows]
+
+
+@catalog_router.get(
+    "/catalog/{integration_id}", response_model=CatalogIntegrationDetail
+)
+async def get_catalog_entry(
+    integration_id: uuid.UUID,
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+) -> CatalogIntegrationDetail:
+    """Get an integration with its connections."""
+    catalog = IntegrationCatalogService(session, role=role)
+    connections_svc = ConnectionsService(session, role=role)
+
+    try:
+        integration = await catalog.get_integration(integration_id)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+
+    conns = await connections_svc.list_connection_summaries(integration)
+    auth_options = await catalog.auth_options_for(integration)
+
+    return CatalogIntegrationDetail(
+        id=integration.id,
+        workspace_id=integration.workspace_id,
+        namespace=integration.namespace,
+        display_name=integration.display_name,
+        description=integration.description,
+        icon_url=integration.icon_url,
+        source=integration.source,
+        auth_options=auth_options,
+        created_at=integration.created_at,
+        updated_at=integration.updated_at,
+        connections=conns,
+    )
+
+
+# ----------------------------------------------------------------------
+# Connections (per-integration)
+# ----------------------------------------------------------------------
+
+
+@catalog_router.get(
+    "/catalog/{integration_id}/connections",
+    response_model=list[CatalogConnectionRead],
+)
+async def list_connections(
+    integration_id: uuid.UUID,
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+) -> list[CatalogConnectionRead]:
+    catalog = IntegrationCatalogService(session, role=role)
+    connections = ConnectionsService(session, role=role)
+    try:
+        integration = await catalog.get_integration(integration_id)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    return await connections.list_connection_summaries(integration)
+
+
+@catalog_router.post(
+    "/catalog/{integration_id}/connections",
+    response_model=CatalogConnectionRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_connection(
+    integration_id: uuid.UUID,
+    params: CatalogStaticKVConnectionCreate,
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+) -> CatalogConnectionRead:
+    """Create a static key-value connection for registry credentials."""
+    connections_svc = ConnectionsService(session, role=role)
+    catalog_svc = IntegrationCatalogService(session, role=role)
+    try:
+        integration = await catalog_svc.get_integration(integration_id)
+        await catalog_svc.validate_connection_create(integration, params)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+    connection = await connections_svc.create_connection(integration, params)
+    await session.commit()
+    return connection
+
+
+@catalog_router.delete(
+    "/connections/{connection_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_connection(
+    connection_id: uuid.UUID,
+    role: WorkspaceUserRouteRole,
+    session: AsyncDBSession,
+) -> None:
+    service = ConnectionsService(session, role=role)
+    try:
+        await service.delete_connection(connection_id)
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    await session.commit()

--- a/tracecat/integrations/catalog/schemas.py
+++ b/tracecat/integrations/catalog/schemas.py
@@ -1,0 +1,96 @@
+"""Pydantic schemas for the consolidated integrations API."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tracecat.integrations.enums import (
+    ConnectionAuthMethod,
+    IntegrationSource,
+    IntegrationStatus,
+    OAuthGrantType,
+)
+from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
+
+
+class CatalogCredentialField(BaseModel):
+    """Credential field required by a static/auth configuration option."""
+
+    key: str
+    label: str
+    required: bool = True
+    secret: bool = True
+    multiline: bool = False
+    placeholder: str | None = None
+    description: str | None = None
+
+
+class CatalogAuthOption(BaseModel):
+    """Supported authentication path for a catalog integration."""
+
+    auth_method: ConnectionAuthMethod
+    label: str
+    description: str | None = None
+    provider_id: str | None = None
+    grant_type: OAuthGrantType | None = None
+    requires_config: bool = False
+    enabled: bool = True
+    status: IntegrationStatus | None = None
+    fields: list[CatalogCredentialField] = Field(default_factory=list)
+
+
+class CatalogIntegrationRead(BaseModel):
+    """Catalog row for an integration."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    workspace_id: uuid.UUID | None
+    namespace: str
+    display_name: str
+    description: str | None = None
+    icon_url: str | None = None
+    source: IntegrationSource
+    auth_options: list[CatalogAuthOption] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+
+class CatalogConnectionRead(BaseModel):
+    """A user/workspace authenticated binding to an integration."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    integration_id: uuid.UUID
+    workspace_id: uuid.UUID
+    user_id: uuid.UUID | None
+    auth_method: ConnectionAuthMethod
+    label: str
+    expires_at: datetime | None
+    scope: str | None
+    metadata: dict[str, Any] = Field(default_factory=dict, alias="metadata_")
+    created_at: datetime
+    updated_at: datetime
+    is_expired: bool = False
+
+
+class CatalogIntegrationDetail(CatalogIntegrationRead):
+    """Integration row enriched with related connections."""
+
+    connections: list[CatalogConnectionRead] = Field(default_factory=list)
+
+
+class CatalogStaticKVConnectionCreate(BaseModel):
+    """Connection backed by an arbitrary key-value blob."""
+
+    auth_method: ConnectionAuthMethod = ConnectionAuthMethod.STATIC_KV
+    environment: str = DEFAULT_SECRETS_ENVIRONMENT
+    keys: dict[str, str]
+
+
+CatalogConnectionCreate = CatalogStaticKVConnectionCreate

--- a/tracecat/integrations/catalog/seed.py
+++ b/tracecat/integrations/catalog/seed.py
@@ -1,0 +1,155 @@
+"""Seed Integration catalog rows from API/OAuth provider metadata.
+
+This is invoked after the catalog migration. It is idempotent —
+running again upserts metadata for known namespaces without duplicating.
+
+MCP servers are intentionally excluded from this catalog — they back
+agents, not Tracecat Actions, and live on the MCP page with their own
+backing table (``MCPIntegration``).
+
+Static credentials remain in Secret and are projected through the catalog API.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.db.models import (
+    Integration,
+    PlatformRegistryRepository,
+    PlatformRegistryVersion,
+)
+from tracecat.integrations.enums import IntegrationSource
+from tracecat.integrations.providers import all_providers
+from tracecat.logger import logger
+from tracecat.registry.versions.schemas import RegistryVersionManifest
+
+# Providers ship as separate classes per OAuth grant flow (delegated vs
+# client credentials) but share a base namespace. We want one catalog row
+# per service, not per grant flow, so we strip the variant suffix from the
+# display name before inserting.
+_VARIANT_SUFFIX_RE = re.compile(
+    r"\s*\((?:Delegated|Service account|Service principal)\)\s*$",
+    re.IGNORECASE,
+)
+
+
+def _canonical_display_name(name: str) -> str:
+    return _VARIANT_SUFFIX_RE.sub("", name).strip()
+
+
+def _humanize_namespace(namespace: str) -> str:
+    """Turn a snake_case secret name into a display name.
+
+    ``abuseipdb`` → ``Abuseipdb`` (best-effort; provider-shipped rows
+    overwrite this with a friendlier label via the OAuth metadata seed).
+    """
+    return " ".join(part.capitalize() for part in namespace.split("_"))
+
+
+async def _platform_secret_definitions(
+    session: AsyncSession,
+) -> dict[str, int]:
+    """Aggregate secret namespaces declared by platform-shipped actions.
+
+    Returns a mapping of secret name → action_count. OAuth-only secrets
+    (``RegistryOAuthSecret`` or names ending in ``_oauth``) are skipped
+    since those are already covered by the provider seed.
+    """
+    stmt = (
+        select(PlatformRegistryVersion.manifest)
+        .join(
+            PlatformRegistryRepository,
+            PlatformRegistryVersion.repository_id == PlatformRegistryRepository.id,
+        )
+        .where(
+            PlatformRegistryRepository.current_version_id == PlatformRegistryVersion.id,
+        )
+    )
+    result = await session.execute(stmt)
+    counts: dict[str, int] = {}
+    for (manifest_data,) in result.all():
+        manifest = RegistryVersionManifest.model_validate(manifest_data)
+        for action_name, manifest_action in manifest.actions.items():
+            if not manifest_action.secrets:
+                continue
+            for secret in manifest_action.secrets:
+                name = getattr(secret, "name", None)
+                if not name or name.endswith("_oauth"):
+                    continue
+                counts[name] = counts.get(name, 0) + 1
+            _ = action_name  # silence loop var warning
+    return counts
+
+
+async def seed_platform_integrations(session: AsyncSession) -> int:
+    """Upsert one Integration row per base service (collapsing OAuth variants).
+
+    Returns the number of rows created.
+    """
+    existing_namespaces = set(
+        (
+            await session.execute(
+                select(Integration.namespace).where(Integration.workspace_id.is_(None))
+            )
+        ).scalars()
+    )
+
+    # Track namespaces we've already queued during this seed pass so two
+    # provider classes sharing a namespace (delegated + service principal)
+    # only insert one row.
+    queued_namespaces: set[str] = set()
+    created = 0
+    for provider_cls in all_providers():
+        metadata = getattr(provider_cls, "metadata", None)
+        if metadata is None:
+            continue
+
+        namespace = metadata.id
+        # MCP providers belong on the MCP page, not in the action catalog.
+        if namespace.endswith("_mcp"):
+            continue
+        if namespace in existing_namespaces or namespace in queued_namespaces:
+            continue
+
+        row = Integration(
+            workspace_id=None,
+            namespace=namespace,
+            display_name=_canonical_display_name(metadata.name),
+            description=metadata.description,
+            icon_url=None,
+            source=IntegrationSource.PLATFORM,
+        )
+        session.add(row)
+        queued_namespaces.add(namespace)
+        created += 1
+
+    # Pull every secret namespace declared by platform-shipped actions and
+    # surface them as catalog rows. This is what makes the page show
+    # API-key-backed integrations (abusech, anthropic, ...) without the
+    # user having to dig into the Secrets surface.
+    secret_counts = await _platform_secret_definitions(session)
+    for namespace, action_count in sorted(secret_counts.items()):
+        if namespace in existing_namespaces or namespace in queued_namespaces:
+            continue
+        description = (
+            f"Used by {action_count} action{'s' if action_count != 1 else ''}."
+        )
+        row = Integration(
+            workspace_id=None,
+            namespace=namespace,
+            display_name=_humanize_namespace(namespace),
+            description=description,
+            icon_url=None,
+            source=IntegrationSource.PLATFORM,
+        )
+        session.add(row)
+        queued_namespaces.add(namespace)
+        created += 1
+
+    await session.flush()
+    logger.info("Seeded platform integrations", created=created)
+    return created

--- a/tracecat/integrations/catalog/service.py
+++ b/tracecat/integrations/catalog/service.py
@@ -1,0 +1,751 @@
+"""Services for the consolidated integrations catalog.
+
+- IntegrationCatalogService: read/write the Integration table (catalog)
+- ConnectionsService: expose connection-shaped projections over credential
+  source-of-truth tables.
+
+Static/API-key credentials remain in Secret. OAuth credentials remain in
+OAuthIntegration. The catalog API presents both as "connections" for the UI.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, Sequence
+
+from pydantic import BaseModel, SecretStr
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.secrets import get_db_encryption_key
+from tracecat.auth.types import Role
+from tracecat.db.models import (
+    Integration,
+    OAuthIntegration,
+    PlatformRegistryAction,
+    PlatformRegistryRepository,
+    PlatformRegistryVersion,
+    RegistryAction,
+    RegistryRepository,
+    RegistryVersion,
+    Secret,
+)
+from tracecat.exceptions import TracecatNotFoundError
+from tracecat.integrations.catalog.schemas import (
+    CatalogAuthOption,
+    CatalogConnectionCreate,
+    CatalogConnectionRead,
+    CatalogCredentialField,
+    CatalogIntegrationRead,
+    CatalogStaticKVConnectionCreate,
+)
+from tracecat.integrations.enums import (
+    ConnectionAuthMethod,
+    IntegrationSource,
+    IntegrationStatus,
+    OAuthGrantType,
+)
+from tracecat.integrations.providers import all_providers
+from tracecat.integrations.providers.base import (
+    AuthorizationCodeOAuthProvider,
+    BaseOAuthProvider,
+    ClientCredentialsOAuthProvider,
+    ServiceAccountOAuthProvider,
+)
+from tracecat.logger import logger
+from tracecat.registry.versions.schemas import RegistryVersionManifest
+from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
+from tracecat.secrets.encryption import encrypt_keyvalues
+from tracecat.secrets.enums import SecretType
+from tracecat.secrets.schemas import SecretKeyValue
+from tracecat.service import BaseWorkspaceService
+
+
+def _label_from_key(key: str) -> str:
+    acronyms = {
+        "AI",
+        "API",
+        "AWS",
+        "CA",
+        "GCP",
+        "ID",
+        "IP",
+        "JSON",
+        "JWT",
+        "MCP",
+        "SQL",
+        "SSH",
+        "SSL",
+        "TLS",
+        "URI",
+        "URL",
+    }
+    words: list[str] = []
+    for part in key.split("_"):
+        if part in acronyms:
+            words.append(part)
+        elif not words:
+            words.append(part.lower().capitalize())
+        else:
+            words.append(part.lower())
+    return " ".join(words)
+
+
+def _field_from_key(*, key: str, required: bool) -> CatalogCredentialField:
+    return CatalogCredentialField(
+        key=key,
+        label=_label_from_key(key),
+        required=required,
+        secret=True,
+        multiline=key.endswith("_JSON")
+        or key.endswith("_PRIVATE_KEY")
+        or key.endswith("_CERTIFICATE"),
+    )
+
+
+def _provider_auth_method(
+    provider_cls: type[BaseOAuthProvider],
+) -> ConnectionAuthMethod:
+    if issubclass(provider_cls, ServiceAccountOAuthProvider):
+        return ConnectionAuthMethod.SERVICE_ACCOUNT
+    if issubclass(provider_cls, AuthorizationCodeOAuthProvider):
+        return ConnectionAuthMethod.OAUTH_AUTH_CODE
+    return ConnectionAuthMethod.OAUTH_CLIENT_CREDENTIALS
+
+
+def _fallback_oauth_auth_method(grant_type: OAuthGrantType) -> ConnectionAuthMethod:
+    if grant_type == OAuthGrantType.AUTHORIZATION_CODE:
+        return ConnectionAuthMethod.OAUTH_AUTH_CODE
+    return ConnectionAuthMethod.OAUTH_CLIENT_CREDENTIALS
+
+
+def _provider_cls_for(
+    provider_id: str,
+    grant_type: OAuthGrantType,
+) -> type[BaseOAuthProvider] | None:
+    return next(
+        (
+            cls
+            for cls in all_providers()
+            if cls.id == provider_id and cls.grant_type == grant_type
+        ),
+        None,
+    )
+
+
+def _oauth_connection_label(auth_method: ConnectionAuthMethod) -> str:
+    match auth_method:
+        case ConnectionAuthMethod.OAUTH_AUTH_CODE:
+            return "OAuth account"
+        case ConnectionAuthMethod.OAUTH_CLIENT_CREDENTIALS:
+            return "Client credentials"
+        case ConnectionAuthMethod.SERVICE_ACCOUNT:
+            return "Service account"
+        case _:
+            return _provider_auth_label(auth_method)
+
+
+def _provider_auth_label(auth_method: ConnectionAuthMethod) -> str:
+    match auth_method:
+        case ConnectionAuthMethod.OAUTH_AUTH_CODE:
+            return "OAuth"
+        case ConnectionAuthMethod.OAUTH_CLIENT_CREDENTIALS:
+            return "Client credentials"
+        case ConnectionAuthMethod.SERVICE_ACCOUNT:
+            return "Service account"
+        case _:
+            return auth_method.value.replace("_", " ").title()
+
+
+def _credential_fields_from_secret(
+    secret: Mapping[str, object],
+) -> list[CatalogCredentialField]:
+    fields: list[CatalogCredentialField] = []
+    required_keys = secret.get("keys")
+    if isinstance(required_keys, list):
+        for key in required_keys:
+            if isinstance(key, str):
+                fields.append(_field_from_key(key=key, required=True))
+
+    optional_keys = secret.get("optional_keys")
+    if isinstance(optional_keys, list):
+        for key in optional_keys:
+            if isinstance(key, str):
+                fields.append(_field_from_key(key=key, required=False))
+    return fields
+
+
+def _secret_mapping(secret: object) -> Mapping[str, object] | None:
+    if isinstance(secret, Mapping):
+        return secret
+    if isinstance(secret, BaseModel):
+        return secret.model_dump(mode="json")
+    return None
+
+
+def _record_secret_fields(
+    fields_by_name: dict[str, list[CatalogCredentialField]],
+    raw_secret: object,
+) -> None:
+    secret = _secret_mapping(raw_secret)
+    if secret is None or secret.get("type") == "oauth":
+        return
+    name = secret.get("name")
+    if not isinstance(name, str) or not name:
+        return
+    fields = _credential_fields_from_secret(secret)
+    if not fields:
+        return
+    fields_by_name[name] = _merge_credential_fields(
+        fields_by_name.get(name, []),
+        fields,
+    )
+
+
+def _merge_credential_fields(
+    existing: list[CatalogCredentialField],
+    incoming: list[CatalogCredentialField],
+) -> list[CatalogCredentialField]:
+    by_key = {field.key: field for field in existing}
+    for field in incoming:
+        prior = by_key.get(field.key)
+        if prior is None:
+            by_key[field.key] = field
+            continue
+        if field.required and not prior.required:
+            by_key[field.key] = prior.model_copy(update={"required": True})
+    return list(by_key.values())
+
+
+def _validate_static_kv_fields(
+    static_option: CatalogAuthOption,
+    keys: Mapping[str, str],
+) -> None:
+    required = {field.key for field in static_option.fields if field.required}
+    provided = set(keys)
+    missing = sorted(required - provided)
+    if missing:
+        raise ValueError("Missing required credential fields: " + ", ".join(missing))
+
+
+class IntegrationCatalogService(BaseWorkspaceService):
+    """CRUD over the Integration catalog table."""
+
+    service_name = "integrations.catalog"
+    _static_fields_by_secret_name: dict[str, list[CatalogCredentialField]] | None
+
+    def __init__(self, session: AsyncSession, role: Role | None = None):
+        super().__init__(session, role=role)
+        self._static_fields_by_secret_name = None
+
+    async def list_integrations(
+        self,
+        *,
+        source: IntegrationSource | None = None,
+        search: str | None = None,
+    ) -> Sequence[Integration]:
+        """List integrations visible to the current workspace.
+
+        Returns rows where ``workspace_id`` IS NULL (platform-shipped) OR
+        equals the caller's workspace.
+        """
+        stmt = select(Integration).where(
+            (Integration.workspace_id.is_(None))
+            | (Integration.workspace_id == self.workspace_id)
+        )
+        if source is not None:
+            stmt = stmt.where(Integration.source == source)
+        if search:
+            like = f"%{search.lower()}%"
+            stmt = stmt.where(
+                or_(
+                    func.lower(Integration.display_name).like(like),
+                    func.lower(Integration.namespace).like(like),
+                )
+            )
+        stmt = stmt.order_by(Integration.display_name)
+        result = await self.session.execute(stmt)
+        return result.scalars().all()
+
+    async def to_read_schema(self, integration: Integration) -> CatalogIntegrationRead:
+        return CatalogIntegrationRead(
+            id=integration.id,
+            workspace_id=integration.workspace_id,
+            namespace=integration.namespace,
+            display_name=integration.display_name,
+            description=integration.description,
+            icon_url=integration.icon_url,
+            source=integration.source,
+            auth_options=await self.auth_options_for(integration),
+            created_at=integration.created_at,
+            updated_at=integration.updated_at,
+        )
+
+    async def get_integration(self, integration_id: uuid.UUID) -> Integration:
+        stmt = select(Integration).where(
+            Integration.id == integration_id,
+            (Integration.workspace_id.is_(None))
+            | (Integration.workspace_id == self.workspace_id),
+        )
+        result = await self.session.execute(stmt)
+        integration = result.scalar_one_or_none()
+        if integration is None:
+            raise TracecatNotFoundError(f"Integration {integration_id} not found")
+        return integration
+
+    async def auth_options_for(
+        self, integration: Integration
+    ) -> list[CatalogAuthOption]:
+        """Return auth paths that are actually supported by this integration."""
+        options: list[CatalogAuthOption] = []
+        if integration.source == IntegrationSource.PLATFORM:
+            options.extend(await self._provider_auth_options(integration.namespace))
+
+        static_fields = await self._static_fields_for_secret(integration.namespace)
+        if static_fields:
+            label = "API key" if len(static_fields) == 1 else "Static credentials"
+            options.append(
+                CatalogAuthOption(
+                    auth_method=ConnectionAuthMethod.STATIC_KV,
+                    label=label,
+                    description="Credential fields required by registry actions.",
+                    fields=static_fields,
+                    status=await self._static_connection_status(integration.namespace),
+                )
+            )
+        return options
+
+    async def _provider_auth_options(self, namespace: str) -> list[CatalogAuthOption]:
+        provider_classes = [
+            cls for cls in all_providers() if getattr(cls, "id", None) == namespace
+        ]
+        if not provider_classes:
+            return []
+
+        existing = await self.session.execute(
+            select(OAuthIntegration).where(
+                OAuthIntegration.workspace_id == self.workspace_id,
+                OAuthIntegration.provider_id == namespace,
+            )
+        )
+        integrations_by_grant: dict[OAuthGrantType, IntegrationStatus] = {}
+        for integration in existing.scalars().all():
+            current_status = integrations_by_grant.get(integration.grant_type)
+            next_status = integration.status
+            if current_status is None:
+                integrations_by_grant[integration.grant_type] = next_status
+                continue
+            if next_status == IntegrationStatus.CONNECTED:
+                integrations_by_grant[integration.grant_type] = next_status
+            elif (
+                next_status == IntegrationStatus.CONFIGURED
+                and current_status == IntegrationStatus.NOT_CONFIGURED
+            ):
+                integrations_by_grant[integration.grant_type] = next_status
+
+        options: list[CatalogAuthOption] = []
+        for provider_cls in provider_classes:
+            if not issubclass(
+                provider_cls, ClientCredentialsOAuthProvider
+            ) and not issubclass(
+                provider_cls,
+                AuthorizationCodeOAuthProvider,
+            ):
+                continue
+            auth_method = _provider_auth_method(provider_cls)
+            integration_status = integrations_by_grant.get(provider_cls.grant_type)
+            metadata = provider_cls.metadata
+            options.append(
+                CatalogAuthOption(
+                    auth_method=auth_method,
+                    label=_provider_auth_label(auth_method),
+                    description=metadata.description,
+                    provider_id=provider_cls.id,
+                    grant_type=provider_cls.grant_type,
+                    requires_config=metadata.requires_config,
+                    enabled=metadata.enabled,
+                    status=integration_status or IntegrationStatus.NOT_CONFIGURED,
+                    fields=_provider_config_fields(auth_method),
+                )
+            )
+
+        grant_order = {
+            OAuthGrantType.AUTHORIZATION_CODE: 0,
+            OAuthGrantType.CLIENT_CREDENTIALS: 1,
+        }
+        return sorted(
+            options,
+            key=lambda option: (
+                grant_order.get(
+                    option.grant_type or OAuthGrantType.CLIENT_CREDENTIALS, 99
+                ),
+                option.label,
+            ),
+        )
+
+    async def _static_connection_status(
+        self,
+        namespace: str,
+    ) -> IntegrationStatus:
+        result = await self.session.execute(
+            select(Secret.id)
+            .where(
+                Secret.workspace_id == self.workspace_id,
+                Secret.name == namespace,
+                Secret.environment == DEFAULT_SECRETS_ENVIRONMENT,
+            )
+            .limit(1)
+        )
+        if result.scalar_one_or_none() is None:
+            return IntegrationStatus.NOT_CONFIGURED
+        return IntegrationStatus.CONNECTED
+
+    async def _static_fields_for_secret(
+        self, secret_name: str
+    ) -> list[CatalogCredentialField]:
+        fields_by_name = await self._load_static_fields_by_secret_name()
+        return fields_by_name.get(secret_name, [])
+
+    async def _load_static_fields_by_secret_name(
+        self,
+    ) -> dict[str, list[CatalogCredentialField]]:
+        if self._static_fields_by_secret_name is not None:
+            return self._static_fields_by_secret_name
+
+        fields_by_name: dict[str, list[CatalogCredentialField]] = {}
+
+        platform_result = await self.session.execute(
+            select(PlatformRegistryAction.secrets).where(
+                PlatformRegistryAction.secrets.is_not(None)
+            )
+        )
+        workspace_result = await self.session.execute(
+            select(RegistryAction.secrets).where(
+                RegistryAction.organization_id == self.organization_id,
+                RegistryAction.secrets.is_not(None),
+            )
+        )
+
+        for secrets_payload in [
+            *platform_result.scalars().all(),
+            *workspace_result.scalars().all(),
+        ]:
+            if not isinstance(secrets_payload, list):
+                continue
+            for raw_secret in secrets_payload:
+                _record_secret_fields(fields_by_name, raw_secret)
+
+        await self._record_manifest_static_fields(fields_by_name)
+
+        self._static_fields_by_secret_name = fields_by_name
+        return fields_by_name
+
+    async def _record_manifest_static_fields(
+        self,
+        fields_by_name: dict[str, list[CatalogCredentialField]],
+    ) -> None:
+        """Merge static secret fields from current registry manifests.
+
+        The catalog seed reads platform manifests, while registry action rows can lag
+        in local or freshly migrated environments. Reading both keeps catalog auth
+        capabilities aligned with the rows that were seeded.
+        """
+        platform_manifest_result = await self.session.execute(
+            select(PlatformRegistryVersion.manifest)
+            .join(
+                PlatformRegistryRepository,
+                PlatformRegistryVersion.repository_id == PlatformRegistryRepository.id,
+            )
+            .where(
+                PlatformRegistryRepository.current_version_id
+                == PlatformRegistryVersion.id
+            )
+        )
+        org_manifest_result = await self.session.execute(
+            select(RegistryVersion.manifest)
+            .join(
+                RegistryRepository,
+                RegistryVersion.repository_id == RegistryRepository.id,
+            )
+            .where(
+                RegistryRepository.organization_id == self.organization_id,
+                RegistryRepository.current_version_id == RegistryVersion.id,
+            )
+        )
+
+        for manifest_data in [
+            *platform_manifest_result.scalars().all(),
+            *org_manifest_result.scalars().all(),
+        ]:
+            manifest = RegistryVersionManifest.model_validate(manifest_data)
+            for manifest_action in manifest.actions.values():
+                for raw_secret in manifest_action.secrets or []:
+                    _record_secret_fields(fields_by_name, raw_secret)
+
+    async def validate_connection_create(
+        self,
+        integration: Integration,
+        params: CatalogConnectionCreate,
+    ) -> None:
+        """Validate a connection payload against integration-supported auth options."""
+        supported = await self.auth_options_for(integration)
+        matching = [
+            option for option in supported if option.auth_method == params.auth_method
+        ]
+        if not matching:
+            raise ValueError(
+                f"{integration.display_name} does not support {params.auth_method.value} connections."
+            )
+
+        if any(option.provider_id for option in matching):
+            raise ValueError(
+                f"{integration.display_name} uses the OAuth provider flow for {params.auth_method.value}."
+            )
+
+        if isinstance(params, CatalogStaticKVConnectionCreate):
+            _validate_static_kv_fields(matching[0], params.keys)
+
+
+def _provider_config_fields(
+    auth_method: ConnectionAuthMethod,
+) -> list[CatalogCredentialField]:
+    match auth_method:
+        case ConnectionAuthMethod.OAUTH_AUTH_CODE:
+            return [
+                CatalogCredentialField(
+                    key="client_id",
+                    label="Client ID",
+                    required=True,
+                    secret=False,
+                ),
+                CatalogCredentialField(
+                    key="client_secret",
+                    label="Client secret",
+                    required=True,
+                ),
+            ]
+        case ConnectionAuthMethod.OAUTH_CLIENT_CREDENTIALS:
+            return [
+                CatalogCredentialField(
+                    key="client_id",
+                    label="Client ID",
+                    required=True,
+                    secret=False,
+                ),
+                CatalogCredentialField(
+                    key="client_secret",
+                    label="Client secret",
+                    required=True,
+                ),
+            ]
+        case ConnectionAuthMethod.SERVICE_ACCOUNT:
+            return [
+                CatalogCredentialField(
+                    key="service_account_json",
+                    label="Service account JSON",
+                    required=True,
+                    multiline=True,
+                    placeholder='{"type": "service_account", ...}',
+                ),
+            ]
+        case _:
+            return []
+
+
+class ConnectionsService(BaseWorkspaceService):
+    """Connection-shaped projections over credential source-of-truth tables."""
+
+    service_name = "integrations.connections"
+    _encryption_key: str
+
+    def __init__(self, session: AsyncSession, role: Role | None = None):
+        super().__init__(session, role=role)
+        self._encryption_key = get_db_encryption_key()
+
+    async def list_connection_summaries(
+        self,
+        integration: Integration,
+    ) -> list[CatalogConnectionRead]:
+        """Return connection-shaped rows projected from credential storage.
+
+        Static/API-key credentials live in ``secret``. OAuth provider bindings
+        live in ``oauth_integration``. The catalog projects both into the same
+        read schema for UI consistency.
+        """
+        rows = await self._list_static_connection_summaries(integration)
+        rows.extend(await self._list_oauth_connection_summaries(integration))
+        return sorted(rows, key=lambda row: row.created_at, reverse=True)
+
+    async def _list_static_connection_summaries(
+        self,
+        integration: Integration,
+    ) -> list[CatalogConnectionRead]:
+        result = await self.session.execute(
+            select(Secret).where(
+                Secret.workspace_id == self.workspace_id,
+                Secret.name == integration.namespace,
+            )
+        )
+        rows: list[CatalogConnectionRead] = []
+        for secret in result.scalars().all():
+            rows.append(self._static_connection_read(integration, secret))
+        return rows
+
+    def _static_connection_read(
+        self,
+        integration: Integration,
+        secret: Secret,
+    ) -> CatalogConnectionRead:
+        return CatalogConnectionRead(
+            id=secret.id,
+            integration_id=integration.id,
+            workspace_id=secret.workspace_id,
+            user_id=None,
+            auth_method=ConnectionAuthMethod.STATIC_KV,
+            label=self._static_connection_label(secret),
+            expires_at=None,
+            scope=None,
+            metadata_={
+                "source": "secret",
+                "secret_id": str(secret.id),
+                "secret_name": secret.name,
+                "environment": secret.environment,
+                "secret_type": secret.type,
+            },
+            created_at=secret.created_at,
+            updated_at=secret.updated_at,
+            is_expired=False,
+        )
+
+    @staticmethod
+    def _static_connection_label(secret: Secret) -> str:
+        if secret.environment == DEFAULT_SECRETS_ENVIRONMENT:
+            return "Default"
+        return secret.environment
+
+    async def _list_oauth_connection_summaries(
+        self,
+        integration: Integration,
+    ) -> list[CatalogConnectionRead]:
+        result = await self.session.execute(
+            select(OAuthIntegration).where(
+                OAuthIntegration.workspace_id == self.workspace_id,
+                OAuthIntegration.provider_id == integration.namespace,
+            )
+        )
+        rows: list[CatalogConnectionRead] = []
+        for oauth in result.scalars().all():
+            provider_cls = _provider_cls_for(oauth.provider_id, oauth.grant_type)
+            auth_method = (
+                _provider_auth_method(provider_cls)
+                if provider_cls is not None
+                else _fallback_oauth_auth_method(oauth.grant_type)
+            )
+            if (
+                auth_method == ConnectionAuthMethod.OAUTH_AUTH_CODE
+                and oauth.status != IntegrationStatus.CONNECTED
+            ):
+                continue
+            if (
+                auth_method != ConnectionAuthMethod.OAUTH_AUTH_CODE
+                and oauth.status == IntegrationStatus.NOT_CONFIGURED
+            ):
+                continue
+            if oauth.workspace_id is None:
+                continue
+
+            rows.append(
+                CatalogConnectionRead(
+                    id=oauth.id,
+                    integration_id=integration.id,
+                    workspace_id=oauth.workspace_id,
+                    user_id=oauth.user_id,
+                    auth_method=auth_method,
+                    label=_oauth_connection_label(auth_method),
+                    expires_at=oauth.expires_at,
+                    scope=oauth.scope,
+                    metadata_={
+                        "source": "oauth_integration",
+                        "provider_id": oauth.provider_id,
+                        "grant_type": oauth.grant_type.value,
+                    },
+                    created_at=oauth.created_at,
+                    updated_at=oauth.updated_at,
+                    is_expired=oauth.is_expired,
+                )
+            )
+        return rows
+
+    async def create_connection(
+        self,
+        integration: Integration,
+        params: CatalogConnectionCreate,
+    ) -> CatalogConnectionRead:
+        """Create or replace a static Secret for an integration environment."""
+        if not isinstance(params, CatalogStaticKVConnectionCreate):
+            raise ValueError(f"Unsupported connection payload: {type(params).__name__}")
+        if not params.keys:
+            raise ValueError("At least one credential field is required.")
+        environment = params.environment.strip() or DEFAULT_SECRETS_ENVIRONMENT
+
+        encrypted_keys = encrypt_keyvalues(
+            [
+                SecretKeyValue(key=key, value=SecretStr(value))
+                for key, value in params.keys.items()
+            ],
+            key=self._encryption_key,
+        )
+        result = await self.session.execute(
+            select(Secret).where(
+                Secret.workspace_id == self.workspace_id,
+                Secret.name == integration.namespace,
+                Secret.environment == environment,
+            )
+        )
+        secret = result.scalar_one_or_none()
+        if secret is None:
+            secret = Secret(
+                workspace_id=self.workspace_id,
+                name=integration.namespace,
+                type=SecretType.CUSTOM,
+                description=f"Credentials for {integration.display_name}.",
+                encrypted_keys=encrypted_keys,
+                environment=environment,
+            )
+        else:
+            secret.type = SecretType.CUSTOM
+            secret.encrypted_keys = encrypted_keys
+        self.session.add(secret)
+        await self.session.flush()
+        await self.session.refresh(secret)
+        logger.info(
+            "Stored static integration credentials",
+            secret_id=secret.id,
+            integration_id=integration.id,
+            auth_method=params.auth_method,
+            workspace_id=self.workspace_id,
+        )
+        return self._static_connection_read(integration, secret)
+
+    async def delete_connection(self, connection_id: uuid.UUID) -> None:
+        stmt = select(Secret).where(
+            Secret.id == connection_id,
+            Secret.workspace_id == self.workspace_id,
+        )
+        result = await self.session.execute(stmt)
+        secret = result.scalar_one_or_none()
+        if secret is not None:
+            await self.session.delete(secret)
+            await self.session.flush()
+            return
+
+        oauth_stmt = select(OAuthIntegration).where(
+            OAuthIntegration.id == connection_id,
+            OAuthIntegration.workspace_id == self.workspace_id,
+        )
+        oauth_result = await self.session.execute(oauth_stmt)
+        oauth = oauth_result.scalar_one_or_none()
+        if oauth is None:
+            raise TracecatNotFoundError(f"Connection {connection_id} not found")
+        await self.session.delete(oauth)
+        await self.session.flush()

--- a/tracecat/integrations/enums.py
+++ b/tracecat/integrations/enums.py
@@ -27,3 +27,25 @@ class MCPAuthType(StrEnum):
     OAUTH2 = "OAUTH2"
     CUSTOM = "CUSTOM"
     NONE = "NONE"
+
+
+class IntegrationSource(StrEnum):
+    """Origin of a catalog integration."""
+
+    PLATFORM = "platform"
+    """Tracecat-shipped, available across workspaces."""
+    WORKSPACE = "workspace"
+    """Workspace-authored catalog entry."""
+
+
+class ConnectionAuthMethod(StrEnum):
+    """Auth method for catalog connection projections."""
+
+    OAUTH_AUTH_CODE = "oauth_auth_code"
+    """OAuth 2.0 Authorization Code grant (user-delegated, per-user)."""
+    OAUTH_CLIENT_CREDENTIALS = "oauth_client_credentials"
+    """OAuth 2.0 Client Credentials grant (machine-to-machine)."""
+    SERVICE_ACCOUNT = "service_account"
+    """Service account JSON (e.g. GCP)."""
+    STATIC_KV = "static_kv"
+    """Generic encrypted key-value blob."""

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -12,7 +12,11 @@ from tracecat.audit.logger import audit_log
 from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
-from tracecat.db.models import BaseSecret, OrganizationSecret, Secret
+from tracecat.db.models import (
+    BaseSecret,
+    OrganizationSecret,
+    Secret,
+)
 from tracecat.exceptions import (
     TracecatAuthorizationError,
     TracecatCredentialsNotFoundError,
@@ -294,17 +298,16 @@ class SecretsService(BaseOrgService):
             return []
 
         workspace_id = self._require_workspace_id()
-        stmt = select(Secret).where(Secret.workspace_id == workspace_id)
         fields = params.model_dump(exclude_unset=True)
         self.logger.info("Searching secrets", set_fields=fields)
 
-        if ids := fields.get("ids"):
-            stmt = stmt.where(Secret.id.in_(ids))
+        stmt = select(Secret).where(Secret.workspace_id == workspace_id)
         if names := fields.get("names"):
             stmt = stmt.where(Secret.name.in_(names))
         if "environment" in fields:
             stmt = stmt.where(Secret.environment == fields["environment"])
-
+        if ids := fields.get("ids"):
+            stmt = stmt.where(Secret.id.in_(ids))
         result = await self.session.execute(stmt)
         return result.scalars().all()
 

--- a/tracecat/validation/service.py
+++ b/tracecat/validation/service.py
@@ -8,7 +8,6 @@ from pydantic import (
     ConfigDict,
     ValidationError,
 )
-from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat_registry import (
     RegistryOAuthSecret,
@@ -21,7 +20,7 @@ from tracecat.db.engine import get_async_session_context_manager
 from tracecat.dsl.common import DSLInput, ExecuteSubflowArgs
 from tracecat.dsl.enums import PlatformAction
 from tracecat.dsl.schemas import ActionStatement
-from tracecat.exceptions import RegistryValidationError, TracecatNotFoundError
+from tracecat.exceptions import RegistryValidationError
 from tracecat.expressions import patterns
 from tracecat.expressions.common import ExprType
 from tracecat.expressions.eval import extract_expressions, is_template_only
@@ -37,8 +36,10 @@ from tracecat.interactions.schemas import ResponseInteraction
 from tracecat.logger import logger
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.registry.versions.schemas import RegistryVersionManifest
+from tracecat.secrets.schemas import SecretSearch
 from tracecat.secrets.service import SecretsService
-from tracecat.tiers.entitlements import Entitlement, EntitlementService
+from tracecat.tiers.entitlements import EntitlementService
+from tracecat.tiers.enums import Entitlement
 from tracecat.tiers.service import TierService
 from tracecat.validation.common import json_schema_to_pydantic
 from tracecat.validation.schemas import (
@@ -86,19 +87,21 @@ async def validate_single_secret(
     results: list[SecretValidationResult] = []
     defined_secret = None
 
-    try:
-        defined_secret = await secrets_service.get_secret_by_name(
-            registry_secret.name, environment=environment
-        )
-    except TracecatNotFoundError as e:
+    defined_secrets = await secrets_service.search_secrets(
+        SecretSearch(names={registry_secret.name}, environment=environment)
+    )
+    checked_keys.add(registry_secret.name)
+    if len(defined_secrets) == 1:
+        defined_secret = defined_secrets[0]
+    else:
         # If the secret is required, we fail early
         if not registry_secret.optional:
             secret_repr = f"{registry_secret.name!r} (env: {environment!r})"
-            match e.__cause__:
-                case MultipleResultsFound():
-                    msg = f"Multiple secrets found when searching for secret {secret_repr}."
-                case _:
-                    msg = f"Secret {secret_repr} is missing in the secrets manager."
+            msg = (
+                f"Multiple secrets found when searching for secret {secret_repr}."
+                if len(defined_secrets) > 1
+                else f"Secret {secret_repr} is missing in the secrets manager."
+            )
             return [
                 SecretValidationResult(
                     status="error",
@@ -110,8 +113,6 @@ async def validate_single_secret(
                 )
             ]
         # If the secret is optional, we just log and move on
-    finally:
-        checked_keys.add(registry_secret.name)
 
     # At this point we either have an optional secret, or the secret is defined
     # Validate secret keys


### PR DESCRIPTION
## Summary

- Add a catalog-backed integrations API that anchors connector rows separately from credential storage
- Project static `Secret` and `OAuthIntegration` records as connection summaries
- Add the frontend catalog/detail/connect flow and admin seeding command

## Tests

- `uv run ruff check .`
- `uv run basedpyright packages/tracecat-admin/tracecat_admin/cli.py packages/tracecat-admin/tracecat_admin/commands/integrations.py tests/unit/test_integrations_catalog_auth.py tests/unit/test_validation_service_secrets.py tracecat/api/app.py tracecat/db/models.py tracecat/integrations/catalog/__init__.py tracecat/integrations/catalog/router.py tracecat/integrations/catalog/schemas.py tracecat/integrations/catalog/seed.py tracecat/integrations/catalog/service.py tracecat/integrations/enums.py tracecat/secrets/service.py tracecat/validation/service.py`
- `PG_PORT=5532 REDIS_PORT=6479 MINIO_PORT=9100 TEMPORAL_PORT=7333 uv run pytest tests/unit/test_integrations_catalog_auth.py tests/unit/test_validation_service_secrets.py`
- `pnpm -C frontend check`
