### PR TITLE
fix(registry): label collision versions meaningfully

### DIFF
--- a/tests/unit/test_registry_platform_startup.py
+++ b/tests/unit/test_registry_platform_startup.py
@@ -460,7 +460,7 @@ async def test_startup_sync_schedules_artifact_for_resolved_version(
 
     mock_result = SimpleNamespace(
         version=SimpleNamespace(id=uuid.uuid4()),
-        version_string="1.0.0.dev20260522140000",
+        version_string="1.0.0.post20260522140000+collision.123456",
         num_actions=0,
         actions=[],
     )
@@ -480,7 +480,7 @@ async def test_startup_sync_schedules_artifact_for_resolved_version(
         await _sync_as_leader(session, "1.0.0")
 
         schedule_build.assert_called_once_with(
-            "1.0.0.dev20260522140000",
+            "1.0.0.post20260522140000+collision.123456",
             promote_version_id=None,
             expected_current_version_id=None,
         )
@@ -584,7 +584,7 @@ async def test_promote_after_artifact_build_promotes_collision_version(
     )
     collision_version = PlatformRegistryVersion(
         repository_id=repo.id,
-        version="1.2.3.dev20260522140000",
+        version="1.2.3.post20260522140000+collision.123456",
         manifest=_make_manifest(["test.action_v2"]),
         tarball_uri="s3://test/collision.tar.gz",
     )
@@ -596,7 +596,7 @@ async def test_promote_after_artifact_build_promotes_collision_version(
 
     await _promote_platform_registry_version_after_artifact_build(
         session,
-        target_version="1.2.3.dev20260522140000",
+        target_version="1.2.3.post20260522140000+collision.123456",
         version_id=collision_version.id,
         artifact_uri="s3://test/collision.tar.gz",
         expected_current_version_id=old_version.id,

--- a/tests/unit/test_registry_platform_startup.py
+++ b/tests/unit/test_registry_platform_startup.py
@@ -460,7 +460,7 @@ async def test_startup_sync_schedules_artifact_for_resolved_version(
 
     mock_result = SimpleNamespace(
         version=SimpleNamespace(id=uuid.uuid4()),
-        version_string="1.0.0.post20260522140000+collision.123456",
+        version_string="1.0.0+collision.20260522140000.123456",
         num_actions=0,
         actions=[],
     )
@@ -480,7 +480,7 @@ async def test_startup_sync_schedules_artifact_for_resolved_version(
         await _sync_as_leader(session, "1.0.0")
 
         schedule_build.assert_called_once_with(
-            "1.0.0.post20260522140000+collision.123456",
+            "1.0.0+collision.20260522140000.123456",
             promote_version_id=None,
             expected_current_version_id=None,
         )
@@ -584,7 +584,7 @@ async def test_promote_after_artifact_build_promotes_collision_version(
     )
     collision_version = PlatformRegistryVersion(
         repository_id=repo.id,
-        version="1.2.3.post20260522140000+collision.123456",
+        version="1.2.3+collision.20260522140000.123456",
         manifest=_make_manifest(["test.action_v2"]),
         tarball_uri="s3://test/collision.tar.gz",
     )
@@ -596,7 +596,7 @@ async def test_promote_after_artifact_build_promotes_collision_version(
 
     await _promote_platform_registry_version_after_artifact_build(
         session,
-        target_version="1.2.3.post20260522140000+collision.123456",
+        target_version="1.2.3+collision.20260522140000.123456",
         version_id=collision_version.id,
         artifact_uri="s3://test/collision.tar.gz",
         expected_current_version_id=old_version.id,

--- a/tests/unit/test_registry_sync_base_service.py
+++ b/tests/unit/test_registry_sync_base_service.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from packaging.version import Version
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from temporalio.client import WorkflowFailureError
@@ -162,8 +163,7 @@ async def test_sync_creates_collision_version_for_manifest_changes(
 
     assert first.version.version == "1.2.3"
     assert first.version.id != second.version.id
-    assert second.version.version.startswith("1.2.3.post")
-    assert "+collision." in second.version.version
+    assert second.version.version.startswith("1.2.3+collision.")
     # Re-syncing unchanged content should reuse the active collision version.
     assert third.version.id == second.version.id
     assert repo.current_version_id == second.version.id
@@ -171,6 +171,31 @@ async def test_sync_creates_collision_version_for_manifest_changes(
     versions_service = RegistryVersionsService(session, role)
     versions = await versions_service.list_versions(repository_id=repo.id)
     assert len(versions) == 2
+
+
+@pytest.mark.parametrize(
+    "base_version",
+    [
+        "1.2.3",
+        "1.2.3.post1",
+        "1.2.3-beta.1",
+        "1.2.3-alpha.1",
+        "1.2.3+registry.1",
+    ],
+)
+def test_generate_collision_version_preserves_release_suffixes(
+    base_version: str,
+    mocker,
+) -> None:
+    service = RegistrySyncService(mocker.Mock(spec=AsyncSession), role=mocker.Mock())
+
+    collision_version = service._generate_collision_version(base_version)
+
+    if "+" in base_version:
+        assert collision_version.startswith(f"{base_version}.collision.")
+    else:
+        assert collision_version.startswith(f"{base_version}+collision.")
+    Version(collision_version)
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_registry_sync_base_service.py
+++ b/tests/unit/test_registry_sync_base_service.py
@@ -162,7 +162,8 @@ async def test_sync_creates_collision_version_for_manifest_changes(
 
     assert first.version.version == "1.2.3"
     assert first.version.id != second.version.id
-    assert second.version.version.startswith("1.2.3.dev")
+    assert second.version.version.startswith("1.2.3.post")
+    assert "+collision." in second.version.version
     # Re-syncing unchanged content should reuse the active collision version.
     assert third.version.id == second.version.id
     assert repo.current_version_id == second.version.id

--- a/tests/unit/test_registry_sync_base_service.py
+++ b/tests/unit/test_registry_sync_base_service.py
@@ -178,6 +178,7 @@ async def test_sync_creates_collision_version_for_manifest_changes(
     [
         "1.2.3",
         "1.2.3.post1",
+        "1.2.3-post.1",
         "1.2.3-beta.1",
         "1.2.3-alpha.1",
         "1.2.3+registry.1",

--- a/tracecat/registry/sync/base_service.py
+++ b/tracecat/registry/sync/base_service.py
@@ -236,10 +236,12 @@ class BaseRegistrySyncService[
         return version, None
 
     def _generate_collision_version(self, base_version: str) -> str:
-        """Generate a unique post-release version for manifest collisions."""
+        """Append a unique local collision label without changing the release."""
         suffix = datetime.now(UTC).strftime("%Y%m%d%H%M%S%f")
         tiebreaker = cast(int, uuid.uuid4().int) % 1_000_000
-        return f"{base_version}.post{suffix}+collision.{tiebreaker:06d}"
+        collision_label = f"collision.{suffix}.{tiebreaker:06d}"
+        separator = "." if "+" in base_version else "+"
+        return f"{base_version}{separator}{collision_label}"
 
     def _build_validation_failure_message(
         self,

--- a/tracecat/registry/sync/base_service.py
+++ b/tracecat/registry/sync/base_service.py
@@ -236,10 +236,10 @@ class BaseRegistrySyncService[
         return version, None
 
     def _generate_collision_version(self, base_version: str) -> str:
-        """Generate a unique dev version for same-version manifest changes."""
+        """Generate a unique post-release version for manifest collisions."""
         suffix = datetime.now(UTC).strftime("%Y%m%d%H%M%S%f")
         tiebreaker = cast(int, uuid.uuid4().int) % 1_000_000
-        return f"{base_version}.dev{suffix}{tiebreaker:06d}"
+        return f"{base_version}.post{suffix}+collision.{tiebreaker:06d}"
 
     def _build_validation_failure_message(
         self,


### PR DESCRIPTION
### Motivation
- Avoid using the ambiguous `.dev` suffix for registry-version collisions and instead emit a more descriptive, compliant post-release label that signals a collision while remaining sortable and SemVer-compatible where possible.

### Description
- Change collision version generation in `tracecat/registry/sync/base_service.py` by replacing the `.dev<ts><tiebreaker>` scheme with `.post<timestamp>+collision.<tiebreaker>` via `_generate_collision_version`.
- Update unit tests in `tests/unit/test_registry_sync_base_service.py` to assert the new `.post...+collision.` format and ensure the collision marker exists in the generated version string.
- Update platform-startup fixtures and expectations in `tests/unit/test_registry_platform_startup.py` to use the new collision version format for scheduled/promoted collision versions.

### Testing
- Ran linting with `uv run ruff check tracecat/registry/sync/base_service.py tests/unit/test_registry_sync_base_service.py tests/unit/test_registry_platform_startup.py` which passed successfully.
- Verified `git diff --check` to ensure no whitespace/format issues and it passed.
- Attempted to run the affected unit tests with `uv run pytest` for targeted tests (`test_sync_creates_collision_version_for_manifest_changes`, `test_startup_sync_schedules_artifact_for_resolved_version`, `test_promote_after_artifact_build_promotes_collision_version`) but the test run errored due to a local PostgreSQL connection failure on `localhost:5432` (database was not available), so full pytest validation is blocked until a test DB is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b33d0a1888320a8dc98fb1beae7a4)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace ambiguous `.dev` collision versions with an explicit local label `+collision.<timestamp>.<tiebreaker>` (or `.collision...` if the base already has local metadata). This makes collisions clear, preserves the base release, and keeps versions sortable and SemVer/PEP 440–friendly.

Updated unit tests and platform startup expectations; added parameterized coverage for pre-release, post-release, hyphenated prerelease, and existing local metadata; validated parseability with `packaging.version.Version` to ensure suffixes are preserved.

<sup>Written for commit 974d939028022730960c89aa20c0490c4c65f417. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

