### PR TITLE
feat(mcp): Update Tracecat MCP automation guidance

### DIFF
--- a/.agents/skills/test-tracecat-prompts/SKILL.md
+++ b/.agents/skills/test-tracecat-prompts/SKILL.md
@@ -16,12 +16,16 @@ these evals local-only; do not wire them into CI unless the user explicitly asks
 uv run python scripts/evals/tracecat_authoring/run_local.py --static-only
 ```
 
-2. For live generation evals, first confirm a local Tracecat MCP server is
-running, usually at `http://127.0.0.1:8099/mcp`. Then run a smoke set:
+2. For live generation evals, use the active local cluster MCP URL. Check it
+with `./scripts/cluster ports` and use the `MCP:` URL. If no local cluster is
+running, start one with `just cluster up -d`. Use `http://127.0.0.1:8099/mcp`
+only when you are intentionally running the MCP server directly outside the
+cluster helper.
 
 ```bash
+MCP_URL="$(./scripts/cluster ports | awk '/MCP:/ {print $2}')"
 uv run python scripts/evals/tracecat_authoring/run_local.py \
-  --mcp-url http://127.0.0.1:8099/mcp \
+  --mcp-url "$MCP_URL" \
   --cases smoke \
   --agent codex
 ```
@@ -29,9 +33,10 @@ uv run python scripts/evals/tracecat_authoring/run_local.py \
 3. To compare Claude Code against Codex, run both agents against the same cases:
 
 ```bash
+MCP_URL="$(./scripts/cluster ports | awk '/MCP:/ {print $2}')"
 TRACECAT_EVAL_CLAUDE_MODEL=claude-opus-4-7 \
 uv run python scripts/evals/tracecat_authoring/run_local.py \
-  --mcp-url http://127.0.0.1:8099/mcp \
+  --mcp-url "$MCP_URL" \
   --cases smoke \
   --agents codex,claude-code
 ```
@@ -52,10 +57,14 @@ report starts with a performance matrix:
 
 - Speed is wall-clock duration per agent run.
 - Accuracy is the fraction of structural/rubric checks passed.
-- Improvements are derived from failed rubric checks and invocation errors.
+- MCP efficiency and reliability come from on-disk transcripts: total MCP tool
+  calls, successful calls, failed calls, and schema/input failures.
+- Improvements are derived from failed rubric checks, invocation errors, and
+  failed transcript-derived MCP checks.
 
-If an agent fails before producing structured JSON, inspect that agent's
-`transcript.jsonl` and `final.json` under the case artifact directory.
+Claude Code may return prose instead of strict structured JSON. Inspect
+`transcript.jsonl` and `final.json` under the case artifact directory; the
+transcript is the source of truth for MCP tool-call behavior.
 
 ## Guardrails
 

--- a/.agents/skills/test-tracecat-prompts/SKILL.md
+++ b/.agents/skills/test-tracecat-prompts/SKILL.md
@@ -73,4 +73,5 @@ transcript is the source of truth for MCP tool-call behavior.
 - Do not treat existing unit tests as live generation coverage.
 - Do not inspect or score unrelated dirty repo changes while running the evals.
 - For existing workflow edit cases, expect the agent to use `get_workflow`,
-  validate-only `edit_workflow`, then apply the edit using the returned revision.
+  validate-only `edit_workflow`, then apply the edit using the original
+  `draft_revision` returned by `get_workflow`.

--- a/.agents/skills/test-tracecat-prompts/SKILL.md
+++ b/.agents/skills/test-tracecat-prompts/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: test-tracecat-prompts
+description: Use when evaluating Tracecat MCP prompts, automation-authoring instructions, or agent behavior with the local Tracecat prompt eval harness, including static MCP prompt checks, live local workflow-authoring evals, and Codex vs Claude Code performance comparisons.
+---
+
+# Test Tracecat Prompts
+
+## Workflow
+
+Use the local harness at `scripts/evals/tracecat_authoring/run_local.py`. Keep
+these evals local-only; do not wire them into CI unless the user explicitly asks.
+
+1. For prompt/schema regressions that do not need LLM calls, run:
+
+```bash
+uv run python scripts/evals/tracecat_authoring/run_local.py --static-only
+```
+
+2. For live generation evals, first confirm a local Tracecat MCP server is
+running, usually at `http://127.0.0.1:8099/mcp`. Then run a smoke set:
+
+```bash
+uv run python scripts/evals/tracecat_authoring/run_local.py \
+  --mcp-url http://127.0.0.1:8099/mcp \
+  --cases smoke \
+  --agent codex
+```
+
+3. To compare Claude Code against Codex, run both agents against the same cases:
+
+```bash
+TRACECAT_EVAL_CLAUDE_MODEL=claude-opus-4-7 \
+uv run python scripts/evals/tracecat_authoring/run_local.py \
+  --mcp-url http://127.0.0.1:8099/mcp \
+  --cases smoke \
+  --agents codex,claude-code
+```
+
+Use `TRACECAT_EVAL_WORKSPACE_ID` to pin the workspace,
+`TRACECAT_MCP_BEARER_TOKEN` when the local MCP server requires auth,
+`TRACECAT_EVAL_MODEL` for Codex, and `TRACECAT_EVAL_CLAUDE_MODEL` for Claude
+Code.
+
+## Interpretation
+
+Static and unit tests are fast because they parse prompts and local schemas only.
+They do not call live LLMs. Live agent evals are slower, create or edit workflows
+in the selected local workspace, and spend model credits.
+
+Read `.tracecat/evals/tracecat_authoring/<timestamp>/report.md` first. The
+report starts with a performance matrix:
+
+- Speed is wall-clock duration per agent run.
+- Accuracy is the fraction of structural/rubric checks passed.
+- Improvements are derived from failed rubric checks and invocation errors.
+
+If an agent fails before producing structured JSON, inspect that agent's
+`transcript.jsonl` and `final.json` under the case artifact directory.
+
+## Guardrails
+
+- Keep fixtures synthetic: `example.com`, placeholder ids, no real people, no
+  real tokens.
+- Do not treat existing unit tests as live generation coverage.
+- Do not inspect or score unrelated dirty repo changes while running the evals.
+- For existing workflow edit cases, expect the agent to use `get_workflow`,
+  validate-only `edit_workflow`, then apply the edit using the returned revision.

--- a/.agents/skills/test-tracecat-prompts/agents/openai.yaml
+++ b/.agents/skills/test-tracecat-prompts/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Test Tracecat Prompts"
+  short_description: "Run local Tracecat prompt evals."
+  default_prompt: "Run the local Tracecat prompt eval harness and compare agents."

--- a/.agents/skills/tracecat-automation-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-automation-best-practices/SKILL.md
@@ -96,9 +96,9 @@ For MCP table operations, use `tables_list_tables`, `tables_get_table`, `tables_
 
 - Workflow action names are not MCP tool names. Use MCP tools such as `workflows_create_workflow` to manage workflows, and use action names such as `core.http_request` only inside workflow YAML.
 - Do not invent `tools.*` action names. Discover actions with `workflows_list_actions`, then inspect exact schemas with `workflows_get_action_context`.
-- Do not use `for_each` or scatter/gather for ordinary loops, batching, dedupe, joins, filtering, or table writes. Use `core.script.run_python` loops for normal collection processing.
-- Do not use `upsert=True` unless the table already has a unique index on the intended key column.
-- Do not grant `core.http_request` to an agent unless the user explicitly approves that broad network capability.
+- Use `core.script.run_python` for ordinary collection processing; avoid `for_each` and scatter/gather for normal loops, batching, filtering, joins, or table writes.
+- Do not use table `insert_rows(..., upsert=True)` unless the table has a unique index on the key column used to match existing rows.
+- Do not grant `core.http_request` to an agent unless the user explicitly approves broad network access.
 
 ## Agent Presets
 

--- a/.agents/skills/tracecat-automation-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-automation-best-practices/SKILL.md
@@ -17,6 +17,18 @@ Use this skill for generic Tracecat automation work. Start from live MCP context
 
 When stuck on DSL behavior, Tracecat is open source at https://github.com/TracecatHQ/tracecat and the repo has sample workflows. Treat `platform/automations/001_google_oauth/workflow.yaml` as the clean reference for a readable production automation.
 
+Before building, ask the user to clarify any missing production choice that
+changes the workflow contract: target workspace, provider/integration, secret or
+credential source, publish/run behavior, destructive side effects, approval
+requirements, or acceptance criteria. If the request is already specific enough,
+proceed.
+
+Sketch the workflow shape before authoring it. Prefer a visually readable
+left-to-right or top-to-bottom flow, keep refs human-readable, minimize branch
+fan-out, and keep layout action refs aligned with definition action refs. Use
+the live MCP DSL reference for exact syntax instead of copying examples from
+this skill.
+
 ## Authoring Defaults
 
 - Prefer linear, readable workflow graphs by default. Visual ease and fewer branches are usually more valuable than maximum parallelism.
@@ -39,6 +51,14 @@ args:
 ```
 
 Use `ai.preset_agent` when a reusable agent should be maintained separately from a workflow.
+
+## Existing Workflow Edits
+
+- Prefer `workflows_edit_workflow` over replacing full YAML for focused changes.
+- Patch against the `draft_document` returned by `workflows_get_workflow`; action paths start under `/definition/actions/...`, not `/actions/...`.
+- For nontrivial edits, call `workflows_edit_workflow` with `validate_only: true`, then apply the same patch with `validate_only: false` and the revision returned by validation.
+- Treat `draft_revision` as sequential state. Do not run parallel edits against the same workflow draft; use the returned revision before the next patch.
+- When adding or renaming actions, update `depends_on` and matching layout action refs in the same edit so the graph stays valid and readable.
 
 ## Workflow Architecture
 

--- a/.agents/skills/tracecat-automation-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-automation-best-practices/SKILL.md
@@ -25,6 +25,7 @@ When stuck on DSL behavior, Tracecat is open source at https://github.com/Tracec
 - Use workflow folders to group related parent workflows, subflows, and support utilities.
 - Do not use `core.transform.scatter` / `core.transform.gather` for ordinary data transforms. Normalize, dedupe, join, filter, sort, and batch upsert inside `core.script.run_python`.
 - Prefer agents or agent presets for judgment, summarization, investigation, and tool-using decisions. If the task is just one deterministic API call, use `core.http_request` instead of an agent.
+- Do not give `core.http_request` to an agent unless the user explicitly accepts the risk. It effectively gives the agent unbounded curl-like access. Put deterministic HTTP calls in the workflow graph or a tightly scoped subflow instead.
 - Use HTTP pagination actions for paginated APIs. For transforms, especially nested loops, joins, grouping, dedupe, or large collection shaping, use `core.script.run_python` instead of expression chains.
 - Keep run-python outputs small: downstream rows, summary counts, and bounded error samples.
 - Prefer agent presets when an appropriate preset already exists. Use inline `ai.agent` only when the behavior is tightly coupled to one workflow and the prompt should travel with that workflow.

--- a/.agents/skills/tracecat-automation-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-automation-best-practices/SKILL.md
@@ -20,9 +20,12 @@ When stuck on DSL behavior, Tracecat is open source at https://github.com/Tracec
 ## Authoring Defaults
 
 - Prefer linear, readable workflow graphs when parallelism is not materially useful.
+- Keep a workflow to roughly 20 nodes or fewer. If it grows beyond that, split it into named subflows with clear inputs and outputs.
+- Use workflow folders to group related parent workflows, subflows, and support utilities.
 - Do not use `core.transform.scatter` / `core.transform.gather` for ordinary data transforms. Normalize, dedupe, join, filter, sort, and batch upsert inside `core.script.run_python`.
 - Keep run-python outputs small: downstream rows, summary counts, and bounded error samples.
-- Prefer the `model` object for `ai.agent`; top-level `model_name` and `model_provider` are deprecated unless the user explicitly asks for the legacy shape.
+- Prefer agent presets when an appropriate preset already exists. Use inline `ai.agent` only when the behavior is tightly coupled to one workflow and the prompt should travel with that workflow.
+- Prefer the `model` object for inline `ai.agent`; top-level `model_name` and `model_provider` are deprecated unless the user explicitly asks for the legacy shape.
 
 ```yaml
 args:
@@ -31,7 +34,19 @@ args:
     model_provider: anthropic
 ```
 
-Use `ai.preset_agent` when a reusable agent should be maintained separately from a workflow. Use inline `ai.agent` when the behavior is tightly coupled to one workflow and the prompt should travel with that workflow.
+Use `ai.preset_agent` when a reusable agent should be maintained separately from a workflow.
+
+## Workflow Architecture
+
+- Break large automations into a small orchestrator workflow plus focused subflows. The parent should route, checkpoint, and call subflows; subflows should do one coherent job.
+- Use `core.workflow.execute` for subflows. Prefer `workflow_alias` over hard-coded workflow IDs when aliases are available.
+- For collection fan-out, prefer scattering into subflows instead of building a large parent workflow graph. Keep the parent responsible for preparing inputs and aggregating/checkpointing results.
+- Use subflow `loop_strategy: batch` for most bulk work. It is the default and is safer than fully parallel fan-out.
+- Default subflow loop options are `loop_strategy: batch`, `batch_size: 32`, `fail_strategy: isolated`, and `wait_strategy: detach`.
+- For batched subflows, start with `batch_size: 32`. Lower it for rate-limited APIs or expensive actions; raise it only when the downstream system and Tracecat tier can handle the concurrency.
+- Use `wait_strategy: detach` for fire-and-forget fan-out where the parent only needs child workflow IDs. Use `wait_strategy: wait` when the parent must aggregate child results or gate downstream actions on subflow success.
+- Keep `fail_strategy: isolated` for bulk work so one failed item does not fail the whole batch. Use `fail_strategy: all` only when any subflow failure should fail the parent action.
+- Use tables as checkpoints between stages and subflows. Store normalized inputs, per-item status, run IDs, timestamps, and bounded error samples so reruns can resume or explain partial progress.
 
 ## Run-Python Imports
 

--- a/.agents/skills/tracecat-automation-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-automation-best-practices/SKILL.md
@@ -21,8 +21,11 @@ When stuck on DSL behavior, Tracecat is open source at https://github.com/Tracec
 
 - Prefer linear, readable workflow graphs when parallelism is not materially useful.
 - Keep a workflow to roughly 20 nodes or fewer. If it grows beyond that, split it into named subflows with clear inputs and outputs.
+- Keep agentic workflows to roughly 6 nodes or fewer. The graph should set context, call the agent or preset, and handle the result; move surrounding collection work into subflows or scripts.
 - Use workflow folders to group related parent workflows, subflows, and support utilities.
 - Do not use `core.transform.scatter` / `core.transform.gather` for ordinary data transforms. Normalize, dedupe, join, filter, sort, and batch upsert inside `core.script.run_python`.
+- Prefer agents or agent presets for judgment, summarization, investigation, and tool-using decisions. If the task is just one deterministic API call, use `core.http_request` instead of an agent.
+- Use HTTP pagination actions for paginated APIs. For transforms, especially nested loops, joins, grouping, dedupe, or large collection shaping, use `core.script.run_python` instead of expression chains.
 - Keep run-python outputs small: downstream rows, summary counts, and bounded error samples.
 - Prefer agent presets when an appropriate preset already exists. Use inline `ai.agent` only when the behavior is tightly coupled to one workflow and the prompt should travel with that workflow.
 - Prefer the `model` object for inline `ai.agent`; top-level `model_name` and `model_provider` are deprecated unless the user explicitly asks for the legacy shape.

--- a/.agents/skills/tracecat-automation-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-automation-best-practices/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: tracecat-automation-best-practices
+description: Use when building, editing, validating, or debugging generic Tracecat automations through Tracecat MCP, including workflow DSL/YAML authoring, table design, unique indexes, run-python Tracecat imports, agent presets, ai.agent or ai.preset_agent workflows, executions, validation, and workflow best practices. Do not use for Slack bot-specific setup unless the user asks for Slack, app mentions, interactive messages, or event subscriptions.
+---
+
+# Tracecat Automation Best Practices
+
+## Workflow
+
+Use this skill for generic Tracecat automation work. Start from live MCP context rather than guessing:
+
+1. Discover the workspace with `workspaces_list_workspaces`.
+2. Read `tracecat://platform/dsl-reference` if DSL syntax or examples are needed.
+3. Use `workflows_get_workflow_authoring_context` for action schemas, variables, and secrets.
+4. For existing workflows, use `workflows_get_workflow`, then targeted `workflows_edit_workflow` patches against `draft_document` and `draft_revision`.
+5. Validate with `workflows_validate_workflow`, run a draft or published execution when appropriate, then inspect failures with `workflows_list_workflow_executions` and `workflows_get_workflow_execution`.
+
+When stuck on DSL behavior, Tracecat is open source at https://github.com/TracecatHQ/tracecat and the repo has sample workflows. Treat `platform/automations/001_google_oauth/workflow.yaml` as the clean reference for a readable production automation.
+
+## Authoring Defaults
+
+- Prefer linear, readable workflow graphs when parallelism is not materially useful.
+- Do not use `core.transform.scatter` / `core.transform.gather` for ordinary data transforms. Normalize, dedupe, join, filter, sort, and batch upsert inside `core.script.run_python`.
+- Keep run-python outputs small: downstream rows, summary counts, and bounded error samples.
+- Prefer the `model` object for `ai.agent`; top-level `model_name` and `model_provider` are deprecated unless the user explicitly asks for the legacy shape.
+
+```yaml
+args:
+  model:
+    model_name: claude-sonnet-4-6
+    model_provider: anthropic
+```
+
+Use `ai.preset_agent` when a reusable agent should be maintained separately from a workflow. Use inline `ai.agent` when the behavior is tightly coupled to one workflow and the prompt should travel with that workflow.
+
+## Run-Python Imports
+
+Use direct Tracecat imports inside `core.script.run_python` when consolidating table or HTTP side effects reduces graph noise:
+
+```python
+from tracecat_registry.core.http import http_request
+from tracecat_registry.core.table import create_table, insert_row, insert_rows, lookup, update_row
+
+async def main(rows):
+    await create_table(
+        name="automation_inventory",
+        columns=[
+            {"name": "external_id", "type": "TEXT"},
+            {"name": "payload", "type": "JSONB"},
+        ],
+        raise_on_duplicate=False,
+    )
+
+    inserted = 0
+    for start in range(0, len(rows), 1000):
+        inserted += await insert_rows(
+            table="automation_inventory",
+            rows_data=rows[start:start + 1000],
+            upsert=True,
+        )
+    return {"input_rows": len(rows), "inserted": inserted}
+```
+
+Use `async def main(...)`, `await` imported actions, pass named arguments, and chunk writes. Catch expected per-item failures inside bulk actions and return counts plus a few examples instead of failing the whole workflow.
+
+## Tables
+
+- `core.table.create_table` creates columns but not unique indexes.
+- Before using `insert_rows(..., upsert=True)`, create a unique index on the intended key column.
+- Keep `insert_rows` batches at or below 1000 rows.
+- Use table storage for durable workflow state and agent-readable inventory.
+- Keep opaque identifiers as strings, especially numeric-looking IDs that may exceed integer limits.
+
+For MCP table operations, use `tables_list_tables`, `tables_get_table`, `tables_create_column_index`, `tables_search_table_rows`, and `tables_export_csv` as needed. For workflow YAML, use `core.table.*` actions or `tracecat_registry.core.table` imports inside run-python.
+
+## Agent Presets
+
+Before creating or updating presets, call `agents_get_agent_preset_authoring_context` and `integrations_list_integrations`. Check workspace model credentials, attachable MCP integrations, output type options, variables, and available tools.
+
+Give presets only the tools they need. Encode routing, table names, output style, and production action rules directly in the preset instructions; the agent reads its own instructions, not repo files.

--- a/.agents/skills/tracecat-automation-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-automation-best-practices/SKILL.md
@@ -35,7 +35,7 @@ this skill.
 - Keep a workflow to roughly 20 nodes or fewer. First try to simplify or consolidate with `core.script.run_python` or an agent/preset; split into named subflows only when the remaining work is a real orchestration boundary with clear inputs and outputs.
 - Keep agentic workflows to roughly 6 nodes or fewer. The graph should set context, call the agent or preset, and handle the result; move deterministic collection, joins, filtering, and batching into scripts unless subflows are clearly needed.
 - Use workflow folders to group related parent workflows, subflows, and support utilities.
-- Do not use `core.transform.scatter` / `core.transform.gather` for ordinary data transforms. Normalize, dedupe, join, filter, sort, and batch upsert inside `core.script.run_python`.
+- Do not use `core.transform.scatter` / `core.transform.gather` for ordinary data transforms. Scatter/gather has orchestration overhead and can be much slower than a run-python loop for normal batched transforms. Normalize, dedupe, join, filter, sort, and chunked table writes inside `core.script.run_python`.
 - Prefer agents or agent presets for judgment, summarization, investigation, and tool-using decisions. If the task is just one deterministic API call, use `core.http_request` instead of an agent.
 - Do not give `core.http_request` to an agent unless the user explicitly accepts the risk. It effectively gives the agent unbounded curl-like access. Put deterministic HTTP calls in the workflow graph or a tightly scoped subflow instead.
 - Use HTTP pagination actions for paginated APIs. For transforms, especially nested loops, joins, grouping, dedupe, or large collection shaping, use `core.script.run_python` instead of expression chains.
@@ -56,13 +56,14 @@ Use `ai.preset_agent` when a reusable agent should be maintained separately from
 
 - Prefer `workflows_edit_workflow` over replacing full YAML for focused changes.
 - Patch against the `draft_document` returned by `workflows_get_workflow`; action paths start under `/definition/actions/...`, not `/actions/...`.
-- For nontrivial edits, call `workflows_edit_workflow` with `validate_only: true`, then apply the same patch with `validate_only: false` and the revision returned by validation.
+- For nontrivial edits, call `workflows_edit_workflow` with `validate_only: true`, then apply the same patch with `validate_only: false` against the same `base_revision`. For another patch afterward, use the `draft_revision` returned by the successful write.
 - Treat `draft_revision` as sequential state. Do not run parallel edits against the same workflow draft; use the returned revision before the next patch.
 - When adding or renaming actions, update `depends_on` and matching layout action refs in the same edit so the graph stays valid and readable.
 
 ## Workflow Architecture
 
 - Start with a linear workflow and consolidate deterministic work before adding branches. Prefer `core.script.run_python` for data shaping, API loops, table writes, batching, dedupe, joins, retries, and per-item error handling. Prefer `ai.agent` or `ai.preset_agent` for investigation, judgment, summarization, and tool-using decisions.
+- Use action-level `for_each` for simple per-item repetition of one action. Use `core.loop.start` / `core.loop.end` for while-style loops where the next iteration depends on prior action output. Reserve `core.transform.scatter` / `core.transform.gather` for true parallel fan-out/fan-in where each item needs a separate workflow execution stream; prefer `core.script.run_python` loops with batching for ordinary collection processing.
 - Break large automations into a small orchestrator workflow plus focused subflows only when consolidation would hide important runtime boundaries or when each child workflow is independently useful. The parent should route, checkpoint, and call subflows; subflows should do one coherent job.
 - Use `core.workflow.execute` for subflows. Prefer `workflow_alias` over hard-coded workflow IDs when aliases are available.
 - Do not use subflow fan-out just to avoid writing a compact script. Use subflow fan-out when each item needs the workflow runtime boundary, separate execution history, retries, approvals, long-running actions, or independent checkpointing.
@@ -79,8 +80,8 @@ Use `ai.preset_agent` when a reusable agent should be maintained separately from
 Use direct Tracecat imports inside `core.script.run_python` when consolidating table or HTTP side effects reduces graph noise:
 
 ```python
-from tracecat_registry.core.http import http_request
-from tracecat_registry.core.table import create_table, insert_row, insert_rows, lookup, update_row
+from tracecat_registry.core.http import http_request, http_paginate
+from tracecat_registry.core.table import create_table, insert_rows, lookup, update_row
 
 async def main(rows):
     await create_table(
@@ -97,7 +98,7 @@ async def main(rows):
         inserted += await insert_rows(
             table="automation_inventory",
             rows_data=rows[start:start + 1000],
-            upsert=True,
+            upsert=False,
         )
     return {"input_rows": len(rows), "inserted": inserted}
 ```
@@ -113,6 +114,14 @@ Use `async def main(...)`, `await` imported actions, pass named arguments, and c
 - Keep opaque identifiers as strings, especially numeric-looking IDs that may exceed integer limits.
 
 For MCP table operations, use `tables_list_tables`, `tables_get_table`, `tables_create_column_index`, `tables_search_table_rows`, and `tables_export_csv` as needed. For workflow YAML, use `core.table.*` actions or `tracecat_registry.core.table` imports inside run-python.
+
+## Common Mistakes
+
+- Workflow action names are not MCP tool names. Use MCP tools such as `workflows_create_workflow` to manage workflows, and use action names such as `core.http_request` only inside workflow YAML.
+- Do not invent `tools.*` action names. Discover actions with `workflows_list_actions`, then inspect exact schemas with `workflows_get_action_context`.
+- Do not use scatter/gather for ordinary batching, dedupe, joins, filtering, or table writes. Use `core.script.run_python` for normal collection processing.
+- Do not use `upsert=True` unless the table already has a unique index on the intended key column.
+- Do not grant `core.http_request` to an agent unless the user explicitly approves that broad network capability.
 
 ## Agent Presets
 

--- a/.agents/skills/tracecat-automation-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-automation-best-practices/SKILL.md
@@ -19,9 +19,9 @@ When stuck on DSL behavior, Tracecat is open source at https://github.com/Tracec
 
 ## Authoring Defaults
 
-- Prefer linear, readable workflow graphs when parallelism is not materially useful.
-- Keep a workflow to roughly 20 nodes or fewer. If it grows beyond that, split it into named subflows with clear inputs and outputs.
-- Keep agentic workflows to roughly 6 nodes or fewer. The graph should set context, call the agent or preset, and handle the result; move surrounding collection work into subflows or scripts.
+- Prefer linear, readable workflow graphs by default. Visual ease and fewer branches are usually more valuable than maximum parallelism.
+- Keep a workflow to roughly 20 nodes or fewer. First try to simplify or consolidate with `core.script.run_python` or an agent/preset; split into named subflows only when the remaining work is a real orchestration boundary with clear inputs and outputs.
+- Keep agentic workflows to roughly 6 nodes or fewer. The graph should set context, call the agent or preset, and handle the result; move deterministic collection, joins, filtering, and batching into scripts unless subflows are clearly needed.
 - Use workflow folders to group related parent workflows, subflows, and support utilities.
 - Do not use `core.transform.scatter` / `core.transform.gather` for ordinary data transforms. Normalize, dedupe, join, filter, sort, and batch upsert inside `core.script.run_python`.
 - Prefer agents or agent presets for judgment, summarization, investigation, and tool-using decisions. If the task is just one deterministic API call, use `core.http_request` instead of an agent.
@@ -42,11 +42,13 @@ Use `ai.preset_agent` when a reusable agent should be maintained separately from
 
 ## Workflow Architecture
 
-- Break large automations into a small orchestrator workflow plus focused subflows. The parent should route, checkpoint, and call subflows; subflows should do one coherent job.
+- Start with a linear workflow and consolidate deterministic work before adding branches. Prefer `core.script.run_python` for data shaping, API loops, table writes, batching, dedupe, joins, retries, and per-item error handling. Prefer `ai.agent` or `ai.preset_agent` for investigation, judgment, summarization, and tool-using decisions.
+- Break large automations into a small orchestrator workflow plus focused subflows only when consolidation would hide important runtime boundaries or when each child workflow is independently useful. The parent should route, checkpoint, and call subflows; subflows should do one coherent job.
 - Use `core.workflow.execute` for subflows. Prefer `workflow_alias` over hard-coded workflow IDs when aliases are available.
-- For collection fan-out, prefer scattering into subflows instead of building a large parent workflow graph. Keep the parent responsible for preparing inputs and aggregating/checkpointing results.
-- Use subflow `loop_strategy: batch` for most bulk work. It is the default and is safer than fully parallel fan-out.
-- Default subflow loop options are `loop_strategy: batch`, `batch_size: 32`, `fail_strategy: isolated`, and `wait_strategy: detach`.
+- Do not use subflow fan-out just to avoid writing a compact script. Use subflow fan-out when each item needs the workflow runtime boundary, separate execution history, retries, approvals, long-running actions, or independent checkpointing.
+- For collection fan-out that really is a subflow use case, prefer looped `core.workflow.execute` over building a large parent workflow graph. Keep the parent responsible for preparing inputs and aggregating/checkpointing results.
+- Use subflow `loop_strategy: batch` for most bulk work. It is safer than fully parallel fan-out.
+- Default subflow loop options are `loop_strategy: batch`, `batch_size: 32`, `fail_strategy: isolated`, and `wait_strategy: wait`. Set `wait_strategy: detach` explicitly when the parent should not wait.
 - For batched subflows, start with `batch_size: 32`. Lower it for rate-limited APIs or expensive actions; raise it only when the downstream system and Tracecat tier can handle the concurrency.
 - Use `wait_strategy: detach` for fire-and-forget fan-out where the parent only needs child workflow IDs. Use `wait_strategy: wait` when the parent must aggregate child results or gate downstream actions on subflow success.
 - Keep `fail_strategy: isolated` for bulk work so one failed item does not fail the whole batch. Use `fail_strategy: all` only when any subflow failure should fail the parent action.

--- a/.agents/skills/tracecat-automation-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-automation-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tracecat-automation-best-practices
-description: Use when building, editing, validating, or debugging generic Tracecat automations through Tracecat MCP, including workflow DSL/YAML authoring, table design, unique indexes, run-python Tracecat imports, agent presets, ai.agent or ai.preset_agent workflows, executions, validation, and workflow best practices. Do not use for Slack bot-specific setup unless the user asks for Slack, app mentions, interactive messages, or event subscriptions.
+description: Use when building, editing, validating, or debugging generic Tracecat automations through Tracecat MCP, including workflow DSL/YAML authoring, table design, unique indexes, run-python Tracecat imports, agent presets, ai.agent or ai.preset_agent workflows, executions, validation, and workflow best practices.
 ---
 
 # Tracecat Automation Best Practices

--- a/.agents/skills/tracecat-automation-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-automation-best-practices/SKILL.md
@@ -7,41 +7,34 @@ description: Use when building, editing, validating, or debugging generic Tracec
 
 ## Workflow
 
-Use this skill for generic Tracecat automation work. Start from live MCP context rather than guessing:
+Start from live MCP context rather than guessing:
 
 1. Discover the workspace with `workspaces_list_workspaces`.
-2. Read `tracecat://platform/dsl-reference` if DSL syntax or examples are needed.
+2. Read `tracecat://platform/dsl-reference` when DSL syntax or examples are needed.
 3. Use `workflows_get_workflow_authoring_context` for action schemas, variables, and secrets.
 4. For existing workflows, use `workflows_get_workflow`, then targeted `workflows_edit_workflow` patches against `draft_document` and `draft_revision`.
 5. Validate with `workflows_validate_workflow`, run a draft or published execution when appropriate, then inspect failures with `workflows_list_workflow_executions` and `workflows_get_workflow_execution`.
 
