### PR TITLE
feat(rbac): accept service-account actors and make org:rbac:* assignable

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/rbac/router.py
+++ b/packages/tracecat-ee/tracecat_ee/rbac/router.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError
 
-from tracecat.auth.dependencies import OrgUserRole
+from tracecat.auth.dependencies import OrgActorRole
 from tracecat.authz.controls import require_scope
 from tracecat.authz.enums import ScopeSource
 from tracecat.db.dependencies import AsyncDBSession
@@ -38,7 +38,7 @@ from tracecat_ee.rbac.service import RBACService
 
 
 async def _require_rbac_entitlement(
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
 ) -> None:
     """Router-level dependency that gates all EE RBAC endpoints behind the RBAC entitlement."""
@@ -60,7 +60,7 @@ scopes_router = APIRouter(
 @require_scope("org:rbac:read")
 async def list_scopes(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     include_system: bool = Query(True, description="Include system/registry scopes"),
     source: ScopeSource | None = Query(None, description="Filter by scope source"),
@@ -81,7 +81,7 @@ async def list_scopes(
 @require_scope("org:rbac:read")
 async def get_scope(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     scope_id: UUID,
 ) -> ScopeRead:
@@ -101,7 +101,7 @@ async def get_scope(
 @require_scope("org:rbac:create")
 async def create_scope(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     params: ScopeCreate,
 ) -> ScopeRead:
@@ -131,7 +131,7 @@ async def create_scope(
 @require_scope("org:rbac:delete")
 async def delete_scope(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     scope_id: UUID,
 ) -> None:
@@ -165,7 +165,7 @@ roles_router = APIRouter(
 @require_scope("org:rbac:read")
 async def get_role(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     role_id: UUID,
 ) -> RoleReadWithScopes:
@@ -197,7 +197,7 @@ async def get_role(
 @require_scope("org:rbac:create")
 async def create_role(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     params: RoleCreate,
 ) -> RoleReadWithScopes:
@@ -238,7 +238,7 @@ async def create_role(
 @require_scope("org:rbac:update")
 async def update_role(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     role_id: UUID,
     params: RoleUpdate,
@@ -281,7 +281,7 @@ async def update_role(
 @require_scope("org:rbac:delete")
 async def delete_role(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     role_id: UUID,
 ) -> None:
@@ -319,7 +319,7 @@ groups_router = APIRouter(
 @require_scope("org:rbac:read")
 async def list_groups(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
 ) -> GroupList:
     """List groups for the organization.
@@ -351,7 +351,7 @@ async def list_groups(
 @require_scope("org:rbac:read")
 async def get_group(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     group_id: UUID,
 ) -> GroupReadWithMembers:
@@ -393,7 +393,7 @@ async def get_group(
 @require_scope("org:rbac:create")
 async def create_group(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     params: GroupCreate,
 ) -> GroupReadWithMembers:
@@ -429,7 +429,7 @@ async def create_group(
 @require_scope("org:rbac:update")
 async def update_group(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     group_id: UUID,
     params: GroupUpdate,
@@ -479,7 +479,7 @@ async def update_group(
 @require_scope("org:rbac:delete")
 async def delete_group(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     group_id: UUID,
 ) -> None:
@@ -508,7 +508,7 @@ async def delete_group(
 @require_scope("org:rbac:update")
 async def add_group_member(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     group_id: UUID,
     params: GroupMemberAdd,
@@ -541,7 +541,7 @@ async def add_group_member(
 @require_scope("org:rbac:update")
 async def remove_group_member(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     group_id: UUID,
     user_id: UUID,
@@ -572,7 +572,7 @@ assignments_router = APIRouter(
 @require_scope("org:rbac:read")
 async def list_assignments(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     group_id: UUID | None = Query(None, description="Filter by group ID"),
     workspace_id: UUID | None = Query(None, description="Filter by workspace ID"),
@@ -612,7 +612,7 @@ async def list_assignments(
 @require_scope("org:rbac:read")
 async def get_assignment(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     assignment_id: UUID,
 ) -> GroupRoleAssignmentReadWithDetails:
@@ -647,7 +647,7 @@ async def get_assignment(
 @require_scope("org:rbac:create")
 async def create_assignment(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     params: GroupRoleAssignmentCreate,
 ) -> GroupRoleAssignmentReadWithDetails:
@@ -693,7 +693,7 @@ async def create_assignment(
 @require_scope("org:rbac:update")
 async def update_assignment(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     assignment_id: UUID,
     params: GroupRoleAssignmentUpdate,
@@ -727,7 +727,7 @@ async def update_assignment(
 @require_scope("org:rbac:delete")
 async def delete_assignment(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     assignment_id: UUID,
 ) -> None:

--- a/tests/unit/test_service_accounts_validation.py
+++ b/tests/unit/test_service_accounts_validation.py
@@ -101,6 +101,10 @@ def test_workspace_service_account_assignable_scope_rejects_user_only_scopes(
         "workspace:create",
         "workflow:update",
         "table:read",
+        "org:rbac:read",
+        "org:rbac:create",
+        "org:rbac:update",
+        "org:rbac:delete",
         "action:tools.slack.post_message:execute",
     ],
 )
@@ -119,7 +123,6 @@ def test_org_service_account_assignable_scope_allows_supported_api_key_scopes(
     [
         "org:settings:read",
         "org:settings:update",
-        "org:rbac:read",
         "org:registry:read",
         "org:member:invite",
         "variable:read",

--- a/tracecat/authz/rbac/router.py
+++ b/tracecat/authz/rbac/router.py
@@ -23,7 +23,7 @@ from tracecat_ee.rbac.schemas import (
 from tracecat_ee.rbac.service import RBACService
 
 from tracecat.auth.credentials import RoleACL
-from tracecat.auth.dependencies import OrgUserRole
+from tracecat.auth.dependencies import OrgActorRole
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
@@ -82,7 +82,7 @@ roles_router = APIRouter(prefix="/rbac/roles", tags=["rbac"])
 @roles_router.get("", response_model=RoleList)
 async def list_roles(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
 ) -> RoleList:
     """List roles for the organization.
@@ -152,7 +152,7 @@ def _assignment_to_read(
 @require_scope("org:rbac:read")
 async def list_user_assignments(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     user_id: UUID | None = Query(None, description="Filter by user ID"),
     workspace_id: UUID | None = Query(None, description="Filter by workspace ID"),
@@ -175,7 +175,7 @@ async def list_user_assignments(
 @require_scope("org:rbac:read")
 async def get_user_assignment(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     assignment_id: UUID,
 ) -> UserRoleAssignmentReadWithDetails:
@@ -196,7 +196,7 @@ async def get_user_assignment(
 @require_scope("org:rbac:create")
 async def create_user_assignment(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     params: UserRoleAssignmentCreate,
 ) -> UserRoleAssignmentReadWithDetails:
@@ -231,7 +231,7 @@ async def create_user_assignment(
 @require_scope("org:rbac:update")
 async def update_user_assignment(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     assignment_id: UUID,
     params: UserRoleAssignmentUpdate,
@@ -254,7 +254,7 @@ async def update_user_assignment(
 @require_scope("org:rbac:delete")
 async def delete_user_assignment(
     *,
-    role: OrgUserRole,
+    role: OrgActorRole,
     session: AsyncDBSession,
     assignment_id: UUID,
 ) -> None:

--- a/tracecat/service_accounts/constants.py
+++ b/tracecat/service_accounts/constants.py
@@ -64,6 +64,12 @@ ORG_SERVICE_ACCOUNT_ASSIGNABLE_SCOPES: frozenset[str] = (
             "org:secret:delete",
             "org:workspace:read",
             "workspace:create",
+            # RBAC management — lets a service account mirror user/role
+            # assignments across workspaces (e.g. membership-sync principals).
+            "org:rbac:read",
+            "org:rbac:create",
+            "org:rbac:update",
+            "org:rbac:delete",
         }
     )
 )


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

The portal's workspace **membership-sync** principal (a Tracecat service account / API key) calls `GET` and `PATCH /rbac/user-assignments` to mirror the Default Workspace's user→role assignments into every tenant workspace. Both calls fail today for two coupled reasons:

1. **ACL rejects service accounts.** Every org RBAC endpoint — OSS `user-assignments` + `roles`, and the EE `scopes`/`roles`/`groups`/`assignments` routers — gated on `OrgUserRole`, whose `RoleACL` sets `allow_api_key=False`. A service-account key is rejected at the dependency layer *before* `@require_scope` ever runs, regardless of the scopes it holds.

2. **`org:rbac:*` was never assignable to a service account.** `org:rbac:read/create/update/delete` was absent from `ORG_SERVICE_ACCOUNT_ASSIGNABLE_SCOPES`, so the scope could not be granted to a service account in the first place.

### Changes

- Swap `OrgUserRole` → `OrgActorRole` (`allow_api_key=True`) on all org RBAC endpoints in `tracecat/authz/rbac/router.py` and `tracecat_ee/rbac/router.py`, including the EE `_require_rbac_entitlement` router dependency. `@require_scope("org:rbac:*")` remains the real authorization gate — this only widens the *who* (user **or** service account), not the *what*.
- Add `org:rbac:read/create/update/delete` to `ORG_SERVICE_ACCOUNT_ASSIGNABLE_SCOPES` so the scopes can actually be granted to a service account. `_resolve_assignable_scopes` still prevents privilege escalation (a caller can only grant scopes it already holds).
- Update `test_service_accounts_validation.py`: `org:rbac:*` now asserted assignable to org service accounts.

`get_my_scopes` (`/users/me/scopes`) is intentionally left user-only — it is an identity endpoint, not an RBAC-management one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable service-account API keys to access org RBAC endpoints by accepting service-account actors and making `org:rbac:*` scopes assignable. This unblocks the membership-sync service account to mirror user→role assignments via `GET`/`PATCH /rbac/user-assignments`.

- **New Features**
  - Switched router deps from `OrgUserRole` to `OrgActorRole` across OSS and EE RBAC routers (incl. entitlement check) so users and service accounts pass ACL; `@require_scope("org:rbac:*")` remains the gate.
  - Added `org:rbac:read`, `org:rbac:create`, `org:rbac:update`, `org:rbac:delete` to `ORG_SERVICE_ACCOUNT_ASSIGNABLE_SCOPES`; callers can only grant scopes they hold.
  - Updated tests to assert `org:rbac:*` is assignable to org service accounts; `get_my_scopes` stays user-only.

- **Migration**
  - Grant required `org:rbac:*` scopes to service accounts that manage org RBAC (e.g., the membership-sync key).

<sup>Written for commit 33c1ba4cca04db01916287e4caa158ff31c3b878. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

