### PR TITLE
feat(integrations): add GitHub App service OAuth provider

### DIFF
--- a/tests/unit/test_github_app_oauth_provider.py
+++ b/tests/unit/test_github_app_oauth_provider.py
@@ -1,0 +1,121 @@
+import json
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+import respx
+from pydantic import SecretStr
+
+from tracecat.integrations.enums import OAuthGrantType
+from tracecat.integrations.providers import get_provider_class
+from tracecat.integrations.providers.github.oauth import GitHubAppOAuthProvider
+from tracecat.integrations.schemas import ProviderConfig, ProviderKey
+
+
+def github_app_secret(**overrides: object) -> str:
+    data: dict[str, object] = {
+        "private_key": "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
+        "installation_id": "98765",
+    }
+    data.update(overrides)
+    return json.dumps(data)
+
+
+def test_github_app_provider_is_registered_for_client_credentials():
+    provider = get_provider_class(
+        ProviderKey(id="github", grant_type=OAuthGrantType.CLIENT_CREDENTIALS)
+    )
+
+    assert provider is GitHubAppOAuthProvider
+
+
+def test_github_app_provider_uses_client_id_as_app_id():
+    provider = GitHubAppOAuthProvider(
+        client_id="12345",
+        client_secret=github_app_secret(),
+    )
+
+    assert provider.client_id == "12345"
+    assert provider.installation_id == "98765"
+
+
+def test_github_app_provider_allows_app_id_in_json_credentials():
+    provider = GitHubAppOAuthProvider(
+        client_secret=github_app_secret(app_id="12345"),
+    )
+
+    assert provider.client_id == "12345"
+
+
+def test_github_app_provider_rejects_missing_installation_id():
+    with pytest.raises(ValueError, match="installation_id"):
+        GitHubAppOAuthProvider(
+            client_id="12345",
+            client_secret=github_app_secret(installation_id=""),
+        )
+
+
+def test_github_app_provider_rejects_missing_private_key():
+    with pytest.raises(ValueError, match="private_key"):
+        GitHubAppOAuthProvider(
+            client_id="12345",
+            client_secret=github_app_secret(private_key=""),
+        )
+
+
+def test_github_app_provider_can_be_built_from_provider_config():
+    provider = GitHubAppOAuthProvider.from_config(
+        ProviderConfig(
+            client_id="12345",
+            client_secret=SecretStr(github_app_secret()),
+            token_endpoint="https://api.github.example.com",
+        )
+    )
+
+    assert provider.client_id == "12345"
+    assert provider.token_endpoint == "https://api.github.example.com"
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_github_app_provider_mints_installation_token(monkeypatch):
+    captured_payload = {}
+
+    def fake_encode(payload, key, algorithm):
+        captured_payload.update(payload)
+        assert key == "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"
+        assert algorithm == "RS256"
+        return "app-jwt"
+
+    monkeypatch.setattr(
+        "tracecat.integrations.providers.github.oauth.jwt.encode", fake_encode
+    )
+    route = respx.post(
+        "https://api.github.com/app/installations/98765/access_tokens"
+    ).mock(
+        return_value=httpx.Response(
+            201,
+            json={
+                "token": "installation-token",
+                "expires_at": (datetime.now(UTC) + timedelta(minutes=30)).isoformat(),
+            },
+        )
+    )
+    provider = GitHubAppOAuthProvider(
+        client_id="12345",
+        client_secret=github_app_secret(),
+    )
+
+    result = await provider.get_client_credentials_token()
+
+    assert result.access_token.get_secret_value() == "installation-token"
+    assert result.refresh_token is None
+    assert result.token_type == "Bearer"
+    assert 0 < result.expires_in <= 1800
+    assert captured_payload["iss"] == "12345"
+    assert captured_payload["exp"] - captured_payload["iat"] == 600
+    assert route.called
+    request = route.calls.last.request
+    assert request.headers["Authorization"] == "Bearer app-jwt"
+    assert request.headers["Accept"] == "application/vnd.github+json"
+    assert request.headers["X-GitHub-Api-Version"] == "2026-03-10"

