### PR TITLE
fix(ui): scope last workspace cookie by user

### DIFF
--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -4,7 +4,6 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query"
-import Cookies from "js-cookie"
 import { AlertTriangleIcon, CircleCheck } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useCallback, useRef, useState } from "react"
@@ -353,8 +352,8 @@ import {
   workspacesListWorkspaces,
   workspacesUpdateWorkspace,
 } from "@/client"
-
 import { toast } from "@/components/ui/use-toast"
+import { useAuth } from "@/hooks/use-auth"
 import { type AgentSessionWithStatus, enrichAgentSession } from "@/lib/agents"
 import { client as apiClient, getBaseUrl } from "@/lib/api"
 import {
@@ -365,6 +364,11 @@ import { invalidateCaseActivityQueries } from "@/lib/cases/invalidation"
 import type { ModelInfo } from "@/lib/chat"
 import { retryHandler, type TracecatApiError } from "@/lib/errors"
 import type { WorkflowExecutionReadCompact } from "@/lib/event-history"
+import {
+  clearLastWorkspaceIdForUser,
+  getLastWorkspaceIdForUser,
+  setLastWorkspaceIdForUser,
+} from "@/lib/last-workspace"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 interface AppInfo {
@@ -881,6 +885,8 @@ export function useWorkflowManager(
 export function useWorkspaceManager() {
   const queryClient = useQueryClient()
   const router = useRouter()
+  const { user } = useAuth()
+  const userId = user?.id
 
   // List workspaces
   const {
@@ -966,19 +972,17 @@ export function useWorkspaceManager() {
 
   // Cookies
   const getLastWorkspaceId = useCallback(
-    () => Cookies.get("__tracecat:workspaces:last-viewed"),
-    []
+    () => getLastWorkspaceIdForUser(userId),
+    [userId]
   )
-  const setLastWorkspaceId = useCallback((id?: string) => {
-    if (!id) {
-      Cookies.set("__tracecat:workspaces:last-viewed", "")
-      return
-    }
-    Cookies.set("__tracecat:workspaces:last-viewed", id)
-  }, [])
-  const clearLastWorkspaceId = useCallback(() => {
-    Cookies.remove("__tracecat:workspaces:last-viewed")
-  }, [])
+  const setLastWorkspaceId = useCallback(
+    (id?: string) => setLastWorkspaceIdForUser(userId, id),
+    [userId]
+  )
+  const clearLastWorkspaceId = useCallback(
+    () => clearLastWorkspaceIdForUser(userId),
+    [userId]
+  )
 
   return {
     workspaces,

--- a/frontend/src/lib/last-workspace.ts
+++ b/frontend/src/lib/last-workspace.ts
@@ -1,0 +1,47 @@
+import Cookies from "js-cookie"
+
+const LAST_WORKSPACE_COOKIE_PREFIX = "__tracecat:workspaces:last-viewed"
+const LEGACY_LAST_WORKSPACE_COOKIE = LAST_WORKSPACE_COOKIE_PREFIX
+
+function userLastWorkspaceCookieName(userId: string): string {
+  return `${LAST_WORKSPACE_COOKIE_PREFIX}:${encodeURIComponent(userId)}`
+}
+
+/**
+ * Reads the client-side last viewed workspace ID for a specific user.
+ *
+ * Anonymous callers use the legacy shared cookie, but authenticated users use a
+ * user-scoped cookie so switching accounts in the same browser does not leak the
+ * previously selected workspace across users.
+ */
+export function getLastWorkspaceIdForUser(userId?: string): string | undefined {
+  if (!userId) {
+    return Cookies.get(LEGACY_LAST_WORKSPACE_COOKIE)
+  }
+  return Cookies.get(userLastWorkspaceCookieName(userId))
+}
+
+/** Stores the client-side last viewed workspace ID for a specific user. */
+export function setLastWorkspaceIdForUser(
+  userId: string | undefined,
+  workspaceId?: string
+) {
+  const cookieName = userId
+    ? userLastWorkspaceCookieName(userId)
+    : LEGACY_LAST_WORKSPACE_COOKIE
+
+  if (!workspaceId) {
+    Cookies.set(cookieName, "")
+    return
+  }
+  Cookies.set(cookieName, workspaceId)
+}
+
+/** Clears the client-side last viewed workspace ID for a specific user. */
+export function clearLastWorkspaceIdForUser(userId?: string) {
+  if (!userId) {
+    Cookies.remove(LEGACY_LAST_WORKSPACE_COOKIE)
+    return
+  }
+  Cookies.remove(userLastWorkspaceCookieName(userId))
+}

--- a/frontend/tests/last-workspace.test.ts
+++ b/frontend/tests/last-workspace.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import Cookies from "js-cookie"
+import {
+  clearLastWorkspaceIdForUser,
+  getLastWorkspaceIdForUser,
+  setLastWorkspaceIdForUser,
+} from "@/lib/last-workspace"
+
+describe("last workspace persistence", () => {
+  beforeEach(() => {
+    Cookies.remove("__tracecat:workspaces:last-viewed")
+    Cookies.remove("__tracecat:workspaces:last-viewed:user-a")
+    Cookies.remove("__tracecat:workspaces:last-viewed:user-b")
+  })
+
+  it("stores the last workspace separately for each user", () => {
+    setLastWorkspaceIdForUser("user-a", "workspace-a")
+    setLastWorkspaceIdForUser("user-b", "workspace-b")
+
+    expect(getLastWorkspaceIdForUser("user-a")).toBe("workspace-a")
+    expect(getLastWorkspaceIdForUser("user-b")).toBe("workspace-b")
+  })
+
+  it("keeps anonymous storage on the legacy shared cookie", () => {
+    setLastWorkspaceIdForUser(undefined, "workspace-anonymous")
+    setLastWorkspaceIdForUser("user-a", "workspace-a")
+
+    expect(getLastWorkspaceIdForUser()).toBe("workspace-anonymous")
+    expect(getLastWorkspaceIdForUser("user-a")).toBe("workspace-a")
+  })
+
+  it("clears only the scoped user's last workspace", () => {
+    setLastWorkspaceIdForUser("user-a", "workspace-a")
+    setLastWorkspaceIdForUser("user-b", "workspace-b")
+
+    clearLastWorkspaceIdForUser("user-a")
+
+    expect(getLastWorkspaceIdForUser("user-a")).toBeUndefined()
+    expect(getLastWorkspaceIdForUser("user-b")).toBe("workspace-b")
+  })
+})


### PR DESCRIPTION
### Motivation
- The client-side "last viewed workspace" value was stored in a single shared cookie (`__tracecat:workspaces:last-viewed`), which could leak a previously selected workspace across different authenticated users in the same browser.
- The change scopes persisted last-viewed workspace IDs to an authenticated user's ID while preserving the legacy behavior for anonymous callers.

### Description
- Add `frontend/src/lib/last-workspace.ts` which exposes `getLastWorkspaceIdForUser`, `setLastWorkspaceIdForUser`, and `clearLastWorkspaceIdForUser`, and uses per-user cookie names `__tracecat:workspaces:last-viewed:<userId>` for authenticated users. 
- Update `useWorkspaceManager` in `frontend/src/lib/hooks.tsx` to read the current user via `useAuth()` and route cookie get/set/clear through the new helpers instead of the shared cookie. 
- Remove direct `Cookies` usage for the shared key in `useWorkspaceManager` so workspace persistence is user-scoped. 
- Add regression tests at `frontend/tests/last-workspace.test.ts` to verify per-user storage, legacy anonymous behavior, and that clearing one user's value does not clear another's.

### Testing
- Ran formatting/type fixes with `pnpm -C frontend exec biome check --write src/lib/hooks.tsx src/lib/last-workspace.ts tests/last-workspace.test.ts` which completed and autofixed one file. (success)
- Ran the new unit tests with `pnpm -C frontend test -- last-workspace.test.ts` and all tests passed (`3 passed`). (success)
- Ran TypeScript typecheck with `pnpm -C frontend run typecheck` which completed without type errors. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b35f532288320a8d5f1dc77c9eb3f)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the “last viewed workspace” cookie by user to prevent cross-account leakage in the same browser. Keeps the legacy shared cookie for anonymous sessions.

- Bug Fixes
  - Store last workspace per user via `__tracecat:workspaces:last-viewed:<userId>`.
  - Add `getLastWorkspaceIdForUser`, `setLastWorkspaceIdForUser`, `clearLastWorkspaceIdForUser` in `frontend/src/lib/last-workspace.ts`.
  - Update `useWorkspaceManager` to use `useAuth()` and the new helpers; remove direct `Cookies` usage.
  - Preserve `__tracecat:workspaces:last-viewed` for anonymous users.
  - Add tests in `frontend/tests/last-workspace.test.ts` for per-user storage, legacy behavior, and scoped clearing.

<sup>Written for commit dd8687aa41da1877111532f48ad4da272def4384. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

