### PR TITLE
chore: enable cluster sandbox by default

### DIFF
--- a/scripts/cluster
+++ b/scripts/cluster
@@ -39,7 +39,7 @@ ENV_FILE="${REPO_ROOT}/.env"
 # Default profile
 PROFILE="dev"
 CLUSTER_EE_MULTI_TENANT=""
-CLUSTER_USE_SANDBOX_COMPOSE=false
+CLUSTER_USE_SANDBOX_COMPOSE=true
 
 # Get worktree identifier for namespacing clusters
 # Returns "main" for the main worktree, or a sanitized branch/directory name for worktrees
@@ -380,8 +380,12 @@ Tenant mode:
   --single-tenant                 Set TRACECAT__EE_MULTI_TENANT=false
   --multi-tenant                  Set TRACECAT__EE_MULTI_TENANT=true
   --ee-multi-tenant true|false    Set TRACECAT__EE_MULTI_TENANT explicitly
-  --sandbox                       Enable nsjail sandboxing with the ephemeral
-                                  executor backend and layer sandbox privileges
+
+Sandbox mode:
+  Enabled by default for cluster development.
+  --sandbox                       Keep nsjail sandboxing enabled
+  --no-sandbox                    Disable nsjail sandboxing and sandbox
+                                  compose privileges
 
 Commands:
   up [args]     Start the cluster (e.g., up -d)
@@ -392,6 +396,7 @@ Commands:
                 user, and all default tier entitlements by default for the dev
                 profile. Use --no-seed to skip.
                 Use --default-tier-entitlements all|none|a,b to override.
+                Use --no-sandbox to opt out of nsjail sandboxing.
   seed [args]   Seed or update the dev superuser, tenant user, and default tier
                 for an already running cluster. Use
                 --default-tier-entitlements all|none|a,b to override.
@@ -416,12 +421,12 @@ Nuke options:
   nuke volumes          List and select volumes to remove
 
 Examples:
-  ./cluster up -d                Start cluster and create dev users
+  ./cluster up -d                Start sandboxed cluster and create dev users
   ./cluster up -d --single-tenant
                                   Start cluster with multi-tenancy disabled
   ./cluster --ee-multi-tenant false up -d
                                   Start cluster with explicit tenant mode
-  ./cluster --sandbox up -d       Start cluster with nsjail sandboxing
+  ./cluster up -d --no-sandbox    Start cluster without nsjail sandboxing
   ./cluster up -d --new          Force a new cluster on next available number
   ./cluster up -d --no-seed      Start cluster without creating dev tenant user
   ./cluster up -d --default-tier-entitlements none
@@ -530,6 +535,7 @@ build_env() {
         export TRACECAT__EXECUTOR_BACKEND=ephemeral
     else
         # Default to direct executor backend for development
+        export TRACECAT__DISABLE_NSJAIL=true
         export TRACECAT__EXECUTOR_BACKEND="${TRACECAT__EXECUTOR_BACKEND:-direct}"
     fi
 
@@ -659,6 +665,10 @@ while [[ $# -gt 0 ]]; do
             CLUSTER_USE_SANDBOX_COMPOSE=true
             shift
             ;;
+        --no-sandbox)
+            CLUSTER_USE_SANDBOX_COMPOSE=false
+            shift
+            ;;
         *)
             break
             ;;
@@ -728,6 +738,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --sandbox)
             CLUSTER_USE_SANDBOX_COMPOSE=true
+            shift
+            ;;
+        --no-sandbox)
+            CLUSTER_USE_SANDBOX_COMPOSE=false
             shift
             ;;
         *)

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -536,7 +536,7 @@ build_env() {
     else
         # Default to direct executor backend for development
         export TRACECAT__DISABLE_NSJAIL=true
-        export TRACECAT__EXECUTOR_BACKEND="${TRACECAT__EXECUTOR_BACKEND:-direct}"
+        export TRACECAT__EXECUTOR_BACKEND=direct
     fi
 
     # Cluster development always defaults to multi-tenant mode. Only the


### PR DESCRIPTION
## Summary
- Enable sandbox compose layering by default for `scripts/cluster`
- Keep `--sandbox` as an explicit no-op-style enable flag and add `--no-sandbox` to opt out
- Force `TRACECAT__DISABLE_NSJAIL=true` when opting out so stale env values do not keep nsjail enabled

## Test plan
- `bash -n scripts/cluster`
- `shellcheck -x scripts/cluster`
- `git diff --check -- scripts/cluster`
- `./scripts/cluster 1 config --format json | jq -r '.services.executor.privileged, .services.executor.environment.TRACECAT__DISABLE_NSJAIL, .services.executor.environment.TRACECAT__EXECUTOR_BACKEND'`
- `./scripts/cluster 1 config --no-sandbox --format json | jq -r '.services.executor.privileged // false, .services.executor.environment.TRACECAT__DISABLE_NSJAIL, .services.executor.environment.TRACECAT__EXECUTOR_BACKEND'`
- `uv run ruff check .`
- `uv run basedpyright scripts/cluster`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable sandbox mode by default for cluster development. Opting out with --no-sandbox disables nsjail and sandbox compose privileges and forces the direct executor backend; --sandbox remains a no-op.

- **Migration**
  - Clusters start sandboxed by default; use --no-sandbox to disable.
  - Opting out sets TRACECAT__DISABLE_NSJAIL=true and TRACECAT__EXECUTOR_BACKEND=direct.
  - Sandbox uses ephemeral executor; no-sandbox runs direct.

<sup>Written for commit d446324d7605652930199fd2054d088f71ee92e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2776?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

