### PR TITLE
fix(ui): sync workspace chat frontend plumbing

### DIFF
--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -33,7 +33,7 @@ import {
   Webhook,
 } from "lucide-react"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   type FieldErrors,
@@ -187,6 +187,7 @@ const RESERVED_SUBAGENT_ALIASES = new Set([
   "root",
   "task",
 ])
+const AGENT_PRESET_TAB_QUERY_PARAM = "tab"
 
 /**
  * Maps MCP integration slugs to provider IDs for icon lookup.
@@ -476,10 +477,14 @@ export function AgentPresetsBuilder({
   builderPrompt?: string
 }) {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const workspaceId = useWorkspaceId()
   const { hasEntitlement, isLoading: entitlementsLoading } = useEntitlements()
   const agentAddonsEnabled = hasEntitlement("agent_addons")
   const activePresetId = presetId
+  const queryTab = parseAgentPresetSideTab(
+    searchParams.get(AGENT_PRESET_TAB_QUERY_PARAM)
+  )
 
   const { presets, presetsIsLoading, presetsError } = useAgentPresets(
     workspaceId,
@@ -527,9 +532,24 @@ export function AgentPresetsBuilder({
         return
       }
       const nextPath = `/workspaces/${workspaceId}/agents/${normalizedId}`
-      router.replace(nextPath)
+      const params = new URLSearchParams(searchParams.toString())
+      const queryString = params.toString()
+      router.replace(queryString ? `${nextPath}?${queryString}` : nextPath)
     },
-    [activePresetId, router, workspaceId]
+    [activePresetId, router, searchParams, workspaceId]
+  )
+
+  const handleTabChange = useCallback(
+    (tab: AgentPresetSideTab) => {
+      const params = new URLSearchParams(searchParams.toString())
+      params.set(AGENT_PRESET_TAB_QUERY_PARAM, tab)
+      const queryString = params.toString()
+      const path = activePresetId
+        ? `/workspaces/${workspaceId}/agents/${activePresetId}`
+        : `/workspaces/${workspaceId}/agents`
+      router.replace(queryString ? `${path}?${queryString}` : path)
+    },
+    [activePresetId, router, searchParams, workspaceId]
   )
 
   const {
@@ -684,6 +704,8 @@ export function AgentPresetsBuilder({
               }
             : undefined
         }
+        initialTab={queryTab ?? "live-chat"}
+        onTabChange={handleTabChange}
       />
     </div>
   )
@@ -1025,6 +1047,26 @@ type AgentPresetSideTab =
   | "structured-output"
   | "versions"
 
+const AGENT_PRESET_SIDE_TABS = new Set<AgentPresetSideTab>([
+  "live-chat",
+  "assistant",
+  "configuration",
+  "subagents",
+  "skills",
+  "channels",
+  "structured-output",
+  "versions",
+])
+
+function parseAgentPresetSideTab(
+  value: string | null | undefined
+): AgentPresetSideTab | null {
+  if (!value || !AGENT_PRESET_SIDE_TABS.has(value as AgentPresetSideTab)) {
+    return null
+  }
+  return value as AgentPresetSideTab
+}
+
 function getAgentPresetErrorTab(
   errors: FieldErrors<AgentPresetFormValues>
 ): AgentPresetSideTab | null {
@@ -1264,6 +1306,8 @@ type AgentPresetFormProps = {
   enabledModelsLoaded: boolean
   mcpIntegrations: McpIntegrationOption[]
   mcpIntegrationsIsLoading: boolean
+  initialTab?: AgentPresetSideTab
+  onTabChange?: (tab: AgentPresetSideTab) => void
 }
 
 function AgentPresetForm({
@@ -1284,11 +1328,13 @@ function AgentPresetForm({
   enabledModelsLoaded,
   mcpIntegrations,
   mcpIntegrationsIsLoading,
+  initialTab = "live-chat",
+  onTabChange,
 }: AgentPresetFormProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [isDuplicating, setIsDuplicating] = useState(false)
   const isDuplicatingRef = useRef(false)
-  const [activeTab, setActiveTab] = useState<AgentPresetSideTab>("live-chat")
+  const [activeTab, setActiveTab] = useState<AgentPresetSideTab>(initialTab)
   const { isFeatureEnabled: isFeatureEnabledFlag } = useFeatureFlag()
   const channelsEnabled = isFeatureEnabledFlag("agent-channels")
   const form = useForm<AgentPresetFormValues>({
@@ -1326,6 +1372,18 @@ function AgentPresetForm({
       enabled:
         watchedAgentsEnabled && selectedPinnedSubagentPresetIds.length > 0,
     }
+  )
+
+  useEffect(() => {
+    setActiveTab(initialTab)
+  }, [initialTab])
+
+  const handleTabChange = useCallback(
+    (tab: AgentPresetSideTab) => {
+      setActiveTab(tab)
+      onTabChange?.(tab)
+    },
+    [onTabChange]
   )
 
   const handleConfirmDelete = async () => {
@@ -1453,7 +1511,7 @@ function AgentPresetForm({
               message: eligibilityIssue.message,
             }
           )
-          setActiveTab("subagents")
+          handleTabChange("subagents")
           return
         }
       }
@@ -1473,7 +1531,7 @@ function AgentPresetForm({
     (errors) => {
       const nextTab = getAgentPresetErrorTab(errors)
       if (nextTab) {
-        setActiveTab(nextTab)
+        handleTabChange(nextTab)
       }
     }
   )
@@ -1580,7 +1638,7 @@ function AgentPresetForm({
           <ResizablePanel defaultSize={38} minSize={26}>
             <AgentPresetRightPanel
               activeTab={effectiveTab}
-              onTabChange={setActiveTab}
+              onTabChange={handleTabChange}
               channelsEnabled={channelsEnabled}
               preset={preset}
               workspaceId={workspaceId}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,10 +4,12 @@ const { fontFamily } = require("tailwindcss/defaultTheme")
 module.exports = {
   darkMode: ["class"],
   content: [
-    "src/**/*.{ts,tsx}",
     "src/app/**/*.{ts,tsx}",
     "src/components/**/*.{ts,tsx}",
