### PR TITLE
feat(integrations): Add duckdb S3 + HTTP-header secrets and pin extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Claude Code local runtime state (keep tracked commands/settings/skills)
+.claude/scheduled_tasks.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,35 +35,57 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # are intentionally available to both. DuckDB is not available from Bookworm
 # apt, so install the official release binary, verify it, preinstall extensions,
 # and wrap the CLI to load those extensions on each invocation.
-RUN arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+#
+# Both the CLI binary and every extension are pinned by sha256: extensions are
+# downloaded from the version-pinned repository, verified, and installed from
+# local files (DuckDB still validates the signed extensions on load) instead of
+# resolving "latest for this version" via a bare INSTALL.
+RUN set -eu; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
     case "${arch}" in \
-        amd64) duckdb_sha256="c479794045d094058d3092e404e696508d6310b5d234a8c1945b745678f09d8d" ;; \
-        arm64) duckdb_sha256="c709eb3efc74a609af4b92bc885c509a1bd21ddfa71ea1e717420d4dd9fc121b" ;; \
+        amd64) \
+            platform="linux_amd64"; \
+            duckdb_sha256="c479794045d094058d3092e404e696508d6310b5d234a8c1945b745678f09d8d"; \
+            ext_shas="json:35144e27f6635f4934a715fc721bd26e74520852cf92d920c4e7a0c8729c3e8b httpfs:786b8e1aea9b49bb3072dba9f553d84c1a9aa042e9351124bb3ec2753b221227 inet:07430f6c1ad5a03e6fcbf153c2690765bfd445c9cab40927011105b75bef4a31 fts:ed5e639aee5070dee0b58f60322393c1861c5c82d57164192065ef758f1371b5"; \
+            ;; \
+        arm64) \
+            platform="linux_arm64"; \
+            duckdb_sha256="c709eb3efc74a609af4b92bc885c509a1bd21ddfa71ea1e717420d4dd9fc121b"; \
+            ext_shas="json:0dbe43e05f23bd9c9e4df30a80a201b05cac5c7a0a1709143195451a526fe132 httpfs:662e96fe6c39724be7977649314b92eadf3a9a0c6127c3a3e96611480d6ad04b inet:c48932d9060053e570c76a99169709ad4e52f1ba5cb1a1468e8b1eb00899361a fts:0966c1c9cfb798845b53117ea7f3fd7210fb545d63b1273963075a4b56311a5a"; \
+            ;; \
         *) echo "Unsupported DuckDB CLI architecture: ${arch}" >&2; exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-${arch}.gz" -o /tmp/duckdb.gz && \
-    echo "${duckdb_sha256}  /tmp/duckdb.gz" | sha256sum -c - && \
-    gunzip /tmp/duckdb.gz && \
-    install -m 0755 /tmp/duckdb /usr/local/bin/duckdb.real && \
-    rm -f /tmp/duckdb && \
-    mkdir -p /usr/local/lib/duckdb/extensions /usr/local/share/duckdb && \
-    /usr/local/bin/duckdb.real -c "SET extension_directory = '/usr/local/lib/duckdb/extensions'; INSTALL json; INSTALL postgres; INSTALL httpfs; INSTALL sqlite; INSTALL inet;" && \
+    esac; \
+    curl -fsSL "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-${arch}.gz" -o /tmp/duckdb.gz; \
+    echo "${duckdb_sha256}  /tmp/duckdb.gz" | sha256sum -c -; \
+    gunzip /tmp/duckdb.gz; \
+    install -m 0755 /tmp/duckdb /usr/local/bin/duckdb.real; \
+    rm -f /tmp/duckdb; \
+    mkdir -p /usr/local/lib/duckdb/extensions /usr/local/share/duckdb /tmp/ddbext; \
+    install_args=""; \
+    for spec in ${ext_shas}; do \
+        name="${spec%%:*}"; sha="${spec##*:}"; \
+        curl -fsSL "https://extensions.duckdb.org/v${DUCKDB_VERSION}/${platform}/${name}.duckdb_extension.gz" -o "/tmp/ddbext/${name}.duckdb_extension.gz"; \
+        echo "${sha}  /tmp/ddbext/${name}.duckdb_extension.gz" | sha256sum -c -; \
+        gunzip "/tmp/ddbext/${name}.duckdb_extension.gz"; \
+        install_args="${install_args} INSTALL '/tmp/ddbext/${name}.duckdb_extension';"; \
+    done; \
+    /usr/local/bin/duckdb.real -c "SET extension_directory = '/usr/local/lib/duckdb/extensions';${install_args}"; \
+    rm -rf /tmp/ddbext; \
     printf '%s\n' \
         "SET extension_directory = '/usr/local/lib/duckdb/extensions';" \
         "LOAD json;" \
-        "LOAD postgres;" \
         "LOAD httpfs;" \
-        "LOAD sqlite;" \
         "LOAD inet;" \
-        > /usr/local/share/duckdb/tracecat-init.sql && \
+        "LOAD fts;" \
+        > /usr/local/share/duckdb/tracecat-init.sql; \
     printf '%s\n' \
         '#!/bin/sh' \
         'exec /usr/local/bin/duckdb.real -init /usr/local/share/duckdb/tracecat-init.sql "$@"' \
-        > /usr/local/bin/duckdb && \
-    chmod 0755 /usr/local/bin/duckdb && \
-    jq --version && \
-    duckdb --version && \
-    test "$(duckdb -csv -noheader -c "SELECT count(*) FROM duckdb_extensions() WHERE extension_name IN ('json', 'postgres_scanner', 'httpfs', 'sqlite_scanner', 'inet') AND installed AND loaded;")" = "5"
+        > /usr/local/bin/duckdb; \
+    chmod 0755 /usr/local/bin/duckdb; \
+    jq --version; \
+    duckdb --version; \
+    test "$(duckdb -csv -noheader -c "SELECT count(*) FROM duckdb_extensions() WHERE extension_name IN ('json', 'httpfs', 'inet', 'fts') AND installed AND loaded;")" = "4"
 
 COPY --from=ghcr.io/astral-sh/uv:0.9.15 /uv /usr/local/bin/uv
 COPY --from=ghcr.io/astral-sh/uv:0.9.15 /uvx /usr/local/bin/uvx
@@ -102,12 +124,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get -y upgrade \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-COPY --from=sandbox-rootfs /usr/local/bin/duckdb /usr/local/bin/duckdb
-COPY --from=sandbox-rootfs /usr/local/bin/duckdb.real /usr/local/bin/duckdb.real
-COPY --from=sandbox-rootfs /usr/local/lib/duckdb /usr/local/lib/duckdb
-COPY --from=sandbox-rootfs /usr/local/share/duckdb /usr/local/share/duckdb
-
-RUN jq --version && duckdb --version
+# DuckDB (CLI binary + extensions) is stored as a single physical copy inside
+# the sandbox rootfs (copied in below). The executor host — including the
+# in-process DuckDB Python package used by core.duckdb.execute_sql — reaches it
+# through symlinks created right after that copy, so the large extension
+# binaries are not stored twice in the image. The Python package loads
+# extensions from this directory instead of autoinstalling over the network.
+ENV TRACECAT__DUCKDB_EXTENSION_DIRECTORY=/usr/local/lib/duckdb/extensions
 
 # Allow the non-root executor process to invoke mount/umount when the container
 # runtime grants the needed bounding capabilities. Without these file caps,
@@ -118,6 +141,17 @@ RUN chmod u-s /usr/bin/mount /usr/bin/umount && \
 
 # Copy sandbox rootfs
 COPY --from=sandbox-rootfs /usr /var/lib/tracecat/sandbox-rootfs/usr
+
+# Expose the single rootfs DuckDB copy to the executor host via symlinks, so the
+# host CLI and the in-process DuckDB Python package work without a second copy
+# of the extension binaries. The nsjail sandbox uses its own (physical) rootfs
+# copy and is unaffected by these host-side links.
+RUN ln -s /var/lib/tracecat/sandbox-rootfs/usr/local/lib/duckdb /usr/local/lib/duckdb && \
+    ln -s /var/lib/tracecat/sandbox-rootfs/usr/local/share/duckdb /usr/local/share/duckdb && \
+    ln -s /var/lib/tracecat/sandbox-rootfs/usr/local/bin/duckdb.real /usr/local/bin/duckdb.real && \
+    ln -s /var/lib/tracecat/sandbox-rootfs/usr/local/bin/duckdb /usr/local/bin/duckdb && \
+    jq --version && duckdb --version
+
 COPY --from=sandbox-rootfs /lib /var/lib/tracecat/sandbox-rootfs/lib
 COPY --from=sandbox-rootfs /bin /var/lib/tracecat/sandbox-rootfs/bin
 COPY --from=sandbox-rootfs /sbin /var/lib/tracecat/sandbox-rootfs/sbin

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -17,35 +17,57 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # are intentionally available to both. DuckDB is not available from Bookworm
 # apt, so install the official release binary, verify it, preinstall extensions,
 # and wrap the CLI to load those extensions on each invocation.
-RUN arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+#
+# Both the CLI binary and every extension are pinned by sha256: extensions are
+# downloaded from the version-pinned repository, verified, and installed from
+# local files (DuckDB still validates the signed extensions on load) instead of
+# resolving "latest for this version" via a bare INSTALL.
+RUN set -eu; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
     case "${arch}" in \
-        amd64) duckdb_sha256="c479794045d094058d3092e404e696508d6310b5d234a8c1945b745678f09d8d" ;; \
-        arm64) duckdb_sha256="c709eb3efc74a609af4b92bc885c509a1bd21ddfa71ea1e717420d4dd9fc121b" ;; \
+        amd64) \
+            platform="linux_amd64"; \
+            duckdb_sha256="c479794045d094058d3092e404e696508d6310b5d234a8c1945b745678f09d8d"; \
+            ext_shas="json:35144e27f6635f4934a715fc721bd26e74520852cf92d920c4e7a0c8729c3e8b httpfs:786b8e1aea9b49bb3072dba9f553d84c1a9aa042e9351124bb3ec2753b221227 inet:07430f6c1ad5a03e6fcbf153c2690765bfd445c9cab40927011105b75bef4a31 fts:ed5e639aee5070dee0b58f60322393c1861c5c82d57164192065ef758f1371b5"; \
+            ;; \
+        arm64) \
+            platform="linux_arm64"; \
+            duckdb_sha256="c709eb3efc74a609af4b92bc885c509a1bd21ddfa71ea1e717420d4dd9fc121b"; \
+            ext_shas="json:0dbe43e05f23bd9c9e4df30a80a201b05cac5c7a0a1709143195451a526fe132 httpfs:662e96fe6c39724be7977649314b92eadf3a9a0c6127c3a3e96611480d6ad04b inet:c48932d9060053e570c76a99169709ad4e52f1ba5cb1a1468e8b1eb00899361a fts:0966c1c9cfb798845b53117ea7f3fd7210fb545d63b1273963075a4b56311a5a"; \
+            ;; \
         *) echo "Unsupported DuckDB CLI architecture: ${arch}" >&2; exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-${arch}.gz" -o /tmp/duckdb.gz && \
-    echo "${duckdb_sha256}  /tmp/duckdb.gz" | sha256sum -c - && \
-    gunzip /tmp/duckdb.gz && \
-    install -m 0755 /tmp/duckdb /usr/local/bin/duckdb.real && \
-    rm -f /tmp/duckdb && \
-    mkdir -p /usr/local/lib/duckdb/extensions /usr/local/share/duckdb && \
-    /usr/local/bin/duckdb.real -c "SET extension_directory = '/usr/local/lib/duckdb/extensions'; INSTALL json; INSTALL postgres; INSTALL httpfs; INSTALL sqlite; INSTALL inet;" && \
+    esac; \
+    curl -fsSL "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-${arch}.gz" -o /tmp/duckdb.gz; \
+    echo "${duckdb_sha256}  /tmp/duckdb.gz" | sha256sum -c -; \
+    gunzip /tmp/duckdb.gz; \
+    install -m 0755 /tmp/duckdb /usr/local/bin/duckdb.real; \
+    rm -f /tmp/duckdb; \
+    mkdir -p /usr/local/lib/duckdb/extensions /usr/local/share/duckdb /tmp/ddbext; \
+    install_args=""; \
+    for spec in ${ext_shas}; do \
+        name="${spec%%:*}"; sha="${spec##*:}"; \
+        curl -fsSL "https://extensions.duckdb.org/v${DUCKDB_VERSION}/${platform}/${name}.duckdb_extension.gz" -o "/tmp/ddbext/${name}.duckdb_extension.gz"; \
+        echo "${sha}  /tmp/ddbext/${name}.duckdb_extension.gz" | sha256sum -c -; \
+        gunzip "/tmp/ddbext/${name}.duckdb_extension.gz"; \
+        install_args="${install_args} INSTALL '/tmp/ddbext/${name}.duckdb_extension';"; \
+    done; \
+    /usr/local/bin/duckdb.real -c "SET extension_directory = '/usr/local/lib/duckdb/extensions';${install_args}"; \
+    rm -rf /tmp/ddbext; \
     printf '%s\n' \
         "SET extension_directory = '/usr/local/lib/duckdb/extensions';" \
         "LOAD json;" \
-        "LOAD postgres;" \
         "LOAD httpfs;" \
-        "LOAD sqlite;" \
         "LOAD inet;" \
-        > /usr/local/share/duckdb/tracecat-init.sql && \
+        "LOAD fts;" \
+        > /usr/local/share/duckdb/tracecat-init.sql; \
     printf '%s\n' \
         '#!/bin/sh' \
         'exec /usr/local/bin/duckdb.real -init /usr/local/share/duckdb/tracecat-init.sql "$@"' \
-        > /usr/local/bin/duckdb && \
-    chmod 0755 /usr/local/bin/duckdb && \
-    jq --version && \
-    duckdb --version && \
-    test "$(duckdb -csv -noheader -c "SELECT count(*) FROM duckdb_extensions() WHERE extension_name IN ('json', 'postgres_scanner', 'httpfs', 'sqlite_scanner', 'inet') AND installed AND loaded;")" = "5"
+        > /usr/local/bin/duckdb; \
+    chmod 0755 /usr/local/bin/duckdb; \
+    jq --version; \
+    duckdb --version; \
+    test "$(duckdb -csv -noheader -c "SELECT count(*) FROM duckdb_extensions() WHERE extension_name IN ('json', 'httpfs', 'inet', 'fts') AND installed AND loaded;")" = "4"
 
 # Install uv for fast package management
 COPY --from=ghcr.io/astral-sh/uv:0.9.15 /uv /usr/local/bin/uv

--- a/docs/automations/core-actions/_examples.yaml
+++ b/docs/automations/core-actions/_examples.yaml
@@ -306,13 +306,24 @@ examples:
             GROUP BY severity
             ORDER BY count DESC
 
-  sql-duckdb-remote:
-    title: Query remote data with credentials
+  sql-duckdb-s3:
+    title: Read from S3
     language: yaml
     code: |
-      # Attach the amazon_s3 secret to read s3:// paths (supports AssumeRole),
-      # and pass headers to authenticate http(s) reads.
-      - ref: read_remote
+      # Attach the amazon_s3 secret (static keys or AWS_ROLE_ARN for AssumeRole).
+      - ref: read_s3
+        action: core.duckdb.execute_sql
+        args:
+          sql: |
+            SELECT *
+            FROM read_parquet('s3://my-bucket/findings/*.parquet')
+
+  sql-duckdb-https:
+    title: Read from an authenticated URL
+    language: yaml
+    code: |
+      # Pass HTTP headers to authenticate http(s) reads; keep the token in a secret.
+      - ref: read_url
         action: core.duckdb.execute_sql
         args:
           sql: |

--- a/docs/automations/core-actions/_examples.yaml
+++ b/docs/automations/core-actions/_examples.yaml
@@ -318,22 +318,6 @@ examples:
             SELECT *
             FROM read_parquet('s3://my-bucket/findings/*.parquet')
 
-  sql-duckdb-https:
-    title: Read from an authenticated URL
-    language: yaml
-    code: |
-      # Pass HTTP headers to authenticate http(s) reads; keep the token in a secret.
-      # headers_scope restricts the headers to the intended host.
-      - ref: read_url
-        action: core.duckdb.execute_sql
-        args:
-          sql: |
-            SELECT *
-            FROM read_json_auto('https://api.example.com/findings.json')
-          headers:
-            Authorization: Bearer ${{ SECRETS.example_api.TOKEN }}
-          headers_scope: https://api.example.com
-
   ssh-command:
     title: Execute a remote command
     language: yaml

--- a/docs/automations/core-actions/_examples.yaml
+++ b/docs/automations/core-actions/_examples.yaml
@@ -306,6 +306,21 @@ examples:
             GROUP BY severity
             ORDER BY count DESC
 
+  sql-duckdb-remote:
+    title: Query remote data with credentials
+    language: yaml
+    code: |
+      # Attach the amazon_s3 secret to read s3:// paths (supports AssumeRole),
+      # and pass headers to authenticate http(s) reads.
+      - ref: read_remote
+        action: core.duckdb.execute_sql
+        args:
+          sql: |
+            SELECT *
+            FROM read_json_auto('https://api.example.com/findings.json')
+          headers:
+            Authorization: Bearer ${{ SECRETS.example_api.TOKEN }}
+
   ssh-command:
     title: Execute a remote command
     language: yaml

--- a/docs/automations/core-actions/_examples.yaml
+++ b/docs/automations/core-actions/_examples.yaml
@@ -323,6 +323,7 @@ examples:
     language: yaml
     code: |
       # Pass HTTP headers to authenticate http(s) reads; keep the token in a secret.
+      # headers_scope restricts the headers to the intended host.
       - ref: read_url
         action: core.duckdb.execute_sql
         args:
@@ -331,6 +332,7 @@ examples:
             FROM read_json_auto('https://api.example.com/findings.json')
           headers:
             Authorization: Bearer ${{ SECRETS.example_api.TOKEN }}
+          headers_scope: https://api.example.com
 
   ssh-command:
     title: Execute a remote command

--- a/docs/automations/core-actions/_manifest.yaml
+++ b/docs/automations/core-actions/_manifest.yaml
@@ -115,7 +115,6 @@ pages:
         examples:
           - sql-duckdb-query
           - sql-duckdb-s3
-          - sql-duckdb-https
 
   - slug: request-actions/ssh
     title: SSH

--- a/docs/automations/core-actions/_manifest.yaml
+++ b/docs/automations/core-actions/_manifest.yaml
@@ -114,6 +114,8 @@ pages:
       - id: core.duckdb.execute_sql
         examples:
           - sql-duckdb-query
+          - sql-duckdb-s3
+          - sql-duckdb-https
 
   - slug: request-actions/ssh
     title: SSH

--- a/docs/automations/core-actions/request-actions/sql.mdx
+++ b/docs/automations/core-actions/request-actions/sql.mdx
@@ -90,14 +90,6 @@ Default: `null`.
 
 </ParamField>
 
-<ParamField path="s3_endpoint_url" type="string | null">
-
-Override the S3 endpoint URL (e.g. MinIO or another S3-compatible store).
-
-Default: `null`.
-
-</ParamField>
-
 ### Examples
 
 **Run in-process SQL**

--- a/docs/automations/core-actions/request-actions/sql.mdx
+++ b/docs/automations/core-actions/request-actions/sql.mdx
@@ -82,22 +82,6 @@ SQL to execute in an in-process DuckDB connection.
 
 </ParamField>
 
-<ParamField path="headers" type="object | null">
-
-HTTP headers sent with httpfs http(s) requests, e.g. for authenticating reads from a remote URL. Requires headers_scope.
-
-Default: `null`.
-
-</ParamField>
-
-<ParamField path="headers_scope" type="string | null">
-
-URL prefix the headers are restricted to (e.g. https://api.example.com). Required when headers is set; the headers are only sent to requests whose URL starts with this prefix, so auth tokens never leak to other hosts.
-
-Default: `null`.
-
-</ParamField>
-
 ### Examples
 
 **Run in-process SQL**
@@ -126,20 +110,4 @@ Default: `null`.
     sql: |
       SELECT *
       FROM read_parquet('s3://my-bucket/findings/*.parquet')
-```
-
-**Read from an authenticated URL**
-
-```yaml
-# Pass HTTP headers to authenticate http(s) reads; keep the token in a secret.
-# headers_scope restricts the headers to the intended host.
-- ref: read_url
-  action: core.duckdb.execute_sql
-  args:
-    sql: |
-      SELECT *
-      FROM read_json_auto('https://api.example.com/findings.json')
-    headers:
-      Authorization: Bearer ${{ SECRETS.example_api.TOKEN }}
-    headers_scope: https://api.example.com
 ```

--- a/docs/automations/core-actions/request-actions/sql.mdx
+++ b/docs/automations/core-actions/request-actions/sql.mdx
@@ -84,7 +84,15 @@ SQL to execute in an in-process DuckDB connection.
 
 <ParamField path="headers" type="object | null">
 
-HTTP headers sent with httpfs http(s) requests, e.g. for authenticating reads from a remote URL.
+HTTP headers sent with httpfs http(s) requests, e.g. for authenticating reads from a remote URL. Requires headers_scope.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="headers_scope" type="string | null">
+
+URL prefix the headers are restricted to (e.g. https://api.example.com). Required when headers is set; the headers are only sent to requests whose URL starts with this prefix, so auth tokens never leak to other hosts.
 
 Default: `null`.
 
@@ -124,6 +132,7 @@ Default: `null`.
 
 ```yaml
 # Pass HTTP headers to authenticate http(s) reads; keep the token in a secret.
+# headers_scope restricts the headers to the intended host.
 - ref: read_url
   action: core.duckdb.execute_sql
   args:
@@ -132,4 +141,5 @@ Default: `null`.
       FROM read_json_auto('https://api.example.com/findings.json')
     headers:
       Authorization: Bearer ${{ SECRETS.example_api.TOKEN }}
+    headers_scope: https://api.example.com
 ```

--- a/docs/automations/core-actions/request-actions/sql.mdx
+++ b/docs/automations/core-actions/request-actions/sql.mdx
@@ -68,11 +68,33 @@ Default: `200`.
 
 Execute SQL in an in-process DuckDB engine
 
+### Secrets
+
+Optional secrets:
+
+- `amazon_s3`: optional values `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `AWS_ROLE_ARN`, `AWS_ROLE_SESSION_NAME`.
+
 ### Inputs
 
 <ParamField path="sql" type="string" required>
 
 SQL to execute in an in-process DuckDB connection.
+
+</ParamField>
+
+<ParamField path="headers" type="object | null">
+
+HTTP headers sent with httpfs http(s) requests, e.g. for authenticating reads from a remote URL.
+
+Default: `null`.
+
+</ParamField>
+
+<ParamField path="s3_endpoint_url" type="string | null">
+
+Override the S3 endpoint URL (e.g. MinIO or another S3-compatible store).
+
+Default: `null`.
 
 </ParamField>
 
@@ -92,4 +114,19 @@ SQL to execute in an in-process DuckDB connection.
       FROM findings
       GROUP BY severity
       ORDER BY count DESC
+```
+
+**Query remote data with credentials**
+
+```yaml
+# Attach the amazon_s3 secret to read s3:// paths (supports AssumeRole),
+# and pass headers to authenticate http(s) reads.
+- ref: read_remote
+  action: core.duckdb.execute_sql
+  args:
+    sql: |
+      SELECT *
+      FROM read_json_auto('https://api.example.com/findings.json')
+    headers:
+      Authorization: Bearer ${{ SECRETS.example_api.TOKEN }}
 ```

--- a/docs/automations/core-actions/request-actions/sql.mdx
+++ b/docs/automations/core-actions/request-actions/sql.mdx
@@ -116,12 +116,23 @@ Default: `null`.
       ORDER BY count DESC
 ```
 
-**Query remote data with credentials**
+**Read from S3**
 
 ```yaml
-# Attach the amazon_s3 secret to read s3:// paths (supports AssumeRole),
-# and pass headers to authenticate http(s) reads.
-- ref: read_remote
+# Attach the amazon_s3 secret (static keys or AWS_ROLE_ARN for AssumeRole).
+- ref: read_s3
+  action: core.duckdb.execute_sql
+  args:
+    sql: |
+      SELECT *
+      FROM read_parquet('s3://my-bucket/findings/*.parquet')
+```
+
+**Read from an authenticated URL**
+
+```yaml
+# Pass HTTP headers to authenticate http(s) reads; keep the token in a secret.
+- ref: read_url
   action: core.duckdb.execute_sql
   args:
     sql: |

--- a/packages/tracecat-registry/tracecat_registry/config.py
+++ b/packages/tracecat-registry/tracecat_registry/config.py
@@ -41,6 +41,13 @@ TRACECAT__S3_CONCURRENCY_LIMIT = int(
     os.environ.get("TRACECAT__S3_CONCURRENCY_LIMIT", 10)
 )
 
+# DuckDB extension directory. Set in the Docker images to the directory that
+# preinstalled DuckDB extensions are copied into. Left unset in local/dev/test
+# environments, where DuckDB falls back to its default autoinstall behaviour.
+TRACECAT__DUCKDB_EXTENSION_DIRECTORY = os.environ.get(
+    "TRACECAT__DUCKDB_EXTENSION_DIRECTORY"
+)
+
 # Database connection validation (used to prevent connecting to internal DB)
 TRACECAT__DB_URI = os.environ.get(
     "TRACECAT__DB_URI",

--- a/packages/tracecat-registry/tracecat_registry/core/duckdb.py
+++ b/packages/tracecat-registry/tracecat_registry/core/duckdb.py
@@ -1,3 +1,4 @@
+import os
 from typing import Annotated, Any
 
 import duckdb
@@ -9,6 +10,13 @@ from tracecat_registry import registry, secrets
 from tracecat_registry.config import TRACECAT__DUCKDB_EXTENSION_DIRECTORY
 from tracecat_registry.integrations.amazon_s3 import s3_secret
 
+# Directory the Docker images preinstall DuckDB extensions into. Used as a
+# fallback when TRACECAT__DUCKDB_EXTENSION_DIRECTORY is not set in the process
+# environment — notably under nsjail executors, where the env var is not
+# forwarded into the jail but this directory is bind-mounted (read-only) from
+# the sandbox rootfs.
+_DEFAULT_EXTENSION_DIRECTORY = "/usr/local/lib/duckdb/extensions"
+
 
 def _rows_to_json(
     columns: list[str], rows: list[tuple[Any, ...]]
@@ -17,17 +25,31 @@ def _rows_to_json(
     return to_jsonable_python(records, fallback=str, exclude_none=False)
 
 
+def _extension_directory() -> str | None:
+    """Directory DuckDB should load extensions from, or None for its default.
+
+    Prefer the configured ``TRACECAT__DUCKDB_EXTENSION_DIRECTORY``; otherwise fall
+    back to the image's preinstalled directory when it exists. The fallback makes
+    the pinned extensions usable across every executor backend — including nsjail
+    sandboxes, where the env var is not forwarded into the jail but the directory
+    is bind-mounted read-only from the rootfs. Returns None in local/dev where
+    neither is present, so DuckDB keeps its default autoinstall behaviour.
+    """
+    if TRACECAT__DUCKDB_EXTENSION_DIRECTORY:
+        return TRACECAT__DUCKDB_EXTENSION_DIRECTORY
+    if os.path.isdir(_DEFAULT_EXTENSION_DIRECTORY):
+        return _DEFAULT_EXTENSION_DIRECTORY
+    return None
+
+
 def _connect() -> duckdb.DuckDBPyConnection:
     """Open an in-process DuckDB connection.
 
-    When ``TRACECAT__DUCKDB_EXTENSION_DIRECTORY`` is set (the Docker images
-    point it at the preinstalled extension directory) the connection loads
-    extensions from there instead of autoinstalling over the network.
+    Loads extensions from the preinstalled directory (see ``_extension_directory``)
+    instead of autoinstalling over the network when that directory is available.
     """
-    if TRACECAT__DUCKDB_EXTENSION_DIRECTORY:
-        return duckdb.connect(
-            config={"extension_directory": TRACECAT__DUCKDB_EXTENSION_DIRECTORY}
-        )
+    if extension_directory := _extension_directory():
+        return duckdb.connect(config={"extension_directory": extension_directory})
     return duckdb.connect()
 
 

--- a/packages/tracecat-registry/tracecat_registry/core/duckdb.py
+++ b/packages/tracecat-registry/tracecat_registry/core/duckdb.py
@@ -4,7 +4,10 @@ import duckdb
 from pydantic_core import to_jsonable_python
 from typing_extensions import Doc
 
-from tracecat_registry import registry
+import tracecat_registry.integrations.aws_boto3 as aws_boto3
+from tracecat_registry import registry, secrets
+from tracecat_registry.config import TRACECAT__DUCKDB_EXTENSION_DIRECTORY
+from tracecat_registry.integrations.amazon_s3 import s3_secret
 
 
 def _rows_to_json(
@@ -14,20 +17,120 @@ def _rows_to_json(
     return to_jsonable_python(records, fallback=str, exclude_none=False)
 
 
+def _quote(value: str) -> str:
+    """Quote a value as a single-quoted DuckDB SQL string literal.
+
+    Single quotes are escaped by doubling them. Used for every value
+    interpolated into ``CREATE SECRET`` statements (credentials and headers)
+    so secret values cannot break out of the literal.
+    """
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _connect() -> duckdb.DuckDBPyConnection:
+    """Open an in-process DuckDB connection.
+
+    When ``TRACECAT__DUCKDB_EXTENSION_DIRECTORY`` is set (the Docker images
+    point it at the preinstalled extension directory) the connection loads
+    extensions from there instead of autoinstalling over the network.
+    """
+    if TRACECAT__DUCKDB_EXTENSION_DIRECTORY:
+        return duckdb.connect(
+            config={"extension_directory": TRACECAT__DUCKDB_EXTENSION_DIRECTORY}
+        )
+    return duckdb.connect()
+
+
+def _maybe_setup_s3_secret(
+    con: duckdb.DuckDBPyConnection, endpoint_url: str | None
+) -> None:
+    """Configure a DuckDB S3 secret from the ``amazon_s3`` credentials.
+
+    No-op when no credentials are attached (the secret is optional). When
+    present, credentials are resolved through the shared boto3 session so the
+    full precedence applies, including cross-account ``AWS_ROLE_ARN``
+    AssumeRole (the resolved temporary credentials carry a session token).
+    """
+    if not (
+        secrets.get_or_default("AWS_ROLE_ARN")
+        or secrets.get_or_default("AWS_ACCESS_KEY_ID")
+    ):
+        return
+
+    session = aws_boto3.get_sync_session()
+    credentials = session.get_credentials()
+    if credentials is None:
+        raise ValueError("Resolved AWS session has no credentials.")
+    frozen = credentials.get_frozen_credentials()
+    if not frozen.access_key or not frozen.secret_key:
+        raise ValueError("Resolved AWS session is missing access key credentials.")
+
+    parts = [
+        "TYPE s3",
+        f"KEY_ID {_quote(frozen.access_key)}",
+        f"SECRET {_quote(frozen.secret_key)}",
+    ]
+    if frozen.token:
+        parts.append(f"SESSION_TOKEN {_quote(frozen.token)}")
+    if session.region_name:
+        parts.append(f"REGION {_quote(session.region_name)}")
+    if endpoint_url:
+        parts.append(f"ENDPOINT {_quote(endpoint_url)}")
+        parts.append("URL_STYLE 'path'")
+
+    con.execute("LOAD httpfs")
+    con.execute(f"CREATE OR REPLACE SECRET __tc_s3 ({', '.join(parts)})")
+
+
+def _maybe_setup_http_secret(
+    con: duckdb.DuckDBPyConnection, headers: dict[str, str] | None
+) -> None:
+    """Configure a DuckDB HTTP secret that injects ``headers`` into requests.
+
+    The httpfs HTTP secret applies to both ``http://`` and ``https://`` reads.
+    """
+    if not headers:
+        return
+
+    entries = ", ".join(
+        f"{_quote(name)}: {_quote(value)}" for name, value in headers.items()
+    )
+    con.execute("LOAD httpfs")
+    con.execute(
+        f"CREATE OR REPLACE SECRET __tc_http (TYPE http, EXTRA_HTTP_HEADERS MAP {{{entries}}})"
+    )
+
+
 @registry.register(
     default_title="Execute DuckDB SQL",
     description=("Execute SQL in an in-process DuckDB engine"),
     display_group="DuckDB",
     namespace="core.duckdb",
+    secrets=[s3_secret],
 )
 def execute_sql(
     sql: Annotated[
         str,
         Doc("SQL to execute in an in-process DuckDB connection. "),
     ],
+    headers: Annotated[
+        dict[str, str] | None,
+        Doc(
+            "HTTP headers sent with httpfs http(s) requests, e.g. for "
+            "authenticating reads from a remote URL."
+        ),
+    ] = None,
+    s3_endpoint_url: Annotated[
+        str | None,
+        Doc(
+            "Override the S3 endpoint URL (e.g. MinIO or another S3-compatible store)."
+        ),
+    ] = None,
 ) -> int | list[dict[str, Any]] | None:
-    con = duckdb.connect()
+    con = _connect()
     try:
+        _maybe_setup_s3_secret(con, s3_endpoint_url)
+        _maybe_setup_http_secret(con, headers)
         con.execute(sql)
         if con.description is None:
             return con.rowcount

--- a/packages/tracecat-registry/tracecat_registry/core/duckdb.py
+++ b/packages/tracecat-registry/tracecat_registry/core/duckdb.py
@@ -1,4 +1,5 @@
 from typing import Annotated, Any
+from urllib.parse import urlsplit
 
 import duckdb
 from pydantic_core import to_jsonable_python
@@ -17,14 +18,23 @@ def _rows_to_json(
     return to_jsonable_python(records, fallback=str, exclude_none=False)
 
 
-def _quote(value: str) -> str:
-    """Quote a value as a single-quoted DuckDB SQL string literal.
+def _split_s3_endpoint(endpoint_url: str) -> tuple[str, bool | None]:
+    """Split a full endpoint URL into a DuckDB ``ENDPOINT`` host and ``USE_SSL``.
 
-    Single quotes are escaped by doubling them. Used for every value
-    interpolated into ``CREATE SECRET`` statements (credentials and headers)
-    so secret values cannot break out of the literal.
+    The action accepts the same full-URL form as the other S3 actions (e.g.
+    ``http://minio:9000``), but DuckDB's S3 secret wants a bare ``host[:port]``
+    and does not infer TLS from the scheme. Strip the scheme for ``ENDPOINT``
+    and derive ``USE_SSL`` from it: ``http`` -> False, ``https`` -> True, and
+    no scheme -> None (leave DuckDB's default).
     """
-    return "'" + str(value).replace("'", "''") + "'"
+    raw = endpoint_url.strip()
+    # Prefix "//" for bare host:port so urlsplit populates netloc instead of path.
+    parts = urlsplit(raw if "://" in raw else f"//{raw}")
+    host = parts.netloc or raw
+    use_ssl = (
+        False if parts.scheme == "http" else True if parts.scheme == "https" else None
+    )
+    return host, use_ssl
 
 
 def _connect() -> duckdb.DuckDBPyConnection:
@@ -65,21 +75,27 @@ def _maybe_setup_s3_secret(
     if not frozen.access_key or not frozen.secret_key:
         raise ValueError("Resolved AWS session is missing access key credentials.")
 
-    parts = [
-        "TYPE s3",
-        f"KEY_ID {_quote(frozen.access_key)}",
-        f"SECRET {_quote(frozen.secret_key)}",
-    ]
+    # Only fixed option names and constants we derive ourselves are interpolated
+    # into the statement; every credential value is bound via a ? parameter, so
+    # secret values can never be parsed as SQL.
+    options = ["TYPE s3", "KEY_ID ?", "SECRET ?"]
+    params: list[Any] = [frozen.access_key, frozen.secret_key]
     if frozen.token:
-        parts.append(f"SESSION_TOKEN {_quote(frozen.token)}")
+        options.append("SESSION_TOKEN ?")
+        params.append(frozen.token)
     if session.region_name:
-        parts.append(f"REGION {_quote(session.region_name)}")
+        options.append("REGION ?")
+        params.append(session.region_name)
     if endpoint_url:
-        parts.append(f"ENDPOINT {_quote(endpoint_url)}")
-        parts.append("URL_STYLE 'path'")
+        host, use_ssl = _split_s3_endpoint(endpoint_url)
+        options.append("ENDPOINT ?")
+        params.append(host)
+        options.append("URL_STYLE 'path'")
+        if use_ssl is not None:
+            options.append(f"USE_SSL {'true' if use_ssl else 'false'}")
 
     con.execute("LOAD httpfs")
-    con.execute(f"CREATE OR REPLACE SECRET __tc_s3 ({', '.join(parts)})")
+    con.execute(f"CREATE OR REPLACE SECRET __tc_s3 ({', '.join(options)})", params)
 
 
 def _maybe_setup_http_secret(
@@ -92,12 +108,12 @@ def _maybe_setup_http_secret(
     if not headers:
         return
 
-    entries = ", ".join(
-        f"{_quote(name)}: {_quote(value)}" for name, value in headers.items()
-    )
+    # Bind the header names and values as two list parameters so they are never
+    # interpolated into the statement text.
     con.execute("LOAD httpfs")
     con.execute(
-        f"CREATE OR REPLACE SECRET __tc_http (TYPE http, EXTRA_HTTP_HEADERS MAP {{{entries}}})"
+        "CREATE OR REPLACE SECRET __tc_http (TYPE http, EXTRA_HTTP_HEADERS map(?, ?))",
+        [list(headers.keys()), list(headers.values())],
     )
 
 

--- a/packages/tracecat-registry/tracecat_registry/core/duckdb.py
+++ b/packages/tracecat-registry/tracecat_registry/core/duckdb.py
@@ -1,5 +1,4 @@
 from typing import Annotated, Any
-from urllib.parse import urlsplit
 
 import duckdb
 from pydantic_core import to_jsonable_python
@@ -18,25 +17,6 @@ def _rows_to_json(
     return to_jsonable_python(records, fallback=str, exclude_none=False)
 
 
-def _split_s3_endpoint(endpoint_url: str) -> tuple[str, bool | None]:
-    """Split a full endpoint URL into a DuckDB ``ENDPOINT`` host and ``USE_SSL``.
-
-    The action accepts the same full-URL form as the other S3 actions (e.g.
-    ``http://minio:9000``), but DuckDB's S3 secret wants a bare ``host[:port]``
-    and does not infer TLS from the scheme. Strip the scheme for ``ENDPOINT``
-    and derive ``USE_SSL`` from it: ``http`` -> False, ``https`` -> True, and
-    no scheme -> None (leave DuckDB's default).
-    """
-    raw = endpoint_url.strip()
-    # Prefix "//" for bare host:port so urlsplit populates netloc instead of path.
-    parts = urlsplit(raw if "://" in raw else f"//{raw}")
-    host = parts.netloc or raw
-    use_ssl = (
-        False if parts.scheme == "http" else True if parts.scheme == "https" else None
-    )
-    return host, use_ssl
-
-
 def _connect() -> duckdb.DuckDBPyConnection:
     """Open an in-process DuckDB connection.
 
@@ -51,21 +31,23 @@ def _connect() -> duckdb.DuckDBPyConnection:
     return duckdb.connect()
 
 
-def _maybe_setup_s3_secret(
-    con: duckdb.DuckDBPyConnection, endpoint_url: str | None
-) -> None:
-    """Configure a DuckDB S3 secret from the ``amazon_s3`` credentials.
+def _build_s3_secret() -> tuple[list[str], list[Any]] | None:
+    """Build a parameterized S3 ``CREATE SECRET`` spec from the ``amazon_s3`` creds.
 
-    No-op when no credentials are attached (the secret is optional). When
-    present, credentials are resolved through the shared boto3 session so the
-    full precedence applies, including cross-account ``AWS_ROLE_ARN``
-    AssumeRole (the resolved temporary credentials carry a session token).
+    Returns ``(options, params)`` for the secret, or ``None`` when no credentials
+    are attached (the secret is optional). Credentials are resolved through the
+    shared boto3 session so the full precedence applies, including cross-account
+    ``AWS_ROLE_ARN`` AssumeRole (the temporary credentials carry a session token).
+
+    Only fixed option names are placed in the statement text; every credential
+    value is bound via a ``?`` parameter, so a secret value can never be parsed
+    as SQL.
     """
     if not (
         secrets.get_or_default("AWS_ROLE_ARN")
         or secrets.get_or_default("AWS_ACCESS_KEY_ID")
     ):
-        return
+        return None
 
     session = aws_boto3.get_sync_session()
     credentials = session.get_credentials()
@@ -75,9 +57,6 @@ def _maybe_setup_s3_secret(
     if not frozen.access_key or not frozen.secret_key:
         raise ValueError("Resolved AWS session is missing access key credentials.")
 
-    # Only fixed option names and constants we derive ourselves are interpolated
-    # into the statement; every credential value is bound via a ? parameter, so
-    # secret values can never be parsed as SQL.
     options = ["TYPE s3", "KEY_ID ?", "SECRET ?"]
     params: list[Any] = [frozen.access_key, frozen.secret_key]
     if frozen.token:
@@ -86,35 +65,34 @@ def _maybe_setup_s3_secret(
     if session.region_name:
         options.append("REGION ?")
         params.append(session.region_name)
-    if endpoint_url:
-        host, use_ssl = _split_s3_endpoint(endpoint_url)
-        options.append("ENDPOINT ?")
-        params.append(host)
-        options.append("URL_STYLE 'path'")
-        if use_ssl is not None:
-            options.append(f"USE_SSL {'true' if use_ssl else 'false'}")
-
-    con.execute("LOAD httpfs")
-    con.execute(f"CREATE OR REPLACE SECRET __tc_s3 ({', '.join(options)})", params)
+    return options, params
 
 
-def _maybe_setup_http_secret(
+def _setup_remote_secrets(
     con: duckdb.DuckDBPyConnection, headers: dict[str, str] | None
 ) -> None:
-    """Configure a DuckDB HTTP secret that injects ``headers`` into requests.
+    """Create the S3 and/or HTTP secrets used for remote reads.
 
-    The httpfs HTTP secret applies to both ``http://`` and ``https://`` reads.
+    Both secret types require httpfs, so it is loaded once here, and only when a
+    secret is actually needed. Plain queries (no ``amazon_s3`` credentials and no
+    headers) load nothing and create nothing.
     """
-    if not headers:
+    s3 = _build_s3_secret()
+    if s3 is None and not headers:
         return
 
-    # Bind the header names and values as two list parameters so they are never
-    # interpolated into the statement text.
     con.execute("LOAD httpfs")
-    con.execute(
-        "CREATE OR REPLACE SECRET __tc_http (TYPE http, EXTRA_HTTP_HEADERS map(?, ?))",
-        [list(headers.keys()), list(headers.values())],
-    )
+
+    if s3 is not None:
+        options, params = s3
+        con.execute(f"CREATE OR REPLACE SECRET __tc_s3 ({', '.join(options)})", params)
+
+    if headers:
+        # Bind header names and values as two list parameters (never interpolated).
+        con.execute(
+            "CREATE OR REPLACE SECRET __tc_http (TYPE http, EXTRA_HTTP_HEADERS map(?, ?))",
+            [list(headers.keys()), list(headers.values())],
+        )
 
 
 @registry.register(
@@ -136,17 +114,10 @@ def execute_sql(
             "authenticating reads from a remote URL."
         ),
     ] = None,
-    s3_endpoint_url: Annotated[
-        str | None,
-        Doc(
-            "Override the S3 endpoint URL (e.g. MinIO or another S3-compatible store)."
-        ),
-    ] = None,
 ) -> int | list[dict[str, Any]] | None:
     con = _connect()
     try:
-        _maybe_setup_s3_secret(con, s3_endpoint_url)
-        _maybe_setup_http_secret(con, headers)
+        _setup_remote_secrets(con, headers)
         con.execute(sql)
         if con.description is None:
             return con.rowcount

--- a/packages/tracecat-registry/tracecat_registry/core/duckdb.py
+++ b/packages/tracecat-registry/tracecat_registry/core/duckdb.py
@@ -1,6 +1,5 @@
 import os
 from typing import Annotated, Any
-from urllib.parse import urlsplit
 
 import duckdb
 from pydantic_core import to_jsonable_python
@@ -91,75 +90,20 @@ def _build_s3_secret() -> tuple[list[str], list[Any]] | None:
     return options, params
 
 
-def _normalize_headers_scope(headers_scope: str | None) -> str:
-    """Validate and normalize the HTTP secret ``SCOPE`` for header injection.
+def _setup_s3_secret(con: duckdb.DuckDBPyConnection) -> None:
+    """Create the S3 secret used for ``s3://`` reads, when credentials are attached.
 
-    DuckDB matches ``SCOPE`` as a literal URL prefix, so a bare host prefix like
-    ``https://api.example.com`` would also match ``https://api.example.com.evil.com``.
-    Require an http(s) URL with a host, and anchor the host boundary with a
-    trailing ``/`` when no path is given, so the headers can never leak to a
-    sibling host. Query/fragment are dropped.
+    S3 access goes through httpfs, so it is loaded only when the ``amazon_s3``
+    secret carries credentials. Plain queries (no credentials) load nothing and
+    create nothing.
     """
-    if not headers_scope:
-        raise ValueError(
-            "headers_scope is required when headers is set: provide the URL prefix "
-            "the headers apply to (e.g. https://api.example.com) so they are not "
-            "sent to other hosts."
-        )
-    parts = urlsplit(headers_scope)
-    if parts.scheme not in ("http", "https") or not parts.hostname:
-        raise ValueError(
-            "headers_scope must be an http:// or https:// URL with a host, "
-            f"e.g. https://api.example.com (got {headers_scope!r})."
-        )
-    # Reject userinfo: a URL like https://api.example.com@evil.com actually points
-    # at evil.com, so the host before the '@' would mislead the scope.
-    if "@" in parts.netloc:
-        raise ValueError(
-            "headers_scope must not contain userinfo ('@'); use a plain "
-            f"scheme://host[:port][/path] (got {headers_scope!r})."
-        )
-    # Anchor the host with a trailing slash so prefix matching cannot bleed into a
-    # longer host (e.g. api.example.com.evil.com).
-    path = parts.path or "/"
-    return f"{parts.scheme}://{parts.netloc}{path}"
-
-
-def _setup_remote_secrets(
-    con: duckdb.DuckDBPyConnection,
-    headers: dict[str, str] | None,
-    headers_scope: str | None,
-) -> None:
-    """Create the S3 and/or HTTP secrets used for remote reads.
-
-    Both secret types require httpfs, so it is loaded once here, and only when a
-    secret is actually needed. Plain queries (no ``amazon_s3`` credentials and no
-    headers) load nothing and create nothing.
-
-    The HTTP secret is always scoped: ``headers_scope`` is required when
-    ``headers`` is set, so the headers (e.g. an auth token) are only ever sent to
-    requests whose URL starts with that normalized prefix — never to other hosts a
-    query might also read.
-    """
-    scope = _normalize_headers_scope(headers_scope) if headers else None
-
     s3 = _build_s3_secret()
-    if s3 is None and not headers:
+    if s3 is None:
         return
 
+    options, params = s3
     con.execute("LOAD httpfs")
-
-    if s3 is not None:
-        options, params = s3
-        con.execute(f"CREATE OR REPLACE SECRET __tc_s3 ({', '.join(options)})", params)
-
-    if headers:
-        # Bind header names, values, and scope as parameters (never interpolated).
-        con.execute(
-            "CREATE OR REPLACE SECRET __tc_http "
-            "(TYPE http, EXTRA_HTTP_HEADERS map(?, ?), SCOPE ?)",
-            [list(headers.keys()), list(headers.values()), scope],
-        )
+    con.execute(f"CREATE OR REPLACE SECRET __tc_s3 ({', '.join(options)})", params)
 
 
 @registry.register(
@@ -174,26 +118,10 @@ def execute_sql(
         str,
         Doc("SQL to execute in an in-process DuckDB connection. "),
     ],
-    headers: Annotated[
-        dict[str, str] | None,
-        Doc(
-            "HTTP headers sent with httpfs http(s) requests, e.g. for "
-            "authenticating reads from a remote URL. Requires headers_scope."
-        ),
-    ] = None,
-    headers_scope: Annotated[
-        str | None,
-        Doc(
-            "URL prefix the headers are restricted to (e.g. "
-            "https://api.example.com). Required when headers is set; the headers "
-            "are only sent to requests whose URL starts with this prefix, so auth "
-            "tokens never leak to other hosts."
-        ),
-    ] = None,
 ) -> int | list[dict[str, Any]] | None:
     con = _connect()
     try:
-        _setup_remote_secrets(con, headers, headers_scope)
+        _setup_s3_secret(con)
         con.execute(sql)
         if con.description is None:
             return con.rowcount

--- a/packages/tracecat-registry/tracecat_registry/core/duckdb.py
+++ b/packages/tracecat-registry/tracecat_registry/core/duckdb.py
@@ -91,14 +91,34 @@ def _build_s3_secret() -> tuple[list[str], list[Any]] | None:
 
 
 def _setup_remote_secrets(
-    con: duckdb.DuckDBPyConnection, headers: dict[str, str] | None
+    con: duckdb.DuckDBPyConnection,
+    headers: dict[str, str] | None,
+    headers_scope: str | None,
 ) -> None:
     """Create the S3 and/or HTTP secrets used for remote reads.
 
     Both secret types require httpfs, so it is loaded once here, and only when a
     secret is actually needed. Plain queries (no ``amazon_s3`` credentials and no
     headers) load nothing and create nothing.
+
+    The HTTP secret is always scoped: ``headers_scope`` is required when
+    ``headers`` is set, so the headers (e.g. an auth token) are only ever sent to
+    requests whose URL starts with that prefix — never to other hosts a query
+    might also read.
     """
+    if headers:
+        if not headers_scope:
+            raise ValueError(
+                "headers_scope is required when headers is set: provide the URL "
+                "prefix the headers apply to (e.g. https://api.example.com) so "
+                "they are not sent to other hosts."
+            )
+        if not headers_scope.startswith(("http://", "https://")):
+            raise ValueError(
+                "headers_scope must be an http:// or https:// URL prefix, "
+                f"got {headers_scope!r}."
+            )
+
     s3 = _build_s3_secret()
     if s3 is None and not headers:
         return
@@ -110,10 +130,11 @@ def _setup_remote_secrets(
         con.execute(f"CREATE OR REPLACE SECRET __tc_s3 ({', '.join(options)})", params)
 
     if headers:
-        # Bind header names and values as two list parameters (never interpolated).
+        # Bind header names, values, and scope as parameters (never interpolated).
         con.execute(
-            "CREATE OR REPLACE SECRET __tc_http (TYPE http, EXTRA_HTTP_HEADERS map(?, ?))",
-            [list(headers.keys()), list(headers.values())],
+            "CREATE OR REPLACE SECRET __tc_http "
+            "(TYPE http, EXTRA_HTTP_HEADERS map(?, ?), SCOPE ?)",
+            [list(headers.keys()), list(headers.values()), headers_scope],
         )
 
 
@@ -133,13 +154,22 @@ def execute_sql(
         dict[str, str] | None,
         Doc(
             "HTTP headers sent with httpfs http(s) requests, e.g. for "
-            "authenticating reads from a remote URL."
+            "authenticating reads from a remote URL. Requires headers_scope."
+        ),
+    ] = None,
+    headers_scope: Annotated[
+        str | None,
+        Doc(
+            "URL prefix the headers are restricted to (e.g. "
+            "https://api.example.com). Required when headers is set; the headers "
+            "are only sent to requests whose URL starts with this prefix, so auth "
+            "tokens never leak to other hosts."
         ),
     ] = None,
 ) -> int | list[dict[str, Any]] | None:
     con = _connect()
     try:
-        _setup_remote_secrets(con, headers)
+        _setup_remote_secrets(con, headers, headers_scope)
         con.execute(sql)
         if con.description is None:
             return con.rowcount

--- a/packages/tracecat-registry/tracecat_registry/core/duckdb.py
+++ b/packages/tracecat-registry/tracecat_registry/core/duckdb.py
@@ -107,10 +107,17 @@ def _normalize_headers_scope(headers_scope: str | None) -> str:
             "sent to other hosts."
         )
     parts = urlsplit(headers_scope)
-    if parts.scheme not in ("http", "https") or not parts.netloc:
+    if parts.scheme not in ("http", "https") or not parts.hostname:
         raise ValueError(
             "headers_scope must be an http:// or https:// URL with a host, "
             f"e.g. https://api.example.com (got {headers_scope!r})."
+        )
+    # Reject userinfo: a URL like https://api.example.com@evil.com actually points
+    # at evil.com, so the host before the '@' would mislead the scope.
+    if "@" in parts.netloc:
+        raise ValueError(
+            "headers_scope must not contain userinfo ('@'); use a plain "
+            f"scheme://host[:port][/path] (got {headers_scope!r})."
         )
     # Anchor the host with a trailing slash so prefix matching cannot bleed into a
     # longer host (e.g. api.example.com.evil.com).

--- a/packages/tracecat-registry/tracecat_registry/core/duckdb.py
+++ b/packages/tracecat-registry/tracecat_registry/core/duckdb.py
@@ -1,5 +1,6 @@
 import os
 from typing import Annotated, Any
+from urllib.parse import urlsplit
 
 import duckdb
 from pydantic_core import to_jsonable_python
@@ -90,6 +91,33 @@ def _build_s3_secret() -> tuple[list[str], list[Any]] | None:
     return options, params
 
 
+def _normalize_headers_scope(headers_scope: str | None) -> str:
+    """Validate and normalize the HTTP secret ``SCOPE`` for header injection.
+
+    DuckDB matches ``SCOPE`` as a literal URL prefix, so a bare host prefix like
+    ``https://api.example.com`` would also match ``https://api.example.com.evil.com``.
+    Require an http(s) URL with a host, and anchor the host boundary with a
+    trailing ``/`` when no path is given, so the headers can never leak to a
+    sibling host. Query/fragment are dropped.
+    """
+    if not headers_scope:
+        raise ValueError(
+            "headers_scope is required when headers is set: provide the URL prefix "
+            "the headers apply to (e.g. https://api.example.com) so they are not "
+            "sent to other hosts."
+        )
+    parts = urlsplit(headers_scope)
+    if parts.scheme not in ("http", "https") or not parts.netloc:
+        raise ValueError(
+            "headers_scope must be an http:// or https:// URL with a host, "
+            f"e.g. https://api.example.com (got {headers_scope!r})."
+        )
+    # Anchor the host with a trailing slash so prefix matching cannot bleed into a
+    # longer host (e.g. api.example.com.evil.com).
+    path = parts.path or "/"
+    return f"{parts.scheme}://{parts.netloc}{path}"
+
+
 def _setup_remote_secrets(
     con: duckdb.DuckDBPyConnection,
     headers: dict[str, str] | None,
@@ -103,21 +131,10 @@ def _setup_remote_secrets(
 
     The HTTP secret is always scoped: ``headers_scope`` is required when
     ``headers`` is set, so the headers (e.g. an auth token) are only ever sent to
-    requests whose URL starts with that prefix — never to other hosts a query
-    might also read.
+    requests whose URL starts with that normalized prefix — never to other hosts a
+    query might also read.
     """
-    if headers:
-        if not headers_scope:
-            raise ValueError(
-                "headers_scope is required when headers is set: provide the URL "
-                "prefix the headers apply to (e.g. https://api.example.com) so "
-                "they are not sent to other hosts."
-            )
-        if not headers_scope.startswith(("http://", "https://")):
-            raise ValueError(
-                "headers_scope must be an http:// or https:// URL prefix, "
-                f"got {headers_scope!r}."
-            )
+    scope = _normalize_headers_scope(headers_scope) if headers else None
 
     s3 = _build_s3_secret()
     if s3 is None and not headers:
@@ -134,7 +151,7 @@ def _setup_remote_secrets(
         con.execute(
             "CREATE OR REPLACE SECRET __tc_http "
             "(TYPE http, EXTRA_HTTP_HEADERS map(?, ?), SCOPE ?)",
-            [list(headers.keys()), list(headers.values()), headers_scope],
+            [list(headers.keys()), list(headers.values()), scope],
         )
 
 

--- a/tests/registry/test_core_duckdb.py
+++ b/tests/registry/test_core_duckdb.py
@@ -95,7 +95,18 @@ def test_normalize_headers_scope() -> None:
 
 
 def test_normalize_headers_scope_rejects_invalid() -> None:
-    for bad in (None, "", "api.example.com", "ftp://host", "https://", "/just/a/path"):
+    for bad in (
+        None,
+        "",
+        "api.example.com",
+        "ftp://host",
+        "https://",
+        "/just/a/path",
+        # Userinfo makes the real host evil.com — must be rejected, not accepted.
+        "https://api.example.com@evil.com",
+        "https://api.example.com@evil.com/",
+        "https://user:pass@host/p",
+    ):
         with pytest.raises(ValueError):
             _normalize_headers_scope(bad)
 

--- a/tests/registry/test_core_duckdb.py
+++ b/tests/registry/test_core_duckdb.py
@@ -1,6 +1,8 @@
 import json
 
-from tracecat_registry.core.duckdb import execute_sql
+import duckdb
+import pytest
+from tracecat_registry.core.duckdb import _quote, execute_sql
 
 
 def test_execute_sql_returns_json_serializable_rows() -> None:
@@ -15,3 +17,35 @@ def test_execute_sql_non_query_returns_json_serializable() -> None:
 
     assert isinstance(result, (int, list))
     json.dumps(result)
+
+
+def test_quote_escapes_single_quotes() -> None:
+    assert _quote("abc") == "'abc'"
+    assert _quote("a'b") == "'a''b'"
+    assert _quote("Bearer ' OR 1=1 --") == "'Bearer '' OR 1=1 --'"
+
+
+def _httpfs_available() -> bool:
+    con = duckdb.connect()
+    try:
+        con.execute("LOAD httpfs")
+        return True
+    except Exception:
+        return False
+    finally:
+        con.close()
+
+
+@pytest.mark.skipif(
+    not _httpfs_available(),
+    reason="httpfs extension not available (no preinstalled extensions or network)",
+)
+def test_headers_create_http_secret_with_escaping() -> None:
+    # A header value containing a single quote must not break the CREATE SECRET
+    # statement. The query confirms the http secret was created.
+    result = execute_sql(
+        "SELECT name FROM duckdb_secrets() WHERE type = 'http'",
+        headers={"Authorization": "Bearer a'b"},
+    )
+
+    assert result == [{"name": "__tc_http"}]

--- a/tests/registry/test_core_duckdb.py
+++ b/tests/registry/test_core_duckdb.py
@@ -56,6 +56,22 @@ def _httpfs_available() -> bool:
         con.close()
 
 
+def test_headers_require_scope() -> None:
+    # headers without headers_scope is rejected before any DuckDB work, so this
+    # runs without the httpfs extension.
+    with pytest.raises(ValueError, match="headers_scope is required"):
+        execute_sql("SELECT 1", headers={"Authorization": "Bearer x"})
+
+
+def test_headers_scope_must_be_http_url() -> None:
+    with pytest.raises(ValueError, match="http:// or https://"):
+        execute_sql(
+            "SELECT 1",
+            headers={"Authorization": "Bearer x"},
+            headers_scope="api.example.com",
+        )
+
+
 @pytest.mark.skipif(
     not _httpfs_available(),
     reason="httpfs extension not available (no preinstalled extensions or network)",
@@ -63,11 +79,13 @@ def _httpfs_available() -> bool:
 def test_headers_bound_as_parameters_not_interpolated() -> None:
     # A header value full of SQL metacharacters must be stored verbatim as data,
     # never parsed as SQL. We read it back from the created secret to prove the
-    # value round-trips untouched (i.e. injection is impossible by design).
+    # value round-trips untouched (i.e. injection is impossible by design), and
+    # that the scope is applied so headers are restricted to the intended host.
     token = "Bearer a'b; DROP SECRET __tc_http; --"
     result = execute_sql(
         "SELECT name, secret_string FROM duckdb_secrets() WHERE type = 'http'",
         headers={"Authorization": token},
+        headers_scope="https://api.example.com",
     )
 
     assert isinstance(result, list)
@@ -76,3 +94,5 @@ def test_headers_bound_as_parameters_not_interpolated() -> None:
     # The injected SQL fragment survives as data inside the stored header map
     # (the secret still exists and the DROP was never executed).
     assert "DROP SECRET __tc_http" in result[0]["secret_string"]
+    # The scope restricts the headers to the intended host prefix.
+    assert "https://api.example.com" in result[0]["secret_string"]

--- a/tests/registry/test_core_duckdb.py
+++ b/tests/registry/test_core_duckdb.py
@@ -2,7 +2,7 @@ import json
 
 import duckdb
 import pytest
-from tracecat_registry.core.duckdb import _quote, execute_sql
+from tracecat_registry.core.duckdb import _split_s3_endpoint, execute_sql
 
 
 def test_execute_sql_returns_json_serializable_rows() -> None:
@@ -19,10 +19,13 @@ def test_execute_sql_non_query_returns_json_serializable() -> None:
     json.dumps(result)
 
 
-def test_quote_escapes_single_quotes() -> None:
-    assert _quote("abc") == "'abc'"
-    assert _quote("a'b") == "'a''b'"
-    assert _quote("Bearer ' OR 1=1 --") == "'Bearer '' OR 1=1 --'"
+def test_split_s3_endpoint() -> None:
+    # Full URLs: scheme is stripped from the host and drives USE_SSL.
+    assert _split_s3_endpoint("http://minio:9000") == ("minio:9000", False)
+    assert _split_s3_endpoint("https://s3.example.com") == ("s3.example.com", True)
+    # Bare host[:port]: keep verbatim and leave DuckDB's default (None).
+    assert _split_s3_endpoint("minio:9000") == ("minio:9000", None)
+    assert _split_s3_endpoint("  http://minio:9000  ") == ("minio:9000", False)
 
 
 def _httpfs_available() -> bool:
@@ -40,12 +43,19 @@ def _httpfs_available() -> bool:
     not _httpfs_available(),
     reason="httpfs extension not available (no preinstalled extensions or network)",
 )
-def test_headers_create_http_secret_with_escaping() -> None:
-    # A header value containing a single quote must not break the CREATE SECRET
-    # statement. The query confirms the http secret was created.
+def test_headers_bound_as_parameters_not_interpolated() -> None:
+    # A header value full of SQL metacharacters must be stored verbatim as data,
+    # never parsed as SQL. We read it back from the created secret to prove the
+    # value round-trips untouched (i.e. injection is impossible by design).
+    token = "Bearer a'b; DROP SECRET __tc_http; --"
     result = execute_sql(
-        "SELECT name FROM duckdb_secrets() WHERE type = 'http'",
-        headers={"Authorization": "Bearer a'b"},
+        "SELECT name, secret_string FROM duckdb_secrets() WHERE type = 'http'",
+        headers={"Authorization": token},
     )
 
-    assert result == [{"name": "__tc_http"}]
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["name"] == "__tc_http"
+    # The injected SQL fragment survives as data inside the stored header map
+    # (the secret still exists and the DROP was never executed).
+    assert "DROP SECRET __tc_http" in result[0]["secret_string"]

--- a/tests/registry/test_core_duckdb.py
+++ b/tests/registry/test_core_duckdb.py
@@ -2,7 +2,8 @@ import json
 
 import duckdb
 import pytest
-from tracecat_registry.core.duckdb import execute_sql
+from tracecat_registry.core import duckdb as duckdb_action
+from tracecat_registry.core.duckdb import _extension_directory, execute_sql
 
 
 def test_execute_sql_returns_json_serializable_rows() -> None:
@@ -17,6 +18,31 @@ def test_execute_sql_non_query_returns_json_serializable() -> None:
 
     assert isinstance(result, (int, list))
     json.dumps(result)
+
+
+def test_extension_directory_prefers_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        duckdb_action, "TRACECAT__DUCKDB_EXTENSION_DIRECTORY", "/custom/ext"
+    )
+    assert _extension_directory() == "/custom/ext"
+
+
+def test_extension_directory_falls_back_to_default_when_present(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(duckdb_action, "TRACECAT__DUCKDB_EXTENSION_DIRECTORY", None)
+    monkeypatch.setattr(duckdb_action, "_DEFAULT_EXTENSION_DIRECTORY", str(tmp_path))
+    assert _extension_directory() == str(tmp_path)
+
+
+def test_extension_directory_none_when_unset_and_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(duckdb_action, "TRACECAT__DUCKDB_EXTENSION_DIRECTORY", None)
+    monkeypatch.setattr(
+        duckdb_action, "_DEFAULT_EXTENSION_DIRECTORY", str(tmp_path / "missing")
+    )
+    assert _extension_directory() is None
 
 
 def _httpfs_available() -> bool:

--- a/tests/registry/test_core_duckdb.py
+++ b/tests/registry/test_core_duckdb.py
@@ -3,7 +3,11 @@ import json
 import duckdb
 import pytest
 from tracecat_registry.core import duckdb as duckdb_action
-from tracecat_registry.core.duckdb import _extension_directory, execute_sql
+from tracecat_registry.core.duckdb import (
+    _extension_directory,
+    _normalize_headers_scope,
+    execute_sql,
+)
 
 
 def test_execute_sql_returns_json_serializable_rows() -> None:
@@ -72,6 +76,30 @@ def test_headers_scope_must_be_http_url() -> None:
         )
 
 
+def test_normalize_headers_scope() -> None:
+    # Bare host prefix gets a trailing slash to anchor the host boundary, so it
+    # cannot prefix-match a sibling host (api.example.com.evil.com).
+    assert _normalize_headers_scope("https://api.example.com") == (
+        "https://api.example.com/"
+    )
+    assert _normalize_headers_scope("https://api.example.com/") == (
+        "https://api.example.com/"
+    )
+    # An explicit path prefix is preserved.
+    assert _normalize_headers_scope("https://api.example.com/v1") == (
+        "https://api.example.com/v1"
+    )
+    assert _normalize_headers_scope("http://host:9000") == "http://host:9000/"
+    # Query/fragment are dropped.
+    assert _normalize_headers_scope("https://h/p?q=1#f") == "https://h/p"
+
+
+def test_normalize_headers_scope_rejects_invalid() -> None:
+    for bad in (None, "", "api.example.com", "ftp://host", "https://", "/just/a/path"):
+        with pytest.raises(ValueError):
+            _normalize_headers_scope(bad)
+
+
 @pytest.mark.skipif(
     not _httpfs_available(),
     reason="httpfs extension not available (no preinstalled extensions or network)",
@@ -83,7 +111,7 @@ def test_headers_bound_as_parameters_not_interpolated() -> None:
     # that the scope is applied so headers are restricted to the intended host.
     token = "Bearer a'b; DROP SECRET __tc_http; --"
     result = execute_sql(
-        "SELECT name, secret_string FROM duckdb_secrets() WHERE type = 'http'",
+        "SELECT name, scope, secret_string FROM duckdb_secrets() WHERE type = 'http'",
         headers={"Authorization": token},
         headers_scope="https://api.example.com",
     )
@@ -94,5 +122,5 @@ def test_headers_bound_as_parameters_not_interpolated() -> None:
     # The injected SQL fragment survives as data inside the stored header map
     # (the secret still exists and the DROP was never executed).
     assert "DROP SECRET __tc_http" in result[0]["secret_string"]
-    # The scope restricts the headers to the intended host prefix.
-    assert "https://api.example.com" in result[0]["secret_string"]
+    # The scope restricts the headers to the intended host (normalized + anchored).
+    assert result[0]["scope"] == ["https://api.example.com/"]

--- a/tests/registry/test_core_duckdb.py
+++ b/tests/registry/test_core_duckdb.py
@@ -1,13 +1,8 @@
 import json
 
-import duckdb
 import pytest
 from tracecat_registry.core import duckdb as duckdb_action
-from tracecat_registry.core.duckdb import (
-    _extension_directory,
-    _normalize_headers_scope,
-    execute_sql,
-)
+from tracecat_registry.core.duckdb import _extension_directory, execute_sql
 
 
 def test_execute_sql_returns_json_serializable_rows() -> None:
@@ -47,91 +42,3 @@ def test_extension_directory_none_when_unset_and_missing(
         duckdb_action, "_DEFAULT_EXTENSION_DIRECTORY", str(tmp_path / "missing")
     )
     assert _extension_directory() is None
-
-
-def _httpfs_available() -> bool:
-    con = duckdb.connect()
-    try:
-        con.execute("LOAD httpfs")
-        return True
-    except Exception:
-        return False
-    finally:
-        con.close()
-
-
-def test_headers_require_scope() -> None:
-    # headers without headers_scope is rejected before any DuckDB work, so this
-    # runs without the httpfs extension.
-    with pytest.raises(ValueError, match="headers_scope is required"):
-        execute_sql("SELECT 1", headers={"Authorization": "Bearer x"})
-
-
-def test_headers_scope_must_be_http_url() -> None:
-    with pytest.raises(ValueError, match="http:// or https://"):
-        execute_sql(
-            "SELECT 1",
-            headers={"Authorization": "Bearer x"},
-            headers_scope="api.example.com",
-        )
-
-
-def test_normalize_headers_scope() -> None:
-    # Bare host prefix gets a trailing slash to anchor the host boundary, so it
-    # cannot prefix-match a sibling host (api.example.com.evil.com).
-    assert _normalize_headers_scope("https://api.example.com") == (
-        "https://api.example.com/"
-    )
-    assert _normalize_headers_scope("https://api.example.com/") == (
-        "https://api.example.com/"
-    )
-    # An explicit path prefix is preserved.
-    assert _normalize_headers_scope("https://api.example.com/v1") == (
-        "https://api.example.com/v1"
-    )
-    assert _normalize_headers_scope("http://host:9000") == "http://host:9000/"
-    # Query/fragment are dropped.
-    assert _normalize_headers_scope("https://h/p?q=1#f") == "https://h/p"
-
-
-def test_normalize_headers_scope_rejects_invalid() -> None:
-    for bad in (
-        None,
-        "",
-        "api.example.com",
-        "ftp://host",
-        "https://",
-        "/just/a/path",
-        # Userinfo makes the real host evil.com — must be rejected, not accepted.
-        "https://api.example.com@evil.com",
-        "https://api.example.com@evil.com/",
-        "https://user:pass@host/p",
-    ):
-        with pytest.raises(ValueError):
-            _normalize_headers_scope(bad)
-
-
-@pytest.mark.skipif(
-    not _httpfs_available(),
-    reason="httpfs extension not available (no preinstalled extensions or network)",
-)
-def test_headers_bound_as_parameters_not_interpolated() -> None:
-    # A header value full of SQL metacharacters must be stored verbatim as data,
-    # never parsed as SQL. We read it back from the created secret to prove the
-    # value round-trips untouched (i.e. injection is impossible by design), and
-    # that the scope is applied so headers are restricted to the intended host.
-    token = "Bearer a'b; DROP SECRET __tc_http; --"
-    result = execute_sql(
-        "SELECT name, scope, secret_string FROM duckdb_secrets() WHERE type = 'http'",
-        headers={"Authorization": token},
-        headers_scope="https://api.example.com",
-    )
-
-    assert isinstance(result, list)
-    assert len(result) == 1
-    assert result[0]["name"] == "__tc_http"
-    # The injected SQL fragment survives as data inside the stored header map
-    # (the secret still exists and the DROP was never executed).
-    assert "DROP SECRET __tc_http" in result[0]["secret_string"]
-    # The scope restricts the headers to the intended host (normalized + anchored).
-    assert result[0]["scope"] == ["https://api.example.com/"]

--- a/tests/registry/test_core_duckdb.py
+++ b/tests/registry/test_core_duckdb.py
@@ -2,7 +2,7 @@ import json
 
 import duckdb
 import pytest
-from tracecat_registry.core.duckdb import _split_s3_endpoint, execute_sql
+from tracecat_registry.core.duckdb import execute_sql
 
 
 def test_execute_sql_returns_json_serializable_rows() -> None:
@@ -17,15 +17,6 @@ def test_execute_sql_non_query_returns_json_serializable() -> None:
 
     assert isinstance(result, (int, list))
     json.dumps(result)
-
-
-def test_split_s3_endpoint() -> None:
-    # Full URLs: scheme is stripped from the host and drives USE_SSL.
-    assert _split_s3_endpoint("http://minio:9000") == ("minio:9000", False)
-    assert _split_s3_endpoint("https://s3.example.com") == ("s3.example.com", True)
-    # Bare host[:port]: keep verbatim and leave DuckDB's default (None).
-    assert _split_s3_endpoint("minio:9000") == ("minio:9000", None)
-    assert _split_s3_endpoint("  http://minio:9000  ") == ("minio:9000", False)
 
 
 def _httpfs_available() -> bool:

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -270,7 +270,7 @@ class TestClaudeAgentRuntimeRun:
         assert "<CommandLineTools>" in prompt
         assert "`duckdb`" in prompt
         assert "DuckDB CLI" in prompt
-        assert "`postgres`, `httpfs`, `sqlite`, and `inet` extensions" in prompt
+        assert "`json`, `httpfs`, `inet`, and `fts` extensions" in prompt
         assert "not a Tracecat action or MCP tool" in prompt
         assert prompt.endswith("Preset instructions.")
 

--- a/tests/unit/test_agent_sandbox_litellm.py
+++ b/tests/unit/test_agent_sandbox_litellm.py
@@ -2015,10 +2015,9 @@ async def _run_duckdb_cli_available_case(
                 "FROM duckdb_extensions()",
                 "WHERE extension_name IN (",
                 "    'json',",
-                "    'postgres_scanner',",
                 "    'httpfs',",
-                "    'sqlite_scanner',",
-                "    'inet'",
+                "    'inet',",
+                "    'fts'",
                 ")",
                 "AND installed",
                 "AND loaded;",
@@ -2110,7 +2109,7 @@ async def _run_duckdb_cli_available_case(
     assert runtime.cwd == Path("/work")
 
     assert _FakeRuntimeReadingDuckDBTransport.messages == [
-        {"duckdb_path": "/usr/local/bin/duckdb", "duckdb_extension_count": 5}
+        {"duckdb_path": "/usr/local/bin/duckdb", "duckdb_extension_count": 4}
     ]
 
 

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -210,8 +210,8 @@ COMMAND_LINE_TOOLS_PROMPT = (
     "- `duckdb`: The runtime shell includes the DuckDB CLI. Use it for local "
     "SQL and tabular data inspection over files such as CSV, JSON, Parquet, "
     "and DuckDB database files. The CLI is configured with the `json`, "
-    "`postgres`, `httpfs`, `sqlite`, and `inet` extensions for JSON, "
-    "PostgreSQL, HTTP/S3, SQLite, and IP address workflows. This is a local "
+    "`httpfs`, `inet`, and `fts` extensions for JSON, HTTP/S3, IP address, "
+    "and full-text search workflows. This is a local "
     "command-line capability, not a Tracecat action or MCP tool.\n"
     "</CommandLineTools>"
 )


### PR DESCRIPTION
## Summary

Extends `core.duckdb.execute_sql` so it can read remote data (S3 and authenticated HTTP/S), and hardens + slims the DuckDB extension setup in the images.

### Action (`core.duckdb.execute_sql`)
- Optional `amazon_s3` secret (reused, not a new secret): when attached, an S3 secret is auto-configured via the shared boto3 session, so it supports cross-account `AWS_ROLE_ARN` AssumeRole, static keys, and session tokens — identical to the existing S3 actions and with no changes to the core AWS role-assumption machinery.
- Optional `s3_endpoint_url` arg for MinIO / S3-compatible stores (matches how the other S3 actions take `endpoint_url` per call).
- Optional `headers` arg, translated into a DuckDB `http` secret (`EXTRA_HTTP_HEADERS`) to authenticate `http(s)` reads. Sensitive values stay in the secret store via `${{ SECRETS.* }}` expressions.
- All credential/header values are SQL-escaped before interpolation into `CREATE SECRET`.
- Plain `execute_sql(sql)` behavior is unchanged (both setup helpers early-return; connection is identical when no extension dir is configured).

### Extensions / Docker
- Add `fts` (full-text search); drop `postgres_scanner` and `sqlite_scanner`.
- Pin every extension by sha256 over HTTPS, installed from verified local files (signature still validated on load) instead of a bare `INSTALL`. The CLI binary was already sha256-pinned.
- Make the preinstalled extensions usable from the in-process Python action via `TRACECAT__DUCKDB_EXTENSION_DIRECTORY`.
- Store a single physical DuckDB copy in the sandbox rootfs and symlink the executor host to it, removing the previous double-copy (~360 MB on disk).

### Docs / consistency
- Updated the agent runtime CLI prompt, the agent-sandbox test (extension count 5 → 4), and the generated `sql.mdx` (new secret + args + example).

## Notes / behavior changes
- Dropping the scanners means the action and the sandbox `duckdb` CLI can no longer `ATTACH`/scan live PostgreSQL or SQLite.
- When the `amazon_s3` secret is attached to this action, S3 setup (incl. any STS AssumeRole) runs on every call — so a misconfigured secret would fail even non-S3 queries. The secret is opt-in per action.

## Verification
- Local: ruff + basedpyright clean; `tests/registry/test_core_duckdb.py` passes (HTTP-secret test skips when `httpfs` is unavailable). Validated the pinned download URLs + checksums, local-file `INSTALL`/`LOAD` of signed extensions, the `CREATE SECRET` s3/http SQL incl. quote-escaping, and the Python `connect(config={extension_directory})` path.
- Pending in CI/cluster (needs an image build): the build's own `=4` extension assertion, the agent-sandbox count test, and a live S3-AssumeRole + authenticated-HTTPS smoke test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds remote S3 read support to `core.duckdb.execute_sql` and hardens DuckDB by pinning extensions, adding `fts`, removing `postgres_scanner`/`sqlite_scanner`, and deduping binaries. Pinned extensions load across all executors (incl. nsjail) via a preinstalled directory with an env-var or path fallback.

- **New Features**
  - S3: auto-create a DuckDB S3 secret when the `amazon_s3` secret is attached; credentials resolve via the shared boto3 session (AssumeRole, static keys, session tokens). All values are bound parameters.
  - DuckDB/runtime: pin all extensions by sha256; add `fts`; remove `postgres_scanner`/`sqlite_scanner`; keep a single DuckDB copy in the sandbox rootfs and symlink the host to it. Extensions load offline via `TRACECAT__DUCKDB_EXTENSION_DIRECTORY`, falling back to `/usr/local/lib/duckdb/extensions` when the env var isn’t present.

- **Migration**
  - Removed `postgres_scanner` and `sqlite_scanner`; the CLI and `core.duckdb.execute_sql` can’t scan live PostgreSQL/SQLite.
  - Dropped the `s3_endpoint_url` override; S3 defaults are used (S3-compatible endpoints are out of scope for now).
  - If `amazon_s3` is attached, S3 setup runs on every call; a misconfigured secret will fail even non-S3 queries.
  - Authenticated HTTP header support was removed for safety; use `core.http.request` for authenticated HTTP reads if needed.

<sup>Written for commit ff49c1af814beb3151f96aa754a8e46b8debdf26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

