### PR TITLE
perf(chat): smooth workspace chat streaming

### DIFF
--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -88,6 +88,7 @@ import {
   ToolOutput,
 } from "@/components/ai-elements/tool"
 import { ChatEmptyHero } from "@/components/chat/chat-empty-hero"
+import { SmoothResponse } from "@/components/chat/smooth-response"
 import { CodeEditor } from "@/components/editor/codemirror/code-editor"
 import { getIcon, ProviderIcon } from "@/components/icons"
 import { JsonViewWithControls } from "@/components/json-viewer"
@@ -1478,7 +1479,10 @@ export function MessagePart({
     return (
       <Message key={`${id}-${partIdx}`} from={role}>
         <MessageContent variant="flat">
-          <Response>{part.text}</Response>
+          <SmoothResponse
+            text={part.text}
+            animate={status === "streaming" && isLastMessage}
+          />
         </MessageContent>
       </Message>
     )

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -1121,7 +1121,10 @@ export function ChatSessionPane({
     <div className={cn("flex h-full min-h-0 flex-col", className)}>
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         <div className="flex min-h-0 flex-1 flex-col">
-          <Conversation className="flex-1">
+          <Conversation
+            className="flex-1"
+            resize={status === "streaming" ? "instant" : "smooth"}
+          >
             <ConversationContent className={chatContentCenterClass}>
               {lastError && (
                 <Alert variant="destructive" className="mb-4">

--- a/frontend/src/components/chat/smooth-response.test.tsx
+++ b/frontend/src/components/chat/smooth-response.test.tsx
@@ -1,0 +1,102 @@
+import { act, render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { SmoothResponse } from "@/components/chat/smooth-response"
+
+jest.mock("@/components/ai-elements/response", () => ({
+  Response: ({ children }: { children: ReactNode }) => (
+    <div data-testid="response">{children}</div>
+  ),
+}))
+
+describe("SmoothResponse", () => {
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame
+  const originalWindowCancelAnimationFrame = window.cancelAnimationFrame
+  const originalWindowRequestAnimationFrame = window.requestAnimationFrame
+  let frameCallbacks: Map<number, FrameRequestCallback>
+  let nextFrameId: number
+  let cancelAnimationFrameMock: jest.Mock<void, [number]>
+  let requestAnimationFrameMock: jest.Mock<number, [FrameRequestCallback]>
+
+  beforeEach(() => {
+    frameCallbacks = new Map()
+    nextFrameId = 1
+    jest.spyOn(performance, "now").mockReturnValue(0)
+    cancelAnimationFrameMock = jest.fn((frameId: number) => {
+      frameCallbacks.delete(frameId)
+    })
+    requestAnimationFrameMock = jest.fn((callback: FrameRequestCallback) => {
+      const frameId = nextFrameId
+      nextFrameId += 1
+      frameCallbacks.set(frameId, callback)
+      return frameId
+    })
+
+    Object.defineProperty(globalThis, "cancelAnimationFrame", {
+      configurable: true,
+      value: cancelAnimationFrameMock,
+    })
+    Object.defineProperty(globalThis, "requestAnimationFrame", {
+      configurable: true,
+      value: requestAnimationFrameMock,
+    })
+    Object.defineProperty(window, "cancelAnimationFrame", {
+      configurable: true,
+      value: cancelAnimationFrameMock,
+    })
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: requestAnimationFrameMock,
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    Object.defineProperty(globalThis, "cancelAnimationFrame", {
+      configurable: true,
+      value: originalCancelAnimationFrame,
+    })
+    Object.defineProperty(globalThis, "requestAnimationFrame", {
+      configurable: true,
+      value: originalRequestAnimationFrame,
+    })
+    Object.defineProperty(window, "cancelAnimationFrame", {
+      configurable: true,
+      value: originalWindowCancelAnimationFrame,
+    })
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: originalWindowRequestAnimationFrame,
+    })
+  })
+
+  function runFrame(frameId: number, now: number) {
+    const callback = frameCallbacks.get(frameId)
+    expect(callback).toBeDefined()
+    frameCallbacks.delete(frameId)
+    act(() => {
+      callback?.(now)
+    })
+  }
+
+  it("stops the reveal loop when caught up and restarts when text grows", () => {
+    const { rerender } = render(<SmoothResponse text="Hello" animate={true} />)
+
+    expect(screen.getByTestId("response")).toHaveTextContent("Hello")
+    expect(requestAnimationFrameMock).not.toHaveBeenCalled()
+
+    rerender(<SmoothResponse text="Hello world" animate={true} />)
+
+    expect(screen.getByTestId("response")).toHaveTextContent("Hello")
+    expect(requestAnimationFrameMock).toHaveBeenCalledTimes(1)
+
+    runFrame(1, 100)
+
+    expect(screen.getByTestId("response")).toHaveTextContent("Hello world")
+    expect(requestAnimationFrameMock).toHaveBeenCalledTimes(1)
+
+    rerender(<SmoothResponse text="Hello world!" animate={true} />)
+
+    expect(requestAnimationFrameMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/components/chat/smooth-response.tsx
+++ b/frontend/src/components/chat/smooth-response.tsx
@@ -21,11 +21,11 @@ interface SmoothResponseProps {
 /**
  * Renders streamed markdown with a frame-aligned reveal.
  *
- * The chat SDK flushes streamed text on a fixed timer (`experimental_throttle`),
- * so text grows in visible ~50ms chunks. While `animate` is true this component
- * advances a locally-held reveal length on each animation frame, so the same
- * deltas read as smooth 60fps growth. The reveal state is local, so per-frame
- * updates only re-render this component, not the surrounding message list.
+ * Streamed text can arrive in uneven network-sized chunks. While `animate` is
+ * true this component advances a locally-held reveal length on each animation
+ * frame, so bursty deltas read as smooth 60fps growth. The reveal state is
+ * local, so per-frame updates only re-render this component, not the
+ * surrounding message list.
  */
 export function SmoothResponse({ text, animate }: SmoothResponseProps) {
   const [shownLen, setShownLen] = useState(text.length)

--- a/frontend/src/components/chat/smooth-response.tsx
+++ b/frontend/src/components/chat/smooth-response.tsx
@@ -34,58 +34,112 @@ interface SmoothResponseProps {
  */
 export function SmoothResponse({ text, animate }: SmoothResponseProps) {
   const [shownLen, setShownLen] = useState(text.length)
+  const animateRef = useRef(animate)
+  animateRef.current = animate
   // Track the latest target length without restarting the RAF loop on every
   // text update.
   const targetLenRef = useRef(text.length)
   targetLenRef.current = text.length
+  const shownLenRef = useRef(shownLen)
+  shownLenRef.current = shownLen
+  const rafIdRef = useRef<number | null>(null)
+  const lastFrameAtRef = useRef(0)
+  const carryRef = useRef(0)
 
   useEffect(() => {
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    function stopRevealLoop() {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current)
+        rafIdRef.current = null
+      }
+      carryRef.current = 0
+    }
+
+    function syncShownLen(nextShownLen: number) {
+      if (shownLenRef.current === nextShownLen) {
+        return
+      }
+      shownLenRef.current = nextShownLen
+      setShownLen(nextShownLen)
+    }
+
     if (!animate) {
       // Snap to the full text when the stream settles.
-      setShownLen(targetLenRef.current)
+      stopRevealLoop()
+      syncShownLen(targetLenRef.current)
       return
     }
 
-    let lastFrameAt = performance.now()
-    let carry = 0
+    const targetLen = targetLenRef.current
+    if (shownLenRef.current > targetLen) {
+      carryRef.current = 0
+      syncShownLen(targetLen)
+      return
+    }
+    if (shownLenRef.current >= targetLen || rafIdRef.current !== null) {
+      carryRef.current = 0
+      return
+    }
 
-    let rafId = requestAnimationFrame(function tick(now) {
-      const elapsedSeconds = Math.min((now - lastFrameAt) / 1000, 0.1)
-      lastFrameAt = now
+    lastFrameAtRef.current = performance.now()
+    rafIdRef.current = requestAnimationFrame(function tick(now) {
+      rafIdRef.current = null
+      if (!animateRef.current) {
+        carryRef.current = 0
+        return
+      }
 
-      setShownLen((prev) => {
-        const target = targetLenRef.current
-        if (prev > target) {
-          carry = 0
-          return target
-        }
-        if (prev >= target) {
-          carry = 0
-          return prev
-        }
+      const elapsedSeconds = Math.min(
+        (now - lastFrameAtRef.current) / 1000,
+        0.1
+      )
+      lastFrameAtRef.current = now
 
+      const prev = shownLenRef.current
+      const target = targetLenRef.current
+      let next = prev
+
+      if (prev > target) {
+        carryRef.current = 0
+        next = target
+      } else if (prev < target) {
         const buffered = target - prev
         const charsPerSecond =
           buffered > CATCHUP_THRESHOLD_CHARS
             ? CATCHUP_CHARS_PER_SECOND
             : STEADY_CHARS_PER_SECOND
-        const exactStep = charsPerSecond * elapsedSeconds + carry
+        const exactStep = charsPerSecond * elapsedSeconds + carryRef.current
         const step = Math.min(
           Math.floor(exactStep),
           MAX_CHARS_PER_FRAME,
           buffered
         )
-        carry = exactStep - Math.floor(exactStep)
+        carryRef.current = exactStep - Math.floor(exactStep)
         if (step < 1) {
-          return prev
+          next = prev
+        } else {
+          next = Math.min(target, prev + step)
         }
-        return Math.min(target, prev + step)
-      })
-      rafId = requestAnimationFrame(tick)
-    })
+      } else {
+        carryRef.current = 0
+      }
 
-    return () => cancelAnimationFrame(rafId)
-  }, [animate])
+      syncShownLen(next)
+      if (next < targetLenRef.current) {
+        rafIdRef.current = requestAnimationFrame(tick)
+      } else {
+        carryRef.current = 0
+      }
+    })
+  }, [animate, text.length])
 
   const shown = animate ? text.slice(0, shownLen) : text
   return <Response>{shown}</Response>

--- a/frontend/src/components/chat/smooth-response.tsx
+++ b/frontend/src/components/chat/smooth-response.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { Response } from "@/components/ai-elements/response"
+
+/** Minimum characters revealed per animation frame while catching up. */
+const MIN_CHARS_PER_FRAME = 3
+/** Fraction of the outstanding gap revealed each frame (eases out bursts). */
+const CATCHUP_FRACTION = 0.25
+
+interface SmoothResponseProps {
+  text: string
+  /**
+   * When true, newly-arrived characters are revealed on
+   * `requestAnimationFrame` instead of appearing in the SDK's coarse throttle
+   * steps. When false the full text renders immediately.
+   */
+  animate: boolean
+}
+
+/**
+ * Renders streamed markdown with a frame-aligned reveal.
+ *
+ * The chat SDK flushes streamed text on a fixed timer (`experimental_throttle`),
+ * so text grows in visible ~50ms chunks. While `animate` is true this component
+ * advances a locally-held reveal length on each animation frame, so the same
+ * deltas read as smooth 60fps growth. The reveal state is local, so per-frame
+ * updates only re-render this component, not the surrounding message list.
+ */
+export function SmoothResponse({ text, animate }: SmoothResponseProps) {
+  const [shownLen, setShownLen] = useState(text.length)
+  // Track the latest target length without restarting the RAF loop on every
+  // text update.
+  const targetLenRef = useRef(text.length)
+  targetLenRef.current = text.length
+
+  useEffect(() => {
+    if (!animate) {
+      // Snap to the full text when the stream settles.
+      setShownLen(targetLenRef.current)
+      return
+    }
+
+    let rafId = requestAnimationFrame(function tick() {
+      setShownLen((prev) => {
+        const target = targetLenRef.current
+        if (prev >= target) {
+          // Caught up: identical state value, React skips the re-render.
+          return prev
+        }
+        const step = Math.max(
+          MIN_CHARS_PER_FRAME,
+          Math.ceil((target - prev) * CATCHUP_FRACTION)
+        )
+        return Math.min(target, prev + step)
+      })
+      rafId = requestAnimationFrame(tick)
+    })
+
+    return () => cancelAnimationFrame(rafId)
+  }, [animate])
+
+  const shown = animate ? text.slice(0, shownLen) : text
+  return <Response>{shown}</Response>
+}

--- a/frontend/src/components/chat/smooth-response.tsx
+++ b/frontend/src/components/chat/smooth-response.tsx
@@ -3,17 +3,21 @@
 import { useEffect, useRef, useState } from "react"
 import { Response } from "@/components/ai-elements/response"
 
-/** Minimum characters revealed per animation frame while catching up. */
-const MIN_CHARS_PER_FRAME = 3
-/** Fraction of the outstanding gap revealed each frame (eases out bursts). */
-const CATCHUP_FRACTION = 0.25
+/** Normal reveal speed. At 60fps this is roughly 3 characters per frame. */
+const STEADY_CHARS_PER_SECOND = 180
+/** Catch-up speed used only when the hidden buffer grows large. */
+const CATCHUP_CHARS_PER_SECOND = 420
+/** Start catching up once the UI is meaningfully behind the source stream. */
+const CATCHUP_THRESHOLD_CHARS = 140
+/** Prevent a single frame from dumping a large buffered chunk. */
+const MAX_CHARS_PER_FRAME = 12
 
 interface SmoothResponseProps {
   text: string
   /**
    * When true, newly-arrived characters are revealed on
-   * `requestAnimationFrame` instead of appearing in the SDK's coarse throttle
-   * steps. When false the full text renders immediately.
+   * `requestAnimationFrame` instead of appearing in uneven stream-sized chunks.
+   * When false the full text renders immediately.
    */
   animate: boolean
 }
@@ -22,10 +26,11 @@ interface SmoothResponseProps {
  * Renders streamed markdown with a frame-aligned reveal.
  *
  * Streamed text can arrive in uneven network-sized chunks. While `animate` is
- * true this component advances a locally-held reveal length on each animation
- * frame, so bursty deltas read as smooth 60fps growth. The reveal state is
- * local, so per-frame updates only re-render this component, not the
- * surrounding message list.
+ * true this component treats incoming text as a hidden buffer and drains it at
+ * a steady frame-aligned rate. This avoids the "catch up, pause, catch up"
+ * pulse that happens when each network burst is revealed as fast as possible.
+ * The reveal state is local, so per-frame updates only re-render this
+ * component, not the surrounding message list.
  */
 export function SmoothResponse({ text, animate }: SmoothResponseProps) {
   const [shownLen, setShownLen] = useState(text.length)
@@ -41,17 +46,39 @@ export function SmoothResponse({ text, animate }: SmoothResponseProps) {
       return
     }
 
-    let rafId = requestAnimationFrame(function tick() {
+    let lastFrameAt = performance.now()
+    let carry = 0
+
+    let rafId = requestAnimationFrame(function tick(now) {
+      const elapsedSeconds = Math.min((now - lastFrameAt) / 1000, 0.1)
+      lastFrameAt = now
+
       setShownLen((prev) => {
         const target = targetLenRef.current
+        if (prev > target) {
+          carry = 0
+          return target
+        }
         if (prev >= target) {
-          // Caught up: identical state value, React skips the re-render.
+          carry = 0
           return prev
         }
-        const step = Math.max(
-          MIN_CHARS_PER_FRAME,
-          Math.ceil((target - prev) * CATCHUP_FRACTION)
+
+        const buffered = target - prev
+        const charsPerSecond =
+          buffered > CATCHUP_THRESHOLD_CHARS
+            ? CATCHUP_CHARS_PER_SECOND
+            : STEADY_CHARS_PER_SECOND
+        const exactStep = charsPerSecond * elapsedSeconds + carry
+        const step = Math.min(
+          Math.floor(exactStep),
+          MAX_CHARS_PER_FRAME,
+          buffered
         )
+        carry = exactStep - Math.floor(exactStep)
+        if (step < 1) {
+          return prev
+        }
         return Math.min(target, prev + step)
       })
       rafId = requestAnimationFrame(tick)

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -454,7 +454,6 @@ export function useVercelChat({
   const chat = aiSdk.useChat({
     id: chatId,
     resume: !!chatId,
-    experimental_throttle: 50,
     messages,
     transport: new DefaultChatTransport({
       api: apiEndpoint,


### PR DESCRIPTION
## Description

This PR smooths Workspace Chat assistant streaming independently from the per-session tools work.

- Add `SmoothResponse`, which treats incoming streamed text as a hidden buffer and drains it on `requestAnimationFrame` at a steadier rate.
- Remove `experimental_throttle: 50` from `useChat` so the SDK no longer adds an extra fixed 50ms flush cadence.
- Switch conversation resize-following to `instant` while streaming, avoiding smooth scroll/resize pulses as content grows.

## Related Issues

N/A

## Screenshots / Recordings

Tested live on the local workspace chat cluster. The response rendered correctly after streaming, with markdown headings, bullets, inline code, and links intact.

## Steps to QA

1. Open Workspace Chat.
2. Send a prompt that produces a medium-length markdown response.
3. Confirm text reveal is smoother and the transcript does not visibly jump as the response grows.
4. Confirm completed markdown renders normally after streaming finishes.

## Checklist

- [x] PR only implements a single frontend performance change.
- [x] `pnpm -C frontend run typecheck`
- [x] `pnpm -C frontend exec jest chat-session-pane`
- [x] `uv run ruff check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes streamed chat replies reveal smoothly with a `requestAnimationFrame` loop, eliminating the 50ms chunking from the SDK throttle. Improves readability and keeps per-frame updates scoped to the active message.

- **Refactors**
  - Added `SmoothResponse` to drain buffered text at a steady rate and snap to full when streaming ends.
  - Set `Conversation` resize to `instant` while `status === "streaming"`, otherwise `smooth`.
  - Removed `experimental_throttle` in `useVercelChat` to avoid double buffering.

- **Bug Fixes**
  - Stop the smooth-reveal loop when the UI catches up, and restart when new text arrives; added a unit test for this behavior.

<sup>Written for commit cc6b7663ae5e4402683747cfeeb669ffc315a906. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

