### PR TITLE
fix(agents): add case artifact triggers

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/ee/tasks.py
+++ b/packages/tracecat-registry/tracecat_registry/core/ee/tasks.py
@@ -188,6 +188,9 @@ async def delete_task(
         str,
         Doc("The ID of the task to delete."),
     ],
-) -> None:
+) -> dict[str, str]:
     """Delete a case task."""
-    await get_context().cases.delete_task(task_id)
+    ctx = get_context()
+    task = await ctx.cases.get_task(task_id)
+    await ctx.cases.delete_task(task_id)
+    return {"case_id": str(task["case_id"])}

--- a/tests/registry/test_core_cases.py
+++ b/tests/registry/test_core_cases.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import tracecat_registry.core.cases as cases_core
+import tracecat_registry.core.ee.tasks as case_tasks_core
 import tracecat_registry.types as registry_types
 from tracecat_registry.core.cases import (
     add_case_tag,
@@ -36,6 +37,7 @@ from tracecat_registry.core.cases import (
     upload_attachment,
     upload_attachment_from_url,
 )
+from tracecat_registry.core.ee.tasks import delete_task
 from tracecat_registry.sdk.exceptions import (
     TracecatValidationError,
 )
@@ -876,6 +878,26 @@ class TestCoreDeleteCase:
 
         mock_cases_client.delete_case.assert_called_once_with(case_id)
         assert result is None
+
+
+@pytest.mark.anyio
+class TestCoreDeleteTask:
+    """Test cases for case task deletion UDF artifact context."""
+
+    async def test_delete_task_returns_parent_case_marker(self):
+        """Delete task returns parent case ID for artifact projection."""
+        task_id = str(uuid.uuid4())
+        case_id = str(uuid.uuid4())
+        mock_cases_client = AsyncMock()
+        mock_cases_client.get_task.return_value = {"id": task_id, "case_id": case_id}
+        fake_ctx = SimpleNamespace(cases=mock_cases_client)
+
+        with patch.object(case_tasks_core, "get_context", return_value=fake_ctx):
+            result = await delete_task(task_id=task_id)
+
+        mock_cases_client.get_task.assert_awaited_once_with(task_id)
+        mock_cases_client.delete_task.assert_awaited_once_with(task_id)
+        assert result == {"case_id": case_id}
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_stream_artifacts.py
+++ b/tests/unit/test_agent_stream_artifacts.py
@@ -32,6 +32,7 @@ from tracecat.artifacts.projection import (
 from tracecat.artifacts.resolution import resolve_artifact_side_effects
 from tracecat.artifacts.schemas import ArtifactAdapter
 from tracecat.auth.types import Role
+from tracecat.cases.enums import CaseSeverity, CaseStatus
 from tracecat.chat import tokens
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.redis.client import RedisClient
@@ -269,6 +270,158 @@ async def test_resolve_artifact_side_effects_skips_invalid_table_name_ref(
     )
 
     assert resolved == []
+
+
+@pytest.mark.anyio
+async def test_resolve_artifact_side_effects_resolves_case_comment_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    comment_id = uuid.UUID("33333333-3333-4333-8333-333333333333")
+    case_id = uuid.UUID("44444444-4444-4444-8444-444444444444")
+
+    async def fake_get_comment(
+        _service: object,
+        requested_comment_id: uuid.UUID,
+    ) -> SimpleNamespace:
+        assert requested_comment_id == comment_id
+        return SimpleNamespace(case_id=case_id)
+
+    async def fake_get_case(
+        _service: object,
+        requested_case_id: uuid.UUID,
+    ) -> SimpleNamespace:
+        assert requested_case_id == case_id
+        return SimpleNamespace(
+            id=case_id,
+            summary="Suspicious login",
+            severity=CaseSeverity.HIGH,
+            status=CaseStatus.IN_PROGRESS,
+        )
+
+    monkeypatch.setattr(
+        "tracecat.artifacts.resolution.CaseCommentsService.get_comment",
+        fake_get_comment,
+    )
+    monkeypatch.setattr(
+        "tracecat.artifacts.resolution.CasesService.get_case",
+        fake_get_case,
+    )
+
+    artifact = ArtifactAdapter.validate_python(
+        {
+            "type": "case",
+            "id": str(comment_id),
+            "title": str(comment_id),
+            "severity": "unknown",
+            "status": "unknown",
+        }
+    )
+
+    resolved = await resolve_artifact_side_effects(
+        [
+            ArtifactSideEffect(
+                op="upsert",
+                artifact=artifact,
+                identity_ref=ArtifactIdentityRef(
+                    artifact_type="case",
+                    ref=str(comment_id),
+                    ref_kind="comment_id",
+                ),
+            )
+        ],
+        session=cast(AsyncSession, object()),
+        role=Role(
+            type="service",
+            service_id="tracecat-api",
+            workspace_id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+        ),
+    )
+
+    assert len(resolved) == 1
+    case_artifact = resolved[0].artifact
+    assert case_artifact.type == "case"
+    assert case_artifact.id == str(case_id)
+    assert case_artifact.title == "Suspicious login"
+    assert case_artifact.severity == CaseSeverity.HIGH
+    assert case_artifact.status == CaseStatus.IN_PROGRESS
+    assert resolved[0].identity_ref is None
+
+
+@pytest.mark.anyio
+async def test_resolve_artifact_side_effects_resolves_case_task_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task_id = uuid.UUID("55555555-5555-4555-8555-555555555555")
+    case_id = uuid.UUID("66666666-6666-4666-8666-666666666666")
+
+    async def fake_get_task(
+        _service: object,
+        requested_task_id: uuid.UUID,
+    ) -> SimpleNamespace:
+        assert requested_task_id == task_id
+        return SimpleNamespace(case_id=case_id)
+
+    async def fake_get_case(
+        _service: object,
+        requested_case_id: uuid.UUID,
+    ) -> SimpleNamespace:
+        assert requested_case_id == case_id
+        return SimpleNamespace(
+            id=case_id,
+            summary="Containment",
+            severity=CaseSeverity.MEDIUM,
+            status=CaseStatus.NEW,
+        )
+
+    monkeypatch.setattr(
+        "tracecat.artifacts.resolution.CaseTasksService.get_task",
+        fake_get_task,
+    )
+    monkeypatch.setattr(
+        "tracecat.artifacts.resolution.CasesService.get_case",
+        fake_get_case,
+    )
+
+    artifact = ArtifactAdapter.validate_python(
+        {
+            "type": "case",
+            "id": str(task_id),
+            "title": str(task_id),
+            "severity": "unknown",
+            "status": "unknown",
+        }
+    )
+
+    resolved = await resolve_artifact_side_effects(
+        [
+            ArtifactSideEffect(
+                op="upsert",
+                artifact=artifact,
+                identity_ref=ArtifactIdentityRef(
+                    artifact_type="case",
+                    ref=str(task_id),
+                    ref_kind="task_id",
+                ),
+            )
+        ],
+        session=cast(AsyncSession, object()),
+        role=Role(
+            type="service",
+            service_id="tracecat-api",
+            workspace_id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+        ),
+    )
+
+    assert len(resolved) == 1
+    case_artifact = resolved[0].artifact
+    assert case_artifact.type == "case"
+    assert case_artifact.id == str(case_id)
+    assert case_artifact.title == "Containment"
+    assert case_artifact.severity == CaseSeverity.MEDIUM
+    assert case_artifact.status == CaseStatus.NEW
+    assert resolved[0].identity_ref is None
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -228,6 +228,33 @@ def test_artifact_bindings_list_canonical_tool_names() -> None:
         "core.cases.list_cases": "upsert",
         "core.cases.search_cases": "upsert",
         "core.cases.delete_case": "remove",
+        "core.cases.create_comment": "upsert",
+        "core.cases.reply_to_comment": "upsert",
+        "core.cases.update_comment": "upsert",
+        "core.cases.list_case_events": "upsert",
+        "core.cases.list_comments": "upsert",
+        "core.cases.list_comment_threads": "upsert",
+        "core.cases.get_comment_thread": "upsert",
+        "core.cases.assign_user": "upsert",
+        "core.cases.assign_user_by_email": "upsert",
+        "core.cases.add_case_tag": "upsert",
+        "core.cases.remove_case_tag": "upsert",
+        "core.cases.upload_attachment": "upsert",
+        "core.cases.upload_attachment_from_url": "upsert",
+        "core.cases.list_attachments": "upsert",
+        "core.cases.download_attachment": "upsert",
+        "core.cases.get_attachment": "upsert",
+        "core.cases.delete_attachment": "upsert",
+        "core.cases.get_attachment_download_url": "upsert",
+        "core.cases.link_row": "upsert",
+        "core.cases.unlink_row": "upsert",
+        "core.cases.insert_row": "upsert",
+        "core.cases.create_task": "upsert",
+        "core.cases.get_task": "upsert",
+        "core.cases.list_tasks": "upsert",
+        "core.cases.update_task": "upsert",
+        "core.cases.delete_task": "upsert",
+        "core.cases.get_case_metrics": "upsert",
         "core.table.create_table": "upsert",
         "core.table.list_tables": "upsert",
         "core.table.get_table_metadata": "upsert",
@@ -287,6 +314,144 @@ def test_case_delete_tool_result_emits_remove_side_effect() -> None:
             "status": "unknown",
         },
     }
