### PR TITLE
feat(ee): hydrate mounted chat artifacts

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/artifacts/hydrators.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/artifacts/hydrators.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 
 import uuid
 
+from pydantic_core import to_jsonable_python
+
 from tracecat.agent.artifacts.hydration import (
     ArtifactHydrationContext,
     ArtifactHydratorRegistry,
     MountedArtifactContent,
 )
-from tracecat.artifacts.schemas import Artifact, CaseArtifact
+from tracecat.agent.preset.service import AgentPresetService
+from tracecat.artifacts.schemas import (
+    AgentArtifact,
+    Artifact,
+    CaseArtifact,
+    TableArtifact,
+)
 from tracecat.auth.schemas import UserRead
 from tracecat.cases.dropdowns.schemas import CaseDropdownValueRead
 from tracecat.cases.dropdowns.service import CaseDropdownValuesService
@@ -23,6 +31,10 @@ from tracecat.cases.service import CasesService
 from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.logger import logger
+from tracecat.pagination import CursorPaginationParams
+from tracecat.tables.enums import SqlType
+from tracecat.tables.schemas import TableColumnRead, TableRead
+from tracecat.tables.service import TablesService
 from tracecat.tiers.enums import Entitlement
 
 
@@ -116,6 +128,117 @@ class CaseArtifactHydrator:
         )
 
 
+class TableArtifactHydrator:
+    """Hydrate a table artifact projection into metadata and a row preview."""
+
+    async def hydrate(
+        self,
+        artifact: Artifact,
+        ctx: ArtifactHydrationContext,
+    ) -> MountedArtifactContent | None:
+        """Load the current table schema and first page of rows."""
+        if not isinstance(artifact, TableArtifact):
+            return None
+
+        try:
+            table_id = uuid.UUID(artifact.id)
+        except ValueError:
+            logger.warning(
+                "Cannot hydrate table artifact with non-UUID id",
+                artifact_id=artifact.id,
+            )
+            return None
+
+        async with get_async_session_context_manager() as session:
+            service = TablesService(session, ctx.role)
+            table = await service.get_table(table_id)
+            index_columns = await service.get_index(table)
+            table_read = TableRead(
+                id=table.id,
+                name=table.name,
+                columns=[
+                    TableColumnRead(
+                        id=column.id,
+                        name=column.name,
+                        type=SqlType(column.type),
+                        nullable=column.nullable,
+                        default=column.default,
+                        is_index=column.name in index_columns,
+                        options=column.options,
+                    )
+                    for column in table.columns
+                ],
+            )
+            rows_page = await service.list_rows(
+                table,
+                CursorPaginationParams(limit=100),
+            )
+
+        return MountedArtifactContent(
+            filename="table.json",
+            content_type="table.read",
+            payload={
+                "table": table_read.model_dump(mode="json", by_alias=True),
+                "rows": to_jsonable_python(rows_page.items, fallback=str),
+                "pagination": {
+                    "next_cursor": rows_page.next_cursor,
+                    "prev_cursor": rows_page.prev_cursor,
+                    "has_more": rows_page.has_more,
+                    "has_previous": rows_page.has_previous,
+                    "total_estimate": rows_page.total_estimate,
+                },
+            },
+        )
+
+
+class AgentArtifactHydrator:
+    """Hydrate an agent artifact projection into a full preset read model."""
+
+    async def hydrate(
+        self,
+        artifact: Artifact,
+        ctx: ArtifactHydrationContext,
+    ) -> MountedArtifactContent | None:
+        """Load the current agent preset content for the mounted working copy."""
+        if not isinstance(artifact, AgentArtifact):
+            return None
+
+        try:
+            preset_id = uuid.UUID(artifact.id)
+        except ValueError:
+            logger.warning(
+                "Cannot hydrate agent artifact with non-UUID id",
+                artifact_id=artifact.id,
+            )
+            return None
+
+        async with AgentPresetService.with_session(role=ctx.role) as service:
+            preset = await service.get_preset(preset_id)
+            if preset is None:
+                logger.warning(
+                    "Cannot hydrate missing agent artifact",
+                    preset_id=preset_id,
+                )
+                return None
+            preset_read = await service.build_preset_read(preset)
+
+        return MountedArtifactContent(
+            filename="agent.json",
+            content_type="agent_preset.read",
+            payload=preset_read.model_dump(
+                mode="json",
+                by_alias=True,
+                exclude_none=True,
+            ),
+        )
+
+
 def build_hydrator_registry() -> ArtifactHydratorRegistry:
     """Build the EE source-available artifact hydrator registry."""
