### PR TITLE
feat(ui): deep link workspace chat artifacts

### DIFF
--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -34,7 +34,14 @@ import {
 } from "lucide-react"
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  type FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import {
   type FieldErrors,
   type UseFormReturn,
@@ -711,6 +718,117 @@ export function AgentPresetsBuilder({
   )
 }
 
+/**
+ * Embeds the preset builder in surfaces that need a stacked, narrow layout.
+ */
+export function AgentPresetArtifactView({
+  preset,
+  workspaceId,
+  initialTab,
+  onTabChange,
+}: {
+  preset: AgentPresetRead
+  workspaceId: string
+  initialTab?: string | null
+  onTabChange?: (tab: string) => void
+}) {
+  const { presets } = useAgentPresets(workspaceId)
+  const { registryActions } = useRegistryActions()
+  const { models, providers } = useWorkspaceAgentModels(workspaceId)
+  const enabledModelsLoaded = models !== undefined
+  const { mcpIntegrations, mcpIntegrationsIsLoading } =
+    useListMcpIntegrations(workspaceId)
+  const { updateAgentPreset, updateAgentPresetIsPending } =
+    useUpdateAgentPreset(workspaceId)
+
+  const actionSuggestions: Suggestion[] = useMemo(() => {
+    if (!registryActions) {
+      return []
+    }
+    return registryActions
+      .map((action) => ({
+        id: action.id,
+        label: action.default_title ?? action.name,
+        value: action.action,
+        description: action.description,
+        group: action.namespace,
+        icon: getIcon(action.action, {
+          className: "size-6 p-[3px] border-[0.5px]",
+        }),
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  }, [registryActions])
+
+  const namespaceSuggestions: Suggestion[] = useMemo(() => {
+    if (!registryActions) {
+      return []
+    }
+    const seen = new Set<string>()
+    const entries: Suggestion[] = []
+    for (const action of registryActions) {
+      if (action.namespace && !seen.has(action.namespace)) {
+        seen.add(action.namespace)
+        entries.push({
+          id: action.namespace,
+          label: action.namespace,
+          value: action.namespace,
+        })
+      }
+    }
+    return entries.sort((a, b) => a.label.localeCompare(b.label))
+  }, [registryActions])
+
+  const enabledModelOptions = useMemo(
+    () => buildEnabledModelOptions(models, providers),
+    [models, providers]
+  )
+
+  const mcpIntegrationsForForm = useMemo(() => {
+    if (!mcpIntegrations) {
+      return []
+    }
+
+    return mcpIntegrations
+      .map((integration) => ({
+        id: integration.id,
+        name: integration.name,
+        description: integration.description,
+        providerId: getMcpProviderId(integration.slug),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }, [mcpIntegrations])
+
+  return (
+    <AgentPresetForm
+      key={preset.id}
+      preset={preset}
+      mode="edit"
+      workspaceId={workspaceId}
+      agentPresets={presets ?? []}
+      onCreate={async () => {
+        throw new Error("Agent artifacts cannot create presets.")
+      }}
+      onUpdate={async (presetId, payload) => {
+        return await updateAgentPreset({
+          presetId,
+          ...payload,
+        })
+      }}
+      isSaving={updateAgentPresetIsPending}
+      isDeleting={false}
+      actionSuggestions={actionSuggestions}
+      namespaceSuggestions={namespaceSuggestions}
+      enabledModelOptions={enabledModelOptions}
+      enabledModelsLoaded={enabledModelsLoaded}
+      mcpIntegrations={mcpIntegrationsForForm}
+      mcpIntegrationsIsLoading={mcpIntegrationsIsLoading}
+      layout="stacked"
+      initialTab={parseAgentPresetSideTab(initialTab) ?? "configuration"}
+      onTabChange={onTabChange}
+    />
+  )
+}
+
 function AgentPresetChatPane({
   preset,
   workspaceId,
@@ -1306,6 +1424,7 @@ type AgentPresetFormProps = {
   enabledModelsLoaded: boolean
   mcpIntegrations: McpIntegrationOption[]
   mcpIntegrationsIsLoading: boolean
+  layout?: "split" | "stacked"
   initialTab?: AgentPresetSideTab
   onTabChange?: (tab: AgentPresetSideTab) => void
 }
@@ -1328,6 +1447,7 @@ function AgentPresetForm({
   enabledModelsLoaded,
   mcpIntegrations,
   mcpIntegrationsIsLoading,
+  layout = "split",
   initialTab = "live-chat",
   onTabChange,
 }: AgentPresetFormProps) {
@@ -1602,72 +1722,99 @@ function AgentPresetForm({
     [appendSkillBinding]
   )
 
+  const documentPanel = (
+    <AgentPresetDocumentPanel
+      form={form}
+      mode={mode}
+      isSaving={isSaving}
+      isDeleting={isDeleting}
+      canSubmit={canSubmit}
+      presetName={preset?.name ?? ""}
+      onDuplicate={onDuplicate ? handleDuplicate : undefined}
+      isDuplicating={isDuplicating}
+      onDelete={onDelete}
+      deleteDialogOpen={deleteDialogOpen}
+      onDeleteDialogChange={handleDeleteDialogChange}
+      onConfirmDelete={handleConfirmDelete}
+    />
+  )
+
+  const rightPanel = (
+    <AgentPresetRightPanel
+      activeTab={effectiveTab}
+      onTabChange={handleTabChange}
+      channelsEnabled={channelsEnabled}
+      preset={preset}
+      workspaceId={workspaceId}
+      agentPresets={agentPresets}
+      subagentVersionsByPresetId={subagentVersionsByPresetId}
+      subagentVersionsByPresetIdIsLoading={subagentVersionsByPresetIdIsLoading}
+      builderPrompt={builderPrompt}
+      form={form}
+      isSaving={isSaving}
+      actionSuggestions={actionSuggestions}
+      namespaceSuggestions={namespaceSuggestions}
+      enabledModelOptions={enabledModelOptions}
+      enabledModelsLoaded={enabledModelsLoaded}
+      mcpIntegrations={mcpIntegrations}
+      mcpIntegrationsIsLoading={mcpIntegrationsIsLoading}
+      skillFields={skillFields}
+      onAddSkillBinding={handleAddSkillBinding}
+      onRemoveSkillBinding={removeSkillBinding}
+      toolApprovalFields={toolApprovalFields}
+      onAddToolApproval={handleAddToolApproval}
+      onRemoveToolApproval={removeToolApproval}
+      subagentFields={subagentFields}
+      onAddSubagent={handleAddSubagent}
+      onRemoveSubagent={removeSubagent}
+    />
+  )
+
+  const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    // Ignore submits bubbling from nested forms (e.g., chat prompt inputs).
+    if (event.target !== event.currentTarget) {
+      return
+    }
+    void handleSubmit()
+  }
+
   return (
     <Form {...form}>
-      <form
-        onSubmit={(event) => {
-          event.preventDefault()
-          // Ignore submits bubbling from nested forms (e.g., chat prompt inputs).
-          if (event.target !== event.currentTarget) {
-            return
-          }
-          void handleSubmit()
-        }}
-        className="h-full"
-      >
-        <ResizablePanelGroup direction="horizontal" className="h-full">
-          <ResizablePanel defaultSize={62} minSize={40}>
-            <AgentPresetDocumentPanel
-              form={form}
-              mode={mode}
-              isSaving={isSaving}
-              isDeleting={isDeleting}
-              canSubmit={canSubmit}
-              presetName={preset?.name ?? ""}
-              onDuplicate={onDuplicate ? handleDuplicate : undefined}
-              isDuplicating={isDuplicating}
-              onDelete={onDelete}
-              deleteDialogOpen={deleteDialogOpen}
-              onDeleteDialogChange={handleDeleteDialogChange}
-              onConfirmDelete={handleConfirmDelete}
-            />
-          </ResizablePanel>
+      <form onSubmit={handleFormSubmit} className="h-full min-h-0">
+        {layout === "stacked" ? (
+          <ResizablePanelGroup direction="vertical" className="h-full">
+            <ResizablePanel
+              defaultSize={42}
+              minSize={28}
+              className="overflow-hidden"
+            >
+              {documentPanel}
+            </ResizablePanel>
 
-          <ResizableHandle withHandle />
+            <ResizableHandle />
 
-          <ResizablePanel defaultSize={38} minSize={26}>
-            <AgentPresetRightPanel
-              activeTab={effectiveTab}
-              onTabChange={handleTabChange}
-              channelsEnabled={channelsEnabled}
-              preset={preset}
-              workspaceId={workspaceId}
-              agentPresets={agentPresets}
-              subagentVersionsByPresetId={subagentVersionsByPresetId}
-              subagentVersionsByPresetIdIsLoading={
-                subagentVersionsByPresetIdIsLoading
-              }
-              builderPrompt={builderPrompt}
-              form={form}
-              isSaving={isSaving}
-              actionSuggestions={actionSuggestions}
-              namespaceSuggestions={namespaceSuggestions}
-              enabledModelOptions={enabledModelOptions}
-              enabledModelsLoaded={enabledModelsLoaded}
-              mcpIntegrations={mcpIntegrations}
-              mcpIntegrationsIsLoading={mcpIntegrationsIsLoading}
-              skillFields={skillFields}
-              onAddSkillBinding={handleAddSkillBinding}
-              onRemoveSkillBinding={removeSkillBinding}
-              toolApprovalFields={toolApprovalFields}
-              onAddToolApproval={handleAddToolApproval}
-              onRemoveToolApproval={removeToolApproval}
-              subagentFields={subagentFields}
-              onAddSubagent={handleAddSubagent}
-              onRemoveSubagent={removeSubagent}
-            />
-          </ResizablePanel>
-        </ResizablePanelGroup>
+            <ResizablePanel
+              defaultSize={58}
+              minSize={32}
+              className="overflow-hidden"
+            >
+              {rightPanel}
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        ) : (
+          <ResizablePanelGroup direction="horizontal" className="h-full">
+            <ResizablePanel defaultSize={62} minSize={40}>
+              {documentPanel}
+            </ResizablePanel>
+
+            <ResizableHandle withHandle />
+
+            <ResizablePanel defaultSize={38} minSize={26}>
+              {rightPanel}
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        )}
       </form>
     </Form>
   )

--- a/frontend/src/components/cases/case-panel-view.tsx
+++ b/frontend/src/components/cases/case-panel-view.tsx
@@ -77,6 +77,22 @@ import { cn, undoSlugify } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 type CasePanelTab = "comments" | "activity" | "attachments" | "rows" | "payload"
+const CASE_PANEL_TABS = new Set<CasePanelTab>([
+  "comments",
+  "activity",
+  "attachments",
+  "rows",
+  "payload",
+])
+
+function parseCasePanelTab(
+  value: string | null | undefined
+): CasePanelTab | null {
+  if (!value || !CASE_PANEL_TABS.has(value as CasePanelTab)) {
+    return null
+  }
+  return value as CasePanelTab
+}
 
 function isCustomFieldValueEmpty(value: unknown): boolean {
   if (value === null || value === undefined) return true
@@ -92,11 +108,15 @@ function isCustomFieldValueEmpty(value: unknown): boolean {
 interface CasePanelContentProps {
   caseId: string
   embedded?: boolean
+  initialTab?: string | null
+  onTabChange?: (tab: string) => void
 }
 
 export function CasePanelView({
   caseId,
   embedded = false,
+  initialTab,
+  onTabChange,
 }: CasePanelContentProps) {
   const workspaceId = useWorkspaceId()
   const { members } = useWorkspaceMembers(workspaceId)
@@ -138,10 +158,9 @@ export function CasePanelView({
     [caseData?.fields]
   )
   const [showAllCustomFields, setShowAllCustomFields] = useState(false)
-  const [embeddedTab, setEmbeddedTab] = useState<CasePanelTab>("comments")
-  useEffect(() => {
-    setEmbeddedTab("comments")
-  }, [caseId])
+  const [embeddedTab, setEmbeddedTab] = useState<CasePanelTab>(
+    () => parseCasePanelTab(initialTab) ?? "comments"
+  )
   const visibleCustomFields = useMemo(
     () =>
       showAllCustomFields
@@ -165,26 +184,31 @@ export function CasePanelView({
   )
 
   // Get active tab from URL query params, default to "comments"
-  const routeTab = (
-    searchParams &&
-    ["comments", "activity", "attachments", "rows", "payload"].includes(
-      searchParams.get("tab") || ""
-    )
-      ? (searchParams.get("tab") ?? "comments")
-      : "comments"
-  ) as CasePanelTab
+  const routeTab = parseCasePanelTab(searchParams?.get("tab")) ?? "comments"
   const activeTab = embedded ? embeddedTab : routeTab
+
+  useEffect(() => {
+    if (!embedded) {
+      return
+    }
+    const nextTab = parseCasePanelTab(initialTab) ?? "comments"
+    if (nextTab !== embeddedTab) {
+      setEmbeddedTab(nextTab)
+    }
+  }, [caseId, embedded, embeddedTab, initialTab])
 
   // Function to handle tab changes and update URL
   const handleTabChange = useCallback(
     (tab: string) => {
+      const nextTab = parseCasePanelTab(tab) ?? "comments"
       if (embedded) {
-        setEmbeddedTab(tab as CasePanelTab)
+        setEmbeddedTab(nextTab)
+        onTabChange?.(nextTab)
         return
       }
-      router.push(`/workspaces/${workspaceId}/cases/${caseId}?tab=${tab}`)
+      router.push(`/workspaces/${workspaceId}/cases/${caseId}?tab=${nextTab}`)
     },
-    [embedded, router, workspaceId, caseId]
+    [embedded, router, workspaceId, caseId, onTabChange]
   )
 
   if (caseDataIsLoading) {

--- a/frontend/src/components/workspace-chat/artifacts/artifact-content.tsx
+++ b/frontend/src/components/workspace-chat/artifacts/artifact-content.tsx
@@ -2,6 +2,8 @@
 
 import { ExternalLink } from "lucide-react"
 import Link from "next/link"
+import { useEffect, useMemo } from "react"
+import { AgentPresetArtifactView } from "@/components/agents/agent-presets-builder"
 import { CasePanelView } from "@/components/cases/case-panel-view"
 import { AlertNotification } from "@/components/notifications"
 import { TablePanelProvider } from "@/components/tables/table-panel-context"
@@ -15,29 +17,97 @@ import {
   getArtifactHref,
 } from "@/components/workspace-chat/artifacts/artifact-registry"
 import { ArtifactIcon } from "@/components/workspace-chat/artifacts/artifact-tabs"
+import { useAgentPreset } from "@/hooks/use-agent-presets"
 import { useGetTable } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 import type { WorkspaceChatArtifact } from "@/types/workspace-chat-artifacts"
 
+const CASE_ARTIFACT_TABS = new Set([
+  "comments",
+  "activity",
+  "attachments",
+  "rows",
+  "payload",
+])
+const AGENT_ARTIFACT_TABS = new Set([
+  "live-chat",
+  "assistant",
+  "configuration",
+  "subagents",
+  "skills",
+  "channels",
+  "structured-output",
+  "versions",
+])
+
 export interface ArtifactContentProps {
   artifact: WorkspaceChatArtifact
   workspaceId: string
+  activeTab: string | null
+  onTabChange: (tab: string | null) => void
 }
 
 /** Render the active artifact content with type-specific embedded views. */
 export function ArtifactContent({
   artifact,
   workspaceId,
+  activeTab,
+  onTabChange,
 }: ArtifactContentProps) {
+  const normalizedTab = useMemo(
+    () => normalizeArtifactTab(artifact, activeTab),
+    [artifact, activeTab]
+  )
+
+  useEffect(() => {
+    if (activeTab !== null && normalizedTab === null) {
+      onTabChange(null)
+    }
+  }, [activeTab, normalizedTab, onTabChange])
+
   switch (artifact.type) {
     case "case":
-      return <CasePanelView caseId={artifact.id} embedded />
+      return (
+        <CasePanelView
+          caseId={artifact.id}
+          embedded
+          initialTab={normalizedTab}
+          onTabChange={onTabChange}
+        />
+      )
     case "table":
       return (
         <EmbeddedTableArtifact artifact={artifact} workspaceId={workspaceId} />
       )
+    case "agent":
+      return (
+        <EmbeddedAgentArtifact
+          artifact={artifact}
+          workspaceId={workspaceId}
+          activeTab={normalizedTab}
+          onTabChange={onTabChange}
+        />
+      )
     default:
       return <ArtifactSummary artifact={artifact} workspaceId={workspaceId} />
+  }
+}
+
+function normalizeArtifactTab(
+  artifact: WorkspaceChatArtifact,
+  tab: string | null
+): string | null {
+  if (!tab) {
+    return null
+  }
+
+  switch (artifact.type) {
+    case "case":
+      return CASE_ARTIFACT_TABS.has(tab) ? tab : null
+    case "agent":
+      return AGENT_ARTIFACT_TABS.has(tab) ? tab : null
+    default:
+      return null
   }
 }
 
@@ -83,6 +153,53 @@ function EmbeddedTableArtifact({
         </TablePanelProvider>
       </TableSelectionProvider>
     </div>
+  )
+}
+
+function EmbeddedAgentArtifact({
+  artifact,
+  workspaceId,
+  activeTab,
+  onTabChange,
+}: {
+  artifact: Extract<WorkspaceChatArtifact, { type: "agent" }>
+  workspaceId: string
+  activeTab: string | null
+  onTabChange: (tab: string | null) => void
+}) {
+  const { preset, presetIsLoading, presetError } = useAgentPreset(
+    workspaceId,
+    artifact.id
+  )
+
+  if (presetIsLoading) {
+    return (
+      <div className="flex h-full flex-col gap-3 p-4">
+        <Skeleton className="h-5 w-1/2" />
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+    )
+  }
+
+  if (presetError || !preset) {
+    return (
+      <div className="p-4">
+        <AlertNotification
+          message={presetError?.message ?? "Error loading agent"}
+          variant="error"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <AgentPresetArtifactView
+      preset={preset}
+      workspaceId={workspaceId}
+      initialTab={activeTab}
+      onTabChange={onTabChange}
+    />
   )
 }
 

--- a/frontend/src/components/workspace-chat/artifacts/artifact-panel.tsx
+++ b/frontend/src/components/workspace-chat/artifacts/artifact-panel.tsx
@@ -15,6 +15,8 @@ export interface ArtifactPanelProps {
   setActiveArtifactKey: (key: string | null) => void
   closeArtifact: (type: ArtifactType, id: string) => void
   workspaceId: string
+  artifactTab: string | null
+  setArtifactTab: (tab: string | null) => void
   className?: string
   /** Triggered when the user manually collapses the panel. */
   onCollapse: () => void
@@ -32,6 +34,8 @@ export function ArtifactPanel({
   setActiveArtifactKey,
   closeArtifact,
   workspaceId,
+  artifactTab,
+  setArtifactTab,
   className,
   onCollapse,
 }: ArtifactPanelProps) {
@@ -61,6 +65,8 @@ export function ArtifactPanel({
             <ArtifactContent
               artifact={activeArtifact}
               workspaceId={workspaceId}
+              activeTab={artifactTab}
+              onTabChange={setArtifactTab}
             />
           </div>
         </>

--- a/frontend/src/components/workspace-chat/artifacts/artifact-registry.tsx
+++ b/frontend/src/components/workspace-chat/artifacts/artifact-registry.tsx
@@ -8,6 +8,7 @@ import {
   KeyRound,
   LayersIcon,
   ListVideoIcon,
+  MousePointerClickIcon,
   Table2Icon,
   WorkflowIcon,
 } from "lucide-react"
@@ -82,6 +83,33 @@ export const ARTIFACT_REGISTRY = {
       })
       queryClient.invalidateQueries({
         queryKey: ["tables", workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["rows", artifact.id],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["rows", "paginated", artifact.id, workspaceId],
+      })
+    },
+  },
+  agent: {
+    label: "Agents",
+    singularLabel: "Agent",
+    icon: MousePointerClickIcon,
+    href: (artifact, workspaceId) =>
+      `/workspaces/${workspaceId}/agents/${artifact.id}`,
+    invalidateQueries: (queryClient, workspaceId, artifact) => {
+      queryClient.invalidateQueries({
+        queryKey: ["agent-preset", workspaceId, artifact.id],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["agent-presets", workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["agent-directory-items", workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["agent-preset-versions", workspaceId, artifact.id],
       })
     },
   },

--- a/frontend/src/components/workspace-chat/workspace-chat-view.tsx
+++ b/frontend/src/components/workspace-chat/workspace-chat-view.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import { useQueryClient } from "@tanstack/react-query"
-import type { UIMessage } from "ai"
+import type { ChatOnDataCallback, UIMessage } from "ai"
 import { PanelLeftIcon } from "lucide-react"
+import { useSearchParams } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { AgentSessionsGetSessionVercelResponse } from "@/client"
 import { useScopeCheck } from "@/components/auth/scope-guard"
@@ -29,12 +30,48 @@ import { useWorkspaceId } from "@/providers/workspace-id"
 import {
   ARTIFACT_DATA_PART_TYPE,
   type ArtifactType,
+  parseWorkspaceChatArtifactStreamPart,
   type WorkspaceChatArtifact,
   type WorkspaceChatArtifactStreamPart,
 } from "@/types/workspace-chat-artifacts"
 
 const EMPTY_MESSAGES: UIMessage[] = []
 const EMPTY_ARTIFACTS: WorkspaceChatArtifact[] = []
+const ARTIFACT_QUERY_PARAM = "artifact"
+const ARTIFACT_TAB_QUERY_PARAM = "tab"
+const ARTIFACT_TYPES = new Set<ArtifactType>([
+  "case",
+  "workflow",
+  "run",
+  "table",
+  "agent",
+  "alert",
+  "integration",
+  "secret",
+  "generic",
+])
+
+function parseArtifactQueryValue(value: string | null): string | null {
+  if (!value) {
+    return null
+  }
+  const separatorIndex = value.indexOf(":")
+  if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
+    return null
+  }
+  const type = value.slice(0, separatorIndex)
+  if (!ARTIFACT_TYPES.has(type as ArtifactType)) {
+    return null
+  }
+  return value
+}
+
+function parseArtifactTabQueryValue(value: string | null): string | null {
+  if (!value || !/^[a-z0-9-]+$/.test(value)) {
+    return null
+  }
+  return value
+}
 
 function sessionArtifacts(
   chat: AgentSessionsGetSessionVercelResponse | undefined
@@ -54,6 +91,13 @@ function sessionArtifacts(
  */
 export function WorkspaceChatView({ chatId }: { chatId?: string }) {
   const workspaceId = useWorkspaceId()
+  const searchParams = useSearchParams()
+  const initialArtifactKeyRef = useRef(
+    parseArtifactQueryValue(searchParams.get(ARTIFACT_QUERY_PARAM))
+  )
+  const initialArtifactTabRef = useRef(
+    parseArtifactTabQueryValue(searchParams.get(ARTIFACT_TAB_QUERY_PARAM))
+  )
   const queryClient = useQueryClient()
   const canAccessMissionControl = useScopeCheck(
     undefined,
@@ -68,6 +112,9 @@ export function WorkspaceChatView({ chatId }: { chatId?: string }) {
     AgentSessionsGetSessionVercelResponse | undefined
   >()
   const [isPanelCollapsed, setIsPanelCollapsed] = useState(true)
+  const [artifactTab, setArtifactTab] = useState<string | null>(
+    initialArtifactTabRef.current
+  )
   const { removeArtifact } = useRemoveSessionArtifact(workspaceId)
   const persistedArtifacts = useMemo(() => sessionArtifacts(chat), [chat])
   const closePersistedArtifact = useCallback(
@@ -97,8 +144,19 @@ export function WorkspaceChatView({ chatId }: { chatId?: string }) {
     },
     [queryClient, workspaceId]
   )
+  const handleStreamData = useCallback<ChatOnDataCallback<UIMessage>>(
+    (dataPart) => {
+      const part = parseWorkspaceChatArtifactStreamPart(dataPart)
+      if (!part) {
+        return
+      }
+      handleArtifactStreamPart(part)
+    },
+    [handleArtifactStreamPart]
+  )
   const artifactsState = useWorkspaceChatArtifacts(messages, {
     enabled: true,
+    initialActiveArtifactKey: initialArtifactKeyRef.current,
     persistedArtifacts,
     onArtifactStreamPart: handleArtifactStreamPart,
     onCloseArtifact: closePersistedArtifact,
@@ -119,6 +177,30 @@ export function WorkspaceChatView({ chatId }: { chatId?: string }) {
     }
     prevHasArtifactsRef.current = next
   }, [artifactCount])
+
+  useEffect(() => {
+    if (chat === undefined && !hasArtifacts) {
+      return
+    }
+
+    const url = new URL(window.location.href)
+    if (artifactsState.activeArtifactKey) {
+      url.searchParams.set(
+        ARTIFACT_QUERY_PARAM,
+        artifactsState.activeArtifactKey
+      )
+      if (artifactTab) {
+        url.searchParams.set(ARTIFACT_TAB_QUERY_PARAM, artifactTab)
+      } else {
+        url.searchParams.delete(ARTIFACT_TAB_QUERY_PARAM)
+      }
+    } else {
+      url.searchParams.delete(ARTIFACT_QUERY_PARAM)
+      url.searchParams.delete(ARTIFACT_TAB_QUERY_PARAM)
+    }
+    url.hash = ""
+    window.history.replaceState(window.history.state, "", url.toString())
+  }, [artifactTab, artifactsState.activeArtifactKey, chat, hasArtifacts])
 
   const collapsePanel = useCallback(() => setIsPanelCollapsed(true), [])
   const expandPanel = useCallback(() => setIsPanelCollapsed(false), [])
@@ -168,6 +250,7 @@ export function WorkspaceChatView({ chatId }: { chatId?: string }) {
             placeholder="Ask Tracecat..."
             surface="workspace-chat"
             onMessagesChange={setMessages}
+            onData={handleStreamData}
             onChatChange={setChat}
             headerActions={
               showExpandButton ? (
@@ -208,6 +291,8 @@ export function WorkspaceChatView({ chatId }: { chatId?: string }) {
               setActiveArtifactKey={artifactsState.setActiveArtifactKey}
               closeArtifact={artifactsState.closeArtifact}
               workspaceId={workspaceId}
+              artifactTab={artifactTab}
+              setArtifactTab={setArtifactTab}
               onCollapse={collapsePanel}
             />
           </ResizablePanel>

--- a/frontend/src/hooks/use-workspace-chat-artifacts.test.tsx
+++ b/frontend/src/hooks/use-workspace-chat-artifacts.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { useWorkspaceChatArtifacts } from "@/hooks/use-workspace-chat-artifacts"
+import type { WorkspaceChatArtifact } from "@/types/workspace-chat-artifacts"
+
+const caseArtifact: WorkspaceChatArtifact = {
+  id: "case-1",
+  type: "case",
+  title: "Case artifact",
+  severity: "medium",
+  status: "new",
+}
+
+const tableArtifact: WorkspaceChatArtifact = {
+  id: "table-1",
+  type: "table",
+  title: "Table artifact",
+}
+
+describe("useWorkspaceChatArtifacts", () => {
+  it("honors the initial active artifact when persisted artifacts hydrate", async () => {
+    const { result, rerender } = renderHook(
+      ({
+        persistedArtifacts,
+      }: {
+        persistedArtifacts: WorkspaceChatArtifact[]
+      }) =>
+        useWorkspaceChatArtifacts([], {
+          initialActiveArtifactKey: "table:table-1",
+          persistedArtifacts,
+        }),
+      {
+        initialProps: {
+          persistedArtifacts: [] as WorkspaceChatArtifact[],
+        },
+      }
+    )
+
+    expect(result.current.activeArtifactKey).toBeNull()
+
+    rerender({
+      persistedArtifacts: [caseArtifact, tableArtifact],
+    })
+
+    await waitFor(() =>
+      expect(result.current.activeArtifactKey).toBe("table:table-1")
+    )
+  })
+})

--- a/frontend/src/hooks/use-workspace-chat-artifacts.ts
+++ b/frontend/src/hooks/use-workspace-chat-artifacts.ts
@@ -24,6 +24,7 @@ export type UseWorkspaceChatArtifactsResult = {
 /** Options for projecting artifact stream parts into workspace chat state. */
 export type UseWorkspaceChatArtifactsOptions = {
   enabled?: boolean
+  initialActiveArtifactKey?: string | null
   persistedArtifacts?: WorkspaceChatArtifact[]
   onArtifactStreamPart?: (part: WorkspaceChatArtifactStreamPart) => void
   onCloseArtifact?: (type: ArtifactType, id: string) => void | Promise<void>
@@ -39,7 +40,7 @@ const EMPTY_ARTIFACTS: WorkspaceChatArtifact[] = []
 function reduceArtifactPayload(
   next: Map<string, WorkspaceChatArtifact>,
   payload: ArtifactDataPayload
-) {
+): void {
   const key = artifactKey(payload.artifact)
   switch (payload.op) {
     case "upsert":
@@ -54,7 +55,7 @@ function reduceArtifactPayload(
 function reduceWorkspaceChatArtifactStreamPart(
   next: Map<string, WorkspaceChatArtifact>,
   part: WorkspaceChatArtifactStreamPart
-) {
+): void {
   switch (part.type) {
     case ARTIFACT_DATA_PART_TYPE:
       reduceArtifactPayload(next, part.data)
@@ -152,6 +153,20 @@ function lastArtifactKey(artifacts: WorkspaceChatArtifact[]): string | null {
   return artifact ? artifactKey(artifact) : null
 }
 
+function selectActiveArtifactKey(
+  artifacts: WorkspaceChatArtifact[],
+  preferredKey: string | null,
+  fallbackKey: string | null
+): string | null {
+  if (
+    preferredKey &&
+    artifacts.some((artifact) => artifactKey(artifact) === preferredKey)
+  ) {
+    return preferredKey
+  }
+  return fallbackKey
+}
+
 function notifyArtifactStreamParts(
   streamParts: WorkspaceChatArtifactMessageStreamPart[],
   onArtifactStreamPart: UseWorkspaceChatArtifactsOptions["onArtifactStreamPart"]
@@ -176,6 +191,7 @@ export function useWorkspaceChatArtifacts(
   options: UseWorkspaceChatArtifactsOptions = {}
 ): UseWorkspaceChatArtifactsResult {
   const enabled = options.enabled ?? true
+  const initialActiveArtifactKey = options.initialActiveArtifactKey ?? null
   const persistedArtifacts = options.persistedArtifacts ?? EMPTY_ARTIFACTS
   const onArtifactStreamPart = options.onArtifactStreamPart
   const onCloseArtifact = options.onCloseArtifact
@@ -191,13 +207,24 @@ export function useWorkspaceChatArtifacts(
   const previousPersistedArtifactSignatureRef = useRef(
     persistedArtifactSignature
   )
+  const initialActiveArtifactKeyRef = useRef(initialActiveArtifactKey)
   const [activeArtifactKey, setActiveArtifactKey] = useState<string | null>(
     () => {
       if (!enabled) {
         return null
       }
       const initialParts = messageStreamParts(messages)
-      return lastUpsertKey(initialParts) ?? lastArtifactKey(persistedArtifacts)
+      const initialArtifacts = Array.from(
+        artifactMapFromArtifactsAndMessageStreamParts(
+          persistedArtifacts,
+          initialParts
+        ).values()
+      )
+      return selectActiveArtifactKey(
+        initialArtifacts,
+        initialActiveArtifactKeyRef.current,
+        lastUpsertKey(initialParts) ?? lastArtifactKey(persistedArtifacts)
+      )
     }
   )
   const [streamArtifacts, setStreamArtifacts] = useState<
@@ -215,6 +242,13 @@ export function useWorkspaceChatArtifacts(
       initialParts
     )
   })
+  const setActiveArtifactKeyAndClearInitial = useCallback(
+    (key: string | null) => {
+      initialActiveArtifactKeyRef.current = null
+      setActiveArtifactKey(key)
+    },
+    []
+  )
 
   useEffect(() => {
     const firstMessageId = messages[0]?.id ?? null
@@ -249,14 +283,17 @@ export function useWorkspaceChatArtifacts(
       processedMessagePartKeysRef.current = new Set(
         currentParts.map(({ eventKey }) => eventKey)
       )
-      setStreamArtifacts(
-        artifactMapFromArtifactsAndMessageStreamParts(
-          persistedArtifacts,
-          currentParts
-        )
+      const nextArtifacts = artifactMapFromArtifactsAndMessageStreamParts(
+        persistedArtifacts,
+        currentParts
       )
+      setStreamArtifacts(nextArtifacts)
       setActiveArtifactKey(
-        lastUpsertKey(currentParts) ?? lastArtifactKey(persistedArtifacts)
+        selectActiveArtifactKey(
+          Array.from(nextArtifacts.values()),
+          initialActiveArtifactKeyRef.current,
+          lastUpsertKey(currentParts) ?? lastArtifactKey(persistedArtifacts)
+        )
       )
       return
     }
@@ -270,15 +307,20 @@ export function useWorkspaceChatArtifacts(
       for (const { eventKey } of pendingParts) {
         processedMessagePartKeysRef.current.add(eventKey)
       }
-      setStreamArtifacts(
-        artifactMapFromArtifactsAndMessageStreamParts(
-          persistedArtifacts,
-          pendingParts
-        )
+      const nextArtifacts = artifactMapFromArtifactsAndMessageStreamParts(
+        persistedArtifacts,
+        pendingParts
       )
+      setStreamArtifacts(nextArtifacts)
       const nextActiveArtifactKey =
         lastUpsertKey(pendingParts) ?? lastArtifactKey(persistedArtifacts)
-      setActiveArtifactKey(nextActiveArtifactKey)
+      setActiveArtifactKey(
+        selectActiveArtifactKey(
+          Array.from(nextArtifacts.values()),
+          initialActiveArtifactKeyRef.current,
+          nextActiveArtifactKey
+        )
+      )
       return
     }
 
@@ -300,6 +342,7 @@ export function useWorkspaceChatArtifacts(
 
     const nextActiveArtifactKey = lastUpsertKey(pendingParts)
     if (nextActiveArtifactKey) {
+      initialActiveArtifactKeyRef.current = null
       setActiveArtifactKey(nextActiveArtifactKey)
     }
   }, [
@@ -333,6 +376,7 @@ export function useWorkspaceChatArtifacts(
       switch (part.type) {
         case ARTIFACT_DATA_PART_TYPE:
           if (part.data.op === "upsert") {
+            initialActiveArtifactKeyRef.current = null
             setActiveArtifactKey(artifactKey(part.data.artifact))
           }
           return
@@ -375,6 +419,18 @@ export function useWorkspaceChatArtifacts(
       return
     }
 
+    if (
+      initialActiveArtifactKeyRef.current &&
+      artifacts.some(
+        (artifact) =>
+          artifactKey(artifact) === initialActiveArtifactKeyRef.current
+      )
+    ) {
+      setActiveArtifactKey(initialActiveArtifactKeyRef.current)
+      return
+    }
+
+    initialActiveArtifactKeyRef.current = null
     setActiveArtifactKey(artifactKey(artifacts[artifacts.length - 1]))
   }, [activeArtifactKey, artifacts])
 
@@ -390,6 +446,7 @@ export function useWorkspaceChatArtifacts(
         return next
       })
       if (activeArtifactKey === key) {
+        initialActiveArtifactKeyRef.current = null
         const fallback = artifacts.find(
           (artifact) => artifactKey(artifact) !== key
         )
@@ -404,7 +461,7 @@ export function useWorkspaceChatArtifacts(
     artifacts,
     lanes,
     activeArtifactKey,
-    setActiveArtifactKey,
+    setActiveArtifactKey: setActiveArtifactKeyAndClearInitial,
     closeArtifact,
     applyStreamPart,
   }

--- a/frontend/src/types/workspace-chat-artifacts.ts
+++ b/frontend/src/types/workspace-chat-artifacts.ts
@@ -51,6 +51,10 @@ export type TableArtifact = BaseArtifact & {
   rowCount?: number
 }
 
+export type AgentArtifact = BaseArtifact & {
+  type: "agent"
+}
+
 export type AlertArtifact = BaseArtifact & {
   type: "alert"
 }
@@ -73,6 +77,7 @@ export type WorkspaceChatArtifact =
   | WorkflowArtifact
   | RunArtifact
   | TableArtifact
+  | AgentArtifact
   | AlertArtifact
   | IntegrationArtifact
   | SecretArtifact


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute to Tracecat!

  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [ ] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [ ] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

<!--
Please do not leave this blank.
What does this PR implement/fix? Explain your changes.
E.g. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Issues

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Screenshots / Recordings

<!-- Visual changes require screenshots -->

## Steps to QA

<!--
Please provide some steps for the reviewer to test your change. If you wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deep links for workspace chat artifacts and per‑artifact tabs via URL params to share and restore context. Also embeds agent preset views with a stacked layout and synchronized tabs.

- New Features
  - Workspace chat reads/writes `?artifact=<type>:<id>` and `?tab=<tab>` with validation; URL stays in sync via history replace as artifacts open/close or tabs change. Invalid params are cleared.
  - Tabs are validated per artifact type (case, agent). Embedded `CasePanelView` and `AgentPresetArtifactView` accept `initialTab` and emit `onTabChange`.
  - Added agent artifacts: registry entry (icon, href), query invalidations, and embedded `AgentPresetArtifactView` with a stacked layout; tabs stay in sync.
  - Streaming via `onData` parses artifact events to update selection. Preferred artifact and tab from the URL are honored on hydration and cleared after first use; includes a unit test.
  - Table query invalidations expanded to refresh `rows` and paginated rows.

<sup>Written for commit bbdc3e5320c8f4e21baab5b86687be8dce2535f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

