### PR TITLE
ci: schedule action doc link test

### DIFF
--- a/.github/workflows/test-action-doc-links.yml
+++ b/.github/workflows/test-action-doc-links.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: test-action-doc-links-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-action-doc-links:
     runs-on: blacksmith-2vcpu-ubuntu-2204
@@ -15,21 +19,24 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          fetch-depth: 1
           persist-credentials: false
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
       - name: Install uv
-        uses: useblacksmith/setup-uv@f4588471335f14dcb60198856207b916701a9e9f # v4
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.7"
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
+            packages/*/pyproject.toml
             uv.lock
-
-      - name: Set up Python 3.12
-        uses: useblacksmith/setup-python@943b05a7c4ca70c2360391137527a37bee33fb1d # v6
-        with:
-          python-version: "3.12"
+          cache-suffix: action-doc-links
 
       - name: Install dependencies
         run: uv sync --frozen
@@ -37,4 +44,4 @@ jobs:
       - name: Check action documentation links
         env:
           TRACECAT_TEST_ACTION_DOC_LINKS: "1"
-        run: uv run pytest scripts/tests/test_action_doc_links.py -ra
+        run: uv run --no-sync pytest scripts/tests/test_action_doc_links.py -ra

--- a/.github/workflows/test-action-doc-links.yml
+++ b/.github/workflows/test-action-doc-links.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   test-action-doc-links:
-    runs-on: blacksmith-8vcpu-ubuntu-2204
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/test-action-doc-links.yml
+++ b/.github/workflows/test-action-doc-links.yml
@@ -1,0 +1,40 @@
+name: Test action documentation links
+
+on:
+  schedule:
+    # Runs daily at 10:17 UTC.
+    - cron: "17 10 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  test-action-doc-links:
+    runs-on: blacksmith-8vcpu-ubuntu-2204
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: useblacksmith/setup-uv@f4588471335f14dcb60198856207b916701a9e9f # v4
+        with:
+          version: "0.9.7"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python 3.12
+        uses: useblacksmith/setup-python@943b05a7c4ca70c2360391137527a37bee33fb1d # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Check action documentation links
+        env:
+          TRACECAT_TEST_ACTION_DOC_LINKS: "1"
+        run: uv run pytest scripts/tests/test_action_doc_links.py -ra

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -67,34 +67,6 @@ jobs:
           env -u UV_SYSTEM_PYTHON uv pip install --python .venv/bin/python .
           .venv/bin/python -c "import custom_actions"
 
-  test-action-doc-links:
-    runs-on: blacksmith-8vcpu-ubuntu-2204
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Install uv
-        uses: useblacksmith/setup-uv@f4588471335f14dcb60198856207b916701a9e9f # v4
-        with:
-          version: "0.9.7"
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-
-      - name: Set up Python 3.12
-        uses: useblacksmith/setup-python@943b05a7c4ca70c2360391137527a37bee33fb1d # v6
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: uv sync --frozen
-
-      - name: Check action documentation links
-        env:
-          TRACECAT_TEST_ACTION_DOC_LINKS: "1"
-        run: uv run pytest scripts/tests/test_action_doc_links.py -ra
-
   test-all:
     runs-on: blacksmith-8vcpu-ubuntu-2204
     timeout-minutes: 60

--- a/scripts/tests/test_action_doc_links.py
+++ b/scripts/tests/test_action_doc_links.py
@@ -11,6 +11,10 @@ import pytest
 
 from tracecat.registry.repository import Repository
 
+_ALLOWED_UNREACHABLE_STATUS_CODES = {401, 403, 429}
+_MAX_LINK_CHECK_ATTEMPTS = 3
+_TRANSIENT_STATUS_CODES = {408, 425, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524}
+
 
 def _action_doc_urls() -> dict[str, tuple[str, ...]]:
     repo = Repository()
@@ -57,19 +61,51 @@ def test_ai_actions_link_to_tracecat_docs() -> None:
     assert repo.get("ai.action").doc_url == "https://docs.tracecat.com/agents/ai-action"
 
 
+async def _request_url(client: httpx.AsyncClient, url: str) -> int:
+    response = await client.head(url, follow_redirects=True)
+    if response.status_code in {405, 501}:
+        response = await client.get(url, follow_redirects=True)
+    return response.status_code
+
+
+def _is_transient_status(status_code: int) -> bool:
+    return status_code >= 500 or status_code in _TRANSIENT_STATUS_CODES
+
+
 async def _check_url(
     client: httpx.AsyncClient,
     semaphore: asyncio.Semaphore,
     url: str,
 ) -> tuple[int | None, str | None]:
     async with semaphore:
-        try:
-            response = await client.head(url, follow_redirects=True)
-            if response.status_code in {405, 501}:
-                response = await client.get(url, follow_redirects=True)
-        except httpx.HTTPError as exc:
-            return None, f"{type(exc).__name__}: {exc}"
-        return response.status_code, None
+        last_error: str | None = None
+        last_status_code: int | None = None
+        for attempt in range(1, _MAX_LINK_CHECK_ATTEMPTS + 1):
+            try:
+                status_code = await _request_url(client, url)
+            except httpx.TransportError as exc:
+                last_error = f"{type(exc).__name__}: {exc}"
+                last_status_code = None
+            except httpx.HTTPError as exc:
+                return None, f"{type(exc).__name__}: {exc}"
+            else:
+                last_status_code = status_code
+                last_error = None
+                if not _is_transient_status(status_code):
+                    return status_code, None
+
+            if attempt < _MAX_LINK_CHECK_ATTEMPTS:
+                await asyncio.sleep(0.5 * attempt)
+
+        if last_error:
+            return None, f"{last_error} after {_MAX_LINK_CHECK_ATTEMPTS} attempts"
+        return last_status_code, None
+
+
+def _is_broken_link_status(status_code: int | None) -> bool:
+    return status_code is None or (
+        status_code >= 400 and status_code not in _ALLOWED_UNREACHABLE_STATUS_CODES
+    )
 
 
 @pytest.mark.skipif(
@@ -78,11 +114,11 @@ async def _check_url(
 )
 def test_action_doc_urls_are_reachable() -> None:
     url_actions = _action_doc_urls()
-    timeout = httpx.Timeout(20.0, connect=10.0)
+    timeout = httpx.Timeout(12.0, connect=5.0)
     headers = {"User-Agent": "Tracecat-CI-Link-Checker/1.0"}
 
     async def check_all() -> dict[str, str]:
-        semaphore = asyncio.Semaphore(16)
+        semaphore = asyncio.Semaphore(8)
         async with httpx.AsyncClient(timeout=timeout, headers=headers) as client:
             results = await asyncio.gather(
                 *(
@@ -95,9 +131,7 @@ def test_action_doc_urls_are_reachable() -> None:
         for url, (status_code, error) in zip(url_actions, results, strict=True):
             if error:
                 broken[url] = error
-            elif status_code is None or (
-                status_code >= 400 and status_code not in {401, 403, 429}
-            ):
+            elif _is_broken_link_status(status_code):
                 broken[url] = f"HTTP {status_code}"
         return broken
 


### PR DESCRIPTION
## Summary

- Move `test-action-doc-links` out of the hot `Run Python tests` workflow.
- Add a dedicated scheduled workflow that runs the action documentation link check daily.
- Run the scheduled check on Blacksmith's 2 vCPU Ubuntu 22.04 runner.
- Improve cache affinity by using upstream cache-aware setup actions and a dedicated uv cache suffix.
- Reduce wasted work with shallow checkout, scheduled-run concurrency cancellation, and `uv run --no-sync` after the explicit sync step.
- Make live link checks more resilient with retries for transient transport and temporary HTTP failures, lower request concurrency, and shorter per-attempt timeouts.

## Testing

- `uv run ruff check .`
- `uv run basedpyright scripts/tests/test_action_doc_links.py`
- `uv run pytest scripts/tests/test_action_doc_links.py -ra`
- `TRACECAT_TEST_ACTION_DOC_LINKS=1 uv run pytest scripts/tests/test_action_doc_links.py -ra`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test-action-doc-links.yml"); puts "parsed"'`
- `git diff --check -- .github/workflows/test-action-doc-links.yml scripts/tests/test_action_doc_links.py`
- pre-commit YAML, Ruff, and Python type-check hooks during `git commit`