-    return ArtifactHydratorRegistry({"case": CaseArtifactHydrator()})
+    return ArtifactHydratorRegistry(
+        {
+            "case": CaseArtifactHydrator(),
+            "table": TableArtifactHydrator(),
+            "agent": AgentArtifactHydrator(),
+        }
+    )

--- a/packages/tracecat-ee/tracecat_ee/agent/artifacts/mount_only_provider.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/artifacts/mount_only_provider.py
@@ -26,6 +26,7 @@ from tracecat.logger import logger
 from tracecat_ee.agent.artifacts.hydrators import build_hydrator_registry
 
 _SAFE_PATH_SEGMENT_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+_LOG_PREVIEW_BYTES = 4000
 
 
 class MountOnlyArtifactWorkingSetProvider:
@@ -42,6 +43,15 @@ class MountOnlyArtifactWorkingSetProvider:
         host_root = ctx.host_work_dir / ".tracecat" / "artifacts"
         runtime_root = ctx.runtime_work_dir / ".tracecat" / "artifacts"
         host_root.mkdir(parents=True, exist_ok=True)
+
+        logger.info(
+            "Preparing Workspace Chat artifact working set",
+            session_id=str(ctx.session_id),
+            workspace_id=str(ctx.workspace_id),
+            artifact_count=len(ctx.artifacts),
+            host_root=str(host_root),
+            runtime_root=str(runtime_root),
+        )
 
         entries = [
             await self._write_artifact_files(
@@ -61,6 +71,15 @@ class MountOnlyArtifactWorkingSetProvider:
         (host_root / "manifest.json").write_text(
             manifest.model_dump_json(indent=2, exclude_none=True),
             encoding="utf-8",
+        )
+        logger.info(
+            "Prepared Workspace Chat artifact manifest",
+            session_id=str(ctx.session_id),
+            manifest_path=str(runtime_root / "manifest.json"),
+            artifact_count=len(entries),
+            prompt_fragment_preview=_preview_text(_build_prompt_fragment(manifest))
+            if entries
+            else None,
         )
         return ArtifactWorkingSetResult(
             manifest=manifest,
@@ -85,16 +104,19 @@ class MountOnlyArtifactWorkingSetProvider:
         projection_relative_path = artifact_dir / "artifact.json"
         projection_runtime_path = runtime_root / projection_relative_path
 
-        self._write_json(
-            host_root / projection_relative_path,
-            artifact.model_dump(mode="json", by_alias=True, exclude_none=True),
+        projection_payload = artifact.model_dump(
+            mode="json",
+            by_alias=True,
+            exclude_none=True,
         )
+        self._write_json(host_root / projection_relative_path, projection_payload)
 
         primary_relative_path = projection_relative_path
         metadata: dict[str, Any] = {
             "hydrated": False,
             "projection_path": str(projection_runtime_path),
         }
+        content_preview = _json_preview(projection_payload)
 
         content = await self._hydrate_artifact(artifact, ctx=ctx)
         if content is not None:
@@ -102,13 +124,28 @@ class MountOnlyArtifactWorkingSetProvider:
             self._write_json(host_root / primary_relative_path, content.payload)
             metadata["hydrated"] = True
             metadata["content_type"] = content.content_type
+            content_preview = _json_preview(content.payload)
+
+        runtime_path = runtime_root / primary_relative_path
+        logger.info(
+            "Mounted Workspace Chat artifact file",
+            session_id=str(ctx.session_id),
+            artifact_type=artifact.type,
+            artifact_id=artifact.id,
+            title=artifact.title,
+            projection_path=str(projection_runtime_path),
+            path=str(runtime_path),
+            hydrated=metadata["hydrated"],
+            content_type=metadata.get("content_type"),
+            preview=content_preview,
+        )
 
         return ArtifactWorkingSetEntry(
             artifact_id=f"{artifact.type}:{artifact.id}",
             type=artifact.type,
             id=artifact.id,
             title=artifact.title,
-            path=str(runtime_root / primary_relative_path),
+            path=str(runtime_path),
             metadata=metadata,
         )
 
@@ -150,6 +187,17 @@ def build_provider() -> ArtifactWorkingSetProvider:
 def _safe_path_segment(value: str) -> str:
     safe_value = _SAFE_PATH_SEGMENT_RE.sub("_", value).strip("._")
     return safe_value or "artifact"
+
+
+def _json_preview(payload: Any) -> str:
+    text = orjson.dumps(payload, default=str).decode("utf-8")
+    return _preview_text(text)
+
+
+def _preview_text(text: str) -> str:
+    if len(text) <= _LOG_PREVIEW_BYTES:
+        return text
+    return f"{text[:_LOG_PREVIEW_BYTES]}... [truncated]"
 
 
 def _build_prompt_fragment(manifest: ArtifactWorkingSetManifest) -> str:

--- a/tracecat/agent/runtime/claude_code/broker.py
+++ b/tracecat/agent/runtime/claude_code/broker.py
@@ -24,6 +24,9 @@ from tracecat.agent.runtime.session_paths import (
     AgentSandboxPathMapping,
     build_agent_sandbox_path_mapping,
 )
+from tracecat.logger import logger
+
+_LOG_PREVIEW_CHARS = 4000
 
 
 class ConcurrentSessionTurnError(RuntimeError):
@@ -149,6 +152,15 @@ class ClaudeRuntimeBroker:
                     )
                 )
                 artifact_prompt_fragment = working_set.prompt_fragment
+                logger.info(
+                    "Prepared artifact prompt fragment for Claude runtime",
+                    session_id=str(request.init_payload.session_id),
+                    artifact_count=len(working_set.manifest.artifacts),
+                    artifact_root=working_set.manifest.root,
+                    prompt_fragment_preview=_preview_text(
+                        artifact_prompt_fragment or ""
+                    ),
+                )
             runtime = ClaudeAgentRuntime(
                 handler,
                 transport_factory=lambda options: SandboxedCLITransport(
@@ -193,3 +205,9 @@ class ClaudeRuntimeBroker:
             session_id=session_id,
             disable_nsjail=TRACECAT__DISABLE_NSJAIL,
         )
+
+
+def _preview_text(text: str) -> str:
+    if len(text) <= _LOG_PREVIEW_CHARS:
+        return text
+    return f"{text[:_LOG_PREVIEW_CHARS]}... [truncated]"

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -84,6 +84,7 @@ from tracecat.logger import logger
 
 CLAUDE_PROJECT_DIR_MAX_LENGTH = 200
 CLAUDE_PROJECT_DIR_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9]")
+LOG_PREVIEW_CHARS = 8000
 
 
 def _claude_project_dir_name(cwd: Path) -> str:
@@ -106,6 +107,12 @@ def _claude_project_dir_name(cwd: Path) -> str:
 def _ensure_supported_claude_project_dir_name(cwd: Path) -> None:
     """Ensure Claude can persist sessions under the runtime cwd."""
     _claude_project_dir_name(cwd)
+
+
+def _preview_text(text: str, *, limit: int = LOG_PREVIEW_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}... [truncated]"
 
 
 class RuntimeEventWriter(Protocol):
@@ -1168,6 +1175,17 @@ class ClaudeAgentRuntime:
         stderr: Callable[[str], None],
     ) -> ClaudeAgentOptions:
         """Build Claude SDK options from runtime policy and payload config."""
+        system_prompt = self._build_system_prompt(
+            payload.config.instructions,
+            payload.config.output_type,
+        )
+        logger.info(
+            "Claude runtime system prompt prepared",
+            session_id=str(payload.session_id),
+            system_prompt_length=len(system_prompt),
+            system_prompt_fragment_count=len(self._system_prompt_fragments),
+            system_prompt_preview=_preview_text(system_prompt),
+        )
         return ClaudeAgentOptions(
             include_partial_messages=True,
             resume=resume_session_id,
@@ -1184,9 +1202,7 @@ class ClaudeAgentRuntime:
                 model_name=payload.config.model_name,
                 passthrough=payload.config.passthrough,
             ),
-            system_prompt=self._build_system_prompt(
-                payload.config.instructions, payload.config.output_type
-            ),
+            system_prompt=system_prompt,
             mcp_servers=mcp_servers,
             allowed_tools=self._root_allowed_tools(
                 actions=payload.allowed_actions,
@@ -1361,11 +1377,25 @@ class ClaudeAgentRuntime:
                     "prompt_length": len(APPROVAL_CONTINUATION_PROMPT),
                     "is_meta": True,
                 }
-                logger.debug("Approval continuation with meta prompt")
+                logger.info(
+                    "Claude runtime user prompt prepared",
+                    session_id=str(payload.session_id),
+                    is_continuation=True,
+                    is_meta=True,
+                    prompt_length=len(APPROVAL_CONTINUATION_PROMPT),
+                    prompt_preview=_preview_text(APPROVAL_CONTINUATION_PROMPT),
+                )
             else:
                 query_input = payload.user_prompt
                 query_log_extra = {"prompt_length": len(query_input)}
-                logger.debug("Normal turn with user prompt")
+                logger.info(
+                    "Claude runtime user prompt prepared",
+                    session_id=str(payload.session_id),
+                    is_continuation=False,
+                    is_meta=False,
+                    prompt_length=len(query_input),
+                    prompt_preview=_preview_text(query_input),
+                )
 
             transport = self._transport_factory(options)
             client = ClaudeSDKClient(options=options, transport=transport)


### PR DESCRIPTION
## Stack
- Base PR: #2772

## Summary
- Add first-class workspace chat artifact stream events and Vercel `data-artifact` mapping.
- Add artifact projection/reducer logic for `upsert`/`remove` operations.
- Persist and hydrate artifact panel state from `agent_session.artifacts` provided by the base PR.
- Rename the user-facing workspace entrypoint to Chat at `/workspaces/:workspaceId/chat`, with `WorkspaceChat*` internals and a `workspace-chat` stream surface.
- Add throttled workspace chat updates with `experimental_throttle: 50`.
- Replace the temporary case panel CSS with Tailwind container-query classes and improve narrow artifact responsiveness.
- Update Linear docs for the current v1 boundary and add a backend pipeline regression.

## Tests
- `uv run pytest tests/unit/test_agent_stream_artifacts.py tests/unit/test_vercel_stream_context.py tests/unit/test_artifacts.py tests/unit/test_agent_stream_connector.py`
- `pnpm -C frontend test -- workspace-chat-artifacts.test.ts workspace-landing-page.test.tsx chat-session-pane.test.tsx use-chat.test.tsx --runInBand`
- `uv run ruff check .`
- `uv run ruff format --check tracecat/agent/session/service.py`
- `uv run basedpyright --warnings --threads 4 tests/unit/test_agent_stream_artifacts.py tracecat/agent/stream/artifacts.py tracecat/artifacts/schemas.py tracecat/artifacts/bindings.py tracecat/artifacts/projection.py`
- `uv run basedpyright --warnings --threads 4 tracecat/agent/session/service.py`
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hydrates mounted Workspace Chat artifacts (case, table, agent) and adds structured previews and logging for artifacts and Claude prompts to improve context and debugging. Keeps the artifact side panel, deep links, and lazy session creation for a smoother Chat flow.

- **New Features**
  - Runtime (EE): Mount and hydrate Workspace Chat artifacts; table hydration loads the current schema and first 100 rows with cursor pagination and index flags as `table.read` in `table.json`; agent hydration returns the full preset read as `agent_preset.read` in `agent.json`; files are written under `.tracecat/artifacts` and included in a manifest prompt fragment; configurable via `TRACECAT__AGENT_ARTIFACT_PROVIDER` (default `tracecat_ee.agent.artifacts.mount_only_provider:build_provider`).
  - Observability: Structured logs for working set prep and manifest writes (with prompt fragment preview); per-artifact mount logs include projection/hydrated JSON previews truncated to 4k; Claude broker logs the artifact prompt fragment (4k preview); Claude runtime logs system and user prompts (continuation/meta or normal) with length and 8k previews.

- **Refactors**
  - Rename “Copilot” to “Workspace Chat” and gate UI on the `workspace_chat` entitlement; sidebar surfaces Chat first and workspaces land on Chat by default.

<sup>Written for commit 09b3955c9948d125c66143c495644fa5313950d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