+
+
+def test_case_comment_create_emits_parent_case_upsert_from_input() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.cases.create_comment",
+            tool_input={"case_id": "case_123", "content": "Investigating"},
+            tool_output={"id": "comment_123", "content": "Investigating"},
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert len(effects) == 1
+    assert effects[0].op == "upsert"
+    assert effects[0].identity_ref == ArtifactIdentityRef(
+        artifact_type="case",
+        ref="case_123",
+        ref_kind="id",
+    )
+    assert artifact_data_payload(effects[0].op, effects[0].artifact) == {
+        "op": "upsert",
+        "artifact": {
+            "type": "case",
+            "id": "case_123",
+            "title": "case_123",
+            "scope": {"parentToolCallId": "toolu_123"},
+            "severity": "unknown",
+            "status": "unknown",
+        },
+    }
+
+
+def test_case_comment_update_emits_parent_case_upsert_from_comment_ref() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.cases.update_comment",
+            tool_input={"comment_id": "comment_123", "content": "Updated"},
+            tool_output={"id": "comment_123", "content": "Updated"},
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert len(effects) == 1
+    assert effects[0].op == "upsert"
+    assert effects[0].identity_ref == ArtifactIdentityRef(
+        artifact_type="case",
+        ref="comment_123",
+        ref_kind="comment_id",
+    )
+    assert effects[0].artifact.id == "comment_123"
+
+
+def test_case_task_update_emits_parent_case_upsert_from_output() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.cases.update_task",
+            tool_input={"task_id": "task_123", "status": "completed"},
+            tool_output={
+                "id": "task_123",
+                "case_id": "case_123",
+                "title": "Investigate",
+                "status": "completed",
+            },
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert len(effects) == 1
+    assert effects[0].op == "upsert"
+    assert effects[0].identity_ref == ArtifactIdentityRef(
+        artifact_type="case",
+        ref="case_123",
+        ref_kind="id",
+    )
+    assert effects[0].artifact.id == "case_123"
+
+
+def test_case_row_link_emits_parent_case_upsert_not_row_artifact() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.cases.link_row",
+            tool_input={
+                "case_id": "case_123",
+                "table_id": "table_123",
+                "row_id": "row_123",
+            },
+            tool_output={
+                "id": "case_row_link_123",
+                "case_id": "case_123",
+                "table_id": "table_123",
+                "row_id": "row_123",
+            },
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert len(effects) == 1
+    assert effects[0].artifact.type == "case"
+    assert effects[0].artifact.id == "case_123"
+
+
+def test_case_metrics_emit_one_case_upsert_per_case() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.cases.get_case_metrics",
+            tool_input={"case_ids": ["case_123", "case_456"]},
+            tool_output=[
+                {
+                    "case_id": "case_123",
+                    "case_short_id": "CASE-0123",
+                    "case_severity": "high",
+                    "case_status": "new",
+                },
+                {
+                    "case_id": "case_123",
+                    "case_short_id": "CASE-0123",
+                    "case_severity": "high",
+                    "case_status": "new",
+                },
+                {
+                    "case_id": "case_456",
+                    "case_short_id": "CASE-0456",
+                    "case_severity": "medium",
+                    "case_status": "closed",
+                },
+            ],
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert [effect.artifact.id for effect in effects] == ["case_123", "case_456"]
+    assert [effect.artifact.title for effect in effects] == ["CASE-0123", "CASE-0456"]
+    assert [effect.identity_ref for effect in effects] == [None, None]
 
 
 def test_table_tool_result_content_block_emits_upsert_side_effect() -> None:

