### PR TITLE
feat(mcp): Add MCP skill management tools

### DIFF
--- a/docs/snippets/mcp-tools.mdx
+++ b/docs/snippets/mcp-tools.mdx
@@ -349,16 +349,40 @@
 
 <ResponseField name="create_agent_preset" type="tool">
   Create an agent preset in the selected workspace.
+
+  Use ``skills`` to attach published skill versions. Each binding requires ``skill_id`` and ``skill_version_id`` from ``list_skills`` and ``publish_skill``.
 </ResponseField>
 
 <ResponseField name="update_agent_preset" type="tool">
   Update an existing agent preset in the selected workspace.
+
+  Use ``skills`` to replace attached published skill-version bindings. Each binding requires ``skill_id`` and ``skill_version_id``. Omit ``skills`` to leave bindings unchanged, or pass an empty list to detach all skills.
+</ResponseField>
+
+<ResponseField name="list_skills" type="tool">
+  List workspace skills with IDs, names, and current published versions.
+
+  Use this before updating, publishing, or attaching skills to agent presets.
 </ResponseField>
 
 <ResponseField name="upload_skill" type="tool">
   Upload a local skill directory into Tracecat as a workspace skill.
 
+  This creates a new logical skill. Use ``update_skill`` when replacing an existing skill draft to avoid duplicate skill rows with the same name.
+
   Agents should read the local directory themselves, preserve relative paths, include the root ``SKILL.md`` file, and pass every file in ``files`` using ``content_base64``.
+</ResponseField>
+
+<ResponseField name="update_skill" type="tool">
+  Replace an existing skill draft with a local skill directory.
+
+  This does not publish the draft. Call ``publish_skill`` after the update if the skill should be attachable to agent presets.
+</ResponseField>
+
+<ResponseField name="publish_skill" type="tool">
+  Publish a skill draft into an immutable skill version.
+
+  Only published skill versions can be attached to agent presets.
 </ResponseField>
 
 <ResponseField name="list_agent_presets" type="tool">

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -29,7 +29,12 @@ from tracecat.agent.common.stream_types import (
     UnifiedStreamEvent,
 )
 from tracecat.agent.preset.schemas import AgentPresetRead
-from tracecat.agent.skill.schemas import SkillRead, SkillUploadFile
+from tracecat.agent.skill.schemas import (
+    SkillRead,
+    SkillReadMinimal,
+    SkillUploadFile,
+    SkillVersionRead,
+)
 from tracecat.agent.stream.events import StreamDelta, StreamEnd
 from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
 from tracecat.expressions.common import ExprType
