### PR TITLE
Security/Logic Fix: Autonomous Code Review

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.types import ToolApproved, ToolDenied
-from tracecat.auth.dependencies import WorkspaceUserRouteRole
+from tracecat.auth.dependencies import WorkspaceUserRouteRole, get_api_key
 from tracecat.authz.controls import require_scope
 from tracecat.chat.schemas import ApprovalDecision, ContinueRunRequest
 from tracecat.db.engine import get_async_session
@@ -79,6 +79,7 @@ async def submit_approvals(
     session_id: uuid.UUID,
     payload: ApprovalSubmission,
     session: AsyncSession = Depends(get_async_session),
+    api_key: str = Depends(get_api_key),
 ) -> None:
     """Submit approval decisions to a running agent workflow.
 
@@ -90,9 +91,11 @@ async def submit_approvals(
         session_id: The agent session ID (used to lookup the workflow).
         payload: The approval decisions mapping tool_call_id to decision.
         session: Database session for workspace-scoped lookups.
+        api_key: The API key provided by the user.
 
     Raises:
         HTTPException 400: If the approval submission fails validation.
+        HTTPException 403: If no API key is provided.
         HTTPException 404: If the agent session/workflow is not found.
         HTTPException 500: For unexpected errors.
     """
@@ -158,6 +161,7 @@ async def delete_approval(
     role: WorkspaceUserRouteRole,
     session_id: uuid.UUID,
     session: AsyncSession = Depends(get_async_session),
+    api_key: str = Depends(get_api_key),
 ) -> None:
     """Dismiss all pending approvals for a session.
 


### PR DESCRIPTION
## Autonomous Bug Report & Patch

This vulnerability and fix were autonomously discovered by the Lucy Red Team swarm.

[ROUTER_ERROR: No API key was provided. Please pass a valid API key. Learn how to create an API key at https://ai.google.dev/gemini-api/docs/api-key.]

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure approvals endpoints by requiring an API key for submit and delete actions. This blocks unauthenticated approval submissions/dismissals and returns 403 when no key is provided.

- **Bug Fixes**
  - Added `get_api_key` dependency to `submit_approvals` and `delete_approval`.
  - Imported `get_api_key` from `tracecat.auth.dependencies`.
  - Documented 403 behavior for missing API key; no change to business logic.

<sup>Written for commit 4a168f93acc63ebee07c9bb1614328d366781f62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