--- a/tracecat/artifacts/bindings.py
+++ b/tracecat/artifacts/bindings.py
@@ -26,7 +26,7 @@ from tracecat.artifacts.schemas import (
 from tracecat.cases.enums import CaseSeverity, CaseStatus
 
 type RunStatus = Literal["running", "success", "failed", "cancelled"]
-type ArtifactIdentityRefKind = Literal["id", "name"]
+type ArtifactIdentityRefKind = Literal["id", "name", "comment_id", "task_id"]
 
 
 class CaseArtifactPayload(TypedDict):
@@ -101,6 +101,38 @@ class _CaseToolResult(_ArtifactProjectionModel):
 
 class _CaseDeleteToolInput(_ArtifactProjectionModel):
     case_id: str = Field(validation_alias=AliasChoices("case_id", "caseId", "id"))
+
+
+class _CaseIdToolInput(_ArtifactProjectionModel):
+    case_id: str = Field(validation_alias=AliasChoices("case_id", "caseId"))
+
+
+class _CaseIdToolResult(_ArtifactProjectionModel):
+    case_id: str = Field(validation_alias=AliasChoices("case_id", "caseId"))
+
+
+class _CaseCommentToolInput(_ArtifactProjectionModel):
+    comment_id: str = Field(validation_alias=AliasChoices("comment_id", "commentId"))
+
+
+class _CaseTaskToolInput(_ArtifactProjectionModel):
+    task_id: str = Field(validation_alias=AliasChoices("task_id", "taskId"))
+
+
+class _CaseMetricToolResult(_ArtifactProjectionModel):
+    case_id: str = Field(validation_alias=AliasChoices("case_id", "caseId"))
+    title: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("case_short_id", "caseShortId", "short_id"),
+    )
+    severity: CaseSeverity = Field(
+        default=CaseSeverity.UNKNOWN,
+        validation_alias=AliasChoices("case_severity", "caseSeverity", "severity"),
+    )
+    status: CaseStatus = Field(
+        default=CaseStatus.UNKNOWN,
+        validation_alias=AliasChoices("case_status", "caseStatus", "status"),
+    )
 
 
 class _TableToolResult(_ArtifactProjectionModel):