@@ -7300,6 +7305,291 @@ async def test_create_agent_preset_resolves_catalog_id_for_custom_provider(
 
 
 @pytest.mark.anyio
+async def test_create_agent_preset_passes_skill_bindings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    catalog_id = uuid.uuid4()
+    skill_id = uuid.uuid4()
+    skill_version_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    created: dict[str, Any] = {}
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _AgentManagementService:
+        async def get_default_model_selection(self) -> SimpleNamespace:
+            return SimpleNamespace(
+                catalog_id=catalog_id,
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+            )
+
+    class _AccessService:
+        async def is_catalog_enabled(
+            self, requested_catalog_id: uuid.UUID, *, workspace_id: uuid.UUID
+        ) -> bool:
+            assert requested_catalog_id == catalog_id
+            return True
+
+    class _PresetService(_PresetReadBuilder):
+        async def create_preset(self, params: Any) -> SimpleNamespace:
+            created["params"] = params
+            now = datetime.now(UTC)
+            return SimpleNamespace(
+                id=uuid.uuid4(),
+                workspace_id=workspace_id,
+                name=params.name,
+                slug="security-triage",
+                description=params.description,
+                instructions=params.instructions,
+                model_name=params.model_name,
+                model_provider=params.model_provider,
+                catalog_id=params.catalog_id,
+                base_url=params.base_url,
+                output_type=params.output_type,
+                actions=params.actions,
+                namespaces=params.namespaces,
+                tool_approvals=params.tool_approvals,
+                mcp_integrations=params.mcp_integrations,
+                agents={},
+                retries=params.retries,
+                enable_thinking=params.enable_thinking,
+                enable_internet_access=params.enable_internet_access,
+                current_version_id=None,
+                created_at=now,
+                updated_at=now,
+            )
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentManagementService,
+        "with_session",
+        lambda role: _AsyncContext(_AgentManagementService()),
+    )
+    monkeypatch.setattr(
+        mcp_server.AgentModelAccessService,
+        "with_session",
+        lambda role: _AsyncContext(_AccessService()),
+    )
+    monkeypatch.setattr(
+        mcp_server.AgentPresetService,
+        "with_session",
+        lambda role: _AsyncContext(_PresetService()),
+    )
+
+    await _tool(mcp_server.create_agent_preset)(
+        workspace_id=str(workspace_id),
+        name="Security triage",
+        skills=[
+            {
+                "skill_id": str(skill_id),
+                "skill_version_id": str(skill_version_id),
+            }
+        ],
+    )
+
+    params = created["params"]
+    assert len(params.skills) == 1
+    assert params.skills[0].skill_id == skill_id
+    assert params.skills[0].skill_version_id == skill_version_id
+
+
+@pytest.mark.anyio
+async def test_update_agent_preset_passes_skill_bindings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    skill_id = uuid.uuid4()
+    skill_version_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    captured: dict[str, Any] = {}
+    now = datetime.now(UTC)
+    preset = SimpleNamespace(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        name="Security triage",
+        slug="security-triage",
+        description=None,
+        instructions="Original prompt",
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        catalog_id=None,
+        base_url=None,
+        output_type=None,
+        actions=None,
+        namespaces=None,
+        tool_approvals=None,
+        mcp_integrations=None,
+        agents={},
+        retries=3,
+        enable_thinking=True,
+        enable_internet_access=False,
+        current_version_id=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _PresetService(_PresetReadBuilder):
+        async def get_preset_by_slug(self, preset_slug: str) -> SimpleNamespace:
+            assert preset_slug == "security-triage"
+            return preset
+
+        async def update_preset(
+            self, current_preset: Any, params: Any
+        ) -> SimpleNamespace:
+            assert current_preset is preset
+            captured["params"] = params
+            return SimpleNamespace(**{**preset.__dict__, "updated_at": now})
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentPresetService,
+        "with_session",
+        lambda role: _AsyncContext(_PresetService()),
+    )
+
+    await _tool(mcp_server.update_agent_preset)(
+        workspace_id=str(workspace_id),
+        preset_slug="security-triage",
+        skills=[
+            {
+                "skill_id": str(skill_id),
+                "skill_version_id": str(skill_version_id),
+            }
+        ],
+    )
+
+    params = captured["params"]
+    assert len(params.skills) == 1
+    assert params.skills[0].skill_id == skill_id
+    assert params.skills[0].skill_version_id == skill_version_id
+
+
+@pytest.mark.anyio
+async def test_update_agent_preset_can_clear_skill_bindings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    captured: dict[str, Any] = {}
+    now = datetime.now(UTC)
+    preset = SimpleNamespace(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        name="Security triage",
+        slug="security-triage",
+        description=None,
+        instructions="Original prompt",
+        model_name="gpt-4o-mini",
+        model_provider="openai",
+        catalog_id=None,
+        base_url=None,
+        output_type=None,
+        actions=None,
+        namespaces=None,
+        tool_approvals=None,
+        mcp_integrations=None,
+        agents={},
+        retries=3,
+        enable_thinking=True,
+        enable_internet_access=False,
+        current_version_id=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _PresetService(_PresetReadBuilder):
+        async def get_preset_by_slug(self, preset_slug: str) -> SimpleNamespace:
+            assert preset_slug == "security-triage"
+            return preset
+
+        async def update_preset(
+            self, current_preset: Any, params: Any
+        ) -> SimpleNamespace:
+            assert current_preset is preset
+            captured["params"] = params
+            return SimpleNamespace(**{**preset.__dict__, "updated_at": now})
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentPresetService,
+        "with_session",
+        lambda role: _AsyncContext(_PresetService()),
+    )
+
+    await _tool(mcp_server.update_agent_preset)(
+        workspace_id=str(workspace_id),
+        preset_slug="security-triage",
+        skills=[],
+    )
+
+    assert captured["params"].skills == []
+
+
+@pytest.mark.anyio
+async def test_list_skills_uses_workspace_skill_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tracecat.pagination import CursorPaginatedResponse
+
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    skill_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    captured: dict[str, Any] = {}
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _SkillService:
+        async def list_skills(self, params):
+            captured["params"] = params
+            return CursorPaginatedResponse(
+                items=[
+                    SkillReadMinimal(
+                        id=skill_id,
+                        workspace_id=workspace_id,
+                        name="botsv3-ir",
+                        description="BOTSv3 IR skill",
+                        current_version_id=uuid.uuid4(),
+                        created_at=now,
+                        updated_at=now,
+                        archived_at=None,
+                    )
+                ],
+                next_cursor=None,
+                prev_cursor=None,
+                has_more=False,
+                has_previous=False,
+            )
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.SkillService,
+        "with_session",
+        lambda role: _AsyncContext(_SkillService()),
+    )
+
+    result = await _tool(mcp_server.list_skills)(
+        workspace_id=str(workspace_id),
+        limit=10,
+    )
+
+    payload = _payload(result)
+    assert captured["params"].limit == 10
+    assert payload["items"][0]["id"] == str(skill_id)
+    assert payload["items"][0]["name"] == "botsv3-ir"
+
+
+@pytest.mark.anyio
 async def test_upload_skill_uses_workspace_skill_service(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -7670,6 +7960,124 @@ async def test_upload_skill_rejects_non_utf8_root_skill_markdown_before_upload(
         )
 
     assert upload_called is False
+
+
+@pytest.mark.anyio
+async def test_update_skill_replaces_existing_draft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    skill_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    captured: dict[str, Any] = {}
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _SkillService:
+        async def replace_skill_draft(self, *, skill_id: uuid.UUID, params):
+            captured["skill_id"] = skill_id
+            captured["params"] = params
+            now = datetime.now(UTC)
+            return SkillRead(
+                id=skill_id,
+                workspace_id=workspace_id,
+                name=params.name,
+                description="Updated description",
+                current_version_id=None,
+                draft_revision=2,
+                created_at=now,
+                updated_at=now,
+                archived_at=None,
+                current_version=None,
+                is_draft_publishable=True,
+                draft_validation_errors=[],
+                draft_file_count=len(params.files),
+            )
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.SkillService,
+        "with_session",
+        lambda role: _AsyncContext(_SkillService()),
+    )
+
+    result = await _tool(mcp_server.update_skill)(
+        workspace_id=str(workspace_id),
+        skill_id=skill_id,
+        name="botsv3-ir",
+        description="Updated description",
+        files=[
+            SkillUploadFile(
+                path="SKILL.md",
+                content_base64=base64.b64encode(
+                    b"---\nname: old-name\n---\n\n# Triage\n"
+                ).decode("ascii"),
+                content_type="text/markdown; charset=utf-8",
+            )
+        ],
+    )
+
+    payload = _payload(result)
+    params = captured["params"]
+    uploaded_content = base64.b64decode(params.files[0].content_base64).decode("utf-8")
+    assert captured["skill_id"] == skill_id
+    assert params.name == "botsv3-ir"
+    assert "name: botsv3-ir" in uploaded_content
+    assert "description: Updated description" in uploaded_content
+    assert payload["id"] == str(skill_id)
+    assert payload["draft_revision"] == 2
+
+
+@pytest.mark.anyio
+async def test_publish_skill_uses_workspace_skill_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    skill_id = uuid.uuid4()
+    version_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    captured: dict[str, Any] = {}
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _SkillService:
+        async def publish_skill(self, requested_skill_id: uuid.UUID):
+            captured["skill_id"] = requested_skill_id
+            now = datetime.now(UTC)
+            return SkillVersionRead(
+                id=version_id,
+                skill_id=requested_skill_id,
+                workspace_id=workspace_id,
+                version=1,
+                manifest_sha256="0" * 64,
+                file_count=1,
+                total_size_bytes=42,
+                name="botsv3-ir",
+                description="BOTSv3 IR skill",
+                created_at=now,
+                updated_at=now,
+                files=[],
+            )
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.SkillService,
+        "with_session",
+        lambda role: _AsyncContext(_SkillService()),
+    )
+
+    result = await _tool(mcp_server.publish_skill)(
+        workspace_id=str(workspace_id),
+        skill_id=skill_id,
+    )
+
+    payload = _payload(result)
+    assert captured["skill_id"] == skill_id
+    assert payload["id"] == str(version_id)
+    assert payload["skill_id"] == str(skill_id)
+    assert payload["version"] == 1
 
 
 def _prompt_source_text() -> str:

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -351,6 +351,78 @@ class TestSkillService:
         assert created.name == "duplicate-skill"
         assert created.id is not None
 