-When stuck on DSL behavior, Tracecat is open source at https://github.com/TracecatHQ/tracecat and the repo has sample workflows. Treat `platform/automations/001_google_oauth/workflow.yaml` as the clean reference for a readable production automation.
+Clarify production choices that change the workflow contract: workspace, integration/provider, secret source, publish/run behavior, destructive side effects, approvals, or acceptance criteria. If the request is already specific enough, proceed.
 
-Before building, ask the user to clarify any missing production choice that
-changes the workflow contract: target workspace, provider/integration, secret or
-credential source, publish/run behavior, destructive side effects, approval
-requirements, or acceptance criteria. If the request is already specific enough,
-proceed.
-
-Sketch the workflow shape before authoring it. Prefer a visually readable
-left-to-right or top-to-bottom flow, keep refs human-readable, minimize branch
-fan-out, and keep layout action refs aligned with definition action refs. Use
-the live MCP DSL reference for exact syntax instead of copying examples from
-this skill.
+Sketch the workflow shape before authoring. Prefer readable left-to-right or top-to-bottom flows, human-readable refs, few branches, and layout refs aligned with definition refs. Use the live DSL reference for exact syntax.
 
 ## Authoring Defaults
 
-- Prefer linear, readable workflow graphs by default. Visual ease and fewer branches are usually more valuable than maximum parallelism.
-- Keep a workflow to roughly 20 nodes or fewer. First try to simplify or consolidate with `core.script.run_python` or an agent/preset; split into named subflows only when the remaining work is a real orchestration boundary with clear inputs and outputs.
-- Keep agentic workflows to roughly 6 nodes or fewer. The graph should set context, call the agent or preset, and handle the result; move deterministic collection, joins, filtering, and batching into scripts unless subflows are clearly needed.
-- Use workflow folders to group related parent workflows, subflows, and support utilities.
-- Do not use `core.transform.scatter` / `core.transform.gather` for ordinary data transforms. Scatter/gather has orchestration overhead and can be much slower than a run-python loop for normal batched transforms. Normalize, dedupe, join, filter, sort, and chunked table writes inside `core.script.run_python`.
-- Prefer agents or agent presets for judgment, summarization, investigation, and tool-using decisions. If the task is just one deterministic API call, use `core.http_request` instead of an agent.
-- Do not give `core.http_request` to an agent unless the user explicitly accepts the risk. It effectively gives the agent unbounded curl-like access. Put deterministic HTTP calls in the workflow graph or a tightly scoped subflow instead.
-- Use HTTP pagination actions for paginated APIs. For transforms, especially nested loops, joins, grouping, dedupe, or large collection shaping, use `core.script.run_python` instead of expression chains.
-- Keep run-python outputs small: downstream rows, summary counts, and bounded error samples.
-- Prefer agent presets when an appropriate preset already exists. Use inline `ai.agent` only when the behavior is tightly coupled to one workflow and the prompt should travel with that workflow.
-- Prefer the `model` object for inline `ai.agent`; top-level `model_name` and `model_provider` are deprecated unless the user explicitly asks for the legacy shape.
+- Prefer linear, readable graphs. Keep ordinary workflows around 20 nodes or fewer and agentic workflows around 6 nodes or fewer.
+- Consolidate deterministic work with `core.script.run_python`: data shaping, API loops, retries, batching, dedupe, joins, sorting, chunked table writes, and per-item error handling.
+- Prefer `ai.agent` or `ai.preset_agent` for investigation, judgment, summarization, and tool-using decisions. Use `core.http_request` for deterministic API calls.
+- Do not give `core.http_request` to an agent unless the user explicitly accepts the broad network capability. Put deterministic HTTP in the workflow graph or a tightly scoped subflow.
+- Use HTTP pagination actions for paginated APIs. Keep paginated results bounded before storing or returning them.
+- Prefer `core.script.run_python` loops over action-level `for_each`, even for bounded lists. `for_each` can create enough scheduled work to hurt the scheduler. Use it only when the user explicitly needs separate workflow action runs per item and accepts the concurrency tradeoff.
+- Prefer `core.script.run_python` loops over `core.transform.scatter` / `core.transform.gather`. Scatter/gather has the same scheduler/concurrency risk and should be reserved for explicit workflow-stream fan-out/fan-in requirements.
+- Use `core.loop.start` / `core.loop.end` only when each iteration depends on prior action output.
+- Split into subflows only when there is a real orchestration boundary, reusable child workflow, separate execution history, approvals, long-running actions, retries, or independent checkpointing.
+- Use `core.workflow.execute` for subflows and prefer `workflow_alias` over hard-coded workflow IDs.
+- For subflow bulk work, default to `loop_strategy: batch`, `batch_size: 32`, `fail_strategy: isolated`, and `wait_strategy: wait`. Use `wait_strategy: detach` only when the parent does not need child results.
+- Keep run-python and agent outputs small: downstream rows, summary counts, and bounded error samples.
+- Prefer agent presets when reusable behavior already exists. Use inline `ai.agent` only when the prompt should live with one workflow.
+- Prefer the `model` object for inline `ai.agent`; top-level `model_name` and `model_provider` are deprecated unless the user asks for the legacy shape.
 
 ```yaml
 args:
@@ -50,30 +43,13 @@ args:
     model_provider: anthropic
 ```
 
-Use `ai.preset_agent` when a reusable agent should be maintained separately from a workflow.
-
 ## Existing Workflow Edits
 
 - Prefer `workflows_edit_workflow` over replacing full YAML for focused changes.
 - Patch against the `draft_document` returned by `workflows_get_workflow`; action paths start under `/definition/actions/...`, not `/actions/...`.
-- For nontrivial edits, call `workflows_edit_workflow` with `validate_only: true`, then apply the same patch with `validate_only: false` against the same `base_revision`. For another patch afterward, use the `draft_revision` returned by the successful write.
-- Treat `draft_revision` as sequential state. Do not run parallel edits against the same workflow draft; use the returned revision before the next patch.
-- When adding or renaming actions, update `depends_on` and matching layout action refs in the same edit so the graph stays valid and readable.
-
-## Workflow Architecture
-
-- Start with a linear workflow and consolidate deterministic work before adding branches. Prefer `core.script.run_python` for data shaping, API loops, table writes, batching, dedupe, joins, retries, and per-item error handling. Prefer `ai.agent` or `ai.preset_agent` for investigation, judgment, summarization, and tool-using decisions.
-- Use action-level `for_each` for simple per-item repetition of one action. Use `core.loop.start` / `core.loop.end` for while-style loops where the next iteration depends on prior action output. Reserve `core.transform.scatter` / `core.transform.gather` for true parallel fan-out/fan-in where each item needs a separate workflow execution stream; prefer `core.script.run_python` loops with batching for ordinary collection processing.
-- Break large automations into a small orchestrator workflow plus focused subflows only when consolidation would hide important runtime boundaries or when each child workflow is independently useful. The parent should route, checkpoint, and call subflows; subflows should do one coherent job.
-- Use `core.workflow.execute` for subflows. Prefer `workflow_alias` over hard-coded workflow IDs when aliases are available.
-- Do not use subflow fan-out just to avoid writing a compact script. Use subflow fan-out when each item needs the workflow runtime boundary, separate execution history, retries, approvals, long-running actions, or independent checkpointing.
-- For collection fan-out that really is a subflow use case, prefer looped `core.workflow.execute` over building a large parent workflow graph. Keep the parent responsible for preparing inputs and aggregating/checkpointing results.
-- Use subflow `loop_strategy: batch` for most bulk work. It is safer than fully parallel fan-out.
-- Default subflow loop options are `loop_strategy: batch`, `batch_size: 32`, `fail_strategy: isolated`, and `wait_strategy: wait`. Set `wait_strategy: detach` explicitly when the parent should not wait.
-- For batched subflows, start with `batch_size: 32`. Lower it for rate-limited APIs or expensive actions; raise it only when the downstream system and Tracecat tier can handle the concurrency.
-- Use `wait_strategy: detach` for fire-and-forget fan-out where the parent only needs child workflow IDs. Use `wait_strategy: wait` when the parent must aggregate child results or gate downstream actions on subflow success.
-- Keep `fail_strategy: isolated` for bulk work so one failed item does not fail the whole batch. Use `fail_strategy: all` only when any subflow failure should fail the parent action.
-- Use tables as checkpoints between stages and subflows. Store normalized inputs, per-item status, run IDs, timestamps, and bounded error samples so reruns can resume or explain partial progress.
+- For nontrivial edits, call `workflows_edit_workflow` with `validate_only: true`, then apply the same patch with `validate_only: false` against the same `base_revision`.
+- Treat `draft_revision` as sequential state. After a successful write, use the returned revision before the next patch.
+- When adding or renaming actions, update `depends_on` and matching layout action refs in the same edit.
 
 ## Run-Python Imports
 
@@ -110,16 +86,17 @@ Use `async def main(...)`, `await` imported actions, pass named arguments, and c
 - `core.table.create_table` creates columns but not unique indexes.
 - Before using `insert_rows(..., upsert=True)`, create a unique index on the intended key column.
 - Keep `insert_rows` batches at or below 1000 rows.
-- Use table storage for durable workflow state and agent-readable inventory.
+- Use table storage for durable workflow state, checkpoints between stages and subflows, per-item status, run IDs, timestamps, and bounded error samples.
 - Keep opaque identifiers as strings, especially numeric-looking IDs that may exceed integer limits.
+- Keep table names, column names, and case field names under 63 characters.
 
-For MCP table operations, use `tables_list_tables`, `tables_get_table`, `tables_create_column_index`, `tables_search_table_rows`, and `tables_export_csv` as needed. For workflow YAML, use `core.table.*` actions or `tracecat_registry.core.table` imports inside run-python.
+For MCP table operations, use `tables_list_tables`, `tables_get_table`, `tables_create_column_index`, `tables_search_table_rows`, and `tables_export_csv`. For workflow YAML, use `core.table.*` actions or `tracecat_registry.core.table` imports inside run-python.
 
 ## Common Mistakes
 
 - Workflow action names are not MCP tool names. Use MCP tools such as `workflows_create_workflow` to manage workflows, and use action names such as `core.http_request` only inside workflow YAML.
 - Do not invent `tools.*` action names. Discover actions with `workflows_list_actions`, then inspect exact schemas with `workflows_get_action_context`.
-- Do not use scatter/gather for ordinary batching, dedupe, joins, filtering, or table writes. Use `core.script.run_python` for normal collection processing.
+- Do not use `for_each` or scatter/gather for ordinary loops, batching, dedupe, joins, filtering, or table writes. Use `core.script.run_python` loops for normal collection processing.
 - Do not use `upsert=True` unless the table already has a unique index on the intended key column.
 - Do not grant `core.http_request` to an agent unless the user explicitly approves that broad network capability.
 

--- a/.agents/skills/tracecat-slackbot-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-slackbot-best-practices/SKILL.md
@@ -36,8 +36,7 @@ For setup:
 
 - Configure the Tracecat workflow webhook.
 - Add the webhook to Slack interactivity at `https://api.slack.com/apps/{app_id}/interactive-messages`.
-- For @mention back-and-forth chat, configure Slack event subscriptions for app mentions and put the webhook URL in Slack with `?echo=true` appended.
-- The `?echo=true` suffix is required for reliable mention-thread loops.
+- For @mention back-and-forth chat, configure Slack event subscriptions for app mentions and put the webhook URL in Slack with `?echo=true` appended for reliable mention-thread loops.
 
 Typical event handling:
 

--- a/.agents/skills/tracecat-slackbot-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-slackbot-best-practices/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: tracecat-slackbot-best-practices
+description: Use when building, editing, validating, or debugging Tracecat Slack bots and Slack-facing automations through Tracecat MCP, including Slack app mentions, interactive messages, event subscriptions, webhooks, thread replies, Slack tools, ai.agent or ai.preset_agent bots, Slack tone, and Slack smoke tests.
+---
+
+# Tracecat Slackbot Best Practices
+
+## When To Use
+
+Use this skill only for Slack-facing Tracecat automations: Slack bots, app mentions, Slack interactivity, button callbacks, thread replies, message reads, Slack event subscriptions, or Slack smoke tests.
+
+For generic Tracecat workflow, table, run-python, or agent-preset guidance, use `$tracecat-automation-best-practices` instead.
+
+## Bot Architecture
+
+Build Slack bots with `ai.agent` or `ai.preset_agent`.
+
+- Use inline `ai.agent` when the Slack behavior is specific to one workflow and should travel with that workflow.
+- Use `ai.preset_agent` when the bot persona, tools, and instructions should be reusable across workflows.
+- Give the agent Slack send/post message tools plus list/read message or reply tools when it needs thread context.
+- Fetch the Slack thread before invoking the agent, and tell the agent that thread context is required input.
+- Post visible replies back to the original channel and thread. Do not answer only in the agent transcript.
+
+Prefer the `model` object for `ai.agent`; top-level `model_name` and `model_provider` are deprecated unless the user explicitly asks for the legacy shape.
+
+```yaml
+args:
+  model:
+    model_name: claude-sonnet-4-6
+    model_provider: anthropic
+```
+
+## Slack App Setup
+
+For setup:
+
+- Configure the Tracecat workflow webhook.
+- Add the webhook to Slack interactivity at `https://api.slack.com/apps/{app_id}/interactive-messages`.
+- For @mention back-and-forth chat, configure Slack event subscriptions for app mentions and put the webhook URL in Slack with `?echo=true` appended.
+- The `?echo=true` suffix is required for reliable mention-thread loops.
+
+Typical event handling:
+
+1. Receive Slack `event_callback` for `app_mention`.
+2. Extract `event.channel`, `event.ts`, `event.thread_ts || event.ts`, `event.user`, and `event.text`.
+3. Add a lightweight processing reaction if desired.
+4. Fetch the whole Slack thread with a Slack list replies/messages tool.
+5. Build an agent prompt that includes the sanitized thread JSON.
+6. Invoke the agent.
+7. Remove the processing reaction after the agent finishes.
+
+## Interactivity
+
+For Slack buttons and block actions:
+
+- Parse the `payload` string when Slack sends URL-encoded interactivity.
+- Extract `actions[0].action_id`, `actions[0].value`, `channel.id`, `message.ts`, `message.thread_ts || message.ts`, and `user.id`.
+- Button clicks should post a visible thread reply unless the product requirement is to update the original message.
+- Do not add or remove reactions for button clicks unless the workflow explicitly requires it.
+
+## Prompting Rules
+
+Slack-facing agents need explicit production posting rules in their own instructions:
+
+- Always post to the original Slack channel and thread.
+- Use Slack mrkdwn, not generic Markdown, when posting text.
+- Use Block Kit only when the response needs buttons, links, compact review layout, or structured blocks.
+- Use a reasonable, calm, critical tone. Do not be alarmist, speculate about compromise, or inflate severity without evidence.
+- Avoid emojis unless they make the point clearer or are part of a deliberate lightweight status convention.
+- Keep style rules in the preset or `ai.agent` instructions. The agent reads its own instructions, not repo files.
+- If a Slack post fails, return a concise failure reason and enough context for workflow debugging.
+
+## Testing
+
+After publishing a Slack-facing automation, do a live smoke test:
+
+1. Send a normal Slack message that mentions the bot.
+2. Confirm the bot posts a visible reply in the original thread.
+3. Confirm the Tracecat run was `trigger_type: webhook` and `execution_type: published`.
+4. Inspect the execution timeline and failed action payloads with Tracecat MCP if the reply is missing or delayed.
+5. Confirm processing reactions are cleaned up after completion.
+
+Do not paste secret-bearing Slack payloads or Tracecat action outputs into docs or chat. Summarize routing, status, action refs, timing, and non-sensitive behavior.

--- a/scripts/evals/tracecat_authoring/README.md
+++ b/scripts/evals/tracecat_authoring/README.md
@@ -1,0 +1,85 @@
+# Tracecat Automation Authoring Evals
+
+Local-only eval harness for Tracecat automation authoring through the local
+Tracecat MCP server. It runs Codex from an isolated temporary workspace that
+contains only the generic automation skill, then scores created or edited
+workflows through MCP and parser/schema checks.
+
+## Static prompt checks
+
+```bash
+uv run python scripts/evals/tracecat_authoring/run_local.py --static-only
+```
+
+Static checks parse fenced JSON/YAML blocks in the MCP instructions, validate
+JSON Patch examples structurally, validate complete workflow YAML examples with
+`WorkflowYamlPayload`, validate action snippets inside minimal DSL wrappers, and
+run budget plus PII/secret regex checks. These checks are parser/schema driven,
+not brittle string comparisons.
+
+## Smoke agent eval
+
+Start a local Tracecat app plus MCP server, then run:
+
+```bash
+uv run python scripts/evals/tracecat_authoring/run_local.py \
+  --mcp-url http://127.0.0.1:8099/mcp \
+  --cases smoke \
+  --agent codex
+```
+
+The runner uses `TRACECAT_EVAL_WORKSPACE_ID` when set. Otherwise it uses the
+first workspace returned by `workspaces_list_workspaces`. If the MCP server
+requires a bearer token, set `TRACECAT_MCP_BEARER_TOKEN`.
+
+## Codex vs Claude Code
+
+Run both agents against the same case set:
+
+```bash
+TRACECAT_EVAL_CLAUDE_MODEL=claude-opus-4-7 \
+uv run python scripts/evals/tracecat_authoring/run_local.py \
+  --mcp-url http://127.0.0.1:8099/mcp \
+  --cases smoke \
+  --agents codex,claude-code
+```
+
+`report.md` and `report.json` include a performance matrix with per-agent model,
+pass rate, average rubric accuracy, average wall-clock duration, transcript MCP
+tool-call count, workflow node count, branch count, and failed-check-driven
+improvement notes.
+
+## Full local eval
+
+```bash
+uv run python scripts/evals/tracecat_authoring/run_local.py --agent codex
+```
+
+Optional environment:
+
+- `TRACECAT_EVAL_WORKSPACE_ID`: workspace id to author into.
+- `TRACECAT_MCP_BEARER_TOKEN`: bearer token for local MCP calls.
+- `TRACECAT_EVAL_MODEL`: model passed to `codex exec --model`.
+- `TRACECAT_EVAL_CLAUDE_MODEL`: model passed to `claude --model`; defaults to
+  `claude-opus-4-7` for the comparison path.
+- `TRACECAT_EVAL_AGENT_TIMEOUT_SECONDS`: per-case agent subprocess timeout;
+  defaults to 900 seconds.
+- `TRACECAT_EVAL_CODEX_BYPASS_APPROVALS=1`: run Codex with
+  `--dangerously-bypass-approvals-and-sandbox` for local, disposable eval
+  sandboxes where MCP calls must execute without interactive approval.
+
+Artifacts are written under ignored
+`.tracecat/evals/tracecat_authoring/<timestamp>/`:
+
+- `report.json`: machine-readable case and rubric results.
+- `report.md`: concise human-readable summary.
+- `cases/<agent>/<case_id>/transcript.jsonl`: agent JSON event stream.
+- `cases/<agent>/<case_id>/final.json`: final structured agent response.
+- `cases/<agent>/<case_id>/workspace/`: isolated temporary agent workspace.
+
+Use `--agent-cmd` to override the agent command while keeping the same scoring
+harness. The command may use `{workspace}`, `{final}`, `{schema}`, `{mcp_url}`,
+`{case_id}`, and `{prompt}` placeholders; if `{prompt}` is omitted, the runner
+appends the prompt as the final argument. The default Codex invocation is
+non-interactive, ephemeral, and pointed only at the supplied local Tracecat MCP
+URL.

--- a/scripts/evals/tracecat_authoring/README.md
+++ b/scripts/evals/tracecat_authoring/README.md
@@ -17,13 +17,26 @@ JSON Patch examples structurally, validate complete workflow YAML examples with
 run budget plus PII/secret regex checks. These checks are parser/schema driven,
 not brittle string comparisons.
 
+## Local MCP URL
+
+Live evals should target the active local cluster MCP server:
+
+```bash
+MCP_URL="$(./scripts/cluster ports | awk '/MCP:/ {print $2}')"
+```
+
+If no local cluster is running, start one with `just cluster up -d`. Use
+`http://127.0.0.1:8099/mcp` only when intentionally running the MCP server
+directly outside the cluster helper.
+
 ## Smoke agent eval
 
 Start a local Tracecat app plus MCP server, then run:
 
 ```bash
+MCP_URL="$(./scripts/cluster ports | awk '/MCP:/ {print $2}')"
 uv run python scripts/evals/tracecat_authoring/run_local.py \
-  --mcp-url http://127.0.0.1:8099/mcp \
+  --mcp-url "$MCP_URL" \
   --cases smoke \
   --agent codex
 ```
@@ -37,17 +50,20 @@ requires a bearer token, set `TRACECAT_MCP_BEARER_TOKEN`.
 Run both agents against the same case set:
 
 ```bash
+MCP_URL="$(./scripts/cluster ports | awk '/MCP:/ {print $2}')"
 TRACECAT_EVAL_CLAUDE_MODEL=claude-opus-4-7 \
 uv run python scripts/evals/tracecat_authoring/run_local.py \
-  --mcp-url http://127.0.0.1:8099/mcp \
+  --mcp-url "$MCP_URL" \
   --cases smoke \
   --agents codex,claude-code
 ```
 
 `report.md` and `report.json` include a performance matrix with per-agent model,
 pass rate, average rubric accuracy, average wall-clock duration, transcript MCP
-tool-call count, workflow node count, branch count, and failed-check-driven
-improvement notes.
+tool-call count, failed MCP calls, schema/input failures, workflow node count,
+branch count, and failed-check-driven improvement notes. Claude Code may return
+prose; transcript-derived MCP behavior is the source of truth for tool-call
+reliability.
 
 ## Full local eval
 

--- a/scripts/evals/tracecat_authoring/cases.yaml
+++ b/scripts/evals/tracecat_authoring/cases.yaml
@@ -50,7 +50,8 @@ cases:
       - `source`: string
 
       Use targeted JSON Patch edits against the draft document. First perform a
-      validate-only edit, then apply the real edit with the returned revision.
+      validate-only edit, then apply the real edit by reusing the original
+      `draft_revision` returned by `workflows_get_workflow`.
       Keep the layout entries consistent with the definition action refs.
     rubric:
       - starts_from_live_context

--- a/scripts/evals/tracecat_authoring/cases.yaml
+++ b/scripts/evals/tracecat_authoring/cases.yaml
@@ -61,6 +61,57 @@ cases:
       - layout_refs_match_actions
       - changed_seed_workflow
 
+  - id: workflow_metadata_update_tool
+    groups: [builder, full]
+    seed_workflow: true
+    prompt: |
+      Update the existing seeded workflow metadata only. Set a clearer title,
+      description, offline status, and a unique alias that starts with the run
+      prefix. Use the MCP workflow metadata update tool for metadata only.
+
+      Do not replace or edit the workflow definition for this task. Do not use
+      the workflow YAML reference as the source of truth for MCP tool arguments;
+      use the live MCP tool schema.
+    rubric:
+      - discovered_workspace
+      - fetched_existing_workflow
+      - used_update_workflow_metadata_only
+      - no_update_workflow_patch_ops
+
+  - id: builder_table_schema_and_index
+    groups: [builder, full]
+    prompt: |
+      Create a workspace table for automation builder test assets. Include
+      columns for an external id, status, optional metadata JSON, and a
+      multi-select tag list. Use uppercase table column types and only put
+      options on select-style fields. Use a short table name under 63
+      characters.
+
+      After creating the table, fetch the table definition and create a unique
+      index on the external id column using the real column UUID from the table
+      response.
+    rubric:
+      - discovered_workspace
+      - created_table_with_valid_columns
+      - created_table_index_from_fetched_table
+
+  - id: builder_custom_case_fields
+    groups: [builder, full]
+    prompt: |
+      Create custom case fields for automation builder triage:
+
+      - a long-text analyst notes field
+      - a URL field for evidence links
+      - a select field for triage state with three options
+
+      Use the MCP case field tools and exact live tool schemas. List fields
+      first, create the fields with valid uppercase SQL types and valid kind
+      values, then update the select field options to add one more allowed
+      value.
+    rubric:
+      - discovered_workspace
+      - created_and_updated_case_fields
+
   - id: bulk_rows_consolidation
     groups: [full]
     prompt: |

--- a/scripts/evals/tracecat_authoring/cases.yaml
+++ b/scripts/evals/tracecat_authoring/cases.yaml
@@ -1,0 +1,153 @@
+cases:
+  - id: new_linear_summary_workflow
+    groups: [smoke, full]
+    prompt: |
+      Create a new workflow that accepts a trigger input named `events`, a list
+      of event objects with `severity`, `source`, and `message` fields.
+
+      The workflow should summarize the collection deterministically with
+      `core.script.run_python`, returning counts by severity, the first five
+      sources sorted alphabetically, and at most five sample messages. Keep the
+      workflow small and linear.
+    rubric:
+      - starts_from_live_context
+      - created_workflow
+      - valid_workflow_yaml
+      - declares_trigger_inputs
+      - uses_core_script_run_python
+      - linear_small_graph
+      - bounded_output
+      - no_scatter_gather
+      - no_third_party_tools
+
+  - id: paginated_api_enrichment
+    groups: [full]
+    prompt: |
+      Create a new workflow that accepts `account_id` and fetches all pages from
+      a synthetic API endpoint at `https://api.example.com/v1/accounts/${{ TRIGGER.account_id }}/findings`.
+
+      Use the Tracecat pagination action for the paginated request. Then use a
+      deterministic transform to return the page items as a list plus a count.
+      Do not use a third-party integration.
+    rubric:
+      - starts_from_live_context
+      - created_workflow
+      - valid_workflow_yaml
+      - declares_trigger_inputs
+      - uses_core_http_paginate
+      - treats_paginate_result_as_list
+      - no_third_party_tools
+
+  - id: existing_workflow_sequential_patch
+    groups: [smoke, full]
+    seed_workflow: true
+    prompt: |
+      Update the existing seeded workflow. Add a deterministic Python step after
+      the current step that normalizes the seeded output into:
+
+      - `ok`: boolean
+      - `summary`: string
+      - `source`: string
+
+      Use targeted JSON Patch edits against the draft document. First perform a
+      validate-only edit, then apply the real edit with the returned revision.
+      Keep the layout entries consistent with the definition action refs.
+    rubric:
+      - starts_from_live_context
+      - fetched_existing_workflow
+      - used_edit_workflow
+      - used_validate_only_edit
+      - valid_workflow_yaml
+      - layout_refs_match_actions
+      - changed_seed_workflow
+
+  - id: bulk_rows_consolidation
+    groups: [full]
+    prompt: |
+      Create a workflow that accepts `rows`, a large list of JSON records from
+      `example.com` inventory exports. Normalize records, dedupe by `asset_id`,
+      batch rows into groups of 1000, and return only counts and up to ten
+      rejected examples.
+
+      Keep the workflow readable. Do not build a large graph for the collection
+      processing.
+    rubric:
+      - starts_from_live_context
+      - created_workflow
+      - valid_workflow_yaml
+      - uses_core_script_run_python
+      - no_scatter_gather
+      - linear_small_graph
+      - bounded_output
+
+  - id: agentic_triage_minimal_graph
+    groups: [full]
+    prompt: |
+      Create a workflow that accepts a compact case summary and a list of
+      synthetic alerts. It should prepare concise deterministic context, ask an
+      agent or preset agent to judge likely priority and next steps, then return
+      a bounded triage object.
+
+      Keep deterministic prep and response shaping outside the agent. Keep the
+      graph small.
+    rubric:
+      - starts_from_live_context
+      - created_workflow
+      - valid_workflow_yaml
+      - uses_agent_action
+      - small_agentic_graph
+      - deterministic_prep_outside_agent
+      - agent_without_broad_http_tool
+      - no_third_party_tools
+
+  - id: subflow_boundary_case
+    groups: [full]
+    prompt: |
+      Create a parent workflow for isolated per-customer processing. It accepts
+      `customers`, a list of objects with `customer_id` and `plan`.
+
+      Call the child workflow by alias `eval_customer_child` using
+      `core.workflow.execute`. Use batch loop semantics, an explicit batch size,
+      isolated failure behavior, and an explicit wait strategy. Return a small
+      summary of scheduled or completed child runs.
+    rubric:
+      - starts_from_live_context
+      - created_workflow
+      - valid_workflow_yaml
+      - uses_workflow_execute
+      - uses_workflow_alias
+      - explicit_batch_loop_options
+      - explicit_wait_strategy
+
+  - id: third_party_tool_gating
+    groups: [smoke, full]
+    prompt: |
+      Create a workflow for generic IP reputation enrichment of indicators from
+      a trigger input named `indicators`. The user has not named any enrichment
+      provider or specific integration.
+
+      Follow the Tracecat third-party tool policy. Either scaffold with core
+      actions and placeholder `example.com` endpoints, or explain in final notes
+      what provider confirmation is needed before adding provider-specific
+      `tools.*` actions.
+    rubric:
+      - starts_from_live_context
+      - valid_or_clarified
+      - no_third_party_tools
+      - provider_gating_note_or_core_http
+
+  - id: safe_debug_run
+    groups: [smoke, full]
+    prompt: |
+      Create a deterministic workflow that accepts `name`, formats
+      `hello, <name>` with `core.script.run_python`, validates it, runs the
+      draft workflow safely with `{"name": "example"}`, and inspects the
+      execution before claiming success.
+    rubric:
+      - starts_from_live_context
+      - created_workflow
+      - valid_workflow_yaml
+      - uses_core_script_run_python
+      - validated_workflow
+      - ran_draft_workflow
+      - inspected_execution

