### PR TITLE
feat(artifacts): bind workspace chat domain tools

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/chat/[chatId]/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/chat/[chatId]/page.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { useParams } from "next/navigation"
+import { WorkspaceChatView } from "@/components/workspace-chat/workspace-chat-view"
+
+/**
+ * Deep link to a single workspace chat session: /chat/:chatId.
+ *
+ * The `chatId` route segment is the chat session id (a.k.a. sessionId); the
+ * chat client refers to it as `chatId` throughout, so we keep that name here.
+ */
+export default function WorkspaceChatSessionPage() {
+  const params = useParams<{ chatId: string }>()
+  return <WorkspaceChatView chatId={params?.chatId} />
+}

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1212,6 +1212,40 @@ export const $AdminUserRead = {
   description: "Admin view of a user.",
 } as const
 
+export const $AgentArtifact = {
+  properties: {
+    id: {
+      type: "string",
+      title: "Id",
+    },
+    title: {
+      type: "string",
+      title: "Title",
+    },
+    scope: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/ArtifactScope",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    type: {
+      type: "string",
+      const: "agent",
+      title: "Type",
+      default: "agent",
+    },
+  },
+  additionalProperties: false,
+  type: "object",
+  required: ["id", "title"],
+  title: "AgentArtifact",
+  description: "Agent preset artifact shown in artifact-capable chat surfaces.",
+} as const
+
 export const $AgentCatalogListResponse = {
   properties: {
     items: {
@@ -4651,6 +4685,9 @@ export const $Artifact = {
       $ref: "#/components/schemas/TableArtifact",
     },
     {
+      $ref: "#/components/schemas/AgentArtifact",
+    },
+    {
       $ref: "#/components/schemas/AlertArtifact",
     },
     {
@@ -4666,6 +4703,7 @@ export const $Artifact = {
   discriminator: {
     propertyName: "type",
     mapping: {
+      agent: "#/components/schemas/AgentArtifact",
       alert: "#/components/schemas/AlertArtifact",
       case: "#/components/schemas/CaseArtifact",
       generic: "#/components/schemas/GenericArtifact",
@@ -4727,6 +4765,7 @@ export const $ArtifactType = {
     "workflow",
     "run",
     "table",
+    "agent",
     "alert",
     "integration",
     "secret",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -320,6 +320,16 @@ export type AdminUserRead = {
 }
 
 /**
+ * Agent preset artifact shown in artifact-capable chat surfaces.
+ */
+export type AgentArtifact = {
+  id: string
+  title: string
+  scope?: ArtifactScope | null
+  type?: "agent"
+}
+
+/**
  * List catalog entries with pagination.
  */
 export type AgentCatalogListResponse = {
@@ -1154,6 +1164,7 @@ export type Artifact =
   | WorkflowArtifact
   | RunArtifact
   | TableArtifact
+  | AgentArtifact
   | AlertArtifact
   | IntegrationArtifact
   | SecretArtifact
@@ -1173,6 +1184,7 @@ export type ArtifactType =
   | "workflow"
   | "run"
   | "table"
+  | "agent"
   | "alert"
   | "integration"
   | "secret"

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -34,7 +34,14 @@ import {
 } from "lucide-react"
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  type FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import {
   type FieldErrors,
   type UseFormReturn,
@@ -711,6 +718,117 @@ export function AgentPresetsBuilder({
   )
 }
 
+/**
+ * Embeds the preset builder in surfaces that need a stacked, narrow layout.
+ */
+export function AgentPresetArtifactView({
+  preset,
+  workspaceId,
+  initialTab,
+  onTabChange,
+}: {
+  preset: AgentPresetRead
+  workspaceId: string
+  initialTab?: string | null
+  onTabChange?: (tab: string) => void
+}) {
+  const { presets } = useAgentPresets(workspaceId)
+  const { registryActions } = useRegistryActions()
+  const { models, providers } = useWorkspaceAgentModels(workspaceId)
+  const enabledModelsLoaded = models !== undefined
+  const { mcpIntegrations, mcpIntegrationsIsLoading } =
+    useListMcpIntegrations(workspaceId)
+  const { updateAgentPreset, updateAgentPresetIsPending } =
+    useUpdateAgentPreset(workspaceId)
+
+  const actionSuggestions: Suggestion[] = useMemo(() => {
+    if (!registryActions) {
+      return []
+    }
+    return registryActions
+      .map((action) => ({
+        id: action.id,
+        label: action.default_title ?? action.name,
+        value: action.action,
+        description: action.description,
+        group: action.namespace,
+        icon: getIcon(action.action, {
+          className: "size-6 p-[3px] border-[0.5px]",
+        }),
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  }, [registryActions])
+
+  const namespaceSuggestions: Suggestion[] = useMemo(() => {
+    if (!registryActions) {
+      return []
+    }
+    const seen = new Set<string>()
+    const entries: Suggestion[] = []
+    for (const action of registryActions) {
+      if (action.namespace && !seen.has(action.namespace)) {
+        seen.add(action.namespace)
+        entries.push({
+          id: action.namespace,
+          label: action.namespace,
+          value: action.namespace,
+        })
+      }
+    }
+    return entries.sort((a, b) => a.label.localeCompare(b.label))
+  }, [registryActions])
+
+  const enabledModelOptions = useMemo(
+    () => buildEnabledModelOptions(models, providers),
+    [models, providers]
+  )
+
+  const mcpIntegrationsForForm = useMemo(() => {
+    if (!mcpIntegrations) {
+      return []
+    }
+
+    return mcpIntegrations
+      .map((integration) => ({
+        id: integration.id,
+        name: integration.name,
+        description: integration.description,
+        providerId: getMcpProviderId(integration.slug),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }, [mcpIntegrations])
+
+  return (
+    <AgentPresetForm
+      key={preset.id}
+      preset={preset}
+      mode="edit"
+      workspaceId={workspaceId}
+      agentPresets={presets ?? []}
+      onCreate={async () => {
+        throw new Error("Agent artifacts cannot create presets.")
+      }}
+      onUpdate={async (presetId, payload) => {
+        return await updateAgentPreset({
+          presetId,
+          ...payload,
+        })
+      }}
+      isSaving={updateAgentPresetIsPending}
+      isDeleting={false}
+      actionSuggestions={actionSuggestions}
+      namespaceSuggestions={namespaceSuggestions}
+      enabledModelOptions={enabledModelOptions}
+      enabledModelsLoaded={enabledModelsLoaded}
+      mcpIntegrations={mcpIntegrationsForForm}
+      mcpIntegrationsIsLoading={mcpIntegrationsIsLoading}
+      layout="stacked"
+      initialTab={parseAgentPresetSideTab(initialTab) ?? "configuration"}
+      onTabChange={onTabChange}
+    />
+  )
+}
+
 function AgentPresetChatPane({
   preset,
   workspaceId,
@@ -1306,6 +1424,7 @@ type AgentPresetFormProps = {
   enabledModelsLoaded: boolean
   mcpIntegrations: McpIntegrationOption[]
   mcpIntegrationsIsLoading: boolean
+  layout?: "split" | "stacked"
   initialTab?: AgentPresetSideTab
   onTabChange?: (tab: AgentPresetSideTab) => void
 }
@@ -1328,6 +1447,7 @@ function AgentPresetForm({
   enabledModelsLoaded,
   mcpIntegrations,
   mcpIntegrationsIsLoading,
+  layout = "split",
   initialTab = "live-chat",
   onTabChange,
 }: AgentPresetFormProps) {
@@ -1602,72 +1722,99 @@ function AgentPresetForm({
     [appendSkillBinding]
   )
 
+  const documentPanel = (
+    <AgentPresetDocumentPanel
+      form={form}
+      mode={mode}
+      isSaving={isSaving}
+      isDeleting={isDeleting}
+      canSubmit={canSubmit}
+      presetName={preset?.name ?? ""}
+      onDuplicate={onDuplicate ? handleDuplicate : undefined}
+      isDuplicating={isDuplicating}
+      onDelete={onDelete}
+      deleteDialogOpen={deleteDialogOpen}
+      onDeleteDialogChange={handleDeleteDialogChange}
+      onConfirmDelete={handleConfirmDelete}
+    />
+  )
+
+  const rightPanel = (
+    <AgentPresetRightPanel
+      activeTab={effectiveTab}
+      onTabChange={handleTabChange}
+      channelsEnabled={channelsEnabled}
+      preset={preset}
+      workspaceId={workspaceId}
+      agentPresets={agentPresets}
+      subagentVersionsByPresetId={subagentVersionsByPresetId}
+      subagentVersionsByPresetIdIsLoading={subagentVersionsByPresetIdIsLoading}
+      builderPrompt={builderPrompt}
+      form={form}
+      isSaving={isSaving}
+      actionSuggestions={actionSuggestions}
+      namespaceSuggestions={namespaceSuggestions}
+      enabledModelOptions={enabledModelOptions}
+      enabledModelsLoaded={enabledModelsLoaded}
+      mcpIntegrations={mcpIntegrations}
+      mcpIntegrationsIsLoading={mcpIntegrationsIsLoading}
+      skillFields={skillFields}
+      onAddSkillBinding={handleAddSkillBinding}
+      onRemoveSkillBinding={removeSkillBinding}
+      toolApprovalFields={toolApprovalFields}
+      onAddToolApproval={handleAddToolApproval}
+      onRemoveToolApproval={removeToolApproval}
+      subagentFields={subagentFields}
+      onAddSubagent={handleAddSubagent}
+      onRemoveSubagent={removeSubagent}
+    />
+  )
+
+  const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    // Ignore submits bubbling from nested forms (e.g., chat prompt inputs).
+    if (event.target !== event.currentTarget) {
+      return
+    }
+    void handleSubmit()
+  }
+
   return (
     <Form {...form}>
-      <form
-        onSubmit={(event) => {
-          event.preventDefault()
-          // Ignore submits bubbling from nested forms (e.g., chat prompt inputs).
-          if (event.target !== event.currentTarget) {
-            return
-          }
-          void handleSubmit()
-        }}
-        className="h-full"
-      >
-        <ResizablePanelGroup direction="horizontal" className="h-full">
-          <ResizablePanel defaultSize={62} minSize={40}>
-            <AgentPresetDocumentPanel
-              form={form}
-              mode={mode}
-              isSaving={isSaving}
-              isDeleting={isDeleting}
-              canSubmit={canSubmit}
-              presetName={preset?.name ?? ""}
-              onDuplicate={onDuplicate ? handleDuplicate : undefined}
-              isDuplicating={isDuplicating}
-              onDelete={onDelete}
-              deleteDialogOpen={deleteDialogOpen}
-              onDeleteDialogChange={handleDeleteDialogChange}
-              onConfirmDelete={handleConfirmDelete}
-            />
-          </ResizablePanel>
+      <form onSubmit={handleFormSubmit} className="h-full min-h-0">
+        {layout === "stacked" ? (
+          <ResizablePanelGroup direction="vertical" className="h-full">
+            <ResizablePanel
+              defaultSize={42}
+              minSize={28}
+              className="overflow-hidden"
+            >
+              {documentPanel}
+            </ResizablePanel>
 
-          <ResizableHandle withHandle />
+            <ResizableHandle />
 
-          <ResizablePanel defaultSize={38} minSize={26}>
-            <AgentPresetRightPanel
-              activeTab={effectiveTab}
-              onTabChange={handleTabChange}
-              channelsEnabled={channelsEnabled}
-              preset={preset}
-              workspaceId={workspaceId}
-              agentPresets={agentPresets}
-              subagentVersionsByPresetId={subagentVersionsByPresetId}
-              subagentVersionsByPresetIdIsLoading={
-                subagentVersionsByPresetIdIsLoading
-              }
-              builderPrompt={builderPrompt}
-              form={form}
-              isSaving={isSaving}
-              actionSuggestions={actionSuggestions}
-              namespaceSuggestions={namespaceSuggestions}
-              enabledModelOptions={enabledModelOptions}
-              enabledModelsLoaded={enabledModelsLoaded}
-              mcpIntegrations={mcpIntegrations}
-              mcpIntegrationsIsLoading={mcpIntegrationsIsLoading}
-              skillFields={skillFields}
-              onAddSkillBinding={handleAddSkillBinding}
-              onRemoveSkillBinding={removeSkillBinding}
-              toolApprovalFields={toolApprovalFields}
-              onAddToolApproval={handleAddToolApproval}
-              onRemoveToolApproval={removeToolApproval}
-              subagentFields={subagentFields}
-              onAddSubagent={handleAddSubagent}
-              onRemoveSubagent={removeSubagent}
-            />
-          </ResizablePanel>
-        </ResizablePanelGroup>
+            <ResizablePanel
+              defaultSize={58}
+              minSize={32}
+              className="overflow-hidden"
+            >
+              {rightPanel}
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        ) : (
+          <ResizablePanelGroup direction="horizontal" className="h-full">
+            <ResizablePanel defaultSize={62} minSize={40}>
+              {documentPanel}
+            </ResizablePanel>
+
+            <ResizableHandle withHandle />
+
+            <ResizablePanel defaultSize={38} minSize={26}>
+              {rightPanel}
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        )}
       </form>
     </Form>
   )

--- a/frontend/src/components/ai-elements/reasoning.test.tsx
+++ b/frontend/src/components/ai-elements/reasoning.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningTrigger,
+} from "@/components/ai-elements/reasoning"
+
+// Isolate the reasoning scroll behavior from the markdown rendering pipeline.
+jest.mock("./response", () => ({
+  Response: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}))
+
+/**
+ * jsdom has no layout engine, so scroll geometry is always 0 and `scrollTop`
+ * writes are ignored. Install real read/write metrics on the element so the
+ * stick-to-bottom math is observable.
+ */
+function installScrollMetrics(
+  el: HTMLElement,
+  { scrollHeight, clientHeight }: { scrollHeight: number; clientHeight: number }
+) {
+  let scrollTop = 0
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value: number) => {
+      scrollTop = value
+    },
+  })
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    get: () => scrollHeight,
+  })
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    get: () => clientHeight,
+  })
+}
+
+function getScrollContainer(container: HTMLElement): HTMLElement {
+  const el = container.querySelector('[data-slot="reasoning-content"]')
+  if (!(el instanceof HTMLElement)) {
+    throw new Error("reasoning scroll container not found")
+  }
+  return el
+}
+
+function ReasoningHarness({
+  isStreaming,
+  text,
+}: {
+  isStreaming: boolean
+  text: string
+}) {
+  return (
+    <Reasoning isStreaming={isStreaming} open>
+      <ReasoningTrigger />
+      <ReasoningContent>{text}</ReasoningContent>
+    </Reasoning>
+  )
+}
+
+describe("ReasoningContent", () => {
+  it("renders reasoning inside a bounded, scrollable container", () => {
+    const { container } = render(
+      <ReasoningHarness isStreaming text="thinking out loud" />
+    )
+
+    const scroll = getScrollContainer(container)
+    expect(scroll).toHaveClass("max-h-60", "overflow-y-auto")
+    expect(screen.getByText("thinking out loud")).toBeInTheDocument()
+  })
+
+  it("scrolls to the bottom as deltas stream in", () => {
+    const { container, rerender } = render(
+      <ReasoningHarness isStreaming text="delta 1" />
+    )
+
+    const scroll = getScrollContainer(container)
+    installScrollMetrics(scroll, { scrollHeight: 1000, clientHeight: 100 })
+    scroll.scrollTop = 0
+
+    rerender(<ReasoningHarness isStreaming text="delta 1 delta 2 delta 3" />)
+
+    expect(scroll.scrollTop).toBe(1000)
+  })
+
+  it("does not auto-scroll when it is not streaming", () => {
+    const { container, rerender } = render(
+      <ReasoningHarness isStreaming={false} text="final 1" />
+    )
+
+    const scroll = getScrollContainer(container)
+    installScrollMetrics(scroll, { scrollHeight: 1000, clientHeight: 100 })
+    scroll.scrollTop = 0
+
+    rerender(<ReasoningHarness isStreaming={false} text="final 1 final 2" />)
+
+    expect(scroll.scrollTop).toBe(0)
+  })
+
+  it("stops following once the user scrolls away from the bottom", () => {
+    const { container, rerender } = render(
+      <ReasoningHarness isStreaming text="delta 1" />
+    )
+
+    const scroll = getScrollContainer(container)
+    installScrollMetrics(scroll, { scrollHeight: 1000, clientHeight: 100 })
+
+    // Simulate the user scrolling up, away from the bottom.
+    scroll.scrollTop = 0
+    fireEvent.scroll(scroll)
+
+    rerender(<ReasoningHarness isStreaming text="delta 1 delta 2 delta 3" />)
+
+    expect(scroll.scrollTop).toBe(0)
+  })
+})

--- a/frontend/src/components/ai-elements/reasoning.tsx
+++ b/frontend/src/components/ai-elements/reasoning.tsx
@@ -3,7 +3,15 @@
 import { useControllableState } from "@radix-ui/react-use-controllable-state"
 import { BrainIcon, ChevronDownIcon } from "lucide-react"
 import type { ComponentProps } from "react"
-import { createContext, memo, useContext, useEffect, useState } from "react"
+import {
+  createContext,
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import {
   Collapsible,
   CollapsibleContent,
@@ -39,6 +47,8 @@ export type ReasoningProps = ComponentProps<typeof Collapsible> & {
 
 const AUTO_CLOSE_DELAY = 1000
 const MS_IN_S = 1000
+// Treat the user as "pinned" when within this many px of the bottom.
+const STICK_TO_BOTTOM_THRESHOLD_PX = 16
 
 export const Reasoning = memo(
   ({
@@ -168,18 +178,54 @@ export type ReasoningContentProps = ComponentProps<
 }
 
 export const ReasoningContent = memo(
-  ({ className, children, ...props }: ReasoningContentProps) => (
-    <CollapsibleContent
-      className={cn(
-        "mt-4 text-sm",
-        "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-muted-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
-        className
-      )}
-      {...props}
-    >
-      <Response className="grid gap-2">{children}</Response>
-    </CollapsibleContent>
-  )
+  ({ className, children, ...props }: ReasoningContentProps) => {
+    const { isStreaming } = useReasoning()
+    const scrollRef = useRef<HTMLDivElement>(null)
+    // Stay pinned to the latest reasoning unless the user scrolls away.
+    const pinnedToBottomRef = useRef(true)
+
+    const handleScroll = useCallback(() => {
+      const el = scrollRef.current
+      if (!el) {
+        return
+      }
+      const distanceFromBottom =
+        el.scrollHeight - el.scrollTop - el.clientHeight
+      pinnedToBottomRef.current =
+        distanceFromBottom <= STICK_TO_BOTTOM_THRESHOLD_PX
+    }, [])
+
+    // Follow streaming deltas by scrolling to the bottom while pinned.
+    useEffect(() => {
+      if (!isStreaming || !pinnedToBottomRef.current) {
+        return
+      }
+      const el = scrollRef.current
+      if (el) {
+        el.scrollTop = el.scrollHeight
+      }
+    }, [children, isStreaming])
+
+    return (
+      <CollapsibleContent
+        className={cn(
+          "mt-4 text-sm",
+          "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-muted-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
+          className
+        )}
+        {...props}
+      >
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          data-slot="reasoning-content"
+          className="max-h-60 overflow-y-auto overscroll-contain pr-1"
+        >
+          <Response className="grid gap-2">{children}</Response>
+        </div>
+      </CollapsibleContent>
+    )
+  }
 )
 
 Reasoning.displayName = "Reasoning"

--- a/frontend/src/components/cases/case-panel-view.tsx
+++ b/frontend/src/components/cases/case-panel-view.tsx
@@ -77,6 +77,22 @@ import { cn, undoSlugify } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 type CasePanelTab = "comments" | "activity" | "attachments" | "rows" | "payload"
+const CASE_PANEL_TABS = new Set<CasePanelTab>([
+  "comments",
+  "activity",
+  "attachments",
+  "rows",
+  "payload",
+])
+
+function parseCasePanelTab(
+  value: string | null | undefined
+): CasePanelTab | null {
+  if (!value || !CASE_PANEL_TABS.has(value as CasePanelTab)) {
+    return null
+  }
+  return value as CasePanelTab
+}
 
 function isCustomFieldValueEmpty(value: unknown): boolean {
   if (value === null || value === undefined) return true
@@ -92,11 +108,15 @@ function isCustomFieldValueEmpty(value: unknown): boolean {
 interface CasePanelContentProps {
   caseId: string
   embedded?: boolean
+  initialTab?: string | null
+  onTabChange?: (tab: string) => void
 }
 
 export function CasePanelView({
   caseId,
   embedded = false,
+  initialTab,
+  onTabChange,
 }: CasePanelContentProps) {
   const workspaceId = useWorkspaceId()
   const { members } = useWorkspaceMembers(workspaceId)
@@ -138,10 +158,9 @@ export function CasePanelView({
     [caseData?.fields]
   )
   const [showAllCustomFields, setShowAllCustomFields] = useState(false)
-  const [embeddedTab, setEmbeddedTab] = useState<CasePanelTab>("comments")
-  useEffect(() => {
-    setEmbeddedTab("comments")
-  }, [caseId])
+  const [embeddedTab, setEmbeddedTab] = useState<CasePanelTab>(
+    () => parseCasePanelTab(initialTab) ?? "comments"
+  )
   const visibleCustomFields = useMemo(
     () =>
       showAllCustomFields
@@ -165,26 +184,31 @@ export function CasePanelView({
   )
 
   // Get active tab from URL query params, default to "comments"
-  const routeTab = (
-    searchParams &&
-    ["comments", "activity", "attachments", "rows", "payload"].includes(
-      searchParams.get("tab") || ""
-    )
-      ? (searchParams.get("tab") ?? "comments")
-      : "comments"
-  ) as CasePanelTab
+  const routeTab = parseCasePanelTab(searchParams?.get("tab")) ?? "comments"
   const activeTab = embedded ? embeddedTab : routeTab
+
+  useEffect(() => {
+    if (!embedded) {
+      return
+    }
+    const nextTab = parseCasePanelTab(initialTab) ?? "comments"
+    if (nextTab !== embeddedTab) {
+      setEmbeddedTab(nextTab)
+    }
+  }, [caseId, embedded, embeddedTab, initialTab])
 
   // Function to handle tab changes and update URL
   const handleTabChange = useCallback(
     (tab: string) => {
+      const nextTab = parseCasePanelTab(tab) ?? "comments"
       if (embedded) {
-        setEmbeddedTab(tab as CasePanelTab)
+        setEmbeddedTab(nextTab)
+        onTabChange?.(nextTab)
         return
       }
-      router.push(`/workspaces/${workspaceId}/cases/${caseId}?tab=${tab}`)
+      router.push(`/workspaces/${workspaceId}/cases/${caseId}?tab=${nextTab}`)
     },
-    [embedded, router, workspaceId, caseId]
+    [embedded, router, workspaceId, caseId, onTabChange]
   )
 
   if (caseDataIsLoading) {

--- a/frontend/src/components/chat/chat-interface.tsx
+++ b/frontend/src/components/chat/chat-interface.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import type { UIMessage } from "ai"
+import { useQueryClient } from "@tanstack/react-query"
+import type { ChatOnDataCallback, UIMessage } from "ai"
 import { ArrowRight, ChevronDown, Plus } from "lucide-react"
 import Link from "next/link"
 import { type ReactNode, useEffect, useState } from "react"
@@ -69,6 +70,8 @@ interface ChatInterfaceProps {
   surface?: ChatSurface
   /** Called on every chat message update; lets parents derive side-panel state. */
   onMessagesChange?: (messages: UIMessage[]) => void
+  /** Called for data stream parts as soon as the chat transport receives them. */
+  onData?: ChatOnDataCallback<UIMessage>
   /** Called when the selected chat payload changes. */
   onChatChange?: (
     chat: AgentSessionsGetSessionVercelResponse | undefined
@@ -87,6 +90,8 @@ type PresetConfigLike = Pick<
   "model_name" | "model_provider" | "base_url"
 >
 
+const NOOP = () => {}
+
 export function ChatInterface({
   chatId,
   entityType,
@@ -97,10 +102,12 @@ export function ChatInterface({
   placeholder,
   surface = "regular",
   onMessagesChange,
+  onData,
   onChatChange,
   headerActions,
 }: ChatInterfaceProps) {
   const workspaceId = useWorkspaceId()
+  const queryClient = useQueryClient()
   const { hasEntitlement } = useEntitlements()
   const agentAddonsEnabled = hasEntitlement("agent_addons")
   const [selectedChatId, setSelectedChatId] = useState<string | undefined>(
@@ -108,7 +115,7 @@ export function ChatInterface({
   )
   const [newChatDialogOpen, setNewChatDialogOpen] = useState(false)
   const [autoCreateAttempted, setAutoCreateAttempted] = useState(false)
-  const [isCaseDraftChat, setIsCaseDraftChat] = useState(false)
+  const [isDraftChat, setIsDraftChat] = useState(false)
   const [pendingFirstMessage, setPendingFirstMessage] =
     useState<PendingFirstMessage | null>(null)
 
@@ -116,7 +123,7 @@ export function ChatInterface({
   useEffect(() => {
     setSelectedChatId(chatId)
     if (chatId) {
-      setIsCaseDraftChat(false)
+      setIsDraftChat(false)
     }
   }, [chatId])
 
@@ -141,7 +148,25 @@ export function ChatInterface({
 
   const presetsEnabled =
     agentAddonsEnabled && (entityType === "case" || entityType === "copilot")
-  const headerRowClassName = "flex w-full items-center justify-between"
+  const inWorkspaceChat = surface === "workspace-chat"
+  // Surfaces that defer server-side session creation until the first message,
+  // showing a draft composer instead of an eagerly-created empty session.
+  const deferSessionCreation = entityType === "case" || inWorkspaceChat
+
+  // Mirror the active workspace-chat session into the URL so sessions are
+  // deep-linkable (/chat/:sessionId). Uses replaceState to avoid remounting the
+  // chat view, keeping the optimistic first-message flow intact.
+  useEffect(() => {
+    if (!inWorkspaceChat || typeof window === "undefined") {
+      return
+    }
+    const base = `/workspaces/${workspaceId}/chat`
+    const nextPath = selectedChatId ? `${base}/${selectedChatId}` : base
+    if (window.location.pathname !== nextPath) {
+      const nextUrl = `${nextPath}${window.location.search}`
+      window.history.replaceState(window.history.state, "", nextUrl)
+    }
+  }, [inWorkspaceChat, workspaceId, selectedChatId])
 
   const {
     presets: presetOptions,
@@ -172,27 +197,28 @@ export function ChatInterface({
 
   useEffect(() => {
     setAutoCreateAttempted(false)
-    setIsCaseDraftChat(false)
+    setIsDraftChat(false)
     setPendingFirstMessage(null)
   }, [entityType, entityId])
 
   // Auto-select the first chat when available.
-  // For non-case entities we preserve the legacy behavior of creating a chat
-  // automatically when none exists.
+  // Workspace chat always opens a fresh draft, so it never auto-selects.
+  // Surfaces that defer session creation skip the legacy auto-create path.
   useEffect(() => {
     if (!chats || chatsLoading || createChatPending) return
 
     if (
       chats.length > 0 &&
       !selectedChatId &&
-      !(entityType === "case" && isCaseDraftChat)
+      !inWorkspaceChat &&
+      !(entityType === "case" && isDraftChat)
     ) {
       // Select first existing chat
       const firstChatId = chats[0].id
       setSelectedChatId(firstChatId)
       onChatSelect?.(firstChatId)
     } else if (
-      entityType !== "case" &&
+      !deferSessionCreation &&
       chats.length === 0 &&
       !selectedChatId &&
       !autoCreateAttempted
@@ -222,14 +248,16 @@ export function ChatInterface({
     entityType,
     entityId,
     autoCreateAttempted,
-    isCaseDraftChat,
+    isDraftChat,
+    inWorkspaceChat,
+    deferSessionCreation,
   ])
 
   const handleCreateChat = async () => {
     setNewChatDialogOpen(false)
 
-    if (entityType === "case") {
-      setIsCaseDraftChat(true)
+    if (deferSessionCreation) {
+      setIsDraftChat(true)
       setPendingFirstMessage(null)
       setSelectedChatId(undefined)
       return
@@ -248,25 +276,33 @@ export function ChatInterface({
     }
   }
 
-  const handleCreateCaseChatOnFirstSend = async (
+  const handleCreateSessionOnFirstSend = async (
     messageText: string,
     selectedTools?: string[]
   ) => {
-    if (entityType !== "case" || createChatPending) {
+    if (!deferSessionCreation || createChatPending) {
       return null
     }
 
     try {
       const newChat = await createChat({
         title: `Chat ${(chats?.length || 0) + 1}`,
-        entity_type: "case",
+        entity_type: entityType,
         entity_id: entityId,
         tools: selectedTools,
         agent_preset_id: effectivePresetId,
         agent_preset_version_id: selectedPresetVersionId,
       })
 
-      setIsCaseDraftChat(false)
+      // Prime the vercel chat cache with the freshly created (empty) session so
+      // the session view mounts and sends the pending message immediately,
+      // rather than waiting on a fetch of a session we already know is empty.
+      queryClient.setQueryData<AgentSessionsGetSessionVercelResponse>(
+        ["chat", newChat.id, workspaceId, "vercel"],
+        { ...newChat, messages: [] }
+      )
+
+      setIsDraftChat(false)
       setSelectedChatId(newChat.id)
       setPendingFirstMessage({
         chatId: newChat.id,
@@ -275,7 +311,7 @@ export function ChatInterface({
       onChatSelect?.(newChat.id)
       return newChat.id
     } catch (error) {
-      console.error("Failed to create case chat on first message:", error)
+      console.error("Failed to create chat on first message:", error)
       toast({
         title: "Failed to create chat",
         description: parseChatError(error),
@@ -286,7 +322,7 @@ export function ChatInterface({
   }
 
   const handleSelectChat = (chatId: string) => {
-    setIsCaseDraftChat(false)
+    setIsDraftChat(false)
     setSelectedChatId(chatId)
     onChatSelect?.(chatId)
   }
@@ -294,7 +330,7 @@ export function ChatInterface({
   // Show loading while chats are loading or being auto-created
   if (
     chatsLoading ||
-    (entityType !== "case" && chats && chats.length === 0 && createChatPending)
+    (!deferSessionCreation && chats && chats.length === 0 && createChatPending)
   ) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -311,11 +347,38 @@ export function ChatInterface({
     )
   }
 
+  const toolsEnabled = !activePreset && !inWorkspaceChat
+  const draftMode =
+    deferSessionCreation &&
+    (inWorkspaceChat || isDraftChat || chats?.length === 0)
+  const presetSelector = presetsEnabled
+    ? {
+        label: presetMenuLabel,
+        presets: presetOptions,
+        presetsError,
+        presetsIsLoading,
+        selectedPresetId: effectivePresetId,
+        disabled: presetMenuDisabled,
+        showSpinner: showPresetSpinner,
+        noPresetDescription: "Use workspace default case agent instructions.",
+        onSelect: (presetId: string | null) =>
+          void handlePresetChange(presetId),
+      }
+    : undefined
+  const pendingMessageText =
+    selectedChatId && pendingFirstMessage?.chatId === selectedChatId
+      ? pendingFirstMessage.text
+      : null
+  const handlePendingMessageSent = () =>
+    setPendingFirstMessage((current) =>
+      current?.chatId === selectedChatId ? null : current
+    )
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       {/* Chat Header */}
       <div className="px-4 py-2">
-        <div className={headerRowClassName}>
+        <div className="flex w-full items-center justify-between">
           {/* Unified New-chat / History dropdown */}
           <div className="flex items-center gap-2">
             {title ? (
@@ -359,8 +422,8 @@ export function ChatInterface({
                 <AlertDialogHeader>
                   <AlertDialogTitle>Start a new chat?</AlertDialogTitle>
                   <AlertDialogDescription>
-                    {entityType === "case"
-                      ? "This opens a fresh case chat draft. A new conversation will be created after you send your first message."
+                    {deferSessionCreation
+                      ? "This starts a fresh chat. A new conversation is created after you send your first message."
                       : "This will create a new conversation. Your current chat will remain accessible from the conversations menu."}
                   </AlertDialogDescription>
                 </AlertDialogHeader>
@@ -389,42 +452,18 @@ export function ChatInterface({
           chatError={chatError}
           selectedPreset={activePreset}
           selectedPresetConfigError={selectedPresetConfigError}
-          toolsEnabled={!activePreset}
-          draftMode={
-            entityType === "case" && (isCaseDraftChat || chats?.length === 0)
-          }
-          presetSelector={
-            presetsEnabled
-              ? {
-                  label: presetMenuLabel,
-                  presets: presetOptions,
-                  presetsError,
-                  presetsIsLoading,
-                  selectedPresetId: effectivePresetId,
-                  disabled: presetMenuDisabled,
-                  showSpinner: showPresetSpinner,
-                  noPresetDescription:
-                    "Use workspace default case agent instructions.",
-                  onSelect: (presetId) => void handlePresetChange(presetId),
-                }
-              : undefined
-          }
+          toolsEnabled={toolsEnabled}
+          draftMode={draftMode}
+          presetSelector={presetSelector}
           onCreateSessionBeforeSend={
-            entityType === "case" ? handleCreateCaseChatOnFirstSend : undefined
+            deferSessionCreation ? handleCreateSessionOnFirstSend : undefined
           }
           draftInputDisabled={createChatPending}
-          pendingMessage={
-            selectedChatId && pendingFirstMessage?.chatId === selectedChatId
-              ? pendingFirstMessage.text
-              : null
-          }
-          onPendingMessageSent={() =>
-            setPendingFirstMessage((current) =>
-              current?.chatId === selectedChatId ? null : current
-            )
-          }
+          pendingMessage={pendingMessageText}
+          onPendingMessageSent={handlePendingMessageSent}
           surface={surface}
           onMessagesChange={onMessagesChange}
+          onData={onData}
         />
       </div>
     </div>
@@ -464,6 +503,7 @@ interface ChatBodyProps {
   onPendingMessageSent: () => void
   surface: ChatSurface
   onMessagesChange?: (messages: UIMessage[]) => void
+  onData?: ChatOnDataCallback<UIMessage>
 }
 
 function ChatBody({
@@ -486,6 +526,7 @@ function ChatBody({
   onPendingMessageSent,
   surface,
   onMessagesChange,
+  onData,
 }: ChatBodyProps) {
   const {
     ready: chatReady,
@@ -589,10 +630,12 @@ function ChatBody({
         toolsEnabled={toolsEnabled}
         presetSelector={presetSelector}
         onBeforeSend={onCreateSessionBeforeSend}
+        optimisticBeforeSend
         inputDisabled={draftInputDisabled}
         inputDisabledPlaceholder="Creating chat..."
         surface={surface}
         onMessagesChange={onMessagesChange}
+        onData={onData}
       />
     )
   }
@@ -620,6 +663,7 @@ function ChatBody({
       onPendingMessageSent={onPendingMessageSent}
       surface={surface}
       onMessagesChange={onMessagesChange}
+      onData={onData}
     />
   )
 }
@@ -630,11 +674,10 @@ function ChatBody({
  * settings where a default model can be selected.
  */
 function NoDefaultModelComposer() {
-  const noop = () => {}
   return (
     <div className="space-y-3">
       <PromptInput
-        onSubmit={noop}
+        onSubmit={NOOP}
         aria-disabled="true"
         className="pointer-events-none select-none [&_[data-slot=input-group]]:rounded-2xl [&_[data-slot=input-group]]:border-muted-foreground/25 [&_[data-slot=input-group]]:shadow-none"
       >

--- a/frontend/src/components/chat/chat-session-pane.test.tsx
+++ b/frontend/src/components/chat/chat-session-pane.test.tsx
@@ -1,7 +1,17 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { UIMessage } from "ai"
 import type { ReactNode } from "react"
 import { ChatSessionPane } from "@/components/chat/chat-session-pane"
+
+const mockUseVercelChatResult = {
+  clearError: jest.fn(),
+  lastError: null as string | null,
+  messages: [] as UIMessage[],
+  regenerate: jest.fn(),
+  sendMessage: jest.fn(),
+  status: "ready" as const,
+}
 
 jest.mock("@/components/chat/chat-empty-hero", () => ({
   ChatEmptyHero: ({ children }: { children: ReactNode }) => (
@@ -43,14 +53,7 @@ jest.mock("@/hooks/use-chat", () => ({
     isUpdating: false,
     updateChat: jest.fn(),
   }),
-  useVercelChat: () => ({
-    clearError: jest.fn(),
-    lastError: null,
-    messages: [],
-    regenerate: jest.fn(),
-    sendMessage: jest.fn(),
-    status: "ready",
-  }),
+  useVercelChat: () => mockUseVercelChatResult,
 }))
 
 jest.mock("@/lib/hooks", () => ({
@@ -69,22 +72,40 @@ function renderChatSessionPane(
     },
   })
 
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <ChatSessionPane
-        workspaceId="workspace-1"
-        modelInfo={{ name: "gpt-test", provider: "openai" }}
-        placeholder="Ask Tracecat..."
-        inputDisabledPlaceholder="Creating chat..."
-        surface="workspace-chat"
-        toolsEnabled={false}
-        {...props}
-      />
-    </QueryClientProvider>
-  )
+  function renderPane(nextProps = props) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ChatSessionPane
+          workspaceId="workspace-1"
+          modelInfo={{ name: "gpt-test", provider: "openai" }}
+          placeholder="Ask Tracecat..."
+          inputDisabledPlaceholder="Creating chat..."
+          surface="workspace-chat"
+          toolsEnabled={false}
+          {...nextProps}
+        />
+      </QueryClientProvider>
+    )
+  }
+
+  const view = render(renderPane())
+  return {
+    ...view,
+    rerenderChatSessionPane: (nextProps = props) =>
+      view.rerender(renderPane(nextProps)),
+  }
 }
 
 describe("ChatSessionPane optimistic first send", () => {
+  beforeEach(() => {
+    mockUseVercelChatResult.clearError.mockClear()
+    mockUseVercelChatResult.regenerate.mockClear()
+    mockUseVercelChatResult.sendMessage.mockClear()
+    mockUseVercelChatResult.lastError = null
+    mockUseVercelChatResult.messages = []
+    mockUseVercelChatResult.status = "ready"
+  })
+
   it("shows the submitted message and loading dots before a session exists", async () => {
     const onBeforeSend = jest.fn(
       () => new Promise<string | null>(() => undefined)
@@ -129,5 +150,50 @@ describe("ChatSessionPane optimistic first send", () => {
     await waitFor(() => expect(input).not.toBeDisabled())
     expect(input).toHaveValue("Try again")
     expect(screen.queryByTestId("dots-loader")).not.toBeInTheDocument()
+  })
+
+  it("keeps the optimistic message when prior history has matching text", async () => {
+    const onBeforeSend = jest.fn(
+      () => new Promise<string | null>(() => undefined)
+    )
+    const priorMessage: UIMessage = {
+      id: "message-old",
+      role: "user",
+      parts: [{ type: "text", text: "Repeat this" }],
+    }
+    mockUseVercelChatResult.messages = [priorMessage]
+
+    const props = {
+      onBeforeSend,
+      optimisticBeforeSend: true,
+    }
+    const { rerenderChatSessionPane } = renderChatSessionPane(props)
+
+    const input = screen.getByPlaceholderText("Ask Tracecat...")
+    fireEvent.change(input, {
+      target: { value: "Repeat this" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }))
+
+    await waitFor(() => expect(onBeforeSend).toHaveBeenCalled())
+    expect(screen.getByTestId("dots-loader")).toBeInTheDocument()
+
+    rerenderChatSessionPane(props)
+
+    expect(screen.getByTestId("dots-loader")).toBeInTheDocument()
+
+    mockUseVercelChatResult.messages = [
+      priorMessage,
+      {
+        id: "message-new",
+        role: "user",
+        parts: [{ type: "text", text: "Repeat this" }],
+      },
+    ]
+    rerenderChatSessionPane(props)
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("dots-loader")).not.toBeInTheDocument()
+    )
   })
 })

--- a/frontend/src/components/chat/chat-session-pane.test.tsx
+++ b/frontend/src/components/chat/chat-session-pane.test.tsx
@@ -1,0 +1,133 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { ChatSessionPane } from "@/components/chat/chat-session-pane"
+
+jest.mock("@/components/chat/chat-empty-hero", () => ({
+  ChatEmptyHero: ({ children }: { children: ReactNode }) => (
+    <div data-testid="chat-empty-hero">{children}</div>
+  ),
+}))
+
+jest.mock("@/components/icons", () => ({
+  getIcon: () => null,
+  ProviderIcon: () => <span data-testid="provider-icon" />,
+}))
+
+jest.mock("@/components/ai-elements/tool", () => ({
+  getStatusBadge: () => null,
+  Tool: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ToolContent: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ToolHeader: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ToolInput: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ToolOutput: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock("@/components/editor/codemirror/code-editor", () => ({
+  CodeEditor: ({ value }: { value?: string }) => <pre>{value}</pre>,
+}))
+
+jest.mock("@/components/json-viewer", () => ({
+  JsonViewWithControls: ({ data }: { data?: unknown }) => (
+    <pre>{JSON.stringify(data)}</pre>
+  ),
+}))
+
+jest.mock("@/hooks/use-chat", () => ({
+  makeContinueMessage: jest.fn(),
+  parseChatError: (error: unknown) =>
+    error instanceof Error ? error.message : "Chat error",
+  useUpdateChat: () => ({
+    isUpdating: false,
+    updateChat: jest.fn(),
+  }),
+  useVercelChat: () => ({
+    clearError: jest.fn(),
+    lastError: null,
+    messages: [],
+    regenerate: jest.fn(),
+    sendMessage: jest.fn(),
+    status: "ready",
+  }),
+}))
+
+jest.mock("@/lib/hooks", () => ({
+  useBuilderRegistryActions: () => ({
+    registryActions: [],
+    registryActionsIsLoading: false,
+  }),
+}))
+
+function renderChatSessionPane(
+  props: Partial<Parameters<typeof ChatSessionPane>[0]> = {}
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ChatSessionPane
+        workspaceId="workspace-1"
+        modelInfo={{ name: "gpt-test", provider: "openai" }}
+        placeholder="Ask Tracecat..."
+        inputDisabledPlaceholder="Creating chat..."
+        surface="workspace-chat"
+        toolsEnabled={false}
+        {...props}
+      />
+    </QueryClientProvider>
+  )
+}
+
+describe("ChatSessionPane optimistic first send", () => {
+  it("shows the submitted message and loading dots before a session exists", async () => {
+    const onBeforeSend = jest.fn(
+      () => new Promise<string | null>(() => undefined)
+    )
+
+    renderChatSessionPane({
+      onBeforeSend,
+      optimisticBeforeSend: true,
+    })
+
+    const input = screen.getByPlaceholderText("Ask Tracecat...")
+    fireEvent.change(input, {
+      target: { value: "Summarize this workspace" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }))
+
+    await waitFor(() =>
+      expect(onBeforeSend).toHaveBeenCalledWith("Summarize this workspace", [])
+    )
+
+    expect(
+      await screen.findByText("Summarize this workspace")
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("dots-loader")).toBeInTheDocument()
+    expect(screen.getByPlaceholderText("Creating chat...")).toBeDisabled()
+  })
+
+  it("restores the draft when the session creation is cancelled", async () => {
+    const onBeforeSend = jest.fn(async () => null)
+
+    renderChatSessionPane({
+      onBeforeSend,
+      optimisticBeforeSend: true,
+    })
+
+    const input = screen.getByPlaceholderText("Ask Tracecat...")
+    fireEvent.change(input, {
+      target: { value: "Try again" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }))
+
+    await waitFor(() => expect(input).not.toBeDisabled())
+    expect(input).toHaveValue("Try again")
+    expect(screen.queryByTestId("dots-loader")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -143,6 +143,37 @@ function messageHasVisibleParts(message: UIMessage): boolean {
   return message.parts.some((part) => part.type !== ARTIFACT_DATA_PART_TYPE)
 }
 
+function matchingUserTextPartKeys(
+  messages: UIMessage[],
+  text: string
+): Set<string> {
+  const keys = new Set<string>()
+  for (const message of messages) {
+    if (message.role !== "user") {
+      continue
+    }
+    for (const [partIndex, part] of message.parts.entries()) {
+      if (part.type === "text" && part.text === text) {
+        keys.add(`${message.id}:${partIndex}`)
+      }
+    }
+  }
+  return keys
+}
+
+function hasNewMatchingUserTextPart(
+  messages: UIMessage[],
+  text: string,
+  knownKeys: Set<string>
+): boolean {
+  for (const key of matchingUserTextPartKeys(messages, text)) {
+    if (!knownKeys.has(key)) {
+      return true
+    }
+  }
+  return false
+}
+
 function areToolListsEqual(left: string[], right: string[]): boolean {
   return (
     left.length === right.length &&
@@ -285,6 +316,7 @@ export function ChatSessionPane({
   const [optimisticMessageText, setOptimisticMessageText] = useState<
     string | null
   >(null)
+  const optimisticMessageKnownTextPartKeysRef = useRef<Set<string>>(new Set())
   const { updateChat, isUpdating: isUpdatingTools } = useUpdateChat(workspaceId)
   const { registryActions, registryActionsIsLoading } =
     useBuilderRegistryActions()
@@ -318,13 +350,10 @@ export function ChatSessionPane({
   const hasOptimisticMessageInStream = useMemo(
     () =>
       optimisticMessageText
-        ? messages.some((message) =>
-            message.role === "user"
-              ? message.parts.some(
-                  (part) =>
-                    part.type === "text" && part.text === optimisticMessageText
-                )
-              : false
+        ? hasNewMatchingUserTextPart(
+            messages,
+            optimisticMessageText,
+            optimisticMessageKnownTextPartKeysRef.current
           )
         : false,
     [messages, optimisticMessageText]
@@ -332,6 +361,7 @@ export function ChatSessionPane({
 
   useEffect(() => {
     if (hasOptimisticMessageInStream) {
+      optimisticMessageKnownTextPartKeysRef.current = new Set()
       setOptimisticMessageText(null)
     }
   }, [hasOptimisticMessageInStream])
@@ -894,6 +924,8 @@ export function ChatSessionPane({
 
     if (onBeforeSend) {
       if (optimisticBeforeSend) {
+        optimisticMessageKnownTextPartKeysRef.current =
+          matchingUserTextPartKeys(messages, messageText)
         setOptimisticMessageText(messageText)
         setInput("")
       }
@@ -904,6 +936,7 @@ export function ChatSessionPane({
       if (result !== null) {
         setInput("")
       } else if (optimisticBeforeSend) {
+        optimisticMessageKnownTextPartKeysRef.current = new Set()
         setOptimisticMessageText(null)
         setInput(messageText)
       }

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -2,6 +2,7 @@
 
 import { useQueryClient } from "@tanstack/react-query"
 import {
+  type ChatOnDataCallback,
   type ChatStatus,
   getToolName,
   isToolUIPart,
@@ -196,6 +197,7 @@ export interface ChatSessionPaneProps {
   className?: string
   placeholder?: string
   onMessagesChange?: (messages: UIMessage[]) => void
+  onData?: ChatOnDataCallback<UIMessage>
   modelInfo: ModelInfo
   toolsEnabled?: boolean
   /** Autofocus the prompt input when the pane mounts. */
@@ -210,6 +212,11 @@ export interface ChatSessionPaneProps {
     messageText: string,
     selectedTools?: string[]
   ) => Promise<string | null>
+  /**
+   * Render a temporary user message and assistant loading dots while
+   * onBeforeSend is creating a session or fork before the real stream mounts.
+   */
+  optimisticBeforeSend?: boolean
   /**
    * Message to send immediately on mount. Used after forking a session
    * to send the user's message to the newly forked session.
@@ -245,10 +252,12 @@ export function ChatSessionPane({
   className,
   placeholder = "Ask your question...",
   onMessagesChange,
+  onData,
   modelInfo,
   toolsEnabled = true,
   autoFocusInput = false,
   onBeforeSend,
+  optimisticBeforeSend = false,
   pendingMessage,
   onPendingMessageSent,
   inputDisabled = false,
@@ -273,6 +282,9 @@ export function ChatSessionPane({
   const [input, setInput] = useState<string>("")
   const [toolMention, setToolMention] = useState<ToolMentionState>()
   const [selectedTools, setSelectedTools] = useState<string[]>([])
+  const [optimisticMessageText, setOptimisticMessageText] = useState<
+    string | null
+  >(null)
   const { updateChat, isUpdating: isUpdatingTools } = useUpdateChat(workspaceId)
   const { registryActions, registryActionsIsLoading } =
     useBuilderRegistryActions()
@@ -300,7 +312,29 @@ export function ChatSessionPane({
       workspaceId,
       messages: uiMessages,
       modelInfo,
+      onData,
     })
+
+  const hasOptimisticMessageInStream = useMemo(
+    () =>
+      optimisticMessageText
+        ? messages.some((message) =>
+            message.role === "user"
+              ? message.parts.some(
+                  (part) =>
+                    part.type === "text" && part.text === optimisticMessageText
+                )
+              : false
+          )
+        : false,
+    [messages, optimisticMessageText]
+  )
+
+  useEffect(() => {
+    if (hasOptimisticMessageInStream) {
+      setOptimisticMessageText(null)
+    }
+  }, [hasOptimisticMessageInStream])
 
   // Track pending message sends to avoid duplicate sends
   const pendingMessageSentRef = useRef<string | null>(null)
@@ -349,7 +383,9 @@ export function ChatSessionPane({
     return false
   }, [status, messages])
 
-  const isInputDisabled = isReadonly || inputDisabled || !canSubmit
+  const isOptimisticBeforeSendPending = optimisticMessageText !== null
+  const isInputDisabled =
+    isReadonly || inputDisabled || isOptimisticBeforeSendPending || !canSubmit
   const isInputDisabledRef = useRef(isInputDisabled)
   isInputDisabledRef.current = isInputDisabled
   const wasInputDisabledRef = useRef(isInputDisabled)
@@ -857,11 +893,19 @@ export function ChatSessionPane({
     const messageText = message.text || ""
 
     if (onBeforeSend) {
+      if (optimisticBeforeSend) {
+        setOptimisticMessageText(messageText)
+        setInput("")
+      }
+
       const result = await onBeforeSend(messageText, selectedTools)
       // Only clear input if onBeforeSend succeeded (non-null)
       // If null, the action was cancelled and user keeps their draft
       if (result !== null) {
         setInput("")
+      } else if (optimisticBeforeSend) {
+        setOptimisticMessageText(null)
+        setInput(messageText)
       }
       // Parent will handle switching sessions and sending via pendingMessage
       return
@@ -986,7 +1030,8 @@ export function ChatSessionPane({
             placeholder={
               isReadonly
                 ? "This is a legacy session (read-only)"
-                : inputDisabled && inputDisabledPlaceholder
+                : (inputDisabled || isOptimisticBeforeSendPending) &&
+                    inputDisabledPlaceholder
                   ? inputDisabledPlaceholder
                   : placeholder
             }
@@ -1021,6 +1066,7 @@ export function ChatSessionPane({
     isWorkspaceChat &&
     !isReadonly &&
     !lastError &&
+    !optimisticMessageText &&
     !isWaitingForResponse &&
     !transformedMessages.some(messageHasVisibleParts)
 
@@ -1049,6 +1095,9 @@ export function ChatSessionPane({
                   <AlertDescription>{lastError}</AlertDescription>
                 </Alert>
               )}
+              {optimisticMessageText ? (
+                <OptimisticPendingMessage text={optimisticMessageText} />
+              ) : null}
               {transformedMessages.map(({ id, role, parts }) => {
                 const visibleParts = parts?.filter(
                   (part) => part.type !== ARTIFACT_DATA_PART_TYPE
@@ -1140,6 +1189,27 @@ export function ChatSessionPane({
         </div>
       </div>
     </div>
+  )
+}
+
+function OptimisticPendingMessage({ text }: { text: string }) {
+  return (
+    <>
+      <Message from="user">
+        <MessageContent variant="flat">
+          <Response>{text}</Response>
+        </MessageContent>
+      </Message>
+      <motion.div
+        className="mt-5"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.3, ease: "easeInOut" }}
+      >
+        <Dots />
+      </motion.div>
+    </>
   )
 }
 

--- a/frontend/src/components/workspace-chat/artifacts/artifact-content.tsx
+++ b/frontend/src/components/workspace-chat/artifacts/artifact-content.tsx
@@ -2,6 +2,8 @@
 
 import { ExternalLink } from "lucide-react"
 import Link from "next/link"
+import { useEffect, useMemo } from "react"
+import { AgentPresetArtifactView } from "@/components/agents/agent-presets-builder"
 import { CasePanelView } from "@/components/cases/case-panel-view"
 import { AlertNotification } from "@/components/notifications"
 import { TablePanelProvider } from "@/components/tables/table-panel-context"
@@ -15,29 +17,97 @@ import {
   getArtifactHref,
 } from "@/components/workspace-chat/artifacts/artifact-registry"
 import { ArtifactIcon } from "@/components/workspace-chat/artifacts/artifact-tabs"
+import { useAgentPreset } from "@/hooks/use-agent-presets"
 import { useGetTable } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 import type { WorkspaceChatArtifact } from "@/types/workspace-chat-artifacts"
 
+const CASE_ARTIFACT_TABS = new Set([
+  "comments",
+  "activity",
+  "attachments",
+  "rows",
+  "payload",
+])
+const AGENT_ARTIFACT_TABS = new Set([
+  "live-chat",
+  "assistant",
+  "configuration",
+  "subagents",
+  "skills",
+  "channels",
+  "structured-output",
+  "versions",
+])
+
 export interface ArtifactContentProps {
   artifact: WorkspaceChatArtifact
   workspaceId: string
+  activeTab: string | null
+  onTabChange: (tab: string | null) => void
 }
 
 /** Render the active artifact content with type-specific embedded views. */
 export function ArtifactContent({
   artifact,
   workspaceId,
+  activeTab,
+  onTabChange,
 }: ArtifactContentProps) {
+  const normalizedTab = useMemo(
+    () => normalizeArtifactTab(artifact, activeTab),
+    [artifact, activeTab]
+  )
+
+  useEffect(() => {
+    if (activeTab !== null && normalizedTab === null) {
+      onTabChange(null)
+    }
+  }, [activeTab, normalizedTab, onTabChange])
+
   switch (artifact.type) {
     case "case":
-      return <CasePanelView caseId={artifact.id} embedded />
+      return (
+        <CasePanelView
+          caseId={artifact.id}
+          embedded
+          initialTab={normalizedTab}
+          onTabChange={onTabChange}
+        />
+      )
     case "table":
       return (
         <EmbeddedTableArtifact artifact={artifact} workspaceId={workspaceId} />
       )
+    case "agent":
+      return (
+        <EmbeddedAgentArtifact
+          artifact={artifact}
+          workspaceId={workspaceId}
+          activeTab={normalizedTab}
+          onTabChange={onTabChange}
+        />
+      )
     default:
       return <ArtifactSummary artifact={artifact} workspaceId={workspaceId} />
+  }
+}
+
+function normalizeArtifactTab(
+  artifact: WorkspaceChatArtifact,
+  tab: string | null
+): string | null {
+  if (!tab) {
+    return null
+  }
+
+  switch (artifact.type) {
+    case "case":
+      return CASE_ARTIFACT_TABS.has(tab) ? tab : null
+    case "agent":
+      return AGENT_ARTIFACT_TABS.has(tab) ? tab : null
+    default:
+      return null
   }
 }
 
@@ -83,6 +153,53 @@ function EmbeddedTableArtifact({
         </TablePanelProvider>
       </TableSelectionProvider>
     </div>
+  )
+}
+
+function EmbeddedAgentArtifact({
+  artifact,
+  workspaceId,
+  activeTab,
+  onTabChange,
+}: {
+  artifact: Extract<WorkspaceChatArtifact, { type: "agent" }>
+  workspaceId: string
+  activeTab: string | null
+  onTabChange: (tab: string | null) => void
+}) {
+  const { preset, presetIsLoading, presetError } = useAgentPreset(
+    workspaceId,
+    artifact.id
+  )
+
+  if (presetIsLoading) {
+    return (
+      <div className="flex h-full flex-col gap-3 p-4">
+        <Skeleton className="h-5 w-1/2" />
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+    )
+  }
+
+  if (presetError || !preset) {
+    return (
+      <div className="p-4">
+        <AlertNotification
+          message={presetError?.message ?? "Error loading agent"}
+          variant="error"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <AgentPresetArtifactView
+      preset={preset}
+      workspaceId={workspaceId}
+      initialTab={activeTab}
+      onTabChange={onTabChange}
+    />
   )
 }
 

--- a/frontend/src/components/workspace-chat/artifacts/artifact-panel.tsx
+++ b/frontend/src/components/workspace-chat/artifacts/artifact-panel.tsx
@@ -15,6 +15,8 @@ export interface ArtifactPanelProps {
   setActiveArtifactKey: (key: string | null) => void
   closeArtifact: (type: ArtifactType, id: string) => void
   workspaceId: string
+  artifactTab: string | null
+  setArtifactTab: (tab: string | null) => void
   className?: string
   /** Triggered when the user manually collapses the panel. */
   onCollapse: () => void
@@ -32,6 +34,8 @@ export function ArtifactPanel({
   setActiveArtifactKey,
   closeArtifact,
   workspaceId,
+  artifactTab,
+  setArtifactTab,
   className,
   onCollapse,
 }: ArtifactPanelProps) {
@@ -61,6 +65,8 @@ export function ArtifactPanel({
             <ArtifactContent
               artifact={activeArtifact}
               workspaceId={workspaceId}
+              activeTab={artifactTab}
+              onTabChange={setArtifactTab}
             />
           </div>
         </>

--- a/frontend/src/components/workspace-chat/artifacts/artifact-registry.tsx
+++ b/frontend/src/components/workspace-chat/artifacts/artifact-registry.tsx
@@ -8,6 +8,7 @@ import {
   KeyRound,
   LayersIcon,
   ListVideoIcon,
+  MousePointerClickIcon,
   Table2Icon,
   WorkflowIcon,
 } from "lucide-react"
@@ -82,6 +83,33 @@ export const ARTIFACT_REGISTRY = {
       })
       queryClient.invalidateQueries({
         queryKey: ["tables", workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["rows", artifact.id],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["rows", "paginated", artifact.id, workspaceId],
+      })
+    },
+  },
+  agent: {
+    label: "Agents",
+    singularLabel: "Agent",
+    icon: MousePointerClickIcon,
+    href: (artifact, workspaceId) =>
+      `/workspaces/${workspaceId}/agents/${artifact.id}`,
+    invalidateQueries: (queryClient, workspaceId, artifact) => {
+      queryClient.invalidateQueries({
+        queryKey: ["agent-preset", workspaceId, artifact.id],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["agent-presets", workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["agent-directory-items", workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["agent-preset-versions", workspaceId, artifact.id],
       })
     },
   },

--- a/frontend/src/components/workspace-chat/workspace-chat-view.tsx
+++ b/frontend/src/components/workspace-chat/workspace-chat-view.tsx
@@ -1,9 +1,9 @@
 "use client"
 
 import { useQueryClient } from "@tanstack/react-query"
-import type { UIMessage } from "ai"
+import type { ChatOnDataCallback, UIMessage } from "ai"
 import { PanelLeftIcon } from "lucide-react"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { AgentSessionsGetSessionVercelResponse } from "@/client"
 import { useScopeCheck } from "@/components/auth/scope-guard"
@@ -30,12 +30,48 @@ import { useWorkspaceId } from "@/providers/workspace-id"
 import {
   ARTIFACT_DATA_PART_TYPE,
   type ArtifactType,
+  parseWorkspaceChatArtifactStreamPart,
   type WorkspaceChatArtifact,
   type WorkspaceChatArtifactStreamPart,
 } from "@/types/workspace-chat-artifacts"
 
 const EMPTY_MESSAGES: UIMessage[] = []
 const EMPTY_ARTIFACTS: WorkspaceChatArtifact[] = []
+const ARTIFACT_QUERY_PARAM = "artifact"
+const ARTIFACT_TAB_QUERY_PARAM = "tab"
+const ARTIFACT_TYPES = new Set<ArtifactType>([
+  "case",
+  "workflow",
+  "run",
+  "table",
+  "agent",
+  "alert",
+  "integration",
+  "secret",
+  "generic",
+])
+
+function parseArtifactQueryValue(value: string | null): string | null {
+  if (!value) {
+    return null
+  }
+  const separatorIndex = value.indexOf(":")
+  if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
+    return null
+  }
+  const type = value.slice(0, separatorIndex)
+  if (!ARTIFACT_TYPES.has(type as ArtifactType)) {
+    return null
+  }
+  return value
+}
+
+function parseArtifactTabQueryValue(value: string | null): string | null {
+  if (!value || !/^[a-z0-9-]+$/.test(value)) {
+    return null
+  }
+  return value
+}
 
 function sessionArtifacts(
   chat: AgentSessionsGetSessionVercelResponse | undefined
@@ -56,6 +92,13 @@ function sessionArtifacts(
 export function WorkspaceChatView({ chatId }: { chatId?: string }) {
   const workspaceId = useWorkspaceId()
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const initialArtifactKeyRef = useRef(
+    parseArtifactQueryValue(searchParams.get(ARTIFACT_QUERY_PARAM))
+  )
+  const initialArtifactTabRef = useRef(
+    parseArtifactTabQueryValue(searchParams.get(ARTIFACT_TAB_QUERY_PARAM))
+  )
   const queryClient = useQueryClient()
   const canAccessMissionControl = useScopeCheck(
     undefined,
@@ -70,6 +113,9 @@ export function WorkspaceChatView({ chatId }: { chatId?: string }) {
     AgentSessionsGetSessionVercelResponse | undefined
   >()
   const [isPanelCollapsed, setIsPanelCollapsed] = useState(true)
+  const [artifactTab, setArtifactTab] = useState<string | null>(
+    initialArtifactTabRef.current
+  )
   const { removeArtifact } = useRemoveSessionArtifact(workspaceId)
   const persistedArtifacts = useMemo(() => sessionArtifacts(chat), [chat])
   const closePersistedArtifact = useCallback(
@@ -99,8 +145,19 @@ export function WorkspaceChatView({ chatId }: { chatId?: string }) {
     },
     [queryClient, workspaceId]
   )
+  const handleStreamData = useCallback<ChatOnDataCallback<UIMessage>>(
+    (dataPart) => {
+      const part = parseWorkspaceChatArtifactStreamPart(dataPart)
+      if (!part) {
+        return
+      }
+      handleArtifactStreamPart(part)
+    },
+    [handleArtifactStreamPart]
+  )
   const artifactsState = useWorkspaceChatArtifacts(messages, {
     enabled: true,
+    initialActiveArtifactKey: initialArtifactKeyRef.current,
     persistedArtifacts,
     onArtifactStreamPart: handleArtifactStreamPart,
     onCloseArtifact: closePersistedArtifact,
@@ -121,6 +178,30 @@ export function WorkspaceChatView({ chatId }: { chatId?: string }) {
     }
     prevHasArtifactsRef.current = next
   }, [artifactCount])
+
+  useEffect(() => {
+    if (chat === undefined && !hasArtifacts) {
+      return
+    }
+
+    const url = new URL(window.location.href)
+    if (artifactsState.activeArtifactKey) {
+      url.searchParams.set(
+        ARTIFACT_QUERY_PARAM,
+        artifactsState.activeArtifactKey
+      )
+      if (artifactTab) {
+        url.searchParams.set(ARTIFACT_TAB_QUERY_PARAM, artifactTab)
+      } else {
+        url.searchParams.delete(ARTIFACT_TAB_QUERY_PARAM)
+      }
+    } else {
+      url.searchParams.delete(ARTIFACT_QUERY_PARAM)
+      url.searchParams.delete(ARTIFACT_TAB_QUERY_PARAM)
+    }
+    url.hash = ""
+    window.history.replaceState(window.history.state, "", url.toString())
+  }, [artifactTab, artifactsState.activeArtifactKey, chat, hasArtifacts])
 
   const collapsePanel = useCallback(() => setIsPanelCollapsed(true), [])
   const expandPanel = useCallback(() => setIsPanelCollapsed(false), [])
@@ -179,6 +260,7 @@ export function WorkspaceChatView({ chatId }: { chatId?: string }) {
             placeholder="Ask Tracecat..."
             surface="workspace-chat"
             onMessagesChange={setMessages}
+            onData={handleStreamData}
             onChatChange={setChat}
             headerActions={
               showExpandButton ? (
@@ -219,6 +301,8 @@ export function WorkspaceChatView({ chatId }: { chatId?: string }) {
               setActiveArtifactKey={artifactsState.setActiveArtifactKey}
               closeArtifact={artifactsState.closeArtifact}
               workspaceId={workspaceId}
+              artifactTab={artifactTab}
+              setArtifactTab={setArtifactTab}
               onCollapse={collapsePanel}
             />
           </ResizablePanel>

--- a/frontend/src/components/workspace-chat/workspace-chat-view.tsx
+++ b/frontend/src/components/workspace-chat/workspace-chat-view.tsx
@@ -46,7 +46,14 @@ function sessionArtifacts(
   return chat.artifacts as WorkspaceChatArtifact[]
 }
 
-export function WorkspaceChatView() {
+/**
+ * Workspace chat surface. When `chatId` is provided (deep link via
+ * /chat/:chatId) it opens that session; otherwise it starts a fresh draft.
+ *
+ * `chatId` is the chat session id (a.k.a. sessionId) — the chat client names
+ * it `chatId` everywhere, so the prop matches that convention.
+ */
+export function WorkspaceChatView({ chatId }: { chatId?: string }) {
   const workspaceId = useWorkspaceId()
   const router = useRouter()
   const queryClient = useQueryClient()
@@ -165,6 +172,7 @@ export function WorkspaceChatView() {
       >
         <div className="flex size-full min-w-[320px] flex-col">
           <ChatInterface
+            chatId={chatId}
             entityType="copilot"
             entityId={workspaceId}
             bodyClassName="min-h-0"

--- a/frontend/src/hooks/use-workspace-chat-artifacts.test.tsx
+++ b/frontend/src/hooks/use-workspace-chat-artifacts.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { useWorkspaceChatArtifacts } from "@/hooks/use-workspace-chat-artifacts"
+import type { WorkspaceChatArtifact } from "@/types/workspace-chat-artifacts"
+
+const caseArtifact: WorkspaceChatArtifact = {
+  id: "case-1",
+  type: "case",
+  title: "Case artifact",
+  severity: "medium",
+  status: "new",
+}
+
+const tableArtifact: WorkspaceChatArtifact = {
+  id: "table-1",
+  type: "table",
+  title: "Table artifact",
+}
+
+describe("useWorkspaceChatArtifacts", () => {
+  it("honors the initial active artifact when persisted artifacts hydrate", async () => {
+    const { result, rerender } = renderHook(
+      ({
+        persistedArtifacts,
+      }: {
+        persistedArtifacts: WorkspaceChatArtifact[]
+      }) =>
+        useWorkspaceChatArtifacts([], {
+          initialActiveArtifactKey: "table:table-1",
+          persistedArtifacts,
+        }),
+      {
+        initialProps: {
+          persistedArtifacts: [] as WorkspaceChatArtifact[],
+        },
+      }
+    )
+
+    expect(result.current.activeArtifactKey).toBeNull()
+
+    rerender({
+      persistedArtifacts: [caseArtifact, tableArtifact],
+    })
+
+    await waitFor(() =>
+      expect(result.current.activeArtifactKey).toBe("table:table-1")
+    )
+  })
+})

--- a/frontend/src/hooks/use-workspace-chat-artifacts.test.tsx
+++ b/frontend/src/hooks/use-workspace-chat-artifacts.test.tsx
@@ -1,6 +1,9 @@
 import { renderHook, waitFor } from "@testing-library/react"
 import { useWorkspaceChatArtifacts } from "@/hooks/use-workspace-chat-artifacts"
-import type { WorkspaceChatArtifact } from "@/types/workspace-chat-artifacts"
+import {
+  parseWorkspaceChatArtifactStreamPart,
+  type WorkspaceChatArtifact,
+} from "@/types/workspace-chat-artifacts"
 
 const caseArtifact: WorkspaceChatArtifact = {
   id: "case-1",
@@ -14,6 +17,12 @@ const tableArtifact: WorkspaceChatArtifact = {
   id: "table-1",
   type: "table",
   title: "Table artifact",
+}
+
+const agentArtifact: WorkspaceChatArtifact = {
+  id: "agent-1",
+  type: "agent",
+  title: "Agent artifact",
 }
 
 describe("useWorkspaceChatArtifacts", () => {
@@ -44,5 +53,23 @@ describe("useWorkspaceChatArtifacts", () => {
     await waitFor(() =>
       expect(result.current.activeArtifactKey).toBe("table:table-1")
     )
+  })
+
+  it("accepts streamed agent artifacts", () => {
+    const part = parseWorkspaceChatArtifactStreamPart({
+      type: "data-artifact",
+      data: {
+        op: "upsert",
+        artifact: agentArtifact,
+      },
+    })
+
+    expect(part).toEqual({
+      type: "data-artifact",
+      data: {
+        op: "upsert",
+        artifact: agentArtifact,
+      },
+    })
   })
 })

--- a/frontend/src/hooks/use-workspace-chat-artifacts.ts
+++ b/frontend/src/hooks/use-workspace-chat-artifacts.ts
@@ -24,6 +24,7 @@ export type UseWorkspaceChatArtifactsResult = {
 /** Options for projecting artifact stream parts into workspace chat state. */
 export type UseWorkspaceChatArtifactsOptions = {
   enabled?: boolean
+  initialActiveArtifactKey?: string | null
   persistedArtifacts?: WorkspaceChatArtifact[]
   onArtifactStreamPart?: (part: WorkspaceChatArtifactStreamPart) => void
   onCloseArtifact?: (type: ArtifactType, id: string) => void | Promise<void>
@@ -39,7 +40,7 @@ const EMPTY_ARTIFACTS: WorkspaceChatArtifact[] = []
 function reduceArtifactPayload(
   next: Map<string, WorkspaceChatArtifact>,
   payload: ArtifactDataPayload
-) {
+): void {
   const key = artifactKey(payload.artifact)
   switch (payload.op) {
     case "upsert":
@@ -54,7 +55,7 @@ function reduceArtifactPayload(
 function reduceWorkspaceChatArtifactStreamPart(
   next: Map<string, WorkspaceChatArtifact>,
   part: WorkspaceChatArtifactStreamPart
-) {
+): void {
   switch (part.type) {
     case ARTIFACT_DATA_PART_TYPE:
       reduceArtifactPayload(next, part.data)
@@ -152,6 +153,20 @@ function lastArtifactKey(artifacts: WorkspaceChatArtifact[]): string | null {
   return artifact ? artifactKey(artifact) : null
 }
 
+function selectActiveArtifactKey(
+  artifacts: WorkspaceChatArtifact[],
+  preferredKey: string | null,
+  fallbackKey: string | null
+): string | null {
+  if (
+    preferredKey &&
+    artifacts.some((artifact) => artifactKey(artifact) === preferredKey)
+  ) {
+    return preferredKey
+  }
+  return fallbackKey
+}
+
 function notifyArtifactStreamParts(
   streamParts: WorkspaceChatArtifactMessageStreamPart[],
   onArtifactStreamPart: UseWorkspaceChatArtifactsOptions["onArtifactStreamPart"]
@@ -176,6 +191,7 @@ export function useWorkspaceChatArtifacts(
   options: UseWorkspaceChatArtifactsOptions = {}
 ): UseWorkspaceChatArtifactsResult {
   const enabled = options.enabled ?? true
+  const initialActiveArtifactKey = options.initialActiveArtifactKey ?? null
   const persistedArtifacts = options.persistedArtifacts ?? EMPTY_ARTIFACTS
   const onArtifactStreamPart = options.onArtifactStreamPart
   const onCloseArtifact = options.onCloseArtifact
@@ -191,13 +207,24 @@ export function useWorkspaceChatArtifacts(
   const previousPersistedArtifactSignatureRef = useRef(
     persistedArtifactSignature
   )
+  const initialActiveArtifactKeyRef = useRef(initialActiveArtifactKey)
   const [activeArtifactKey, setActiveArtifactKey] = useState<string | null>(
     () => {
       if (!enabled) {
         return null
       }
       const initialParts = messageStreamParts(messages)
-      return lastUpsertKey(initialParts) ?? lastArtifactKey(persistedArtifacts)
+      const initialArtifacts = Array.from(
+        artifactMapFromArtifactsAndMessageStreamParts(
+          persistedArtifacts,
+          initialParts
+        ).values()
+      )
+      return selectActiveArtifactKey(
+        initialArtifacts,
+        initialActiveArtifactKeyRef.current,
+        lastUpsertKey(initialParts) ?? lastArtifactKey(persistedArtifacts)
+      )
     }
   )
   const [streamArtifacts, setStreamArtifacts] = useState<
@@ -215,6 +242,13 @@ export function useWorkspaceChatArtifacts(
       initialParts
     )
   })
+  const setActiveArtifactKeyAndClearInitial = useCallback(
+    (key: string | null) => {
+      initialActiveArtifactKeyRef.current = null
+      setActiveArtifactKey(key)
+    },
+    []
+  )
 
   useEffect(() => {
     const firstMessageId = messages[0]?.id ?? null
@@ -249,14 +283,17 @@ export function useWorkspaceChatArtifacts(
       processedMessagePartKeysRef.current = new Set(
         currentParts.map(({ eventKey }) => eventKey)
       )
-      setStreamArtifacts(
-        artifactMapFromArtifactsAndMessageStreamParts(
-          persistedArtifacts,
-          currentParts
-        )
+      const nextArtifacts = artifactMapFromArtifactsAndMessageStreamParts(
+        persistedArtifacts,
+        currentParts
       )
+      setStreamArtifacts(nextArtifacts)
       setActiveArtifactKey(
-        lastUpsertKey(currentParts) ?? lastArtifactKey(persistedArtifacts)
+        selectActiveArtifactKey(
+          Array.from(nextArtifacts.values()),
+          initialActiveArtifactKeyRef.current,
+          lastUpsertKey(currentParts) ?? lastArtifactKey(persistedArtifacts)
+        )
       )
       return
     }
@@ -270,15 +307,20 @@ export function useWorkspaceChatArtifacts(
       for (const { eventKey } of pendingParts) {
         processedMessagePartKeysRef.current.add(eventKey)
       }
-      setStreamArtifacts(
-        artifactMapFromArtifactsAndMessageStreamParts(
-          persistedArtifacts,
-          pendingParts
-        )
+      const nextArtifacts = artifactMapFromArtifactsAndMessageStreamParts(
+        persistedArtifacts,
+        pendingParts
       )
+      setStreamArtifacts(nextArtifacts)
       const nextActiveArtifactKey =
         lastUpsertKey(pendingParts) ?? lastArtifactKey(persistedArtifacts)
-      setActiveArtifactKey(nextActiveArtifactKey)
+      setActiveArtifactKey(
+        selectActiveArtifactKey(
+          Array.from(nextArtifacts.values()),
+          initialActiveArtifactKeyRef.current,
+          nextActiveArtifactKey
+        )
+      )
       return
     }
 
@@ -300,6 +342,7 @@ export function useWorkspaceChatArtifacts(
 
     const nextActiveArtifactKey = lastUpsertKey(pendingParts)
     if (nextActiveArtifactKey) {
+      initialActiveArtifactKeyRef.current = null
       setActiveArtifactKey(nextActiveArtifactKey)
     }
   }, [
@@ -333,6 +376,7 @@ export function useWorkspaceChatArtifacts(
       switch (part.type) {
         case ARTIFACT_DATA_PART_TYPE:
           if (part.data.op === "upsert") {
+            initialActiveArtifactKeyRef.current = null
             setActiveArtifactKey(artifactKey(part.data.artifact))
           }
           return
@@ -375,6 +419,18 @@ export function useWorkspaceChatArtifacts(
       return
     }
 
+    if (
+      initialActiveArtifactKeyRef.current &&
+      artifacts.some(
+        (artifact) =>
+          artifactKey(artifact) === initialActiveArtifactKeyRef.current
+      )
+    ) {
+      setActiveArtifactKey(initialActiveArtifactKeyRef.current)
+      return
+    }
+
+    initialActiveArtifactKeyRef.current = null
     setActiveArtifactKey(artifactKey(artifacts[artifacts.length - 1]))
   }, [activeArtifactKey, artifacts])
 
@@ -390,6 +446,7 @@ export function useWorkspaceChatArtifacts(
         return next
       })
       if (activeArtifactKey === key) {
+        initialActiveArtifactKeyRef.current = null
         const fallback = artifacts.find(
           (artifact) => artifactKey(artifact) !== key
         )
@@ -404,7 +461,7 @@ export function useWorkspaceChatArtifacts(
     artifacts,
     lanes,
     activeArtifactKey,
-    setActiveArtifactKey,
+    setActiveArtifactKey: setActiveArtifactKeyAndClearInitial,
     closeArtifact,
     applyStreamPart,
   }

--- a/frontend/src/types/workspace-chat-artifacts.ts
+++ b/frontend/src/types/workspace-chat-artifacts.ts
@@ -199,6 +199,8 @@ function isArtifact(value: unknown): value is WorkspaceChatArtifact {
       )
     case "table":
       return value.rowCount === undefined || typeof value.rowCount === "number"
+    case "agent":
+      return true
     case "alert":
     case "integration":
     case "secret":

--- a/frontend/src/types/workspace-chat-artifacts.ts
+++ b/frontend/src/types/workspace-chat-artifacts.ts
@@ -51,6 +51,10 @@ export type TableArtifact = BaseArtifact & {
   rowCount?: number
 }
 
+export type AgentArtifact = BaseArtifact & {
+  type: "agent"
+}
+
 export type AlertArtifact = BaseArtifact & {
   type: "alert"
 }
@@ -73,6 +77,7 @@ export type WorkspaceChatArtifact =
   | WorkflowArtifact
   | RunArtifact
   | TableArtifact
+  | AgentArtifact
   | AlertArtifact
   | IntegrationArtifact
   | SecretArtifact

--- a/frontend/tests/mission-control-view.test.tsx
+++ b/frontend/tests/mission-control-view.test.tsx
@@ -15,6 +15,7 @@ const mockHasEntitlement = jest.fn<boolean, [string]>()
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ replace: mockRouterReplace }),
+  useSearchParams: () => new URLSearchParams(),
 }))
 
 jest.mock("@/components/auth/scope-guard", () => ({

--- a/packages/tracecat-ee/tracecat_ee/agent/artifacts/hydrators.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/artifacts/hydrators.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 
 import uuid
 
+from pydantic_core import to_jsonable_python
+
 from tracecat.agent.artifacts.hydration import (
     ArtifactHydrationContext,
     ArtifactHydratorRegistry,
     MountedArtifactContent,
 )
-from tracecat.artifacts.schemas import Artifact, CaseArtifact
+from tracecat.agent.preset.service import AgentPresetService
+from tracecat.artifacts.schemas import (
+    AgentArtifact,
+    Artifact,
+    CaseArtifact,
+    TableArtifact,
+)
 from tracecat.auth.schemas import UserRead
 from tracecat.authz.controls import has_scope
 from tracecat.cases.dropdowns.schemas import CaseDropdownValueRead
@@ -25,6 +33,10 @@ from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.exceptions import ScopeDeniedError
 from tracecat.logger import logger
+from tracecat.pagination import CursorPaginationParams
+from tracecat.tables.enums import SqlType
+from tracecat.tables.schemas import TableColumnRead, TableRead
+from tracecat.tables.service import TablesService
 from tracecat.tiers.enums import Entitlement
 
 
@@ -120,9 +132,120 @@ class CaseArtifactHydrator:
         )
 
 
+class TableArtifactHydrator:
+    """Hydrate a table artifact projection into metadata and a row preview."""
+
+    async def hydrate(
+        self,
+        artifact: Artifact,
+        ctx: ArtifactHydrationContext,
+    ) -> MountedArtifactContent | None:
+        """Load the current table schema and first page of rows."""
+        if not isinstance(artifact, TableArtifact):
+            return None
+
+        try:
+            table_id = uuid.UUID(artifact.id)
+        except ValueError:
+            logger.warning(
+                "Cannot hydrate table artifact with non-UUID id",
+                artifact_id=artifact.id,
+            )
+            return None
+
+        async with get_async_session_context_manager() as session:
+            service = TablesService(session, ctx.role)
+            table = await service.get_table(table_id)
+            index_columns = await service.get_index(table)
+            table_read = TableRead(
+                id=table.id,
+                name=table.name,
+                columns=[
+                    TableColumnRead(
+                        id=column.id,
+                        name=column.name,
+                        type=SqlType(column.type),
+                        nullable=column.nullable,
+                        default=column.default,
+                        is_index=column.name in index_columns,
+                        options=column.options,
+                    )
+                    for column in table.columns
+                ],
+            )
+            rows_page = await service.list_rows(
+                table,
+                CursorPaginationParams(limit=100),
+            )
+
+        return MountedArtifactContent(
+            filename="table.json",
+            content_type="table.read",
+            payload={
+                "table": table_read.model_dump(mode="json", by_alias=True),
+                "rows": to_jsonable_python(rows_page.items, fallback=str),
+                "pagination": {
+                    "next_cursor": rows_page.next_cursor,
+                    "prev_cursor": rows_page.prev_cursor,
+                    "has_more": rows_page.has_more,
+                    "has_previous": rows_page.has_previous,
+                    "total_estimate": rows_page.total_estimate,
+                },
+            },
+        )
+
+
+class AgentArtifactHydrator:
+    """Hydrate an agent artifact projection into a full preset read model."""
+
+    async def hydrate(
+        self,
+        artifact: Artifact,
+        ctx: ArtifactHydrationContext,
+    ) -> MountedArtifactContent | None:
+        """Load the current agent preset content for the mounted working copy."""
+        if not isinstance(artifact, AgentArtifact):
+            return None
+
+        try:
+            preset_id = uuid.UUID(artifact.id)
+        except ValueError:
+            logger.warning(
+                "Cannot hydrate agent artifact with non-UUID id",
+                artifact_id=artifact.id,
+            )
+            return None
+
+        async with AgentPresetService.with_session(role=ctx.role) as service:
+            preset = await service.get_preset(preset_id)
+            if preset is None:
+                logger.warning(
+                    "Cannot hydrate missing agent artifact",
+                    preset_id=preset_id,
+                )
+                return None
+            preset_read = await service.build_preset_read(preset)
+
+        return MountedArtifactContent(
+            filename="agent.json",
+            content_type="agent_preset.read",
+            payload=preset_read.model_dump(
+                mode="json",
+                by_alias=True,
+                exclude_none=True,
+            ),
+        )
+
+
 def build_hydrator_registry() -> ArtifactHydratorRegistry:
     """Build the EE source-available artifact hydrator registry."""
-    return ArtifactHydratorRegistry({"case": CaseArtifactHydrator()})
+    return ArtifactHydratorRegistry(
+        {
+            "case": CaseArtifactHydrator(),
+            "table": TableArtifactHydrator(),
+            "agent": AgentArtifactHydrator(),
+        }
+    )
 
 
 def _require_case_read_scope(ctx: ArtifactHydrationContext) -> None:

--- a/packages/tracecat-ee/tracecat_ee/agent/artifacts/hydrators.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/artifacts/hydrators.py
@@ -218,6 +218,8 @@ class AgentArtifactHydrator:
             )
             return None
 
+        _require_agent_read_scope(ctx)
+
         async with AgentPresetService.with_session(role=ctx.role) as service:
             preset = await service.get_preset(preset_id)
             if preset is None:
@@ -256,6 +258,10 @@ def _require_case_read_scope(ctx: ArtifactHydrationContext) -> None:
 
 def _require_table_read_scope(ctx: ArtifactHydrationContext) -> None:
     _require_artifact_scope(ctx, "table:read")
+
+
+def _require_agent_read_scope(ctx: ArtifactHydrationContext) -> None:
+    _require_artifact_scope(ctx, "agent:read")
 
 
 def _require_artifact_scope(ctx: ArtifactHydrationContext, required_scope: str) -> None:

--- a/packages/tracecat-ee/tracecat_ee/agent/artifacts/hydrators.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/artifacts/hydrators.py
@@ -153,6 +153,8 @@ class TableArtifactHydrator:
             )
             return None
 
+        _require_table_read_scope(ctx)
+
         async with get_async_session_context_manager() as session:
             service = TablesService(session, ctx.role)
             table = await service.get_table(table_id)
@@ -249,10 +251,18 @@ def build_hydrator_registry() -> ArtifactHydratorRegistry:
 
 
 def _require_case_read_scope(ctx: ArtifactHydrationContext) -> None:
+    _require_artifact_scope(ctx, "case:read")
+
+
+def _require_table_read_scope(ctx: ArtifactHydrationContext) -> None:
+    _require_artifact_scope(ctx, "table:read")
+
+
+def _require_artifact_scope(ctx: ArtifactHydrationContext, required_scope: str) -> None:
     scopes = ctx.role.scopes or frozenset()
-    if has_scope(scopes, "case:read"):
+    if has_scope(scopes, required_scope):
         return
     raise ScopeDeniedError(
-        required_scopes=["case:read"],
-        missing_scopes=["case:read"],
+        required_scopes=[required_scope],
+        missing_scopes=[required_scope],
     )

--- a/packages/tracecat-ee/tracecat_ee/agent/artifacts/mount_only_provider.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/artifacts/mount_only_provider.py
@@ -118,7 +118,6 @@ class MountOnlyArtifactWorkingSetProvider:
             "hydrated": False,
             "projection_path": str(projection_runtime_path),
         }
-        content_preview = _json_preview(projection_payload)
 
         content = await self._hydrate_artifact(artifact, ctx=ctx)
         if content is not None:
@@ -126,7 +125,6 @@ class MountOnlyArtifactWorkingSetProvider:
             self._write_json(host_root / primary_relative_path, content.payload)
             metadata["hydrated"] = True
             metadata["content_type"] = content.content_type
-            content_preview = _json_preview(content.payload)
 
         runtime_path = runtime_root / primary_relative_path
         logger.info(
@@ -139,7 +137,6 @@ class MountOnlyArtifactWorkingSetProvider:
             path=str(runtime_path),
             hydrated=metadata["hydrated"],
             content_type=metadata.get("content_type"),
-            preview=content_preview,
         )
 
         return ArtifactWorkingSetEntry(
@@ -224,11 +221,6 @@ def _remove_path_without_following_symlink(path: Path) -> None:
         shutil.rmtree(path)
     else:
         path.unlink()
-
-
-def _json_preview(payload: Any) -> str:
-    text = orjson.dumps(payload, default=str).decode("utf-8")
-    return _preview_text(text)
 
 
 def _preview_text(text: str) -> str:

--- a/packages/tracecat-ee/tracecat_ee/agent/artifacts/mount_only_provider.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/artifacts/mount_only_provider.py
@@ -29,6 +29,7 @@ from tracecat.logger import logger
 from tracecat_ee.agent.artifacts.hydrators import build_hydrator_registry
 
 _SAFE_PATH_SEGMENT_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+_LOG_PREVIEW_BYTES = 4000
 
 
 class MountOnlyArtifactWorkingSetProvider:
@@ -44,6 +45,15 @@ class MountOnlyArtifactWorkingSetProvider:
         """Prepare scratch artifact files for a Workspace Chat turn."""
         host_root = _prepare_host_artifact_root(ctx.host_work_dir)
         runtime_root = ctx.runtime_work_dir / ".tracecat" / "artifacts"
+
+        logger.info(
+            "Preparing Workspace Chat artifact working set",
+            session_id=str(ctx.session_id),
+            workspace_id=str(ctx.workspace_id),
+            artifact_count=len(ctx.artifacts),
+            host_root=str(host_root),
+            runtime_root=str(runtime_root),
+        )
 
         entries = [
             await self._write_artifact_files(
@@ -63,6 +73,15 @@ class MountOnlyArtifactWorkingSetProvider:
         (host_root / "manifest.json").write_text(
             manifest.model_dump_json(indent=2, exclude_none=True),
             encoding="utf-8",
+        )
+        logger.info(
+            "Prepared Workspace Chat artifact manifest",
+            session_id=str(ctx.session_id),
+            manifest_path=str(runtime_root / "manifest.json"),
+            artifact_count=len(entries),
+            prompt_fragment_preview=_preview_text(_build_prompt_fragment(manifest))
+            if entries
+            else None,
         )
         return ArtifactWorkingSetResult(
             manifest=manifest,
@@ -87,16 +106,19 @@ class MountOnlyArtifactWorkingSetProvider:
         projection_relative_path = artifact_dir / "artifact.json"
         projection_runtime_path = runtime_root / projection_relative_path
 
-        self._write_json(
-            host_root / projection_relative_path,
-            artifact.model_dump(mode="json", by_alias=True, exclude_none=True),
+        projection_payload = artifact.model_dump(
+            mode="json",
+            by_alias=True,
+            exclude_none=True,
         )
+        self._write_json(host_root / projection_relative_path, projection_payload)
 
         primary_relative_path = projection_relative_path
         metadata: dict[str, Any] = {
             "hydrated": False,
             "projection_path": str(projection_runtime_path),
         }
+        content_preview = _json_preview(projection_payload)
 
         content = await self._hydrate_artifact(artifact, ctx=ctx)
         if content is not None:
@@ -104,13 +126,28 @@ class MountOnlyArtifactWorkingSetProvider:
             self._write_json(host_root / primary_relative_path, content.payload)
             metadata["hydrated"] = True
             metadata["content_type"] = content.content_type
+            content_preview = _json_preview(content.payload)
+
+        runtime_path = runtime_root / primary_relative_path
+        logger.info(
+            "Mounted Workspace Chat artifact file",
+            session_id=str(ctx.session_id),
+            artifact_type=artifact.type,
+            artifact_id=artifact.id,
+            title=artifact.title,
+            projection_path=str(projection_runtime_path),
+            path=str(runtime_path),
+            hydrated=metadata["hydrated"],
+            content_type=metadata.get("content_type"),
+            preview=content_preview,
+        )
 
         return ArtifactWorkingSetEntry(
             artifact_id=f"{artifact.type}:{artifact.id}",
             type=artifact.type,
             id=artifact.id,
             title=artifact.title,
-            path=str(runtime_root / primary_relative_path),
+            path=str(runtime_path),
             metadata=metadata,
         )
 
@@ -187,6 +224,17 @@ def _remove_path_without_following_symlink(path: Path) -> None:
         shutil.rmtree(path)
     else:
         path.unlink()
+
+
+def _json_preview(payload: Any) -> str:
+    text = orjson.dumps(payload, default=str).decode("utf-8")
+    return _preview_text(text)
+
+
+def _preview_text(text: str) -> str:
+    if len(text) <= _LOG_PREVIEW_BYTES:
+        return text
+    return f"{text[:_LOG_PREVIEW_BYTES]}... [truncated]"
 
 
 def _build_prompt_fragment(manifest: ArtifactWorkingSetManifest) -> str:

--- a/packages/tracecat-ee/tracecat_ee/agent/artifacts/mount_only_provider.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/artifacts/mount_only_provider.py
@@ -29,7 +29,6 @@ from tracecat.logger import logger
 from tracecat_ee.agent.artifacts.hydrators import build_hydrator_registry
 
 _SAFE_PATH_SEGMENT_RE = re.compile(r"[^A-Za-z0-9_.-]+")
-_LOG_PREVIEW_BYTES = 4000
 
 
 class MountOnlyArtifactWorkingSetProvider:
@@ -79,9 +78,6 @@ class MountOnlyArtifactWorkingSetProvider:
             session_id=str(ctx.session_id),
             manifest_path=str(runtime_root / "manifest.json"),
             artifact_count=len(entries),
-            prompt_fragment_preview=_preview_text(_build_prompt_fragment(manifest))
-            if entries
-            else None,
         )
         return ArtifactWorkingSetResult(
             manifest=manifest,
@@ -221,12 +217,6 @@ def _remove_path_without_following_symlink(path: Path) -> None:
         shutil.rmtree(path)
     else:
         path.unlink()
-
-
-def _preview_text(text: str) -> str:
-    if len(text) <= _LOG_PREVIEW_BYTES:
-        return text
-    return f"{text[:_LOG_PREVIEW_BYTES]}... [truncated]"
 
 
 def _build_prompt_fragment(manifest: ArtifactWorkingSetManifest) -> str:

--- a/tests/unit/test_agent_artifact_working_set.py
+++ b/tests/unit/test_agent_artifact_working_set.py
@@ -6,7 +6,10 @@ from types import SimpleNamespace
 
 import orjson
 import pytest
-from tracecat_ee.agent.artifacts.hydrators import CaseArtifactHydrator
+from tracecat_ee.agent.artifacts.hydrators import (
+    CaseArtifactHydrator,
+    TableArtifactHydrator,
+)
 from tracecat_ee.agent.artifacts.mount_only_provider import (
     MountOnlyArtifactWorkingSetProvider,
 )
@@ -30,6 +33,7 @@ from tracecat.artifacts.schemas import (
     ArtifactType,
     CaseArtifact,
     GenericArtifact,
+    TableArtifact,
 )
 from tracecat.auth.types import Role
 from tracecat.cases.enums import CaseSeverity, CaseStatus
@@ -182,6 +186,24 @@ async def test_case_artifact_hydrator_requires_case_read_scope() -> None:
                 title="Case",
                 severity=CaseSeverity.HIGH,
                 status=CaseStatus.NEW,
+            ),
+            ArtifactHydrationContext(
+                session_id=uuid.uuid4(),
+                workspace_id=workspace_id,
+                role=_role(workspace_id),
+            ),
+        )
+
+
+@pytest.mark.anyio
+async def test_table_artifact_hydrator_requires_table_read_scope() -> None:
+    workspace_id = uuid.uuid4()
+
+    with pytest.raises(ScopeDeniedError):
+        await TableArtifactHydrator().hydrate(
+            TableArtifact(
+                id=str(uuid.uuid4()),
+                title="Table",
             ),
             ArtifactHydrationContext(
                 session_id=uuid.uuid4(),

--- a/tests/unit/test_agent_artifact_working_set.py
+++ b/tests/unit/test_agent_artifact_working_set.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import orjson
 import pytest
 from tracecat_ee.agent.artifacts.hydrators import (
+    AgentArtifactHydrator,
     CaseArtifactHydrator,
     TableArtifactHydrator,
 )
@@ -29,6 +30,7 @@ from tracecat.agent.artifacts.providers import (
 )
 from tracecat.agent.artifacts.working_set import ArtifactWorkingSetContext
 from tracecat.artifacts.schemas import (
+    AgentArtifact,
     Artifact,
     ArtifactType,
     CaseArtifact,
@@ -204,6 +206,24 @@ async def test_table_artifact_hydrator_requires_table_read_scope() -> None:
             TableArtifact(
                 id=str(uuid.uuid4()),
                 title="Table",
+            ),
+            ArtifactHydrationContext(
+                session_id=uuid.uuid4(),
+                workspace_id=workspace_id,
+                role=_role(workspace_id),
+            ),
+        )
+
+
+@pytest.mark.anyio
+async def test_agent_artifact_hydrator_requires_agent_read_scope() -> None:
+    workspace_id = uuid.uuid4()
+
+    with pytest.raises(ScopeDeniedError):
+        await AgentArtifactHydrator().hydrate(
+            AgentArtifact(
+                id=str(uuid.uuid4()),
+                title="Agent",
             ),
             ArtifactHydrationContext(
                 session_id=uuid.uuid4(),

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -284,7 +284,13 @@ async def test_tool_result_emits_artifact_side_effect_from_tracked_call() -> Non
     handler = _make_handler()
     stream = _FakeStream()
     handler._stream_sink = stream
-    persist_artifact_side_effects = AsyncMock()
+
+    async def persist_passthrough(
+        effects: list[ArtifactSideEffect],
+    ) -> list[ArtifactSideEffect]:
+        return effects
+
+    persist_artifact_side_effects = AsyncMock(side_effect=persist_passthrough)
     handler._persist_artifact_side_effects = persist_artifact_side_effects
 
     await handler.send_stream_event(

--- a/tests/unit/test_agent_session_preset_versioning.py
+++ b/tests/unit/test_agent_session_preset_versioning.py
@@ -12,6 +12,7 @@ from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.subagents import ResolvedAgentsConfig
 from tracecat.auth.types import Role
+from tracecat.chat.tools import WORKSPACE_CHAT_DEFAULT_TOOLS
 from tracecat.db.models import AgentSession
 from tracecat.exceptions import TracecatValidationError
 
@@ -63,6 +64,28 @@ async def test_create_session_preserves_null_preset_version_for_current() -> Non
     assert created.agent_preset_id == preset_id
     assert created.agent_preset_version_id is None
     assert created.agents_binding is None
+    session.add.assert_called_once_with(created)
+    session.commit.assert_awaited_once()
+    session.refresh.assert_awaited_once_with(created)
+
+
+@pytest.mark.anyio
+async def test_create_workspace_chat_session_applies_current_default_tools() -> None:
+    service, session, _role = _build_service()
+    validate_mock = AsyncMock(return_value=None)
+    agents_binding_mock = AsyncMock(return_value=None)
+    service._validate_preset_version_for_assignment = validate_mock
+    service._resolve_agents_binding_for_preset_version_id = agents_binding_mock
+
+    created = await service.create_session(
+        AgentSessionCreate(
+            title="Chat",
+            entity_type=AgentSessionEntity.WORKSPACE_CHAT,
+            entity_id=uuid.uuid4(),
+        )
+    )
+
+    assert created.tools == WORKSPACE_CHAT_DEFAULT_TOOLS
     session.add.assert_called_once_with(created)
     session.commit.assert_awaited_once()
     session.refresh.assert_awaited_once_with(created)

--- a/tests/unit/test_agent_session_preset_versioning.py
+++ b/tests/unit/test_agent_session_preset_versioning.py
@@ -12,12 +12,28 @@ from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.subagents import ResolvedAgentsConfig
 from tracecat.auth.types import Role
-from tracecat.chat.tools import WORKSPACE_CHAT_DEFAULT_TOOLS
+from tracecat.chat.tools import WORKSPACE_CHAT_DEFAULT_TOOLS, get_default_tools
 from tracecat.db.models import AgentSession
 from tracecat.exceptions import TracecatValidationError
+from tracecat.tiers.enums import Entitlement
 
 
-def _build_service() -> tuple[AgentSessionService, SimpleNamespace, Role]:
+class _TestAgentSessionService(AgentSessionService):
+    agent_addons_enabled: bool = True
+    entitlement_checks: list[Entitlement]
+
+    def __init__(self, session: Any, role: Role) -> None:
+        super().__init__(session, role)
+        self.entitlement_checks = []
+
+    async def has_entitlement(self, entitlement: Entitlement) -> bool:
+        self.entitlement_checks.append(entitlement)
+        if entitlement is Entitlement.AGENT_ADDONS:
+            return self.agent_addons_enabled
+        return True
+
+
+def _build_service() -> tuple[_TestAgentSessionService, SimpleNamespace, Role]:
     workspace_id = uuid.uuid4()
     role = Role(
         type="service",
@@ -31,7 +47,8 @@ def _build_service() -> tuple[AgentSessionService, SimpleNamespace, Role]:
         commit=AsyncMock(),
         refresh=AsyncMock(),
     )
-    return AgentSessionService(cast(Any, session), role), session, role
+    service = _TestAgentSessionService(cast(Any, session), role)
+    return service, session, role
 
 
 @pytest.mark.anyio
@@ -86,6 +103,35 @@ async def test_create_workspace_chat_session_applies_current_default_tools() -> 
     )
 
     assert created.tools == WORKSPACE_CHAT_DEFAULT_TOOLS
+    session.add.assert_called_once_with(created)
+    session.commit.assert_awaited_once()
+    session.refresh.assert_awaited_once_with(created)
+
+
+@pytest.mark.anyio
+async def test_create_workspace_chat_session_omits_agent_tools_without_entitlement() -> (
+    None
+):
+    service, session, _role = _build_service()
+    service.agent_addons_enabled = False
+    validate_mock = AsyncMock(return_value=None)
+    agents_binding_mock = AsyncMock(return_value=None)
+    service._validate_preset_version_for_assignment = validate_mock
+    service._resolve_agents_binding_for_preset_version_id = agents_binding_mock
+
+    created = await service.create_session(
+        AgentSessionCreate(
+            title="Chat",
+            entity_type=AgentSessionEntity.WORKSPACE_CHAT,
+            entity_id=uuid.uuid4(),
+        )
+    )
+
+    assert created.tools == get_default_tools(
+        AgentSessionEntity.WORKSPACE_CHAT.value,
+        agent_addons_enabled=False,
+    )
+    assert service.entitlement_checks == [Entitlement.AGENT_ADDONS]
     session.add.assert_called_once_with(created)
     session.commit.assert_awaited_once()
     session.refresh.assert_awaited_once_with(created)

--- a/tests/unit/test_agent_stream_artifacts.py
+++ b/tests/unit/test_agent_stream_artifacts.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 
 import orjson
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.adapter.vercel import (
     DataEventPayload,
@@ -19,13 +20,20 @@ from tracecat.agent.stream.artifacts import (
     artifact_stream_events_for_tool_result,
 )
 from tracecat.agent.stream.connector import AgentStream
-from tracecat.artifacts.bindings import artifact_side_effects_for_tool_result
+from tracecat.artifacts.bindings import (
+    ArtifactIdentityRef,
+    ArtifactSideEffect,
+    artifact_side_effects_for_tool_result,
+)
 from tracecat.artifacts.projection import (
     apply_artifact_side_effects,
     serialize_artifacts,
 )
+from tracecat.artifacts.resolution import resolve_artifact_side_effects
 from tracecat.artifacts.schemas import ArtifactAdapter
+from tracecat.auth.types import Role
 from tracecat.chat import tokens
+from tracecat.exceptions import TracecatNotFoundError
 from tracecat.redis.client import RedisClient
 
 
@@ -96,6 +104,124 @@ def test_artifact_stream_events_for_tool_result_projects_side_effects() -> None:
         "severity": "high",
         "status": "new",
     }
+
+
+@pytest.mark.anyio
+async def test_resolve_artifact_side_effects_resolves_table_name_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_get_table_by_name(
+        _service: object,
+        table_name: str,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=uuid.UUID("11111111-1111-4111-8111-111111111111"),
+            name=table_name,
+        )
+
+    monkeypatch.setattr(
+        "tracecat.artifacts.resolution.TablesService.get_table_by_name",
+        fake_get_table_by_name,
+    )
+
+    artifact = ArtifactAdapter.validate_python(
+        {
+            "type": "table",
+            "id": "indicators",
+            "title": "indicators",
+        }
+    )
+    effects = [
+        ArtifactSideEffect(
+            op="upsert",
+            artifact=artifact,
+            identity_ref=ArtifactIdentityRef(
+                artifact_type="table",
+                ref="indicators",
+                ref_kind="name",
+            ),
+        )
+    ]
+
+    resolved = await resolve_artifact_side_effects(
+        effects,
+        session=cast(AsyncSession, object()),
+        role=Role(
+            type="service",
+            service_id="tracecat-api",
+            workspace_id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+        ),
+    )
+
+    assert len(resolved) == 1
+    assert resolved[0].op == "upsert"
+    assert resolved[0].artifact.id == "11111111-1111-4111-8111-111111111111"
+    assert resolved[0].artifact.title == "indicators"
+    assert resolved[0].identity_ref is None
+
+
+@pytest.mark.anyio
+async def test_resolve_artifact_side_effects_resolves_table_id_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    table_id = uuid.UUID("22222222-2222-4222-8222-222222222222")
+
+    async def fake_get_table_by_name(
+        _service: object,
+        _table_name: str,
+    ) -> None:
+        raise TracecatNotFoundError("Table not found")
+
+    async def fake_get_table(
+        _service: object,
+        requested_table_id: uuid.UUID,
+    ) -> SimpleNamespace:
+        assert requested_table_id == table_id
+        return SimpleNamespace(id=table_id, name="indicators")
+
+    monkeypatch.setattr(
+        "tracecat.artifacts.resolution.TablesService.get_table_by_name",
+        fake_get_table_by_name,
+    )
+    monkeypatch.setattr(
+        "tracecat.artifacts.resolution.TablesService.get_table",
+        fake_get_table,
+    )
+
+    artifact = ArtifactAdapter.validate_python(
+        {
+            "type": "table",
+            "id": str(table_id),
+            "title": str(table_id),
+        }
+    )
+
+    resolved = await resolve_artifact_side_effects(
+        [
+            ArtifactSideEffect(
+                op="upsert",
+                artifact=artifact,
+                identity_ref=ArtifactIdentityRef(
+                    artifact_type="table",
+                    ref=str(table_id),
+                    ref_kind="id",
+                ),
+            )
+        ],
+        session=cast(AsyncSession, object()),
+        role=Role(
+            type="service",
+            service_id="tracecat-api",
+            workspace_id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+        ),
+    )
+
+    assert len(resolved) == 1
+    assert resolved[0].artifact.id == str(table_id)
+    assert resolved[0].artifact.title == "indicators"
+    assert resolved[0].identity_ref is None
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_stream_artifacts.py
+++ b/tests/unit/test_agent_stream_artifacts.py
@@ -225,6 +225,53 @@ async def test_resolve_artifact_side_effects_resolves_table_id_identity(
 
 
 @pytest.mark.anyio
+async def test_resolve_artifact_side_effects_skips_invalid_table_name_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_get_table_by_name(
+        _service: object,
+        _table_name: str,
+    ) -> None:
+        raise ValueError("Invalid table name")
+
+    monkeypatch.setattr(
+        "tracecat.artifacts.resolution.TablesService.get_table_by_name",
+        fake_get_table_by_name,
+    )
+
+    artifact = ArtifactAdapter.validate_python(
+        {
+            "type": "table",
+            "id": "bad-name",
+            "title": "bad-name",
+        }
+    )
+
+    resolved = await resolve_artifact_side_effects(
+        [
+            ArtifactSideEffect(
+                op="upsert",
+                artifact=artifact,
+                identity_ref=ArtifactIdentityRef(
+                    artifact_type="table",
+                    ref="bad-name",
+                    ref_kind="name",
+                ),
+            )
+        ],
+        session=cast(AsyncSession, object()),
+        role=Role(
+            type="service",
+            service_id="tracecat-api",
+            workspace_id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+        ),
+    )
+
+    assert resolved == []
+
+
+@pytest.mark.anyio
 async def test_tool_result_artifact_pipeline_persists_and_streams_data_part() -> None:
     """Cover tool result -> projection -> Redis event -> Vercel data-artifact."""
     effects = list(

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from tracecat.artifacts.bindings import (
     ARTIFACT_BINDINGS,
+    ArtifactIdentityRef,
     ArtifactSideEffect,
     artifact_side_effects_for_tool_result,
 )
@@ -20,6 +21,7 @@ from tracecat.artifacts.schemas import (
     artifact_data_payload,
 )
 from tracecat.cases.enums import CaseSeverity, CaseStatus
+from tracecat.chat.tools import WORKSPACE_CHAT_DEFAULT_TOOLS
 
 
 def test_artifact_data_payload_serializes_camel_case_fields() -> None:
@@ -222,11 +224,41 @@ def test_artifact_bindings_list_canonical_tool_names() -> None:
     } == {
         "core.cases.create_case": "upsert",
         "core.cases.update_case": "upsert",
+        "core.cases.get_case": "upsert",
+        "core.cases.list_cases": "upsert",
+        "core.cases.search_cases": "upsert",
         "core.cases.delete_case": "remove",
         "core.table.create_table": "upsert",
+        "core.table.list_tables": "upsert",
+        "core.table.get_table_metadata": "upsert",
+        "core.table.update_table": "upsert",
+        "core.table.create_column": "upsert",
+        "core.table.update_column": "upsert",
+        "core.table.delete_column": "upsert",
+        "core.table.lookup": "upsert",
+        "core.table.lookup_many": "upsert",
+        "core.table.is_in": "upsert",
+        "core.table.search_rows": "upsert",
+        "core.table.insert_row": "upsert",
+        "core.table.insert_rows": "upsert",
+        "core.table.update_row": "upsert",
+        "core.table.delete_row": "upsert",
+        "core.table.download": "upsert",
+        "ai.agent.create_preset": "upsert",
+        "ai.agent.get_preset": "upsert",
+        "ai.agent.list_presets": "upsert",
+        "ai.agent.update_preset": "upsert",
         "core.workflow.execute": "upsert",
         "core.workflow.get_status": "upsert",
     }
+
+
+def test_workspace_chat_domain_tools_have_artifact_bindings() -> None:
+    bound_tool_names = {
+        tool_name for binding in ARTIFACT_BINDINGS for tool_name in binding.tool_names
+    }
+
+    assert set(WORKSPACE_CHAT_DEFAULT_TOOLS).issubset(bound_tool_names)
 
 
 def test_case_delete_tool_result_emits_remove_side_effect() -> None:
@@ -287,6 +319,238 @@ def test_table_tool_result_content_block_emits_upsert_side_effect() -> None:
             "scope": {"parentToolCallId": "toolu_123"},
         },
     }
+    assert effects[0].identity_ref is None
+
+
+def test_table_schema_tool_result_emits_upsert_side_effect() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.table.update_column",
+            tool_input={"table": "indicators", "column": "score"},
+            tool_output={
+                "id": "table_123",
+                "name": "indicators",
+                "columns": [{"name": "score", "type": "NUMERIC"}],
+            },
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert len(effects) == 1
+    assert effects[0].op == "upsert"
+    payload = artifact_data_payload(effects[0].op, effects[0].artifact)
+    assert payload == {
+        "op": "upsert",
+        "artifact": {
+            "type": "table",
+            "id": "table_123",
+            "title": "indicators",
+            "scope": {"parentToolCallId": "toolu_123"},
+        },
+    }
+    assert effects[0].identity_ref is None
+
+
+def test_table_row_delete_tool_result_emits_upsert_side_effect_from_input() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.table.delete_row",
+            tool_input={"table": "table_123", "row_id": "row_123"},
+            tool_output=None,
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert len(effects) == 1
+    assert effects[0].op == "upsert"
+    payload = artifact_data_payload(effects[0].op, effects[0].artifact)
+    assert payload == {
+        "op": "upsert",
+        "artifact": {
+            "type": "table",
+            "id": "table_123",
+            "title": "table_123",
+            "scope": {"parentToolCallId": "toolu_123"},
+        },
+    }
+    assert effects[0].identity_ref == ArtifactIdentityRef(
+        artifact_type="table",
+        ref="table_123",
+        ref_kind="name",
+    )
+
+
+def test_table_input_artifact_identity_supports_table_id_alias() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.table.insert_rows",
+            tool_input={"table_id": "11111111-1111-4111-8111-111111111111"},
+            tool_output=2,
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert len(effects) == 1
+    assert effects[0].identity_ref == ArtifactIdentityRef(
+        artifact_type="table",
+        ref="11111111-1111-4111-8111-111111111111",
+        ref_kind="id",
+    )
+
+
+def test_case_list_tool_result_emits_upsert_side_effects() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.cases.list_cases",
+            tool_input={"limit": 2},
+            tool_output={
+                "items": [
+                    {
+                        "id": "case_123",
+                        "summary": "Suspicious login",
+                        "severity": "high",
+                        "status": "new",
+                    },
+                    {
+                        "id": "case_456",
+                        "summary": "Malware alert",
+                        "severity": "critical",
+                        "status": "in_progress",
+                    },
+                ],
+                "has_more": False,
+            },
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert [effect.op for effect in effects] == ["upsert", "upsert"]
+    assert [effect.artifact.id for effect in effects] == ["case_123", "case_456"]
+
+
+def test_table_list_tool_result_emits_upsert_side_effects() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.table.list_tables",
+            tool_input=None,
+            tool_output=[
+                {"id": "table_123", "name": "indicators"},
+                {"id": "table_456", "name": "alerts"},
+            ],
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert [effect.op for effect in effects] == ["upsert", "upsert"]
+    assert [effect.artifact.id for effect in effects] == ["table_123", "table_456"]
+
+
+def test_table_search_tool_result_emits_upsert_side_effect_from_input() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.table.search_rows",
+            tool_input={"table": "indicators", "search_term": "evil.com"},
+            tool_output={
+                "items": [{"id": "row_123", "domain": "evil.com"}],
+                "has_more": False,
+            },
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert len(effects) == 1
+    assert effects[0].op == "upsert"
+    payload = artifact_data_payload(effects[0].op, effects[0].artifact)
+    assert payload == {
+        "op": "upsert",
+        "artifact": {
+            "type": "table",
+            "id": "indicators",
+            "title": "indicators",
+            "scope": {"parentToolCallId": "toolu_123"},
+        },
+    }
+    assert effects[0].identity_ref == ArtifactIdentityRef(
+        artifact_type="table",
+        ref="indicators",
+        ref_kind="name",
+    )
+
+
+def test_table_download_tool_result_emits_upsert_side_effect_from_name_input() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.table.download",
+            tool_input={"name": "indicators", "format": "json"},
+            tool_output=[{"domain": "evil.com"}],
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert len(effects) == 1
+    assert effects[0].artifact.id == "indicators"
+    assert effects[0].identity_ref == ArtifactIdentityRef(
+        artifact_type="table",
+        ref="indicators",
+        ref_kind="name",
+    )
+
+
+def test_agent_preset_tool_result_emits_upsert_side_effect() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="ai.agent.create_preset",
+            tool_input={"name": "Case Triage"},
+            tool_output={
+                "id": "preset_123",
+                "name": "Case Triage",
+                "slug": "case-triage",
+            },
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert len(effects) == 1
+    assert effects[0].op == "upsert"
+    payload = artifact_data_payload(effects[0].op, effects[0].artifact)
+    assert payload == {
+        "op": "upsert",
+        "artifact": {
+            "type": "agent",
+            "id": "preset_123",
+            "title": "Case Triage",
+            "scope": {"parentToolCallId": "toolu_123"},
+        },
+    }
+
+
+def test_agent_preset_list_tool_result_emits_upsert_side_effects() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="ai.agent.list_presets",
+            tool_input=None,
+            tool_output=[
+                {"id": "preset_123", "name": "Case Triage"},
+                {"id": "preset_456", "name": "Table Builder"},
+            ],
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert [effect.op for effect in effects] == ["upsert", "upsert"]
+    assert [effect.artifact.id for effect in effects] == [
+        "preset_123",
+        "preset_456",
+    ]
 
 
 def test_table_tool_result_mapping_content_emits_upsert_side_effect() -> None:

--- a/tests/unit/test_chat_tools.py
+++ b/tests/unit/test_chat_tools.py
@@ -2,12 +2,34 @@ from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.chat.tools import get_default_tools
 
 
-def test_workspace_chat_defaults_include_table_authoring_tools() -> None:
-    default_tools = set(get_default_tools(AgentSessionEntity.WORKSPACE_CHAT.value))
+def test_workspace_chat_default_tools_include_authoring_actions() -> None:
+    tools = get_default_tools(AgentSessionEntity.WORKSPACE_CHAT.value)
 
-    assert {
+    assert tools == [
+        "ai.agent.create_preset",
+        "ai.agent.get_preset",
+        "ai.agent.list_presets",
+        "ai.agent.update_preset",
+        "core.table.list_tables",
+        "core.table.get_table_metadata",
+        "core.table.create_table",
         "core.table.update_table",
         "core.table.create_column",
         "core.table.update_column",
         "core.table.delete_column",
-    } <= default_tools
+        "core.table.lookup",
+        "core.table.lookup_many",
+        "core.table.is_in",
+        "core.table.search_rows",
+        "core.table.insert_row",
+        "core.table.insert_rows",
+        "core.table.update_row",
+        "core.table.delete_row",
+        "core.table.download",
+        "core.cases.create_case",
+        "core.cases.update_case",
+        "core.cases.delete_case",
+        "core.cases.list_cases",
+        "core.cases.get_case",
+        "core.cases.search_cases",
+    ]

--- a/tests/unit/test_chat_tools.py
+++ b/tests/unit/test_chat_tools.py
@@ -1,5 +1,5 @@
 from tracecat.agent.session.types import AgentSessionEntity
-from tracecat.chat.tools import get_default_tools
+from tracecat.chat.tools import WORKSPACE_CHAT_AGENT_DEFAULT_TOOLS, get_default_tools
 
 
 def test_workspace_chat_default_tools_include_authoring_actions() -> None:
@@ -33,3 +33,16 @@ def test_workspace_chat_default_tools_include_authoring_actions() -> None:
         "core.cases.get_case",
         "core.cases.search_cases",
     ]
+
+
+def test_workspace_chat_default_tools_exclude_agent_actions_without_entitlement() -> (
+    None
+):
+    tools = get_default_tools(
+        AgentSessionEntity.WORKSPACE_CHAT.value,
+        agent_addons_enabled=False,
+    )
+
+    assert all(tool not in tools for tool in WORKSPACE_CHAT_AGENT_DEFAULT_TOOLS)
+    assert "core.table.list_tables" in tools
+    assert "core.cases.list_cases" in tools

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -44,6 +44,7 @@ from tracecat.artifacts.bindings import (
     ArtifactSideEffect,
     artifact_side_effects_for_tool_result,
 )
+from tracecat.artifacts.resolution import resolve_artifact_side_effects
 from tracecat.auth.types import Role
 from tracecat.db.engine import (
     get_async_session_bypass_rls_context_manager,
@@ -641,7 +642,7 @@ class LoopbackHandler:
                 tool_call_id=tool_call_id,
             )
         )
-        await self._persist_artifact_side_effects(artifact_effects)
+        artifact_effects = await self._persist_artifact_side_effects(artifact_effects)
 
         for artifact_effect in artifact_effects:
             await stream_sink.append(
@@ -655,9 +656,9 @@ class LoopbackHandler:
     async def _persist_artifact_side_effects(
         self,
         artifact_effects: Sequence[ArtifactSideEffect],
-    ) -> None:
+    ) -> Sequence[ArtifactSideEffect]:
         if not artifact_effects:
-            return
+            return artifact_effects
 
         try:
             async with get_async_session_bypass_rls_context_manager() as session:
@@ -672,7 +673,7 @@ class LoopbackHandler:
                         session_id=self.input.session_id,
                         workspace_id=self.input.workspace_id,
                     )
-                    return
+                    return artifact_effects
 
                 role = Role(
                     type="service",
@@ -680,6 +681,14 @@ class LoopbackHandler:
                     workspace_id=self.input.workspace_id,
                     organization_id=organization_id,
                 )
+                artifact_effects = await resolve_artifact_side_effects(
+                    artifact_effects,
+                    session=session,
+                    role=role,
+                )
+                if not artifact_effects:
+                    return artifact_effects
+
                 service = AgentSessionService(session, role)
                 await service.apply_artifact_side_effects(
                     self.input.session_id,
@@ -692,6 +701,7 @@ class LoopbackHandler:
                 error=str(e),
             )
             raise
+        return artifact_effects
 
     async def send_stream_event(self, event: UnifiedStreamEvent) -> None:
         """Handle a stream event emitted by the runtime."""

--- a/tracecat/agent/runtime/claude_code/broker.py
+++ b/tracecat/agent/runtime/claude_code/broker.py
@@ -24,6 +24,9 @@ from tracecat.agent.runtime.session_paths import (
     AgentSandboxPathMapping,
     build_agent_sandbox_path_mapping,
 )
+from tracecat.logger import logger
+
+_LOG_PREVIEW_CHARS = 4000
 
 
 class ConcurrentSessionTurnError(RuntimeError):
@@ -149,6 +152,15 @@ class ClaudeRuntimeBroker:
                     )
                 )
                 artifact_prompt_fragment = working_set.prompt_fragment
+                logger.info(
+                    "Prepared artifact prompt fragment for Claude runtime",
+                    session_id=str(request.init_payload.session_id),
+                    artifact_count=len(working_set.manifest.artifacts),
+                    artifact_root=working_set.manifest.root,
+                    prompt_fragment_preview=_preview_text(
+                        artifact_prompt_fragment or ""
+                    ),
+                )
             runtime = ClaudeAgentRuntime(
                 handler,
                 transport_factory=lambda options: SandboxedCLITransport(
@@ -193,3 +205,9 @@ class ClaudeRuntimeBroker:
             session_id=session_id,
             disable_nsjail=TRACECAT__DISABLE_NSJAIL,
         )
+
+
+def _preview_text(text: str) -> str:
+    if len(text) <= _LOG_PREVIEW_CHARS:
+        return text
+    return f"{text[:_LOG_PREVIEW_CHARS]}... [truncated]"

--- a/tracecat/agent/runtime/claude_code/broker.py
+++ b/tracecat/agent/runtime/claude_code/broker.py
@@ -26,8 +26,6 @@ from tracecat.agent.runtime.session_paths import (
 )
 from tracecat.logger import logger
 
-_LOG_PREVIEW_CHARS = 4000
-
 
 class ConcurrentSessionTurnError(RuntimeError):
     """Raised when a second concurrent turn is started for the same session."""
@@ -157,9 +155,6 @@ class ClaudeRuntimeBroker:
                     session_id=str(request.init_payload.session_id),
                     artifact_count=len(working_set.manifest.artifacts),
                     artifact_root=working_set.manifest.root,
-                    prompt_fragment_preview=_preview_text(
-                        artifact_prompt_fragment or ""
-                    ),
                 )
             runtime = ClaudeAgentRuntime(
                 handler,
@@ -205,9 +200,3 @@ class ClaudeRuntimeBroker:
             session_id=session_id,
             disable_nsjail=TRACECAT__DISABLE_NSJAIL,
         )
-
-
-def _preview_text(text: str) -> str:
-    if len(text) <= _LOG_PREVIEW_CHARS:
-        return text
-    return f"{text[:_LOG_PREVIEW_CHARS]}... [truncated]"

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -1394,7 +1394,6 @@ class ClaudeAgentRuntime:
                     is_continuation=False,
                     is_meta=False,
                     prompt_length=len(query_input),
-                    prompt_preview=_preview_text(query_input),
                 )
 
             transport = self._transport_factory(options)

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -1184,7 +1184,6 @@ class ClaudeAgentRuntime:
             session_id=str(payload.session_id),
             system_prompt_length=len(system_prompt),
             system_prompt_fragment_count=len(self._system_prompt_fragments),
-            system_prompt_preview=_preview_text(system_prompt),
         )
         return ClaudeAgentOptions(
             include_partial_messages=True,

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -84,6 +84,7 @@ from tracecat.logger import logger
 
 CLAUDE_PROJECT_DIR_MAX_LENGTH = 200
 CLAUDE_PROJECT_DIR_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9]")
+LOG_PREVIEW_CHARS = 8000
 
 
 def _claude_project_dir_name(cwd: Path) -> str:
@@ -106,6 +107,12 @@ def _claude_project_dir_name(cwd: Path) -> str:
 def _ensure_supported_claude_project_dir_name(cwd: Path) -> None:
     """Ensure Claude can persist sessions under the runtime cwd."""
     _claude_project_dir_name(cwd)
+
+
+def _preview_text(text: str, *, limit: int = LOG_PREVIEW_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}... [truncated]"
 
 
 class RuntimeEventWriter(Protocol):
@@ -1168,6 +1175,17 @@ class ClaudeAgentRuntime:
         stderr: Callable[[str], None],
     ) -> ClaudeAgentOptions:
         """Build Claude SDK options from runtime policy and payload config."""
+        system_prompt = self._build_system_prompt(
+            payload.config.instructions,
+            payload.config.output_type,
+        )
+        logger.info(
+            "Claude runtime system prompt prepared",
+            session_id=str(payload.session_id),
+            system_prompt_length=len(system_prompt),
+            system_prompt_fragment_count=len(self._system_prompt_fragments),
+            system_prompt_preview=_preview_text(system_prompt),
+        )
         return ClaudeAgentOptions(
             include_partial_messages=True,
             resume=resume_session_id,
@@ -1184,9 +1202,7 @@ class ClaudeAgentRuntime:
                 model_name=payload.config.model_name,
                 passthrough=payload.config.passthrough,
             ),
-            system_prompt=self._build_system_prompt(
-                payload.config.instructions, payload.config.output_type
-            ),
+            system_prompt=system_prompt,
             mcp_servers=mcp_servers,
             allowed_tools=self._root_allowed_tools(
                 actions=payload.allowed_actions,
@@ -1361,11 +1377,25 @@ class ClaudeAgentRuntime:
                     "prompt_length": len(APPROVAL_CONTINUATION_PROMPT),
                     "is_meta": True,
                 }
-                logger.debug("Approval continuation with meta prompt")
+                logger.info(
+                    "Claude runtime user prompt prepared",
+                    session_id=str(payload.session_id),
+                    is_continuation=True,
+                    is_meta=True,
+                    prompt_length=len(APPROVAL_CONTINUATION_PROMPT),
+                    prompt_preview=_preview_text(APPROVAL_CONTINUATION_PROMPT),
+                )
             else:
                 query_input = payload.user_prompt
                 query_log_extra = {"prompt_length": len(query_input)}
-                logger.debug("Normal turn with user prompt")
+                logger.info(
+                    "Claude runtime user prompt prepared",
+                    session_id=str(payload.session_id),
+                    is_continuation=False,
+                    is_meta=False,
+                    prompt_length=len(query_input),
+                    prompt_preview=_preview_text(query_input),
+                )
 
             transport = self._transport_factory(options)
             client = ClaudeSDKClient(options=options, transport=transport)

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -23,6 +23,7 @@ from tracecat.agent.stream.artifacts import artifact_stream_event
 from tracecat.agent.stream.connector import AgentStream
 from tracecat.agent.subagents import ResolvedAgentsConfig
 from tracecat.artifacts.bindings import artifact_side_effects_for_tool_result
+from tracecat.artifacts.resolution import resolve_artifact_side_effects
 from tracecat.auth.types import Role
 from tracecat.chat.schemas import ChatMessage
 from tracecat.contexts import ctx_role
@@ -383,10 +384,16 @@ async def reconcile_tool_results_activity(
         if artifact_effects:
             try:
                 async with AgentSessionService.with_session(role=input.role) as service:
-                    await service.apply_artifact_side_effects(
-                        input.session_id,
+                    artifact_effects = await resolve_artifact_side_effects(
                         artifact_effects,
+                        session=service.session,
+                        role=service.role,
                     )
+                    if artifact_effects:
+                        await service.apply_artifact_side_effects(
+                            input.session_id,
+                            artifact_effects,
+                        )
             except Exception as e:
                 logger.warning(
                     "Failed to persist artifact side effects",

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -80,7 +80,10 @@ from tracecat.chat.schemas import (
     VercelChatRequest,
 )
 from tracecat.chat.service import ChatService
-from tracecat.chat.tools import get_default_tools
+from tracecat.chat.tools import (
+    filter_workspace_chat_tools_for_entitlements,
+    get_default_tools,
+)
 from tracecat.db.models import (
     AgentSession,
     AgentSessionHistory,
@@ -127,6 +130,28 @@ class AgentSessionService(BaseWorkspaceService):
 
     service_name = "agent-session"
 
+    async def _get_default_tools(self, entity_type: AgentSessionEntity) -> list[str]:
+        """Get entitlement-aware default tools for a session entity type."""
+        agent_addons_enabled = True
+        if entity_type is AgentSessionEntity.WORKSPACE_CHAT:
+            agent_addons_enabled = await self.has_entitlement(Entitlement.AGENT_ADDONS)
+        return get_default_tools(
+            entity_type.value,
+            agent_addons_enabled=agent_addons_enabled,
+        )
+
+    async def _workspace_chat_tools_for_entitlements(
+        self,
+        tools: list[str] | None,
+    ) -> list[str] | None:
+        """Filter stored Workspace chat tools by current entitlements."""
+        if tools is None:
+            return None
+        return filter_workspace_chat_tools_for_entitlements(
+            tools,
+            agent_addons_enabled=await self.has_entitlement(Entitlement.AGENT_ADDONS),
+        )
+
     def _build_direct_agent_search_attributes(
         self, session_id: uuid.UUID
     ) -> TypedSearchAttributes:
@@ -171,7 +196,7 @@ class AgentSessionService(BaseWorkspaceService):
         # Apply default tools based on entity type if tools not provided
         tools = args.tools
         if not tools and args.entity_type:
-            tools = get_default_tools(args.entity_type.value)
+            tools = await self._get_default_tools(args.entity_type)
         logical_preset_id = self._resolve_logical_preset_id(
             entity_type=args.entity_type,
             entity_id=args.entity_id,
@@ -1536,12 +1561,15 @@ class AgentSessionService(BaseWorkspaceService):
             else:
                 # Copilot without preset uses org-level credentials (default)
                 async with agent_svc.with_model_config() as model_config:
+                    actions = await self._workspace_chat_tools_for_entitlements(
+                        agent_session.tools
+                    )
                     yield AgentConfig(
                         instructions=entity_instructions,
                         model_name=model_config.name,
                         model_provider=model_config.provider,
                         catalog_id=model_config.catalog_id,
-                        actions=agent_session.tools,
+                        actions=actions,
                     )
         elif session_entity in (
             AgentSessionEntity.WORKFLOW,

--- a/tracecat/artifacts/bindings.py
+++ b/tracecat/artifacts/bindings.py
@@ -16,10 +16,17 @@ from pydantic import (
     ValidationError,
 )
 
-from tracecat.artifacts.schemas import Artifact, ArtifactAdapter, ArtifactOp
+from tracecat.artifacts.schemas import (
+    Artifact,
+    ArtifactAdapter,
+    ArtifactOp,
+    ArtifactSchema,
+    ArtifactType,
+)
 from tracecat.cases.enums import CaseSeverity, CaseStatus
 
 type RunStatus = Literal["running", "success", "failed", "cancelled"]
+type ArtifactIdentityRefKind = Literal["id", "name"]
 
 
 class CaseArtifactPayload(TypedDict):
@@ -39,6 +46,14 @@ class TableArtifactPayload(TypedDict):
     id: str
     title: str
     rowCount: NotRequired[int]
+
+
+class AgentArtifactPayload(TypedDict):
+    """Raw payload used to validate an agent preset artifact."""
+
+    type: Literal["agent"]
+    id: str
+    title: str
 
 
 class RunArtifactPayload(TypedDict):
@@ -89,6 +104,24 @@ class _TableToolResult(_ArtifactProjectionModel):
     )
 
 
+class _TableMutationToolInput(_ArtifactProjectionModel):
+    table: str = Field(
+        validation_alias=AliasChoices("table", "name", "table_id", "tableId")
+    )
+
+
+class _TableIdToolInput(_ArtifactProjectionModel):
+    table_id: str = Field(validation_alias=AliasChoices("table_id", "tableId"))
+
+
+class _AgentPresetToolResult(_ArtifactProjectionModel):
+    id: str
+    title: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("name", "title"),
+    )
+
+
 class _WorkflowRunToolResult(_ArtifactProjectionModel):
     run_id: str = Field(
         validation_alias=AliasChoices("wf_exec_id", "wfExecId", "run_id", "id")
@@ -113,11 +146,21 @@ class _WorkflowRunToolInput(_ArtifactProjectionModel):
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
+class ArtifactIdentityRef:
+    """Unresolved reference to the domain object backing an artifact."""
+
+    artifact_type: ArtifactType
+    ref: str
+    ref_kind: ArtifactIdentityRefKind
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
 class ArtifactSideEffect:
     """Artifact operation derived from an action result."""
 
     op: ArtifactOp
     artifact: Artifact
+    identity_ref: ArtifactIdentityRef | None = None
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -131,7 +174,13 @@ class ArtifactProjectionContext:
     tool_call_id: str | None
 
 
-type ArtifactBuilder = Callable[[ArtifactProjectionContext], Artifact | None]
+type ArtifactBuilder = Callable[
+    [ArtifactProjectionContext], Artifact | Iterable[Artifact] | None
+]
+type ArtifactIdentityBuilder = Callable[
+    [ArtifactProjectionContext],
+    ArtifactIdentityRef | None,
+]
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -141,18 +190,59 @@ class ArtifactBinding:
     tool_names: tuple[str, ...]
     op: ArtifactOp
     build: ArtifactBuilder
+    identity: ArtifactIdentityBuilder | None = None
 
 
 def _build_case_artifact(ctx: ArtifactProjectionContext) -> Artifact | None:
     return _case_artifact_from_output(ctx.tool_output, ctx.tool_call_id)
 
 
+def _build_case_artifacts(ctx: ArtifactProjectionContext) -> Iterable[Artifact]:
+    return _case_artifacts_from_output(ctx.tool_output, ctx.tool_call_id)
+
+
 def _build_deleted_case_artifact(ctx: ArtifactProjectionContext) -> Artifact | None:
     return _deleted_case_artifact(ctx.tool_input, ctx.tool_call_id)
 
 
-def _build_table_artifact(ctx: ArtifactProjectionContext) -> Artifact | None:
+def _build_table_mutation_artifact(ctx: ArtifactProjectionContext) -> Artifact | None:
+    artifact = _table_artifact_from_output(ctx.tool_output, ctx.tool_call_id)
+    if artifact is not None:
+        return artifact
+    return _table_artifact_from_input(ctx.tool_input, ctx.tool_call_id)
+
+
+def _build_table_input_artifact(ctx: ArtifactProjectionContext) -> Artifact | None:
+    artifact = _table_artifact_from_input(ctx.tool_input, ctx.tool_call_id)
+    if artifact is not None:
+        return artifact
     return _table_artifact_from_output(ctx.tool_output, ctx.tool_call_id)
+
+
+def _table_identity_from_input(
+    ctx: ArtifactProjectionContext,
+) -> ArtifactIdentityRef | None:
+    return _table_identity_ref_from_input(ctx.tool_input)
+
+
+def _table_identity_from_input_when_output_missing(
+    ctx: ArtifactProjectionContext,
+) -> ArtifactIdentityRef | None:
+    if _table_artifact_from_output(ctx.tool_output, ctx.tool_call_id) is not None:
+        return None
+    return _table_identity_ref_from_input(ctx.tool_input)
+
+
+def _build_table_artifacts(ctx: ArtifactProjectionContext) -> Iterable[Artifact]:
+    return _table_artifacts_from_output(ctx.tool_output, ctx.tool_call_id)
+
+
+def _build_agent_artifact(ctx: ArtifactProjectionContext) -> Artifact | None:
+    return _agent_artifact_from_output(ctx.tool_output, ctx.tool_call_id)
+
+
+def _build_agent_artifacts(ctx: ArtifactProjectionContext) -> Iterable[Artifact]:
+    return _agent_artifacts_from_output(ctx.tool_output, ctx.tool_call_id)
 
 
 def _build_workflow_run_artifact(ctx: ArtifactProjectionContext) -> Artifact | None:
@@ -161,9 +251,18 @@ def _build_workflow_run_artifact(ctx: ArtifactProjectionContext) -> Artifact | N
 
 ARTIFACT_BINDINGS: tuple[ArtifactBinding, ...] = (
     ArtifactBinding(
-        tool_names=("core.cases.create_case", "core.cases.update_case"),
+        tool_names=(
+            "core.cases.create_case",
+            "core.cases.update_case",
+            "core.cases.get_case",
+        ),
         op="upsert",
         build=_build_case_artifact,
+    ),
+    ArtifactBinding(
+        tool_names=("core.cases.list_cases", "core.cases.search_cases"),
+        op="upsert",
+        build=_build_case_artifacts,
     ),
     ArtifactBinding(
         tool_names=("core.cases.delete_case",),
@@ -171,9 +270,52 @@ ARTIFACT_BINDINGS: tuple[ArtifactBinding, ...] = (
         build=_build_deleted_case_artifact,
     ),
     ArtifactBinding(
-        tool_names=("core.table.create_table",),
+        tool_names=(
+            "core.table.create_table",
+            "core.table.get_table_metadata",
+            "core.table.update_table",
+            "core.table.create_column",
+            "core.table.update_column",
+            "core.table.delete_column",
+        ),
         op="upsert",
-        build=_build_table_artifact,
+        build=_build_table_mutation_artifact,
+        identity=_table_identity_from_input_when_output_missing,
+    ),
+    ArtifactBinding(
+        tool_names=("core.table.list_tables",),
+        op="upsert",
+        build=_build_table_artifacts,
+    ),
+    ArtifactBinding(
+        tool_names=(
+            "core.table.lookup",
+            "core.table.lookup_many",
+            "core.table.is_in",
+            "core.table.search_rows",
+            "core.table.insert_row",
+            "core.table.insert_rows",
+            "core.table.update_row",
+            "core.table.delete_row",
+            "core.table.download",
+        ),
+        op="upsert",
+        build=_build_table_input_artifact,
+        identity=_table_identity_from_input,
+    ),
+    ArtifactBinding(
+        tool_names=(
+            "ai.agent.create_preset",
+            "ai.agent.get_preset",
+            "ai.agent.update_preset",
+        ),
+        op="upsert",
+        build=_build_agent_artifact,
+    ),
+    ArtifactBinding(
+        tool_names=("ai.agent.list_presets",),
+        op="upsert",
+        build=_build_agent_artifacts,
     ),
     ArtifactBinding(
         tool_names=("core.workflow.execute", "core.workflow.get_status"),
@@ -196,6 +338,18 @@ def _index_artifact_bindings(
 
 
 _ARTIFACT_BINDINGS_BY_TOOL_NAME = _index_artifact_bindings(ARTIFACT_BINDINGS)
+
+
+def _artifact_tuple(
+    artifacts: Artifact | Iterable[Artifact] | None,
+) -> tuple[Artifact, ...]:
+    match artifacts:
+        case None:
+            return ()
+        case ArtifactSchema():
+            return (artifacts,)
+        case _:
+            return tuple(artifacts)
 
 
 def artifact_side_effects_for_tool_result(
@@ -231,8 +385,17 @@ def artifact_side_effects_for_tool_result(
     if binding is None:
         return
 
-    if artifact := binding.build(ctx):
-        yield ArtifactSideEffect(op=binding.op, artifact=artifact)
+    artifacts = _artifact_tuple(binding.build(ctx))
+    if not artifacts:
+        return
+
+    identity_ref = binding.identity(ctx) if binding.identity else None
+    for artifact in artifacts:
+        yield ArtifactSideEffect(
+            op=binding.op,
+            artifact=artifact,
+            identity_ref=identity_ref,
+        )
 
 
 _EXPLICIT_ARTIFACT_SOURCES: tuple[tuple[str, ArtifactOp], ...] = (
@@ -316,6 +479,23 @@ def _case_artifact_from_output(value: Any, tool_call_id: str | None) -> Artifact
     return ArtifactAdapter.validate_python(_with_parent_scope(payload, tool_call_id))
 
 
+def _case_artifacts_from_output(
+    value: Any, tool_call_id: str | None
+) -> Iterator[Artifact]:
+    for data in _iter_mappings_from_tool_output(value):
+        if result := _CaseToolResult.try_validate(data):
+            payload: CaseArtifactPayload = {
+                "type": "case",
+                "id": result.id,
+                "title": result.title or result.id,
+                "severity": result.severity,
+                "status": result.status,
+            }
+            yield ArtifactAdapter.validate_python(
+                _with_parent_scope(payload, tool_call_id)
+            )
+
+
 def _deleted_case_artifact(
     tool_input: Mapping[str, Any] | None, tool_call_id: str | None
 ) -> Artifact | None:
@@ -356,6 +536,98 @@ def _table_artifact_from_output(
         payload["rowCount"] = result.row_count
 
     return ArtifactAdapter.validate_python(_with_parent_scope(payload, tool_call_id))
+
+
+def _table_artifacts_from_output(
+    value: Any, tool_call_id: str | None
+) -> Iterator[Artifact]:
+    for data in _iter_mappings_from_tool_output(value):
+        if result := _TableToolResult.try_validate(data):
+            payload: TableArtifactPayload = {
+                "type": "table",
+                "id": result.id,
+                "title": result.title or result.id,
+            }
+            if result.row_count is not None:
+                payload["rowCount"] = result.row_count
+            yield ArtifactAdapter.validate_python(
+                _with_parent_scope(payload, tool_call_id)
+            )
+
+
+def _table_artifact_from_input(
+    value: Mapping[str, Any] | None, tool_call_id: str | None
+) -> Artifact | None:
+    if value is None:
+        return None
+
+    result = _TableMutationToolInput.try_validate(value)
+    if result is None:
+        return None
+
+    payload: TableArtifactPayload = {
+        "type": "table",
+        "id": result.table,
+        "title": result.table,
+    }
+    return ArtifactAdapter.validate_python(_with_parent_scope(payload, tool_call_id))
+
+
+def _table_identity_ref_from_input(
+    value: Mapping[str, Any] | None,
+) -> ArtifactIdentityRef | None:
+    if value is None:
+        return None
+
+    if table_id := _TableIdToolInput.try_validate(value):
+        return ArtifactIdentityRef(
+            artifact_type="table",
+            ref=table_id.table_id,
+            ref_kind="id",
+        )
+
+    if table := _TableMutationToolInput.try_validate(value):
+        return ArtifactIdentityRef(
+            artifact_type="table",
+            ref=table.table,
+            ref_kind="name",
+        )
+    return None
+
+
+def _agent_artifact_from_output(
+    value: Any, tool_call_id: str | None
+) -> Artifact | None:
+    data = _mapping_from_tool_output(value)
+    if data is None:
+        return None
+
+    result = _AgentPresetToolResult.try_validate(data)
+    if result is None:
+        return None
+
+    payload: AgentArtifactPayload = {
+        "type": "agent",
+        "id": result.id,
+        "title": result.title or result.id,
+    }
+
+    return ArtifactAdapter.validate_python(_with_parent_scope(payload, tool_call_id))
+
+
+def _agent_artifacts_from_output(
+    value: Any, tool_call_id: str | None
+) -> Iterator[Artifact]:
+    for data in _iter_mappings_from_tool_output(value):
+        if result := _AgentPresetToolResult.try_validate(data):
+            payload: AgentArtifactPayload = {
+                "type": "agent",
+                "id": result.id,
+                "title": result.title or result.id,
+            }
+            yield ArtifactAdapter.validate_python(
+                _with_parent_scope(payload, tool_call_id)
+            )
 
 
 def _run_artifact_from_output(
@@ -403,6 +675,43 @@ def _mapping_from_tool_output(value: Any) -> Mapping[str, Any] | None:
             return _mapping_from_content_blocks(items)
         case _:
             return None
+
+
+def _iter_mappings_from_tool_output(value: Any) -> Iterator[Mapping[str, Any]]:
+    match value:
+        case Mapping() as mapping:
+            if content := mapping.get("content"):
+                yield from _iter_mappings_from_tool_output(content)
+                return
+
+            text = mapping.get("text")
+            if isinstance(text, str):
+                if decoded := _json_value_from_text(text):
+                    yield from _iter_mappings_from_tool_output(decoded)
+                    return
+
+            if items := mapping.get("items"):
+                yield from _iter_mappings_from_tool_output(items)
+                return
+
+            yield cast(Mapping[str, Any], mapping)
+        case str() as text:
+            if decoded := _json_value_from_text(text):
+                yield from _iter_mappings_from_tool_output(decoded)
+        case list() as items:
+            for item in items:
+                yield from _iter_mappings_from_tool_output(item)
+        case tuple() as items:
+            for item in items:
+                yield from _iter_mappings_from_tool_output(item)
+        case _:
+            model_dump = getattr(value, "model_dump", None)
+            if callable(model_dump):
+                try:
+                    dumped = model_dump()
+                except Exception:
+                    return
+                yield from _iter_mappings_from_tool_output(dumped)
 
 
 def _mapping_from_content_blocks(value: Any) -> Mapping[str, Any] | None:
@@ -454,13 +763,17 @@ def _mapping_from_content_block(item: Any) -> Mapping[str, Any] | None:
 
 
 def _mapping_from_json_text(text: str) -> Mapping[str, Any] | None:
-    try:
-        decoded = orjson.loads(text)
-    except orjson.JSONDecodeError:
-        return None
+    decoded = _json_value_from_text(text)
     if isinstance(decoded, dict):
         return cast(Mapping[str, Any], decoded)
     return None
+
+
+def _json_value_from_text(text: str) -> Any | None:
+    try:
+        return orjson.loads(text)
+    except orjson.JSONDecodeError:
+        return None
 
 
 def _with_parent_scope(

--- a/tracecat/artifacts/resolution.py
+++ b/tracecat/artifacts/resolution.py
@@ -80,7 +80,7 @@ async def _resolve_table_identity_ref(
         case "name":
             try:
                 table = await table_service.get_table_by_name(identity_ref.ref)
-            except TracecatNotFoundError:
+            except (TracecatNotFoundError, ValueError):
                 return None
         case "id":
             try:

--- a/tracecat/artifacts/resolution.py
+++ b/tracecat/artifacts/resolution.py
@@ -1,0 +1,97 @@
+"""Resolve artifact identity refs into canonical artifacts."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.artifacts.bindings import ArtifactIdentityRef, ArtifactSideEffect
+from tracecat.auth.types import Role
+from tracecat.exceptions import TracecatNotFoundError
+from tracecat.logger import logger
+from tracecat.tables.service import TablesService
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolvedArtifactIdentity:
+    id: str
+    title: str
+
+
+async def resolve_artifact_side_effects(
+    effects: Sequence[ArtifactSideEffect],
+    *,
+    session: AsyncSession,
+    role: Role,
+) -> list[ArtifactSideEffect]:
+    """Resolve domain identity refs before artifact persistence or streaming."""
+    if not effects:
+        return []
+
+    table_service: TablesService | None = None
+    resolved_effects: list[ArtifactSideEffect] = []
+    for effect in effects:
+        identity_ref = effect.identity_ref
+        if identity_ref is None:
+            resolved_effects.append(effect)
+            continue
+
+        resolved_identity: _ResolvedArtifactIdentity | None = None
+        match identity_ref.artifact_type:
+            case "table":
+                table_service = table_service or TablesService(session, role=role)
+                resolved_identity = await _resolve_table_identity_ref(
+                    table_service,
+                    identity_ref,
+                )
+            case _:
+                resolved_identity = None
+
+        if resolved_identity is None:
+            logger.warning(
+                "Failed to resolve artifact identity ref",
+                artifact_type=identity_ref.artifact_type,
+                ref_kind=identity_ref.ref_kind,
+            )
+            continue
+
+        resolved_effects.append(
+            ArtifactSideEffect(
+                op=effect.op,
+                artifact=effect.artifact.model_copy(
+                    update={
+                        "id": resolved_identity.id,
+                        "title": resolved_identity.title,
+                    }
+                ),
+            )
+        )
+    return resolved_effects
+
+
+async def _resolve_table_identity_ref(
+    table_service: TablesService,
+    identity_ref: ArtifactIdentityRef,
+) -> _ResolvedArtifactIdentity | None:
+    match identity_ref.ref_kind:
+        case "name":
+            try:
+                table = await table_service.get_table_by_name(identity_ref.ref)
+            except TracecatNotFoundError:
+                return None
+        case "id":
+            try:
+                table_id = uuid.UUID(identity_ref.ref)
+            except ValueError:
+                return None
+            try:
+                table = await table_service.get_table(table_id)
+            except TracecatNotFoundError:
+                return None
+        case _:
+            return None
+
+    return _ResolvedArtifactIdentity(id=str(table.id), title=table.name)

--- a/tracecat/artifacts/schemas.py
+++ b/tracecat/artifacts/schemas.py
@@ -17,6 +17,7 @@ type ArtifactType = Literal[
     "workflow",
     "run",
     "table",
+    "agent",
     "alert",
     "integration",
     "secret",
@@ -78,6 +79,12 @@ class TableArtifact(BaseArtifact):
     row_count: int | None = Field(default=None, alias="rowCount")
 
 
+class AgentArtifact(BaseArtifact):
+    """Agent preset artifact shown in artifact-capable chat surfaces."""
+
+    type: Literal["agent"] = "agent"
+
+
 class AlertArtifact(BaseArtifact):
     """Alert artifact stub. Extend when alert surfaces are wired."""
 
@@ -108,6 +115,7 @@ type Artifact = Annotated[
     | WorkflowArtifact
     | RunArtifact
     | TableArtifact
+    | AgentArtifact
     | AlertArtifact
     | IntegrationArtifact
     | SecretArtifact

--- a/tracecat/chat/tools.py
+++ b/tracecat/chat/tools.py
@@ -2,11 +2,14 @@
 from tracecat.agent.mcp.internal_tools import BUILDER_INTERNAL_TOOL_NAMES
 from tracecat.agent.session.types import AgentSessionEntity
 
-WORKSPACE_CHAT_DEFAULT_TOOLS = [
+WORKSPACE_CHAT_AGENT_DEFAULT_TOOLS = [
     "ai.agent.create_preset",
     "ai.agent.get_preset",
     "ai.agent.list_presets",
     "ai.agent.update_preset",
+]
+
+WORKSPACE_CHAT_BASE_DEFAULT_TOOLS = [
     "core.table.list_tables",
     "core.table.get_table_metadata",
     "core.table.create_table",
@@ -31,6 +34,11 @@ WORKSPACE_CHAT_DEFAULT_TOOLS = [
     "core.cases.search_cases",
 ]
 
+WORKSPACE_CHAT_DEFAULT_TOOLS = [
+    *WORKSPACE_CHAT_AGENT_DEFAULT_TOOLS,
+    *WORKSPACE_CHAT_BASE_DEFAULT_TOOLS,
+]
+
 TOOL_DEFAULTS = {
     AgentSessionEntity.CASE: [
         "core.cases.get_case",
@@ -45,6 +53,30 @@ TOOL_DEFAULTS = {
 }
 
 
-def get_default_tools(entity_type: str) -> list[str]:
+def filter_workspace_chat_tools_for_entitlements(
+    tools: list[str],
+    *,
+    agent_addons_enabled: bool,
+) -> list[str]:
+    """Filter Workspace chat default tools by enabled entitlements."""
+    if agent_addons_enabled:
+        return list(tools)
+
+    blocked_defaults = set(WORKSPACE_CHAT_AGENT_DEFAULT_TOOLS)
+    return [tool for tool in tools if tool not in blocked_defaults]
+
+
+def get_default_tools(
+    entity_type: str,
+    *,
+    agent_addons_enabled: bool = True,
+) -> list[str]:
     """Get default tools for an entity type."""
-    return TOOL_DEFAULTS.get(AgentSessionEntity(entity_type), [])
+    entity = AgentSessionEntity(entity_type)
+    tools = TOOL_DEFAULTS.get(entity, [])
+    if entity is AgentSessionEntity.WORKSPACE_CHAT:
+        return filter_workspace_chat_tools_for_entitlements(
+            tools,
+            agent_addons_enabled=agent_addons_enabled,
+        )
+    return list(tools)

--- a/tracecat/chat/tools.py
+++ b/tracecat/chat/tools.py
@@ -2,6 +2,35 @@
 from tracecat.agent.mcp.internal_tools import BUILDER_INTERNAL_TOOL_NAMES
 from tracecat.agent.session.types import AgentSessionEntity
 
+WORKSPACE_CHAT_DEFAULT_TOOLS = [
+    "ai.agent.create_preset",
+    "ai.agent.get_preset",
+    "ai.agent.list_presets",
+    "ai.agent.update_preset",
+    "core.table.list_tables",
+    "core.table.get_table_metadata",
+    "core.table.create_table",
+    "core.table.update_table",
+    "core.table.create_column",
+    "core.table.update_column",
+    "core.table.delete_column",
+    "core.table.lookup",
+    "core.table.lookup_many",
+    "core.table.is_in",
+    "core.table.search_rows",
+    "core.table.insert_row",
+    "core.table.insert_rows",
+    "core.table.update_row",
+    "core.table.delete_row",
+    "core.table.download",
+    "core.cases.create_case",
+    "core.cases.update_case",
+    "core.cases.delete_case",
+    "core.cases.list_cases",
+    "core.cases.get_case",
+    "core.cases.search_cases",
+]
+
 TOOL_DEFAULTS = {
     AgentSessionEntity.CASE: [
         "core.cases.get_case",
@@ -12,19 +41,7 @@ TOOL_DEFAULTS = {
     ],
     AgentSessionEntity.AGENT_PRESET: [],
     AgentSessionEntity.AGENT_PRESET_BUILDER: BUILDER_INTERNAL_TOOL_NAMES,
-    AgentSessionEntity.WORKSPACE_CHAT: [
-        "core.table.list_tables",
-        "core.table.get_table_metadata",
-        "core.table.update_table",
-        "core.table.create_column",
-        "core.table.update_column",
-        "core.table.delete_column",
-        "core.table.lookup",
-        "core.table.search_rows",
-        "core.cases.list_cases",
-        "core.cases.get_case",
-        "core.cases.search_cases",
-    ],
+    AgentSessionEntity.WORKSPACE_CHAT: WORKSPACE_CHAT_DEFAULT_TOOLS,
 }
 
 


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind workspace chat domain tools and deep links with lazy session creation and optimistic UI, plus streaming agent/table/case artifacts with identity resolution. Adds an `agent` artifact with a stacked preset builder, improves reasoning auto-scroll, and hydrates mounted artifacts into the Claude runtime prompt.

- New Features
  - Lazy session creation with optimistic composer; `onData` exposed for streaming parts.
  - Deep links for sessions and artifact tabs (`/workspaces/:workspaceId/chat/:chatId` and `?artifact=<type>:<id>&tab=<tab>`), kept in sync with navigation.
  - Artifacts: new `agent` artifact and stacked preset view; bindings for agent presets (create/get/list/update), tables (CRUD, lookup/search, columns, download), and cases (get/list/search). Identity refs (name/id) are resolved before persist/stream; list endpoints can emit multiple artifacts.
  - Reasoning UX: bounded container with stick-to-bottom auto-scroll that pauses on user scroll.
  - Workspace chat defaults: expanded tools on session create, including agent preset authoring and full table/case actions.
  - EE runtime: hydrate mounted chat artifacts into an on-disk working set and include a prompt fragment for the Claude runtime.

- Bug Fixes
  - Optimistic sends: pending user messages now match and clear when the real stream arrives.
  - Streamed `agent` artifacts render in the artifact panel; invalid table identity refs are ignored during resolution.
  - Default tools are gated by entitlement in workspace chat.
  - Logging: avoid logging user prompt previews, stop logging system and artifact prompt previews, and truncate mounted artifact prompt fragments.
  - Guard hydration for table and agent artifacts to prevent errors.
  - Frontend tests: mock workspace chat search params to stabilize workspace chat tests.

<sup>Written for commit 8d3f292b28205d0b6f0a3f7b7a089a8f0d60d84e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