@@ -227,6 +259,40 @@ def _build_deleted_case_artifact(ctx: ArtifactProjectionContext) -> Artifact | N
     return _deleted_case_artifact(ctx.tool_input, ctx.tool_call_id)
 
 
+def _build_case_parent_artifact(ctx: ArtifactProjectionContext) -> Artifact | None:
+    artifact = _case_artifact_from_case_id_output(
+        ctx.tool_output,
+        ctx.tool_call_id,
+    )
+    if artifact is not None:
+        return artifact
+    return _case_artifact_from_case_id_input(ctx.tool_input, ctx.tool_call_id)
+
+
+def _build_case_from_comment_artifact(
+    ctx: ArtifactProjectionContext,
+) -> Artifact | None:
+    return _case_artifact_from_comment_input(ctx.tool_input, ctx.tool_call_id)
+
+
+def _build_case_metrics_artifacts(ctx: ArtifactProjectionContext) -> Iterable[Artifact]:
+    return _case_metric_artifacts_from_output(ctx.tool_output, ctx.tool_call_id)
+
+
+def _case_identity_from_parent_ref(
+    ctx: ArtifactProjectionContext,
+) -> ArtifactIdentityRef | None:
+    if ref := _case_identity_ref_from_case_id_output(ctx.tool_output):
+        return ref
+    return _case_identity_ref_from_case_id_input(ctx.tool_input)
+
+
+def _case_identity_from_comment_input(
+    ctx: ArtifactProjectionContext,
+) -> ArtifactIdentityRef | None:
+    return _case_identity_ref_from_comment_input(ctx.tool_input)
+
+
 def _build_table_mutation_artifact(ctx: ArtifactProjectionContext) -> Artifact | None:
     artifact = _table_artifact_from_output(ctx.tool_output, ctx.tool_call_id)
     if artifact is not None:
@@ -281,6 +347,8 @@ ARTIFACT_BINDINGS: tuple[ArtifactBinding, ...] = (
             "core.cases.create_case",
             "core.cases.update_case",
             "core.cases.get_case",
+            "core.cases.assign_user",
+            "core.cases.assign_user_by_email",
         ),
         op="upsert",
         build=_build_case_artifact,
@@ -294,6 +362,49 @@ ARTIFACT_BINDINGS: tuple[ArtifactBinding, ...] = (
         tool_names=("core.cases.delete_case",),
         op="remove",
         build=_build_deleted_case_artifact,
+    ),
+    ArtifactBinding(
+        tool_names=(
+            "core.cases.create_comment",
+            "core.cases.reply_to_comment",
+            "core.cases.list_case_events",
+            "core.cases.list_comments",
+            "core.cases.list_comment_threads",
+            "core.cases.add_case_tag",
+            "core.cases.remove_case_tag",
+            "core.cases.upload_attachment",
+            "core.cases.upload_attachment_from_url",
+            "core.cases.list_attachments",
+            "core.cases.download_attachment",
+            "core.cases.get_attachment",
+            "core.cases.delete_attachment",
+            "core.cases.get_attachment_download_url",
+            "core.cases.link_row",
+            "core.cases.unlink_row",
+            "core.cases.insert_row",
+            "core.cases.create_task",
+            "core.cases.get_task",
+            "core.cases.list_tasks",
+            "core.cases.update_task",
+            "core.cases.delete_task",
+        ),
+        op="upsert",
+        build=_build_case_parent_artifact,
+        identity=_case_identity_from_parent_ref,
+    ),
+    ArtifactBinding(
+        tool_names=(
+            "core.cases.update_comment",
+            "core.cases.get_comment_thread",
+        ),
+        op="upsert",
+        build=_build_case_from_comment_artifact,
+        identity=_case_identity_from_comment_input,
+    ),
+    ArtifactBinding(
+        tool_names=("core.cases.get_case_metrics",),
+        op="upsert",
+        build=_build_case_metrics_artifacts,
     ),
     ArtifactBinding(
         tool_names=(
@@ -525,6 +636,133 @@ def _case_artifacts_from_output(
             yield ArtifactAdapter.validate_python(
                 _with_parent_scope(payload, tool_call_id)
             )
+
+
+def _case_artifact_from_case_id(
+    case_id: str,
+    tool_call_id: str | None,
+    *,
+    title: str | None = None,
+    severity: CaseSeverity = CaseSeverity.UNKNOWN,
+    status: CaseStatus = CaseStatus.UNKNOWN,
+) -> Artifact:
+    payload: CaseArtifactPayload = {
+        "type": "case",
+        "id": case_id,
+        "title": title or case_id,
+        "severity": severity,
+        "status": status,
+    }
+    return ArtifactAdapter.validate_python(_with_parent_scope(payload, tool_call_id))
+
+
+def _case_artifact_from_case_id_input(
+    value: Mapping[str, Any] | None,
+    tool_call_id: str | None,
+) -> Artifact | None:
+    if value is None:
+        return None
+
+    result = _CaseIdToolInput.try_validate(value)
+    if result is None:
+        return None
+    return _case_artifact_from_case_id(result.case_id, tool_call_id)
+
+
+def _case_artifact_from_case_id_output(
+    value: Any,
+    tool_call_id: str | None,
+) -> Artifact | None:
+    data = _mapping_from_tool_output(value)
+    if data is None:
+        return None
+
+    result = _CaseIdToolResult.try_validate(data)
+    if result is None:
+        return None
+    return _case_artifact_from_case_id(result.case_id, tool_call_id)
+
+
+def _case_artifact_from_comment_input(
+    value: Mapping[str, Any] | None,
+    tool_call_id: str | None,
+) -> Artifact | None:
+    if value is None:
+        return None
+
+    result = _CaseCommentToolInput.try_validate(value)
+    if result is None:
+        return None
+    return _case_artifact_from_case_id(result.comment_id, tool_call_id)
+
+
+def _case_metric_artifacts_from_output(
+    value: Any,
+    tool_call_id: str | None,
+) -> Iterator[Artifact]:
+    seen_case_ids: set[str] = set()
+    for data in _iter_mappings_from_tool_output(value):
+        if result := _CaseMetricToolResult.try_validate(data):
+            if result.case_id in seen_case_ids:
+                continue
+            seen_case_ids.add(result.case_id)
+            yield _case_artifact_from_case_id(
+                result.case_id,
+                tool_call_id,
+                title=result.title,
+                severity=result.severity,
+                status=result.status,
+            )
+
+
+def _case_identity_ref_from_case_id_input(
+    value: Mapping[str, Any] | None,
+) -> ArtifactIdentityRef | None:
+    if value is None:
+        return None
+
+    if result := _CaseIdToolInput.try_validate(value):
+        return ArtifactIdentityRef(
+            artifact_type="case",
+            ref=result.case_id,
+            ref_kind="id",
+        )
+    return None
+
+
+def _case_identity_ref_from_case_id_output(value: Any) -> ArtifactIdentityRef | None:
+    data = _mapping_from_tool_output(value)
+    if data is None:
+        return None
+
+    if result := _CaseIdToolResult.try_validate(data):
+        return ArtifactIdentityRef(
+            artifact_type="case",
+            ref=result.case_id,
+            ref_kind="id",
+        )
+    return None
+
+
+def _case_identity_ref_from_comment_input(
+    value: Mapping[str, Any] | None,
+) -> ArtifactIdentityRef | None:
+    if value is None:
+        return None
+
+    if result := _CaseCommentToolInput.try_validate(value):
+        return ArtifactIdentityRef(
+            artifact_type="case",
+            ref=result.comment_id,
+            ref_kind="comment_id",
+        )
+    if result := _CaseTaskToolInput.try_validate(value):
+        return ArtifactIdentityRef(
+            artifact_type="case",
+            ref=result.task_id,
+            ref_kind="task_id",
+        )
+    return None
 
 
 def _deleted_case_artifact(

--- a/tracecat/artifacts/resolution.py
+++ b/tracecat/artifacts/resolution.py
@@ -10,6 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.artifacts.bindings import ArtifactIdentityRef, ArtifactSideEffect
 from tracecat.auth.types import Role
+from tracecat.cases.enums import CaseSeverity, CaseStatus
+from tracecat.cases.service import CaseCommentsService, CasesService, CaseTasksService
 from tracecat.exceptions import TracecatNotFoundError
 from tracecat.logger import logger
 from tracecat.tables.service import TablesService
@@ -19,6 +21,8 @@ from tracecat.tables.service import TablesService
 class _ResolvedArtifactIdentity:
     id: str
     title: str
+    severity: CaseSeverity | None = None
+    status: CaseStatus | None = None
 
 
 async def resolve_artifact_side_effects(
@@ -31,6 +35,9 @@ async def resolve_artifact_side_effects(
     if not effects:
         return []
 
+    case_service: CasesService | None = None
+    case_comments_service: CaseCommentsService | None = None
+    case_tasks_service: CaseTasksService | None = None
     table_service: TablesService | None = None
     resolved_effects: list[ArtifactSideEffect] = []
     for effect in effects:
@@ -41,6 +48,27 @@ async def resolve_artifact_side_effects(
 
         resolved_identity: _ResolvedArtifactIdentity | None = None
         match identity_ref.artifact_type:
+            case "case":
+                case_service = case_service or CasesService(session, role=role)
+                if identity_ref.ref_kind == "comment_id":
+                    case_comments_service = (
+                        case_comments_service
+                        or CaseCommentsService(
+                            session,
+                            role=role,
+                        )
+                    )
+                if identity_ref.ref_kind == "task_id":
+                    case_tasks_service = case_tasks_service or CaseTasksService(
+                        session,
+                        role=role,
+                    )
+                resolved_identity = await _resolve_case_identity_ref(
+                    case_service,
+                    identity_ref,
+                    comment_service=case_comments_service,
+                    task_service=case_tasks_service,
+                )
             case "table":
                 table_service = table_service or TablesService(session, role=role)
                 resolved_identity = await _resolve_table_identity_ref(
@@ -58,18 +86,62 @@ async def resolve_artifact_side_effects(
             )
             continue
 
+        update: dict[str, object] = {
+            "id": resolved_identity.id,
+            "title": resolved_identity.title,
+        }
+        if effect.artifact.type == "case":
+            if resolved_identity.severity is not None:
+                update["severity"] = resolved_identity.severity
+            if resolved_identity.status is not None:
+                update["status"] = resolved_identity.status
+
         resolved_effects.append(
             ArtifactSideEffect(
                 op=effect.op,
-                artifact=effect.artifact.model_copy(
-                    update={
-                        "id": resolved_identity.id,
-                        "title": resolved_identity.title,
-                    }
-                ),
+                artifact=effect.artifact.model_copy(update=update),
             )
         )
     return resolved_effects
+
+
+async def _resolve_case_identity_ref(
+    case_service: CasesService,
+    identity_ref: ArtifactIdentityRef,
+    *,
+    comment_service: CaseCommentsService | None = None,
+    task_service: CaseTasksService | None = None,
+) -> _ResolvedArtifactIdentity | None:
+    try:
+        match identity_ref.ref_kind:
+            case "id":
+                case_id = uuid.UUID(identity_ref.ref)
+            case "comment_id":
+                if comment_service is None:
+                    return None
+                comment = await comment_service.get_comment(uuid.UUID(identity_ref.ref))
+                if comment is None:
+                    return None
+                case_id = comment.case_id
+            case "task_id":
+                if task_service is None:
+                    return None
+                task = await task_service.get_task(uuid.UUID(identity_ref.ref))
+                case_id = task.case_id
+            case _:
+                return None
+    except (TracecatNotFoundError, ValueError):
+        return None
+
+    case = await case_service.get_case(case_id)
+    if case is None:
+        return None
+    return _ResolvedArtifactIdentity(
+        id=str(case.id),
+        title=case.summary,
+        severity=case.severity,
+        status=case.status,
+    )
 
 
 async def _resolve_table_identity_ref(


### PR DESCRIPTION
## Summary

- Add missing case artifact upsert triggers for case comments, tags, attachments, row links, tasks, assignment, and metrics tools
- Resolve case artifacts from case IDs, comment IDs, and task IDs so streamed artifacts hydrate title, severity, and status
- Return the parent case marker from `core.cases.delete_task` so post-delete artifact projection can still upsert the case

## Testing

- `uv run pytest tests/unit/test_artifacts.py tests/unit/test_agent_stream_artifacts.py tests/registry/test_core_cases.py -q`
- `uv run ruff check tracecat/artifacts/bindings.py tracecat/artifacts/resolution.py packages/tracecat-registry/tracecat_registry/core/ee/tasks.py tests/unit/test_artifacts.py tests/unit/test_agent_stream_artifacts.py tests/registry/test_core_cases.py`
- `uv run ruff format --check tracecat/artifacts/bindings.py tracecat/artifacts/resolution.py packages/tracecat-registry/tracecat_registry/core/ee/tasks.py tests/unit/test_artifacts.py tests/unit/test_agent_stream_artifacts.py tests/registry/test_core_cases.py`
- `uv run basedpyright tracecat/artifacts/bindings.py tracecat/artifacts/resolution.py packages/tracecat-registry/tracecat_registry/core/ee/tasks.py tests/unit/test_artifacts.py tests/unit/test_agent_stream_artifacts.py tests/registry/test_core_cases.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing case artifact triggers and resolve case identity from case, comment, and task references so streamed case artifacts hydrate title, severity, and status. Also return the parent case from `core.cases.delete_task` to keep artifact upserts working after task deletion.

- **New Features**
  - Added upsert triggers for case comments, tags, attachments, row links, tasks, assignments, and metrics in `tracecat/artifacts/bindings.py`.
  - Supported `identity_ref` kinds `comment_id` and `task_id`, resolving to the parent case and hydrating title/severity/status in `tracecat/artifacts/resolution.py`.
  - Updated `packages/tracecat-registry/tracecat_registry/core/ee/tasks.py` so `core.cases.delete_task` returns `{"case_id": ...}` for post-delete projections.

<sup>Written for commit 2bb155edf94c02a3f70642fd0785ff9b9994ec74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