--- a/tracecat/integrations/providers/__init__.py
+++ b/tracecat/integrations/providers/__init__.py
@@ -2,7 +2,10 @@ from typing import Final
 
 from tracecat.integrations.providers.base import BaseOAuthProvider
 from tracecat.integrations.providers.github.mcp import GitHubMCPProvider
-from tracecat.integrations.providers.github.oauth import GitHubOAuthProvider
+from tracecat.integrations.providers.github.oauth import (
+    GitHubAppOAuthProvider,
+    GitHubOAuthProvider,
+)
 from tracecat.integrations.providers.google import (
     GoogleDocsOAuthProvider,
     GoogleServiceAccountOAuthProvider,
@@ -41,6 +44,7 @@ from tracecat.integrations.schemas import ProviderKey
 
 _PROVIDER_CLASSES: list[type[BaseOAuthProvider]] = [
     GitHubOAuthProvider,
+    GitHubAppOAuthProvider,
     GitHubMCPProvider,
     GoogleDocsOAuthProvider,
     GoogleDriveACProvider,

--- a/tracecat/integrations/providers/github/oauth.py
+++ b/tracecat/integrations/providers/github/oauth.py
@@ -1,9 +1,25 @@
-"""GitHub OAuth provider using authorization code flow."""
+"""GitHub OAuth providers."""
 
+import time
+from datetime import UTC, datetime
 from typing import ClassVar
 
-from tracecat.integrations.providers.base import AuthorizationCodeOAuthProvider
+import httpx
+import jwt
+from pydantic import SecretStr
+
+from tracecat.integrations.providers.base import (
+    AuthorizationCodeOAuthProvider,
+    ServiceAccountOAuthProvider,
+)
 from tracecat.integrations.schemas import ProviderMetadata, ProviderScopes
+from tracecat.integrations.types import TokenResponse
+
+GITHUB_API_BASE_URL = "https://api.github.com"
+GITHUB_APP_AUTH_URL = "https://github.com/apps"
+GITHUB_OAUTH_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+GITHUB_OAUTH_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_API_VERSION = "2026-03-10"
 
 
 class GitHubOAuthProvider(AuthorizationCodeOAuthProvider):
@@ -22,9 +38,115 @@ class GitHubOAuthProvider(AuthorizationCodeOAuthProvider):
         troubleshooting_url="https://docs.github.com/en/apps/oauth-apps/maintaining-oauth-apps/troubleshooting-authorization-request-errors",
     )
     # Endpoints stay optional to respect BaseOAuthProvider's nullable defaults
-    default_authorization_endpoint: ClassVar[str | None] = (
-        "https://github.com/login/oauth/authorize"
+    default_authorization_endpoint: ClassVar[str | None] = GITHUB_OAUTH_AUTHORIZE_URL
+    default_token_endpoint: ClassVar[str | None] = GITHUB_OAUTH_TOKEN_URL
+
+
+class GitHubAppOAuthProvider(ServiceAccountOAuthProvider):
+    """GitHub App provider using installation access tokens."""
+
+    id: ClassVar[str] = "github"
+    scopes: ClassVar[ProviderScopes] = ProviderScopes(default=[])
+    metadata: ClassVar[ProviderMetadata] = ProviderMetadata(
+        id="github",
+        name="GitHub App (Service account)",
+        description=(
+            "Authenticate to GitHub REST APIs using a GitHub App installation token."
+        ),
+        requires_config=True,
+        enabled=True,
+        api_docs_url="https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app",
+        setup_guide_url="https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app",
+        troubleshooting_url="https://docs.github.com/en/apps/maintaining-github-apps/troubleshooting-github-app-installation-token-generation",
     )
-    default_token_endpoint: ClassVar[str | None] = (
-        "https://github.com/login/oauth/access_token"
-    )
+    default_authorization_endpoint: ClassVar[str | None] = GITHUB_APP_AUTH_URL
+    default_token_endpoint: ClassVar[str | None] = GITHUB_API_BASE_URL
+
+    @property
+    def installation_id(self) -> str:
+        value = self.service_account_info["installation_id"]
+        return str(value).strip()
+
+    @property
+    def private_key(self) -> str:
+        value = self.service_account_info["private_key"]
+        return str(value)
+
+    def _load_service_account_info(self, client_secret: str | None) -> dict:
+        info = super()._load_service_account_info(client_secret)
+
+        private_key = info.get("private_key")
+        if not isinstance(private_key, str) or not private_key.strip():
+            raise ValueError("GitHub App credentials must include 'private_key'.")
+
+        installation_id = str(info.get("installation_id", "")).strip()
+        if not installation_id:
+            raise ValueError("GitHub App credentials must include 'installation_id'.")
+
+        return info
+
+    def _derive_client_id(self, info: dict, configured_client_id: str | None) -> str:
+        app_id = str(info.get("app_id") or configured_client_id or "").strip()
+        if not app_id:
+            raise ValueError(
+                "GitHub App ID is required as the Client ID or as 'app_id' in the JSON credentials."
+            )
+        return app_id
+
+    def _create_app_jwt(self) -> str:
+        now = int(time.time())
+        payload = {
+            "iat": now - 60,
+            "exp": now + 540,
+            "iss": self.client_id,
+        }
+        token = jwt.encode(payload, self.private_key, algorithm="RS256")
+        if isinstance(token, bytes):
+            return token.decode()
+        return token
+
+    async def get_client_credentials_token(self) -> TokenResponse:
+        app_jwt = self._create_app_jwt()
+        url = (
+            f"{self.token_endpoint.rstrip('/')}/app/installations/"
+            f"{self.installation_id}/access_tokens"
+        )
+
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.post(
+                url,
+                headers={
+                    "Authorization": f"Bearer {app_jwt}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": GITHUB_API_VERSION,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        token = data.get("token")
+        if not isinstance(token, str) or not token.strip():
+            raise ValueError("GitHub did not return an installation access token.")
+
+        return TokenResponse(
+            access_token=SecretStr(token),
+            refresh_token=None,
+            expires_in=self._compute_expires_in(data.get("expires_at")),
+            scope="",
+            token_type="Bearer",
+        )
+
+    @staticmethod
+    def _compute_expires_in(expires_at: object) -> int:
+        if not isinstance(expires_at, str) or not expires_at.strip():
+            return 3600
+
+        try:
+            expiry = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+        except ValueError:
+            return 3600
+
+        if expiry.tzinfo is None:
+            expiry = expiry.replace(tzinfo=UTC)
+        delta = int((expiry.astimezone(UTC) - datetime.now(UTC)).total_seconds())
+        return max(delta, 0)


### PR DESCRIPTION
## Summary
- add a GitHub App service-account OAuth provider for provider_id=github + client_credentials
- mint GitHub App installation access tokens from app ID, private key, and installation ID
- register the provider so registry templates can resolve GITHUB_SERVICE_TOKEN

## Testing
- uv run ruff check tracecat/integrations/providers/github/oauth.py tracecat/integrations/providers/__init__.py tests/unit/test_github_app_oauth_provider.py
- uv run ruff format --check tracecat/integrations/providers/github/oauth.py tracecat/integrations/providers/__init__.py tests/unit/test_github_app_oauth_provider.py
- uv run basedpyright tracecat/integrations/providers/github/oauth.py tests/unit/test_github_app_oauth_provider.py
- uv run pytest tests/unit/test_integrations_service.py::TestClientCredentialsOAuthProvider tests/unit/test_github_app_oauth_provider.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub App service-account OAuth provider for the client credentials flow to mint installation access tokens for REST API calls. Registers the provider so registry templates can resolve GITHUB_SERVICE_TOKEN.

- **New Features**
  - Introduced GitHub App provider (`provider_id=github`, `client_credentials`) that signs a JWT with the App’s private key and exchanges it for an installation token via `POST /app/installations/{id}/access_tokens` (default base `https://api.github.com`).
  - Accepts App ID from `client_id` or `app_id` in JSON, validates `private_key` and `installation_id`, and sets GitHub headers including API version `2026-03-10`.
  - Registered in `tracecat.integrations.providers` and added unit tests for registration, config parsing, and token minting.

<sup>Written for commit c1379ce30d733cf1d7319a3efe648b8424b3acf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