+    async def test_replace_skill_draft_updates_existing_skill(
+        self,
+        skill_service: SkillService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Replacing a draft should update one skill instead of creating a duplicate."""
+
+        async def _has_entitlement(_entitlement):
+            return True
+
+        monkeypatch.setattr(skill_service, "has_entitlement", _has_entitlement)
+
+        created = await skill_service.upload_skill(
+            SkillUpload(
+                name="replace-skill",
+                files=[
+                    SkillUploadFile(
+                        path="SKILL.md",
+                        content_base64=base64.b64encode(
+                            b"---\nname: replace-skill\n---\n\n# Original\n"
+                        ).decode(),
+                        content_type="text/markdown; charset=utf-8",
+                    ),
+                    SkillUploadFile(
+                        path="old.txt",
+                        content_base64=base64.b64encode(b"old").decode(),
+                        content_type="text/plain; charset=utf-8",
+                    ),
+                ],
+            )
+        )
+
+        updated = await skill_service.replace_skill_draft(
+            skill_id=created.id,
+            params=SkillUpload(
+                name="replace-skill",
+                files=[
+                    SkillUploadFile(
+                        path="SKILL.md",
+                        content_base64=base64.b64encode(
+                            b"---\n"
+                            b"name: replace-skill\n"
+                            b"description: Updated description\n"
+                            b"---\n\n"
+                            b"# Updated\n"
+                        ).decode(),
+                        content_type="text/markdown; charset=utf-8",
+                    ),
+                    SkillUploadFile(
+                        path="payload.bin",
+                        content_base64=base64.b64encode(b"\x00\x01").decode(),
+                        content_type="application/octet-stream",
+                    ),
+                ],
+            ),
+        )
+
+        draft = await skill_service.get_draft(created.id)
+        old_file = await skill_service.get_draft_file(
+            skill_id=created.id,
+            path="old.txt",
+        )
+
+        assert updated.id == created.id
+        assert updated.description == "Updated description"
+        assert updated.draft_revision == created.draft_revision + 1
+        assert updated.draft_file_count == 2
+        assert draft is not None
+        assert draft.is_publishable is True
+        assert {file.path for file in draft.files} == {"SKILL.md", "payload.bin"}
+        assert old_file is None
+
     async def test_upload_skill_reuses_blob_across_distinct_file_content_types(
         self,
         skill_service: SkillService,

--- a/tests/unit/test_skill_service.py
+++ b/tests/unit/test_skill_service.py
@@ -423,6 +423,69 @@ class TestSkillService:
         assert {file.path for file in draft.files} == {"SKILL.md", "payload.bin"}
         assert old_file is None
 
+    async def test_replace_skill_draft_rejects_invalid_manifest_before_blob_upload(
+        self,
+        skill_service: SkillService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Invalid replacements should fail before writing blob objects."""
+
+        async def _has_entitlement(_entitlement):
+            return True
+
+        monkeypatch.setattr(skill_service, "has_entitlement", _has_entitlement)
+
+        created = await skill_service.upload_skill(
+            SkillUpload(
+                name="invalid-replace-skill",
+                files=[
+                    SkillUploadFile(
+                        path="SKILL.md",
+                        content_base64=base64.b64encode(
+                            b"---\nname: invalid-replace-skill\n---\n\n# Original\n"
+                        ).decode(),
+                        content_type="text/markdown; charset=utf-8",
+                    )
+                ],
+            )
+        )
+        upload_called = False
+
+        async def fake_upload_file(
+            *,
+            content: bytes,
+            key: str,
+            bucket: str,
+            content_type: str,
+        ) -> None:
+            del content, key, bucket, content_type
+            nonlocal upload_called
+            upload_called = True
+
+        monkeypatch.setattr(
+            "tracecat.agent.skill.service.blob.upload_file",
+            fake_upload_file,
+        )
+
+        with pytest.raises(TracecatValidationError, match="failed validation"):
+            await skill_service.replace_skill_draft(
+                skill_id=created.id,
+                params=SkillUpload(
+                    name="invalid-replace-skill",
+                    files=[
+                        SkillUploadFile(
+                            path="notes.txt",
+                            content_base64=base64.b64encode(
+                                b"not a valid skill manifest"
+                            ).decode(),
+                            content_type="text/plain; charset=utf-8",
+                        )
+                    ],
+                ),
+            )
+
+        assert upload_called is False
+
     async def test_upload_skill_reuses_blob_across_distinct_file_content_types(
         self,
         skill_service: SkillService,

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -1318,6 +1318,55 @@ class SkillService(BaseWorkspaceService):
         await self.session.refresh(skill)
         return await self._build_skill_read(skill)
 
+    @require_scope("agent:update")
+    @requires_entitlement(Entitlement.AGENT_ADDONS)
+    async def replace_skill_draft(
+        self, *, skill_id: uuid.UUID, params: SkillUpload
+    ) -> SkillRead:
+        """Replace an existing skill's mutable draft with a full file tree."""
+
+        skill = await self._get_skill_for_update(skill_id)
+        if skill is None:
+            raise TracecatNotFoundError(f"Skill '{skill_id}' not found")
+
+        prepared_files = self._prepare_upload_files(params.files)
+        validation = self._validate_prepared_upload_files(prepared_files)
+        if validation.errors:
+            raise TracecatValidationError(
+                "Uploaded skill draft failed validation",
+                detail={
+                    "code": "skill_upload_validation_failed",
+                    "errors": [
+                        error.model_dump(mode="json") for error in validation.errors
+                    ],
+                },
+            )
+        if validation.name != params.name:
+            raise TracecatValidationError(
+                "Uploaded skill name must match the root SKILL.md frontmatter name",
+                detail={
+                    "code": "skill_name_mismatch",
+                    "expected_name": params.name,
+                    "actual_name": validation.name,
+                },
+            )
+
+        path_to_blob = {
+            file.path: SkillFileBlobRef(
+                blob=await self._get_or_create_blob(content=file.content),
+                content_type=file.content_type,
+            )
+            for file in prepared_files
+        }
+        await self._replace_draft_with_blob_map(skill=skill, path_to_blob=path_to_blob)
+        if skill.current_version_id is None:
+            skill.name = params.name
+            skill.description = validation.description
+            self.session.add(skill)
+        await self.session.commit()
+        await self.session.refresh(skill)
+        return await self._build_skill_read(skill)
+
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def list_skills(
         self, params: CursorPaginationParams

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -103,6 +103,14 @@ class PreparedSkillUploadFile:
 
 
 @dataclass(frozen=True, slots=True)
+class PreparedSkillUploadDraft:
+    """Validated one-shot upload files materialized as skill blob references."""
+
+    validation: ManifestValidationResult
+    path_to_blob: dict[str, SkillFileBlobRef]
+
+
+@dataclass(frozen=True, slots=True)
 class PreparedDraftTextFileOp:
     """Validated draft text-file upsert ready for blob materialization."""
 
@@ -897,6 +905,45 @@ class SkillService(BaseWorkspaceService):
             )
         return prepared_files
 
+    async def _prepare_validated_upload_draft(
+        self, params: SkillUpload
+    ) -> PreparedSkillUploadDraft:
+        """Validate and materialize a one-shot upload into draft blob refs."""
+
+        prepared_files = self._prepare_upload_files(params.files)
+        validation = self._validate_prepared_upload_files(prepared_files)
+        if validation.errors:
+            raise TracecatValidationError(
+                "Uploaded skill draft failed validation",
+                detail={
+                    "code": "skill_upload_validation_failed",
+                    "errors": [
+                        error.model_dump(mode="json") for error in validation.errors
+                    ],
+                },
+            )
+        if validation.name != params.name:
+            raise TracecatValidationError(
+                "Uploaded skill name must match the root SKILL.md frontmatter name",
+                detail={
+                    "code": "skill_name_mismatch",
+                    "expected_name": params.name,
+                    "actual_name": validation.name,
+                },
+            )
+
+        path_to_blob = {
+            file.path: SkillFileBlobRef(
+                blob=await self._get_or_create_blob(content=file.content),
+                content_type=file.content_type,
+            )
+            for file in prepared_files
+        }
+        return PreparedSkillUploadDraft(
+            validation=validation,
+            path_to_blob=path_to_blob,
+        )
+
     async def _create_version_from_blob_refs(
         self,
         *,
@@ -1276,44 +1323,19 @@ class SkillService(BaseWorkspaceService):
             The created skill summary.
         """
 
-        prepared_files = self._prepare_upload_files(params.files)
-        validation = self._validate_prepared_upload_files(prepared_files)
-        if validation.errors:
-            raise TracecatValidationError(
-                "Uploaded skill draft failed validation",
-                detail={
-                    "code": "skill_upload_validation_failed",
-                    "errors": [
-                        error.model_dump(mode="json") for error in validation.errors
-                    ],
-                },
-            )
-        if validation.name != params.name:
-            raise TracecatValidationError(
-                "Uploaded skill name must match the root SKILL.md frontmatter name",
-                detail={
-                    "code": "skill_name_mismatch",
-                    "expected_name": params.name,
-                    "actual_name": validation.name,
-                },
-            )
-
-        path_to_blob = {
-            file.path: SkillFileBlobRef(
-                blob=await self._get_or_create_blob(content=file.content),
-                content_type=file.content_type,
-            )
-            for file in prepared_files
-        }
+        prepared_draft = await self._prepare_validated_upload_draft(params)
         skill = Skill(
             workspace_id=self.workspace_id,
             name=params.name,
             draft_revision=0,
-            description=validation.description,
+            description=prepared_draft.validation.description,
         )
         self.session.add(skill)
         await self.session.flush()
-        await self._replace_draft_with_blob_map(skill=skill, path_to_blob=path_to_blob)
+        await self._replace_draft_with_blob_map(
+            skill=skill,
+            path_to_blob=prepared_draft.path_to_blob,
+        )
         await self.session.commit()
         await self.session.refresh(skill)
         return await self._build_skill_read(skill)
@@ -1329,39 +1351,14 @@ class SkillService(BaseWorkspaceService):
         if skill is None:
             raise TracecatNotFoundError(f"Skill '{skill_id}' not found")
 
-        prepared_files = self._prepare_upload_files(params.files)
-        validation = self._validate_prepared_upload_files(prepared_files)
-        if validation.errors:
-            raise TracecatValidationError(
-                "Uploaded skill draft failed validation",
-                detail={
-                    "code": "skill_upload_validation_failed",
-                    "errors": [
-                        error.model_dump(mode="json") for error in validation.errors
-                    ],
-                },
-            )
-        if validation.name != params.name:
-            raise TracecatValidationError(
-                "Uploaded skill name must match the root SKILL.md frontmatter name",
-                detail={
-                    "code": "skill_name_mismatch",
-                    "expected_name": params.name,
-                    "actual_name": validation.name,
-                },
-            )
-
-        path_to_blob = {
-            file.path: SkillFileBlobRef(
-                blob=await self._get_or_create_blob(content=file.content),
-                content_type=file.content_type,
-            )
-            for file in prepared_files
-        }
-        await self._replace_draft_with_blob_map(skill=skill, path_to_blob=path_to_blob)
+        prepared_draft = await self._prepare_validated_upload_draft(params)
+        await self._replace_draft_with_blob_map(
+            skill=skill,
+            path_to_blob=prepared_draft.path_to_blob,
+        )
         if skill.current_version_id is None:
             skill.name = params.name
-            skill.description = validation.description
+            skill.description = prepared_draft.validation.description
             self.session.add(skill)
         await self.session.commit()
         await self.session.refresh(skill)

--- a/tracecat/mcp/README.md
+++ b/tracecat/mcp/README.md
@@ -124,8 +124,12 @@ Case field and table `type` values are:
 
 - `list_integrations(workspace_id)`
 - `get_agent_preset_authoring_context(workspace_id)`
-- `create_agent_preset(workspace_id, name, slug=None, description=None, instructions=None, model_name=None, model_provider=None, base_url=None, output_type=None, actions=None, namespaces=None, tool_approvals=None, mcp_integration_ids=None, retries=None, enable_thinking=None, enable_internet_access=None)`
-- `update_agent_preset(workspace_id, preset_slug, name=None, slug=None, description=None, instructions=None, model_name=None, model_provider=None, base_url=None, output_type=None, actions=None, namespaces=None, tool_approvals=None, mcp_integration_ids=None, retries=None, enable_thinking=None, enable_internet_access=None)`
+- `list_skills(workspace_id, limit=20, cursor=None)`
+- `upload_skill(workspace_id, name, files, description=None)`
+- `update_skill(workspace_id, skill_id, name, files, description=None)`
+- `publish_skill(workspace_id, skill_id)`
+- `create_agent_preset(workspace_id, name, slug=None, description=None, instructions=None, model_name=None, model_provider=None, base_url=None, output_type=None, actions=None, namespaces=None, tool_approvals=None, mcp_integration_ids=None, retries=None, enable_thinking=None, enable_internet_access=None, skills=None)`
+- `update_agent_preset(workspace_id, preset_slug, name=None, slug=None, description=None, instructions=None, model_name=None, model_provider=None, base_url=None, output_type=None, actions=None, namespaces=None, tool_approvals=None, mcp_integration_ids=None, retries=None, enable_thinking=None, enable_internet_access=None, skills=None)`
 - `list_agent_presets(workspace_id, limit=20, cursor=None)`
 - `get_agent_preset(workspace_id, preset_slug)`
 - `run_agent_preset(workspace_id, preset_slug, prompt, preset_version=None, timeout_seconds=120)`

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -58,6 +58,7 @@ from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEve
 from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
     AgentPresetRead,
+    AgentPresetSkillBindingBase,
     AgentPresetUpdate,
 )
 from tracecat.agent.preset.service import AgentPresetService
@@ -67,8 +68,10 @@ from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
 from tracecat.agent.skill.schemas import (
     SkillRead,
+    SkillReadMinimal,
     SkillUpload,
     SkillUploadFile,
+    SkillVersionRead,
 )
 from tracecat.agent.skill.service import SkillService
 from tracecat.agent.stream.connector import AgentStream
@@ -7816,8 +7819,14 @@ async def create_agent_preset(
     retries: int | None = None,
     enable_thinking: bool | None = None,
     enable_internet_access: bool | None = None,
+    skills: list[AgentPresetSkillBindingBase] | None = None,
 ) -> AgentPresetRead:
-    """Create an agent preset in the selected workspace."""
+    """Create an agent preset in the selected workspace.
+
+    Use ``skills`` to attach published skill versions. Each binding requires
+    ``skill_id`` and ``skill_version_id`` from ``list_skills`` and
+    ``publish_skill``.
+    """
 
     try:
         _, role = await _resolve_workspace_role(workspace_id)
@@ -7849,6 +7858,7 @@ async def create_agent_preset(
             "retries": retries,
             "enable_thinking": enable_thinking,
             "enable_internet_access": enable_internet_access,
+            "skills": skills,
         }
         create_data.update(
             {
@@ -7892,8 +7902,14 @@ async def update_agent_preset(
     retries: int | None = None,
     enable_thinking: bool | None = None,
     enable_internet_access: bool | None = None,
+    skills: list[AgentPresetSkillBindingBase] | None = None,
 ) -> AgentPresetRead:
-    """Update an existing agent preset in the selected workspace."""
+    """Update an existing agent preset in the selected workspace.
+
+    Use ``skills`` to replace attached published skill-version bindings. Each
+    binding requires ``skill_id`` and ``skill_version_id``. Omit ``skills`` to
+    leave bindings unchanged, or pass an empty list to detach all skills.
+    """
 
     try:
         _, role = await _resolve_workspace_role(workspace_id)
@@ -7912,6 +7928,7 @@ async def update_agent_preset(
             "retries": retries,
             "enable_thinking": enable_thinking,
             "enable_internet_access": enable_internet_access,
+            "skills": skills,
         }
         update_data.update(
             {
@@ -7955,6 +7972,41 @@ async def update_agent_preset(
 
 
 @mcp.tool()
+async def list_skills(
+    workspace_id: uuid.UUID,
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
+) -> CursorPaginatedResponse[SkillReadMinimal]:
+    """List workspace skills with IDs, names, and current published versions.
+
+    Use this before updating, publishing, or attaching skills to agent presets.
+    """
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        async with SkillService.with_session(role=role) as svc:
+            return await svc.list_skills(
+                CursorPaginationParams(
+                    limit=_normalize_limit(
+                        limit,
+                        default=config.TRACECAT__LIMIT_DEFAULT,
+                        max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+                    ),
+                    cursor=cursor,
+                )
+            )
+    except ToolError:
+        raise
+    except ValidationError as e:
+        raise ToolError(str(e)) from e
+    except TracecatValidationError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to list skills", error=str(e))
+        raise ToolError(f"Failed to list skills: {e}") from None
+
+
+@mcp.tool()
 async def upload_skill(
     workspace_id: uuid.UUID,
     name: str,
@@ -7962,6 +8014,9 @@ async def upload_skill(
     description: str | None = None,
 ) -> SkillRead:
     """Upload a local skill directory into Tracecat as a workspace skill.
+
+    This creates a new logical skill. Use ``update_skill`` when replacing an
+    existing skill draft to avoid duplicate skill rows with the same name.
 
     Agents should read the local directory themselves, preserve relative paths,
     include the root ``SKILL.md`` file, and pass every file in ``files`` using
@@ -7995,6 +8050,78 @@ async def upload_skill(
     except Exception as e:
         logger.error("Failed to upload skill", error=str(e), name=name)
         raise ToolError(f"Failed to upload skill: {e}") from None
+
+
+@mcp.tool()
+async def update_skill(
+    workspace_id: uuid.UUID,
+    skill_id: uuid.UUID,
+    name: str,
+    files: list[SkillUploadFile],
+    description: str | None = None,
+) -> SkillRead:
+    """Replace an existing skill draft with a local skill directory.
+
+    This does not publish the draft. Call ``publish_skill`` after the update if
+    the skill should be attachable to agent presets.
+    """
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        files_for_upload = _merge_uploaded_skill_markdown_metadata(
+            files,
+            name=name,
+            description=description,
+        )
+        params = SkillUpload.model_validate(
+            {
+                "name": name,
+                "files": SkillUploadFile.list_adapter().dump_python(
+                    files_for_upload, mode="json"
+                ),
+            }
+        )
+        async with SkillService.with_session(role=role) as svc:
+            updated = await svc.replace_skill_draft(skill_id=skill_id, params=params)
+        return SkillRead.model_validate(updated)
+    except ToolError:
+        raise
+    except ValidationError as e:
+        raise ToolError(str(e)) from e
+    except TracecatValidationError as e:
+        raise ToolError(str(e)) from e
+    except TracecatNotFoundError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to update skill", error=str(e), skill_id=str(skill_id))
+        raise ToolError(f"Failed to update skill: {e}") from None
+
+
+@mcp.tool()
+async def publish_skill(
+    workspace_id: uuid.UUID,
+    skill_id: uuid.UUID,
+) -> SkillVersionRead:
+    """Publish a skill draft into an immutable skill version.
+
+    Only published skill versions can be attached to agent presets.
+    """
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        async with SkillService.with_session(role=role) as svc:
+            return await svc.publish_skill(skill_id)
+    except ToolError:
+        raise
+    except ValidationError as e:
+        raise ToolError(str(e)) from e
+    except TracecatValidationError as e:
+        raise ToolError(str(e)) from e
+    except TracecatNotFoundError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to publish skill", error=str(e), skill_id=str(skill_id))
+        raise ToolError(f"Failed to publish skill: {e}") from None
 
 
 # ── Agent Presets ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add MCP tools to list workspace skills, update an existing skill draft, and publish a skill version.
- Allow MCP agent preset create/update calls to attach published skill-version bindings via `skills`.
- Add a SkillService full-draft replacement path so MCP updates do not create duplicate logical skills with the same name.
- Regenerate MCP tool docs and cover the new behavior in unit tests.

## Why

The existing MCP surface could upload a skill, but upload always created a new skill row. That made repeated lab updates produce duplicate BOTSv3 skills and left no MCP path to publish or attach a skill to a preset.

## Validation

- `uv run pytest tests/unit/test_mcp_server.py -k "skill or agent_preset"`
- `uv run pytest tests/unit/test_skill_service.py -k replace_skill_draft`
- `uv run ruff check tracecat/mcp/server.py tracecat/agent/skill/service.py tests/unit/test_mcp_server.py tests/unit/test_skill_service.py`
- `uv run basedpyright tracecat/agent/skill/service.py tracecat/mcp/server.py`
- commit hooks: ruff, basedpyright, generated MCP docs, frontend client update check, hardcoded secret scan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP tools to list, update, and publish workspace skills, and lets presets attach published skill versions via the `skills` field. Draft validation and blob prep are now shared to prevent duplicate skills and avoid blob writes on invalid manifests.

- **New Features**
  - New MCP tools: `list_skills`, `update_skill`, `publish_skill` (with clarified `upload_skill` docs).
  - `create_agent_preset` and `update_agent_preset` accept `skills` to attach/replace bindings; omit to keep, pass `[]` to clear.
  - `SkillService.replace_skill_draft` uses shared validated upload prep, replaces drafts in full, and updates name/description when no version is published; validates before any blob writes.
  - Docs and unit tests added for the new flows.

- **Migration**
  - To attach skills to presets: `list_skills` → `update_skill` or `upload_skill` → `publish_skill` → pass `skills` to preset create/update.
  - Use `update_skill` (not `upload_skill`) when replacing an existing draft to avoid duplicate skill rows.

<sup>Written for commit 002ed72c9e8dbde934c05b76e7b41aeb4949ae46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

