### PR TITLE
feat: support disabling TLS verification for blob storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,9 @@ TRACECAT__BLOB_STORAGE_BUCKET_REGISTRY=tracecat-registry
 TRACECAT__BLOB_STORAGE_BUCKET_AGENT=tracecat-agent
 # Total request attempts (initial try + retries) for transient S3/MinIO failures.
 TRACECAT__BLOB_STORAGE_MAX_ATTEMPTS=5
+# Verify TLS certificates when connecting to blob storage (S3/MinIO).
+# Set to false for self-hosted S3-compatible storage with self-signed/absent certs.
+TRACECAT__BLOB_STORAGE_SSL_VERIFY=true
 
 # --- MinIO ---
 MINIO_ROOT_USER=minio

--- a/tests/unit/test_storage_blob.py
+++ b/tests/unit/test_storage_blob.py
@@ -91,7 +91,7 @@ class TestS3Operations:
                 "s3",
                 endpoint_url="http://localhost:9002",
                 config=blob_module._STORAGE_CLIENT_CONFIG,
-                verify=True,
+                verify=None,
                 aws_access_key_id="minioadmin",
                 aws_secret_access_key="minioadmin",
             )
@@ -120,7 +120,7 @@ class TestS3Operations:
             async with get_storage_client() as client:
                 assert client is mock_client
             mock_session.client.assert_called_once_with(
-                "s3", config=blob_module._STORAGE_CLIENT_CONFIG, verify=True
+                "s3", config=blob_module._STORAGE_CLIENT_CONFIG, verify=None
             )
 
     @pytest.mark.anyio

--- a/tests/unit/test_storage_blob.py
+++ b/tests/unit/test_storage_blob.py
@@ -71,6 +71,12 @@ class TestS3Operations:
             "http://localhost:9002",
             raising=False,
         )
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_SSL_VERIFY",
+            True,
+            raising=False,
+        )
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", "minioadmin")
         monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "minioadmin")
 
@@ -85,6 +91,7 @@ class TestS3Operations:
                 "s3",
                 endpoint_url="http://localhost:9002",
                 config=blob_module._STORAGE_CLIENT_CONFIG,
+                verify=True,
                 aws_access_key_id="minioadmin",
                 aws_secret_access_key="minioadmin",
             )
@@ -98,6 +105,12 @@ class TestS3Operations:
             None,
             raising=False,
         )
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_SSL_VERIFY",
+            True,
+            raising=False,
+        )
 
         with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
             mock_session = mock_session_cls.return_value
@@ -107,8 +120,60 @@ class TestS3Operations:
             async with get_storage_client() as client:
                 assert client is mock_client
             mock_session.client.assert_called_once_with(
-                "s3", config=blob_module._STORAGE_CLIENT_CONFIG
+                "s3", config=blob_module._STORAGE_CLIENT_CONFIG, verify=True
             )
