### PR TITLE
perf(chat): smooth reasoning token streaming

### DIFF
--- a/frontend/src/components/ai-elements/reasoning.tsx
+++ b/frontend/src/components/ai-elements/reasoning.tsx
@@ -17,6 +17,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
+import { useSmoothText } from "@/hooks/use-smooth-text"
 import { cn } from "@/lib/utils"
 import { Response } from "./response"
 
@@ -180,6 +181,9 @@ export type ReasoningContentProps = ComponentProps<
 export const ReasoningContent = memo(
   ({ className, children, ...props }: ReasoningContentProps) => {
     const { isStreaming } = useReasoning()
+    // Reveal reasoning deltas at a steady frame-aligned rate so they don't
+    // appear in uneven network-sized bursts while thinking streams in.
+    const shownText = useSmoothText(children, isStreaming)
     const scrollRef = useRef<HTMLDivElement>(null)
     // Stay pinned to the latest reasoning unless the user scrolls away.
     const pinnedToBottomRef = useRef(true)
@@ -204,7 +208,7 @@ export const ReasoningContent = memo(
       if (el) {
         el.scrollTop = el.scrollHeight
       }
-    }, [children, isStreaming])
+    }, [children, shownText, isStreaming])
 
     return (
       <CollapsibleContent
@@ -221,7 +225,7 @@ export const ReasoningContent = memo(
           data-slot="reasoning-content"
           className="max-h-60 overflow-y-auto overscroll-contain pr-1"
         >
-          <Response className="grid gap-2">{children}</Response>
+          <Response className="grid gap-2">{shownText}</Response>
         </div>
       </CollapsibleContent>
     )

--- a/frontend/src/components/chat/smooth-response.tsx
+++ b/frontend/src/components/chat/smooth-response.tsx
@@ -1,16 +1,7 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
 import { Response } from "@/components/ai-elements/response"
-
-/** Normal reveal speed. At 60fps this is roughly 3 characters per frame. */
-const STEADY_CHARS_PER_SECOND = 180
-/** Catch-up speed used only when the hidden buffer grows large. */
-const CATCHUP_CHARS_PER_SECOND = 420
-/** Start catching up once the UI is meaningfully behind the source stream. */
-const CATCHUP_THRESHOLD_CHARS = 140
-/** Prevent a single frame from dumping a large buffered chunk. */
-const MAX_CHARS_PER_FRAME = 12
+import { useSmoothText } from "@/hooks/use-smooth-text"
 
 interface SmoothResponseProps {
   text: string
@@ -26,121 +17,11 @@ interface SmoothResponseProps {
  * Renders streamed markdown with a frame-aligned reveal.
  *
  * Streamed text can arrive in uneven network-sized chunks. While `animate` is
- * true this component treats incoming text as a hidden buffer and drains it at
- * a steady frame-aligned rate. This avoids the "catch up, pause, catch up"
- * pulse that happens when each network burst is revealed as fast as possible.
- * The reveal state is local, so per-frame updates only re-render this
- * component, not the surrounding message list.
+ * true the incoming text is revealed at a steady frame-aligned rate via
+ * {@link useSmoothText}, avoiding the "catch up, pause, catch up" pulse that
+ * happens when each network burst is revealed as fast as possible.
  */
 export function SmoothResponse({ text, animate }: SmoothResponseProps) {
-  const [shownLen, setShownLen] = useState(text.length)
-  const animateRef = useRef(animate)
-  animateRef.current = animate
-  // Track the latest target length without restarting the RAF loop on every
-  // text update.
-  const targetLenRef = useRef(text.length)
-  targetLenRef.current = text.length
-  const shownLenRef = useRef(shownLen)
-  shownLenRef.current = shownLen
-  const rafIdRef = useRef<number | null>(null)
-  const lastFrameAtRef = useRef(0)
-  const carryRef = useRef(0)
-
-  useEffect(() => {
-    return () => {
-      if (rafIdRef.current !== null) {
-        cancelAnimationFrame(rafIdRef.current)
-      }
-    }
-  }, [])
-
-  useEffect(() => {
-    function stopRevealLoop() {
-      if (rafIdRef.current !== null) {
-        cancelAnimationFrame(rafIdRef.current)
-        rafIdRef.current = null
-      }
-      carryRef.current = 0
-    }
-
-    function syncShownLen(nextShownLen: number) {
-      if (shownLenRef.current === nextShownLen) {
-        return
-      }
-      shownLenRef.current = nextShownLen
-      setShownLen(nextShownLen)
-    }
-
-    if (!animate) {
-      // Snap to the full text when the stream settles.
-      stopRevealLoop()
-      syncShownLen(targetLenRef.current)
-      return
-    }
-
-    const targetLen = targetLenRef.current
-    if (shownLenRef.current > targetLen) {
-      carryRef.current = 0
-      syncShownLen(targetLen)
-      return
-    }
-    if (shownLenRef.current >= targetLen || rafIdRef.current !== null) {
-      carryRef.current = 0
-      return
-    }
-
-    lastFrameAtRef.current = performance.now()
-    rafIdRef.current = requestAnimationFrame(function tick(now) {
-      rafIdRef.current = null
-      if (!animateRef.current) {
-        carryRef.current = 0
-        return
-      }
-
-      const elapsedSeconds = Math.min(
-        (now - lastFrameAtRef.current) / 1000,
-        0.1
-      )
-      lastFrameAtRef.current = now
-
-      const prev = shownLenRef.current
-      const target = targetLenRef.current
-      let next = prev
-
-      if (prev > target) {
-        carryRef.current = 0
-        next = target
-      } else if (prev < target) {
-        const buffered = target - prev
-        const charsPerSecond =
-          buffered > CATCHUP_THRESHOLD_CHARS
-            ? CATCHUP_CHARS_PER_SECOND
-            : STEADY_CHARS_PER_SECOND
-        const exactStep = charsPerSecond * elapsedSeconds + carryRef.current
-        const step = Math.min(
-          Math.floor(exactStep),
-          MAX_CHARS_PER_FRAME,
-          buffered
-        )
-        carryRef.current = exactStep - Math.floor(exactStep)
-        if (step < 1) {
-          next = prev
-        } else {
-          next = Math.min(target, prev + step)
-        }
-      } else {
-        carryRef.current = 0
-      }
-
-      syncShownLen(next)
-      if (next < targetLenRef.current) {
-        rafIdRef.current = requestAnimationFrame(tick)
-      } else {
-        carryRef.current = 0
-      }
-    })
-  }, [animate, text.length])
-
-  const shown = animate ? text.slice(0, shownLen) : text
+  const shown = useSmoothText(text, animate)
   return <Response>{shown}</Response>
 }

--- a/frontend/src/hooks/use-smooth-text.ts
+++ b/frontend/src/hooks/use-smooth-text.ts
@@ -1,0 +1,136 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+/** Normal reveal speed. At 60fps this is roughly 3 characters per frame. */
+const STEADY_CHARS_PER_SECOND = 180
+/** Catch-up speed used only when the hidden buffer grows large. */
+const CATCHUP_CHARS_PER_SECOND = 420
+/** Start catching up once the UI is meaningfully behind the source stream. */
+const CATCHUP_THRESHOLD_CHARS = 140
+/** Prevent a single frame from dumping a large buffered chunk. */
+const MAX_CHARS_PER_FRAME = 12
+
+/**
+ * Reveals streamed text on a frame-aligned cadence.
+ *
+ * Streamed text arrives in uneven network-sized chunks. While `animate` is
+ * true this hook treats the incoming `text` as a hidden buffer and drains it at
+ * a steady frame-aligned rate. This avoids the "catch up, pause, catch up"
+ * pulse that happens when each network burst is revealed as fast as possible.
+ * When `animate` is false the full text is returned immediately.
+ *
+ * The reveal length is local state, so per-frame updates only re-render the
+ * consuming component, not its surrounding tree.
+ */
+export function useSmoothText(text: string, animate: boolean): string {
+  const [shownLen, setShownLen] = useState(text.length)
+  const animateRef = useRef(animate)
+  animateRef.current = animate
+  // Track the latest target length without restarting the RAF loop on every
+  // text update.
+  const targetLenRef = useRef(text.length)
+  targetLenRef.current = text.length
+  const shownLenRef = useRef(shownLen)
+  shownLenRef.current = shownLen
+  const rafIdRef = useRef<number | null>(null)
+  const lastFrameAtRef = useRef(0)
+  const carryRef = useRef(0)
+
+  useEffect(() => {
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    function stopRevealLoop() {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current)
+        rafIdRef.current = null
+      }
+      carryRef.current = 0
+    }
+
+    function syncShownLen(nextShownLen: number) {
+      if (shownLenRef.current === nextShownLen) {
+        return
+      }
+      shownLenRef.current = nextShownLen
+      setShownLen(nextShownLen)
+    }
+
+    if (!animate) {
+      // Snap to the full text when the stream settles.
+      stopRevealLoop()
+      syncShownLen(targetLenRef.current)
+      return
+    }
+
+    const targetLen = targetLenRef.current
+    if (shownLenRef.current > targetLen) {
+      carryRef.current = 0
+      syncShownLen(targetLen)
+      return
+    }
+    if (shownLenRef.current >= targetLen || rafIdRef.current !== null) {
+      carryRef.current = 0
+      return
+    }
+
+    lastFrameAtRef.current = performance.now()
+    rafIdRef.current = requestAnimationFrame(function tick(now) {
+      rafIdRef.current = null
+      if (!animateRef.current) {
+        carryRef.current = 0
+        return
+      }
+
+      const elapsedSeconds = Math.min(
+        (now - lastFrameAtRef.current) / 1000,
+        0.1
+      )
+      lastFrameAtRef.current = now
+
+      const prev = shownLenRef.current
+      const target = targetLenRef.current
+      let next = prev
+
+      if (prev > target) {
+        carryRef.current = 0
+        next = target
+      } else if (prev < target) {
+        const buffered = target - prev
+        const charsPerSecond =
+          buffered > CATCHUP_THRESHOLD_CHARS
+            ? CATCHUP_CHARS_PER_SECOND
+            : STEADY_CHARS_PER_SECOND
+        const exactStep = charsPerSecond * elapsedSeconds + carryRef.current
+        const step = Math.min(
+          Math.floor(exactStep),
+          MAX_CHARS_PER_FRAME,
+          buffered
+        )
+        carryRef.current = exactStep - Math.floor(exactStep)
+        if (step < 1) {
+          next = prev
+        } else {
+          next = Math.min(target, prev + step)
+        }
+      } else {
+        carryRef.current = 0
+      }
+
+      syncShownLen(next)
+      if (next < targetLenRef.current) {
+        rafIdRef.current = requestAnimationFrame(tick)
+      } else {
+        carryRef.current = 0
+      }
+    })
+  }, [animate, text.length])
+
+  return animate ? text.slice(0, shownLen) : text
+}


### PR DESCRIPTION
## Problem

Assistant **text** streams smoothly (it goes through `SmoothResponse`, which
reveals characters on a frame-aligned `requestAnimationFrame` cadence). But the
**Thinking / reasoning** block did not: `ReasoningContent` rendered `part.text`
straight into `Response` on every `THINKING_DELTA`. Since deltas arrive in
uneven, network-sized bursts (and the backend does no emission-side throttling),
the thinking text revealed in those same bursts — a visible "catch up, pause,
catch up" pulse.

## Fix

- Extract the frame-aligned reveal logic out of `SmoothResponse` into a shared
  `useSmoothText(text, animate)` hook in `frontend/src/hooks/`. This keeps the
  reveal cadence in one place and avoids `ai-elements/` importing from `chat/`.
- `SmoothResponse` now just calls the hook (behavior unchanged).
- `ReasoningContent` reveals its text through the same hook while streaming, so
  thinking streams in at a steady rate instead of pulsing.
- The reasoning auto-scroll now also tracks the revealed text, so the tail stays
  pinned to the bottom during catch-up (not just on each delta arrival).

No backend or protocol changes — purely a client-side rendering cadence change.

## Test plan

- `pnpm -C frontend exec jest src/components/ai-elements/reasoning.test.tsx src/components/chat/smooth-response.test.tsx` — 5/5 pass.
- `pnpm -C frontend run typecheck` — clean.
- `pnpm -C frontend exec biome check` on the changed files — clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smooths reasoning token streaming by revealing text at a steady, frame-aligned rate, removing the pulsing effect and matching assistant message streaming. Auto-scroll now follows the revealed thinking text so the tail stays pinned during catch-up.

- **Refactors**
  - Extracted reveal logic into a shared `useSmoothText(text, animate)` hook.
  - Updated `SmoothResponse` to use the hook (behavior unchanged).
  - Applied the hook in `ReasoningContent` to stream thinking smoothly and drive auto-scroll off the revealed text.

<sup>Written for commit b3bd8959614eaab0c40ed7842d898e7b0da69922. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

