### PR TITLE
feat(chat): capabilities-first tools picker, browsable integrations

### DIFF
--- a/frontend/src/components/chat/chat-history-dropdown.tsx
+++ b/frontend/src/components/chat/chat-history-dropdown.tsx
@@ -44,6 +44,13 @@ export function ChatHistoryDropdown({
     setOpen(false)
   }
 
+  // Hide the selector entirely when there is no chat history — an empty
+  // dropdown is just noise. Still render while loading or on error so those
+  // states aren't silently swallowed.
+  if (!isLoading && !error && (chats?.length ?? 0) === 0) {
+    return null
+  }
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>

--- a/frontend/src/components/chat/chat-interface.tsx
+++ b/frontend/src/components/chat/chat-interface.tsx
@@ -458,6 +458,7 @@ export function ChatInterface({
           selectedPreset={activePreset}
           selectedPresetConfigError={selectedPresetConfigError}
           toolsEnabled={toolsEnabled}
+          agentAddonsEnabled={agentAddonsEnabled}
           mcpEnabled={sessionMcpEnabled}
           draftMode={draftMode}
           presetSelector={presetSelector}
@@ -488,6 +489,7 @@ interface ChatBodyProps {
   selectedPreset?: PresetConfigLike
   selectedPresetConfigError?: unknown
   toolsEnabled: boolean
+  agentAddonsEnabled: boolean
   mcpEnabled: boolean
   draftMode: boolean
   presetSelector?: {
@@ -526,6 +528,7 @@ function ChatBody({
   selectedPreset,
   selectedPresetConfigError,
   toolsEnabled,
+  agentAddonsEnabled,
   mcpEnabled,
   draftMode,
   presetSelector,
@@ -637,6 +640,7 @@ function ChatBody({
         className="flex-1 min-h-0"
         modelInfo={modelInfo}
         toolsEnabled={toolsEnabled}
+        agentAddonsEnabled={agentAddonsEnabled}
         mcpEnabled={mcpEnabled}
         presetSelector={presetSelector}
         onBeforeSend={onCreateSessionBeforeSend}
@@ -668,6 +672,7 @@ function ChatBody({
       className="flex-1 min-h-0"
       modelInfo={modelInfo}
       toolsEnabled={toolsEnabled}
+      agentAddonsEnabled={agentAddonsEnabled}
       mcpEnabled={mcpEnabled}
       presetSelector={presetSelector}
       pendingMessage={pendingMessage ?? undefined}

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -233,6 +233,7 @@ export interface ChatSessionPaneProps {
   onData?: ChatOnDataCallback<UIMessage>
   modelInfo: ModelInfo
   toolsEnabled?: boolean
+  agentAddonsEnabled?: boolean
   mcpEnabled?: boolean
   /** Autofocus the prompt input when the pane mounts. */
   autoFocusInput?: boolean
@@ -290,6 +291,7 @@ export function ChatSessionPane({
   onData,
   modelInfo,
   toolsEnabled = true,
+  agentAddonsEnabled = true,
   mcpEnabled = false,
   autoFocusInput = false,
   onBeforeSend,
@@ -1194,6 +1196,7 @@ export function ChatSessionPane({
                 mcpIntegrations={mcpIntegrations ?? []}
                 selectedMcpIntegrations={selectedMcpIntegrations}
                 onMcpChange={commitSelectedMcpIntegrations}
+                agentAddonsEnabled={agentAddonsEnabled}
                 mcpEnabled={sessionMcpEnabled}
                 disabled={inputDisabled || isUpdatingTools}
                 mcpIntegrationsHref={`/workspaces/${workspaceId}/mcp-servers`}

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -1199,6 +1199,7 @@ export function ChatSessionPane({
                 agentAddonsEnabled={agentAddonsEnabled}
                 mcpEnabled={sessionMcpEnabled}
                 disabled={inputDisabled || isUpdatingTools}
+                surface={surface}
                 mcpIntegrationsHref={`/workspaces/${workspaceId}/mcp-servers`}
               />
             )}

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -1196,6 +1196,7 @@ export function ChatSessionPane({
                 onMcpChange={commitSelectedMcpIntegrations}
                 mcpEnabled={sessionMcpEnabled}
                 disabled={inputDisabled || isUpdatingTools}
+                mcpIntegrationsHref={`/workspaces/${workspaceId}/mcp-servers`}
               />
             )}
             {!isReadonly ? (

--- a/frontend/src/components/chat/chat-tools-picker.test.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react"
-import type { MCPIntegrationRead } from "@/client"
+import type { MCPIntegrationRead, RegistryActionReadMinimal } from "@/client"
 import { ChatToolsPicker } from "@/components/chat/chat-tools-picker"
 
 jest.mock("@/components/ui/popover", () => ({
@@ -31,6 +31,22 @@ const runrevealIntegration = {
   created_at: "2024-01-01T00:00:00.000Z",
   updated_at: "2024-01-01T00:00:00.000Z",
 } satisfies MCPIntegrationRead
+
+function registryAction(
+  action: string,
+  overrides: Partial<RegistryActionReadMinimal> = {}
+): RegistryActionReadMinimal {
+  return {
+    id: action,
+    name: action,
+    description: `${action} description`,
+    namespace: action.split(".").slice(0, -1).join("."),
+    type: "udf",
+    origin: "tracecat",
+    action,
+    ...overrides,
+  }
+}
 
 describe("ChatToolsPicker", () => {
   it("hides MCP integrations when they are not enabled for the chat surface", () => {
@@ -120,6 +136,44 @@ describe("ChatToolsPicker", () => {
     expect(screen.getByText("No longer available")).toBeInTheDocument()
 
     fireEvent.click(screen.getByText("tools.deleted.action"))
+
+    expect(onToolsChange).toHaveBeenCalledWith([])
+  })
+
+  it("shows selected default registry tools in search so they can be removed", () => {
+    const onToolsChange = jest.fn()
+
+    render(
+      <ChatToolsPicker
+        registryActions={[
+          registryAction("core.cases.list_cases", {
+            default_title: "List cases",
+            display_group: "Cases",
+          }),
+        ]}
+        selectedTools={["core.cases.list_cases"]}
+        onToolsChange={onToolsChange}
+        mcpIntegrations={[]}
+        selectedMcpIntegrations={[]}
+        onMcpChange={jest.fn()}
+      />
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Tools (1)" })
+    ).toBeInTheDocument()
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Search capabilities & tools..."),
+      {
+        target: { value: "list cases" },
+      }
+    )
+
+    expect(screen.getByText("List cases")).toBeInTheDocument()
+    expect(screen.getByText("Included by default")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText("List cases"))
 
     expect(onToolsChange).toHaveBeenCalledWith([])
   })

--- a/frontend/src/components/chat/chat-tools-picker.test.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.test.tsx
@@ -140,6 +140,41 @@ describe("ChatToolsPicker", () => {
     expect(onToolsChange).toHaveBeenCalledWith([])
   })
 
+  it("allows regular chat surfaces to add workspace-chat default tools", () => {
+    const onToolsChange = jest.fn()
+
+    render(
+      <ChatToolsPicker
+        registryActions={[
+          registryAction("core.table.search_rows", {
+            default_title: "Search rows",
+            display_group: "Tables",
+          }),
+        ]}
+        selectedTools={[]}
+        onToolsChange={onToolsChange}
+        mcpIntegrations={[]}
+        selectedMcpIntegrations={[]}
+        onMcpChange={jest.fn()}
+        surface="regular"
+      />
+    )
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Search capabilities & tools..."),
+      {
+        target: { value: "search rows" },
+      }
+    )
+
+    expect(screen.getByText("Search rows")).toBeInTheDocument()
+    expect(screen.queryByText("Included by default")).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText("Search rows"))
+
+    expect(onToolsChange).toHaveBeenCalledWith(["core.table.search_rows"])
+  })
+
   it("shows selected default registry tools in search so they can be removed", () => {
     const onToolsChange = jest.fn()
 
@@ -156,6 +191,7 @@ describe("ChatToolsPicker", () => {
         mcpIntegrations={[]}
         selectedMcpIntegrations={[]}
         onMcpChange={jest.fn()}
+        surface="workspace-chat"
       />
     )
 
@@ -188,6 +224,7 @@ describe("ChatToolsPicker", () => {
         selectedMcpIntegrations={[]}
         onMcpChange={jest.fn()}
         agentAddonsEnabled={false}
+        surface="workspace-chat"
       />
     )
 

--- a/frontend/src/components/chat/chat-tools-picker.test.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.test.tsx
@@ -177,4 +177,21 @@ describe("ChatToolsPicker", () => {
 
     expect(onToolsChange).toHaveBeenCalledWith([])
   })
+
+  it("hides add-on capabilities when agent add-ons are disabled", () => {
+    render(
+      <ChatToolsPicker
+        registryActions={[]}
+        selectedTools={[]}
+        onToolsChange={jest.fn()}
+        mcpIntegrations={[]}
+        selectedMcpIntegrations={[]}
+        onMcpChange={jest.fn()}
+        agentAddonsEnabled={false}
+      />
+    )
+
+    expect(screen.getByText("Cases")).toBeInTheDocument()
+    expect(screen.queryByText("Agent presets")).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/chat/chat-tools-picker.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/popover"
 import { Switch } from "@/components/ui/switch"
 import { cn } from "@/lib/utils"
+import type { ChatSurface } from "@/types/chat-surface"
 
 interface ChatToolsPickerProps {
   registryActions: RegistryActionReadMinimal[]
@@ -30,6 +31,8 @@ interface ChatToolsPickerProps {
   agentAddonsEnabled?: boolean
   mcpEnabled?: boolean
   disabled?: boolean
+  /** Selects which chat surface-specific default capabilities are read-only. */
+  surface?: ChatSurface
   /**
    * Link to the workspace MCP servers page. When provided, the empty MCP
    * state becomes a CTA pointing there.
@@ -123,6 +126,7 @@ const DEFAULT_CAPABILITY_GROUPS: CapabilityGroup[] = [
 const DEFAULT_TOOL_VALUES = new Set(
   DEFAULT_CAPABILITY_GROUPS.flatMap((group) => group.tools)
 )
+const EMPTY_DEFAULT_TOOL_VALUES = new Set<string>()
 
 /** Humanize an action id (e.g. `core.table.list_tables` -> `List tables`). */
 function humanizeAction(action: string): string {
@@ -152,10 +156,15 @@ export function ChatToolsPicker({
   agentAddonsEnabled = true,
   mcpEnabled = true,
   disabled = false,
+  surface = "regular",
   mcpIntegrationsHref,
 }: ChatToolsPickerProps) {
   const [query, setQuery] = useState("")
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const isWorkspaceChat = surface === "workspace-chat"
+  const defaultToolValues = isWorkspaceChat
+    ? DEFAULT_TOOL_VALUES
+    : EMPTY_DEFAULT_TOOL_VALUES
 
   const addedCount =
     selectedTools.length + (mcpEnabled ? selectedMcpIntegrations.length : 0)
@@ -192,17 +201,18 @@ export function ChatToolsPicker({
 
   const visibleCapabilityGroups = useMemo(
     () =>
-      DEFAULT_CAPABILITY_GROUPS.filter(
-        (group) => !group.addon || agentAddonsEnabled
-      ),
-    [agentAddonsEnabled]
+      isWorkspaceChat
+        ? DEFAULT_CAPABILITY_GROUPS.filter(
+            (group) => !group.addon || agentAddonsEnabled
+          )
+        : [],
+    [agentAddonsEnabled, isWorkspaceChat]
   )
 
-  // Tools the user can add: everything except the always-on defaults.
+  // Tools the user can add: everything except this surface's always-on defaults.
   const addableTools = useMemo<ToolOption[]>(
-    () =>
-      toolOptions.filter((option) => !DEFAULT_TOOL_VALUES.has(option.value)),
-    [toolOptions]
+    () => toolOptions.filter((option) => !defaultToolValues.has(option.value)),
+    [defaultToolValues, toolOptions]
   )
 
   // Group addable tools by their integration (display group) for browsing.
@@ -228,7 +238,7 @@ export function ChatToolsPicker({
   const selectedDefaultTools = useMemo<ToolOption[]>(
     () =>
       selectedTools
-        .filter((value) => DEFAULT_TOOL_VALUES.has(value))
+        .filter((value) => defaultToolValues.has(value))
         .map((value) => {
           const option = optionByValue.get(value)
           if (option) {
@@ -244,7 +254,7 @@ export function ChatToolsPicker({
             description: "This tool is already included by default.",
           }
         }),
-    [optionByValue, selectedTools]
+    [defaultToolValues, optionByValue, selectedTools]
   )
 
   // Selected tools that are no longer in the registry, surfaced so they can be
@@ -253,8 +263,7 @@ export function ChatToolsPicker({
     () =>
       selectedTools
         .filter(
-          (value) =>
-            !DEFAULT_TOOL_VALUES.has(value) && !optionByValue.has(value)
+          (value) => !defaultToolValues.has(value) && !optionByValue.has(value)
         )
         .map((value) => ({
           value,
@@ -263,7 +272,7 @@ export function ChatToolsPicker({
           description: "This tool is no longer available.",
           stale: true,
         })),
-    [optionByValue, selectedTools]
+    [defaultToolValues, optionByValue, selectedTools]
   )
 
   const searchResults = useMemo<ToolOption[]>(() => {
@@ -388,16 +397,20 @@ export function ChatToolsPicker({
             </>
           ) : (
             <>
-              <GroupLabel pill="Always on">Active capabilities</GroupLabel>
-              {visibleCapabilityGroups.map((group) => (
-                <CapabilityRow
-                  key={group.id}
-                  group={group}
-                  optionByValue={optionByValue}
-                  open={expanded.has(`cap:${group.id}`)}
-                  onToggle={() => toggleExpanded(`cap:${group.id}`)}
-                />
-              ))}
+              {isWorkspaceChat ? (
+                <>
+                  <GroupLabel pill="Always on">Active capabilities</GroupLabel>
+                  {visibleCapabilityGroups.map((group) => (
+                    <CapabilityRow
+                      key={group.id}
+                      group={group}
+                      optionByValue={optionByValue}
+                      open={expanded.has(`cap:${group.id}`)}
+                      onToggle={() => toggleExpanded(`cap:${group.id}`)}
+                    />
+                  ))}
+                </>
+              ) : null}
 
               {mcpEnabled && (
                 <>
@@ -496,7 +509,8 @@ export function ChatToolsPicker({
         </div>
 
         <div className="border-t px-3 py-2 text-[11px] text-muted-foreground">
-          {addedCount} added · Tracecat defaults always included
+          {addedCount} added
+          {isWorkspaceChat ? " · Tracecat defaults always included" : ""}
         </div>
       </PopoverContent>
     </Popover>

--- a/frontend/src/components/chat/chat-tools-picker.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.tsx
@@ -27,6 +27,7 @@ interface ChatToolsPickerProps {
   mcpIntegrations: MCPIntegrationRead[]
   selectedMcpIntegrations: string[]
   onMcpChange: (next: string[]) => void
+  agentAddonsEnabled?: boolean
   mcpEnabled?: boolean
   disabled?: boolean
   /**
@@ -148,6 +149,7 @@ export function ChatToolsPicker({
   mcpIntegrations,
   selectedMcpIntegrations,
   onMcpChange,
+  agentAddonsEnabled = true,
   mcpEnabled = true,
   disabled = false,
   mcpIntegrationsHref,
@@ -186,6 +188,14 @@ export function ChatToolsPicker({
   const optionByValue = useMemo(
     () => new Map(toolOptions.map((option) => [option.value, option])),
     [toolOptions]
+  )
+
+  const visibleCapabilityGroups = useMemo(
+    () =>
+      DEFAULT_CAPABILITY_GROUPS.filter(
+        (group) => !group.addon || agentAddonsEnabled
+      ),
+    [agentAddonsEnabled]
   )
 
   // Tools the user can add: everything except the always-on defaults.
@@ -379,7 +389,7 @@ export function ChatToolsPicker({
           ) : (
             <>
               <GroupLabel pill="Always on">Active capabilities</GroupLabel>
-              {DEFAULT_CAPABILITY_GROUPS.map((group) => (
+              {visibleCapabilityGroups.map((group) => (
                 <CapabilityRow
                   key={group.id}
                   group={group}

--- a/frontend/src/components/chat/chat-tools-picker.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.tsx
@@ -213,12 +213,39 @@ export function ChatToolsPicker({
       .sort((a, b) => a.group.localeCompare(b.group))
   }, [addableTools])
 
+  // Default tools should not be persisted as extras, but older sessions or the
+  // mention menu can still put them in selectedTools. Surface them as removable.
+  const selectedDefaultTools = useMemo<ToolOption[]>(
+    () =>
+      selectedTools
+        .filter((value) => DEFAULT_TOOL_VALUES.has(value))
+        .map((value) => {
+          const option = optionByValue.get(value)
+          if (option) {
+            return {
+              ...option,
+              group: "Included by default",
+            }
+          }
+          return {
+            value,
+            label: humanizeAction(value),
+            group: "Included by default",
+            description: "This tool is already included by default.",
+          }
+        }),
+    [optionByValue, selectedTools]
+  )
+
   // Selected tools that are no longer in the registry, surfaced so they can be
   // removed even when the user is not searching.
   const staleSelectedTools = useMemo<ToolOption[]>(
     () =>
       selectedTools
-        .filter((value) => !optionByValue.has(value))
+        .filter(
+          (value) =>
+            !DEFAULT_TOOL_VALUES.has(value) && !optionByValue.has(value)
+        )
         .map((value) => ({
           value,
           label: value,
@@ -235,12 +262,16 @@ export function ChatToolsPicker({
       return []
     }
     return fuzzysort
-      .go<ToolOption>(needle, [...addableTools, ...staleSelectedTools], {
-        keys: ["value", "label", "description", "group"],
-        limit: TOOL_SEARCH_LIMIT,
-      })
+      .go<ToolOption>(
+        needle,
+        [...addableTools, ...selectedDefaultTools, ...staleSelectedTools],
+        {
+          keys: ["value", "label", "description", "group"],
+          limit: TOOL_SEARCH_LIMIT,
+        }
+      )
       .map((result) => result.obj)
-  }, [query, addableTools, staleSelectedTools])
+  }, [query, addableTools, selectedDefaultTools, staleSelectedTools])
 
   const mcpOptionById = useMemo(
     () =>
@@ -405,6 +436,16 @@ export function ChatToolsPicker({
               )}
 
               <GroupLabel>Add tools</GroupLabel>
+              {selectedDefaultTools.map((tool) => (
+                <Row
+                  key={tool.value}
+                  dotClassName="bg-emerald-500"
+                  title={tool.label}
+                  subtitle={tool.group}
+                  checked
+                  onToggle={() => toggleTool(tool.value)}
+                />
+              ))}
               {staleSelectedTools.map((tool) => (
                 <Row
                   key={tool.value}
@@ -436,7 +477,8 @@ export function ChatToolsPicker({
                     />
                   )
                 })
-              ) : staleSelectedTools.length === 0 ? (
+              ) : staleSelectedTools.length === 0 &&
+                selectedDefaultTools.length === 0 ? (
                 <EmptyHint>No registry tools available.</EmptyHint>
               ) : null}
             </>

--- a/frontend/src/components/chat/chat-tools-picker.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.tsx
@@ -1,7 +1,14 @@
 "use client"
 
 import fuzzysort from "fuzzysort"
-import { SearchIcon, SlidersHorizontalIcon } from "lucide-react"
+import {
+  ArrowRightIcon,
+  ChevronRightIcon,
+  PlugZapIcon,
+  SearchIcon,
+  SlidersHorizontalIcon,
+} from "lucide-react"
+import Link from "next/link"
 import { useMemo, useState } from "react"
 import type { MCPIntegrationRead, RegistryActionReadMinimal } from "@/client"
 import { PromptInputButton } from "@/components/ai-elements/prompt-input"
@@ -22,6 +29,11 @@ interface ChatToolsPickerProps {
   onMcpChange: (next: string[]) => void
   mcpEnabled?: boolean
   disabled?: boolean
+  /**
+   * Link to the workspace MCP servers page. When provided, the empty MCP
+   * state becomes a CTA pointing there.
+   */
+  mcpIntegrationsHref?: string
 }
 
 type ToolOption = {
@@ -39,12 +51,95 @@ type McpOption = {
   stale?: boolean
 }
 
+type CapabilityGroup = {
+  id: string
+  label: string
+  tools: string[]
+  addon?: boolean
+}
+
 const TOOL_SEARCH_LIMIT = 24
 
 /**
- * Unified picker for attaching extra registry tools and MCP integrations to a
- * chat session. Tracecat platform defaults are always on and merged at runtime;
- * this control only manages additions on top of that baseline.
+ * Always-on workspace chat capabilities, grouped for display. Mirrors
+ * `WORKSPACE_CHAT_DEFAULT_TOOLS` in `tracecat/chat/tools.py` — keep in sync when
+ * the backend default tool set changes. These are surfaced read-only so users
+ * can see what the agent can already do before adding anything.
+ */
+const DEFAULT_CAPABILITY_GROUPS: CapabilityGroup[] = [
+  {
+    id: "cases",
+    label: "Cases",
+    tools: [
+      "core.cases.create_case",
+      "core.cases.update_case",
+      "core.cases.delete_case",
+      "core.cases.list_cases",
+      "core.cases.get_case",
+      "core.cases.search_cases",
+    ],
+  },
+  {
+    id: "tables",
+    label: "Tables",
+    tools: [
+      "core.table.list_tables",
+      "core.table.get_table_metadata",
+      "core.table.create_table",
+      "core.table.update_table",
+      "core.table.create_column",
+      "core.table.update_column",
+      "core.table.delete_column",
+      "core.table.lookup",
+      "core.table.lookup_many",
+      "core.table.is_in",
+      "core.table.search_rows",
+      "core.table.insert_row",
+      "core.table.insert_rows",
+      "core.table.update_row",
+      "core.table.delete_row",
+      "core.table.download",
+    ],
+  },
+  {
+    id: "workflows",
+    label: "Workflows",
+    tools: ["core.workflow.create_workflow"],
+  },
+  {
+    id: "presets",
+    label: "Agent presets",
+    addon: true,
+    tools: [
+      "ai.agent.create_preset",
+      "ai.agent.get_preset",
+      "ai.agent.list_presets",
+      "ai.agent.update_preset",
+    ],
+  },
+]
+
+const DEFAULT_TOOL_VALUES = new Set(
+  DEFAULT_CAPABILITY_GROUPS.flatMap((group) => group.tools)
+)
+
+/** Humanize an action id (e.g. `core.table.list_tables` -> `List tables`). */
+function humanizeAction(action: string): string {
+  const last = action.split(".").pop() ?? action
+  const spaced = last.replace(/_/g, " ")
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+/** "1 tool" / "4 tools" */
+function toolCountLabel(count: number): string {
+  return `${count} tool${count === 1 ? "" : "s"}`
+}
+
+/**
+ * Unified picker for inspecting always-on capabilities and attaching extra
+ * registry tools and MCP integrations to a chat session. Tracecat platform
+ * defaults are always on and merged at runtime; this control surfaces them
+ * read-only and manages additions on top of that baseline.
  */
 export function ChatToolsPicker({
   registryActions,
@@ -55,11 +150,25 @@ export function ChatToolsPicker({
   onMcpChange,
   mcpEnabled = true,
   disabled = false,
+  mcpIntegrationsHref,
 }: ChatToolsPickerProps) {
   const [query, setQuery] = useState("")
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
 
   const addedCount =
     selectedTools.length + (mcpEnabled ? selectedMcpIntegrations.length : 0)
+
+  const toggleExpanded = (key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }
 
   const toolOptions = useMemo<ToolOption[]>(
     () =>
@@ -79,38 +188,59 @@ export function ChatToolsPicker({
     [toolOptions]
   )
 
-  const selectedToolOptions = useMemo<ToolOption[]>(
+  // Tools the user can add: everything except the always-on defaults.
+  const addableTools = useMemo<ToolOption[]>(
     () =>
-      selectedTools.map(
-        (value) =>
-          optionByValue.get(value) ?? {
-            value,
-            label: value,
-            group: "No longer available",
-            description: "This tool is no longer available.",
-            stale: true,
-          }
-      ),
+      toolOptions.filter((option) => !DEFAULT_TOOL_VALUES.has(option.value)),
+    [toolOptions]
+  )
+
+  // Group addable tools by their integration (display group) for browsing.
+  const addableGroups = useMemo<
+    { group: string; tools: ToolOption[] }[]
+  >(() => {
+    const byGroup = new Map<string, ToolOption[]>()
+    for (const tool of addableTools) {
+      const list = byGroup.get(tool.group)
+      if (list) {
+        list.push(tool)
+      } else {
+        byGroup.set(tool.group, [tool])
+      }
+    }
+    return Array.from(byGroup.entries())
+      .map(([group, tools]) => ({ group, tools }))
+      .sort((a, b) => a.group.localeCompare(b.group))
+  }, [addableTools])
+
+  // Selected tools that are no longer in the registry, surfaced so they can be
+  // removed even when the user is not searching.
+  const staleSelectedTools = useMemo<ToolOption[]>(
+    () =>
+      selectedTools
+        .filter((value) => !optionByValue.has(value))
+        .map((value) => ({
+          value,
+          label: value,
+          group: "No longer available",
+          description: "This tool is no longer available.",
+          stale: true,
+        })),
     [optionByValue, selectedTools]
   )
 
-  const visibleTools = useMemo<ToolOption[]>(() => {
+  const searchResults = useMemo<ToolOption[]>(() => {
     const needle = query.trim()
     if (!needle) {
-      // No query: surface only the tools already attached so they can be removed.
-      return selectedToolOptions
+      return []
     }
-    const searchableTools = [
-      ...toolOptions,
-      ...selectedToolOptions.filter((option) => option.stale),
-    ]
     return fuzzysort
-      .go<ToolOption>(needle, searchableTools, {
+      .go<ToolOption>(needle, [...addableTools, ...staleSelectedTools], {
         keys: ["value", "label", "description", "group"],
         limit: TOOL_SEARCH_LIMIT,
       })
       .map((result) => result.obj)
-  }, [query, toolOptions, selectedToolOptions])
+  }, [query, addableTools, staleSelectedTools])
 
   const mcpOptionById = useMemo(
     () =>
@@ -147,6 +277,21 @@ export function ChatToolsPicker({
     onToolsChange([...selectedTools, value])
   }
 
+  const toggleGroup = (tools: ToolOption[]) => {
+    const values = tools.map((tool) => tool.value)
+    const allSelected = values.every((value) => selectedTools.includes(value))
+    if (allSelected) {
+      const remove = new Set(values)
+      onToolsChange(selectedTools.filter((tool) => !remove.has(tool)))
+      return
+    }
+    const next = new Set(selectedTools)
+    for (const value of values) {
+      next.add(value)
+    }
+    onToolsChange(Array.from(next))
+  }
+
   const toggleMcp = (id: string) => {
     if (selectedMcpIntegrations.includes(id)) {
       onMcpChange(selectedMcpIntegrations.filter((value) => value !== id))
@@ -154,6 +299,8 @@ export function ChatToolsPicker({
     }
     onMcpChange([...selectedMcpIntegrations, id])
   }
+
+  const isSearching = query.trim().length > 0
 
   return (
     <Popover>
@@ -163,71 +310,136 @@ export function ChatToolsPicker({
           <span>{addedCount > 0 ? `Tools (${addedCount})` : "Tools"}</span>
         </PromptInputButton>
       </PopoverTrigger>
-      <PopoverContent align="start" className="w-80 p-0">
+      <PopoverContent
+        align="start"
+        className="w-80 p-0 font-normal text-[13px]"
+      >
         <div className="flex items-center gap-2 border-b px-3 py-2">
           <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
           <input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search tools & integrations..."
-            className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            placeholder="Search capabilities & tools..."
+            className="w-full bg-transparent text-[13px] outline-none placeholder:text-muted-foreground"
           />
         </div>
 
         <div className="max-h-80 overflow-y-auto py-1.5">
-          <GroupLabel>Sources</GroupLabel>
-          <div className="flex items-center gap-2.5 px-3 py-1.5">
-            <Dot className="bg-emerald-500" />
-            <span className="flex-1 text-sm">Tracecat platform</span>
-            <span className="rounded border px-1.5 py-0.5 text-[10px] text-muted-foreground">
-              Always on
-            </span>
-          </div>
-
-          {mcpEnabled && (
+          {isSearching ? (
             <>
-              <GroupLabel>MCP integrations</GroupLabel>
-              {visibleMcpIntegrations.length > 0 ? (
-                visibleMcpIntegrations.map((integration) => (
+              <GroupLabel>Add tools</GroupLabel>
+              {searchResults.length > 0 ? (
+                searchResults.map((tool) => (
                   <Row
-                    key={integration.id}
+                    key={tool.value}
                     dotClassName={
-                      integration.stale ? "bg-muted-foreground" : "bg-sky-500"
+                      tool.stale ? "bg-muted-foreground" : "bg-amber-500"
                     }
-                    title={integration.name}
-                    subtitle={integration.description}
-                    checked={selectedMcpIntegrations.includes(integration.id)}
-                    onToggle={() => toggleMcp(integration.id)}
+                    title={tool.label}
+                    subtitle={tool.group}
+                    checked={selectedTools.includes(tool.value)}
+                    onToggle={() => toggleTool(tool.value)}
                   />
                 ))
               ) : (
-                <EmptyHint>
-                  No MCP integrations connected in this workspace.
-                </EmptyHint>
+                <EmptyHint>No tools found.</EmptyHint>
               )}
             </>
-          )}
-
-          <GroupLabel>Tools</GroupLabel>
-          {visibleTools.length > 0 ? (
-            visibleTools.map((tool) => (
-              <Row
-                key={tool.value}
-                dotClassName={
-                  tool.stale ? "bg-muted-foreground" : "bg-amber-500"
-                }
-                title={tool.label}
-                subtitle={tool.group}
-                checked={selectedTools.includes(tool.value)}
-                onToggle={() => toggleTool(tool.value)}
-              />
-            ))
           ) : (
-            <EmptyHint>
-              {query.trim()
-                ? "No tools found."
-                : "Search to add registry tools."}
-            </EmptyHint>
+            <>
+              <GroupLabel pill="Always on">Active capabilities</GroupLabel>
+              {DEFAULT_CAPABILITY_GROUPS.map((group) => (
+                <CapabilityRow
+                  key={group.id}
+                  group={group}
+                  optionByValue={optionByValue}
+                  open={expanded.has(`cap:${group.id}`)}
+                  onToggle={() => toggleExpanded(`cap:${group.id}`)}
+                />
+              ))}
+
+              {mcpEnabled && (
+                <>
+                  <GroupLabel>MCP integrations</GroupLabel>
+                  {visibleMcpIntegrations.length > 0 ? (
+                    visibleMcpIntegrations.map((integration) => (
+                      <Row
+                        key={integration.id}
+                        dotClassName={
+                          integration.stale
+                            ? "bg-muted-foreground"
+                            : "bg-sky-500"
+                        }
+                        title={integration.name}
+                        subtitle={integration.description}
+                        checked={selectedMcpIntegrations.includes(
+                          integration.id
+                        )}
+                        onToggle={() => toggleMcp(integration.id)}
+                      />
+                    ))
+                  ) : mcpIntegrationsHref ? (
+                    <Link
+                      href={mcpIntegrationsHref}
+                      className="mx-2.5 my-1 flex items-center gap-3 rounded-md border border-dashed px-3 py-2.5 text-foreground hover:bg-muted"
+                    >
+                      <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                        <PlugZapIcon className="size-4" />
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="text-[13px] font-medium">
+                          Connect an MCP server
+                        </div>
+                        <p className="truncate text-[11px] text-muted-foreground">
+                          Bring your own tools into chat.
+                        </p>
+                      </div>
+                      <ArrowRightIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                    </Link>
+                  ) : (
+                    <EmptyHint>
+                      No MCP integrations connected in this workspace.
+                    </EmptyHint>
+                  )}
+                </>
+              )}
+
+              <GroupLabel>Add tools</GroupLabel>
+              {staleSelectedTools.map((tool) => (
+                <Row
+                  key={tool.value}
+                  dotClassName="bg-muted-foreground"
+                  title={tool.label}
+                  subtitle={tool.group}
+                  checked
+                  onToggle={() => toggleTool(tool.value)}
+                />
+              ))}
+              {addableGroups.length > 0 ? (
+                addableGroups.map(({ group, tools }) => {
+                  const values = tools.map((tool) => tool.value)
+                  const selectedInGroup = values.filter((value) =>
+                    selectedTools.includes(value)
+                  ).length
+                  return (
+                    <AddGroupRow
+                      key={group}
+                      group={group}
+                      tools={tools}
+                      selectedCount={selectedInGroup}
+                      allSelected={selectedInGroup === values.length}
+                      open={expanded.has(`add:${group}`)}
+                      onToggleOpen={() => toggleExpanded(`add:${group}`)}
+                      onToggleGroup={() => toggleGroup(tools)}
+                      onToggleTool={toggleTool}
+                      selectedTools={selectedTools}
+                    />
+                  )
+                })
+              ) : staleSelectedTools.length === 0 ? (
+                <EmptyHint>No registry tools available.</EmptyHint>
+              ) : null}
+            </>
           )}
         </div>
 
@@ -239,16 +451,40 @@ export function ChatToolsPicker({
   )
 }
 
-function GroupLabel({ children }: { children: React.ReactNode }) {
+function GroupLabel({
+  children,
+  pill,
+}: {
+  children: React.ReactNode
+  pill?: string
+}) {
   return (
-    <div className="px-3 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-      {children}
+    <div className="flex items-center gap-2 px-3 pb-1 pt-2">
+      <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        {children}
+      </span>
+      {pill ? (
+        <span className="rounded border px-1 py-0 text-[9px] leading-4 text-muted-foreground">
+          {pill}
+        </span>
+      ) : null}
     </div>
   )
 }
 
 function Dot({ className }: { className?: string }) {
   return <span className={cn("size-2 shrink-0 rounded-full", className)} />
+}
+
+function Chevron({ open }: { open: boolean }) {
+  return (
+    <ChevronRightIcon
+      className={cn(
+        "size-3.5 shrink-0 text-muted-foreground transition-transform",
+        open && "rotate-90"
+      )}
+    />
+  )
 }
 
 function EmptyHint({ children }: { children: React.ReactNode }) {
@@ -272,12 +508,132 @@ function Row({
     <label className="flex cursor-pointer items-center gap-2.5 px-3 py-1.5 hover:bg-muted">
       <Dot className={dotClassName} />
       <div className="min-w-0 flex-1">
-        <div className="truncate text-sm">{title}</div>
+        <div className="truncate text-[13px] text-foreground/70">{title}</div>
         {subtitle ? (
           <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
         ) : null}
       </div>
       <Switch checked={checked} onCheckedChange={onToggle} />
     </label>
+  )
+}
+
+/** Collapsible always-on capability group (read-only). */
+function CapabilityRow({
+  group,
+  optionByValue,
+  open,
+  onToggle,
+}: {
+  group: CapabilityGroup
+  optionByValue: Map<string, ToolOption>
+  open: boolean
+  onToggle: () => void
+}) {
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left hover:bg-muted"
+      >
+        <Chevron open={open} />
+        <Dot className="bg-emerald-500" />
+        <span className="flex-1 truncate text-[13px] text-foreground/70">
+          {group.label}
+        </span>
+        <span className="text-[11px] text-muted-foreground">
+          {toolCountLabel(group.tools.length)}
+          {group.addon ? " · add-on" : ""}
+        </span>
+      </button>
+      {open ? (
+        <div className="bg-muted/30">
+          {group.tools.map((value) => (
+            <div
+              key={value}
+              className="flex items-center gap-2.5 py-1 pl-9 pr-3"
+            >
+              <span className="size-1.5 shrink-0 rounded-full bg-emerald-500/50" />
+              <span className="flex-1 truncate text-[13px] text-foreground/70">
+                {optionByValue.get(value)?.label ?? humanizeAction(value)}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+/** Collapsible integration group of addable tools with a group-level toggle. */
+function AddGroupRow({
+  group,
+  tools,
+  selectedCount,
+  allSelected,
+  open,
+  onToggleOpen,
+  onToggleGroup,
+  onToggleTool,
+  selectedTools,
+}: {
+  group: string
+  tools: ToolOption[]
+  selectedCount: number
+  allSelected: boolean
+  open: boolean
+  onToggleOpen: () => void
+  onToggleGroup: () => void
+  onToggleTool: (value: string) => void
+  selectedTools: string[]
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-2.5 px-3 py-1.5 hover:bg-muted">
+        <button
+          type="button"
+          onClick={onToggleOpen}
+          className="flex min-w-0 flex-1 items-center gap-2.5 text-left"
+        >
+          <Chevron open={open} />
+          <Dot className="bg-amber-500" />
+          <span className="flex-1 truncate text-[13px] text-foreground/70">
+            {group}
+          </span>
+          <span className="text-[11px] text-muted-foreground">
+            {selectedCount > 0
+              ? `${selectedCount}/${tools.length} on`
+              : toolCountLabel(tools.length)}
+          </span>
+        </button>
+        <Switch checked={allSelected} onCheckedChange={onToggleGroup} />
+      </div>
+      {open ? (
+        <div className="bg-muted/30">
+          {tools.map((tool) => (
+            <label
+              key={tool.value}
+              className="flex cursor-pointer items-center gap-2.5 py-1 pl-9 pr-3 hover:bg-muted"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-[13px] text-foreground/70">
+                  {tool.label}
+                </div>
+                {tool.description ? (
+                  <p className="truncate text-[11px] text-muted-foreground">
+                    {tool.description}
+                  </p>
+                ) : null}
+              </div>
+              <Switch
+                checked={selectedTools.includes(tool.value)}
+                onCheckedChange={() => onToggleTool(tool.value)}
+              />
+            </label>
+          ))}
+        </div>
+      ) : null}
+    </div>
   )
 }

--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -75,6 +75,8 @@ type NavItem = {
   requiredScope?: string
   badgeCount?: number
   badgeLabel?: string
+  /** Small status pill shown after the title, e.g. "Beta". */
+  tag?: string
   items?: {
     title: string
     url: string
@@ -148,6 +150,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         title: "Chat",
         url: `${basePath}/chat`,
         icon: BotIcon,
+        tag: "Beta",
         isActive: pathname?.startsWith(`${basePath}/chat`),
         visible: canAccessMissionControl,
         isLocked: entitlementsIsLoading || !workspaceChatEnabled,
@@ -337,6 +340,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                               <Link href={item.url!}>
                                 <item.icon />
                                 <span>{item.title}</span>
+                                {item.tag ? (
+                                  <span className="ml-auto shrink-0 rounded-full border px-1.5 py-px text-[10px] font-medium leading-none text-muted-foreground">
+                                    {item.tag}
+                                  </span>
+                                ) : null}
                               </Link>
                             </SidebarMenuButton>
                           )}


### PR DESCRIPTION
## What

Reworks the workspace chat **Tools** picker so the agent's existing abilities are visible and the registry is browsable, plus a couple of related polish fixes.

### Visibility — what the agent can already do
- Replaces the opaque "Tracecat platform · Always on" line with expandable, read-only **Active capabilities** groups: Cases, Tables, Workflows, Agent presets (sourced from `WORKSPACE_CHAT_DEFAULT_TOOLS`).

### Discoverability — adding tools
- **Add tools** now lists every registry integration grouped by display group and is browsable without searching, with a per-integration enable-all toggle and per-tool toggles. Search still flattens to ranked matches.

### MCP empty state
- When no MCP integrations are connected, shows a CTA linking to the workspace MCP servers page instead of a dead-end message.

### Polish
- Slimmer "Always on" badge, removed the redundant per-row "on", reset to normal font weight, and softened 13px labels.
- Hide the chat history ("Chats") dropdown when there is no chat history.
- Tag the **Chat** sidebar nav item with a small **Beta** pill (renders only on the unlocked path).

## Notes
- `DEFAULT_CAPABILITY_GROUPS` in `chat-tools-picker.tsx` mirrors `tracecat/chat/tools.py` (`WORKSPACE_CHAT_DEFAULT_TOOLS`) — keep in sync if the backend default tool set changes. No backend/API change.
- The "Add tools" list groups by `display_group`; surfacing every integration also exposes a few pre-existing registry data-quality quirks (e.g. inconsistent `ai`/`AI` display groups). Out of scope here.

## Testing
- `pnpm run typecheck`, `biome check`, and `chat-tools-picker.test.tsx` (4 tests) pass.
- Manually verified live (workspace chat): capabilities expand, browse + search work, the MCP CTA navigates to the MCP servers page, and the empty Chats dropdown is hidden.
