### PR TITLE
fix(executor): bound for_each iteration concurrency

### DIFF
--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -10,11 +10,13 @@ from pydantic import SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat_registry import RegistryOAuthSecret, SecretNotFoundError
 
+from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.db.models import RegistryVersion
 from tracecat.dsl.common import create_default_execution_context
 from tracecat.dsl.schemas import ActionStatement, RunActionInput, RunContext
 from tracecat.exceptions import ExecutionError, LoopExecutionError
+from tracecat.executor import service as executor_service
 from tracecat.executor.backends.test import TestBackend
 from tracecat.executor.schemas import ActionImplementation, ExecutorActionErrorInfo
 from tracecat.executor.service import (
@@ -852,6 +854,57 @@ async def test_dispatcher(
         assert e.value.loop_errors[0].info.loop_vars == {"x": None}
     finally:
         ctx_role.reset(token)
+
+
+@pytest.mark.anyio
+async def test_dispatch_action_for_each_uses_configured_worker_limit(
+    monkeypatch,
+    test_role,
+    mock_run_context,
+):
+    monkeypatch.setattr(config, "TRACECAT__EXECUTOR_FOR_EACH_MAX_CONCURRENCY", 2)
+
+    active_iterations = 0
+    max_active_iterations = 0
+
+    async def fake_invoke_once(
+        backend: TestBackend,
+        input: RunActionInput,
+        ctx: Any,
+        iteration: int | None = None,
+    ) -> int:
+        nonlocal active_iterations, max_active_iterations
+
+        assert iteration is not None
+        active_iterations += 1
+        max_active_iterations = max(max_active_iterations, active_iterations)
+        try:
+            await asyncio.sleep(0.01)
+            local_vars = input.exec_context.get("var")
+            assert local_vars is not None
+            return local_vars["x"]
+        finally:
+            active_iterations -= 1
+
+    monkeypatch.setattr(executor_service, "invoke_once", fake_invoke_once)
+
+    input = RunActionInput(
+        task=ActionStatement(
+            ref="test",
+            action="testing.add_100",
+            run_if=None,
+            args={"num": "${{ var.x }}"},
+            for_each="${{ for var.x in [1,2,3,4,5,6] }}",
+        ),
+        exec_context=create_default_execution_context(),
+        run_context=mock_run_context,
+        registry_lock=make_registry_lock("testing.add_100"),
+    )
+
+    result = await dispatch_action(TestBackend(), input)
+
+    assert result == [1, 2, 3, 4, 5, 6]
+    assert max_active_iterations == 2
 
 
 @pytest.fixture

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -129,6 +129,11 @@ TRACECAT__EXECUTOR_QUEUE = os.environ.get(
 )
 """Task queue for the ExecutorWorker (Temporal activity queue)."""
 
+TRACECAT__EXECUTOR_FOR_EACH_MAX_CONCURRENCY = int(
+    os.environ.get("TRACECAT__EXECUTOR_FOR_EACH_MAX_CONCURRENCY") or 4
+)
+"""Maximum concurrent iterations for a single executor-side action for_each loop."""
+
 TRACECAT__ACTIVITY_HEARTBEAT_TIMEOUT = int(
     os.environ.get("TRACECAT__ACTIVITY_HEARTBEAT_TIMEOUT") or 60
 )

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -873,13 +873,19 @@ async def dispatch_action(backend: ExecutorBackend, input: RunActionInput) -> An
 
     logger.info("Running for_each on action in parallel", action=task.action)
 
-    # Handle for_each by creating parallel executions
+    # Handle for_each by creating bounded parallel executions
     base_context = input.exec_context
     # We have a list of iterators that give a variable assignment path ".path.to.value"
     # and a collection of values as a tuple.
     iterators = get_iterables_from_expression(expr=task.for_each, operand=base_context)
 
     max_concurrency = max(1, config.TRACECAT__EXECUTOR_FOR_EACH_MAX_CONCURRENCY)
+    # Use a fixed worker pool instead of a semaphore around one task per loop item.
+    # A semaphore would cap active invokes, but still schedules every iteration and
+    # retains per-item task state for large loops. Workers pull lazily from the
+    # iterator, so memory and event-loop pressure scale with max_concurrency.
+    # Keep this loop-local; cross-activity caps must not use asyncio primitives
+    # because activities can run on different event loops.
     loop_items = iter(enumerate(zip(*iterators, strict=False)))
     results: dict[int, ExecutionResult] = {}
     iteration_count = 0

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -14,7 +14,6 @@ from tracecat import config
 from tracecat.auth.executor_tokens import mint_executor_token
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_action_scope
-from tracecat.concurrency import GatheringTaskGroup
 from tracecat.contexts import (
     ctx_interaction,
     ctx_logical_time,
@@ -880,25 +879,38 @@ async def dispatch_action(backend: ExecutorBackend, input: RunActionInput) -> An
     # and a collection of values as a tuple.
     iterators = get_iterables_from_expression(expr=task.for_each, operand=base_context)
 
-    tasks: list[asyncio.Task[ExecutionResult]] = []
+    max_concurrency = max(1, config.TRACECAT__EXECUTOR_FOR_EACH_MAX_CONCURRENCY)
+    loop_items = iter(enumerate(zip(*iterators, strict=False)))
+    results: dict[int, ExecutionResult] = {}
+    iteration_count = 0
+
+    async def worker() -> None:
+        nonlocal iteration_count
+
+        while True:
+            try:
+                i, items = next(loop_items)
+            except StopIteration:
+                return
+
+            iteration_count += 1
+            new_context = base_context.copy()
+            # Patch each loop variable
+            for iterator_path, iterator_value in items:
+                patch_object(
+                    obj=cast(MutableMapping[str, Any], new_context),
+                    path=ExprContext.LOCAL_VARS + iterator_path,
+                    value=iterator_value,
+                )
+            # Create a new task with the patched context
+            new_input = input.model_copy(update={"exec_context": new_context})
+            results[i] = await invoke_once(backend, new_input, ctx, iteration=i)
+
     try:
-        # Create a generator that zips the iterables together
-        # Iterate over the for_each items
-        async with GatheringTaskGroup() as tg:
-            for i, items in enumerate(zip(*iterators, strict=False)):
-                new_context = base_context.copy()
-                # Patch each loop variable
-                for iterator_path, iterator_value in items:
-                    patch_object(
-                        obj=cast(MutableMapping[str, Any], new_context),
-                        path=ExprContext.LOCAL_VARS + iterator_path,
-                        value=iterator_value,
-                    )
-                # Create a new task with the patched context
-                new_input = input.model_copy(update={"exec_context": new_context})
-                coro = invoke_once(backend, new_input, ctx, iteration=i)
-                tasks.append(tg.create_task(coro))
-        return tg.results()
+        async with asyncio.TaskGroup() as tg:
+            for _ in range(max_concurrency):
+                tg.create_task(worker())
+        return [results[i] for i in range(iteration_count)]
     except* ExecutionError as eg:
         loop_errors = flatten_wrapped_exc_error_group(eg)
         raise LoopExecutionError(loop_errors) from eg
@@ -914,10 +926,6 @@ async def dispatch_action(backend: ExecutorBackend, input: RunActionInput) -> An
             ),
             detail={"errors": errors},
         ) from eg
-    finally:
-        logger.debug("Shut down any pending tasks")
-        for t in tasks:
-            t.cancel()
 
 
 """Utilities"""


### PR DESCRIPTION
## Summary

- Add `TRACECAT__EXECUTOR_FOR_EACH_MAX_CONCURRENCY` with a default per-loop cap of 4.
- Replace eager task creation for executor-side `for_each` with a fixed worker pool so large loops do not schedule every iteration at once.
- Preserve map-style result ordering and add unit coverage for the configured worker limit.

## Notes

This is the short-term mitigation: it keeps context/materialization semantics inside the executor while bounding per-loop action fanout. A separate cross-activity process-level limiter can still be explored as the next phase.

## Tests

- `uv run pytest tests/unit/test_executor.py::test_dispatch_action_for_each_uses_configured_worker_limit`
- `uv run pytest tests/unit/test_executor.py tests/unit/test_executor_template_actions.py::test_template_action_for_each`
- `uv run ruff check tracecat/config.py tracecat/executor/service.py tests/unit/test_executor.py`
- `uv run ruff format --check tracecat/config.py tracecat/executor/service.py tests/unit/test_executor.py`
- `uv run pyright tracecat/config.py tracecat/executor/service.py tests/unit/test_executor.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound executor-side for_each concurrency with a per-loop cap to prevent unbounded fanout and reduce resource spikes. Adds a configurable limit (default 4) and preserves result order.

- **Bug Fixes**
  - Added `TRACECAT__EXECUTOR_FOR_EACH_MAX_CONCURRENCY` (default 4) to cap concurrent iterations.
  - Switched to a fixed worker pool (using `asyncio.TaskGroup`) that lazily pulls iterations; documented the rationale and cross-activity limits inline.
  - Preserved result ordering; added unit tests for the concurrency cap.

<sup>Written for commit 10b6ad4e78305a4d0895db69c900511dd88ecaad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