+
+    @pytest.mark.anyio
+    async def test_get_storage_client_minio_ssl_verify_disabled(self, monkeypatch):
+        """SSL verification can be disabled for self-signed MinIO/S3 endpoints."""
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_ENDPOINT",
+            "https://minio.internal:9000",
+            raising=False,
+        )
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_SSL_VERIFY",
+            False,
+            raising=False,
+        )
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "minioadmin")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "minioadmin")
+
+        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_client = AsyncMock()
+            mock_session.client.return_value.__aenter__.return_value = mock_client
+
+            async with get_storage_client() as client:
+                assert client is mock_client
+            assert mock_session.client.call_args.kwargs["verify"] is False
+
+    @pytest.mark.anyio
+    async def test_get_storage_client_s3_ssl_verify_disabled(self, monkeypatch):
+        """SSL verification flag is honored on the default AWS S3 path too."""
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_ENDPOINT",
+            None,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_SSL_VERIFY",
+            False,
+            raising=False,
+        )
+
+        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_client = AsyncMock()
+            mock_session.client.return_value.__aenter__.return_value = mock_client
+
+            async with get_storage_client() as client:
+                assert client is mock_client
+            assert mock_session.client.call_args.kwargs["verify"] is False
 
     @pytest.mark.anyio
     @patch("tracecat.storage.blob.get_storage_client")

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -456,6 +456,14 @@ TRACECAT__BLOB_STORAGE_BUCKET_SKILLS = os.environ.get(
 TRACECAT__BLOB_STORAGE_ENDPOINT = os.environ.get("TRACECAT__BLOB_STORAGE_ENDPOINT", "")
 """Endpoint URL for blob storage."""
 
+TRACECAT__BLOB_STORAGE_SSL_VERIFY = (
+    os.environ.get("TRACECAT__BLOB_STORAGE_SSL_VERIFY", "true").lower() == "true"
+)
+"""Verify TLS certificates when connecting to blob storage (S3/MinIO).
+
+Set to false for self-hosted S3-compatible storage that terminates TLS with a
+self-signed or otherwise unverifiable certificate. Defaults to true."""
+
 TRACECAT__BLOB_STORAGE_MAX_ATTEMPTS = int(
     os.environ.get("TRACECAT__BLOB_STORAGE_MAX_ATTEMPTS") or 5
 )

--- a/tracecat/storage/blob.py
+++ b/tracecat/storage/blob.py
@@ -53,6 +53,11 @@ async def get_storage_client() -> AsyncIterator[S3Client]:
         Configured aioboto3 S3 client
     """
     session = aioboto3.Session()
+    # Only override TLS verification when it is explicitly disabled. Passing
+    # verify=True would bypass botocore's default CA-bundle resolution
+    # (AWS_CA_BUNDLE / the ca_bundle config), so leave it as None in the default
+    # case to preserve that behavior.
+    verify = None if config.TRACECAT__BLOB_STORAGE_SSL_VERIFY else False
     # Configure client based on protocol
     if config.TRACECAT__BLOB_STORAGE_ENDPOINT:
         # MinIO configuration - use AWS_* or MINIO_ROOT_* credentials
@@ -60,7 +65,7 @@ async def get_storage_client() -> AsyncIterator[S3Client]:
             "s3",
             endpoint_url=config.TRACECAT__BLOB_STORAGE_ENDPOINT,
             config=_STORAGE_CLIENT_CONFIG,
-            verify=config.TRACECAT__BLOB_STORAGE_SSL_VERIFY,
+            verify=verify,
             # Defaults to minio default credentials. MUST REPLACE WITH PRODUCTION CREDENTIALS.
             aws_access_key_id=os.environ.get(
                 "AWS_ACCESS_KEY_ID",
@@ -77,7 +82,7 @@ async def get_storage_client() -> AsyncIterator[S3Client]:
         async with session.client(
             "s3",
             config=_STORAGE_CLIENT_CONFIG,
-            verify=config.TRACECAT__BLOB_STORAGE_SSL_VERIFY,
+            verify=verify,
         ) as client:
             yield client
 

--- a/tracecat/storage/blob.py
+++ b/tracecat/storage/blob.py
@@ -60,6 +60,7 @@ async def get_storage_client() -> AsyncIterator[S3Client]:
             "s3",
             endpoint_url=config.TRACECAT__BLOB_STORAGE_ENDPOINT,
             config=_STORAGE_CLIENT_CONFIG,
+            verify=config.TRACECAT__BLOB_STORAGE_SSL_VERIFY,
             # Defaults to minio default credentials. MUST REPLACE WITH PRODUCTION CREDENTIALS.
             aws_access_key_id=os.environ.get(
                 "AWS_ACCESS_KEY_ID",
@@ -73,7 +74,11 @@ async def get_storage_client() -> AsyncIterator[S3Client]:
             yield client
     else:
         # AWS S3 configuration - use AWS credentials from environment or default credential chain
-        async with session.client("s3", config=_STORAGE_CLIENT_CONFIG) as client:
+        async with session.client(
+            "s3",
+            config=_STORAGE_CLIENT_CONFIG,
+            verify=config.TRACECAT__BLOB_STORAGE_SSL_VERIFY,
+        ) as client:
             yield client
 
 


### PR DESCRIPTION
## Summary

Adds a `TRACECAT__BLOB_STORAGE_SSL_VERIFY` setting (default `true`) and threads it into both S3 client paths in `get_storage_client()`, so self-hosted, S3-compatible blob storage that terminates TLS with a self-signed or otherwise unverifiable certificate can be used.

Closes #2539.

## Why

Self-hosted S3-compatible storage is sometimes served over an endpoint with a self-signed or absent TLS certificate. There was previously no way to disable certificate verification for the blob-storage client, so those deployments could not connect.

## Changes

- **`tracecat/config.py`** — new `TRACECAT__BLOB_STORAGE_SSL_VERIFY` (bool, default `true`), following the existing `TRACECAT__BLOB_STORAGE_*` convention.
- **`tracecat/storage/blob.py`** — pass `verify=` to both `session.client("s3", ...)` calls (the custom-endpoint/MinIO path and the default AWS path).
- **`.env.example`** — document the new variable.
- **`tests/unit/test_storage_blob.py`** — update the two existing client tests for the new keyword argument, and add tests covering the disabled path on both branches.

## Notes

- Default is `true`, so existing behavior is unchanged.
- I used `TRACECAT__BLOB_STORAGE_SSL_VERIFY` to match the existing `TRACECAT__BLOB_STORAGE_*` naming rather than the `TRACECAT__S3_SSL_VERIFY` suggested in the issue — happy to rename if you would prefer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TLS verification toggle for blob storage via `TRACECAT__BLOB_STORAGE_SSL_VERIFY` (default true) and only overrides verification when disabled, so self-hosted S3/MinIO endpoints with self-signed certs can connect.

- **New Features**
  - Pass `verify=` to both S3 client paths in `get_storage_client()` (custom endpoint and AWS).
  - Document `TRACECAT__BLOB_STORAGE_SSL_VERIFY` in `.env.example`; add tests for on/off.
  - Default behavior unchanged; set `TRACECAT__BLOB_STORAGE_SSL_VERIFY=false` to disable verification.

<sup>Written for commit a1b18f54f639aab99977f24f295aabac231908c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

