### PR TITLE
feat(chat): create workflow artifacts from chat

### DIFF
--- a/frontend/src/components/builder/canvas/canvas-toolbar.tsx
+++ b/frontend/src/components/builder/canvas/canvas-toolbar.tsx
@@ -5,6 +5,7 @@ import {
   BoxIcon,
   DatabaseIcon,
   LayersIcon,
+  PlusIcon,
   SparklesIcon,
   SquareFunctionIcon,
   Table2Icon,
@@ -271,11 +272,27 @@ function sortActions(
 
 export interface CanvasToolbarProps {
   onAddAction: (action: RegistryActionReadMinimal) => void
+  /**
+   * When true, collapse the toolbar into a small pill that expands into the
+   * full category bar on hover (used in the embedded workflow artifact).
+   */
+  embedded?: boolean
 }
 
-export function CanvasToolbar({ onAddAction }: CanvasToolbarProps) {
+export function CanvasToolbar({
+  onAddAction,
+  embedded = false,
+}: CanvasToolbarProps) {
   const { registryActions, registryActionsIsLoading } =
     useBuilderRegistryActions({ includeLocked: true })
+  const [hovered, setHovered] = useState(false)
+  // Track open category popovers so the bar stays expanded while one is open,
+  // even though the pointer has left the bar to reach the popover.
+  const [openCount, setOpenCount] = useState(0)
+
+  const handleCategoryOpenChange = useCallback((open: boolean) => {
+    setOpenCount((count) => Math.max(0, count + (open ? 1 : -1)))
+  }, [])
 
   const actionsByCategory = useMemo(() => {
     if (!registryActions) return new Map<string, RegistryActionReadMinimal[]>()
@@ -318,24 +335,67 @@ export function CanvasToolbar({ onAddAction }: CanvasToolbarProps) {
     return grouped
   }, [registryActions])
 
+  const bar = (
+    <div
+      className={cn(
+        "flex items-center gap-1 rounded-lg border bg-background/95 p-1 backdrop-blur supports-[backdrop-filter]:bg-background/80",
+        // Keep the standalone builder toolbar elevated; the embedded toolbar stays flat.
+        !embedded && "shadow-lg"
+      )}
+    >
+      {ACTION_CATEGORIES.map((category) => {
+        const Icon = category.icon
+        const actions = actionsByCategory.get(category.id) ?? []
+
+        return (
+          <ToolbarCategoryDropdown
+            key={category.id}
+            category={category}
+            actions={actions}
+            isLoading={registryActionsIsLoading}
+            onAddAction={onAddAction}
+            onOpenChange={embedded ? handleCategoryOpenChange : undefined}
+            Icon={Icon}
+          />
+        )
+      })}
+    </div>
+  )
+
+  if (!embedded) {
+    return <TooltipProvider delayDuration={300}>{bar}</TooltipProvider>
+  }
+
+  // Expanded while hovered or while a category popover is open; otherwise the
+  // bar collapses back into the pill once the pointer leaves.
+  const expanded = hovered || openCount > 0
+
   return (
     <TooltipProvider delayDuration={300}>
-      <div className="flex items-center gap-1 rounded-lg border bg-background/95 p-1 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80">
-        {ACTION_CATEGORIES.map((category) => {
-          const Icon = category.icon
-          const actions = actionsByCategory.get(category.id) ?? []
-
-          return (
-            <ToolbarCategoryDropdown
-              key={category.id}
-              category={category}
-              actions={actions}
-              isLoading={registryActionsIsLoading}
-              onAddAction={onAddAction}
-              Icon={Icon}
-            />
-          )
-        })}
+      <div
+        className="flex items-center justify-center"
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        {expanded ? (
+          <div className="duration-150 animate-in fade-in-0 zoom-in-95">
+            {bar}
+          </div>
+        ) : (
+          <button
+            type="button"
+            aria-label="Show actions"
+            onClick={() => setHovered(true)}
+            className="flex items-center gap-1 rounded-full border bg-background/95 px-2 py-0.5 text-muted-foreground backdrop-blur transition-colors duration-150 animate-in fade-in-0 zoom-in-95 hover:text-foreground supports-[backdrop-filter]:bg-background/80"
+          >
+            <PlusIcon className="size-3" />
+            <span className="flex items-center gap-0.5">
+              <span className="size-0.5 rounded-full bg-muted-foreground/40" />
+              <span className="size-0.5 rounded-full bg-muted-foreground/40" />
+              <span className="size-0.5 rounded-full bg-muted-foreground/40" />
+            </span>
+          </button>
+        )}
       </div>
     </TooltipProvider>
   )
@@ -347,6 +407,8 @@ interface ToolbarCategoryDropdownProps {
   isLoading: boolean
   onAddAction: (action: RegistryActionReadMinimal) => void
   Icon: LucideIcon
+  /** Notified whenever this category's popover opens or closes. */
+  onOpenChange?: (open: boolean) => void
 }
 
 function ToolbarCategoryDropdown({
@@ -355,10 +417,21 @@ function ToolbarCategoryDropdown({
   isLoading,
   onAddAction,
   Icon,
+  onOpenChange,
 }: ToolbarCategoryDropdownProps) {
   const [open, setOpen] = useState(false)
   const [lockedFeatureOpen, setLockedFeatureOpen] = useState(false)
   const [search, setSearch] = useState("")
+
+  // Single funnel for open/close so the parent is notified for both user-driven
+  // (Radix) and programmatic (select) transitions.
+  const setOpenAndNotify = useCallback(
+    (next: boolean) => {
+      setOpen(next)
+      onOpenChange?.(next)
+    },
+    [onOpenChange]
+  )
   const isAiCategory = category.id === "ai"
   const isAgentCategory = category.id === "agent"
   const categoryStyle = CATEGORY_STYLES[category.id]
@@ -376,16 +449,16 @@ function ToolbarCategoryDropdown({
   const handleSelect = useCallback(
     (action: RegistryActionReadMinimal) => {
       if (isLockedAction(action)) {
-        setOpen(false)
+        setOpenAndNotify(false)
         setSearch("")
         setLockedFeatureOpen(true)
         return
       }
       onAddAction(action)
-      setOpen(false)
+      setOpenAndNotify(false)
       setSearch("")
     },
-    [onAddAction]
+    [onAddAction, setOpenAndNotify]
   )
 
   function renderActionIcon(action: RegistryActionReadMinimal) {
@@ -440,7 +513,7 @@ function ToolbarCategoryDropdown({
         open={lockedFeatureOpen}
         onOpenChange={setLockedFeatureOpen}
       />
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover open={open} onOpenChange={setOpenAndNotify}>
         <Tooltip>
           <TooltipTrigger asChild>
             <PopoverTrigger asChild>

--- a/frontend/src/components/builder/canvas/canvas.tsx
+++ b/frontend/src/components/builder/canvas/canvas.tsx
@@ -1063,7 +1063,10 @@ export const WorkflowCanvas = React.forwardRef<
           </Button>
         </Panel>
         <Panel position="bottom-center" className="mb-4">
-          <CanvasToolbar onAddAction={handleToolbarAddAction} />
+          <CanvasToolbar
+            onAddAction={handleToolbarAddAction}
+            embedded={embedded}
+          />
         </Panel>
         <NodeSilhouette
           position={silhouettePosition}

--- a/frontend/src/components/builder/canvas/canvas.tsx
+++ b/frontend/src/components/builder/canvas/canvas.tsx
@@ -75,6 +75,13 @@ const fitViewOptions: FitViewOptions = {
   maxZoom: 1,
 }
 
+// Embedded surfaces (e.g. the workflow artifact panel) start further out so a
+// small graph (or a lone trigger) doesn't fill the panel.
+const embeddedFitViewOptions: FitViewOptions = {
+  minZoom: 0.25,
+  maxZoom: 0.6,
+}
+
 const getId = () => uuid4()
 
 export type NodeTypename = "udf" | "trigger" | "selector"
@@ -145,8 +152,11 @@ export interface WorkflowCanvasRef {
 
 export const WorkflowCanvas = React.forwardRef<
   WorkflowCanvasRef,
-  React.ComponentPropsWithoutRef<typeof ReactFlow>
->((props, ref) => {
+  React.ComponentPropsWithoutRef<typeof ReactFlow> & { embedded?: boolean }
+>(({ embedded = false }, ref) => {
+  const activeFitViewOptions = embedded
+    ? embeddedFitViewOptions
+    : fitViewOptions
   const containerRef = useRef<HTMLDivElement>(null)
   const connectingNodeId = useRef<string | null>(null)
   const connectingHandleId = useRef<string | null>(null)
@@ -1016,7 +1026,7 @@ export const WorkflowCanvas = React.forwardRef<
         proOptions={{ hideAttribution: true }}
         deleteKeyCode={["Backspace", "Delete"]}
         fitView
-        fitViewOptions={fitViewOptions}
+        fitViewOptions={activeFitViewOptions}
         nodeDragThreshold={4}
         maxZoom={1}
         minZoom={0.25}
@@ -1025,7 +1035,10 @@ export const WorkflowCanvas = React.forwardRef<
         onPaneContextMenu={onPaneContextMenu}
       >
         <Background bgColor="#fcfcfc" />
-        <Controls className="rounded-sm" fitViewOptions={fitViewOptions} />
+        <Controls
+          className="rounded-sm"
+          fitViewOptions={activeFitViewOptions}
+        />
         <Panel position="bottom-right" className="flex items-center gap-1">
           <Badge
             variant="outline"

--- a/frontend/src/components/builder/events/events-shared.tsx
+++ b/frontend/src/components/builder/events/events-shared.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import {
+  CalendarSearchIcon,
+  FileInputIcon,
+  type LucideIcon,
+  MessagesSquare,
+  ShapesIcon,
+  WorkflowIcon,
+} from "lucide-react"
+import type { ReactNode } from "react"
+import { $TriggerType, type TriggerType } from "@/client"
+import { ActionEventPane } from "@/components/builder/events/events-selected-action"
+import { WorkflowInteractions } from "@/components/builder/events/events-sidebar-interactions"
+import {
+  WorkflowEvents,
+  WorkflowEventsHeader,
+} from "@/components/builder/events/events-workflow"
+import { Spinner } from "@/components/loading/spinner"
+import { AlertNotification } from "@/components/notifications"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
+import { useLocalStorage } from "@/hooks/use-local-storage"
+import type { WorkflowExecutionReadCompact } from "@/lib/event-history"
+import { useLastExecution } from "@/lib/hooks"
+import { useWorkflowBuilder } from "@/providers/builder"
+import { useWorkflow } from "@/providers/workflow"
+
+// Define the available trigger types for UI generation
+const AVAILABLE_TRIGGER_TYPES: readonly TriggerType[] = $TriggerType.enum
+
+export type EventsSidebarTabs =
+  | "workflow-events"
+  | "action-input"
+  | "action-result"
+  | "action-interaction"
+
+/** A single tab in the workflow events viewer. */
+export interface EventsTabItem {
+  value: EventsSidebarTabs
+  label: string
+  icon: LucideIcon
+  content: ReactNode
+}
+
+/**
+ * Resolution of the execution to show in an events viewer. Returns a `node` to
+ * render directly while the last execution is loading, errored, or absent;
+ * otherwise an `executionId` ready to fetch detailed events for.
+ */
+export type ResolvedLastExecution =
+  | { status: "pending"; node: ReactNode }
+  | { status: "ready"; executionId: string }
+
+/** Centered spinner with a status message, used across events viewers. */
+export function EventsLoading({ message }: { message: string }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center space-y-2">
+      <span className="text-xs text-muted-foreground">{message}</span>
+      <Spinner className="size-6" />
+    </div>
+  )
+}
+
+/**
+ * Resolve which execution an events viewer should display for the workflow in
+ * context: a directly-triggered run if present, otherwise the last execution
+ * matching the user's selected trigger types. Shared by the builder events
+ * sidebar and the embedded workflow artifact so their loading, error, and empty
+ * states stay in sync.
+ */
+export function useResolvedLastExecution(): ResolvedLastExecution {
+  const { workflowId } = useWorkflow()
+  const { currentExecutionId } = useWorkflowBuilder()
+  const [selectedTriggerTypes] = useLocalStorage<TriggerType[]>(
+    "selected-trigger-types",
+    [...AVAILABLE_TRIGGER_TYPES]
+  )
+
+  const { lastExecution, lastExecutionIsLoading, lastExecutionError } =
+    useLastExecution({
+      // Prefer the direct execution id (e.g. a run just triggered) over the query.
+      workflowId: currentExecutionId ? undefined : workflowId,
+      triggerTypes: selectedTriggerTypes,
+    })
+
+  const executionId = currentExecutionId || lastExecution?.id
+
+  if (!currentExecutionId && lastExecutionIsLoading) {
+    return {
+      status: "pending",
+      node: <EventsLoading message="Fetching last execution..." />,
+    }
+  }
+
+  if (!currentExecutionId && lastExecutionError) {
+    return {
+      status: "pending",
+      node: (
+        <AlertNotification
+          level="error"
+          message={`Error loading last execution: ${lastExecutionError.message}`}
+        />
+      ),
+    }
+  }
+
+  if (!executionId) {
+    return { status: "pending", node: <NoWorkflowRuns /> }
+  }
+
+  return { status: "ready", executionId }
+}
+
+/** Empty state shown when a workflow has never run. */
+function NoWorkflowRuns() {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <Empty className="border-none">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <WorkflowIcon />
+          </EmptyMedia>
+          <EmptyTitle>No workflow runs</EmptyTitle>
+          <EmptyDescription>
+            Get started by running your workflow
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    </div>
+  )
+}
+
+/**
+ * Build the tab descriptors (Events / Input / Result / Interaction) for a
+ * workflow execution. The interaction tab is only included when interactions
+ * are enabled, and the header switches to its compact form when `embedded`.
+ */
+export function buildEventsTabItems({
+  execution,
+  interactionsEnabled,
+  embedded = false,
+}: {
+  execution: WorkflowExecutionReadCompact
+  interactionsEnabled: boolean
+  embedded?: boolean
+}): EventsTabItem[] {
+  const tabItems: EventsTabItem[] = [
+    {
+      value: "workflow-events",
+      label: "Events",
+      icon: CalendarSearchIcon,
+      content: (
+        <>
+          <WorkflowEventsHeader execution={execution} embedded={embedded} />
+          {interactionsEnabled && (
+            <WorkflowInteractions execution={execution} />
+          )}
+          <WorkflowEvents events={execution.events} status={execution.status} />
+        </>
+      ),
+    },
+    {
+      value: "action-input",
+      label: "Input",
+      icon: FileInputIcon,
+      content: <ActionEventPane execution={execution} type="input" />,
+    },
+    {
+      value: "action-result",
+      label: "Result",
+      icon: ShapesIcon,
+      content: <ActionEventPane execution={execution} type="result" />,
+    },
+  ]
+  if (interactionsEnabled) {
+    tabItems.push({
+      value: "action-interaction",
+      label: "Interaction",
+      icon: MessagesSquare,
+      content: <ActionEventPane execution={execution} type="interaction" />,
+    })
+  }
+  return tabItems
+}

--- a/frontend/src/components/builder/events/events-sidebar.tsx
+++ b/frontend/src/components/builder/events/events-sidebar.tsx
@@ -1,51 +1,23 @@
 "use client"
 
-import {
-  CalendarSearchIcon,
-  FileInputIcon,
-  MessagesSquare,
-  ShapesIcon,
-  WorkflowIcon,
-} from "lucide-react"
 import { useEffect, useState } from "react"
 import type { ImperativePanelHandle } from "react-resizable-panels"
-import { $TriggerType, type TriggerType } from "@/client"
-import { ActionEventPane } from "@/components/builder/events/events-selected-action"
+import {
+  buildEventsTabItems,
+  EventsLoading,
+  type EventsSidebarTabs,
+  useResolvedLastExecution,
+} from "@/components/builder/events/events-shared"
 import { EventsSidebarEmpty } from "@/components/builder/events/events-sidebar-empty"
-import { WorkflowInteractions } from "@/components/builder/events/events-sidebar-interactions"
-import {
-  WorkflowEvents,
-  WorkflowEventsHeader,
-} from "@/components/builder/events/events-workflow"
-import { Spinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@/components/ui/empty"
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { useLocalStorage } from "@/hooks/use-local-storage"
-import {
-  useCompactWorkflowExecution,
-  useLastExecution,
-  useOrgAppSettings,
-} from "@/lib/hooks"
+import { useCompactWorkflowExecution, useOrgAppSettings } from "@/lib/hooks"
 import { useWorkflowBuilder } from "@/providers/builder"
-import { useWorkflow } from "@/providers/workflow"
 
-// Define the available trigger types for UI generation
-const AVAILABLE_TRIGGER_TYPES: readonly TriggerType[] = $TriggerType.enum
+export type { EventsSidebarTabs }
 
-export type EventsSidebarTabs =
-  | "workflow-events"
-  | "action-input"
-  | "action-result"
-  | "action-interaction"
 /**
  * Interface for controlling the events sidebar through a ref
  */
@@ -61,34 +33,11 @@ export interface EventsSidebarRef extends ImperativePanelHandle {
 }
 
 export function BuilderSidebarEvents() {
-  const { workflowId } = useWorkflow()
-  const { sidebarRef, currentExecutionId } = useWorkflowBuilder()
+  const { sidebarRef } = useWorkflowBuilder()
   const [activeTab, setActiveTab] =
     useState<EventsSidebarTabs>("workflow-events")
   const [open, setOpen] = useState(false)
-  const [selectedTriggerTypes] = useLocalStorage<TriggerType[]>(
-    "selected-trigger-types",
-    [...AVAILABLE_TRIGGER_TYPES]
-  )
-
-  const { lastExecution, lastExecutionIsLoading, lastExecutionError } =
-    useLastExecution({
-      workflowId: currentExecutionId ? undefined : workflowId,
-      triggerTypes: selectedTriggerTypes,
-    })
-
-  // Determine which execution ID to use
-  // Prefer currentExecutionId (from direct trigger) over lastExecution.id (from query)
-  const executionId = currentExecutionId || lastExecution?.id
-
-  console.debug({
-    currentExecId: currentExecutionId,
-    lastExecId: lastExecution?.id,
-    executionIdUsed: executionId,
-    lastExecIsLoading: lastExecutionIsLoading,
-    lastExecError: lastExecutionError,
-    selectedTriggers: selectedTriggerTypes,
-  })
+  const resolved = useResolvedLastExecution()
 
   // Set up the ref methods
   useEffect(() => {
@@ -105,49 +54,15 @@ export function BuilderSidebarEvents() {
     }
   }, [sidebarRef, activeTab, setOpen, open])
 
-  // If we have a direct execution ID, we can skip the loading state for last execution
-  if (!currentExecutionId && lastExecutionIsLoading) {
-    return (
-      <div className="flex h-full flex-col items-center justify-center space-y-2">
-        <span className="text-xs text-muted-foreground">
-          Fetching last execution...
-        </span>
-        <Spinner className="size-6" />
-      </div>
-    )
+  if (resolved.status === "pending") {
+    return resolved.node
   }
 
-  if (!currentExecutionId && lastExecutionError) {
-    return (
-      <AlertNotification
-        level="error"
-        message={`Error loading last execution: ${lastExecutionError.message}`}
-      />
-    )
-  }
-
-  // If we have no execution ID (neither current nor last), show the empty state
-  if (!executionId) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <Empty className="border-none">
-          <EmptyHeader>
-            <EmptyMedia variant="icon">
-              <WorkflowIcon />
-            </EmptyMedia>
-            <EmptyTitle>No workflow runs</EmptyTitle>
-            <EmptyDescription>
-              Get started by running your workflow
-            </EmptyDescription>
-          </EmptyHeader>
-        </Empty>
-      </div>
-    )
-  }
-
-  // We have an execution ID to use
   return (
-    <BuilderSidebarEventsList activeTab={activeTab} executionId={executionId} />
+    <BuilderSidebarEventsList
+      activeTab={activeTab}
+      executionId={resolved.executionId}
+    />
   )
 }
 
@@ -164,21 +79,8 @@ function BuilderSidebarEventsList({
   const { execution, executionIsLoading, executionError } =
     useCompactWorkflowExecution(executionId)
 
-  console.debug({
-    execId: execution?.id,
-    execIsLoading: executionIsLoading,
-    execError: executionError,
-  })
-
   if (executionIsLoading) {
-    return (
-      <div className="flex h-full flex-col items-center justify-center space-y-2">
-        <span className="text-xs text-muted-foreground">
-          Fetching events...
-        </span>
-        <Spinner className="size-6" />
-      </div>
-    )
+    return <EventsLoading message="Fetching events..." />
   }
   if (executionError) {
     return (
@@ -196,42 +98,10 @@ function BuilderSidebarEventsList({
       />
     )
   }
-  const tabItems = [
-    {
-      value: "workflow-events",
-      label: "Events",
-      icon: CalendarSearchIcon,
-      content: (
-        <>
-          <WorkflowEventsHeader execution={execution} />
-          {appSettings?.app_interactions_enabled && (
-            <WorkflowInteractions execution={execution} />
-          )}
-          <WorkflowEvents events={execution.events} status={execution.status} />
-        </>
-      ),
-    },
-    {
-      value: "action-input",
-      label: "Input",
-      icon: FileInputIcon,
-      content: <ActionEventPane execution={execution} type="input" />,
-    },
-    {
-      value: "action-result",
-      label: "Result",
-      icon: ShapesIcon,
-      content: <ActionEventPane execution={execution} type="result" />,
-    },
-  ]
-  if (appSettings?.app_interactions_enabled) {
-    tabItems.push({
-      value: "action-interaction",
-      label: "Interaction",
-      icon: MessagesSquare,
-      content: <ActionEventPane execution={execution} type="interaction" />,
-    })
-  }
+  const tabItems = buildEventsTabItems({
+    execution,
+    interactionsEnabled: !!appSettings?.app_interactions_enabled,
+  })
 
   return (
     <div className="h-full">

--- a/frontend/src/components/builder/events/events-workflow.tsx
+++ b/frontend/src/components/builder/events/events-workflow.tsx
@@ -62,15 +62,105 @@ import { useWorkflowBuilder } from "@/providers/builder"
 import { useWorkflow } from "@/providers/workflow"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
-export function WorkflowEventsHeader({
+/** Run duration as a short human label (e.g. "8s", "1m 12s"), or null. */
+function formatRunDuration(
+  startISO: string | null | undefined,
+  closeISO: string | null | undefined
+): string | null {
+  if (!startISO || !closeISO) {
+    return null
+  }
+  const start = new Date(startISO).getTime()
+  const close = new Date(closeISO).getTime()
+  if (Number.isNaN(start) || Number.isNaN(close) || close < start) {
+    return null
+  }
+  const totalSeconds = Math.round((close - start) / 1000)
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`
+  }
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes < 60) {
+    return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`
+  }
+  const hours = Math.floor(minutes / 60)
+  const remMinutes = minutes % 60
+  return remMinutes ? `${hours}h ${remMinutes}m` : `${hours}h`
+}
+
+/**
+ * Single-row run summary for space-constrained surfaces (e.g. the embedded
+ * workflow artifact): status badge on the left, trigger / duration / start
+ * time muted on the right. Drops the scheduled/start/end breakdown.
+ */
+function CompactWorkflowEventsHeader({
   execution,
 }: {
   execution: WorkflowExecutionReadCompact
+}) {
+  const startTime = execution.execution_time ?? execution.start_time
+  const duration = formatRunDuration(startTime, execution.close_time)
+  const timeLabel = startTime ? new Date(startTime).toLocaleTimeString() : null
+  const detail = execution.status === "RUNNING" ? "Running…" : duration
+
+  return (
+    <div className="flex items-center justify-between gap-3 px-4 py-2.5 text-xs">
+      <Badge
+        variant="secondary"
+        className="flex items-center gap-1 text-foreground/70 hover:cursor-default"
+      >
+        {getExecutionStatusIcon(execution.status, "size-3.5")}
+        {undoSlugify(execution.status.toLowerCase())}
+      </Badge>
+      <div className="flex min-w-0 items-center gap-1.5 text-muted-foreground">
+        <Tooltip delayDuration={500}>
+          <TooltipTrigger asChild>
+            <span className="flex items-center gap-1">
+              {getTriggerTypeIcon(execution.trigger_type)}
+              <span>
+                {execution.trigger_type.charAt(0).toUpperCase() +
+                  execution.trigger_type.slice(1)}
+              </span>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="font-mono tracking-tight">
+            {execution.id}
+          </TooltipContent>
+        </Tooltip>
+        {detail && (
+          <>
+            <span aria-hidden>·</span>
+            <span>{detail}</span>
+          </>
+        )}
+        {timeLabel && (
+          <>
+            <span aria-hidden>·</span>
+            <span className="truncate">{timeLabel}</span>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function WorkflowEventsHeader({
+  execution,
+  embedded = false,
+}: {
+  execution: WorkflowExecutionReadCompact
+  embedded?: boolean
 }) {
   const { setSelectedNodeId } = useWorkflowBuilder()
   const workspaceId = useWorkspaceId()
   const parentExec = execution.parent_wf_exec_id
   const parentExecId = parentExec ? executionId(parentExec) : null
+
+  if (embedded) {
+    return <CompactWorkflowEventsHeader execution={execution} />
+  }
+
   return (
     <div className="space-y-2 p-4 text-xs text-muted-foreground">
       {/* Trigger type */}

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -465,12 +465,15 @@ function normalizeRunValidationErrors(
   return [toDslApiErrorResult(message)]
 }
 
-function WorkflowManualTrigger({
+export function WorkflowManualTrigger({
   disabled = true,
   workflowId,
+  onAfterTrigger,
 }: {
   disabled: boolean
   workflowId: string
+  /** Invoked after a run is successfully started (e.g. to reveal events). */
+  onAfterTrigger?: () => void
 }) {
   const { expandSidebarAndFocusEvents, setCurrentExecutionId, triggerPayload } =
     useWorkflowBuilder()
@@ -509,6 +512,7 @@ function WorkflowManualTrigger({
 
       // Expand sidebar immediately
       expandSidebarAndFocusEvents()
+      onAfterTrigger?.()
     } catch (error) {
       if (error instanceof ApiError) {
         const tracecatError = error as TracecatApiError<{

--- a/frontend/src/components/workspace-chat/artifacts/artifact-content.tsx
+++ b/frontend/src/components/workspace-chat/artifacts/artifact-content.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { ExternalLink } from "lucide-react"
+import dynamic from "next/dynamic"
 import Link from "next/link"
 import { useEffect, useMemo } from "react"
 import { AgentPresetArtifactView } from "@/components/agents/agent-presets-builder"
@@ -21,6 +22,25 @@ import { useAgentPreset } from "@/hooks/use-agent-presets"
 import { useGetTable } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 import type { WorkspaceChatArtifact } from "@/types/workspace-chat-artifacts"
+
+// Lazy-loaded: this pulls in React Flow and the full workflow builder, which
+// would otherwise be statically compiled into the workspace-chat route and
+// bloat its bundle/dev compile. Loaded on demand when a workflow artifact opens.
+const WorkflowArtifactView = dynamic(
+  () =>
+    import("@/components/workspace-chat/artifacts/workflow-artifact-view").then(
+      (mod) => mod.WorkflowArtifactView
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-full flex-col gap-3 p-4">
+        <Skeleton className="h-5 w-1/2" />
+        <Skeleton className="min-h-0 w-full flex-1" />
+      </div>
+    ),
+  }
+)
 
 const CASE_ARTIFACT_TABS = new Set([
   "comments",
@@ -78,6 +98,13 @@ export function ArtifactContent({
     case "table":
       return (
         <EmbeddedTableArtifact artifact={artifact} workspaceId={workspaceId} />
+      )
+    case "workflow":
+      return (
+        <WorkflowArtifactView
+          workflowId={artifact.id}
+          workspaceId={workspaceId}
+        />
       )
     case "agent":
       return (
@@ -245,16 +272,6 @@ function ArtifactSummary({
 
 function ArtifactFields({ artifact }: { artifact: WorkspaceChatArtifact }) {
   switch (artifact.type) {
-    case "workflow":
-      return (
-        <dl className="grid grid-cols-[6rem_1fr] gap-x-3 gap-y-2">
-          <ArtifactField
-            label="Published"
-            value={artifact.isPublished ? "yes" : "no"}
-          />
-          <ArtifactField label="Workflow ID" value={artifact.id} monospace />
-        </dl>
-      )
     case "run":
       return (
         <dl className="grid grid-cols-[6rem_1fr] gap-x-3 gap-y-2">

--- a/frontend/src/components/workspace-chat/artifacts/artifact-registry.tsx
+++ b/frontend/src/components/workspace-chat/artifacts/artifact-registry.tsx
@@ -61,6 +61,12 @@ export const ARTIFACT_REGISTRY = {
     icon: WorkflowIcon,
     href: (artifact, workspaceId) =>
       `/workspaces/${workspaceId}/workflows/${artifact.id}`,
+    invalidateQueries: (queryClient, _workspaceId, artifact) => {
+      // Workflow lists carry a 5-min stale time; refresh them so a chat-created
+      // workflow shows up in dashboards and workflow/subflow pickers immediately.
+      queryClient.invalidateQueries({ queryKey: ["workflows"] })
+      queryClient.invalidateQueries({ queryKey: ["workflow", artifact.id] })
+    },
   },
   run: {
     label: "Runs",

--- a/frontend/src/components/workspace-chat/artifacts/workflow-artifact-view.tsx
+++ b/frontend/src/components/workspace-chat/artifacts/workflow-artifact-view.tsx
@@ -1,17 +1,31 @@
 "use client"
 
 import { ReactFlowProvider } from "@xyflow/react"
-import { WorkflowIcon } from "lucide-react"
+import {
+  CalendarSearchIcon,
+  FileInputIcon,
+  MessagesSquare,
+  ShapesIcon,
+  WorkflowIcon,
+} from "lucide-react"
+import { type MutableRefObject, useEffect, useState } from "react"
 import { $TriggerType, type TriggerType } from "@/client"
 import { WorkflowCanvas } from "@/components/builder/canvas/canvas"
+import { ActionEventPane } from "@/components/builder/events/events-selected-action"
+import type {
+  EventsSidebarRef,
+  EventsSidebarTabs,
+} from "@/components/builder/events/events-sidebar"
 import { EventsSidebarEmpty } from "@/components/builder/events/events-sidebar-empty"
 import { WorkflowInteractions } from "@/components/builder/events/events-sidebar-interactions"
 import {
   WorkflowEvents,
   WorkflowEventsHeader,
 } from "@/components/builder/events/events-workflow"
+import { BuilderPanel } from "@/components/builder/panel/builder-panel"
 import { WorkflowBuilderErrorBoundary } from "@/components/error-boundaries"
 import { Spinner } from "@/components/loading/spinner"
+import { WorkflowManualTrigger } from "@/components/nav/builder-nav"
 import { AlertNotification } from "@/components/notifications"
 import {
   Empty,
@@ -25,6 +39,9 @@ import {
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/components/ui/resizable"
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useLocalStorage } from "@/hooks/use-local-storage"
 import {
   useCompactWorkflowExecution,
@@ -59,25 +76,30 @@ export function WorkflowArtifactView({
       <WorkflowProvider workspaceId={workspaceId} workflowId={workflowId}>
         <ReactFlowProvider>
           <WorkflowBuilderProvider>
-            <ResizablePanelGroup direction="vertical" className="size-full">
-              <ResizablePanel
-                defaultSize={62}
-                minSize={30}
-                className="overflow-hidden"
-              >
-                <WorkflowArtifactCanvas />
-              </ResizablePanel>
+            <div className="flex size-full flex-col">
+              <WorkflowArtifactToolbar workflowId={workflowId} />
+              <div className="min-h-0 flex-1">
+                <ResizablePanelGroup direction="vertical" className="size-full">
+                  <ResizablePanel
+                    defaultSize={62}
+                    minSize={30}
+                    className="overflow-hidden"
+                  >
+                    <WorkflowArtifactCanvas />
+                  </ResizablePanel>
 
-              <ResizableHandle withHandle />
+                  <ResizableHandle withHandle />
 
-              <ResizablePanel
-                defaultSize={38}
-                minSize={20}
-                className="overflow-hidden"
-              >
-                <CompactWorkflowEvents />
-              </ResizablePanel>
-            </ResizablePanelGroup>
+                  <ResizablePanel
+                    defaultSize={38}
+                    minSize={20}
+                    className="overflow-hidden"
+                  >
+                    <WorkflowArtifactBottomPanel />
+                  </ResizablePanel>
+                </ResizablePanelGroup>
+              </div>
+            </div>
           </WorkflowBuilderProvider>
         </ReactFlowProvider>
       </WorkflowProvider>
@@ -85,9 +107,37 @@ export function WorkflowArtifactView({
   )
 }
 
+/** Top toolbar with the manual run trigger for the embedded workflow. */
+function WorkflowArtifactToolbar({ workflowId }: { workflowId: string }) {
+  const { setSelectedNodeId } = useWorkflowBuilder()
+  return (
+    <div className="flex h-10 shrink-0 items-center justify-end gap-2 border-b px-3">
+      <WorkflowManualTrigger
+        disabled={false}
+        workflowId={workflowId}
+        // Reveal the events panel once a run starts by clearing the selection.
+        onAfterTrigger={() => setSelectedNodeId(null)}
+      />
+    </div>
+  )
+}
+
 function WorkflowArtifactCanvas() {
   const { canvasRef } = useWorkflowBuilder()
   return <WorkflowCanvas ref={canvasRef} embedded />
+}
+
+/**
+ * Bottom panel: action inputs for the selected node, or the latest-run events
+ * when nothing is selected. Mirrors the builder's action panel / events split
+ * in the limited vertical space of the artifact.
+ */
+function WorkflowArtifactBottomPanel() {
+  const { selectedNodeId } = useWorkflowBuilder()
+  if (selectedNodeId) {
+    return <BuilderPanel />
+  }
+  return <CompactWorkflowEvents />
 }
 
 /** Latest-run event timeline for the embedded workflow, without sidebar chrome. */
@@ -144,8 +194,34 @@ function CompactWorkflowEvents() {
 
 function CompactWorkflowEventsList({ executionId }: { executionId: string }) {
   const { appSettings } = useOrgAppSettings()
+  const { sidebarRef } = useWorkflowBuilder()
   const { execution, executionIsLoading, executionError } =
     useCompactWorkflowExecution(executionId)
+  const [activeTab, setActiveTab] =
+    useState<EventsSidebarTabs>("workflow-events")
+
+  // The shared events sidebar isn't mounted in the embedded artifact, so wire a
+  // lightweight shim onto sidebarRef. This lets the events list's row actions
+  // ("View last input/result") drive the compact tabs below.
+  useEffect(() => {
+    const ref = sidebarRef as MutableRefObject<EventsSidebarRef | null>
+    ref.current = {
+      setActiveTab,
+      getActiveTab: () => activeTab,
+      setOpen: () => {},
+      isOpen: () => true,
+      collapse: () => {},
+      expand: () => {},
+      getId: () => "embedded-events",
+      getSize: () => 0,
+      isCollapsed: () => false,
+      isExpanded: () => true,
+      resize: () => {},
+    }
+    return () => {
+      ref.current = null
+    }
+  }, [sidebarRef, activeTab])
 
   if (executionIsLoading) {
     return <EventsLoading message="Fetching events..." />
@@ -167,14 +243,79 @@ function CompactWorkflowEventsList({ executionId }: { executionId: string }) {
     )
   }
 
+  const tabItems = [
+    {
+      value: "workflow-events" as EventsSidebarTabs,
+      label: "Events",
+      icon: CalendarSearchIcon,
+      content: (
+        <>
+          <WorkflowEventsHeader execution={execution} embedded />
+          {appSettings?.app_interactions_enabled && (
+            <WorkflowInteractions execution={execution} />
+          )}
+          <WorkflowEvents events={execution.events} status={execution.status} />
+        </>
+      ),
+    },
+    {
+      value: "action-input" as EventsSidebarTabs,
+      label: "Input",
+      icon: FileInputIcon,
+      content: <ActionEventPane execution={execution} type="input" />,
+    },
+    {
+      value: "action-result" as EventsSidebarTabs,
+      label: "Result",
+      icon: ShapesIcon,
+      content: <ActionEventPane execution={execution} type="result" />,
+    },
+  ]
+  if (appSettings?.app_interactions_enabled) {
+    tabItems.push({
+      value: "action-interaction",
+      label: "Interaction",
+      icon: MessagesSquare,
+      content: <ActionEventPane execution={execution} type="interaction" />,
+    })
+  }
+
   return (
-    <div className="size-full overflow-y-auto">
-      <WorkflowEventsHeader execution={execution} />
-      {appSettings?.app_interactions_enabled && (
-        <WorkflowInteractions execution={execution} />
-      )}
-      <WorkflowEvents events={execution.events} status={execution.status} />
-    </div>
+    <Tabs
+      value={activeTab}
+      onValueChange={(value) => setActiveTab(value as EventsSidebarTabs)}
+      className="flex size-full flex-col"
+    >
+      <div className="sticky top-0 z-10 mt-0.5 bg-background">
+        <ScrollArea className="w-full whitespace-nowrap rounded-md">
+          <TabsList className="inline-flex h-8 items-center justify-start bg-transparent p-0">
+            {tabItems.map((tab) => (
+              <TabsTrigger
+                key={tab.value}
+                value={tab.value}
+                className="flex h-full min-w-16 items-center justify-center rounded-none py-0 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+              >
+                <tab.icon className="mr-1.5 size-4" />
+                <span>{tab.label}</span>
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          <ScrollBar orientation="horizontal" className="invisible" />
+        </ScrollArea>
+      </div>
+      <Separator />
+      <div className="size-full overflow-auto">
+        {tabItems.map((tab) => (
+          <TabsContent
+            key={tab.value}
+            value={tab.value}
+            className="m-0 size-full p-0"
+          >
+            {tab.content}
+          </TabsContent>
+        ))}
+      </div>
+    </Tabs>
   )
 }
 

--- a/frontend/src/components/workspace-chat/artifacts/workflow-artifact-view.tsx
+++ b/frontend/src/components/workspace-chat/artifacts/workflow-artifact-view.tsx
@@ -1,39 +1,20 @@
 "use client"
 
 import { ReactFlowProvider } from "@xyflow/react"
-import {
-  CalendarSearchIcon,
-  FileInputIcon,
-  MessagesSquare,
-  ShapesIcon,
-  WorkflowIcon,
-} from "lucide-react"
 import { type MutableRefObject, useEffect, useState } from "react"
-import { $TriggerType, type TriggerType } from "@/client"
 import { WorkflowCanvas } from "@/components/builder/canvas/canvas"
-import { ActionEventPane } from "@/components/builder/events/events-selected-action"
-import type {
-  EventsSidebarRef,
-  EventsSidebarTabs,
-} from "@/components/builder/events/events-sidebar"
-import { EventsSidebarEmpty } from "@/components/builder/events/events-sidebar-empty"
-import { WorkflowInteractions } from "@/components/builder/events/events-sidebar-interactions"
 import {
-  WorkflowEvents,
-  WorkflowEventsHeader,
-} from "@/components/builder/events/events-workflow"
+  buildEventsTabItems,
+  EventsLoading,
+  type EventsSidebarTabs,
+  useResolvedLastExecution,
+} from "@/components/builder/events/events-shared"
+import type { EventsSidebarRef } from "@/components/builder/events/events-sidebar"
+import { EventsSidebarEmpty } from "@/components/builder/events/events-sidebar-empty"
 import { BuilderPanel } from "@/components/builder/panel/builder-panel"
 import { WorkflowBuilderErrorBoundary } from "@/components/error-boundaries"
-import { Spinner } from "@/components/loading/spinner"
 import { WorkflowManualTrigger } from "@/components/nav/builder-nav"
 import { AlertNotification } from "@/components/notifications"
-import {
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@/components/ui/empty"
 import {
   ResizableHandle,
   ResizablePanel,
@@ -42,19 +23,12 @@ import {
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { useLocalStorage } from "@/hooks/use-local-storage"
-import {
-  useCompactWorkflowExecution,
-  useLastExecution,
-  useOrgAppSettings,
-} from "@/lib/hooks"
+import { useCompactWorkflowExecution, useOrgAppSettings } from "@/lib/hooks"
 import {
   useWorkflowBuilder,
   WorkflowBuilderProvider,
 } from "@/providers/builder"
-import { useWorkflow, WorkflowProvider } from "@/providers/workflow"
-
-const AVAILABLE_TRIGGER_TYPES: readonly TriggerType[] = $TriggerType.enum
+import { WorkflowProvider } from "@/providers/workflow"
 
 /**
  * Embedded workflow artifact: the workflow DAG on top and a compact events
@@ -142,54 +116,11 @@ function WorkflowArtifactBottomPanel() {
 
 /** Latest-run event timeline for the embedded workflow, without sidebar chrome. */
 function CompactWorkflowEvents() {
-  const { workflowId } = useWorkflow()
-  const { currentExecutionId } = useWorkflowBuilder()
-  const [selectedTriggerTypes] = useLocalStorage<TriggerType[]>(
-    "selected-trigger-types",
-    [...AVAILABLE_TRIGGER_TYPES]
-  )
-
-  const { lastExecution, lastExecutionIsLoading, lastExecutionError } =
-    useLastExecution({
-      workflowId: currentExecutionId ? undefined : workflowId,
-      triggerTypes: selectedTriggerTypes,
-    })
-
-  // Prefer a direct execution id (e.g. a run just triggered) over the query.
-  const executionId = currentExecutionId || lastExecution?.id
-
-  if (!currentExecutionId && lastExecutionIsLoading) {
-    return <EventsLoading message="Fetching last execution..." />
+  const resolved = useResolvedLastExecution()
+  if (resolved.status === "pending") {
+    return resolved.node
   }
-
-  if (!currentExecutionId && lastExecutionError) {
-    return (
-      <AlertNotification
-        level="error"
-        message={`Error loading last execution: ${lastExecutionError.message}`}
-      />
-    )
-  }
-
-  if (!executionId) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <Empty className="border-none">
-          <EmptyHeader>
-            <EmptyMedia variant="icon">
-              <WorkflowIcon />
-            </EmptyMedia>
-            <EmptyTitle>No workflow runs</EmptyTitle>
-            <EmptyDescription>
-              Get started by running your workflow
-            </EmptyDescription>
-          </EmptyHeader>
-        </Empty>
-      </div>
-    )
-  }
-
-  return <CompactWorkflowEventsList executionId={executionId} />
+  return <CompactWorkflowEventsList executionId={resolved.executionId} />
 }
 
 function CompactWorkflowEventsList({ executionId }: { executionId: string }) {
@@ -243,42 +174,11 @@ function CompactWorkflowEventsList({ executionId }: { executionId: string }) {
     )
   }
 
-  const tabItems = [
-    {
-      value: "workflow-events" as EventsSidebarTabs,
-      label: "Events",
-      icon: CalendarSearchIcon,
-      content: (
-        <>
-          <WorkflowEventsHeader execution={execution} embedded />
-          {appSettings?.app_interactions_enabled && (
-            <WorkflowInteractions execution={execution} />
-          )}
-          <WorkflowEvents events={execution.events} status={execution.status} />
-        </>
-      ),
-    },
-    {
-      value: "action-input" as EventsSidebarTabs,
-      label: "Input",
-      icon: FileInputIcon,
-      content: <ActionEventPane execution={execution} type="input" />,
-    },
-    {
-      value: "action-result" as EventsSidebarTabs,
-      label: "Result",
-      icon: ShapesIcon,
-      content: <ActionEventPane execution={execution} type="result" />,
-    },
-  ]
-  if (appSettings?.app_interactions_enabled) {
-    tabItems.push({
-      value: "action-interaction",
-      label: "Interaction",
-      icon: MessagesSquare,
-      content: <ActionEventPane execution={execution} type="interaction" />,
-    })
-  }
+  const tabItems = buildEventsTabItems({
+    execution,
+    interactionsEnabled: !!appSettings?.app_interactions_enabled,
+    embedded: true,
+  })
 
   return (
     <Tabs
@@ -316,14 +216,5 @@ function CompactWorkflowEventsList({ executionId }: { executionId: string }) {
         ))}
       </div>
     </Tabs>
-  )
-}
-
-function EventsLoading({ message }: { message: string }) {
-  return (
-    <div className="flex h-full flex-col items-center justify-center space-y-2">
-      <span className="text-xs text-muted-foreground">{message}</span>
-      <Spinner className="size-6" />
-    </div>
   )
 }

--- a/frontend/src/components/workspace-chat/artifacts/workflow-artifact-view.tsx
+++ b/frontend/src/components/workspace-chat/artifacts/workflow-artifact-view.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+import { ReactFlowProvider } from "@xyflow/react"
+import { WorkflowIcon } from "lucide-react"
+import { $TriggerType, type TriggerType } from "@/client"
+import { WorkflowCanvas } from "@/components/builder/canvas/canvas"
+import { EventsSidebarEmpty } from "@/components/builder/events/events-sidebar-empty"
+import { WorkflowInteractions } from "@/components/builder/events/events-sidebar-interactions"
+import {
+  WorkflowEvents,
+  WorkflowEventsHeader,
+} from "@/components/builder/events/events-workflow"
+import { WorkflowBuilderErrorBoundary } from "@/components/error-boundaries"
+import { Spinner } from "@/components/loading/spinner"
+import { AlertNotification } from "@/components/notifications"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable"
+import { useLocalStorage } from "@/hooks/use-local-storage"
+import {
+  useCompactWorkflowExecution,
+  useLastExecution,
+  useOrgAppSettings,
+} from "@/lib/hooks"
+import {
+  useWorkflowBuilder,
+  WorkflowBuilderProvider,
+} from "@/providers/builder"
+import { useWorkflow, WorkflowProvider } from "@/providers/workflow"
+
+const AVAILABLE_TRIGGER_TYPES: readonly TriggerType[] = $TriggerType.enum
+
+/**
+ * Embedded workflow artifact: the workflow DAG on top and a compact events
+ * viewer for its latest run on the bottom, split like the agent builder.
+ *
+ * Mounts its own workflow + builder providers keyed to `workflowId` so the
+ * canvas and events stay isolated from the surrounding chat surface.
+ */
+export function WorkflowArtifactView({
+  workflowId,
+  workspaceId,
+}: {
+  workflowId: string
+  workspaceId: string
+}) {
+  return (
+    // Remount per workflow so builder/canvas state never bleeds across artifacts.
+    <WorkflowBuilderErrorBoundary key={workflowId}>
+      <WorkflowProvider workspaceId={workspaceId} workflowId={workflowId}>
+        <ReactFlowProvider>
+          <WorkflowBuilderProvider>
+            <ResizablePanelGroup direction="vertical" className="size-full">
+              <ResizablePanel
+                defaultSize={62}
+                minSize={30}
+                className="overflow-hidden"
+              >
+                <WorkflowArtifactCanvas />
+              </ResizablePanel>
+
+              <ResizableHandle withHandle />
+
+              <ResizablePanel
+                defaultSize={38}
+                minSize={20}
+                className="overflow-hidden"
+              >
+                <CompactWorkflowEvents />
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          </WorkflowBuilderProvider>
+        </ReactFlowProvider>
+      </WorkflowProvider>
+    </WorkflowBuilderErrorBoundary>
+  )
+}
+
+function WorkflowArtifactCanvas() {
+  const { canvasRef } = useWorkflowBuilder()
+  return <WorkflowCanvas ref={canvasRef} embedded />
+}
+
+/** Latest-run event timeline for the embedded workflow, without sidebar chrome. */
+function CompactWorkflowEvents() {
+  const { workflowId } = useWorkflow()
+  const { currentExecutionId } = useWorkflowBuilder()
+  const [selectedTriggerTypes] = useLocalStorage<TriggerType[]>(
+    "selected-trigger-types",
+    [...AVAILABLE_TRIGGER_TYPES]
+  )
+
+  const { lastExecution, lastExecutionIsLoading, lastExecutionError } =
+    useLastExecution({
+      workflowId: currentExecutionId ? undefined : workflowId,
+      triggerTypes: selectedTriggerTypes,
+    })
+
+  // Prefer a direct execution id (e.g. a run just triggered) over the query.
+  const executionId = currentExecutionId || lastExecution?.id
+
+  if (!currentExecutionId && lastExecutionIsLoading) {
+    return <EventsLoading message="Fetching last execution..." />
+  }
+
+  if (!currentExecutionId && lastExecutionError) {
+    return (
+      <AlertNotification
+        level="error"
+        message={`Error loading last execution: ${lastExecutionError.message}`}
+      />
+    )
+  }
+
+  if (!executionId) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Empty className="border-none">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <WorkflowIcon />
+            </EmptyMedia>
+            <EmptyTitle>No workflow runs</EmptyTitle>
+            <EmptyDescription>
+              Get started by running your workflow
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      </div>
+    )
+  }
+
+  return <CompactWorkflowEventsList executionId={executionId} />
+}
+
+function CompactWorkflowEventsList({ executionId }: { executionId: string }) {
+  const { appSettings } = useOrgAppSettings()
+  const { execution, executionIsLoading, executionError } =
+    useCompactWorkflowExecution(executionId)
+
+  if (executionIsLoading) {
+    return <EventsLoading message="Fetching events..." />
+  }
+  if (executionError) {
+    return (
+      <AlertNotification
+        level="error"
+        message={`Error loading execution: ${executionError.message}`}
+      />
+    )
+  }
+  if (!execution) {
+    return (
+      <EventsSidebarEmpty
+        title="Could not find execution"
+        description="Please refresh the page and try again"
+      />
+    )
+  }
+
+  return (
+    <div className="size-full overflow-y-auto">
+      <WorkflowEventsHeader execution={execution} />
+      {appSettings?.app_interactions_enabled && (
+        <WorkflowInteractions execution={execution} />
+      )}
+      <WorkflowEvents events={execution.events} status={execution.status} />
+    </div>
+  )
+}
+
+function EventsLoading({ message }: { message: string }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center space-y-2">
+      <span className="text-xs text-muted-foreground">{message}</span>
+      <Spinner className="size-6" />
+    </div>
+  )
+}

--- a/packages/tracecat-registry/tracecat_registry/core/workflow.py
+++ b/packages/tracecat-registry/tracecat_registry/core/workflow.py
@@ -132,6 +132,37 @@ async def execute(
 
 @registry.register(
     namespace="core.workflow",
+    description=(
+        "Create a new empty workflow in the current workspace and return its id "
+        "and title. Use this when the user asks to create, scaffold, or start a new "
+        "workflow. The workflow starts empty (only a trigger) and can be edited in "
+        "the workflow builder afterwards."
+    ),
+    default_title="Create workflow",
+    display_group="Workflows",
+)
+async def create_workflow(
+    *,
+    title: Annotated[
+        str | None,
+        Doc(
+            "Title for the new workflow (3-100 characters). If omitted, a "
+            "timestamped title is used."
+        ),
+    ] = None,
+    description: Annotated[
+        str | None,
+        Doc("Optional description for the new workflow (up to 1000 characters)."),
+    ] = None,
+) -> dict[str, Any]:
+    """Create a new empty workflow and return ``{"id", "title"}``."""
+    return await get_context().workflows.create_workflow(
+        title=title, description=description
+    )
+
+
+@registry.register(
+    namespace="core.workflow",
     description="Get the status of a workflow execution.",
     default_title="Get workflow status",
     display_group="Workflows",

--- a/packages/tracecat-registry/tracecat_registry/sdk/workflows.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/workflows.py
@@ -51,6 +51,35 @@ class WorkflowsClient:
     def __init__(self, client: TracecatClient) -> None:
         self._client = client
 
+    async def create_workflow(
+        self,
+        *,
+        title: str | None = None,
+        description: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a new empty workflow in the current workspace.
+
+        Args:
+            title: Workflow title (3-100 characters). If omitted, the API assigns
+                a timestamped title.
+            description: Optional workflow description.
+
+        Returns:
+            dict containing:
+                - id: Workflow ID in short ``wf_...`` format.
+                - title: The workflow title.
+
+        Raises:
+            TracecatValidationError: If the title is invalid.
+            TracecatAPIError: For other API errors.
+        """
+        data: dict[str, Any] = {}
+        if title is not None:
+            data["title"] = title
+        if description is not None:
+            data["description"] = description
+        return await self._client.post("/workflows", json=data)
+
     async def execute(
         self,
         *,

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -250,6 +250,7 @@ def test_artifact_bindings_list_canonical_tool_names() -> None:
         "ai.agent.update_preset": "upsert",
         "core.workflow.execute": "upsert",
         "core.workflow.get_status": "upsert",
+        "core.workflow.create_workflow": "upsert",
     }
 
 

--- a/tests/unit/test_chat_tools.py
+++ b/tests/unit/test_chat_tools.py
@@ -32,6 +32,7 @@ def test_workspace_chat_default_tools_include_authoring_actions() -> None:
         "core.cases.list_cases",
         "core.cases.get_case",
         "core.cases.search_cases",
+        "core.workflow.create_workflow",
     ]
 
 

--- a/tracecat/artifacts/bindings.py
+++ b/tracecat/artifacts/bindings.py
@@ -56,6 +56,16 @@ class AgentArtifactPayload(TypedDict):
     title: str
 
 
+class WorkflowArtifactPayload(TypedDict):
+    """Raw payload used to validate a workflow artifact."""
+
+    type: Literal["workflow"]
+    id: str
+    title: str
+    color: str
+    isPublished: NotRequired[bool]
+
+
 class RunArtifactPayload(TypedDict):
     """Raw payload used to validate a workflow run artifact."""
 
@@ -119,6 +129,18 @@ class _AgentPresetToolResult(_ArtifactProjectionModel):
     title: str | None = Field(
         default=None,
         validation_alias=AliasChoices("name", "title"),
+    )
+
+
+class _WorkflowToolResult(_ArtifactProjectionModel):
+    id: str = Field(
+        validation_alias=AliasChoices("id", "workflow_id", "workflowId", "wf_id")
+    )
+    title: str | None = Field(
+        default=None, validation_alias=AliasChoices("title", "name")
+    )
+    is_published: bool | None = Field(
+        default=None, validation_alias=AliasChoices("is_published", "isPublished")
     )
 
 
@@ -249,6 +271,10 @@ def _build_workflow_run_artifact(ctx: ArtifactProjectionContext) -> Artifact | N
     return _run_artifact_from_output(ctx.tool_output, ctx.tool_input, ctx.tool_call_id)
 
 
+def _build_workflow_artifact(ctx: ArtifactProjectionContext) -> Artifact | None:
+    return _workflow_artifact_from_output(ctx.tool_output, ctx.tool_call_id)
+
+
 ARTIFACT_BINDINGS: tuple[ArtifactBinding, ...] = (
     ArtifactBinding(
         tool_names=(
@@ -321,6 +347,11 @@ ARTIFACT_BINDINGS: tuple[ArtifactBinding, ...] = (
         tool_names=("core.workflow.execute", "core.workflow.get_status"),
         op="upsert",
         build=_build_workflow_run_artifact,
+    ),
+    ArtifactBinding(
+        tool_names=("core.workflow.create_workflow",),
+        op="upsert",
+        build=_build_workflow_artifact,
     ),
 )
 
@@ -628,6 +659,34 @@ def _agent_artifacts_from_output(
             yield ArtifactAdapter.validate_python(
                 _with_parent_scope(payload, tool_call_id)
             )
+
+
+# Default swatch color for workflow artifacts created via the chat copilot.
+# Workflows have no inherent color; the UI uses this for the artifact tab swatch.
+_DEFAULT_WORKFLOW_ARTIFACT_COLOR = "#6E56CF"
+
+
+def _workflow_artifact_from_output(
+    value: Any, tool_call_id: str | None
+) -> Artifact | None:
+    data = _mapping_from_tool_output(value)
+    if data is None:
+        return None
+
+    result = _WorkflowToolResult.try_validate(data)
+    if result is None:
+        return None
+
+    payload: WorkflowArtifactPayload = {
+        "type": "workflow",
+        "id": result.id,
+        "title": result.title or result.id,
+        "color": _DEFAULT_WORKFLOW_ARTIFACT_COLOR,
+    }
+    if result.is_published is not None:
+        payload["isPublished"] = result.is_published
+
+    return ArtifactAdapter.validate_python(_with_parent_scope(payload, tool_call_id))
 
 
 def _run_artifact_from_output(

--- a/tracecat/chat/tools.py
+++ b/tracecat/chat/tools.py
@@ -32,6 +32,7 @@ WORKSPACE_CHAT_BASE_DEFAULT_TOOLS = [
     "core.cases.list_cases",
     "core.cases.get_case",
     "core.cases.search_cases",
+    "core.workflow.create_workflow",
 ]
 
 WORKSPACE_CHAT_DEFAULT_TOOLS = [

--- a/tracecat/workflow/executions/internal_router.py
+++ b/tracecat/workflow/executions/internal_router.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 from starlette.status import (
     HTTP_200_OK,
     HTTP_201_CREATED,
@@ -29,6 +29,7 @@ from tracecat.workflow.executions.enums import TriggerType
 from tracecat.workflow.executions.service import WorkflowExecutionsService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.management import WorkflowsManagementService
+from tracecat.workflow.management.schemas import WorkflowCreate
 
 router = APIRouter(
     prefix="/internal/workflows",
@@ -101,6 +102,54 @@ class InternalWorkflowStatusResponse(BaseModel):
     )
     error: str | None = Field(
         default=None, description="Error message (if workflow failed)"
+    )
+
+
+class InternalWorkflowCreateRequest(BaseModel):
+    """Request to create a new workflow."""
+
+    title: str | None = Field(
+        default=None, description="Workflow title (3-100 characters)"
+    )
+    description: str | None = Field(
+        default=None, description="Optional workflow description"
+    )
+
+
+class InternalWorkflowCreateResponse(BaseModel):
+    """Response from workflow creation."""
+
+    id: WorkflowID = Field(..., description="Workflow ID (short wf_... format)")
+    title: str = Field(..., description="Workflow title")
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def validate_id(cls, v: AnyWorkflowID) -> WorkflowID:
+        """Convert any valid workflow ID format to WorkflowUUID."""
+        return WorkflowUUID.new(v)
+
+
+@router.post("", status_code=HTTP_201_CREATED)
+@require_scope("workflow:create")
+async def create_workflow(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    params: InternalWorkflowCreateRequest,
+) -> InternalWorkflowCreateResponse:
+    """Create a new empty workflow in the current workspace."""
+    service = WorkflowsManagementService(session, role)
+    try:
+        workflow = await service.create_workflow(
+            WorkflowCreate(title=params.title, description=params.description)
+        )
+    except (ValueError, ValidationError) as e:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    return InternalWorkflowCreateResponse(
+        id=WorkflowUUID.new(workflow.id), title=workflow.title
     )
 
 


### PR DESCRIPTION
## Summary
- add a Workspace Chat workflow creation tool backed by the internal workflow create API
- project created workflows into chat artifacts so the artifact drawer can open them
- render workflow artifacts with an embedded workflow canvas and compact latest-run events view

## Verification
- `uv run ruff check packages/tracecat-registry/tracecat_registry/core/workflow.py packages/tracecat-registry/tracecat_registry/sdk/workflows.py tracecat/artifacts/bindings.py tracecat/chat/tools.py tracecat/workflow/executions/internal_router.py`
- `uv run basedpyright packages/tracecat-registry/tracecat_registry/core/workflow.py packages/tracecat-registry/tracecat_registry/sdk/workflows.py tracecat/artifacts/bindings.py tracecat/chat/tools.py tracecat/workflow/executions/internal_router.py`
- `pnpm -C frontend exec biome check src/components/builder/canvas/canvas.tsx src/components/workspace-chat/artifacts/artifact-content.tsx src/components/workspace-chat/artifacts/workflow-artifact-view.tsx`
- `pnpm -C frontend run typecheck`
- pre-commit hooks during commit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create and preview workflows directly from chat with a new `workflow` artifact that embeds the canvas, run controls, and a compact run viewer. Adds the `core.workflow.create_workflow` tool and API, and keeps workflow lists in sync when chat creates a new workflow.

- **New Features**
  - Added `core.workflow.create_workflow` tool (enabled in chat defaults); binds results to `workflow` artifacts with id/title and a default swatch color.
  - Introduced `WorkflowArtifactView`: lazy-loaded artifact with embedded `WorkflowCanvas`, a hover-expand actions pill, Manual Run, and a compact Events/Input/Result (+Interaction) viewer with a single-row run header; auto-focuses events on run and shares viewer logic with the builder for consistency.
  - Added `embedded` mode to `WorkflowCanvas` with fit tuned for small graphs and a collapsible toolbar that shrinks to a pill and expands on hover.
  - Exposed `POST /internal/workflows` (`workflow:create` scope; returns id/title) and SDK `WorkflowsClient.create_workflow(...)`.

- **Bug Fixes**
  - Refresh workflow lists and detail queries when a `workflow` artifact streams in so chat-created workflows appear immediately in dashboards and pickers.

<sup>Written for commit 38c0493e22b66eecdbbeb702a1c6d228a0c6b454. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