-    "src/pages/**/*.{ts,tsx}",
+    "src/config/**/*.{ts,tsx}",
+    "src/hooks/**/*.{ts,tsx}",
+    "src/lib/**/*.{ts,tsx}",
+    "src/providers/**/*.{ts,tsx}",
   ],
   theme: {
     container: {

--- a/packages/tracecat-registry/tracecat_registry/core/presets.py
+++ b/packages/tracecat-registry/tracecat_registry/core/presets.py
@@ -36,15 +36,28 @@ async def create_preset(
         ),
     ],
     model_name: Annotated[
-        str,
+        str | None,
         Doc(
-            "The LLM model name to use (e.g., 'gpt-4', 'claude-3-opus', 'gemini-pro')."
+            "Deprecated legacy model name retained for backward compatibility. "
+            "Prefer `catalog_id`, which is the canonical model selector. If omitted, "
+            "the workspace default model is used."
         ),
-    ],
+    ] = None,
     model_provider: Annotated[
-        str,
-        Doc("The LLM provider identifier (e.g., 'openai', 'anthropic', 'google')."),
-    ],
+        str | None,
+        Doc(
+            "Deprecated legacy model provider retained for backward compatibility. "
+            "Prefer `catalog_id`, which is the canonical model selector. If omitted, "
+            "the workspace default provider is used."
+        ),
+    ] = None,
+    catalog_id: Annotated[
+        str | None,
+        Doc(
+            "Canonical model catalog row ID backing this preset. Prefer this over "
+            "legacy `model_name` and `model_provider`."
+        ),
+    ] = None,
     slug: Annotated[
         str | None,
         Doc(
@@ -79,19 +92,51 @@ async def create_preset(
             "List of action identifiers that the agent can use as tools. Format: 'namespace.action' (e.g., ['core.cases.create_case', 'core.cases.update_case']). These actions become available to the agent during execution."
         ),
     ] = None,
-    skills: Annotated[
-        list[dict[str, str]] | None,
+    namespaces: Annotated[
+        list[str] | None,
+        Doc("Optional namespaces to scope dynamic tool discovery."),
+    ] = None,
+    tool_approvals: Annotated[
+        dict[str, bool] | None,
         Doc(
-            "List of skill bindings to attach to the preset. Each entry must include 'skill_id' and 'skill_version_id' UUID strings for a published skill version."
+            "Per-tool approval map. True means the tool requires manual approval; false means auto-run."
         ),
+    ] = None,
+    mcp_integrations: Annotated[
+        list[str] | None,
+        Doc("Optional workspace MCP integration IDs to expose to the preset."),
+    ] = None,
+    agents: Annotated[
+        dict[str, Any] | None,
+        Doc("Optional subagent configuration with `enabled` and `subagents` fields."),
+    ] = None,
+    retries: Annotated[
+        int | None,
+        Doc("Maximum retry count for the preset."),
+    ] = None,
+    enable_thinking: Annotated[
+        bool | None,
+        Doc("Whether to enable model thinking where supported."),
+    ] = None,
+    enable_internet_access: Annotated[
+        bool | None,
+        Doc("Whether to enable internet access for the preset runtime."),
+    ] = None,
+    skills: Annotated[
+        list[dict[str, Any]] | None,
+        Doc("Optional skill bindings for the preset."),
     ] = None,
 ) -> dict[str, Any]:
     # Build kwargs, only including non-None values
-    kwargs: dict[str, Any] = {
-        "name": name,
-        "model_name": model_name,
-        "model_provider": model_provider,
-    }
+    kwargs: dict[str, Any] = {"name": name}
+    # Deprecated legacy fields retained for backward compatibility.
+    # catalog_id is the canonical model selector for new callers.
+    if model_name is not None:
+        kwargs["model_name"] = model_name
+    if model_provider is not None:
+        kwargs["model_provider"] = model_provider
+    if catalog_id is not None:
+        kwargs["catalog_id"] = catalog_id
     if slug is not None:
         kwargs["slug"] = slug
     if description is not None:
@@ -104,6 +149,20 @@ async def create_preset(
         kwargs["output_type"] = output_type
     if actions is not None:
         kwargs["actions"] = actions
+    if namespaces is not None:
+        kwargs["namespaces"] = namespaces
+    if tool_approvals is not None:
+        kwargs["tool_approvals"] = tool_approvals
+    if mcp_integrations is not None:
+        kwargs["mcp_integrations"] = mcp_integrations
+    if agents is not None:
+        kwargs["agents"] = agents
+    if retries is not None:
+        kwargs["retries"] = retries
+    if enable_thinking is not None:
+        kwargs["enable_thinking"] = enable_thinking
+    if enable_internet_access is not None:
+        kwargs["enable_internet_access"] = enable_internet_access
     if skills is not None:
         kwargs["skills"] = skills
 
@@ -157,11 +216,24 @@ async def update_preset(
     ] = None,
     model_name: Annotated[
         str | None,
-        Doc("The updated LLM model name (e.g., 'gpt-4', 'claude-3-opus')."),
+        Doc(
+            "Deprecated legacy model name retained for backward compatibility. "
+            "Prefer `catalog_id`, which is the canonical model selector."
+        ),
     ] = None,
     model_provider: Annotated[
         str | None,
-        Doc("The updated LLM provider identifier (e.g., 'openai', 'anthropic')."),
+        Doc(
+            "Deprecated legacy model provider retained for backward compatibility. "
+            "Prefer `catalog_id`, which is the canonical model selector."
+        ),
+    ] = None,
+    catalog_id: Annotated[
+        str | None,
+        Doc(
+            "The updated canonical model catalog row ID backing this preset. Prefer "
+            "this over legacy `model_name` and `model_provider`."
+        ),
     ] = None,
     new_slug: Annotated[
         str | None,
@@ -197,21 +269,55 @@ async def update_preset(
             "The updated list of action identifiers that the agent can use as tools. Format: 'namespace.action' (e.g., ['core.cases.create_case'])."
         ),
     ] = None,
-    skills: Annotated[
-        list[dict[str, str]] | None,
+    namespaces: Annotated[
+        list[str] | None,
+        Doc("The updated namespaces to scope dynamic tool discovery."),
+    ] = None,
+    tool_approvals: Annotated[
+        dict[str, bool] | None,
         Doc(
-            "The updated skill bindings for the preset. Each entry must include 'skill_id' and 'skill_version_id' UUID strings for a published skill version."
+            "The updated per-tool approval map. True means the tool requires manual approval; false means auto-run."
         ),
+    ] = None,
+    mcp_integrations: Annotated[
+        list[str] | None,
+        Doc("The updated workspace MCP integration IDs to expose to the preset."),
+    ] = None,
+    agents: Annotated[
+        dict[str, Any] | None,
+        Doc(
+            "The updated subagent configuration with `enabled` and `subagents` fields."
+        ),
+    ] = None,
+    retries: Annotated[
+        int | None,
+        Doc("The updated retry count."),
+    ] = None,
+    enable_thinking: Annotated[
+        bool | None,
+        Doc("Whether to enable model thinking where supported."),
+    ] = None,
+    enable_internet_access: Annotated[
+        bool | None,
+        Doc("Whether to enable internet access for the preset runtime."),
+    ] = None,
+    skills: Annotated[
+        list[dict[str, Any]] | None,
+        Doc("The updated skill bindings for the preset."),
     ] = None,
 ) -> dict[str, Any]:
     # Build kwargs, only including non-None values
     kwargs: dict[str, Any] = {}
     if name is not None:
         kwargs["name"] = name
+    # Deprecated legacy fields retained for backward compatibility.
+    # catalog_id is the canonical model selector for new callers.
     if model_name is not None:
         kwargs["model_name"] = model_name
     if model_provider is not None:
         kwargs["model_provider"] = model_provider
+    if catalog_id is not None:
+        kwargs["catalog_id"] = catalog_id
     if new_slug is not None:
         kwargs["new_slug"] = new_slug
     if description is not None:
@@ -224,6 +330,20 @@ async def update_preset(
         kwargs["output_type"] = output_type
     if actions is not None:
         kwargs["actions"] = actions
+    if namespaces is not None:
+        kwargs["namespaces"] = namespaces
+    if tool_approvals is not None:
+        kwargs["tool_approvals"] = tool_approvals
+    if mcp_integrations is not None:
+        kwargs["mcp_integrations"] = mcp_integrations
+    if agents is not None:
+        kwargs["agents"] = agents
+    if retries is not None:
+        kwargs["retries"] = retries
+    if enable_thinking is not None:
+        kwargs["enable_thinking"] = enable_thinking
+    if enable_internet_access is not None:
+        kwargs["enable_internet_access"] = enable_internet_access
     if skills is not None:
         kwargs["skills"] = skills
 

--- a/packages/tracecat-registry/tracecat_registry/core/table.py
+++ b/packages/tracecat-registry/tracecat_registry/core/table.py
@@ -332,6 +332,99 @@ async def get_table_metadata(
 
 
 @registry.register(
+    default_title="Update table",
+    description="Rename a table by name.",
+    display_group="Tables",
+    namespace="core.table",
+)
+async def update_table(
+    name: Annotated[
+        str,
+        Doc("The current name of the table to update."),
+    ],
+    new_name: Annotated[
+        str,
+        Doc("The new table name."),
+    ],
+) -> types.TableRead:
+    return await get_context().tables.update_table(name=name, new_name=new_name)
+
+
+@registry.register(
+    default_title="Create column",
+    description="Add a column to an existing table.",
+    display_group="Tables",
+    namespace="core.table",
+)
+async def create_column(
+    table: Annotated[
+        str,
+        Doc("The table to add the column to."),
+    ],
+    column: Annotated[
+        dict[str, Any],
+        Doc(
+            "Column definition with required `name` and uppercase `type`, plus "
+            "optional `nullable`, `default`, and `options` fields. Use `TEXT`, "
+            "`INTEGER`, `NUMERIC`, `BOOLEAN`, `DATE`, `TIMESTAMPTZ`, `JSONB`, "
+            "`SELECT`, or `MULTI_SELECT`. `options` is required for `SELECT` "
+            "and `MULTI_SELECT`."
+        ),
+    ],
+) -> types.TableRead:
+    return await get_context().tables.create_column(table=table, column=column)
+
+
+@registry.register(
+    default_title="Update column",
+    description="Update a table column's name, type, nullability, default, index, or options.",
+    display_group="Tables",
+    namespace="core.table",
+)
+async def update_column(
+    table: Annotated[
+        str,
+        Doc("The table containing the column."),
+    ],
+    column: Annotated[
+        str,
+        Doc("The current column name."),
+    ],
+    update: Annotated[
+        dict[str, Any],
+        Doc(
+            "Partial column update. Supported fields: `name`, `type`, "
+            "`nullable`, `default`, `is_index`, and `options`."
+        ),
+    ],
+) -> types.TableRead:
+    return await get_context().tables.update_column(
+        table=table,
+        column=column,
+        update=update,
+    )
+
+
+@registry.register(
+    default_title="Delete column",
+    description="Delete a column from an existing table.",
+    display_group="Tables",
+    namespace="core.table",
+)
+async def delete_column(
+    table: Annotated[
+        str,
+        Doc("The table containing the column."),
+    ],
+    column: Annotated[
+        str,
+        Doc("The column name to delete."),
+    ],
+) -> types.TableRead:
+    return await get_context().tables.delete_column(table=table, column=column)
+
+
+@registry.register(
     default_title="Download table data",
     description="Download a table's data by name as list of dicts, JSON string, NDJSON string, CSV or Markdown.",
     display_group="Tables",

--- a/packages/tracecat-registry/tracecat_registry/sdk/agents.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/agents.py
@@ -588,22 +588,35 @@ class AgentsClient:
         self,
         *,
         name: str,
-        model_name: str,
-        model_provider: str,
+        model_name: str | Unset = UNSET,
+        model_provider: str | Unset = UNSET,
+        catalog_id: str | Unset = UNSET,
         slug: str | Unset = UNSET,
         description: str | Unset = UNSET,
         instructions: str | Unset = UNSET,
         base_url: str | Unset = UNSET,
         output_type: str | dict[str, Any] | Unset = UNSET,
         actions: list[str] | Unset = UNSET,
-        skills: list[AgentPresetSkillBinding] | Unset = UNSET,
+        namespaces: list[str] | Unset = UNSET,
+        tool_approvals: dict[str, bool] | Unset = UNSET,
+        mcp_integrations: list[str] | Unset = UNSET,
+        agents: dict[str, Any] | Unset = UNSET,
+        retries: int | Unset = UNSET,
+        enable_thinking: bool | Unset = UNSET,
+        enable_internet_access: bool | Unset = UNSET,
+        skills: list[dict[str, Any]] | Unset = UNSET,
     ) -> dict[str, Any]:
         """Create a new agent preset.
 
         Args:
             name: Human-readable name for the preset.
-            model_name: LLM model name (e.g., 'gpt-4', 'claude-3-opus').
-            model_provider: LLM provider identifier (e.g., 'openai', 'anthropic').
+            model_name: Deprecated legacy model name retained for backward
+                compatibility. Prefer catalog_id. Defaults to workspace default
+                if omitted.
+            model_provider: Deprecated legacy model provider retained for backward
+                compatibility. Prefer catalog_id. Defaults to workspace default
+                if omitted.
+            catalog_id: Canonical model catalog row ID backing this preset.
             slug: URL-friendly identifier. Auto-generated from name if not provided.
             description: Brief description of the preset's purpose.
             instructions: System instructions/prompt for the agent.
@@ -614,11 +627,15 @@ class AgentsClient:
         Returns:
             Created preset data.
         """
-        data: dict[str, Any] = {
-            "name": name,
-            "model_name": model_name,
-            "model_provider": model_provider,
-        }
+        data: dict[str, Any] = {"name": name}
+        # Deprecated legacy fields retained for backward compatibility.
+        # catalog_id is the canonical model selector for new callers.
+        if is_set(model_name):
+            data["model_name"] = model_name
+        if is_set(model_provider):
+            data["model_provider"] = model_provider
+        if is_set(catalog_id):
+            data["catalog_id"] = catalog_id
         if is_set(slug):
             data["slug"] = slug
         if is_set(description):
@@ -631,6 +648,20 @@ class AgentsClient:
             data["output_type"] = output_type
         if is_set(actions):
             data["actions"] = actions
+        if is_set(namespaces):
+            data["namespaces"] = namespaces
+        if is_set(tool_approvals):
+            data["tool_approvals"] = tool_approvals
+        if is_set(mcp_integrations):
+            data["mcp_integrations"] = mcp_integrations
+        if is_set(agents):
+            data["agents"] = agents
+        if is_set(retries):
+            data["retries"] = retries
+        if is_set(enable_thinking):
+            data["enable_thinking"] = enable_thinking
+        if is_set(enable_internet_access):
+            data["enable_internet_access"] = enable_internet_access
         if is_set(skills):
             data["skills"] = skills
         return await self._client.post("/agent/presets", json=data)
@@ -659,10 +690,18 @@ class AgentsClient:
         instructions: str | Unset = UNSET,
         model_name: str | Unset = UNSET,
         model_provider: str | Unset = UNSET,
+        catalog_id: str | Unset = UNSET,
         base_url: str | Unset = UNSET,
         output_type: str | dict[str, Any] | Unset = UNSET,
         actions: list[str] | Unset = UNSET,
-        skills: list[AgentPresetSkillBinding] | Unset = UNSET,
+        namespaces: list[str] | Unset = UNSET,
+        tool_approvals: dict[str, bool] | Unset = UNSET,
+        mcp_integrations: list[str] | Unset = UNSET,
+        agents: dict[str, Any] | Unset = UNSET,
+        retries: int | Unset = UNSET,
+        enable_thinking: bool | Unset = UNSET,
+        enable_internet_access: bool | Unset = UNSET,
+        skills: list[dict[str, Any]] | Unset = UNSET,
     ) -> dict[str, Any]:
         """Update an existing agent preset.
 
@@ -672,8 +711,11 @@ class AgentsClient:
             new_slug: Updated slug identifier.
             description: Updated description.
             instructions: Updated system instructions.
-            model_name: Updated LLM model name.
-            model_provider: Updated LLM provider.
+            model_name: Deprecated legacy model name retained for backward
+                compatibility. Prefer catalog_id.
+            model_provider: Deprecated legacy model provider retained for backward
+                compatibility. Prefer catalog_id.
+            catalog_id: Canonical model catalog row ID backing this preset.
             base_url: Updated custom API endpoint URL.
             output_type: Updated output format.
             actions: Updated list of action identifiers.
@@ -693,16 +735,34 @@ class AgentsClient:
             data["description"] = description
         if is_set(instructions):
             data["instructions"] = instructions
+        # Deprecated legacy fields retained for backward compatibility.
+        # catalog_id is the canonical model selector for new callers.
         if is_set(model_name):
             data["model_name"] = model_name
         if is_set(model_provider):
             data["model_provider"] = model_provider
+        if is_set(catalog_id):
+            data["catalog_id"] = catalog_id
         if is_set(base_url):
             data["base_url"] = base_url
         if is_set(output_type):
             data["output_type"] = output_type
         if is_set(actions):
             data["actions"] = actions
+        if is_set(namespaces):
+            data["namespaces"] = namespaces
+        if is_set(tool_approvals):
+            data["tool_approvals"] = tool_approvals
+        if is_set(mcp_integrations):
+            data["mcp_integrations"] = mcp_integrations
+        if is_set(agents):
+            data["agents"] = agents
+        if is_set(retries):
+            data["retries"] = retries
+        if is_set(enable_thinking):
+            data["enable_thinking"] = enable_thinking
+        if is_set(enable_internet_access):
+            data["enable_internet_access"] = enable_internet_access
         if is_set(skills):
             data["skills"] = skills
         return await self._client.patch(f"/agent/presets/by-slug/{slug}", json=data)

--- a/packages/tracecat-registry/tracecat_registry/sdk/tables.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/tables.py
@@ -51,6 +51,46 @@ class TablesClient:
         """Get table metadata and columns by name."""
         return await self._client.get(f"/tables/{name}/metadata")
 
+    async def update_table(
+        self,
+        *,
+        name: str,
+        new_name: str,
+    ) -> types.TableRead:
+        """Rename a table by name."""
+        return await self._client.patch(f"/tables/{name}", json={"name": new_name})
+
+    async def create_column(
+        self,
+        *,
+        table: str,
+        column: dict[str, Any],
+    ) -> types.TableRead:
+        """Create a column on a table by name."""
+        return await self._client.post(f"/tables/{table}/columns", json=column)
+
+    async def update_column(
+        self,
+        *,
+        table: str,
+        column: str,
+        update: dict[str, Any],
+    ) -> types.TableRead:
+        """Update a column on a table by table and column name."""
+        return await self._client.patch(
+            f"/tables/{table}/columns/{column}",
+            json=update,
+        )
+
+    async def delete_column(
+        self,
+        *,
+        table: str,
+        column: str,
+    ) -> types.TableRead:
+        """Delete a column from a table by table and column name."""
+        return await self._client.delete(f"/tables/{table}/columns/{column}")
+
     async def lookup(
         self,
         *,

--- a/packages/tracecat-registry/tracecat_registry/types.py
+++ b/packages/tracecat-registry/tracecat_registry/types.py
@@ -699,14 +699,27 @@ class AgentPresetRead(TypedDict):
     """Agent preset information."""
 
     id: UUID
+    workspace_id: UUID
     name: str
     slug: str
+    # Deprecated legacy model fields retained for backward compatibility.
+    # catalog_id is the canonical model selector for new callers.
     model_name: str
     model_provider: str
+    catalog_id: UUID | None
     description: str | None
     instructions: str | None
     base_url: str | None
     output_type: Any
     actions: list[str] | None
+    namespaces: list[str] | None
+    tool_approvals: dict[str, bool] | None
+    mcp_integrations: list[str] | None
+    agents: dict[str, Any]
+    retries: int
+    enable_thinking: bool
+    enable_internet_access: bool
+    skills: list[dict[str, Any]]
+    current_version_id: UUID | None
     created_at: datetime
     updated_at: datetime

--- a/tests/registry/test_agents_sdk.py
+++ b/tests/registry/test_agents_sdk.py
@@ -14,6 +14,7 @@ from tracecat_registry.sdk.agents import AgentConfig, AgentsClient
 def mock_tracecat_client() -> MagicMock:
     client = MagicMock()
     client.get = AsyncMock()
+    client.patch = AsyncMock()
     client.post = AsyncMock()
     return client
 
@@ -172,4 +173,68 @@ async def test_restore_skill_version_uses_restore_endpoint(
     assert result == {"current_version_id": "version-id"}
     mock_tracecat_client.post.assert_awaited_once_with(
         "/agent/skills/skill-id/versions/version-id/restore"
+    )
+
+
+@pytest.mark.anyio
+async def test_create_preset_omits_model_fields_when_not_provided(
+    agents_client: AgentsClient,
+    mock_tracecat_client: MagicMock,
+) -> None:
+    await agents_client.create_preset(
+        name="Case Triage",
+        actions=["core.cases.create_case"],
+        enable_internet_access=True,
+    )
+
+    mock_tracecat_client.post.assert_awaited_once_with(
+        "/agent/presets",
+        json={
+            "name": "Case Triage",
+            "actions": ["core.cases.create_case"],
+            "enable_internet_access": True,
+        },
+    )
+
+
+@pytest.mark.anyio
+async def test_create_preset_accepts_canonical_catalog_id_without_legacy_model_fields(
+    agents_client: AgentsClient,
+    mock_tracecat_client: MagicMock,
+) -> None:
+    await agents_client.create_preset(
+        name="Case Triage",
+        catalog_id="catalog_123",
+    )
+
+    mock_tracecat_client.post.assert_awaited_once_with(
+        "/agent/presets",
+        json={
+            "name": "Case Triage",
+            "catalog_id": "catalog_123",
+        },
+    )
+
+
+@pytest.mark.anyio
+async def test_update_preset_serializes_authoring_fields(
+    agents_client: AgentsClient,
+    mock_tracecat_client: MagicMock,
+) -> None:
+    await agents_client.update_preset(
+        "case-triage",
+        instructions="Triage cases.",
+        tool_approvals={"core.cases.update_case": True},
+        agents={"enabled": True, "subagents": []},
+        skills=[{"slug": "triage", "settings": {}}],
+    )
+
+    mock_tracecat_client.patch.assert_awaited_once_with(
+        "/agent/presets/by-slug/case-triage",
+        json={
+            "instructions": "Triage cases.",
+            "tool_approvals": {"core.cases.update_case": True},
+            "agents": {"enabled": True, "subagents": []},
+            "skills": [{"slug": "triage", "settings": {}}],
+        },
     )

--- a/tests/registry/test_tables_sdk.py
+++ b/tests/registry/test_tables_sdk.py
@@ -14,6 +14,8 @@ from tracecat_registry.types import TableSearchResponse
 def mock_tracecat_client() -> MagicMock:
     """Create a mock TracecatClient."""
     client = MagicMock()
+    client.delete = AsyncMock()
+    client.patch = AsyncMock()
     client.post = AsyncMock()
     return client
 
@@ -52,6 +54,40 @@ async def test_search_rows_normalizes_legacy_rows_payload(
     assert paginated_result["has_more"] is True
     assert paginated_result["has_previous"] is False
     assert paginated_result.get("total_estimate") == 7
+
+
+@pytest.mark.anyio
+async def test_table_schema_helpers_use_internal_table_paths(
+    tables_client: TablesClient, mock_tracecat_client: MagicMock
+) -> None:
+    """Schema editing helpers call the expected internal table endpoints."""
+    column = {"name": "score", "type": "NUMERIC"}
+    update = {"nullable": False}
+
+    await tables_client.update_table(name="indicators", new_name="indicators_v2")
+    await tables_client.create_column(table="indicators_v2", column=column)
+    await tables_client.update_column(
+        table="indicators_v2",
+        column="score",
+        update=update,
+    )
+    await tables_client.delete_column(table="indicators_v2", column="score")
+
+    mock_tracecat_client.patch.assert_any_await(
+        "/tables/indicators",
+        json={"name": "indicators_v2"},
+    )
+    mock_tracecat_client.post.assert_any_await(
+        "/tables/indicators_v2/columns",
+        json=column,
+    )
+    mock_tracecat_client.patch.assert_any_await(
+        "/tables/indicators_v2/columns/score",
+        json=update,
+    )
+    mock_tracecat_client.delete.assert_awaited_once_with(
+        "/tables/indicators_v2/columns/score"
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_agent_presets.py
+++ b/tests/unit/api/test_api_agent_presets.py
@@ -7,9 +7,75 @@ from unittest.mock import AsyncMock
 import pytest
 from fastapi import HTTPException, status
 
+from tracecat.agent.preset import internal_router as agent_preset_internal_router
 from tracecat.agent.preset import router as agent_preset_router
 from tracecat.auth.types import Role
-from tracecat.exceptions import TracecatValidationError
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+
+
+@pytest.mark.anyio
+async def test_create_preset_payload_backfills_legacy_model_fields(
+    test_admin_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog_id = uuid.uuid4()
+
+    class FakeAgentManagementService:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def get_default_model_selection(self) -> SimpleNamespace:
+            return SimpleNamespace(
+                model_name="claude-sonnet-4",
+                model_provider="anthropic",
+                catalog_id=catalog_id,
+            )
+
+    monkeypatch.setattr(
+        agent_preset_internal_router,
+        "AgentManagementService",
+        FakeAgentManagementService,
+    )
+
+    payload = await agent_preset_internal_router._create_payload_with_default_model(
+        role=test_admin_role,
+        session=AsyncMock(),
+        params=agent_preset_internal_router.PresetCreateRequest(name="Case Triage"),
+    )
+
+    assert payload == {
+        "name": "Case Triage",
+        # AgentPresetCreate still requires these deprecated legacy fields.
+        "model_name": "claude-sonnet-4",
+        "model_provider": "anthropic",
+        "catalog_id": catalog_id,
+    }
+
+
+@pytest.mark.anyio
+async def test_create_preset_payload_requires_default_model_selection(
+    test_admin_role: Role,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeAgentManagementService:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def get_default_model_selection(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        agent_preset_internal_router,
+        "AgentManagementService",
+        FakeAgentManagementService,
+    )
+
+    with pytest.raises(TracecatNotFoundError, match="No default model set"):
+        await agent_preset_internal_router._create_payload_with_default_model(
+            role=test_admin_role,
+            session=AsyncMock(),
+            params=agent_preset_internal_router.PresetCreateRequest(name="Case Triage"),
+        )
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_internal_tables.py
+++ b/tests/unit/api/test_api_internal_tables.py
@@ -9,7 +9,7 @@ from fastapi import status
 from fastapi.testclient import TestClient
 
 from tracecat.auth.types import Role
-from tracecat.db.models import Table, Workspace
+from tracecat.db.models import Table, TableColumn, Workspace
 from tracecat.tables import internal_router as internal_tables_router
 
 
@@ -24,6 +24,111 @@ def mock_table(test_workspace: Workspace) -> Table:
     )
     table.columns = []
     return table
+
+
+@pytest.fixture
+def mock_table_column(mock_table: Table) -> TableColumn:
+    column = TableColumn(
+        id=uuid.UUID("eeeeeeee-eeee-4eee-eeee-eeeeeeeeeeee"),
+        table_id=mock_table.id,
+        name="score",
+        type="NUMERIC",
+        nullable=True,
+        default=None,
+    )
+    column.table = mock_table
+    mock_table.columns = [column]
+    return column
+
+
+@pytest.mark.anyio
+async def test_internal_update_table_returns_metadata(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    with patch.object(internal_tables_router, "TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_table.name = "indicators_v2"
+        mock_svc.get_table_by_name.return_value = mock_table
+        mock_svc.update_table.return_value = mock_table
+        mock_svc.get_index.return_value = set()
+        MockService.return_value = mock_svc
+
+        response = client.patch(
+            "/internal/tables/indicators",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"name": "indicators_v2"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "id": str(mock_table.id),
+        "name": "indicators_v2",
+        "columns": [],
+    }
+
+
+@pytest.mark.anyio
+async def test_internal_create_column_returns_refreshed_metadata(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+    mock_table_column: TableColumn,
+) -> None:
+    with patch.object(internal_tables_router, "TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_table_by_name.return_value = mock_table
+        mock_svc.create_column.return_value = mock_table_column
+        mock_svc.get_table.return_value = mock_table
+        mock_svc.get_index.return_value = {"score"}
+        MockService.return_value = mock_svc
+
+        response = client.post(
+            f"/internal/tables/{mock_table.name}/columns",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"name": "score", "type": "NUMERIC"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "id": str(mock_table.id),
+        "name": mock_table.name,
+        "columns": [
+            {
+                "id": str(mock_table_column.id),
+                "name": "score",
+                "type": "NUMERIC",
+                "nullable": True,
+                "default": None,
+                "is_index": True,
+                "options": None,
+            }
+        ],
+    }
+
+
+@pytest.mark.anyio
+async def test_internal_update_column_404s_when_column_missing(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_table: Table,
+) -> None:
+    with patch.object(internal_tables_router, "TablesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_svc.get_table_by_name.return_value = mock_table
+        MockService.return_value = mock_svc
+
+        response = client.patch(
+            f"/internal/tables/{mock_table.name}/columns/missing",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={"nullable": False},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert (
+        response.json()["detail"] == "Column 'missing' not found in table 'test_table'"
+    )
 
 
 @pytest.mark.anyio

--- a/tracecat/agent/preset/internal_router.py
+++ b/tracecat/agent/preset/internal_router.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Annotated, cast
+from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, Field, StringConstraints
@@ -17,12 +17,13 @@ from tracecat.agent.preset.schemas import (
     build_subagent_eligibility,
 )
 from tracecat.agent.preset.service import AgentPresetService
+from tracecat.agent.service import AgentManagementService
 from tracecat.agent.subagents import AgentSubagentsConfig, has_manual_tool_approvals
 from tracecat.agent.types import OutputType
 from tracecat.auth.dependencies import ExecutorWorkspaceRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
-from tracecat.exceptions import TracecatValidationError
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 
 router = APIRouter(
     prefix="/internal/agent/presets",
@@ -48,14 +49,35 @@ class PresetCreateRequest(BaseModel):
     """Request body for creating an agent preset."""
 
     name: PresetName
-    model_name: PresetModelField
-    model_provider: PresetModelField
+    model_name: PresetModelField | None = Field(
+        default=None,
+        description=(
+            "Deprecated legacy model name field retained for backward "
+            "compatibility. Prefer catalog_id, which is the canonical model selector."
+        ),
+    )
+    model_provider: PresetModelField | None = Field(
+        default=None,
+        description=(
+            "Deprecated legacy model provider field retained for backward "
+            "compatibility. Prefer catalog_id, which is the canonical model selector."
+        ),
+    )
+    catalog_id: str | None = Field(
+        default=None,
+        description="Canonical model catalog row ID backing this preset.",
+    )
     slug: PresetSlug | None = None
     description: str | None = Field(default=None, max_length=1000)
     instructions: str | None = Field(default=None)
     base_url: str | None = Field(default=None, max_length=500)
     output_type: OutputType | None = Field(default=None)
     actions: list[str] | None = Field(default=None)
+    namespaces: list[str] | None = Field(default=None)
+    tool_approvals: dict[str, bool] | None = Field(default=None)
+    mcp_integrations: list[str] | None = Field(default=None)
+    agents: AgentSubagentsConfig | None = Field(default=None)
+    retries: int | None = Field(default=None, ge=0)
     enable_thinking: bool = Field(default=True)
     enable_internet_access: bool = Field(default=False)
     skills: list[AgentPresetSkillBindingBase] | None = Field(default=None)
@@ -68,14 +90,62 @@ class PresetUpdateRequest(BaseModel):
     slug: PresetSlug | None = None
     description: str | None = Field(default=None, max_length=1000)
     instructions: str | None = Field(default=None)
-    model_name: PresetModelField | None = None
-    model_provider: PresetModelField | None = None
+    model_name: PresetModelField | None = Field(
+        default=None,
+        description=(
+            "Deprecated legacy model name field retained for backward "
+            "compatibility. Prefer catalog_id, which is the canonical model selector."
+        ),
+    )
+    model_provider: PresetModelField | None = Field(
+        default=None,
+        description=(
+            "Deprecated legacy model provider field retained for backward "
+            "compatibility. Prefer catalog_id, which is the canonical model selector."
+        ),
+    )
+    catalog_id: str | None = Field(
+        default=None,
+        description="Canonical model catalog row ID backing this preset.",
+    )
     base_url: str | None = Field(default=None, max_length=500)
     output_type: OutputType | None = Field(default=None)
     actions: list[str] | None = Field(default=None)
+    namespaces: list[str] | None = Field(default=None)
+    tool_approvals: dict[str, bool] | None = Field(default=None)
+    mcp_integrations: list[str] | None = Field(default=None)
+    agents: AgentSubagentsConfig | None = Field(default=None)
+    retries: int | None = Field(default=None, ge=0)
     enable_thinking: bool | None = Field(default=None)
     enable_internet_access: bool | None = Field(default=None)
     skills: list[AgentPresetSkillBindingBase] | None = Field(default=None)
+
+
+async def _create_payload_with_default_model(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    params: PresetCreateRequest,
+) -> dict[str, Any]:
+    """Fill omitted legacy model fields from the canonical default catalog model."""
+    payload = params.model_dump(exclude_unset=True)
+    if payload.get("model_name") and payload.get("model_provider"):
+        return payload
+
+    default_model = await AgentManagementService(
+        session,
+        role=role,
+    ).get_default_model_selection()
+    if default_model is None:
+        raise TracecatNotFoundError("No default model set")
+    if not payload.get("model_name"):
+        payload["model_name"] = default_model.model_name
+    if not payload.get("model_provider"):
+        payload["model_provider"] = default_model.model_provider
+    # AgentPresetCreate still requires the legacy model fields. catalog_id is
+    # canonical for new callers; model_name/provider are backfilled for compat.
+    payload.setdefault("catalog_id", default_model.catalog_id)
+    return payload
 
 
 @router.get("", response_model=list[AgentPresetReadMinimal])
@@ -125,11 +195,19 @@ async def create_preset(
     """Create a new agent preset."""
     service = AgentPresetService(session, role=role)
     try:
-        preset = await service.create_preset(
-            AgentPresetCreate(**params.model_dump(exclude_unset=True))
+        payload = await _create_payload_with_default_model(
+            role=role,
+            session=session,
+            params=params,
         )
+        preset = await service.create_preset(AgentPresetCreate(**payload))
         return await service.build_preset_read(preset)
     except TracecatValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except TracecatNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),

--- a/tracecat/tables/internal_router.py
+++ b/tracecat/tables/internal_router.py
@@ -17,6 +17,7 @@ from tracecat import config
 from tracecat.auth.dependencies import ExecutorWorkspaceRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
+from tracecat.db.models import Table
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.expressions.functions import tabulate
 from tracecat.logger import logger
@@ -26,10 +27,12 @@ from tracecat.tables.enums import SqlType
 from tracecat.tables.schemas import (
     TableColumnCreate,
     TableColumnRead,
+    TableColumnUpdate,
     TableCreate,
     TableRead,
     TableRowInsert,
     TableRowInsertBatch,
+    TableUpdate,
 )
 from tracecat.tables.service import TablesService
 
@@ -79,6 +82,27 @@ class TableRowUpdate(BaseModel):
 
 
 TableDownloadFormat = Literal["json", "ndjson", "csv", "markdown"]
+
+
+async def _build_table_read(service: TablesService, table: Table) -> TableRead:
+    """Build table metadata with index flags for internal callers."""
+    index_columns = await service.get_index(table)
+    return TableRead(
+        id=table.id,
+        name=table.name,
+        columns=[
+            TableColumnRead(
+                id=column.id,
+                name=column.name,
+                type=SqlType(column.type),
+                nullable=column.nullable,
+                default=column.default,
+                is_index=column.name in index_columns,
+                options=column.options,
+            )
+            for column in table.columns
+        ],
+    )
 
 
 @router.get("")
@@ -134,6 +158,38 @@ async def create_table(
     return table.to_dict()
 
 
+@router.patch("/{table_name}", response_model=TableRead)
+@require_scope("table:update")
+async def update_table(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    table_name: str,
+    params: TableUpdate,
+) -> TableRead:
+    """Update table metadata by name."""
+    service = TablesService(session, role=role)
+    try:
+        table = await service.get_table_by_name(table_name)
+        updated = await service.update_table(table, params)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except ProgrammingError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc.__cause__ or exc),
+        ) from exc
+    return await _build_table_read(service, updated)
+
+
 @router.get("/{table_name}/metadata", response_model=TableRead)
 @require_scope("table:read")
 async def get_table_metadata(
@@ -157,23 +213,121 @@ async def get_table_metadata(
             detail=str(exc),
         ) from exc
 
-    index_columns = await service.get_index(table)
-    return TableRead(
-        id=table.id,
-        name=table.name,
-        columns=[
-            TableColumnRead(
-                id=column.id,
-                name=column.name,
-                type=SqlType(column.type),
-                nullable=column.nullable,
-                default=column.default,
-                is_index=column.name in index_columns,
-                options=column.options,
+    return await _build_table_read(service, table)
+
+
+@router.post("/{table_name}/columns", response_model=TableRead)
+@require_scope("table:create")
+async def create_column(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    table_name: str,
+    params: TableColumnCreate,
+) -> TableRead:
+    """Add a column to a table by name."""
+    service = TablesService(session, role=role)
+    try:
+        table = await service.get_table_by_name(table_name)
+        await service.create_column(table, params)
+        refreshed = await service.get_table(table.id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except ProgrammingError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc.__cause__ or exc),
+        ) from exc
+    return await _build_table_read(service, refreshed)
+
+
+@router.patch("/{table_name}/columns/{column_name}", response_model=TableRead)
+@require_scope("table:update")
+async def update_column(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    table_name: str,
+    column_name: str,
+    params: TableColumnUpdate,
+) -> TableRead:
+    """Update a column on a table by table and column name."""
+    service = TablesService(session, role=role)
+    try:
+        table = await service.get_table_by_name(table_name)
+        column = next(
+            (column for column in table.columns if column.name == column_name), None
+        )
+        if column is None:
+            raise TracecatNotFoundError(
+                f"Column '{column_name}' not found in table '{table_name}'"
             )
-            for column in table.columns
-        ],
-    )
+        await service.update_column(column, params)
+        refreshed = await service.get_table(table.id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except ProgrammingError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc.__cause__ or exc),
+        ) from exc
+    return await _build_table_read(service, refreshed)
+
+
+@router.delete("/{table_name}/columns/{column_name}", response_model=TableRead)
+@require_scope("table:delete")
+async def delete_column(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    table_name: str,
+    column_name: str,
+) -> TableRead:
+    """Delete a column from a table by table and column name."""
+    service = TablesService(session, role=role)
+    try:
+        table = await service.get_table_by_name(table_name)
+        column = next(
+            (column for column in table.columns if column.name == column_name), None
+        )
+        if column is None:
+            raise TracecatNotFoundError(
+                f"Column '{column_name}' not found in table '{table_name}'"
+            )
+        await service.delete_column(column)
+        refreshed = await service.get_table(table.id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except TracecatNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except ProgrammingError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc.__cause__ or exc),
+        ) from exc
+    return await _build_table_read(service, refreshed)
 
 
 @router.post("/{table_name}/lookup")


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limited Tailwind `content` scanning to key frontend folders to speed builds and shrink CSS. Synced Agent Presets Builder tabs with the `tab` URL param: validate values, read on load/history, write on tab changes (including error-driven switches), and preserve query params when switching presets.

<sup>Written for commit 715ed548c52ef5f28b61610688da4ccf1f07a5d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

