### PR TITLE
fix(executor): collect for_each loop errors

### DIFF
--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -907,6 +907,65 @@ async def test_dispatch_action_for_each_uses_configured_worker_limit(
     assert max_active_iterations == 2
 
 
+@pytest.mark.anyio
+async def test_dispatch_action_for_each_finishes_after_iteration_error(
+    monkeypatch,
+    test_role,
+    mock_run_context,
+):
+    monkeypatch.setattr(config, "TRACECAT__EXECUTOR_FOR_EACH_MAX_CONCURRENCY", 1)
+
+    seen: list[int] = []
+
+    async def fake_invoke_once(
+        backend: TestBackend,
+        input: RunActionInput,
+        ctx: Any,
+        iteration: int | None = None,
+    ) -> int:
+        assert iteration is not None
+        local_vars = input.exec_context.get("var")
+        assert local_vars is not None
+        value = local_vars["x"]
+        seen.append(value)
+        if value == 2:
+            raise ExecutionError(
+                info=ExecutorActionErrorInfo(
+                    action_name=input.task.action,
+                    type="ValueError",
+                    message="bad loop item",
+                    filename=__file__,
+                    function="fake_invoke_once",
+                    loop_iteration=iteration,
+                    loop_vars=local_vars,
+                )
+            )
+        return value
+
+    monkeypatch.setattr(executor_service, "invoke_once", fake_invoke_once)
+
+    input = RunActionInput(
+        task=ActionStatement(
+            ref="test",
+            action="testing.add_100",
+            run_if=None,
+            args={"num": "${{ var.x }}"},
+            for_each="${{ for var.x in [1,2,3] }}",
+        ),
+        exec_context=create_default_execution_context(),
+        run_context=mock_run_context,
+        registry_lock=make_registry_lock("testing.add_100"),
+    )
+
+    with pytest.raises(LoopExecutionError) as e:
+        await dispatch_action(TestBackend(), input)
+
+    assert seen == [1, 2, 3]
+    assert len(e.value.loop_errors) == 1
+    assert e.value.loop_errors[0].info.loop_iteration == 1
+    assert e.value.loop_errors[0].info.loop_vars == {"x": 2}
+
+
 @pytest.fixture
 def sample_execution_error() -> ExecutionError:
     """Create a sample ExecutionError for testing."""

--- a/tracecat/executor/service.py
+++ b/tracecat/executor/service.py
@@ -888,6 +888,7 @@ async def dispatch_action(backend: ExecutorBackend, input: RunActionInput) -> An
     # because activities can run on different event loops.
     loop_items = iter(enumerate(zip(*iterators, strict=False)))
     results: dict[int, ExecutionResult] = {}
+    loop_errors: dict[int, ExecutionError] = {}
     iteration_count = 0
 
     async def worker() -> None:
@@ -910,16 +911,18 @@ async def dispatch_action(backend: ExecutorBackend, input: RunActionInput) -> An
                 )
             # Create a new task with the patched context
             new_input = input.model_copy(update={"exec_context": new_context})
-            results[i] = await invoke_once(backend, new_input, ctx, iteration=i)
+            try:
+                results[i] = await invoke_once(backend, new_input, ctx, iteration=i)
+            except ExecutionError as e:
+                loop_errors[i] = e
 
     try:
         async with asyncio.TaskGroup() as tg:
             for _ in range(max_concurrency):
                 tg.create_task(worker())
-        return [results[i] for i in range(iteration_count)]
     except* ExecutionError as eg:
-        loop_errors = flatten_wrapped_exc_error_group(eg)
-        raise LoopExecutionError(loop_errors) from eg
+        grouped_loop_errors = flatten_wrapped_exc_error_group(eg)
+        raise LoopExecutionError(grouped_loop_errors) from eg
     except* Exception as eg:
         errors = [str(x) for x in eg.exceptions]
         logger.error("Unexpected error(s) in loop", errors=errors, exc_group=eg)
@@ -932,6 +935,9 @@ async def dispatch_action(backend: ExecutorBackend, input: RunActionInput) -> An
             ),
             detail={"errors": errors},
         ) from eg
+    if loop_errors:
+        raise LoopExecutionError([loop_errors[i] for i in sorted(loop_errors)])
+    return [results[i] for i in range(iteration_count)]
 
 
 """Utilities"""


### PR DESCRIPTION
## Summary

- collect expected per-iteration `ExecutionError`s inside bounded for-each workers
- raise a sorted `LoopExecutionError` after the worker pool drains
- add regression coverage that later loop items still run after one iteration fails

## Testing

- `uv run pytest tests/unit/test_executor.py -ra`
- `uv run ruff check tracecat/executor/service.py tests/unit/test_executor.py`
- `uv run ruff format --check tracecat/executor/service.py tests/unit/test_executor.py`
- `uv run basedpyright tracecat/executor/service.py tests/unit/test_executor.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure for-each loops collect per-iteration errors without stopping the loop, then raise a single `LoopExecutionError` with sorted errors after all items run.

- **Bug Fixes**
  - Capture `ExecutionError` per iteration and continue processing remaining items.
  - After the worker pool finishes, raise a `LoopExecutionError` with errors sorted by iteration.
  - Add regression test to confirm later loop items still run and error metadata (iteration, loop vars) is preserved.

<sup>Written for commit 9d505318764ec573761a23f0a3575e7f62e6155e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