--- a/scripts/evals/tracecat_authoring/codex_output_schema.json
+++ b/scripts/evals/tracecat_authoring/codex_output_schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Tracecat authoring eval final response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["case_id", "workflow_ids", "changed_workflow_ids", "notes"],
+  "properties": {
+    "case_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "workflow_ids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "changed_workflow_ids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/scripts/evals/tracecat_authoring/run_local.py
+++ b/scripts/evals/tracecat_authoring/run_local.py
@@ -31,7 +31,7 @@ from tracecat.mcp.schemas import JsonPatchOperation, WorkflowYamlPayload
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parents[2]
 SKILL_SOURCE = REPO_ROOT / ".agents/skills/tracecat-automation-best-practices/SKILL.md"
-DEFAULT_MCP_URL = "http://127.0.0.1:8099/mcp"
+DEFAULT_DIRECT_MCP_URL = "http://127.0.0.1:8099/mcp"
 DEFAULT_ARTIFACT_ROOT = REPO_ROOT / ".tracecat/evals/tracecat_authoring"
 ALLOWED_PATCH_ROOTS = {
     "metadata",
@@ -80,6 +80,9 @@ class CaseResult:
     duration_seconds: float | None = None
     accuracy: float | None = None
     mcp_tool_calls: int | None = None
+    mcp_tool_successes: int | None = None
+    mcp_tool_failures: int | None = None
+    mcp_schema_input_failures: int | None = None
     workflow_node_count: int | None = None
     branch_count: int | None = None
 
@@ -98,9 +101,38 @@ class CaseResult:
             "duration_seconds": self.duration_seconds,
             "accuracy": self.accuracy,
             "mcp_tool_calls": self.mcp_tool_calls,
+            "mcp_tool_successes": self.mcp_tool_successes,
+            "mcp_tool_failures": self.mcp_tool_failures,
+            "mcp_schema_input_failures": self.mcp_schema_input_failures,
             "workflow_node_count": self.workflow_node_count,
             "branch_count": self.branch_count,
         }
+
+
+@dataclass
+class McpToolCall:
+    call_id: str
+    tool_name: str
+    arguments: dict[str, Any] = field(default_factory=dict)
+    status: str = "unknown"
+    text: str = ""
+    payload: Any = None
+
+
+@dataclass
+class McpToolCallMetrics:
+    total: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    schema_input_failures: int = 0
+
+
+@dataclass
+class TranscriptAnalysis:
+    mcp_metrics: McpToolCallMetrics
+    workflow_ids: list[str] = field(default_factory=list)
+    changed_workflow_ids: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -198,6 +230,247 @@ def extract_json_object(text: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError("Final response is not a JSON object")
     return value
+
+
+UUID_FRAGMENT = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+UUID_PATTERN = re.compile(rf"\b{UUID_FRAGMENT}\b", re.IGNORECASE)
+
+
+def unique_strings(values: Iterable[Any]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        text = str(value)
+        if text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
+
+
+def analyze_transcript(transcript_path: Path | None) -> TranscriptAnalysis:
+    calls: dict[str, McpToolCall] = {}
+    notes: list[str] = []
+    for event in transcript_json_events(transcript_path):
+        collect_actual_mcp_tool_calls(event, calls)
+        if isinstance(event.get("result"), str):
+            notes.append(event["result"])
+
+    metrics = McpToolCallMetrics(total=len(calls))
+    workflow_ids: list[str] = []
+    changed_workflow_ids: list[str] = []
+
+    for call in calls.values():
+        if mcp_call_failed(call):
+            call.status = "failed"
+            metrics.failed += 1
+            if schema_input_failure_text(call.text):
+                metrics.schema_input_failures += 1
+        else:
+            call.status = "succeeded"
+            metrics.succeeded += 1
+
+        workflow_ids.extend(workflow_ids_from_call(call))
+        changed_workflow_ids.extend(changed_workflow_ids_from_call(call))
+
+    return TranscriptAnalysis(
+        mcp_metrics=metrics,
+        workflow_ids=unique_strings(workflow_ids),
+        changed_workflow_ids=unique_strings(changed_workflow_ids),
+        notes=[note for note in notes if note.strip()],
+    )
+
+
+def collect_actual_mcp_tool_calls(value: Any, calls: dict[str, McpToolCall]) -> None:
+    if isinstance(value, list):
+        for item in value:
+            collect_actual_mcp_tool_calls(item, calls)
+        return
+    if not isinstance(value, dict):
+        return
+
+    if (
+        value.get("type") == "tool_use"
+        and isinstance(value.get("name"), str)
+        and value["name"].startswith("mcp__")
+    ):
+        tool_name = tracecat_tool_name(value["name"])
+        if tool_name:
+            calls[str(value["id"])] = McpToolCall(
+                call_id=str(value["id"]),
+                tool_name=tool_name,
+                arguments=value.get("input")
+                if isinstance(value.get("input"), dict)
+                else {},
+            )
+
+    if value.get("type") == "mcp_tool_call":
+        tool_name = tracecat_tool_name(str(value.get("tool", "")))
+        call_id = value.get("id")
+        if tool_name and isinstance(call_id, str):
+            call = calls.setdefault(call_id, McpToolCall(call_id, tool_name))
+            call.tool_name = tool_name
+            if isinstance(value.get("arguments"), dict):
+                call.arguments = value["arguments"]
+            if isinstance(value.get("status"), str):
+                call.status = value["status"].lower()
+            if "result" in value:
+                call.payload = value["result"]
+                call.text += " " + compact_text(value["result"])
+            if "error" in value:
+                call.text += " " + compact_text(value["error"])
+
+    if (
+        value.get("type") == "tool_result"
+        and isinstance(value.get("tool_use_id"), str)
+        and value["tool_use_id"] in calls
+    ):
+        call = calls[value["tool_use_id"]]
+        call.payload = value.get("content")
+        call.text += " " + compact_text(value.get("content"))
+
+    for item in value.values():
+        collect_actual_mcp_tool_calls(item, calls)
+
+
+def compact_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return " ".join(compact_text(item) for item in value)
+    if isinstance(value, dict):
+        return " ".join(compact_text(item) for item in value.values())
+    return str(value)
+
+
+def mcp_call_failed(call: McpToolCall) -> bool:
+    text = call.text.lower()
+    if call.status in {"failed", "error", "errored"}:
+        return True
+    if call.status in {"unknown", "in_progress"} and not text.strip():
+        return True
+    return any(
+        needle in text
+        for needle in (
+            "toolerror",
+            "internal error:",
+            "input validation",
+            "invalid arguments",
+            "invalid input",
+            "401 unauthorized",
+            "403 forbidden",
+            "404 not found",
+            "500 internal server error",
+        )
+    )
+
+
+def schema_input_failure_text(text: str) -> bool:
+    lowered = text.lower()
+    return any(
+        needle in lowered
+        for needle in (
+            "input validation",
+            "invalid arguments",
+            "invalid input",
+            "json schema",
+            "schema validation",
+            "field required",
+            "extra_forbidden",
+            "additional properties",
+            "unexpected keyword",
+            "missing required",
+            "pydantic",
+            "model_validate",
+        )
+    )
+
+
+def workflow_ids_from_call(call: McpToolCall) -> list[str]:
+    if call.tool_name == "workflows_create_workflow":
+        return ids_from_payload_keys(call.payload, "id")
+    if call.tool_name in {
+        "workflows_edit_workflow",
+        "workflows_get_workflow",
+        "workflows_validate_workflow",
+        "workflows_run_draft_workflow",
+        "workflows_run_published_workflow",
+    }:
+        return ids_from_payload_keys(call.payload, "workflow_id", "id")
+    return []
+
+
+def changed_workflow_ids_from_call(call: McpToolCall) -> list[str]:
+    if call.tool_name == "workflows_create_workflow":
+        return ids_from_payload_keys(call.payload, "id")
+    if call.tool_name != "workflows_edit_workflow":
+        return []
+    if call.arguments.get("validate_only") is True:
+        return []
+    return ids_from_payload_keys(call.payload, "workflow_id")
+
+
+def ids_from_payload_keys(payload: Any, *keys: str) -> list[str]:
+    ids: list[str] = []
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return []
+    if isinstance(payload, list):
+        for item in payload:
+            ids.extend(ids_from_payload_keys(item, *keys))
+    elif isinstance(payload, dict):
+        for key in keys:
+            value = payload.get(key)
+            if isinstance(value, str) and UUID_PATTERN.fullmatch(value):
+                ids.append(value)
+        for key in ("content", "structuredContent", "structured_content", "result"):
+            if key in payload:
+                ids.extend(ids_from_payload_keys(payload[key], *keys))
+    return ids
+
+
+def normalize_final_response(
+    raw: Mapping[str, Any], *, case_id: str, analysis: TranscriptAnalysis
+) -> dict[str, Any]:
+    workflow_ids = response_id_list(raw, "workflow_ids", "workflow_id")
+    changed_workflow_ids = response_id_list(
+        raw, "changed_workflow_ids", "changed_workflow_id"
+    )
+    if not workflow_ids:
+        workflow_ids = analysis.workflow_ids
+    if not changed_workflow_ids:
+        changed_workflow_ids = analysis.changed_workflow_ids
+
+    notes = raw.get("notes")
+    if isinstance(notes, str):
+        normalized_notes = [notes]
+    elif isinstance(notes, list):
+        normalized_notes = [str(note) for note in notes if note is not None]
+    else:
+        normalized_notes = analysis.notes
+
+    return {
+        "case_id": str(raw.get("case_id") or case_id),
+        "workflow_ids": unique_strings(workflow_ids),
+        "changed_workflow_ids": unique_strings(changed_workflow_ids),
+        "notes": normalized_notes,
+    }
+
+
+def response_id_list(raw: Mapping[str, Any], *keys: str) -> list[str]:
+    values: list[str] = []
+    for key in keys:
+        value = raw.get(key)
+        if isinstance(value, str):
+            values.append(value)
+        elif isinstance(value, list):
+            values.extend(str(item) for item in value)
+    return [value for value in values if UUID_PATTERN.fullmatch(value)]
 
 
 def normalize_item_list(value: Any) -> list[dict[str, Any]]:
@@ -328,7 +601,7 @@ Important constraints:
 - Use synthetic data only. Use example.com for placeholder endpoints. Do not use real people, real tokens, or provider-specific integrations unless the case names them.
 - Do not inspect the Tracecat source repository. This temporary workspace intentionally contains only the generic automation skill.
 - Do not inspect environment variables or print credential-bearing process state.
-- Final response must match the required JSON schema.
+- Final response may be concise prose or JSON, but it must include the workflow IDs you created or edited when a workflow was created or edited.
 
 Task:
 {case.prompt}
@@ -446,8 +719,6 @@ def run_agent(
             "--mcp-config",
             str(mcp_config_path),
             "--strict-mcp-config",
-            "--json-schema",
-            schema_path.read_text(),
             prompt,
         ]
     else:
@@ -471,11 +742,17 @@ def run_agent(
     duration_seconds = time.monotonic() - started
     if completed.returncode != 0:
         raise RuntimeError(f"Agent exited with code {completed.returncode}")
+    analysis = analyze_transcript(transcript_path)
     if final_path.exists():
-        final_response = extract_json_object(final_path.read_text())
+        raw_final_response = extract_json_object(final_path.read_text())
     else:
-        final_response = extract_final_response_from_transcript(transcript_path)
-        write_json(final_path, final_response)
+        raw_final_response = extract_final_response_from_transcript(transcript_path)
+    final_response = normalize_final_response(
+        raw_final_response,
+        case_id=case.id,
+        analysis=analysis,
+    )
+    write_json(final_path, final_response)
     return AgentRun(
         final_response=final_response,
         duration_seconds=duration_seconds,
@@ -504,7 +781,9 @@ def extract_final_response_from_transcript(transcript_path: Path) -> dict[str, A
             return extract_json_object(candidate)
         except Exception:
             continue
-    raise RuntimeError("Could not extract structured final response from transcript")
+    if candidates:
+        return {"notes": [candidates[-1]]}
+    raise RuntimeError("Could not extract final response from transcript")
 
 
 def iter_text_candidates(value: Any) -> Iterable[str]:
@@ -637,26 +916,24 @@ def iter_tracecat_tool_calls(value: Any) -> Iterable[tuple[str | None, str]]:
 
 
 def count_mcp_tool_calls(transcript_path: Path | None) -> int:
-    seen_ids: set[str] = set()
-    count = 0
-    for event in transcript_json_events(transcript_path):
-        for call_id, _tool_name in iter_tracecat_tool_calls(event):
-            if call_id is not None:
-                if call_id in seen_ids:
-                    continue
-                seen_ids.add(call_id)
-            count += 1
-    return count
+    return analyze_transcript(transcript_path).mcp_metrics.total
 
 
 def source_inspection_detected(transcript: str) -> bool:
     repo = str(REPO_ROOT)
     artifact_root = str(DEFAULT_ARTIFACT_ROOT)
-    transcript = transcript.replace(artifact_root, "")
-    if repo not in transcript:
-        return False
     suspicious_commands = ("sed ", "cat ", "rg ", "grep ", "find ", "ls ")
-    return any(command in transcript for command in suspicious_commands)
+    for line in transcript.splitlines():
+        line = line.replace(artifact_root, "")
+        if repo not in line:
+            continue
+        if not any(command in line for command in suspicious_commands):
+            continue
+        if re.search(r'"(cmd|command)"\s*:', line) or re.search(
+            r'"name"\s*:\s*"(Bash|Read|Grep|Glob|LS|exec_command)"', line
+        ):
+            return True
+    return False
 
 
 async def fetch_workflow_snapshot(
@@ -1072,32 +1349,16 @@ async def score_case(
     seed_workflow_id: str | None,
     duration_seconds: float,
 ) -> CaseResult:
-    schema = json.loads((SCRIPT_DIR / "codex_output_schema.json").read_text())
-    mcp_tool_calls = count_mcp_tool_calls(transcript_path)
-    schema_errors = sorted(
-        Draft202012Validator(schema).iter_errors(final_response),
-        key=lambda error: list(error.path),
-    )
+    transcript_analysis = analyze_transcript(transcript_path)
+    mcp_metrics = transcript_analysis.mcp_metrics
     checks: list[CheckResult] = []
-    if schema_errors:
-        checks.append(
-            CheckResult("final_response_schema", False, schema_errors[0].message)
+    checks.append(
+        CheckResult(
+            "no_failed_mcp_schema_inputs",
+            mcp_metrics.schema_input_failures == 0,
+            f"{mcp_metrics.schema_input_failures} MCP schema/input failures.",
         )
-        return CaseResult(
-            case_id=case.id,
-            agent=agent,
-            passed=False,
-            model=agent_model(agent),
-            checks=checks,
-            transcript_path=str(transcript_path),
-            final_response_path=str(final_path),
-            duration_seconds=duration_seconds,
-            accuracy=accuracy_from_checks(checks),
-            mcp_tool_calls=mcp_tool_calls,
-            workflow_node_count=0,
-            branch_count=0,
-        )
-    checks.append(CheckResult("final_response_schema", True))
+    )
 
     transcript = transcript_text(transcript_path)
     checks.append(
@@ -1110,6 +1371,10 @@ async def score_case(
 
     workflow_ids = [str(x) for x in final_response.get("workflow_ids", [])]
     changed_ids = [str(x) for x in final_response.get("changed_workflow_ids", [])]
+    if not workflow_ids:
+        workflow_ids = transcript_analysis.workflow_ids
+    if not changed_ids:
+        changed_ids = transcript_analysis.changed_workflow_ids
     snapshots: list[WorkflowSnapshot] = []
     for workflow_id in workflow_ids or changed_ids:
         try:
@@ -1160,7 +1425,10 @@ async def score_case(
         final_response_path=str(final_path),
         duration_seconds=duration_seconds,
         accuracy=accuracy_from_checks(checks),
-        mcp_tool_calls=mcp_tool_calls,
+        mcp_tool_calls=mcp_metrics.total,
+        mcp_tool_successes=mcp_metrics.succeeded,
+        mcp_tool_failures=mcp_metrics.failed,
+        mcp_schema_input_failures=mcp_metrics.schema_input_failures,
         workflow_node_count=workflow_node_count(snapshots),
         branch_count=workflow_branch_count(snapshots),
     )
@@ -1490,6 +1758,7 @@ async def run_agent_cases(args: argparse.Namespace) -> list[CaseResult]:
                         duration_seconds=run.duration_seconds,
                     )
                 except Exception as exc:
+                    mcp_metrics = analyze_transcript(transcript_path).mcp_metrics
                     result = CaseResult(
                         case_id=case.id,
                         agent=agent,
@@ -1498,7 +1767,10 @@ async def run_agent_cases(args: argparse.Namespace) -> list[CaseResult]:
                         transcript_path=str(transcript_path),
                         final_response_path=str(final_path),
                         error=f"{type(exc).__name__}: {exc}",
-                        mcp_tool_calls=count_mcp_tool_calls(transcript_path),
+                        mcp_tool_calls=mcp_metrics.total,
+                        mcp_tool_successes=mcp_metrics.succeeded,
+                        mcp_tool_failures=mcp_metrics.failed,
+                        mcp_schema_input_failures=mcp_metrics.schema_input_failures,
                         workflow_node_count=0,
                         branch_count=0,
                     )
@@ -1537,14 +1809,15 @@ def write_reports(artifact_dir: Path, results: Sequence[CaseResult]) -> None:
         "",
         "## Performance matrix",
         "",
-        "| Agent | Model | Cases | Pass rate | Avg accuracy | Avg duration | Avg MCP calls | Avg workflow nodes | Avg branches | Key failures | Improvements |",
-        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |",
+        "| Agent | Model | Cases | Pass rate | Avg accuracy | Avg duration | Avg MCP calls | Failed MCP calls | Schema/input failures | Avg workflow nodes | Avg branches | Key failures | Improvements |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |",
     ]
     for row in matrix:
         lines.append(
             "| {agent} | {model} | {cases} | {pass_rate:.0%} | "
             "{avg_accuracy:.0%} | {avg_duration_seconds:.1f}s | "
-            "{avg_mcp_tool_calls:.1f} | {avg_workflow_nodes:.1f} | "
+            "{avg_mcp_tool_calls:.1f} | {mcp_tool_failures} | "
+            "{mcp_schema_input_failures} | {avg_workflow_nodes:.1f} | "
             "{avg_branch_count:.1f} | {key_failures} | {improvements} |".format(**row)
         )
     lines.append("")
@@ -1559,6 +1832,14 @@ def write_reports(artifact_dir: Path, results: Sequence[CaseResult]) -> None:
             lines.append(f"- accuracy: {result.accuracy:.0%}")
         if result.mcp_tool_calls is not None:
             lines.append(f"- mcp_tool_calls: {result.mcp_tool_calls}")
+        if result.mcp_tool_successes is not None:
+            lines.append(f"- mcp_tool_successes: {result.mcp_tool_successes}")
+        if result.mcp_tool_failures is not None:
+            lines.append(f"- mcp_tool_failures: {result.mcp_tool_failures}")
+        if result.mcp_schema_input_failures is not None:
+            lines.append(
+                f"- mcp_schema_input_failures: {result.mcp_schema_input_failures}"
+            )
         if result.workflow_node_count is not None:
             lines.append(f"- workflow_node_count: {result.workflow_node_count}")
         if result.branch_count is not None:
@@ -1602,6 +1883,10 @@ def performance_matrix(results: Sequence[CaseResult]) -> list[dict[str, Any]]:
             result.mcp_tool_calls
             for result in agent_results
             if result.mcp_tool_calls is not None
+        ]
+        mcp_tool_failures = [result.mcp_tool_failures or 0 for result in agent_results]
+        mcp_schema_input_failures = [
+            result.mcp_schema_input_failures or 0 for result in agent_results
         ]
         workflow_nodes = [
             result.workflow_node_count
@@ -1647,6 +1932,8 @@ def performance_matrix(results: Sequence[CaseResult]) -> list[dict[str, Any]]:
                 "avg_mcp_tool_calls": sum(mcp_tool_calls) / len(mcp_tool_calls)
                 if mcp_tool_calls
                 else 0.0,
+                "mcp_tool_failures": sum(mcp_tool_failures),
+                "mcp_schema_input_failures": sum(mcp_schema_input_failures),
                 "avg_workflow_nodes": sum(workflow_nodes) / len(workflow_nodes)
                 if workflow_nodes
                 else 0.0,
@@ -1660,9 +1947,55 @@ def performance_matrix(results: Sequence[CaseResult]) -> list[dict[str, Any]]:
     return rows
 
 
+def discover_cluster_mcp_url() -> str | None:
+    cluster_script = REPO_ROOT / "scripts/cluster"
+    if not cluster_script.exists():
+        return None
+    try:
+        completed = subprocess.run(
+            [str(cluster_script), "ports"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if completed.returncode != 0:
+        return None
+    match = re.search(r"^\s*MCP:\s+(\S+)\s*$", completed.stdout, re.MULTILINE)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def resolve_mcp_url(explicit_url: str | None) -> str:
+    if explicit_url:
+        return explicit_url
+    if env_url := os.getenv("TRACECAT_EVAL_MCP_URL"):
+        return env_url
+    if cluster_url := discover_cluster_mcp_url():
+        return cluster_url
+    raise RuntimeError(
+        "Could not discover a local Tracecat cluster MCP URL. "
+        "Start one with `just cluster up -d`, set TRACECAT_EVAL_MCP_URL, "
+        f"or pass --mcp-url {DEFAULT_DIRECT_MCP_URL} when running the MCP "
+        "server directly."
+    )
+
+
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--mcp-url", default=DEFAULT_MCP_URL)
+    parser.add_argument(
+        "--mcp-url",
+        default=None,
+        help=(
+            "Tracecat MCP URL. Defaults to TRACECAT_EVAL_MCP_URL or the MCP URL "
+            "reported by ./scripts/cluster ports."
+        ),
+    )
     parser.add_argument("--agent", default="codex", choices=["codex", "claude-code"])
     parser.add_argument(
         "--agents",
@@ -1705,6 +2038,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"Wrote static eval artifacts to {artifact_dir}")
         return 0 if results[0].passed else 1
 
+    args.mcp_url = resolve_mcp_url(args.mcp_url)
     results = asyncio.run(run_agent_cases(args))
     return 0 if all(result.passed for result in results) else 1
 

--- a/scripts/evals/tracecat_authoring/run_local.py
+++ b/scripts/evals/tracecat_authoring/run_local.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import argparse
 import ast
 import asyncio
+import importlib
 import inspect
 import json
 import os
+import pkgutil
 import re
 import shlex
 import shutil
@@ -63,6 +65,12 @@ class CheckResult:
 
     def as_dict(self) -> dict[str, Any]:
         return {"name": self.name, "passed": self.passed, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class PromptSource:
+    name: str
+    text: str
 
 
 @dataclass
@@ -1376,7 +1384,8 @@ async def score_case(
     if not changed_ids:
         changed_ids = transcript_analysis.changed_workflow_ids
     snapshots: list[WorkflowSnapshot] = []
-    for workflow_id in workflow_ids or changed_ids:
+    snapshot_workflow_ids = list(dict.fromkeys([*workflow_ids, *changed_ids]))
+    for workflow_id in snapshot_workflow_ids:
         try:
             snapshots.append(
                 await fetch_workflow_snapshot(
@@ -1467,6 +1476,15 @@ def as_patch_ops(value: Any) -> list[dict[str, Any]] | None:
 
 def validate_yaml_block(block: Any, label: str) -> list[CheckResult]:
     checks: list[CheckResult] = []
+
+    def validatable_action(item: Any) -> dict[str, Any] | None:
+        if not isinstance(item, dict) or "action" not in item:
+            return None
+        action_name = item["action"]
+        if isinstance(action_name, str) and ("<" in action_name or ">" in action_name):
+            return None
+        return item
+
     try:
         if isinstance(block, dict) and "definition" in block:
             WorkflowYamlPayload.model_validate(block)
@@ -1478,12 +1496,19 @@ def validate_yaml_block(block: Any, label: str) -> list[CheckResult]:
             checks.append(CheckResult(f"{label}:dsl_input", True))
         elif isinstance(block, list):
             for index, item in enumerate(block):
-                if isinstance(item, dict) and "action" in item:
+                if validatable_action(item) is not None:
                     action = {"ref": f"snippet_{index}", **item}
                     ActionStatement.model_validate(action)
-            if any(isinstance(item, dict) and "action" in item for item in block):
+            if any(validatable_action(item) is not None for item in block):
                 checks.append(CheckResult(f"{label}:action_snippets", True))
-        elif isinstance(block, dict) and "action" in block:
+        elif isinstance(block, dict) and isinstance(block.get("actions"), list):
+            for index, item in enumerate(block["actions"]):
+                if validatable_action(item) is not None:
+                    action = {"ref": f"snippet_{index}", **item}
+                    ActionStatement.model_validate(action)
+            if any(validatable_action(item) is not None for item in block["actions"]):
+                checks.append(CheckResult(f"{label}:action_snippets", True))
+        elif validatable_action(block) is not None:
             action = {"ref": "snippet", **block}
             ActionStatement.model_validate(action)
             checks.append(CheckResult(f"{label}:action_snippet", True))
@@ -1499,7 +1524,10 @@ def yaml_action_fragments(text: str) -> list[dict[str, Any]]:
     for lang, body in fenced_blocks(text):
         if lang not in {"yaml", "yml"}:
             continue
-        parsed = yaml.safe_load(body)
+        try:
+            parsed = yaml.safe_load(body)
+        except yaml.YAMLError:
+            continue
         if isinstance(parsed, list):
             fragments.extend(
                 item
@@ -1508,6 +1536,20 @@ def yaml_action_fragments(text: str) -> list[dict[str, Any]]:
                 and isinstance(item.get("ref"), str)
                 and isinstance(item.get("action"), str)
             )
+        elif isinstance(parsed, dict) and isinstance(parsed.get("actions"), list):
+            fragments.extend(
+                item
+                for item in parsed["actions"]
+                if isinstance(item, dict)
+                and isinstance(item.get("ref"), str)
+                and isinstance(item.get("action"), str)
+            )
+        elif (
+            isinstance(parsed, dict)
+            and isinstance(parsed.get("ref"), str)
+            and isinstance(parsed.get("action"), str)
+        ):
+            fragments.append(parsed)
     return fragments
 
 
@@ -1533,7 +1575,7 @@ def validate_prompt_action_signatures(text: str) -> list[CheckResult]:
             re.findall(r"ACTIONS\.([A-Za-z_][A-Za-z0-9_]*)", json.dumps(fragment))
         )
         upstream_stubs = [
-            {"ref": ref, "action": "core.noop", "args": {}}
+            {"ref": ref, "action": "core.transform.reshape", "args": {"value": {}}}
             for ref in sorted(action_refs - {fragment["ref"]})
         ]
         actions = [*upstream_stubs, fragment]
@@ -1617,9 +1659,178 @@ def validate_prompt_result_shapes(text: str) -> CheckResult:
     )
 
 
+def registered_core_ai_action_names() -> set[str]:
+    import tracecat_registry.core as core_pkg
+
+    actions: set[str] = set()
+    for module_info in pkgutil.walk_packages(
+        core_pkg.__path__, core_pkg.__name__ + "."
+    ):
+        if "._" in module_info.name:
+            continue
+        module = importlib.import_module(module_info.name)
+        for _, obj in inspect.getmembers(module):
+            action_name = getattr(obj, "__tracecat_udf_key", None)
+            if isinstance(action_name, str) and action_name.startswith(
+                ("core.", "ai.")
+            ):
+                actions.add(action_name)
+    return actions
+
+
+def action_literals(text: str) -> set[str]:
+    pattern = re.compile(
+        r"(?<![A-Za-z0-9_.])(?:core|ai|tools)\."
+        r"[A-Za-z0-9_<>{}.*-]+(?:\.[A-Za-z0-9_<>{}.*-]+)*"
+    )
+    return set(pattern.findall(text))
+
+
+def validate_prompt_action_literals(text: str) -> CheckResult:
+    registered = registered_core_ai_action_names()
+    unknown_core_ai = sorted(
+        literal
+        for literal in action_literals(text)
+        if literal.startswith(("core.", "ai."))
+        and "*" not in literal
+        and "<" not in literal
+        and literal not in registered
+    )
+    concrete_tools = sorted(
+        literal
+        for literal in action_literals(text)
+        if literal.startswith("tools.") and "*" not in literal and "<" not in literal
+    )
+    passed = not unknown_core_ai and not concrete_tools
+    return CheckResult(
+        "prompt_action_literals_registered",
+        passed,
+        f"unknown_core_ai={unknown_core_ai} concrete_tools={concrete_tools}",
+    )
+
+
+def registered_action_section_names(text: str) -> set[str]:
+    match = re.search(
+        r"## Registered Core and AI Actions\n(?P<body>.*?)(?:\n## |\Z)",
+        text,
+        re.DOTALL,
+    )
+    if not match:
+        return set()
+    return {
+        literal
+        for literal in action_literals(match.group("body"))
+        if literal.startswith(("core.", "ai."))
+        and "*" not in literal
+        and "<" not in literal
+    }
+
+
+def validate_registered_action_section(text: str) -> CheckResult:
+    actual = registered_core_ai_action_names()
+    listed = registered_action_section_names(text)
+    missing = sorted(actual - listed)
+    extra = sorted(listed - actual)
+    return CheckResult(
+        "registered_core_ai_action_list_matches_registry",
+        bool(listed) and not missing and not extra,
+        f"missing={missing} extra={extra}",
+    )
+
+
+def prompt_facing_sources() -> list[PromptSource]:
+    return [
+        PromptSource("mcp_instructions", load_mcp_instructions()),
+        PromptSource(
+            "dsl_reference", load_server_string_literal("_DSL_REFERENCE_TEXT")
+        ),
+        PromptSource("best_practices_skill", SKILL_SOURCE.read_text(encoding="utf-8")),
+    ]
+
+
+def combine_prompt_sources(sources: Sequence[PromptSource]) -> str:
+    return "\n".join(source.text for source in sources)
+
+
+def validate_prompt_fenced_blocks(sources: Sequence[PromptSource]) -> list[CheckResult]:
+    checks: list[CheckResult] = []
+    parsed_blocks = 0
+    for source in sources:
+        for index, (lang, body) in enumerate(fenced_blocks(source.text), start=1):
+            label = f"{source.name}:fence_{index}_{lang or 'plain'}"
+            if lang == "json":
+                try:
+                    value = json.loads(body)
+                    parsed_blocks += 1
+                    checks.append(CheckResult(f"{label}:json_parse", True))
+                    if patch_ops := as_patch_ops(value):
+                        ops = [
+                            JsonPatchOperation.model_validate(op) for op in patch_ops
+                        ]
+                        validate_patch_paths(
+                            ops,
+                            allowed_top_level_paths=ALLOWED_PATCH_ROOTS,
+                        )
+                        checks.append(CheckResult(f"{label}:json_patch", True))
+                except Exception as exc:
+                    checks.append(
+                        CheckResult(label, False, f"{type(exc).__name__}: {exc}")
+                    )
+            elif lang in {"yaml", "yml"}:
+                try:
+                    value = yaml.safe_load(body)
+                    parsed_blocks += 1
+                    checks.append(CheckResult(f"{label}:yaml_parse", True))
+                    checks.extend(validate_yaml_block(value, label))
+                except Exception as exc:
+                    checks.append(
+                        CheckResult(label, False, f"{type(exc).__name__}: {exc}")
+                    )
+
+    checks.append(
+        CheckResult(
+            "fenced_blocks_parsed",
+            parsed_blocks > 0,
+            f"parsed {parsed_blocks} JSON/YAML fenced blocks",
+        )
+    )
+    return checks
+
+
+def validate_prompt_table_upsert_examples(
+    sources: Sequence[PromptSource],
+) -> CheckResult:
+    upsert_pattern = re.compile(r"\bupsert\s*[:=]\s*[Tt]rue\b")
+    unique_index_pattern = re.compile(
+        r"(?i)(unique index|tables_create_column_index|create_column_index|"
+        r"unique\s*[:=]\s*true)"
+    )
+    unsafe_hits: list[str] = []
+
+    for source in sources:
+        lines = source.text.splitlines()
+        for line_number, line in enumerate(lines, start=1):
+            if not upsert_pattern.search(line):
+                continue
+            start = max(0, line_number - 8)
+            end = min(len(lines), line_number + 8)
+            nearby_text = "\n".join(lines[start:end])
+            if not unique_index_pattern.search(nearby_text):
+                unsafe_hits.append(f"{source.name}:{line_number}:{line.strip()}")
+
+    return CheckResult(
+        "prompt_table_upserts_have_unique_index_guidance",
+        not unsafe_hits,
+        f"unsafe upsert examples={unsafe_hits}",
+    )
+
+
 def static_prompt_checks() -> list[CheckResult]:
     checks: list[CheckResult] = []
-    text = load_mcp_instructions()
+    sources = prompt_facing_sources()
+    text = sources[0].text
+    dsl_text = sources[1].text
+    prompt_facing_text = combine_prompt_sources(sources)
     checks.append(
         CheckResult(
             "prompt_budget",
@@ -1645,60 +1856,35 @@ def static_prompt_checks() -> list[CheckResult]:
         CheckResult("no_non_example_emails", not email_hits, f"hits={email_hits[:3]}")
     )
 
-    parsed_blocks = 0
-    for index, (lang, body) in enumerate(fenced_blocks(text), start=1):
-        label = f"fence_{index}_{lang or 'plain'}"
-        if lang == "json":
-            try:
-                value = json.loads(body)
-                parsed_blocks += 1
-                checks.append(CheckResult(f"{label}:json_parse", True))
-                if patch_ops := as_patch_ops(value):
-                    ops = [JsonPatchOperation.model_validate(op) for op in patch_ops]
-                    validate_patch_paths(
-                        ops,
-                        allowed_top_level_paths=ALLOWED_PATCH_ROOTS,
-                    )
-                    checks.append(CheckResult(f"{label}:json_patch", True))
-            except Exception as exc:
-                checks.append(CheckResult(label, False, f"{type(exc).__name__}: {exc}"))
-        elif lang in {"yaml", "yml"}:
-            try:
-                value = yaml.safe_load(body)
-                parsed_blocks += 1
-                checks.append(CheckResult(f"{label}:yaml_parse", True))
-                checks.extend(validate_yaml_block(value, label))
-            except Exception as exc:
-                checks.append(CheckResult(label, False, f"{type(exc).__name__}: {exc}"))
-
-    checks.append(
-        CheckResult(
-            "fenced_blocks_parsed",
-            parsed_blocks > 0,
-            f"parsed {parsed_blocks} JSON/YAML fenced blocks",
-        )
-    )
-    checks.extend(validate_prompt_action_signatures(text))
-    checks.append(validate_prompt_result_shapes(text))
+    checks.extend(validate_prompt_fenced_blocks(sources))
+    checks.extend(validate_prompt_action_signatures(prompt_facing_text))
+    checks.append(validate_prompt_result_shapes(prompt_facing_text))
+    checks.append(validate_prompt_action_literals(prompt_facing_text))
+    checks.append(validate_prompt_table_upsert_examples(sources))
+    checks.append(validate_registered_action_section(dsl_text))
     return checks
 
 
 def load_mcp_instructions() -> str:
+    return load_server_string_literal("_MCP_INSTRUCTIONS")
+
+
+def load_server_string_literal(name: str) -> str:
     server_path = REPO_ROOT / "tracecat/mcp/server.py"
     tree = ast.parse(server_path.read_text())
     for node in tree.body:
         if not isinstance(node, ast.Assign):
             continue
         if not any(
-            isinstance(target, ast.Name) and target.id == "_MCP_INSTRUCTIONS"
+            isinstance(target, ast.Name) and target.id == name
             for target in node.targets
         ):
             continue
         value = ast.literal_eval(node.value)
         if not isinstance(value, str):
-            raise TypeError("_MCP_INSTRUCTIONS is not a string literal")
+            raise TypeError(f"{name} is not a string literal")
         return value
-    raise RuntimeError("_MCP_INSTRUCTIONS assignment not found")
+    raise RuntimeError(f"{name} assignment not found")
 
 
 async def run_agent_cases(args: argparse.Namespace) -> list[CaseResult]:
@@ -1782,8 +1968,10 @@ async def run_agent_cases(args: argparse.Namespace) -> list[CaseResult]:
 
 
 def parse_agents(args: argparse.Namespace) -> list[str]:
-    raw = args.agents or args.agent
+    raw = args.agents if args.agents is not None else args.agent
     agents = [agent.strip() for agent in raw.split(",") if agent.strip()]
+    if not agents:
+        raise SystemExit("At least one agent must be specified.")
     valid = {"codex", "claude-code"}
     invalid = set(agents) - valid
     if invalid:

--- a/scripts/evals/tracecat_authoring/run_local.py
+++ b/scripts/evals/tracecat_authoring/run_local.py
@@ -42,7 +42,11 @@ ALLOWED_PATCH_ROOTS = {
     "schedules",
     "case_trigger",
 }
-PROMPT_MAX_CHARS = 18_500
+PROMPT_SOURCE_MAX_CHARS = {
+    "mcp_instructions": 14_500,
+    "dsl_reference": 15_500,
+    "best_practices_skill": 9_500,
+}
 
 
 class Case(BaseModel):
@@ -138,6 +142,7 @@ class McpToolCallMetrics:
 @dataclass
 class TranscriptAnalysis:
     mcp_metrics: McpToolCallMetrics
+    mcp_calls: list[McpToolCall] = field(default_factory=list)
     workflow_ids: list[str] = field(default_factory=list)
     changed_workflow_ids: list[str] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
@@ -284,6 +289,7 @@ def analyze_transcript(transcript_path: Path | None) -> TranscriptAnalysis:
 
     return TranscriptAnalysis(
         mcp_metrics=metrics,
+        mcp_calls=list(calls.values()),
         workflow_ids=unique_strings(workflow_ids),
         changed_workflow_ids=unique_strings(changed_workflow_ids),
         notes=[note for note in notes if note.strip()],
@@ -1204,12 +1210,122 @@ def provider_gating_note_or_core_http(
     )
 
 
+MCP_SQL_TYPES = {
+    "TEXT",
+    "INTEGER",
+    "NUMERIC",
+    "DATE",
+    "BOOLEAN",
+    "TIMESTAMPTZ",
+    "JSONB",
+    "SELECT",
+    "MULTI_SELECT",
+}
+
+
+def mcp_tool_called(calls: Sequence[McpToolCall], tool_name: str) -> bool:
+    return any(call.tool_name == tool_name for call in calls)
+
+
+def update_workflow_metadata_only(calls: Sequence[McpToolCall]) -> bool:
+    for call in calls:
+        if call.tool_name != "workflows_update_workflow":
+            continue
+        if "definition_yaml" in call.arguments:
+            continue
+        if "patch_ops" in call.arguments:
+            continue
+        if any(
+            key in call.arguments
+            for key in ("title", "description", "status", "alias", "error_handler")
+        ):
+            return True
+    return False
+
+
+def no_update_workflow_patch_ops(calls: Sequence[McpToolCall]) -> bool:
+    return not any(
+        call.tool_name == "workflows_update_workflow" and "patch_ops" in call.arguments
+        for call in calls
+    )
+
+
+def table_columns_are_valid(columns: object) -> bool:
+    if not isinstance(columns, list) or not columns:
+        return False
+    for column in columns:
+        if not isinstance(column, dict):
+            return False
+        column_type = column.get("type")
+        if column_type not in MCP_SQL_TYPES:
+            return False
+        has_options = "options" in column and column.get("options") is not None
+        if column_type in {"SELECT", "MULTI_SELECT"}:
+            if not isinstance(column.get("options"), list) or not column["options"]:
+                return False
+        elif has_options:
+            return False
+    return True
+
+
+def created_table_with_valid_columns(calls: Sequence[McpToolCall]) -> bool:
+    return any(
+        call.tool_name == "tables_create_table"
+        and table_columns_are_valid(call.arguments.get("columns"))
+        for call in calls
+    )
+
+
+def created_table_index_from_fetched_table(calls: Sequence[McpToolCall]) -> bool:
+    return mcp_tool_called(calls, "tables_get_table") and mcp_tool_called(
+        calls, "tables_create_column_index"
+    )
+
+
+def case_field_args_are_valid(args: Mapping[str, Any]) -> bool:
+    field_type = args.get("type")
+    if field_type is not None and field_type not in MCP_SQL_TYPES:
+        return False
+    kind = args.get("kind")
+    if kind == "LONG_TEXT" and field_type not in {None, "TEXT"}:
+        return False
+    if kind == "URL" and field_type not in {None, "JSONB"}:
+        return False
+    if kind is not None and kind not in {"LONG_TEXT", "URL"}:
+        return False
+    options = args.get("options")
+    if options is not None and not isinstance(options, list):
+        return False
+    if field_type in {"SELECT", "MULTI_SELECT"}:
+        return isinstance(options, list) and bool(options)
+    if field_type is not None and options is not None:
+        return False
+    return True
+
+
+def created_and_updated_case_fields(calls: Sequence[McpToolCall]) -> bool:
+    create_calls = [
+        call for call in calls if call.tool_name == "cases_create_case_field"
+    ]
+    update_calls = [
+        call for call in calls if call.tool_name == "cases_update_case_field"
+    ]
+    return (
+        bool(create_calls)
+        and bool(update_calls)
+        and mcp_tool_called(calls, "cases_list_case_fields")
+        and all(case_field_args_are_valid(call.arguments) for call in create_calls)
+        and all(case_field_args_are_valid(call.arguments) for call in update_calls)
+    )
+
+
 def evaluate_rubric_item(
     item: str,
     *,
     case: Case,
     snapshots: Sequence[WorkflowSnapshot],
     transcript: str,
+    mcp_calls: Sequence[McpToolCall],
     final_response: Mapping[str, Any],
     seed_workflow_id: str | None,
 ) -> CheckResult:
@@ -1217,6 +1333,10 @@ def evaluate_rubric_item(
     changed_ids = [str(x) for x in final_response.get("changed_workflow_ids", [])]
 
     checks: dict[str, tuple[bool, str]] = {
+        "discovered_workspace": (
+            transcript_contains(transcript, "workspaces_list_workspaces"),
+            "Expected workspaces_list_workspaces in transcript.",
+        ),
         "starts_from_live_context": (
             transcript_contains(transcript, "workspaces_list_workspaces")
             and transcript_contains(
@@ -1340,6 +1460,26 @@ def evaluate_rubric_item(
             or transcript_contains(transcript, "workflows_list_workflow_executions"),
             "Expected execution inspection.",
         ),
+        "used_update_workflow_metadata_only": (
+            update_workflow_metadata_only(mcp_calls),
+            "Expected workflows_update_workflow for metadata only, without definition_yaml or patch_ops.",
+        ),
+        "no_update_workflow_patch_ops": (
+            no_update_workflow_patch_ops(mcp_calls),
+            "Expected no patch_ops argument on workflows_update_workflow.",
+        ),
+        "created_table_with_valid_columns": (
+            created_table_with_valid_columns(mcp_calls),
+            "Expected tables_create_table with valid uppercase column types and select options only on select fields.",
+        ),
+        "created_table_index_from_fetched_table": (
+            created_table_index_from_fetched_table(mcp_calls),
+            "Expected tables_get_table followed by tables_create_column_index using real table/column UUIDs.",
+        ),
+        "created_and_updated_case_fields": (
+            created_and_updated_case_fields(mcp_calls),
+            "Expected cases_list_case_fields plus valid cases_create_case_field and cases_update_case_field calls.",
+        ),
     }
     passed, detail = checks.get(item, (False, f"Unknown rubric item for {case.id}"))
     return CheckResult(item, passed, "" if passed else detail)
@@ -1365,6 +1505,13 @@ async def score_case(
             "no_failed_mcp_schema_inputs",
             mcp_metrics.schema_input_failures == 0,
             f"{mcp_metrics.schema_input_failures} MCP schema/input failures.",
+        )
+    )
+    checks.append(
+        CheckResult(
+            "no_failed_mcp_tool_calls",
+            mcp_metrics.failed == 0,
+            f"{mcp_metrics.failed} failed MCP tool calls.",
         )
     )
 
@@ -1416,6 +1563,7 @@ async def score_case(
                 case=case,
                 snapshots=snapshots,
                 transcript=transcript,
+                mcp_calls=transcript_analysis.mcp_calls,
                 final_response=final_response,
                 seed_workflow_id=seed_workflow_id,
             )
@@ -1752,6 +1900,32 @@ def combine_prompt_sources(sources: Sequence[PromptSource]) -> str:
     return "\n".join(source.text for source in sources)
 
 
+def validate_prompt_source_budgets(
+    sources: Sequence[PromptSource],
+) -> list[CheckResult]:
+    checks: list[CheckResult] = []
+    seen = {source.name for source in sources}
+    for source_name, max_chars in PROMPT_SOURCE_MAX_CHARS.items():
+        if source_name not in seen:
+            checks.append(
+                CheckResult(
+                    f"prompt_budget:{source_name}",
+                    False,
+                    "source is missing",
+                )
+            )
+            continue
+        source = next(item for item in sources if item.name == source_name)
+        checks.append(
+            CheckResult(
+                f"prompt_budget:{source.name}",
+                len(source.text) <= max_chars,
+                f"{len(source.text)} chars > {max_chars}",
+            )
+        )
+    return checks
+
+
 def validate_prompt_fenced_blocks(sources: Sequence[PromptSource]) -> list[CheckResult]:
     checks: list[CheckResult] = []
     parsed_blocks = 0
@@ -1825,19 +1999,44 @@ def validate_prompt_table_upsert_examples(
     )
 
 
+def validate_prompt_loop_parallelism_guardrails(text: str) -> CheckResult:
+    required_phrases = [
+        "Prefer `core.script.run_python` loops over action-level `for_each`",
+        "Prefer `core.script.run_python` loops over `core.transform.scatter` / `core.transform.gather`",
+        "hurt the scheduler",
+    ]
+    missing = [phrase for phrase in required_phrases if phrase not in text]
+    return CheckResult(
+        "prompt_loop_parallelism_guardrails",
+        not missing,
+        f"missing={missing}",
+    )
+
+
+def validate_prompt_mcp_tool_argument_guardrails(text: str) -> CheckResult:
+    required_phrases = [
+        "not an MCP tool argument reference",
+        "MCP tool schemas and tool docstrings are the source of truth",
+        "do not pass `patch_ops`",
+        "call `get_table`, then `create_column_index`",
+        "Case field `type` must be an uppercase SqlType value",
+        "under 63 characters",
+    ]
+    missing = [phrase for phrase in required_phrases if phrase not in text]
+    return CheckResult(
+        "prompt_mcp_tool_argument_guardrails",
+        not missing,
+        f"missing={missing}",
+    )
+
+
 def static_prompt_checks() -> list[CheckResult]:
     checks: list[CheckResult] = []
     sources = prompt_facing_sources()
     text = sources[0].text
     dsl_text = sources[1].text
     prompt_facing_text = combine_prompt_sources(sources)
-    checks.append(
-        CheckResult(
-            "prompt_budget",
-            len(text) <= PROMPT_MAX_CHARS,
-            f"{len(text)} chars > {PROMPT_MAX_CHARS}",
-        )
-    )
+    checks.extend(validate_prompt_source_budgets(sources))
 
     secret_pattern = re.compile(
         r"(?i)(sk-[a-z0-9]{20,}|ghp_[a-z0-9]{20,}|xox[baprs]-[a-z0-9-]{20,})"
@@ -1861,6 +2060,8 @@ def static_prompt_checks() -> list[CheckResult]:
     checks.append(validate_prompt_result_shapes(prompt_facing_text))
     checks.append(validate_prompt_action_literals(prompt_facing_text))
     checks.append(validate_prompt_table_upsert_examples(sources))
+    checks.append(validate_prompt_loop_parallelism_guardrails(prompt_facing_text))
+    checks.append(validate_prompt_mcp_tool_argument_guardrails(prompt_facing_text))
     checks.append(validate_registered_action_section(dsl_text))
     return checks
 

--- a/scripts/evals/tracecat_authoring/run_local.py
+++ b/scripts/evals/tracecat_authoring/run_local.py
@@ -442,7 +442,13 @@ def ids_from_payload_keys(payload: Any, *keys: str) -> list[str]:
             value = payload.get(key)
             if isinstance(value, str) and UUID_PATTERN.fullmatch(value):
                 ids.append(value)
-        for key in ("content", "structuredContent", "structured_content", "result"):
+        for key in (
+            "content",
+            "structuredContent",
+            "structured_content",
+            "result",
+            "text",
+        ):
             if key in payload:
                 ids.extend(ids_from_payload_keys(payload[key], *keys))
     return ids

--- a/scripts/evals/tracecat_authoring/run_local.py
+++ b/scripts/evals/tracecat_authoring/run_local.py
@@ -1,0 +1,1713 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import asyncio
+import inspect
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+from fastmcp import Client
+from jsonschema import Draft202012Validator
+from pydantic import BaseModel, ValidationError
+
+from tracecat.dsl.common import DSLInput
+from tracecat.dsl.schemas import ActionStatement
+from tracecat.mcp.json_patch import validate_patch_paths
+from tracecat.mcp.schemas import JsonPatchOperation, WorkflowYamlPayload
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+SKILL_SOURCE = REPO_ROOT / ".agents/skills/tracecat-automation-best-practices/SKILL.md"
+DEFAULT_MCP_URL = "http://127.0.0.1:8099/mcp"
+DEFAULT_ARTIFACT_ROOT = REPO_ROOT / ".tracecat/evals/tracecat_authoring"
+ALLOWED_PATCH_ROOTS = {
+    "metadata",
+    "definition",
+    "layout",
+    "schedules",
+    "case_trigger",
+}
+PROMPT_MAX_CHARS = 18_500
+
+
+class Case(BaseModel):
+    id: str
+    groups: list[str] = []
+    prompt: str
+    rubric: list[str]
+    seed_workflow: bool = False
+
+
+class CasesFile(BaseModel):
+    cases: list[Case]
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "passed": self.passed, "detail": self.detail}
+
+
+@dataclass
+class CaseResult:
+    case_id: str
+    agent: str
+    passed: bool
+    model: str | None = None
+    workflow_ids: list[str] = field(default_factory=list)
+    changed_workflow_ids: list[str] = field(default_factory=list)
+    checks: list[CheckResult] = field(default_factory=list)
+    transcript_path: str | None = None
+    final_response_path: str | None = None
+    error: str | None = None
+    duration_seconds: float | None = None
+    accuracy: float | None = None
+    mcp_tool_calls: int | None = None
+    workflow_node_count: int | None = None
+    branch_count: int | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "case_id": self.case_id,
+            "agent": self.agent,
+            "model": self.model,
+            "passed": self.passed,
+            "workflow_ids": self.workflow_ids,
+            "changed_workflow_ids": self.changed_workflow_ids,
+            "checks": [check.as_dict() for check in self.checks],
+            "transcript_path": self.transcript_path,
+            "final_response_path": self.final_response_path,
+            "error": self.error,
+            "duration_seconds": self.duration_seconds,
+            "accuracy": self.accuracy,
+            "mcp_tool_calls": self.mcp_tool_calls,
+            "workflow_node_count": self.workflow_node_count,
+            "branch_count": self.branch_count,
+        }
+
+
+@dataclass
+class WorkflowSnapshot:
+    workflow_id: str
+    raw: dict[str, Any]
+    yaml_payload: dict[str, Any] | None
+    definition: DSLInput | None
+    layout: dict[str, Any]
+
+    @property
+    def actions(self) -> list[ActionStatement]:
+        return self.definition.actions if self.definition else []
+
+
+@dataclass
+class AgentRun:
+    final_response: dict[str, Any]
+    duration_seconds: float
+
+
+class TracecatMCP:
+    def __init__(self, url: str, bearer_token: str | None) -> None:
+        self._client = Client(url, auth=bearer_token)
+
+    async def __aenter__(self) -> TracecatMCP:
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        await self._client.__aexit__(*exc_info)
+
+    async def call(self, name: str, arguments: dict[str, Any] | None = None) -> Any:
+        result = await self._client.call_tool(name, arguments or {})
+        return decode_mcp_result(result)
+
+
+def decode_mcp_result(result: Any) -> Any:
+    structured = getattr(result, "structured_content", None)
+    if structured is not None:
+        return structured
+    data = getattr(result, "data", None)
+    if data is not None:
+        return data
+
+    content = getattr(result, "content", None) or []
+    texts = [
+        item.text
+        for item in content
+        if getattr(item, "type", None) == "text" and hasattr(item, "text")
+    ]
+    if len(texts) == 1:
+        try:
+            return json.loads(texts[0])
+        except json.JSONDecodeError:
+            return texts[0]
+    if texts:
+        return "\n".join(texts)
+    return result
+
+
+def load_cases(path: Path) -> list[Case]:
+    raw = yaml.safe_load(path.read_text())
+    return CasesFile.model_validate(raw).cases
+
+
+def select_cases(cases: list[Case], selector: str) -> list[Case]:
+    if selector == "all":
+        return cases
+    selected = [
+        case for case in cases if selector == case.id or selector in set(case.groups)
+    ]
+    if not selected:
+        raise SystemExit(f"No cases match selector {selector!r}")
+    return selected
+
+
+def timestamp() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def extract_json_object(text: str) -> dict[str, Any]:
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if not match:
+            raise
+        value = json.loads(match.group(0))
+    if not isinstance(value, dict):
+        raise ValueError("Final response is not a JSON object")
+    return value
+
+
+def normalize_item_list(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, dict):
+        if isinstance(value.get("items"), list):
+            return [item for item in value["items"] if isinstance(item, dict)]
+        if isinstance(value.get("workspaces"), list):
+            return [item for item in value["workspaces"] if isinstance(item, dict)]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+async def choose_workspace(mcp: TracecatMCP) -> str:
+    workspace_id = os.getenv("TRACECAT_EVAL_WORKSPACE_ID")
+    if workspace_id:
+        return workspace_id
+
+    response = await mcp.call("workspaces_list_workspaces", {"limit": 20})
+    workspaces = normalize_item_list(response)
+    if not workspaces:
+        raise RuntimeError("workspaces_list_workspaces returned no workspaces")
+    for key in ("id", "workspace_id"):
+        if key in workspaces[0]:
+            return str(workspaces[0][key])
+    raise RuntimeError(
+        "Could not find workspace id in workspaces_list_workspaces response"
+    )
+
+
+def isolated_workspace(case_dir: Path) -> Path:
+    workspace = case_dir / "workspace"
+    skill_target = (
+        workspace / ".agents/skills/tracecat-automation-best-practices/SKILL.md"
+    )
+    skill_target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(SKILL_SOURCE, skill_target)
+    return workspace
+
+
+def seed_workflow_yaml(title: str) -> str:
+    return yaml.safe_dump(
+        {
+            "definition": {
+                "title": title,
+                "description": "Synthetic seeded workflow for authoring evals.",
+                "entrypoint": {
+                    "ref": "emit_seed",
+                    "expects": {
+                        "source": {
+                            "type": "str",
+                            "description": "Synthetic source name.",
+                            "default": "example.com",
+                        }
+                    },
+                },
+                "actions": [
+                    {
+                        "ref": "emit_seed",
+                        "action": "core.script.run_python",
+                        "args": {
+                            "inputs": {"source": "${{ TRIGGER.source }}"},
+                            "script": (
+                                "def main(source):\n"
+                                "    return {'source': source, 'message': 'seed'}\n"
+                            ),
+                        },
+                    }
+                ],
+                "returns": "${{ ACTIONS.emit_seed.result }}",
+            },
+            "layout": {
+                "trigger": {"x": 0, "y": 0},
+                "actions": [{"ref": "emit_seed", "x": 320, "y": 0}],
+            },
+        },
+        sort_keys=False,
+    )
+
+
+async def seed_case_workflow(
+    mcp: TracecatMCP,
+    *,
+    workspace_id: str,
+    run_prefix: str,
+    case_id: str,
+) -> str:
+    title = f"{run_prefix}-{case_id}-seed"
+    response = await mcp.call(
+        "workflows_create_workflow",
+        {
+            "workspace_id": workspace_id,
+            "title": title,
+            "description": "Synthetic seeded workflow for authoring evals.",
+            "definition_yaml": seed_workflow_yaml(title),
+        },
+    )
+    if isinstance(response, dict):
+        for key in ("workflow_id", "id"):
+            if key in response:
+                return str(response[key])
+    raise RuntimeError(f"Could not read seed workflow id from response: {response!r}")
+
+
+def build_agent_prompt(
+    *,
+    case: Case,
+    workspace_id: str,
+    run_prefix: str,
+    seed_workflow_id: str | None,
+) -> str:
+    seed_text = (
+        f"\nExisting seeded workflow id: {seed_workflow_id}\n"
+        if seed_workflow_id
+        else ""
+    )
+    return f"""Use the local tracecat-automation-best-practices skill.
+
+You are running a local-only Tracecat automation authoring eval.
+
+Workspace id: {workspace_id}
+Workflow title prefix: {run_prefix}-{case.id}
+Case id: {case.id}
+{seed_text}
+Important constraints:
+- Use the Tracecat MCP tools for workspace discovery, authoring context, action schemas, workflow creation or edits, validation, and safe execution inspection when requested.
+- Use only the MCP server configured for this eval. Do not use globally configured Tracecat MCP servers, remote Tracecat workspaces, or platform.tracecat.com.
+- Use synthetic data only. Use example.com for placeholder endpoints. Do not use real people, real tokens, or provider-specific integrations unless the case names them.
+- Do not inspect the Tracecat source repository. This temporary workspace intentionally contains only the generic automation skill.
+- Do not inspect environment variables or print credential-bearing process state.
+- Final response must match the required JSON schema.
+
+Task:
+{case.prompt}
+"""
+
+
+def codex_config_args(mcp_url: str) -> list[str]:
+    args = ["-c", f'mcp_servers.tracecat.url="{mcp_url}"']
+    if os.getenv("TRACECAT_MCP_BEARER_TOKEN"):
+        args.extend(
+            [
+                "-c",
+                'mcp_servers.tracecat.bearer_token_env_var="TRACECAT_MCP_BEARER_TOKEN"',
+            ]
+        )
+    return args
+
+
+def agent_model(agent: str) -> str:
+    if agent == "codex":
+        return os.getenv("TRACECAT_EVAL_MODEL", "default")
+    if agent == "claude-code":
+        return os.getenv("TRACECAT_EVAL_CLAUDE_MODEL", "claude-opus-4-7")
+    return "n/a"
+
+
+def agent_timeout_seconds() -> float:
+    raw = os.getenv("TRACECAT_EVAL_AGENT_TIMEOUT_SECONDS", "900")
+    try:
+        timeout = float(raw)
+    except ValueError:
+        raise ValueError(
+            "TRACECAT_EVAL_AGENT_TIMEOUT_SECONDS must be numeric"
+        ) from None
+    if timeout <= 0:
+        raise ValueError("TRACECAT_EVAL_AGENT_TIMEOUT_SECONDS must be positive")
+    return timeout
+
+
+def codex_bypass_approvals_enabled() -> bool:
+    return os.getenv("TRACECAT_EVAL_CODEX_BYPASS_APPROVALS") == "1"
+
+
+def run_agent(
+    *,
+    case: Case,
+    workspace: Path,
+    prompt: str,
+    transcript_path: Path,
+    final_path: Path,
+    schema_path: Path,
+    mcp_url: str,
+    agent: str,
+    agent_cmd: str | None,
+) -> AgentRun:
+    model = os.getenv("TRACECAT_EVAL_MODEL")
+    if agent_cmd:
+        replacements = {
+            "workspace": str(workspace),
+            "transcript": str(transcript_path),
+            "final": str(final_path),
+            "schema": str(schema_path),
+            "mcp_url": mcp_url,
+            "case_id": case.id,
+            "prompt": prompt,
+        }
+        rendered = agent_cmd.format(**replacements)
+        cmd = shlex.split(rendered)
+        if "{prompt}" not in agent_cmd:
+            cmd.append(prompt)
+    elif agent == "codex":
+        cmd = [
+            "codex",
+            "--ask-for-approval",
+            "never",
+            "exec",
+        ]
+        if codex_bypass_approvals_enabled():
+            cmd.append("--dangerously-bypass-approvals-and-sandbox")
+        else:
+            cmd.extend(["--sandbox", "workspace-write"])
+        cmd.extend(
+            [
+                "--ignore-user-config",
+                "--skip-git-repo-check",
+                "--ephemeral",
+                "--cd",
+                str(workspace),
+                "--output-schema",
+                str(schema_path),
+                "--output-last-message",
+                str(final_path),
+                "--json",
+                *codex_config_args(mcp_url),
+            ]
+        )
+        if model:
+            cmd.extend(["--model", model])
+        cmd.append(prompt)
+    elif agent == "claude-code":
+        mcp_config_path = workspace / "claude-mcp.json"
+        write_json(mcp_config_path, claude_mcp_config(mcp_url))
+        claude_model = os.getenv("TRACECAT_EVAL_CLAUDE_MODEL", "claude-opus-4-7")
+        cmd = [
+            "claude",
+            "-p",
+            "--no-session-persistence",
+            "--permission-mode",
+            "bypassPermissions",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--model",
+            claude_model,
+            "--mcp-config",
+            str(mcp_config_path),
+            "--strict-mcp-config",
+            "--json-schema",
+            schema_path.read_text(),
+            prompt,
+        ]
+    else:
+        raise ValueError(f"Unsupported agent {agent!r}")
+
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    started = time.monotonic()
+    with transcript_path.open("w") as transcript:
+        try:
+            completed = subprocess.run(
+                cmd,
+                cwd=workspace,
+                stdout=transcript,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=False,
+                timeout=agent_timeout_seconds(),
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(f"Agent exceeded timeout of {exc.timeout:.0f}s") from exc
+    duration_seconds = time.monotonic() - started
+    if completed.returncode != 0:
+        raise RuntimeError(f"Agent exited with code {completed.returncode}")
+    if final_path.exists():
+        final_response = extract_json_object(final_path.read_text())
+    else:
+        final_response = extract_final_response_from_transcript(transcript_path)
+        write_json(final_path, final_response)
+    return AgentRun(
+        final_response=final_response,
+        duration_seconds=duration_seconds,
+    )
+
+
+def claude_mcp_config(mcp_url: str) -> dict[str, Any]:
+    server: dict[str, Any] = {"type": "http", "url": mcp_url}
+    token = os.getenv("TRACECAT_MCP_BEARER_TOKEN")
+    if token:
+        server["headers"] = {"Authorization": "Bearer ${TRACECAT_MCP_BEARER_TOKEN}"}
+    return {"mcpServers": {"tracecatlocal": server}}
+
+
+def extract_final_response_from_transcript(transcript_path: Path) -> dict[str, Any]:
+    candidates: list[str] = []
+    for line in transcript_path.read_text(errors="replace").splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        for value in iter_text_candidates(event):
+            candidates.append(value)
+    for candidate in reversed(candidates):
+        try:
+            return extract_json_object(candidate)
+        except Exception:
+            continue
+    raise RuntimeError("Could not extract structured final response from transcript")
+
+
+def iter_text_candidates(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for item in value:
+            yield from iter_text_candidates(item)
+    elif isinstance(value, dict):
+        if value.get("type") in {"text", "assistant"} and isinstance(
+            value.get("text"), str
+        ):
+            yield value["text"]
+        for key in ("result", "content", "message"):
+            if key in value:
+                yield from iter_text_candidates(value[key])
+
+
+def transcript_text(path: Path | None) -> str:
+    if path is None or not path.exists():
+        return ""
+    return path.read_text(errors="replace")
+
+
+def transcript_contains(transcript: str, *needles: str) -> bool:
+    lowered = transcript.lower()
+    return all(needle.lower() in lowered for needle in needles)
+
+
+def transcript_count(transcript: str, needle: str) -> int:
+    return transcript.lower().count(needle.lower())
+
+
+def transcript_json_events(path: Path | None) -> list[dict[str, Any]]:
+    if path is None or not path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    for line in path.read_text(errors="replace").splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    return events
+
+
+def normalize_tool_name(name: str) -> str:
+    if name.startswith("mcp__"):
+        parts = name.split("__", 2)
+        if len(parts) == 3:
+            return parts[2]
+    if name.startswith("mcp__tracecat__"):
+        return name.removeprefix("mcp__tracecat__")
+    if name.startswith("tracecat__"):
+        return name.removeprefix("tracecat__")
+    return name
+
+
+def tracecat_tool_name(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    name = normalize_tool_name(value)
+    if name in {
+        "workspaces_list_workspaces",
+        "workflows_get_workflow_authoring_context",
+        "workflows_create_workflow",
+        "workflows_get_workflow",
+        "workflows_edit_workflow",
+        "workflows_validate_workflow",
+        "workflows_run_draft_workflow",
+        "workflows_run_published_workflow",
+        "workflows_list_workflow_executions",
+        "workflows_get_workflow_execution",
+    }:
+        return name
+    if re.fullmatch(
+        r"(workspaces|workflows|cases|tables|variables|secrets|integrations|agents)_[a-z_]+",
+        name,
+    ):
+        return name
+    return None
+
+
+def dict_value_text(value: Mapping[str, Any], keys: Iterable[str]) -> str:
+    return " ".join(str(value[key]).lower() for key in keys if key in value)
+
+
+def direct_tool_name(value: Mapping[str, Any]) -> str | None:
+    for key in ("name", "tool_name", "tool", "function", "recipient_name"):
+        candidate = value.get(key)
+        if isinstance(candidate, str):
+            tool_name = tracecat_tool_name(candidate)
+            if tool_name:
+                return tool_name
+    return None
+
+
+def iter_tracecat_tool_calls(value: Any) -> Iterable[tuple[str | None, str]]:
+    if isinstance(value, list):
+        for item in value:
+            yield from iter_tracecat_tool_calls(item)
+        return
+    if not isinstance(value, dict):
+        return
+
+    type_text = dict_value_text(value, ("type", "event", "subtype"))
+    server_text = dict_value_text(value, ("server", "server_name", "mcp_server"))
+    tool_name = direct_tool_name(value)
+    is_tool_call = (
+        "tool_use" in type_text
+        or "tool_call" in type_text
+        or "mcp_tool_call" in type_text
+        or ("tool" in type_text and "call" in type_text)
+        or ("tracecat" in server_text and tool_name is not None)
+    )
+    if is_tool_call and tool_name is not None:
+        call_id = next(
+            (
+                str(value[key])
+                for key in ("id", "call_id", "tool_call_id")
+                if isinstance(value.get(key), str)
+            ),
+            None,
+        )
+        yield call_id, tool_name
+
+    for item in value.values():
+        yield from iter_tracecat_tool_calls(item)
+
+
+def count_mcp_tool_calls(transcript_path: Path | None) -> int:
+    seen_ids: set[str] = set()
+    count = 0
+    for event in transcript_json_events(transcript_path):
+        for call_id, _tool_name in iter_tracecat_tool_calls(event):
+            if call_id is not None:
+                if call_id in seen_ids:
+                    continue
+                seen_ids.add(call_id)
+            count += 1
+    return count
+
+
+def source_inspection_detected(transcript: str) -> bool:
+    repo = str(REPO_ROOT)
+    artifact_root = str(DEFAULT_ARTIFACT_ROOT)
+    transcript = transcript.replace(artifact_root, "")
+    if repo not in transcript:
+        return False
+    suspicious_commands = ("sed ", "cat ", "rg ", "grep ", "find ", "ls ")
+    return any(command in transcript for command in suspicious_commands)
+
+
+async def fetch_workflow_snapshot(
+    mcp: TracecatMCP,
+    *,
+    workspace_id: str,
+    workflow_id: str,
+) -> WorkflowSnapshot:
+    raw = await mcp.call(
+        "workflows_get_workflow",
+        {
+            "workspace_id": workspace_id,
+            "workflow_id": workflow_id,
+            "include_definition_yaml": True,
+        },
+    )
+    if not isinstance(raw, dict):
+        raise RuntimeError(f"workflows_get_workflow returned non-object: {raw!r}")
+
+    definition_yaml = raw.get("definition_yaml")
+    yaml_payload = None
+    definition = None
+    layout: dict[str, Any] = {}
+    if isinstance(definition_yaml, str):
+        loaded = yaml.safe_load(definition_yaml)
+        WorkflowYamlPayload.model_validate(loaded)
+        if isinstance(loaded, dict):
+            yaml_payload = loaded
+            if isinstance(loaded.get("definition"), dict):
+                definition = DSLInput.model_validate(loaded["definition"])
+            if isinstance(loaded.get("layout"), dict):
+                layout = loaded["layout"]
+    elif isinstance(raw.get("definition"), dict):
+        definition = DSLInput.model_validate(raw["definition"])
+    return WorkflowSnapshot(
+        workflow_id=workflow_id,
+        raw=raw,
+        yaml_payload=yaml_payload,
+        definition=definition,
+        layout=layout,
+    )
+
+
+async def fetch_action_schemas(
+    mcp: TracecatMCP,
+    *,
+    workspace_id: str,
+    action_names: Sequence[str],
+) -> dict[str, dict[str, Any]]:
+    if not action_names:
+        return {}
+    try:
+        response = await mcp.call(
+            "workflows_get_workflow_authoring_context",
+            {
+                "workspace_id": workspace_id,
+                "actions": {"action_names": sorted(set(action_names))},
+            },
+        )
+    except Exception:
+        return {}
+    if not isinstance(response, dict):
+        return {}
+    schemas: dict[str, dict[str, Any]] = {}
+    for item in response.get("actions", []):
+        if isinstance(item, dict) and isinstance(item.get("action_name"), str):
+            schema = item.get("parameters_json_schema")
+            if isinstance(schema, dict):
+                schemas[item["action_name"]] = schema
+    return schemas
+
+
+def check_action_args_against_schemas(
+    snapshots: Sequence[WorkflowSnapshot],
+    schemas: Mapping[str, Mapping[str, Any]],
+) -> CheckResult:
+    failures: list[str] = []
+    checked = 0
+    for snapshot in snapshots:
+        for action in snapshot.actions:
+            schema = schemas.get(action.action)
+            if not schema:
+                continue
+            checked += 1
+            errors = sorted(
+                Draft202012Validator(schema).iter_errors(action.args),
+                key=lambda error: list(error.path),
+            )
+            if errors:
+                failures.append(
+                    f"{snapshot.workflow_id}:{action.ref}: {errors[0].message}"
+                )
+    if failures:
+        return CheckResult("action_args_match_live_schemas", False, "; ".join(failures))
+    if checked == 0:
+        return CheckResult(
+            "action_args_match_live_schemas",
+            False,
+            "No live action schemas were available for authored actions.",
+        )
+    return CheckResult(
+        "action_args_match_live_schemas",
+        True,
+        f"Validated {checked} action argument sets.",
+    )
+
+
+def all_actions(snapshots: Sequence[WorkflowSnapshot]) -> list[ActionStatement]:
+    return [action for snapshot in snapshots for action in snapshot.actions]
+
+
+def workflow_node_count(snapshots: Sequence[WorkflowSnapshot]) -> int:
+    return len(all_actions(snapshots))
+
+
+def workflow_branch_count(snapshots: Sequence[WorkflowSnapshot]) -> int:
+    branch_count = 0
+    for snapshot in snapshots:
+        fanout: dict[str, int] = {}
+        for action in snapshot.actions:
+            for dep in action.depends_on:
+                dep_ref = dep.split(".", 1)[0]
+                fanout[dep_ref] = fanout.get(dep_ref, 0) + 1
+        branch_count += sum(1 for count in fanout.values() if count > 1)
+    return branch_count
+
+
+def action_names(snapshots: Sequence[WorkflowSnapshot]) -> set[str]:
+    return {action.action for action in all_actions(snapshots)}
+
+
+def has_action(snapshots: Sequence[WorkflowSnapshot], name: str) -> bool:
+    return name in action_names(snapshots)
+
+
+def has_any_action(snapshots: Sequence[WorkflowSnapshot], names: Iterable[str]) -> bool:
+    names_set = set(names)
+    return bool(action_names(snapshots) & names_set)
+
+
+def no_tools_actions(snapshots: Sequence[WorkflowSnapshot]) -> bool:
+    return not any(
+        action.action.startswith("tools.") for action in all_actions(snapshots)
+    )
+
+
+def no_scatter_gather(snapshots: Sequence[WorkflowSnapshot]) -> bool:
+    forbidden = {"core.transform.scatter", "core.transform.gather"}
+    return not has_any_action(snapshots, forbidden)
+
+
+def linear_small_graph(snapshots: Sequence[WorkflowSnapshot], limit: int = 6) -> bool:
+    for snapshot in snapshots:
+        actions = snapshot.actions
+        if len(actions) > limit:
+            return False
+        branch_fanout: dict[str, int] = {}
+        for action in actions:
+            for dep in action.depends_on:
+                dep_ref = dep.split(".", 1)[0]
+                branch_fanout[dep_ref] = branch_fanout.get(dep_ref, 0) + 1
+        if any(count > 1 for count in branch_fanout.values()):
+            return False
+    return True
+
+
+def layout_refs_match_actions(snapshots: Sequence[WorkflowSnapshot]) -> bool:
+    for snapshot in snapshots:
+        if not snapshot.layout:
+            continue
+        layout_actions = snapshot.layout.get("actions", [])
+        if not isinstance(layout_actions, list):
+            return False
+        layout_refs = {
+            item.get("ref")
+            for item in layout_actions
+            if isinstance(item, dict) and isinstance(item.get("ref"), str)
+        }
+        action_refs = {action.ref for action in snapshot.actions}
+        if not layout_refs.issubset(action_refs):
+            return False
+    return True
+
+
+def declares_trigger_inputs(snapshots: Sequence[WorkflowSnapshot]) -> bool:
+    return all(
+        snapshot.definition is not None
+        and snapshot.definition.entrypoint.expects is not None
+        and bool(snapshot.definition.entrypoint.expects)
+        for snapshot in snapshots
+    )
+
+
+def bounded_output(snapshots: Sequence[WorkflowSnapshot]) -> bool:
+    haystack = json.dumps(
+        [action.model_dump(mode="json") for action in all_actions(snapshots)]
+    ).lower()
+    return any(token in haystack for token in ("[:5]", "[:10]", "limit", "sample"))
+
+
+def treats_paginate_result_as_list(snapshots: Sequence[WorkflowSnapshot]) -> bool:
+    text = json.dumps(
+        [action.model_dump(mode="json") for action in all_actions(snapshots)]
+    )
+    if "core.http_paginate" not in text:
+        return False
+    return ".items" not in text and ".data" not in text
+
+
+def agent_without_broad_http_tool(snapshots: Sequence[WorkflowSnapshot]) -> bool:
+    for action in all_actions(snapshots):
+        if action.action not in {"ai.agent", "ai.preset_agent"}:
+            continue
+        args_text = json.dumps(action.args)
+        if "core.http_request" in args_text:
+            return False
+    return True
+
+
+def deterministic_prep_outside_agent(snapshots: Sequence[WorkflowSnapshot]) -> bool:
+    return has_action(snapshots, "core.script.run_python") and has_any_action(
+        snapshots, {"ai.agent", "ai.preset_agent"}
+    )
+
+
+def workflow_execute_uses_alias(snapshots: Sequence[WorkflowSnapshot]) -> bool:
+    return any(
+        action.action == "core.workflow.execute"
+        and "workflow_alias" in action.args
+        and action.args.get("workflow_alias")
+        for action in all_actions(snapshots)
+    )
+
+
+def explicit_batch_loop_options(snapshots: Sequence[WorkflowSnapshot]) -> bool:
+    for action in all_actions(snapshots):
+        if action.action != "core.workflow.execute":
+            continue
+        text = json.dumps(action.model_dump(mode="json")).lower()
+        if "batch" in text and "batch_size" in text and "isolated" in text:
+            return True
+    return False
+
+
+def explicit_wait_strategy(snapshots: Sequence[WorkflowSnapshot]) -> bool:
+    return any(
+        action.action == "core.workflow.execute"
+        and "wait_strategy" in json.dumps(action.model_dump(mode="json")).lower()
+        for action in all_actions(snapshots)
+    )
+
+
+def provider_gating_note_or_core_http(
+    snapshots: Sequence[WorkflowSnapshot],
+    final_response: Mapping[str, Any],
+) -> bool:
+    notes = " ".join(str(note) for note in final_response.get("notes", [])).lower()
+    return has_action(snapshots, "core.http_request") or any(
+        token in notes for token in ("provider", "integration", "confirmation")
+    )
+
+
+def evaluate_rubric_item(
+    item: str,
+    *,
+    case: Case,
+    snapshots: Sequence[WorkflowSnapshot],
+    transcript: str,
+    final_response: Mapping[str, Any],
+    seed_workflow_id: str | None,
+) -> CheckResult:
+    workflow_ids = [snapshot.workflow_id for snapshot in snapshots]
+    changed_ids = [str(x) for x in final_response.get("changed_workflow_ids", [])]
+
+    checks: dict[str, tuple[bool, str]] = {
+        "starts_from_live_context": (
+            transcript_contains(transcript, "workspaces_list_workspaces")
+            and transcript_contains(
+                transcript, "workflows_get_workflow_authoring_context"
+            ),
+            "Expected workspaces_list_workspaces and "
+            "workflows_get_workflow_authoring_context in transcript.",
+        ),
+        "created_workflow": (
+            transcript_contains(transcript, "workflows_create_workflow")
+            and bool(workflow_ids),
+            "Expected workflows_create_workflow and returned workflow id.",
+        ),
+        "valid_workflow_yaml": (
+            bool(snapshots) and all(snapshot.definition for snapshot in snapshots),
+            "Expected fetched inline workflow YAML to parse as WorkflowYamlPayload/DSLInput.",
+        ),
+        "declares_trigger_inputs": (
+            declares_trigger_inputs(snapshots),
+            "Expected entrypoint.expects to declare trigger inputs.",
+        ),
+        "uses_core_script_run_python": (
+            has_action(snapshots, "core.script.run_python"),
+            "Expected core.script.run_python action.",
+        ),
+        "linear_small_graph": (
+            linear_small_graph(snapshots),
+            "Expected graph with no branch fan-out and at most six actions.",
+        ),
+        "bounded_output": (
+            bounded_output(snapshots),
+            "Expected bounded samples or limits in deterministic output.",
+        ),
+        "no_scatter_gather": (
+            no_scatter_gather(snapshots),
+            "Expected no core.transform.scatter/gather for ordinary shaping.",
+        ),
+        "no_third_party_tools": (
+            no_tools_actions(snapshots),
+            "Expected no tools.* actions.",
+        ),
+        "uses_core_http_paginate": (
+            has_action(snapshots, "core.http_paginate"),
+            "Expected core.http_paginate action.",
+        ),
+        "treats_paginate_result_as_list": (
+            treats_paginate_result_as_list(snapshots),
+            "Expected direct list handling of core.http_paginate result.",
+        ),
+        "fetched_existing_workflow": (
+            transcript_contains(transcript, "workflows_get_workflow"),
+            "Expected workflows_get_workflow before editing.",
+        ),
+        "used_edit_workflow": (
+            transcript_count(transcript, "workflows_edit_workflow") >= 1,
+            "Expected workflows_edit_workflow.",
+        ),
+        "used_validate_only_edit": (
+            transcript_contains(transcript, "validate_only")
+            and transcript_contains(transcript, "true"),
+            "Expected validate_only=true edit pass.",
+        ),
+        "layout_refs_match_actions": (
+            layout_refs_match_actions(snapshots),
+            "Expected layout action refs to match definition refs.",
+        ),
+        "changed_seed_workflow": (
+            seed_workflow_id is not None and seed_workflow_id in changed_ids,
+            "Expected changed_workflow_ids to include seeded workflow.",
+        ),
+        "uses_agent_action": (
+            has_any_action(snapshots, {"ai.agent", "ai.preset_agent"}),
+            "Expected ai.agent or ai.preset_agent.",
+        ),
+        "small_agentic_graph": (
+            linear_small_graph(snapshots, limit=6),
+            "Expected agentic graph to stay small.",
+        ),
+        "deterministic_prep_outside_agent": (
+            deterministic_prep_outside_agent(snapshots),
+            "Expected deterministic prep/handling outside agent.",
+        ),
+        "agent_without_broad_http_tool": (
+            agent_without_broad_http_tool(snapshots),
+            "Expected no broad core.http_request tool granted to agent.",
+        ),
+        "uses_workflow_execute": (
+            has_action(snapshots, "core.workflow.execute"),
+            "Expected core.workflow.execute.",
+        ),
+        "uses_workflow_alias": (
+            workflow_execute_uses_alias(snapshots),
+            "Expected workflow_alias on core.workflow.execute.",
+        ),
+        "explicit_batch_loop_options": (
+            explicit_batch_loop_options(snapshots),
+            "Expected batch loop strategy, batch size, and isolated failure behavior.",
+        ),
+        "explicit_wait_strategy": (
+            explicit_wait_strategy(snapshots),
+            "Expected explicit wait_strategy.",
+        ),
+        "valid_or_clarified": (
+            bool(snapshots) or bool(final_response.get("notes")),
+            "Expected a valid workflow or final clarification notes.",
+        ),
+        "provider_gating_note_or_core_http": (
+            provider_gating_note_or_core_http(snapshots, final_response),
+            "Expected core HTTP scaffolding or provider confirmation note.",
+        ),
+        "validated_workflow": (
+            transcript_contains(transcript, "workflows_validate_workflow"),
+            "Expected workflows_validate_workflow.",
+        ),
+        "ran_draft_workflow": (
+            transcript_contains(transcript, "workflows_run_draft_workflow"),
+            "Expected workflows_run_draft_workflow.",
+        ),
+        "inspected_execution": (
+            transcript_contains(transcript, "workflows_get_workflow_execution")
+            or transcript_contains(transcript, "workflows_list_workflow_executions"),
+            "Expected execution inspection.",
+        ),
+    }
+    passed, detail = checks.get(item, (False, f"Unknown rubric item for {case.id}"))
+    return CheckResult(item, passed, "" if passed else detail)
+
+
+async def score_case(
+    mcp: TracecatMCP,
+    *,
+    case: Case,
+    agent: str,
+    workspace_id: str,
+    final_response: Mapping[str, Any],
+    transcript_path: Path,
+    final_path: Path,
+    seed_workflow_id: str | None,
+    duration_seconds: float,
+) -> CaseResult:
+    schema = json.loads((SCRIPT_DIR / "codex_output_schema.json").read_text())
+    mcp_tool_calls = count_mcp_tool_calls(transcript_path)
+    schema_errors = sorted(
+        Draft202012Validator(schema).iter_errors(final_response),
+        key=lambda error: list(error.path),
+    )
+    checks: list[CheckResult] = []
+    if schema_errors:
+        checks.append(
+            CheckResult("final_response_schema", False, schema_errors[0].message)
+        )
+        return CaseResult(
+            case_id=case.id,
+            agent=agent,
+            passed=False,
+            model=agent_model(agent),
+            checks=checks,
+            transcript_path=str(transcript_path),
+            final_response_path=str(final_path),
+            duration_seconds=duration_seconds,
+            accuracy=accuracy_from_checks(checks),
+            mcp_tool_calls=mcp_tool_calls,
+            workflow_node_count=0,
+            branch_count=0,
+        )
+    checks.append(CheckResult("final_response_schema", True))
+
+    transcript = transcript_text(transcript_path)
+    checks.append(
+        CheckResult(
+            "no_repo_source_inspection",
+            not source_inspection_detected(transcript),
+            "Transcript shows Tracecat repo source inspection outside eval workspace.",
+        )
+    )
+
+    workflow_ids = [str(x) for x in final_response.get("workflow_ids", [])]
+    changed_ids = [str(x) for x in final_response.get("changed_workflow_ids", [])]
+    snapshots: list[WorkflowSnapshot] = []
+    for workflow_id in workflow_ids or changed_ids:
+        try:
+            snapshots.append(
+                await fetch_workflow_snapshot(
+                    mcp, workspace_id=workspace_id, workflow_id=workflow_id
+                )
+            )
+        except Exception as exc:
+            checks.append(
+                CheckResult(
+                    "fetch_workflow",
+                    False,
+                    f"{workflow_id}: {type(exc).__name__}: {exc}",
+                )
+            )
+
+    schemas = await fetch_action_schemas(
+        mcp,
+        workspace_id=workspace_id,
+        action_names=sorted(action_names(snapshots)),
+    )
+    if snapshots:
+        checks.append(check_action_args_against_schemas(snapshots, schemas))
+
+    for item in case.rubric:
+        checks.append(
+            evaluate_rubric_item(
+                item,
+                case=case,
+                snapshots=snapshots,
+                transcript=transcript,
+                final_response=final_response,
+                seed_workflow_id=seed_workflow_id,
+            )
+        )
+
+    passed = all(check.passed for check in checks)
+    return CaseResult(
+        case_id=case.id,
+        agent=agent,
+        passed=passed,
+        model=agent_model(agent),
+        workflow_ids=workflow_ids,
+        changed_workflow_ids=changed_ids,
+        checks=checks,
+        transcript_path=str(transcript_path),
+        final_response_path=str(final_path),
+        duration_seconds=duration_seconds,
+        accuracy=accuracy_from_checks(checks),
+        mcp_tool_calls=mcp_tool_calls,
+        workflow_node_count=workflow_node_count(snapshots),
+        branch_count=workflow_branch_count(snapshots),
+    )
+
+
+def accuracy_from_checks(checks: Sequence[CheckResult]) -> float:
+    if not checks:
+        return 0.0
+    return sum(1 for check in checks if check.passed) / len(checks)
+
+
+def fenced_blocks(text: str) -> list[tuple[str, str]]:
+    return [
+        (match.group("lang").strip().lower(), match.group("body"))
+        for match in re.finditer(
+            r"```(?P<lang>[A-Za-z0-9_-]*)\n(?P<body>.*?)```",
+            text,
+            re.DOTALL,
+        )
+    ]
+
+
+def as_patch_ops(value: Any) -> list[dict[str, Any]] | None:
+    if isinstance(value, dict) and isinstance(value.get("patch_ops"), list):
+        value = value["patch_ops"]
+    if (
+        isinstance(value, list)
+        and value
+        and all(
+            isinstance(item, dict) and "op" in item and "path" in item for item in value
+        )
+    ):
+        return value
+    return None
+
+
+def validate_yaml_block(block: Any, label: str) -> list[CheckResult]:
+    checks: list[CheckResult] = []
+    try:
+        if isinstance(block, dict) and "definition" in block:
+            WorkflowYamlPayload.model_validate(block)
+            checks.append(CheckResult(f"{label}:workflow_yaml", True))
+        elif isinstance(block, dict) and {"title", "entrypoint", "actions"}.issubset(
+            block
+        ):
+            DSLInput.model_validate(block)
+            checks.append(CheckResult(f"{label}:dsl_input", True))
+        elif isinstance(block, list):
+            for index, item in enumerate(block):
+                if isinstance(item, dict) and "action" in item:
+                    action = {"ref": f"snippet_{index}", **item}
+                    ActionStatement.model_validate(action)
+            if any(isinstance(item, dict) and "action" in item for item in block):
+                checks.append(CheckResult(f"{label}:action_snippets", True))
+        elif isinstance(block, dict) and "action" in block:
+            action = {"ref": "snippet", **block}
+            ActionStatement.model_validate(action)
+            checks.append(CheckResult(f"{label}:action_snippet", True))
+    except ValidationError as exc:
+        checks.append(CheckResult(label, False, str(exc.errors()[0])))
+    except Exception as exc:
+        checks.append(CheckResult(label, False, f"{type(exc).__name__}: {exc}"))
+    return checks
+
+
+def yaml_action_fragments(text: str) -> list[dict[str, Any]]:
+    fragments: list[dict[str, Any]] = []
+    for lang, body in fenced_blocks(text):
+        if lang not in {"yaml", "yml"}:
+            continue
+        parsed = yaml.safe_load(body)
+        if isinstance(parsed, list):
+            fragments.extend(
+                item
+                for item in parsed
+                if isinstance(item, dict)
+                and isinstance(item.get("ref"), str)
+                and isinstance(item.get("action"), str)
+            )
+    return fragments
+
+
+def validate_prompt_action_signatures(text: str) -> list[CheckResult]:
+    from tracecat_registry.core.http import http_paginate, http_request
+    from tracecat_registry.core.python import run_python
+
+    action_functions = {
+        "core.script.run_python": run_python,
+        "core.http_request": http_request,
+        "core.http_paginate": http_paginate,
+    }
+    fragments = yaml_action_fragments(text)
+    seen_actions: set[str] = set()
+    checks: list[CheckResult] = []
+
+    for fragment in fragments:
+        action_name = fragment["action"]
+        if action_name not in action_functions:
+            continue
+        seen_actions.add(action_name)
+        action_refs = set(
+            re.findall(r"ACTIONS\.([A-Za-z_][A-Za-z0-9_]*)", json.dumps(fragment))
+        )
+        upstream_stubs = [
+            {"ref": ref, "action": "core.noop", "args": {}}
+            for ref in sorted(action_refs - {fragment["ref"]})
+        ]
+        actions = [*upstream_stubs, fragment]
+        try:
+            DSLInput.model_validate(
+                {
+                    "title": f"Prompt eval {fragment['ref']}",
+                    "description": "Validate MCP prompt action fragment.",
+                    "entrypoint": {"ref": actions[0]["ref"], "expects": {}},
+                    "actions": actions,
+                }
+            )
+            signature = inspect.signature(action_functions[action_name])
+            params = set(signature.parameters)
+            args = set(fragment.get("args", {}))
+            required = {
+                name
+                for name, param in signature.parameters.items()
+                if param.default is inspect.Parameter.empty
+                and param.kind
+                in {
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
+                }
+            }
+            unknown = args - params
+            missing = required - args
+            if unknown or missing:
+                checks.append(
+                    CheckResult(
+                        f"prompt_action_signature:{fragment['ref']}",
+                        False,
+                        f"unknown={sorted(unknown)} missing={sorted(missing)}",
+                    )
+                )
+            else:
+                checks.append(
+                    CheckResult(f"prompt_action_signature:{fragment['ref']}", True)
+                )
+        except Exception as exc:
+            checks.append(
+                CheckResult(
+                    f"prompt_action_signature:{fragment.get('ref', 'unknown')}",
+                    False,
+                    f"{type(exc).__name__}: {exc}",
+                )
+            )
+
+    missing_actions = set(action_functions) - seen_actions
+    checks.append(
+        CheckResult(
+            "prompt_action_signature_coverage",
+            not missing_actions,
+            f"missing={sorted(missing_actions)}",
+        )
+    )
+    return checks
+
+
+def validate_prompt_result_shapes(text: str) -> CheckResult:
+    action_refs = {
+        fragment["ref"]: fragment["action"] for fragment in yaml_action_fragments(text)
+    }
+    list_result_refs = {
+        ref
+        for ref, action_name in action_refs.items()
+        if action_name == "core.http_paginate"
+    }
+    invalid_dereferences: list[str] = []
+    for ref in list_result_refs:
+        invalid_dereferences.extend(
+            re.findall(
+                rf"ACTIONS\.{re.escape(ref)}\.result\.([A-Za-z_][A-Za-z0-9_]*)",
+                text,
+            )
+        )
+    return CheckResult(
+        "prompt_expression_result_shapes",
+        not invalid_dereferences,
+        f"Invalid paginate result dereferences: {invalid_dereferences}",
+    )
+
+
+def static_prompt_checks() -> list[CheckResult]:
+    checks: list[CheckResult] = []
+    text = load_mcp_instructions()
+    checks.append(
+        CheckResult(
+            "prompt_budget",
+            len(text) <= PROMPT_MAX_CHARS,
+            f"{len(text)} chars > {PROMPT_MAX_CHARS}",
+        )
+    )
+
+    secret_pattern = re.compile(
+        r"(?i)(sk-[a-z0-9]{20,}|ghp_[a-z0-9]{20,}|xox[baprs]-[a-z0-9-]{20,})"
+    )
+    email_pattern = re.compile(r"\b[A-Z0-9._%+-]+@([A-Z0-9.-]+\.[A-Z]{2,})\b", re.I)
+    secret_hits = secret_pattern.findall(text)
+    email_hits = [
+        match.group(0)
+        for match in email_pattern.finditer(text)
+        if not match.group(0).lower().endswith("@example.com")
+    ]
+    checks.append(
+        CheckResult("no_secret_literals", not secret_hits, f"hits={secret_hits[:3]}")
+    )
+    checks.append(
+        CheckResult("no_non_example_emails", not email_hits, f"hits={email_hits[:3]}")
+    )
+
+    parsed_blocks = 0
+    for index, (lang, body) in enumerate(fenced_blocks(text), start=1):
+        label = f"fence_{index}_{lang or 'plain'}"
+        if lang == "json":
+            try:
+                value = json.loads(body)
+                parsed_blocks += 1
+                checks.append(CheckResult(f"{label}:json_parse", True))
+                if patch_ops := as_patch_ops(value):
+                    ops = [JsonPatchOperation.model_validate(op) for op in patch_ops]
+                    validate_patch_paths(
+                        ops,
+                        allowed_top_level_paths=ALLOWED_PATCH_ROOTS,
+                    )
+                    checks.append(CheckResult(f"{label}:json_patch", True))
+            except Exception as exc:
+                checks.append(CheckResult(label, False, f"{type(exc).__name__}: {exc}"))
+        elif lang in {"yaml", "yml"}:
+            try:
+                value = yaml.safe_load(body)
+                parsed_blocks += 1
+                checks.append(CheckResult(f"{label}:yaml_parse", True))
+                checks.extend(validate_yaml_block(value, label))
+            except Exception as exc:
+                checks.append(CheckResult(label, False, f"{type(exc).__name__}: {exc}"))
+
+    checks.append(
+        CheckResult(
+            "fenced_blocks_parsed",
+            parsed_blocks > 0,
+            f"parsed {parsed_blocks} JSON/YAML fenced blocks",
+        )
+    )
+    checks.extend(validate_prompt_action_signatures(text))
+    checks.append(validate_prompt_result_shapes(text))
+    return checks
+
+
+def load_mcp_instructions() -> str:
+    server_path = REPO_ROOT / "tracecat/mcp/server.py"
+    tree = ast.parse(server_path.read_text())
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "_MCP_INSTRUCTIONS"
+            for target in node.targets
+        ):
+            continue
+        value = ast.literal_eval(node.value)
+        if not isinstance(value, str):
+            raise TypeError("_MCP_INSTRUCTIONS is not a string literal")
+        return value
+    raise RuntimeError("_MCP_INSTRUCTIONS assignment not found")
+
+
+async def run_agent_cases(args: argparse.Namespace) -> list[CaseResult]:
+    cases = select_cases(load_cases(Path(args.cases_file)), args.cases)
+    agents = parse_agents(args)
+    run_id = timestamp()
+    artifact_dir = (
+        Path(args.output_dir) if args.output_dir else DEFAULT_ARTIFACT_ROOT / run_id
+    )
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    run_prefix = f"eval-tracecat-authoring-{run_id}"
+
+    results: list[CaseResult] = []
+    async with TracecatMCP(args.mcp_url, os.getenv("TRACECAT_MCP_BEARER_TOKEN")) as mcp:
+        workspace_id = await choose_workspace(mcp)
+        for agent in agents:
+            for case in cases:
+                case_dir = artifact_dir / "cases" / agent / case.id
+                final_path = case_dir / "final.json"
+                transcript_path = case_dir / "transcript.jsonl"
+                workspace = isolated_workspace(case_dir)
+                seed_workflow_id = None
+                try:
+                    if case.seed_workflow:
+                        seed_workflow_id = await seed_case_workflow(
+                            mcp,
+                            workspace_id=workspace_id,
+                            run_prefix=f"{run_prefix}-{agent}",
+                            case_id=case.id,
+                        )
+                    prompt = build_agent_prompt(
+                        case=case,
+                        workspace_id=workspace_id,
+                        run_prefix=f"{run_prefix}-{agent}",
+                        seed_workflow_id=seed_workflow_id,
+                    )
+                    run = run_agent(
+                        case=case,
+                        workspace=workspace,
+                        prompt=prompt,
+                        transcript_path=transcript_path,
+                        final_path=final_path,
+                        schema_path=SCRIPT_DIR / "codex_output_schema.json",
+                        mcp_url=args.mcp_url,
+                        agent=agent,
+                        agent_cmd=args.agent_cmd,
+                    )
+                    result = await score_case(
+                        mcp,
+                        case=case,
+                        agent=agent,
+                        workspace_id=workspace_id,
+                        final_response=run.final_response,
+                        transcript_path=transcript_path,
+                        final_path=final_path,
+                        seed_workflow_id=seed_workflow_id,
+                        duration_seconds=run.duration_seconds,
+                    )
+                except Exception as exc:
+                    result = CaseResult(
+                        case_id=case.id,
+                        agent=agent,
+                        passed=False,
+                        model=agent_model(agent),
+                        transcript_path=str(transcript_path),
+                        final_response_path=str(final_path),
+                        error=f"{type(exc).__name__}: {exc}",
+                        mcp_tool_calls=count_mcp_tool_calls(transcript_path),
+                        workflow_node_count=0,
+                        branch_count=0,
+                    )
+                results.append(result)
+
+    write_reports(artifact_dir, results)
+    print(f"Wrote eval artifacts to {artifact_dir}")
+    return results
+
+
+def parse_agents(args: argparse.Namespace) -> list[str]:
+    raw = args.agents or args.agent
+    agents = [agent.strip() for agent in raw.split(",") if agent.strip()]
+    valid = {"codex", "claude-code"}
+    invalid = set(agents) - valid
+    if invalid:
+        raise SystemExit(f"Unsupported agents: {', '.join(sorted(invalid))}")
+    return agents
+
+
+def write_reports(artifact_dir: Path, results: Sequence[CaseResult]) -> None:
+    matrix = performance_matrix(results)
+    payload = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "passed": all(result.passed for result in results),
+        "performance_matrix": matrix,
+        "results": [result.as_dict() for result in results],
+    }
+    write_json(artifact_dir / "report.json", payload)
+
+    lines = [
+        "# Tracecat authoring eval report",
+        "",
+        f"Generated: {payload['generated_at']}",
+        f"Passed: {payload['passed']}",
+        "",
+        "## Performance matrix",
+        "",
+        "| Agent | Model | Cases | Pass rate | Avg accuracy | Avg duration | Avg MCP calls | Avg workflow nodes | Avg branches | Key failures | Improvements |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |",
+    ]
+    for row in matrix:
+        lines.append(
+            "| {agent} | {model} | {cases} | {pass_rate:.0%} | "
+            "{avg_accuracy:.0%} | {avg_duration_seconds:.1f}s | "
+            "{avg_mcp_tool_calls:.1f} | {avg_workflow_nodes:.1f} | "
+            "{avg_branch_count:.1f} | {key_failures} | {improvements} |".format(**row)
+        )
+    lines.append("")
+    for result in results:
+        lines.append(
+            f"## {result.agent} / {result.case_id}: "
+            f"{'PASS' if result.passed else 'FAIL'}"
+        )
+        if result.duration_seconds is not None:
+            lines.append(f"- duration: {result.duration_seconds:.1f}s")
+        if result.accuracy is not None:
+            lines.append(f"- accuracy: {result.accuracy:.0%}")
+        if result.mcp_tool_calls is not None:
+            lines.append(f"- mcp_tool_calls: {result.mcp_tool_calls}")
+        if result.workflow_node_count is not None:
+            lines.append(f"- workflow_node_count: {result.workflow_node_count}")
+        if result.branch_count is not None:
+            lines.append(f"- branch_count: {result.branch_count}")
+        if result.error:
+            lines.append(f"- error: {result.error}")
+        if result.workflow_ids:
+            lines.append(f"- workflow_ids: {', '.join(result.workflow_ids)}")
+        if result.changed_workflow_ids:
+            lines.append(
+                f"- changed_workflow_ids: {', '.join(result.changed_workflow_ids)}"
+            )
+        failed = [check for check in result.checks if not check.passed]
+        if failed:
+            lines.append("- failed checks:")
+            for check in failed:
+                lines.append(f"  - {check.name}: {check.detail}")
+        lines.append("")
+    (artifact_dir / "report.md").write_text("\n".join(lines))
+
+
+def performance_matrix(results: Sequence[CaseResult]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    model_groups = sorted(
+        {(result.agent, result.model or "default") for result in results}
+    )
+    for agent, model in model_groups:
+        agent_results = [
+            result
+            for result in results
+            if result.agent == agent and (result.model or "default") == model
+        ]
+        cases = len(agent_results)
+        passed = sum(1 for result in agent_results if result.passed)
+        durations = [
+            result.duration_seconds
+            for result in agent_results
+            if result.duration_seconds is not None
+        ]
+        mcp_tool_calls = [
+            result.mcp_tool_calls
+            for result in agent_results
+            if result.mcp_tool_calls is not None
+        ]
+        workflow_nodes = [
+            result.workflow_node_count
+            for result in agent_results
+            if result.workflow_node_count is not None
+        ]
+        branch_counts = [
+            result.branch_count
+            for result in agent_results
+            if result.branch_count is not None
+        ]
+        accuracies = [
+            result.accuracy for result in agent_results if result.accuracy is not None
+        ]
+        failures = [
+            check.name
+            for result in agent_results
+            for check in result.checks
+            if not check.passed
+        ]
+        if failures:
+            top_failures = sorted(set(failures))[:4]
+            key_failures = ", ".join(top_failures)
+            improvements = "Improve " + ", ".join(top_failures)
+        elif any(result.error for result in agent_results):
+            key_failures = "runtime errors"
+            improvements = "Fix agent invocation/runtime errors"
+        else:
+            key_failures = "none"
+            improvements = "Maintain current behavior; inspect transcripts for quality."
+        rows.append(
+            {
+                "agent": agent,
+                "model": model,
+                "cases": cases,
+                "pass_rate": passed / cases if cases else 0.0,
+                "avg_accuracy": sum(accuracies) / len(accuracies)
+                if accuracies
+                else 0.0,
+                "avg_duration_seconds": sum(durations) / len(durations)
+                if durations
+                else 0.0,
+                "avg_mcp_tool_calls": sum(mcp_tool_calls) / len(mcp_tool_calls)
+                if mcp_tool_calls
+                else 0.0,
+                "avg_workflow_nodes": sum(workflow_nodes) / len(workflow_nodes)
+                if workflow_nodes
+                else 0.0,
+                "avg_branch_count": sum(branch_counts) / len(branch_counts)
+                if branch_counts
+                else 0.0,
+                "key_failures": key_failures,
+                "improvements": improvements,
+            }
+        )
+    return rows
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mcp-url", default=DEFAULT_MCP_URL)
+    parser.add_argument("--agent", default="codex", choices=["codex", "claude-code"])
+    parser.add_argument(
+        "--agents",
+        default=None,
+        help="Comma-separated agents to compare, e.g. codex,claude-code.",
+    )
+    parser.add_argument("--agent-cmd", default=None)
+    parser.add_argument("--cases", default="all", help="Case id, group, or 'all'.")
+    parser.add_argument(
+        "--cases-file",
+        default=str(SCRIPT_DIR / "cases.yaml"),
+        help="Path to authoring eval cases YAML.",
+    )
+    parser.add_argument("--output-dir", default=None)
+    parser.add_argument("--static-only", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    if args.static_only:
+        checks = static_prompt_checks()
+        results = [
+            CaseResult(
+                case_id="static_prompt_checks",
+                agent="static",
+                passed=all(check.passed for check in checks),
+                model="n/a",
+                checks=checks,
+                accuracy=accuracy_from_checks(checks),
+            )
+        ]
+        artifact_dir = (
+            Path(args.output_dir)
+            if args.output_dir
+            else DEFAULT_ARTIFACT_ROOT / f"{timestamp()}-static"
+        )
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        write_reports(artifact_dir, results)
+        print(f"Wrote static eval artifacts to {artifact_dir}")
+        return 0 if results[0].passed else 1
+
+    results = asyncio.run(run_agent_cases(args))
+    return 0 if all(result.passed for result in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -7783,6 +7783,28 @@ def test_mcp_instruction_action_args_match_registry_signatures() -> None:
     assert seen_actions == set(action_functions)
 
 
+def test_mcp_instruction_expressions_respect_prompt_action_result_shapes() -> None:
+    action_refs = {
+        fragment["ref"]: fragment["action"] for fragment in _mcp_yaml_action_fragments()
+    }
+    list_result_refs = {
+        ref
+        for ref, action_name in action_refs.items()
+        if action_name == "core.http_paginate"
+    }
+
+    invalid_dereferences = []
+    for ref in list_result_refs:
+        invalid_dereferences.extend(
+            re.findall(
+                rf"ACTIONS\.{re.escape(ref)}\.result\.([A-Za-z_][A-Za-z0-9_]*)",
+                mcp_server._MCP_INSTRUCTIONS,
+            )
+        )
+
+    assert not invalid_dereferences
+
+
 def test_mcp_instruction_text_stays_within_context_budget() -> None:
     assert len(mcp_server._MCP_INSTRUCTIONS) <= 18500, (
         "MCP instructions exceeded the prompt budget. Compress existing guidance "

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -7674,53 +7674,73 @@ async def test_upload_skill_rejects_non_utf8_root_skill_markdown_before_upload(
     assert upload_called is False
 
 
-def _mcp_fenced_blocks(language: str) -> list[str]:
-    return re.findall(
-        rf"```{language}\n(.*?)\n```", mcp_server._MCP_INSTRUCTIONS, re.DOTALL
-    )
+def _prompt_source_text() -> str:
+    return "\n".join([mcp_server._MCP_INSTRUCTIONS, mcp_server._DSL_REFERENCE_TEXT])
 
 
-def _mcp_yaml_action_fragments() -> list[dict[str, Any]]:
+def _prompt_fenced_blocks(language: str) -> list[str]:
+    return re.findall(rf"```{language}\n(.*?)\n```", _prompt_source_text(), re.DOTALL)
+
+
+def _prompt_yaml_action_fragments() -> list[dict[str, Any]]:
     fragments: list[dict[str, Any]] = []
-    for block in _mcp_fenced_blocks("yaml"):
+    for block in _prompt_fenced_blocks("yaml"):
         parsed = yaml.safe_load(block)
         if isinstance(parsed, list):
-            fragments.extend(parsed)
+            fragments.extend(
+                item
+                for item in parsed
+                if isinstance(item, dict)
+                and isinstance(item.get("ref"), str)
+                and isinstance(item.get("action"), str)
+            )
+        elif isinstance(parsed, dict) and isinstance(parsed.get("actions"), list):
+            fragments.extend(
+                item
+                for item in parsed["actions"]
+                if isinstance(item, dict)
+                and isinstance(item.get("ref"), str)
+                and isinstance(item.get("action"), str)
+            )
+        elif (
+            isinstance(parsed, dict)
+            and isinstance(parsed.get("definition"), dict)
+            and isinstance(parsed["definition"].get("actions"), list)
+        ):
+            fragments.extend(
+                item
+                for item in parsed["definition"]["actions"]
+                if isinstance(item, dict)
+                and isinstance(item.get("ref"), str)
+                and isinstance(item.get("action"), str)
+            )
+        elif (
+            isinstance(parsed, dict)
+            and isinstance(parsed.get("ref"), str)
+            and isinstance(parsed.get("action"), str)
+        ):
+            fragments.append(parsed)
     return fragments
 
 
-def test_mcp_instruction_json_patch_examples_are_structurally_valid() -> None:
+def test_prompt_json_patch_examples_are_structurally_valid() -> None:
     examples = [
         parsed
-        for block in _mcp_fenced_blocks("json")
+        for block in _prompt_fenced_blocks("json")
         if isinstance(parsed := json.loads(block), dict) and parsed.get("patch_ops")
     ]
 
-    assert len(examples) == 2
+    assert len(examples) >= 1
     for example in examples:
         for op in example["patch_ops"]:
             assert op["op"] in {"add", "copy", "move", "remove", "replace", "test"}
             path_parts = [part for part in op["path"].split("/") if part]
             assert path_parts[0] in {"definition", "layout"}
 
-    path_parts = [
-        [part for part in op["path"].split("/") if part]
-        for op in examples[1]["patch_ops"]
-    ]
-    assert any(
-        parts[:2] == ["definition", "actions"] and parts[-1] == "ref"
-        for parts in path_parts
-    )
-    assert any("depends_on" in parts for parts in path_parts)
-    assert any(
-        parts[:2] == ["layout", "actions"] and parts[-1] == "ref"
-        for parts in path_parts
-    )
 
-
-def test_mcp_instruction_complete_workflow_yaml_examples_are_schema_valid() -> None:
+def test_prompt_complete_workflow_yaml_examples_are_schema_valid() -> None:
     complete_examples = []
-    for block in _mcp_fenced_blocks("yaml"):
+    for block in _prompt_fenced_blocks("yaml"):
         parsed = yaml.safe_load(block)
         if isinstance(parsed, dict) and parsed.get("definition") is not None:
             complete_examples.append(parsed)
@@ -7734,7 +7754,7 @@ def test_mcp_instruction_complete_workflow_yaml_examples_are_schema_valid() -> N
         assert payload.definition.returns
 
 
-def test_mcp_instruction_action_args_match_registry_signatures() -> None:
+def test_prompt_action_args_match_registry_signatures() -> None:
     from tracecat_registry.core.http import http_paginate, http_request
     from tracecat_registry.core.python import run_python
 
@@ -7745,7 +7765,7 @@ def test_mcp_instruction_action_args_match_registry_signatures() -> None:
     }
 
     seen_actions: set[str] = set()
-    for fragment in _mcp_yaml_action_fragments():
+    for fragment in _prompt_yaml_action_fragments():
         if (action_name := fragment["action"]) not in action_functions:
             continue
         seen_actions.add(action_name)
@@ -7753,7 +7773,7 @@ def test_mcp_instruction_action_args_match_registry_signatures() -> None:
             re.findall(r"ACTIONS\.([A-Za-z_][A-Za-z0-9_]*)", json.dumps(fragment))
         )
         upstream_stubs = [
-            {"ref": ref, "action": "core.noop", "args": {}}
+            {"ref": ref, "action": "core.transform.reshape", "args": {"value": {}}}
             for ref in sorted(action_refs - {fragment["ref"]})
         ]
         actions = [*upstream_stubs, fragment]
@@ -7783,9 +7803,10 @@ def test_mcp_instruction_action_args_match_registry_signatures() -> None:
     assert seen_actions == set(action_functions)
 
 
-def test_mcp_instruction_expressions_respect_prompt_action_result_shapes() -> None:
+def test_prompt_expressions_respect_prompt_action_result_shapes() -> None:
     action_refs = {
-        fragment["ref"]: fragment["action"] for fragment in _mcp_yaml_action_fragments()
+        fragment["ref"]: fragment["action"]
+        for fragment in _prompt_yaml_action_fragments()
     }
     list_result_refs = {
         ref
@@ -7798,7 +7819,7 @@ def test_mcp_instruction_expressions_respect_prompt_action_result_shapes() -> No
         invalid_dereferences.extend(
             re.findall(
                 rf"ACTIONS\.{re.escape(ref)}\.result\.([A-Za-z_][A-Za-z0-9_]*)",
-                mcp_server._MCP_INSTRUCTIONS,
+                _prompt_source_text(),
             )
         )
 
@@ -7806,10 +7827,14 @@ def test_mcp_instruction_expressions_respect_prompt_action_result_shapes() -> No
 
 
 def test_mcp_instruction_text_stays_within_context_budget() -> None:
-    assert len(mcp_server._MCP_INSTRUCTIONS) <= 18500, (
+    assert len(mcp_server._MCP_INSTRUCTIONS) <= 14500, (
         "MCP instructions exceeded the prompt budget. Compress existing guidance "
         "or intentionally raise this ceiling with a clear reason."
     )
+
+
+def test_dsl_reference_text_stays_within_context_budget() -> None:
+    assert len(mcp_server._DSL_REFERENCE_TEXT) <= 15500
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -7761,6 +7761,43 @@ def test_mcp_instructions_prefer_edit_workflow_for_existing_workflows() -> None:
     assert "bulk-updating the workflow definition" in mcp_server._MCP_INSTRUCTIONS
 
 
+def test_mcp_instructions_include_automation_authoring_best_practices() -> None:
+    instructions = mcp_server._MCP_INSTRUCTIONS
+
+    assert "Prefer linear, readable workflow graphs" in instructions
+    assert "Do not use `core.transform.scatter` / `core.transform.gather`" in (
+        instructions
+    )
+    assert "from tracecat_registry.core.http import http_request" in instructions
+    assert "from tracecat_registry.core.table import create_table" in instructions
+    assert "Keep `insert_rows` batches at or below 1000 rows" in instructions
+    assert "requires a unique index on that table first" in instructions
+    assert "append `?echo=true` to the webhook URL" in instructions
+
+
+def test_mcp_instructions_prefer_agent_model_object() -> None:
+    instructions = mcp_server._MCP_INSTRUCTIONS
+
+    assert "Prefer the current `model` object field for `ai.agent`" in instructions
+    assert "top-level `model_name` and `model_provider` as deprecated" in instructions
+    assert "model:\n    model_name: claude-sonnet-4-6" in instructions
+
+
+def test_dsl_reference_uses_current_agent_model_shape() -> None:
+    dsl_reference = mcp_server._DSL_REFERENCE_TEXT
+    agent_example = dsl_reference.split("### AI Agent (With Tool Calling)", 1)[1].split(
+        "### For-each Loop", 1
+    )[0]
+
+    assert "model:\n        model_name: claude-sonnet-4-6" in agent_example
+    assert "top-level `model_name` and" in agent_example
+    assert "from tracecat_registry.core.table import create_table" in dsl_reference
+    assert "insert_rows(..., upsert=True)" in dsl_reference
+    assert "model_name: claude-sonnet-4-20250514" not in agent_example
+    assert "\n      model_name:" not in agent_example
+    assert "\n      model_provider:" not in agent_example
+
+
 @pytest.mark.anyio
 async def test_collect_agent_response_returns_text(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -7761,43 +7761,6 @@ def test_mcp_instructions_prefer_edit_workflow_for_existing_workflows() -> None:
     assert "bulk-updating the workflow definition" in mcp_server._MCP_INSTRUCTIONS
 
 
-def test_mcp_instructions_include_automation_authoring_best_practices() -> None:
-    instructions = mcp_server._MCP_INSTRUCTIONS
-
-    assert "Prefer linear, readable workflow graphs" in instructions
-    assert "Do not use `core.transform.scatter` / `core.transform.gather`" in (
-        instructions
-    )
-    assert "from tracecat_registry.core.http import http_request" in instructions
-    assert "from tracecat_registry.core.table import create_table" in instructions
-    assert "Keep `insert_rows` batches at or below 1000 rows" in instructions
-    assert "requires a unique index on that table first" in instructions
-    assert "append `?echo=true` to the webhook URL" in instructions
-
-
-def test_mcp_instructions_prefer_agent_model_object() -> None:
-    instructions = mcp_server._MCP_INSTRUCTIONS
-
-    assert "Prefer the current `model` object field for `ai.agent`" in instructions
-    assert "top-level `model_name` and `model_provider` as deprecated" in instructions
-    assert "model:\n    model_name: claude-sonnet-4-6" in instructions
-
-
-def test_dsl_reference_uses_current_agent_model_shape() -> None:
-    dsl_reference = mcp_server._DSL_REFERENCE_TEXT
-    agent_example = dsl_reference.split("### AI Agent (With Tool Calling)", 1)[1].split(
-        "### For-each Loop", 1
-    )[0]
-
-    assert "model:\n        model_name: claude-sonnet-4-6" in agent_example
-    assert "top-level `model_name` and" in agent_example
-    assert "from tracecat_registry.core.table import create_table" in dsl_reference
-    assert "insert_rows(..., upsert=True)" in dsl_reference
-    assert "model_name: claude-sonnet-4-20250514" not in agent_example
-    assert "\n      model_name:" not in agent_example
-    assert "\n      model_provider:" not in agent_example
-
-
 @pytest.mark.anyio
 async def test_collect_agent_response_returns_text(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -5315,67 +5315,6 @@ def test_watchtower_workspace_resolution_uses_tool_argument() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_dsl_reference_resource_registered():
-    """The DSL reference constant contains expected content."""
-    text = mcp_server._DSL_REFERENCE_TEXT
-    assert isinstance(text, str)
-    assert "Tracecat Workflow DSL Reference" in text
-    assert "FN." in text
-    assert "TRIGGER" in text
-    assert "ACTIONS" in text
-    assert "SECRETS" in text
-
-
-def test_dsl_reference_contains_all_fn_categories():
-    """Verify the DSL reference covers all major FN function categories."""
-    text = mcp_server._DSL_REFERENCE_TEXT
-    for category in [
-        "capitalize",  # String
-        "is_equal",  # Comparison
-        "regex_extract",  # Regex
-        "flatten",  # Array
-        "add",  # Math
-        "merge",  # JSON/Dict
-        "now",  # Time
-        "to_base64",  # Encoding
-        "hash_sha256",  # Hash
-        "extract_cves",  # IOC
-    ]:
-        assert category in text, f"FN function {category!r} missing from DSL reference"
-
-
-def test_domain_reference_resource_registered():
-    """The domain reference constant contains expected enum values."""
-    text = mcp_server._DOMAIN_REFERENCE_TEXT
-    assert isinstance(text, str)
-    assert "Domain Reference" in text
-    # Case management enums
-    for term in ["Priority", "Severity", "Status", "Task Status", "Case Event Types"]:
-        assert term in text, f"Section {term!r} missing from domain reference"
-    # Specific enum values
-    for value in [
-        "critical",
-        "informational",
-        "in_progress",
-        "case_created",
-        "dropdown_value_changed",
-    ]:
-        assert value in text, f"Enum value {value!r} missing from domain reference"
-    # Table column types
-    for col_type in ["TEXT", "INTEGER", "JSONB", "MULTI_SELECT"]:
-        assert col_type in text, (
-            f"Column type {col_type!r} missing from domain reference"
-        )
-    # Workflow control flow
-    for term in ["join_strategy", "loop_strategy", "fail_strategy", "edge_type"]:
-        assert term.replace("_", " ").title().replace(" ", " ") in text or any(
-            kw in text.lower() for kw in [term]
-        ), f"Control flow {term!r} missing from domain reference"
-    # Workflow execution
-    for value in ["manual", "scheduled", "webhook", "draft", "published"]:
-        assert value in text, f"Execution value {value!r} missing from domain reference"
-
-
 @pytest.mark.anyio
 async def test_action_catalog_resource(monkeypatch):
     """The action catalog resource returns actions grouped by namespace."""
@@ -7735,30 +7674,120 @@ async def test_upload_skill_rejects_non_utf8_root_skill_markdown_before_upload(
     assert upload_called is False
 
 
-def test_mcp_instructions_include_agent_preset_authoring_tools() -> None:
-    assert "get_agent_preset_authoring_context" in mcp_server._MCP_INSTRUCTIONS
-    assert "list_integrations" in mcp_server._MCP_INSTRUCTIONS
-    assert "create_agent_preset" in mcp_server._MCP_INSTRUCTIONS
-    assert "update_agent_preset" in mcp_server._MCP_INSTRUCTIONS
+def _mcp_fenced_blocks(language: str) -> list[str]:
+    return re.findall(
+        rf"```{language}\n(.*?)\n```", mcp_server._MCP_INSTRUCTIONS, re.DOTALL
+    )
 
 
-def test_mcp_instructions_prefer_edit_workflow_for_existing_workflows() -> None:
-    assert "Prefer `edit_workflow` for existing workflow changes" in (
-        mcp_server._MCP_INSTRUCTIONS
+def _mcp_yaml_action_fragments() -> list[dict[str, Any]]:
+    fragments: list[dict[str, Any]] = []
+    for block in _mcp_fenced_blocks("yaml"):
+        parsed = yaml.safe_load(block)
+        if isinstance(parsed, list):
+            fragments.extend(parsed)
+    return fragments
+
+
+def test_mcp_instruction_json_patch_examples_are_structurally_valid() -> None:
+    examples = [
+        parsed
+        for block in _mcp_fenced_blocks("json")
+        if isinstance(parsed := json.loads(block), dict) and parsed.get("patch_ops")
+    ]
+
+    assert len(examples) == 2
+    for example in examples:
+        for op in example["patch_ops"]:
+            assert op["op"] in {"add", "copy", "move", "remove", "replace", "test"}
+            path_parts = [part for part in op["path"].split("/") if part]
+            assert path_parts[0] in {"definition", "layout"}
+
+    path_parts = [
+        [part for part in op["path"].split("/") if part]
+        for op in examples[1]["patch_ops"]
+    ]
+    assert any(
+        parts[:2] == ["definition", "actions"] and parts[-1] == "ref"
+        for parts in path_parts
     )
-    assert "already in context when you know they are current" in (
-        mcp_server._MCP_INSTRUCTIONS
+    assert any("depends_on" in parts for parts in path_parts)
+    assert any(
+        parts[:2] == ["layout", "actions"] and parts[-1] == "ref"
+        for parts in path_parts
     )
-    assert "Call `get_workflow` only when the latest draft is missing" in (
-        mcp_server._MCP_INSTRUCTIONS
+
+
+def test_mcp_instruction_complete_workflow_yaml_examples_are_schema_valid() -> None:
+    complete_examples = []
+    for block in _mcp_fenced_blocks("yaml"):
+        parsed = yaml.safe_load(block)
+        if isinstance(parsed, dict) and parsed.get("definition") is not None:
+            complete_examples.append(parsed)
+
+    assert complete_examples
+    for block in complete_examples:
+        payload = mcp_server.WorkflowYamlPayload.model_validate(block)
+        assert payload.definition is not None
+        assert payload.definition.entrypoint.expects
+        assert payload.definition.actions
+        assert payload.definition.returns
+
+
+def test_mcp_instruction_action_args_match_registry_signatures() -> None:
+    from tracecat_registry.core.http import http_paginate, http_request
+    from tracecat_registry.core.python import run_python
+
+    action_functions = {
+        "core.script.run_python": run_python,
+        "core.http_request": http_request,
+        "core.http_paginate": http_paginate,
+    }
+
+    seen_actions: set[str] = set()
+    for fragment in _mcp_yaml_action_fragments():
+        if (action_name := fragment["action"]) not in action_functions:
+            continue
+        seen_actions.add(action_name)
+        action_refs = set(
+            re.findall(r"ACTIONS\.([A-Za-z_][A-Za-z0-9_]*)", json.dumps(fragment))
+        )
+        upstream_stubs = [
+            {"ref": ref, "action": "core.noop", "args": {}}
+            for ref in sorted(action_refs - {fragment["ref"]})
+        ]
+        actions = [*upstream_stubs, fragment]
+        dsl = mcp_server.DSLInput.model_validate(
+            {
+                "title": f"Prompt eval {fragment['ref']}",
+                "description": "Validate MCP prompt action fragment.",
+                "entrypoint": {"ref": actions[0]["ref"], "expects": {}},
+                "actions": actions,
+            }
+        )
+        assert dsl.actions[-1].ref == fragment["ref"]
+
+        signature = inspect.signature(action_functions[fragment["action"]])
+        params = set(signature.parameters)
+        args = set(fragment["args"])
+        required = {
+            name
+            for name, param in signature.parameters.items()
+            if param.default is inspect.Parameter.empty
+            and param.kind
+            in {inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY}
+        }
+        assert args <= params
+        assert required <= args
+
+    assert seen_actions == set(action_functions)
+
+
+def test_mcp_instruction_text_stays_within_context_budget() -> None:
+    assert len(mcp_server._MCP_INSTRUCTIONS) <= 18500, (
+        "MCP instructions exceeded the prompt budget. Compress existing guidance "
+        "or intentionally raise this ceiling with a clear reason."
     )
-    assert "conflict says the draft changed" in mcp_server._MCP_INSTRUCTIONS
-    assert "instead of resending full YAML" in mcp_server._MCP_INSTRUCTIONS
-    assert "Use `update_workflow` without `definition_yaml`" in (
-        mcp_server._MCP_INSTRUCTIONS
-    )
-    assert "only when intentionally replacing" in mcp_server._MCP_INSTRUCTIONS
-    assert "bulk-updating the workflow definition" in mcp_server._MCP_INSTRUCTIONS
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_tracecat_authoring_eval.py
+++ b/tests/unit/test_tracecat_authoring_eval.py
@@ -89,6 +89,53 @@ def test_prompt_action_literal_check_rejects_concrete_tools_action() -> None:
     assert "tools.slack.post_message" in result.detail
 
 
+def test_prompt_action_literal_check_allows_placeholder_tools_syntax() -> None:
+    result = run_local.validate_prompt_action_literals(
+        "Use `tools.<integration_slug>.<action_name>` after discovery."
+    )
+
+    assert result.passed
+
+
+def test_prompt_facing_sources_stay_within_named_budgets() -> None:
+    results = run_local.validate_prompt_source_budgets(
+        run_local.prompt_facing_sources()
+    )
+
+    assert all(result.passed for result in results), [
+        result.detail for result in results if not result.passed
+    ]
+
+
+def test_prompt_action_signature_coverage_spans_all_prompt_sources() -> None:
+    results = run_local.validate_prompt_action_signatures(
+        run_local.combine_prompt_sources(run_local.prompt_facing_sources())
+    )
+    coverage = next(
+        result
+        for result in results
+        if result.name == "prompt_action_signature_coverage"
+    )
+
+    assert coverage.passed, coverage.detail
+
+
+def test_prompt_facing_sources_prefer_run_python_over_workflow_fanout() -> None:
+    result = run_local.validate_prompt_loop_parallelism_guardrails(
+        run_local.combine_prompt_sources(run_local.prompt_facing_sources())
+    )
+
+    assert result.passed, result.detail
+
+
+def test_prompt_facing_sources_include_mcp_tool_argument_guardrails() -> None:
+    result = run_local.validate_prompt_mcp_tool_argument_guardrails(
+        run_local.combine_prompt_sources(run_local.prompt_facing_sources())
+    )
+
+    assert result.passed, result.detail
+
+
 def test_prompt_fenced_block_validation_covers_all_prompt_sources() -> None:
     sources = [
         run_local.PromptSource("mcp_instructions", ""),

--- a/tests/unit/test_tracecat_authoring_eval.py
+++ b/tests/unit/test_tracecat_authoring_eval.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from scripts.evals.tracecat_authoring import run_local
+
+
+def test_parse_agents_rejects_explicit_empty_agents() -> None:
+    args = argparse.Namespace(agent="codex", agents=" , ")
+
+    with pytest.raises(SystemExit, match="At least one agent"):
+        run_local.parse_agents(args)
+
+
+@pytest.mark.anyio
+async def test_score_case_fetches_created_and_changed_workflow_snapshots(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fetched: list[str] = []
+
+    async def fake_fetch_workflow_snapshot(*_args: object, **kwargs: object):
+        workflow_id = str(kwargs["workflow_id"])
+        fetched.append(workflow_id)
+        return run_local.WorkflowSnapshot(
+            workflow_id=workflow_id,
+            raw={},
+            yaml_payload=None,
+            definition=None,
+            layout={},
+        )
+
+    async def fake_fetch_action_schemas(*_args: object, **_kwargs: object):
+        return {}
+
+    monkeypatch.setattr(
+        run_local, "fetch_workflow_snapshot", fake_fetch_workflow_snapshot
+    )
+    monkeypatch.setattr(run_local, "fetch_action_schemas", fake_fetch_action_schemas)
+
+    transcript_path = tmp_path / "transcript.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    final_path = tmp_path / "final.json"
+    final_path.write_text("{}", encoding="utf-8")
+
+    await run_local.score_case(
+        cast(run_local.TracecatMCP, SimpleNamespace()),
+        case=run_local.Case(id="case", prompt="", rubric=[]),
+        agent="codex",
+        workspace_id="workspace",
+        final_response={
+            "workflow_ids": ["created", "overlap"],
+            "changed_workflow_ids": ["overlap", "changed"],
+        },
+        transcript_path=transcript_path,
+        final_path=final_path,
+        seed_workflow_id=None,
+        duration_seconds=0.0,
+    )
+
+    assert fetched == ["created", "overlap", "changed"]
+
+
+def test_prompt_action_literal_check_rejects_unknown_core_action() -> None:
+    result = run_local.validate_prompt_action_literals("Use `core.noop` here.")
+
+    assert not result.passed
+    assert "core.noop" in result.detail
+
+
+def test_prompt_action_literal_check_rejects_unknown_ai_action() -> None:
+    result = run_local.validate_prompt_action_literals("Use `ai.make_things_up` here.")
+
+    assert not result.passed
+    assert "ai.make_things_up" in result.detail
+
+
+def test_prompt_action_literal_check_rejects_concrete_tools_action() -> None:
+    result = run_local.validate_prompt_action_literals(
+        "Use `tools.slack.post_message`."
+    )
+
+    assert not result.passed
+    assert "tools.slack.post_message" in result.detail
+
+
+def test_prompt_fenced_block_validation_covers_all_prompt_sources() -> None:
+    sources = [
+        run_local.PromptSource("mcp_instructions", ""),
+        run_local.PromptSource(
+            "dsl_reference",
+            "```yaml\nactions:\n  - ref: transform\n    action: core.transform.reshape\n    args:\n      value: {}\n```",
+        ),
+        run_local.PromptSource(
+            "best_practices_skill",
+            '```json\n{"patch_ops": [{"op": "add", "path": "/definition/actions/-", "value": {}}]}\n```',
+        ),
+    ]
+
+    results = run_local.validate_prompt_fenced_blocks(sources)
+
+    assert any(
+        result.name == "dsl_reference:fence_1_yaml:yaml_parse" and result.passed
+        for result in results
+    )
+    assert any(
+        result.name == "best_practices_skill:fence_1_json:json_parse" and result.passed
+        for result in results
+    )
+
+
+def test_prompt_table_upsert_check_rejects_unsafe_upsert_examples() -> None:
+    result = run_local.validate_prompt_table_upsert_examples(
+        [
+            run_local.PromptSource(
+                "example",
+                "```python\nawait insert_rows(table='t', rows_data=rows, upsert=True)\n```",
+            )
+        ]
+    )
+
+    assert not result.passed
+    assert "example:2" in result.detail
+
+
+def test_prompt_table_upsert_check_allows_unique_index_guidance() -> None:
+    result = run_local.validate_prompt_table_upsert_examples(
+        [
+            run_local.PromptSource(
+                "example",
+                "Create a unique index on external_id first.\n"
+                "```python\n"
+                "await insert_rows(table='t', rows_data=rows, upsert=True)\n"
+                "```",
+            )
+        ]
+    )
+
+    assert result.passed
+
+
+def test_prompt_facing_sources_do_not_show_unsafe_upsert_examples() -> None:
+    result = run_local.validate_prompt_table_upsert_examples(
+        run_local.prompt_facing_sources()
+    )
+
+    assert result.passed, result.detail

--- a/tests/unit/test_tracecat_authoring_eval.py
+++ b/tests/unit/test_tracecat_authoring_eval.py
@@ -17,6 +17,22 @@ def test_parse_agents_rejects_explicit_empty_agents() -> None:
         run_local.parse_agents(args)
 
 
+def test_workflow_ids_from_call_decodes_mcp_text_content() -> None:
+    workflow_id = "123e4567-e89b-12d3-a456-426614174000"
+    call = run_local.McpToolCall(
+        call_id="call_1",
+        tool_name="workflows_create_workflow",
+        payload=[
+            {
+                "type": "text",
+                "text": f'{{"id":"{workflow_id}","title":"Created"}}',
+            }
+        ],
+    )
+
+    assert run_local.workflow_ids_from_call(call) == [workflow_id]
+
+
 @pytest.mark.anyio
 async def test_score_case_fetches_created_and_changed_workflow_snapshots(
     monkeypatch: pytest.MonkeyPatch,

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -2687,74 +2687,35 @@ _MCP_INSTRUCTIONS = """\
 Tracecat workflow management server.
 
 ## MCP tool namespaces
-All MCP tools are namespaced by resource type and exposed as \
-`<namespace>_<tool_name>`:
+MCP tools are namespaced by resource type and exposed as `<namespace>_<tool_name>`:
 - `workspaces_*` (e.g. `workspaces_list_workspaces`)
 - `workflows_*` (workflow lifecycle, execution, tags, webhook/case-trigger config)
 - `cases_*` (case CRUD, search, comments, tasks, events, tags, custom fields)
 - `tables_*`, `variables_*`, `secrets_*`, `integrations_*`, `agents_*`
 
 Use `workspaces_list_workspaces` to discover available workspaces, then pass \
-`workspace_id` to all other tools.
+`workspace_id` to workspace-scoped tools.
 
-For readability, references below use unprefixed tool names (e.g. \
-`create_workflow`), which correspond to namespaced MCP tools \
-like `workflows_create_workflow`.
+## MCP tools vs workflow actions
+MCP tools manage Tracecat objects directly. Workflow action names are used only \
+inside workflow YAML under `definition.actions[*].action`.
 
-## Action namespaces
-- `core.*` — built-in platform actions (core.http_request, core.script.run_python, \
-core.transform.*, core.table.*, etc.)
-- `core.transform.*` — data transforms (reshape, scatter, gather, filter, map)
-- `tools.*` — third-party integrations
-  - Third-party action name syntax: `tools.<integration_slug>.<action_name>`
-  - Third-party namespace examples: `tools.<integration_slug>.*`
-- `ai.*` — AI/LLM actions:
-  - `ai.action` — simple LLM call (no tools), supports `output_type` for structured output
-  - `ai.agent` — full AI agent with tool calling via `actions` list
-  - `ai.preset_agent` — run a saved agent preset by slug
-
-Use `workflows_list_actions` to discover available actions. Use \
-`workflows_get_action_context` or `workflows_get_workflow_authoring_context` \
-to get parameter schemas for any action \
-(including platform/interface actions like ai.agent, scatter, gather, etc.). \
-Use `agents_get_agent_preset_authoring_context` before creating agent presets \
-to inspect \
-available models, integration options, and output_type configuration.
-
-## Tool selection policy (strict)
-- Only include third-party `tools.*` actions when the user explicitly asks for \
-that specific integration/tool by name.
-- If the user asks for a generic capability (for example, "threat enrichment"), \
-you may discover and present candidate tools, but do NOT add any third-party \
-tool to workflow YAML until the user explicitly confirms the exact integration \
-they want.
-- Do not invent `tools.*` action names. Discover integrations with \
-`workflows_list_actions`, then inspect exact schemas with \
-`workflows_get_action_context` before authoring workflow YAML.
-- Prefer tool-agnostic workflow scaffolding with `core.http_request` and \
-`core.script.run_python` unless the user requests a specific third-party \
-integration.
-
-## Key workflow syntax
-- For `ai.agent`, use the `model` object unless the user explicitly asks for \
-legacy top-level model fields:
-```yaml
-args:
-  model:
-    model_name: claude-sonnet-4-6
-    model_provider: anthropic
-```
-- `core.script.run_python` can import Tracecat core actions:
-```python
-from tracecat_registry.core.http import http_request, http_paginate
-from tracecat_registry.core.table import create_table, insert_rows, lookup, update_row
-
-async def main(rows):
-    await create_table(name="inventory", columns=[{"name": "external_id", "type": "TEXT"}])
-    for start in range(0, len(rows), 1000):
-        await insert_rows(table="inventory", rows_data=rows[start:start + 1000], upsert=False)
-    return {"input_rows": len(rows), "sample": rows[:5]}
-```
+- MCP examples: `workflows_create_workflow`, `workflows_edit_workflow`, \
+`cases_create_case`, `tables_search_table_rows`
+- Action namespaces: `core.*` built-ins, `ai.*` LLM actions, and \
+`tools.<integration_slug>.<action_name>` third-party integration actions
+- Discover actions with `workflows_list_actions`; inspect exact schemas with \
+`workflows_get_action_context` or `workflows_get_workflow_authoring_context`
+- `tracecat://platform/dsl-reference` is a workflow YAML/DSL reference, not an \
+MCP tool argument reference. MCP tool schemas and tool docstrings are the source \
+of truth for tool calls.
+- Do not invent `tools.*` action names. Add third-party actions only after the \
+user explicitly names or confirms the integration/tool. For generic requests, \
+show candidate integrations first.
+- Prefer tool-agnostic scaffolding with `core.http_request` and \
+`core.script.run_python` unless a specific integration is requested.
+- For `ai.agent`, prefer the `model` object. Use legacy top-level \
+`model_name`/`model_provider` only when requested.
 
 ## Expression syntax (used in action `args:` values)
 - `${{ TRIGGER.<field> }}` — workflow trigger input
@@ -2762,53 +2723,26 @@ async def main(rows):
 - `${{ SECRETS.<name>.<KEY> }}` — secret value
 - `${{ VARS.<name>.<key> }}` — workspace variable
 - `${{ FN.<func>(<args>) }}` — built-in function call (e.g. FN.length, FN.join, FN.now)
-- Operators: `||`, `&&`, `==`, `!=`, `<`, `>`, `<=`, `>=`, `+`, `-`, `*`, `/`
-- Ternary: `${{ condition -> true_value : false_value }}`
+- Operators include `||`, `&&`, comparisons, arithmetic, and ternary \
+`${{ condition -> true_value : false_value }}`
 - Literals: `None` (NOT `null`), `true`, `false`, strings, numbers
-- **Important**: There is NO inline `for` comprehension syntax in expressions. \
-Use `core.script.run_python` for list transformations, or `for_each` on actions.
-- **Important**: Use `None` (Python-style) NOT `null` (JSON-style) in expressions.
+- There is NO inline `for` comprehension syntax in expressions. \
+Use `core.script.run_python` for list transformations and loops.
+- Use `None` (Python-style), not `null`, in expressions.
+- Read `tracecat://platform/dsl-reference` for full syntax, functions, and examples.
 
 ## Loop and batching guidance
-- Use action-level `for_each` for simple per-item repetition of one action. It \
-runs iterations in parallel, so keep rate limits in mind.
+- Prefer `core.script.run_python` loops over action-level `for_each`, even for \
+bounded lists. `for_each` can create enough scheduled work to hurt the scheduler.
+- Use `for_each` only when the user explicitly needs separate workflow action \
+runs per item and accepts the scheduler/concurrency tradeoff.
 - Use `core.loop.start` / `core.loop.end` for while-style workflow loops where \
 the next iteration depends on prior action output.
-- Use `core.transform.scatter` / `core.transform.gather` only for true parallel \
-fan-out/fan-in where each item needs its own workflow execution stream. \
-Scatter/gather has overhead and can be much slower than `core.script.run_python` \
-for ordinary batched transforms.
-- Prefer `core.script.run_python` for list transforms, batching, joins, \
-dedupe, sorting, grouping, chunked table writes, and bounded async HTTP loops.
-
-Example `for_each`:
-```yaml
-- ref: process_item
-  action: core.http_request
-  for_each: "${{ for var.item in TRIGGER.items }}"
-  args:
-    url: "https://api.example.com/items/${{ var.item.id }}"
-    method: POST
-```
-
-Example scatter/gather for real parallel fan-out:
-```yaml
-- ref: scatter_items
-  action: core.transform.scatter
-  args:
-    collection: ${{ TRIGGER.items }}
-- ref: process_item
-  action: core.http_request
-  depends_on: [scatter_items]
-  args:
-    url: "https://api.example.com/items/${{ ACTIONS.scatter_items.result.id }}"
-    method: GET
-- ref: gather_results
-  action: core.transform.gather
-  depends_on: [process_item]
-  args:
-    items: ${{ ACTIONS.process_item.result }}
-```
+- Prefer `core.script.run_python` loops over `core.transform.scatter` / \
+`core.transform.gather`. Scatter/gather has the same scheduler/concurrency risk \
+and should be reserved for explicit workflow-stream fan-out/fan-in requirements.
+- Use `core.script.run_python` for list transforms, batching, joins, dedupe, \
+sorting, grouping, chunked table writes, and bounded async HTTP loops.
 
 ## Key DSL fields (inside each action under `actions:`)
 - `ref` — unique slug identifier for the action
@@ -2823,19 +2757,10 @@ Example scatter/gather for real parallel fan-out:
 
 ## Recommended authoring sequence
 1. `get_workflow_authoring_context` — get action schemas, secrets, and variables
-2. Use `create_workflow` to create a blank workflow shell when needed
-3. For existing workflows, use the latest `draft_document` plus `draft_revision`
-already in context when you know they are current; otherwise call `get_workflow`
-4. Prefer `edit_workflow` for existing workflow changes — apply small RFC 6902
-JSON Patch operations to the draft document instead of resending full YAML
-5. Use `get_workflow(include_definition_yaml=true)` when you want full inline YAML,
-or `update_workflow(definition_yaml=...)` only when intentionally replacing or
-bulk-updating the workflow definition from inline YAML
-6. `validate_workflow` — check for structural and expression errors
-7. `publish_workflow` — freeze a versioned snapshot
-8. `run_published_workflow` or `run_draft_workflow` — execute it
-9. `list_workflow_executions` — see run history, find execution IDs
-10. `get_workflow_execution` — inspect execution status, per-action results/errors
+2. `create_workflow` for new workflows, or `get_workflow` for current draft state
+3. Prefer `edit_workflow` for focused existing-workflow edits
+4. `validate_workflow`, then publish and run only when appropriate
+5. Debug runs with `list_workflow_executions` and `get_workflow_execution`
 
 ## Workflow definition editing
 - Default to `edit_workflow` for existing workflows. If the latest
@@ -2845,23 +2770,15 @@ Call `get_workflow` only when the latest draft is missing, stale, or a revision
 conflict says the draft changed.
 - Patch paths are rooted at `draft_document`, so action edits use
 `/definition/actions/N/...`, not `/actions/N/...`.
-- `patch_ops` are applied sequentially. Do not parallelize `edit_workflow` calls
-against the same draft; every successful write returns a new `draft_revision`.
-Use that revision, or refetch with `get_workflow`, before the next patch.
-- RFC 6902 array rules apply: `/-` appends, and indexes shift after
-`add`, `remove`, and `move`.
-- Use `update_workflow` without `definition_yaml` for metadata-only updates.
-- Use inline YAML on `create_workflow` and `update_workflow` only when creating a
-workflow from YAML or intentionally replacing/bulk-updating the definition.
-Inline YAML payloads are supported up to the configured MCP input limit.
-- `get_workflow(include_definition_yaml=true)` returns inline `definition_yaml`
-when the workflow fits within that limit; otherwise it returns
-`definition_transport: "too_large"`. Use `draft_document` and `draft_revision`
-with `edit_workflow` for targeted edits.
+- `patch_ops` are applied sequentially. Every successful write returns a new \
+`draft_revision`; use it as the next `base_revision`, or refetch.
+- For nontrivial patches, run `edit_workflow(validate_only=true)`, then repeat \
+the same patch with `validate_only=false` and the same `base_revision`.
+- RFC 6902 array rules apply: `/-` appends, and indexes shift after array edits.
+- Use `update_workflow` without `definition_yaml` for metadata-only updates. Use \
+inline YAML on `create_workflow`/`update_workflow` only for creation or intentional \
+bulk replacement.
 
-### Sequential JSON Patch cookbook
-Use `get_workflow` -> `edit_workflow(validate_only=true)` ->
-`edit_workflow(validate_only=false)` for nontrivial draft edits:
 ```json
 {
   "base_revision": "<draft_revision from get_workflow>",
@@ -2894,148 +2811,6 @@ Use `get_workflow` -> `edit_workflow(validate_only=true)` ->
   ]
 }
 ```
-If validation succeeds, repeat the same patch with `validate_only: false` and
-the same `base_revision`. For another patch afterward, use the returned
-`draft_revision` as the new `base_revision`, or call `get_workflow` again.
-
-When renaming an action ref, patch the action `ref`, every dependent
-`depends_on` entry, and the matching layout action `ref` in the same call:
-```json
-{
-  "patch_ops": [
-    {
-      "op": "replace",
-      "path": "/definition/actions/1/ref",
-      "value": "parse_event"
-    },
-    {
-      "op": "replace",
-      "path": "/definition/actions/2/depends_on/0",
-      "value": "parse_event"
-    },
-    {
-      "op": "replace",
-      "path": "/layout/actions/1/ref",
-      "value": "parse_event"
-    }
-  ]
-}
-```
-
-### Complete workflow YAML cookbook
-When passing inline `definition_yaml`, put workflow fields under top-level
-`definition:`. Action examples below are fragments unless wrapped under
-`definition.actions`. Declare trigger inputs in `entrypoint.expects` before
-referencing them as `TRIGGER.*`. Quote YAML scalars that contain expressions and
-inner quotes with single quotes.
-```yaml
-definition:
-  title: Event summary
-  description: Summarize trigger events.
-  entrypoint:
-    ref: summarize_events
-    expects:
-      events_json:
-        type: str
-        default: "[]"
-        description: JSON array of event objects.
-      owner:
-        type: str
-        default: unassigned
-  actions:
-    - ref: summarize_events
-      action: core.script.run_python
-      args:
-        inputs:
-          events_json: '${{ TRIGGER.events_json }}'
-          owner: '${{ TRIGGER.owner || "unassigned" }}'
-        timeout_seconds: 60
-        allow_network: false
-        script: |
-          import json
-
-          def main(events_json, owner):
-              events = json.loads(events_json or "[]")
-              return {
-                  "event_count": len(events),
-                  "owner": owner or "unassigned",
-              }
-  returns: '${{ ACTIONS.summarize_events.result }}'
-```
-
-### Core action snippets
-`core.script.run_python` supports bounded inputs, timeouts, optional network
-access, and direct core action imports. Avoid list literal fallbacks such as
-an empty-list fallback in expressions; use `entrypoint.expects` defaults or
-handle defaults in Python.
-```yaml
-- ref: enrich_rows
-  action: core.script.run_python
-  args:
-    inputs:
-      rows_json: '${{ ACTIONS.fetch_rows.result.rows_json }}'
-    timeout_seconds: 120
-    allow_network: true
-    script: |
-      import json
-      from tracecat_registry.core.http import http_paginate, http_request
-      from tracecat_registry.core.table import insert_rows, lookup
-
-      async def main(rows_json):
-          rows = json.loads(rows_json or "[]")
-          for start in range(0, len(rows), 1000):
-              await insert_rows(
-                  table="automation_inventory",
-                  rows_data=rows[start:start + 1000],
-                  upsert=False,
-              )
-          return {"count": len(rows), "rows": rows[:100]}
-```
-
-Use `core.http_request` for single requests with headers, query params, JSON
-payloads, and inline encoding:
-```yaml
-- ref: submit_review
-  action: core.http_request
-  args:
-    method: POST
-    url: 'https://api.example.com/users/${{ FN.url_encode(TRIGGER.user_id) }}'
-    headers:
-      Authorization: Bearer ${{ SECRETS.example.API_TOKEN }}
-      Accept: application/json
-    params:
-      include: profile,groups
-    payload:
-      reason: '${{ TRIGGER.reason || "manual_review" }}'
-      owner: '${{ TRIGGER.owner || "unassigned" }}'
-```
-
-Use `core.http_paginate` when an API returns a repeated item path and a next
-cursor or URL. Check `get_workflow_authoring_context` for the current schema;
-`stop_condition` and `next_request` are Python lambda strings.
-```yaml
-- ref: list_events
-  action: core.http_paginate
-  args:
-    method: GET
-    url: https://api.example.com/events
-    headers:
-      Authorization: Bearer ${{ SECRETS.example.API_TOKEN }}
-    params:
-      since: '${{ FN.to_isoformat(FN.now() - FN.hours(24)) }}'
-    items_jsonpath: $.data[*]
-    stop_condition: "lambda response: response['data'].get('next_cursor') is None"
-    next_request: "lambda response: {'url': 'https://api.example.com/events', 'method': 'GET', 'params': {'cursor': response['data'].get('next_cursor')}}"
-```
-
-Common inline expression patterns:
-```yaml
-args:
-  display_name: '${{ TRIGGER.name || "unknown" }}'
-  summary: '${{ FN.concat("Found ", FN.length(ACTIONS.list_events.result), " events") }}'
-  joined_ids: '${{ FN.join(ACTIONS.normalize.result.ids, ",") }}'
-  since: '${{ FN.to_isoformat(FN.now() - FN.hours(4)) }}'
-```
 
 ## Template and CSV file tools
 - {_TEMPLATE_FILE_WARNING}
@@ -3044,26 +2819,17 @@ args:
 - `export_csv` returns a short-lived download URL for remote `/mcp` clients.
 
 ## Agent preset authoring
-1. `get_agent_preset_authoring_context` — inspect models, provider readiness, integrations, variables, and output_type options
-2. `list_integrations` — inspect workspace MCP integrations and broader provider status
-3. `list_actions` / `get_action_context` — choose preset tools and inspect arg schemas
-4. `create_agent_preset` — create a reusable preset
-5. `update_agent_preset` — revise an existing preset by slug when its prompts, tools, or model settings need to change
-6. `list_agent_presets` — find reusable agents you can invoke by slug without loading their full prompts or tool configs
-7. `get_agent_preset` / `run_agent_preset` — fetch a preset's full configuration when you need to inspect it, or run it once you know which slug to use
+1. `get_agent_preset_authoring_context` — inspect models, integrations, variables, and output_type options
+2. `list_integrations` — inspect attachable MCP integrations and provider status
+3. `list_actions` / `get_action_context` — choose exact tools and schemas
+4. `create_agent_preset` or `update_agent_preset`
+5. `list_agent_presets`, `get_agent_preset`, or `run_agent_preset` as needed
 
 ## Debugging workflow runs
 After running a workflow, use `list_workflow_executions` to see recent runs and their \
 statuses (COMPLETED, FAILED, RUNNING, etc.). Then use `get_workflow_execution` with the \
 execution ID to get a detailed event timeline showing each action's status, timing, \
 inputs, results, and errors.
-
-## Important: workflow actions vs MCP tools
-Action names like `core.http_request` are for use *inside* workflow YAML definitions \
-(in the `action:` field of a workflow action step). They are NOT MCP tool names. \
-To manage cases directly, use the MCP tools `create_case`, `list_cases`, `get_case`, \
-and `update_case`. Similarly, use `create_workflow` (not \
-`core.workflow.execute`) to create workflows via MCP.
 
 ## Tag and case field argument rules
 - Workflow tag definition tools (`list_workflow_tags`, `create_workflow_tag`, \
@@ -3091,19 +2857,19 @@ field name/column id, not a UUID.
 `options` are required for `SELECT` and `MULTI_SELECT`, and invalid for other types.
 
 ## Structured argument schema quick reference
-- `update_webhook.status`: `"online"` or `"offline"`.
-- `update_webhook.methods`: list of uppercase HTTP method strings, e.g. \
-`["GET","POST"]`.
-- `update_webhook.allowlisted_cidrs`: list of CIDR strings, e.g. \
-`["10.0.0.0/8","192.168.1.0/24"]`.
-- `update_case_trigger.status`: `"online"` or `"offline"`.
-- `update_case_trigger.event_types`: list of case event strings. Valid values: \
+- Webhook status: `"online"` or `"offline"`; methods are uppercase HTTP verbs; \
+allowlisted CIDRs are CIDR strings.
+- Case trigger status: `"online"` or `"offline"`; event type values: \
 `{_CASE_EVENT_TYPE_VALUES_JSON}`.
-- `update_case_trigger.tag_filters`: list of tag ref strings, e.g. \
-`["malware","phishing"]`.
 - `create_table.columns`: list of column objects with schema \
 `{{"name": str, "type": SqlType, "nullable": bool?, "default": any?, "options": list[str]?}}`. \
-`options` are only valid for `SELECT` and `MULTI_SELECT`.
+`options` are only valid for `SELECT` and `MULTI_SELECT`. `create_table` does \
+not create unique indexes; call `get_table`, then `create_column_index` with \
+the table UUID and column UUID.
+- Keep table names, column names, and case field names under 63 characters.
+- `update_workflow` accepts metadata plus optional `definition_yaml` and \
+`update_mode`; do not pass `patch_ops` to it. Use `edit_workflow` for RFC 6902 \
+draft patches with `base_revision`.
 - `create_case_field.options` and `update_case_field.options`: list of strings, \
 e.g. `["low","medium","high"]`; use `[]` to clear options on update.
 - Tag `color` values should be hex strings such as `"#ff0000"` when provided.
@@ -3146,6 +2912,10 @@ mcp.add_middleware(
 _DSL_REFERENCE_TEXT = """\
 # Tracecat Workflow DSL Reference
 
+This resource covers workflow YAML/DSL syntax and examples. It is not the source
+of truth for MCP tool arguments; use each MCP tool schema and docstring for calls
+such as workflow updates, table management, and case field changes.
+
 ## Workflow YAML Structure
 
 A workflow definition YAML has four optional top-level sections:
@@ -3179,6 +2949,7 @@ definition:
         payload:
           alert_id: "${{ TRIGGER.alert_id }}"
           result: "${{ ACTIONS.first_action.result }}"
+  returns: "${{ ACTIONS.post_alert.result }}"
 
 layout:                # Optional UI positioning
   trigger:
@@ -3374,7 +3145,7 @@ action: tools.<integration_slug>.search
 
 ## Common Workflow Patterns
 
-### HTTP Request → HTTP Request
+### HTTP Request
 ```yaml
 actions:
   - ref: fetch_data
@@ -3384,31 +3155,19 @@ actions:
       method: GET
       headers:
         Authorization: "Bearer ${{ SECRETS.api_creds.API_TOKEN }}"
-  - ref: forward_data
-    action: core.http_request
-    depends_on: [fetch_data]
-    args:
-      url: "https://api.example.com/ingest"
-      method: POST
-      payload:
-        data: "${{ ACTIONS.fetch_data.result }}"
 ```
 
 ### Scatter/Gather (Parallel Fan-out/Fan-in)
-Use scatter/gather only when each item needs its own workflow execution stream.
-It has orchestration overhead and can be much slower than a run-python loop for
-ordinary list transforms, batching, joins, dedupe, or chunked table writes.
+Prefer `core.script.run_python` loops over scatter/gather, even for bounded
+lists. Scatter/gather creates per-item scheduled work and can hurt the scheduler.
+Use it only when the user explicitly needs separate workflow execution streams
+and accepts the concurrency tradeoff.
 ```yaml
 actions:
-  - ref: get_items
-    action: core.transform.reshape
-    args:
-      value: ${{ TRIGGER.items }}
   - ref: scatter_items
     action: core.transform.scatter
-    depends_on: [get_items]
     args:
-      collection: ${{ ACTIONS.get_items.result }}
+      collection: ${{ TRIGGER.items }}
   - ref: process_item
     action: core.http_request
     depends_on: [scatter_items]
@@ -3455,7 +3214,11 @@ actions:
 ```
 Use top-level `model_name` and `model_provider` only when explicitly requested.
 
-### For-each Loop
+### For-each Syntax (Avoid by Default)
+Prefer `core.script.run_python` loops over `for_each`, even for bounded lists.
+`for_each` creates per-item scheduled work and can hurt the scheduler. Use it
+only when the user explicitly needs separate workflow action runs per item and
+accepts the concurrency tradeoff.
 ```yaml
 actions:
   - ref: process_items
@@ -3464,6 +3227,24 @@ actions:
     args:
       url: "https://api.example.com/process/${{ var.x }}"
       method: POST
+```
+
+### HTTP Pagination
+`core.http_paginate` returns a list of items from `items_jsonpath`; reference
+`ACTIONS.<ref>.result` directly as the list, not `.items` or `.data`.
+`stop_condition` and `next_request` are Python lambda strings.
+```yaml
+actions:
+  - ref: list_events
+    action: core.http_paginate
+    args:
+      method: GET
+      url: https://api.example.com/events
+      headers:
+        Authorization: "Bearer ${{ SECRETS.api.TOKEN }}"
+      items_jsonpath: $.data[*]
+      stop_condition: "lambda response: response['data'].get('next_cursor') is None"
+      next_request: "lambda response: {'method': 'GET', 'url': 'https://api.example.com/events', 'params': {'cursor': response['data'].get('next_cursor')}}"
 ```
 
 ### Conditional Execution
@@ -3494,22 +3275,6 @@ actions:
             return [item for item in raw_data if item["status"] == "active"]
 ```
 
-### HTTP Request with JSON Payload
-```yaml
-actions:
-  - ref: create_ticket
-    action: core.http_request
-    args:
-      url: "https://api.example.com/tickets"
-      method: POST
-      headers:
-        Authorization: "Bearer ${{ SECRETS.api.TOKEN }}"
-        Content-Type: "application/json"
-      payload:
-        title: "${{ TRIGGER.title }}"
-        priority: "${{ TRIGGER.severity }}"
-```
-
 ### Case-Triggered Workflow (Event Ingestion)
 ```yaml
 case_trigger:
@@ -3518,63 +3283,14 @@ case_trigger:
   tag_filters: ["high-priority", "triage"]
 
 actions:
-  - ref: enrich_case
-    action: core.http_request
-    args:
-      url: "https://api.example.com/enrich"
-      method: POST
-      payload:
-        case_id: "${{ TRIGGER.payload.id }}"
-        summary: "${{ TRIGGER.payload.summary }}"
-        tags: "${{ TRIGGER.payload.tags }}"
-  - ref: summarize_enrichment
+  - ref: summarize_case
     action: core.script.run_python
-    depends_on: [enrich_case]
     args:
       inputs:
-        enrichment: "${{ ACTIONS.enrich_case.result }}"
+        case_payload: "${{ TRIGGER.payload }}"
       script: |
-        def main(enrichment):
-            score = enrichment.get("risk_score", 0)
-            return {
-                "risk_score": score,
-                "recommendation": "escalate" if score >= 80 else "monitor",
-            }
-```
-
-### Case Update Pipeline (Read → Analyze → Patch)
-```yaml
-actions:
-  - ref: get_case_context
-    action: core.http_request
-    args:
-      url: "https://api.example.com/cases/${{ TRIGGER.case_id }}"
-      method: GET
-      headers:
-        Authorization: "Bearer ${{ SECRETS.case_api.TOKEN }}"
-  - ref: compute_priority
-    action: core.script.run_python
-    depends_on: [get_case_context]
-    args:
-      inputs:
-        case_data: "${{ ACTIONS.get_case_context.result }}"
-      script: |
-        def main(case_data):
-            indicators = case_data.get("indicators", [])
-            severity = case_data.get("severity", "unknown")
-            if severity in {"critical", "high"} or len(indicators) >= 5:
-                return {"priority": "high"}
-            return {"priority": "medium"}
-  - ref: patch_case
-    action: core.http_request
-    depends_on: [compute_priority]
-    args:
-      url: "https://api.example.com/cases/${{ TRIGGER.case_id }}"
-      method: PATCH
-      headers:
-        Authorization: "Bearer ${{ SECRETS.case_api.TOKEN }}"
-      payload:
-        priority: "${{ ACTIONS.compute_priority.result.priority }}"
+        def main(case_payload):
+            return {"case_id": case_payload.get("id"), "tags": case_payload.get("tags", [])}
 ```
 """
 

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -2732,6 +2732,60 @@ they want.
 `core.script.run_python` unless the user requests a specific third-party \
 integration.
 
+## Workflow authoring best practices
+- Prefer linear, readable workflow graphs when parallelism is not materially \
+useful. Avoid accidental branch joins and redundant diamond dependencies.
+- Do not use `core.transform.scatter` / `core.transform.gather` for ordinary \
+data transformation. Normalize, dedupe, join, filter, sort, batch upsert, and \
+similar work usually belongs in one `core.script.run_python` action.
+- Use bounded async concurrency inside `core.script.run_python` for bulk HTTP or \
+table operations. Keep run-python outputs intentionally small: return \
+downstream-required rows, summary counts, and bounded error samples rather than \
+full intermediate datasets.
+- Prefer the current `model` object field for `ai.agent` workflow YAML. Treat \
+top-level `model_name` and `model_provider` as deprecated unless the user \
+explicitly asks for that legacy shape:
+```yaml
+args:
+  model:
+    model_name: claude-sonnet-4-6
+    model_provider: anthropic
+```
+
+## Tracecat imports in run-python actions
+Use direct core action imports inside `core.script.run_python` when consolidating \
+table or HTTP side effects reduces graph noise:
+```python
+from tracecat_registry.core.http import http_request
+from tracecat_registry.core.table import create_table, insert_row, insert_rows, lookup, update_row
+```
+Define `async def main(...)`, `await` imported actions, pass named arguments, \
+chunk table writes, and return compact summaries/errors. Keep `insert_rows` \
+batches at or below 1000 rows.
+
+## Table guidance
+- `core.table.create_table` creates columns but does not create unique indexes.
+- Any workflow action that uses `insert_rows(..., upsert=True)` requires a unique \
+index on that table first. Use table index tooling to create the unique index \
+before relying on upsert behavior.
+- Use table actions or `tracecat_registry.core.table` imports for durable \
+workflow state; keep lookup keys as strings when identifiers may exceed integer \
+limits.
+
+## Slack bot workflow tips
+- Build Slack bots with `ai.agent` or `ai.preset_agent`, and give the agent the \
+Slack tools it needs, such as send/post message, list messages/replies, and any \
+read tools required for thread context.
+- Put the workflow webhook URL in Slack interactivity at \
+`https://api.slack.com/apps/{app_id}/interactive-messages`.
+- For @mention back-and-forth chat, configure Slack event subscriptions for app \
+mentions and append `?echo=true` to the webhook URL placed in Slack. The echo \
+flag is required for reliable mention-thread loops.
+- If you are truly stuck on Tracecat DSL behavior, Tracecat is open source at \
+https://github.com/TracecatHQ/tracecat and sample workflow files are available. \
+The Google OAuth workflow in `platform/automations/001_google_oauth/workflow.yaml` \
+is the clean reference shape for automation authoring.
+
 ## Expression syntax (used in action `args:` values)
 - `${{ TRIGGER.<field> }}` — workflow trigger input
 - `${{ ACTIONS.<ref>.result }}` — output from a completed action
@@ -3104,6 +3158,42 @@ action: tools.<integration_slug>.search
 
 ## Common Workflow Patterns
 
+### Recommended Workflow Shape
+Keep automation workflows linear and easy to review unless parallelism materially \
+improves the run. Use `core.script.run_python` for ordinary transforms such as \
+normalization, dedupe, joins, filtering, sorting, and batch table upserts. Use \
+scatter/gather only for true fan-out/fan-in work.
+
+Inside `core.script.run_python`, direct Tracecat imports are supported for \
+consolidating table or HTTP side effects:
+
+```python
+from tracecat_registry.core.http import http_request
+from tracecat_registry.core.table import create_table, insert_row, insert_rows, lookup, update_row
+
+async def main(rows):
+    await create_table(
+        name="ioc_inventory",
+        columns=[
+            {"name": "ioc", "type": "TEXT"},
+            {"name": "source", "type": "TEXT"},
+        ],
+        raise_on_duplicate=False,
+    )
+    inserted = 0
+    for start in range(0, len(rows), 1000):
+        inserted += await insert_rows(
+            table="ioc_inventory",
+            rows_data=rows[start:start + 1000],
+            upsert=True,
+        )
+    return {"inserted": inserted, "input_rows": len(rows)}
+```
+
+Keep `insert_rows` batches at or below 1000 rows. Before using \
+`insert_rows(..., upsert=True)`, create a unique index on the intended key \
+column; table creation alone does not create unique indexes.
+
 ### HTTP Request → HTTP Request
 ```yaml
 actions:
@@ -3171,14 +3261,18 @@ actions:
     action: ai.agent
     args:
       user_prompt: "Investigate this alert and recommend case next-steps."
-      model_name: claude-sonnet-4-20250514
-      model_provider: anthropic
+      model:
+        model_name: claude-sonnet-4-6
+        model_provider: anthropic
       actions:
         - core.http_request
         - core.script.run_python
       instructions: "You are a SOC analyst. Be thorough."
       max_tool_calls: 10
 ```
+Prefer the `model` object for `ai.agent`; top-level `model_name` and \
+`model_provider` are deprecated unless the user explicitly asks for that legacy \
+shape.
 
 ### For-each Loop
 ```yaml

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -2814,6 +2814,13 @@ bulk-updating the workflow definition from inline YAML
 them and create the smallest RFC 6902 patch that changes the intended fields.
 Call `get_workflow` only when the latest draft is missing, stale, or a revision
 conflict says the draft changed.
+- Patch paths are rooted at `draft_document`, so action edits use
+`/definition/actions/N/...`, not `/actions/N/...`.
+- `patch_ops` are applied sequentially. Do not parallelize `edit_workflow` calls
+against the same draft; every successful write returns a new `draft_revision`.
+Use that revision, or refetch with `get_workflow`, before the next patch.
+- RFC 6902 array rules apply: `/-` appends, and indexes shift after
+`add`, `remove`, and `move`.
 - Use `update_workflow` without `definition_yaml` for metadata-only updates.
 - Use inline YAML on `create_workflow` and `update_workflow` only when creating a
 workflow from YAML or intentionally replacing/bulk-updating the definition.
@@ -2822,6 +2829,174 @@ Inline YAML payloads are supported up to the configured MCP input limit.
 when the workflow fits within that limit; otherwise it returns
 `definition_transport: "too_large"`. Use `draft_document` and `draft_revision`
 with `edit_workflow` for targeted edits.
+
+### Sequential JSON Patch cookbook
+Use `get_workflow` -> `edit_workflow(validate_only=true)` ->
+`edit_workflow(validate_only=false)` for nontrivial draft edits:
+```json
+{
+  "base_revision": "<draft_revision from get_workflow>",
+  "validate_only": true,
+  "patch_ops": [
+    {
+      "op": "replace",
+      "path": "/definition/actions/2/args/script",
+      "value": "def main(): return {'ok': True}"
+    },
+    {
+      "op": "add",
+      "path": "/definition/actions/-",
+      "value": {
+        "ref": "notify_owner",
+        "action": "core.noop",
+        "depends_on": ["parse_event"],
+        "args": {}
+      }
+    },
+    {
+      "op": "add",
+      "path": "/layout/actions/-",
+      "value": {"ref": "notify_owner", "x": 600, "y": 120}
+    }
+  ]
+}
+```
+If validation succeeds, repeat the same patch with `validate_only: false` and
+the same `base_revision`. For another patch afterward, use the returned
+`draft_revision` as the new `base_revision`, or call `get_workflow` again.
+
+When renaming an action ref, patch the action `ref`, every dependent
+`depends_on` entry, and the matching layout action `ref` in the same call:
+```json
+{
+  "patch_ops": [
+    {
+      "op": "replace",
+      "path": "/definition/actions/1/ref",
+      "value": "parse_event"
+    },
+    {
+      "op": "replace",
+      "path": "/definition/actions/2/depends_on/0",
+      "value": "parse_event"
+    },
+    {
+      "op": "replace",
+      "path": "/layout/actions/1/ref",
+      "value": "parse_event"
+    }
+  ]
+}
+```
+
+### Complete workflow YAML cookbook
+When passing inline `definition_yaml`, put workflow fields under top-level
+`definition:`. Action examples below are fragments unless wrapped under
+`definition.actions`. Declare trigger inputs in `entrypoint.expects` before
+referencing them as `TRIGGER.*`. Quote YAML scalars that contain expressions and
+inner quotes with single quotes.
+```yaml
+definition:
+  title: Event summary
+  description: Summarize trigger events.
+  entrypoint:
+    ref: summarize_events
+    expects:
+      events_json:
+        type: str
+        default: "[]"
+        description: JSON array of event objects.
+      owner:
+        type: str
+        default: unassigned
+  actions:
+    - ref: summarize_events
+      action: core.script.run_python
+      args:
+        inputs:
+          events_json: '${{ TRIGGER.events_json }}'
+          owner: '${{ TRIGGER.owner || "unassigned" }}'
+        timeout_seconds: 60
+        allow_network: false
+        script: |
+          import json
+
+          def main(events_json, owner):
+              events = json.loads(events_json or "[]")
+              return {
+                  "event_count": len(events),
+                  "owner": owner or "unassigned",
+              }
+  returns: '${{ ACTIONS.summarize_events.result }}'
+```
+
+### Core action snippets
+`core.script.run_python` supports bounded inputs, timeouts, optional network
+access, and direct core action imports. Avoid list literal fallbacks such as
+an empty-list fallback in expressions; use `entrypoint.expects` defaults or
+handle defaults in Python.
+```yaml
+- ref: enrich_rows
+  action: core.script.run_python
+  args:
+    inputs:
+      rows_json: '${{ ACTIONS.fetch_rows.result.rows_json }}'
+    timeout_seconds: 120
+    allow_network: true
+    script: |
+      import json
+      from tracecat_registry.core.http import http_request
+      from tracecat_registry.core.table import insert_rows, lookup
+
+      def main(rows_json):
+          rows = json.loads(rows_json or "[]")
+          return {"count": len(rows), "rows": rows[:100]}
+```
+
+Use `core.http_request` for single requests with headers, query params, JSON
+payloads, and inline encoding:
+```yaml
+- ref: submit_review
+  action: core.http_request
+  args:
+    method: POST
+    url: 'https://api.example.com/users/${{ FN.url_encode(TRIGGER.user_id) }}'
+    headers:
+      Authorization: Bearer ${{ SECRETS.example.API_TOKEN }}
+      Accept: application/json
+    params:
+      include: profile,groups
+    payload:
+      reason: '${{ TRIGGER.reason || "manual_review" }}'
+      owner: '${{ TRIGGER.owner || "unassigned" }}'
+```
+
+Use `core.http_paginate` when an API returns a repeated item path and a next
+cursor or URL. Check `get_workflow_authoring_context` for the current schema;
+`stop_condition` and `next_request` are Python lambda strings.
+```yaml
+- ref: list_events
+  action: core.http_paginate
+  args:
+    method: GET
+    url: https://api.example.com/events
+    headers:
+      Authorization: Bearer ${{ SECRETS.example.API_TOKEN }}
+    params:
+      since: '${{ FN.to_isoformat(FN.now() - FN.hours(24)) }}'
+    items_jsonpath: $.data[*]
+    stop_condition: "lambda response: response['data'].get('next_cursor') is None"
+    next_request: "lambda response: {'url': 'https://api.example.com/events', 'method': 'GET', 'params': {'cursor': response['data'].get('next_cursor')}}"
+```
+
+Common inline expression patterns:
+```yaml
+args:
+  display_name: '${{ TRIGGER.name || "unknown" }}'
+  summary: '${{ FN.concat("Found ", FN.length(ACTIONS.list_events.result.items), " events") }}'
+  joined_ids: '${{ FN.join(ACTIONS.normalize.result.ids, ",") }}'
+  since: '${{ FN.to_isoformat(FN.now() - FN.hours(4)) }}'
+```
 
 ## Template and CSV file tools
 - {_TEMPLATE_FILE_WARNING}

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -2728,8 +2728,6 @@ show candidate integrations first.
 - Literals: `None` (NOT `null`), `true`, `false`, strings, numbers
 - There is NO inline `for` comprehension syntax in expressions. \
 Use `core.script.run_python` for list transformations and loops.
-- Use `None` (Python-style), not `null`, in expressions.
-- Read `tracecat://platform/dsl-reference` for full syntax, functions, and examples.
 
 ## Loop and batching guidance
 - Prefer `core.script.run_python` loops over action-level `for_each`, even for \
@@ -2750,8 +2748,7 @@ sorting, grouping, chunked table writes, and bounded async HTTP loops.
 - `args` — action arguments as key-value pairs
 - `depends_on` — list of action refs this action waits for
 - `run_if` — conditional expression to skip execution
-- `for_each` — iterate over a list \
-(syntax: `${{ for var.x in ACTIONS.step.result }}`, access item as `${{ var.x }}`)
+- `for_each` — iterate over a list
 - `retry_policy` — {{max_attempts, timeout}}
 - `join_strategy` — `all` (default) or `any`
 
@@ -2824,12 +2821,6 @@ bulk replacement.
 3. `list_actions` / `get_action_context` — choose exact tools and schemas
 4. `create_agent_preset` or `update_agent_preset`
 5. `list_agent_presets`, `get_agent_preset`, or `run_agent_preset` as needed
-
-## Debugging workflow runs
-After running a workflow, use `list_workflow_executions` to see recent runs and their \
-statuses (COMPLETED, FAILED, RUNNING, etc.). Then use `get_workflow_execution` with the \
-execution ID to get a detailed event timeline showing each action's status, timing, \
-inputs, results, and errors.
 
 ## Tag and case field argument rules
 - Workflow tag definition tools (`list_workflow_tags`, `create_workflow_tag`, \

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -2732,59 +2732,20 @@ they want.
 `core.script.run_python` unless the user requests a specific third-party \
 integration.
 
-## Workflow authoring best practices
-- Prefer linear, readable workflow graphs when parallelism is not materially \
-useful. Avoid accidental branch joins and redundant diamond dependencies.
-- Do not use `core.transform.scatter` / `core.transform.gather` for ordinary \
-data transformation. Normalize, dedupe, join, filter, sort, batch upsert, and \
-similar work usually belongs in one `core.script.run_python` action.
-- Use bounded async concurrency inside `core.script.run_python` for bulk HTTP or \
-table operations. Keep run-python outputs intentionally small: return \
-downstream-required rows, summary counts, and bounded error samples rather than \
-full intermediate datasets.
-- Prefer the current `model` object field for `ai.agent` workflow YAML. Treat \
-top-level `model_name` and `model_provider` as deprecated unless the user \
-explicitly asks for that legacy shape:
+## Key workflow syntax
+- For `ai.agent`, use the `model` object unless the user explicitly asks for \
+legacy top-level model fields:
 ```yaml
 args:
   model:
     model_name: claude-sonnet-4-6
     model_provider: anthropic
 ```
-
-## Tracecat imports in run-python actions
-Use direct core action imports inside `core.script.run_python` when consolidating \
-table or HTTP side effects reduces graph noise:
+- `core.script.run_python` can import Tracecat core actions:
 ```python
 from tracecat_registry.core.http import http_request
 from tracecat_registry.core.table import create_table, insert_row, insert_rows, lookup, update_row
 ```
-Define `async def main(...)`, `await` imported actions, pass named arguments, \
-chunk table writes, and return compact summaries/errors. Keep `insert_rows` \
-batches at or below 1000 rows.
-
-## Table guidance
-- `core.table.create_table` creates columns but does not create unique indexes.
-- Any workflow action that uses `insert_rows(..., upsert=True)` requires a unique \
-index on that table first. Use table index tooling to create the unique index \
-before relying on upsert behavior.
-- Use table actions or `tracecat_registry.core.table` imports for durable \
-workflow state; keep lookup keys as strings when identifiers may exceed integer \
-limits.
-
-## Slack bot workflow tips
-- Build Slack bots with `ai.agent` or `ai.preset_agent`, and give the agent the \
-Slack tools it needs, such as send/post message, list messages/replies, and any \
-read tools required for thread context.
-- Put the workflow webhook URL in Slack interactivity at \
-`https://api.slack.com/apps/{app_id}/interactive-messages`.
-- For @mention back-and-forth chat, configure Slack event subscriptions for app \
-mentions and append `?echo=true` to the webhook URL placed in Slack. The echo \
-flag is required for reliable mention-thread loops.
-- If you are truly stuck on Tracecat DSL behavior, Tracecat is open source at \
-https://github.com/TracecatHQ/tracecat and sample workflow files are available. \
-The Google OAuth workflow in `platform/automations/001_google_oauth/workflow.yaml` \
-is the clean reference shape for automation authoring.
 
 ## Expression syntax (used in action `args:` values)
 - `${{ TRIGGER.<field> }}` — workflow trigger input
@@ -3158,42 +3119,6 @@ action: tools.<integration_slug>.search
 
 ## Common Workflow Patterns
 
-### Recommended Workflow Shape
-Keep automation workflows linear and easy to review unless parallelism materially \
-improves the run. Use `core.script.run_python` for ordinary transforms such as \
-normalization, dedupe, joins, filtering, sorting, and batch table upserts. Use \
-scatter/gather only for true fan-out/fan-in work.
-
-Inside `core.script.run_python`, direct Tracecat imports are supported for \
-consolidating table or HTTP side effects:
-
-```python
-from tracecat_registry.core.http import http_request
-from tracecat_registry.core.table import create_table, insert_row, insert_rows, lookup, update_row
-
-async def main(rows):
-    await create_table(
-        name="ioc_inventory",
-        columns=[
-            {"name": "ioc", "type": "TEXT"},
-            {"name": "source", "type": "TEXT"},
-        ],
-        raise_on_duplicate=False,
-    )
-    inserted = 0
-    for start in range(0, len(rows), 1000):
-        inserted += await insert_rows(
-            table="ioc_inventory",
-            rows_data=rows[start:start + 1000],
-            upsert=True,
-        )
-    return {"inserted": inserted, "input_rows": len(rows)}
-```
-
-Keep `insert_rows` batches at or below 1000 rows. Before using \
-`insert_rows(..., upsert=True)`, create a unique index on the intended key \
-column; table creation alone does not create unique indexes.
-
 ### HTTP Request → HTTP Request
 ```yaml
 actions:
@@ -3270,9 +3195,7 @@ actions:
       instructions: "You are a SOC analyst. Be thorough."
       max_tool_calls: 10
 ```
-Prefer the `model` object for `ai.agent`; top-level `model_name` and \
-`model_provider` are deprecated unless the user explicitly asks for that legacy \
-shape.
+Use top-level `model_name` and `model_provider` only when explicitly requested.
 
 ### For-each Loop
 ```yaml

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -2993,7 +2993,7 @@ Common inline expression patterns:
 ```yaml
 args:
   display_name: '${{ TRIGGER.name || "unknown" }}'
-  summary: '${{ FN.concat("Found ", FN.length(ACTIONS.list_events.result.items), " events") }}'
+  summary: '${{ FN.concat("Found ", FN.length(ACTIONS.list_events.result), " events") }}'
   joined_ids: '${{ FN.join(ACTIONS.normalize.result.ids, ",") }}'
   since: '${{ FN.to_isoformat(FN.now() - FN.hours(4)) }}'
 ```

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -2728,6 +2728,9 @@ that specific integration/tool by name.
 you may discover and present candidate tools, but do NOT add any third-party \
 tool to workflow YAML until the user explicitly confirms the exact integration \
 they want.
+- Do not invent `tools.*` action names. Discover integrations with \
+`workflows_list_actions`, then inspect exact schemas with \
+`workflows_get_action_context` before authoring workflow YAML.
 - Prefer tool-agnostic workflow scaffolding with `core.http_request` and \
 `core.script.run_python` unless the user requests a specific third-party \
 integration.
@@ -2743,8 +2746,14 @@ args:
 ```
 - `core.script.run_python` can import Tracecat core actions:
 ```python
-from tracecat_registry.core.http import http_request
-from tracecat_registry.core.table import create_table, insert_row, insert_rows, lookup, update_row
+from tracecat_registry.core.http import http_request, http_paginate
+from tracecat_registry.core.table import create_table, insert_rows, lookup, update_row
+
+async def main(rows):
+    await create_table(name="inventory", columns=[{"name": "external_id", "type": "TEXT"}])
+    for start in range(0, len(rows), 1000):
+        await insert_rows(table="inventory", rows_data=rows[start:start + 1000], upsert=False)
+    return {"input_rows": len(rows), "sample": rows[:5]}
 ```
 
 ## Expression syntax (used in action `args:` values)
@@ -2760,21 +2769,41 @@ from tracecat_registry.core.table import create_table, insert_row, insert_rows, 
 Use `core.script.run_python` for list transformations, or `for_each` on actions.
 - **Important**: Use `None` (Python-style) NOT `null` (JSON-style) in expressions.
 
-## Scatter/Gather pattern (parallel fan-out)
-Within a scatter stream, each child action accesses its item via \
-`ACTIONS.<scatter_ref>.result`:
+## Loop and batching guidance
+- Use action-level `for_each` for simple per-item repetition of one action. It \
+runs iterations in parallel, so keep rate limits in mind.
+- Use `core.loop.start` / `core.loop.end` for while-style workflow loops where \
+the next iteration depends on prior action output.
+- Use `core.transform.scatter` / `core.transform.gather` only for true parallel \
+fan-out/fan-in where each item needs its own workflow execution stream. \
+Scatter/gather has overhead and can be much slower than `core.script.run_python` \
+for ordinary batched transforms.
+- Prefer `core.script.run_python` for list transforms, batching, joins, \
+dedupe, sorting, grouping, chunked table writes, and bounded async HTTP loops.
+
+Example `for_each`:
 ```yaml
-- ref: my_scatter
-  action: core.transform.scatter
-  args:
-    collection: ${{ ACTIONS.previous_step.result }}
 - ref: process_item
   action: core.http_request
-  depends_on: [my_scatter]
+  for_each: "${{ for var.item in TRIGGER.items }}"
   args:
-    url: "https://api.example.com/${{ ACTIONS.my_scatter.result.id }}"
+    url: "https://api.example.com/items/${{ var.item.id }}"
+    method: POST
+```
+
+Example scatter/gather for real parallel fan-out:
+```yaml
+- ref: scatter_items
+  action: core.transform.scatter
+  args:
+    collection: ${{ TRIGGER.items }}
+- ref: process_item
+  action: core.http_request
+  depends_on: [scatter_items]
+  args:
+    url: "https://api.example.com/items/${{ ACTIONS.scatter_items.result.id }}"
     method: GET
-- ref: my_gather
+- ref: gather_results
   action: core.transform.gather
   depends_on: [process_item]
   args:
@@ -2848,9 +2877,13 @@ Use `get_workflow` -> `edit_workflow(validate_only=true)` ->
       "path": "/definition/actions/-",
       "value": {
         "ref": "notify_owner",
-        "action": "core.noop",
+        "action": "core.http_request",
         "depends_on": ["parse_event"],
-        "args": {}
+        "args": {
+          "method": "POST",
+          "url": "https://api.example.com/notify",
+          "payload": {"owner": "${{ ACTIONS.parse_event.result.owner }}"}
+        }
       }
     },
     {
@@ -2945,11 +2978,17 @@ handle defaults in Python.
     allow_network: true
     script: |
       import json
-      from tracecat_registry.core.http import http_request
+      from tracecat_registry.core.http import http_paginate, http_request
       from tracecat_registry.core.table import insert_rows, lookup
 
-      def main(rows_json):
+      async def main(rows_json):
           rows = json.loads(rows_json or "[]")
+          for start in range(0, len(rows), 1000):
+              await insert_rows(
+                  table="automation_inventory",
+                  rows_data=rows[start:start + 1000],
+                  upsert=False,
+              )
           return {"count": len(rows), "rows": rows[:100]}
 ```
 
@@ -3017,7 +3056,7 @@ args:
 After running a workflow, use `list_workflow_executions` to see recent runs and their \
 statuses (COMPLETED, FAILED, RUNNING, etc.). Then use `get_workflow_execution` with the \
 execution ID to get a detailed event timeline showing each action's status, timing, \
-inputs, results, and errors. This is essential for diagnosing failed runs.
+inputs, results, and errors.
 
 ## Important: workflow actions vs MCP tools
 Action names like `core.http_request` are for use *inside* workflow YAML definitions \
@@ -3252,23 +3291,64 @@ extract_ipv4, extract_ipv6, extract_mac, extract_urls, normalize_email
 
 **IO**: parse_csv
 
-## Core Built-in Actions
+## Registered Core and AI Actions
 
-| Action | Description |
-|--------|-------------|
-| `core.http_request` | Make an HTTP request (GET, POST, PUT, DELETE, PATCH) |
-| `core.transform.reshape` | Reshape data using expressions |
-| `core.transform.scatter` | Fan-out: scatter a collection into parallel streams |
-| `core.transform.gather` | Fan-in: gather results from parallel streams into a list |
-| `core.transform.filter` | Filter a collection using a Python lambda |
-| `core.transform.map` | Map over items |
-| `core.script.run_python` | Run inline Python script in a sandbox |
-| `core.table.insert_row` | Insert a row into a table |
-| `core.table.lookup` | Lookup a value in a table |
-| `core.workflow.execute` | Execute a child workflow |
-| `ai.action` | Call an LLM (no tools), supports structured output via `output_type` |
-| `ai.agent` | AI agent with tool calling (can invoke Tracecat actions) |
-| `ai.preset_agent` | Run a saved agent preset by slug |
+Use these exact registered action names. For argument schemas, call
+`workflows_list_actions` and `workflows_get_action_context`.
+
+HTTP: `core.http_request`, `core.http_paginate`, `core.http_poll`
+
+Email: `core.send_email_smtp`
+
+DuckDB: `core.duckdb.execute_sql`
+
+SQL: `core.sql.execute_query`
+
+SSH: `core.ssh.execute_command`
+
+gRPC: `core.grpc.request`
+
+Transforms: `core.transform.apply`, `core.transform.deduplicate`,
+`core.transform.drop_nulls`, `core.transform.eval_jsonpaths`,
+`core.transform.filter`, `core.transform.flatten_json`,
+`core.transform.gather`, `core.transform.is_duplicate`,
+`core.transform.is_in`, `core.transform.map`, `core.transform.not_in`,
+`core.transform.reshape`, `core.transform.scatter`
+
+Loops: `core.loop.start`, `core.loop.end`
+
+Workflow: `core.workflow.execute`, `core.workflow.get_status`
+
+Tables: `core.table.create_table`, `core.table.delete_row`,
+`core.table.download`, `core.table.get_table_metadata`,
+`core.table.insert_row`, `core.table.insert_rows`, `core.table.is_in`,
+`core.table.list_tables`, `core.table.lookup`, `core.table.lookup_many`,
+`core.table.search_rows`, `core.table.update_row`
+
+Cases: `core.cases.add_case_tag`, `core.cases.assign_user`,
+`core.cases.assign_user_by_email`, `core.cases.create_case`,
+`core.cases.create_comment`, `core.cases.create_task`,
+`core.cases.delete_attachment`, `core.cases.delete_case`,
+`core.cases.delete_task`, `core.cases.download_attachment`,
+`core.cases.get_attachment`, `core.cases.get_attachment_download_url`,
+`core.cases.get_case`, `core.cases.get_case_metrics`,
+`core.cases.get_comment_thread`, `core.cases.get_task`,
+`core.cases.insert_row`, `core.cases.link_row`,
+`core.cases.list_attachments`, `core.cases.list_case_events`,
+`core.cases.list_cases`, `core.cases.list_comment_threads`,
+`core.cases.list_comments`, `core.cases.list_tasks`,
+`core.cases.remove_case_tag`, `core.cases.reply_to_comment`,
+`core.cases.search_cases`, `core.cases.unlink_row`,
+`core.cases.update_case`, `core.cases.update_comment`,
+`core.cases.update_task`, `core.cases.upload_attachment`,
+`core.cases.upload_attachment_from_url`
+
+Require/Python: `core.require`, `core.script.run_python`
+
+AI: `ai.action`, `ai.agent`, `ai.preset_agent`, `ai.rank_documents`,
+`ai.select_field`, `ai.select_fields`, `ai.agent.create_preset`,
+`ai.agent.delete_preset`, `ai.agent.get_preset`, `ai.agent.list_presets`,
+`ai.agent.update_preset`
 
 ## Third-Party Integration Action Syntax
 
@@ -3315,6 +3395,9 @@ actions:
 ```
 
 ### Scatter/Gather (Parallel Fan-out/Fan-in)
+Use scatter/gather only when each item needs its own workflow execution stream.
+It has orchestration overhead and can be much slower than a run-python loop for
+ordinary list transforms, batching, joins, dedupe, or chunked table writes.
 ```yaml
 actions:
   - ref: get_items


### PR DESCRIPTION
## Summary
- Simplify the Tracecat MCP server context so it keeps only compact usage/syntax notes instead of broad best-practice prose.
- Keep key syntax for `ai.agent` model objects and Tracecat core imports inside `core.script.run_python`.
- Add repo-local skills under `.agents/skills` for generic Tracecat automation best practices and Slackbot-specific best practices.

## Validation
- `python3 /Users/chris/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/tracecat-automation-best-practices`
- `python3 /Users/chris/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/tracecat-slackbot-best-practices`
- `uv run ruff check tracecat/mcp/server.py`
- Commit pre-commit hooks passed, including ruff, type check, and generated MCP docs hooks.