### PR TITLE
feat(mcp): add agent folder tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,9 @@ just gen-functions
   before writing files, and search for the original strings before committing.
 - Do not assume PostgreSQL superuser access in migrations, queries, or scripts.
 - Never add methods to `tracecat/db/models.py`; keep database models minimal.
+- Never branch on exception or error-message strings to choose behavior, status
+  codes, or retry policy. Use explicit exception types, machine-readable error
+  codes in exception details, or structured error objects instead.
 - Use `pnpm` instead of `npm`, and prefer `rg` over slower text-search tools.
 - Ask clarifying questions when the task lacks enough context to make a safe
   change.

--- a/docs/snippets/mcp-tools.mdx
+++ b/docs/snippets/mcp-tools.mdx
@@ -34,6 +34,18 @@
   Create a workflow folder by absolute path.
 </ResponseField>
 
+<ResponseField name="rename_workflow_folder" type="tool">
+  Rename a workflow folder by absolute path.
+</ResponseField>
+
+<ResponseField name="move_workflow_folder" type="tool">
+  Move a workflow folder under a new parent path.
+</ResponseField>
+
+<ResponseField name="delete_workflow_folder" type="tool">
+  Delete a workflow folder by absolute path.
+</ResponseField>
+
 <ResponseField name="move_workflows" type="tool">
   Move workflows into or out of a folder.
 
@@ -303,8 +315,16 @@
   Insert a table row.
 </ResponseField>
 
+<ResponseField name="insert_rows" type="tool">
+  Insert multiple table rows.
+</ResponseField>
+
 <ResponseField name="update_table_row" type="tool">
   Update a table row.
+</ResponseField>
+
+<ResponseField name="update_rows" type="tool">
+  Update multiple table rows with the same values.
 </ResponseField>
 
 <ResponseField name="search_table_rows" type="tool">
@@ -357,6 +377,30 @@
   Update an existing agent preset in the selected workspace.
 
   Use ``skills`` to replace attached published skill-version bindings. Each binding requires ``skill_id`` and ``skill_version_id``. Omit ``skills`` to leave bindings unchanged, or pass an empty list to detach all skills.
+</ResponseField>
+
+<ResponseField name="list_agent_tree" type="tool">
+  List agent folders and presets under a path.
+</ResponseField>
+
+<ResponseField name="create_agent_folder" type="tool">
+  Create an agent folder by absolute path.
+</ResponseField>
+
+<ResponseField name="rename_agent_folder" type="tool">
+  Rename an agent folder by absolute path.
+</ResponseField>
+
+<ResponseField name="move_agent_folder" type="tool">
+  Move an agent folder under a new parent path.
+</ResponseField>
+
+<ResponseField name="delete_agent_folder" type="tool">
+  Delete an agent folder by absolute path.
+</ResponseField>
+
+<ResponseField name="move_agent_presets" type="tool">
+  Move agent presets into or out of a folder by preset slug.
 </ResponseField>
 
 <ResponseField name="list_skills" type="tool">

--- a/frontend/src/components/dashboard/create-workflow-button.tsx
+++ b/frontend/src/components/dashboard/create-workflow-button.tsx
@@ -42,7 +42,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
-import type { TracecatApiError } from "@/lib/errors"
+import { getApiErrorDetail, type TracecatApiError } from "@/lib/errors"
 import { useFolders, useWorkflowManager } from "@/lib/hooks"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
@@ -229,8 +229,9 @@ function CreateFolderDialog({
       onOpenChange(false)
     } catch (error) {
       console.log("Error creating folder:", error)
+      const detail = getApiErrorDetail(error)
       form.setError("name", {
-        message: "Folder already exists or another error occurred.",
+        message: detail ?? "Folder already exists or another error occurred.",
       })
     }
   }

--- a/tests/unit/api/test_api_workflow_folders.py
+++ b/tests/unit/api/test_api_workflow_folders.py
@@ -1,0 +1,51 @@
+"""HTTP-level tests for workflow folder API endpoints."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tracecat.auth.types import Role
+from tracecat.exceptions import TracecatValidationError
+from tracecat.workflow.management.folders import router as workflow_folder_router
+
+
+def _mock_service_with_async_method(
+    method_name: str,
+    *,
+    side_effect: Exception | None = None,
+    return_value: object = None,
+) -> MagicMock:
+    service = MagicMock()
+    service_method = AsyncMock()
+    if side_effect is not None:
+        service_method.side_effect = side_effect
+    else:
+        service_method.return_value = return_value
+    setattr(service, method_name, service_method)
+    return service
+
+
+@pytest.mark.anyio
+async def test_update_folder_conflict_returns_409(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Duplicate workflow folder rename paths should surface as conflicts."""
+    with patch.object(
+        workflow_folder_router, "WorkflowFolderService"
+    ) as mock_service_cls:
+        mock_service = _mock_service_with_async_method(
+            "rename_folder",
+            side_effect=TracecatValidationError("Folder /detections/ already exists"),
+        )
+        mock_service_cls.return_value = mock_service
+
+        folder_id = uuid.uuid4()
+        response = client.patch(f"/folders/{folder_id}", json={"name": "detections"})
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json()["detail"] == "Folder /detections/ already exists"
+    mock_service.rename_folder.assert_awaited_once_with(folder_id, "detections")

--- a/tests/unit/api/test_api_workflow_folders.py
+++ b/tests/unit/api/test_api_workflow_folders.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from tracecat.auth.types import Role
 from tracecat.exceptions import TracecatValidationError
 from tracecat.workflow.management.folders import router as workflow_folder_router
+from tracecat.workflow.management.folders.service import WorkflowFolderErrorCode
 
 
 def _mock_service_with_async_method(
@@ -39,7 +40,10 @@ async def test_update_folder_conflict_returns_409(
     ) as mock_service_cls:
         mock_service = _mock_service_with_async_method(
             "rename_folder",
-            side_effect=TracecatValidationError("Folder /detections/ already exists"),
+            side_effect=TracecatValidationError(
+                "Duplicate target",
+                detail={"code": WorkflowFolderErrorCode.CONFLICT.value},
+            ),
         )
         mock_service_cls.return_value = mock_service
 
@@ -47,5 +51,5 @@ async def test_update_folder_conflict_returns_409(
         response = client.patch(f"/folders/{folder_id}", json={"name": "detections"})
 
     assert response.status_code == status.HTTP_409_CONFLICT
-    assert response.json()["detail"] == "Folder /detections/ already exists"
+    assert response.json()["detail"] == "Duplicate target"
     mock_service.rename_folder.assert_awaited_once_with(folder_id, "detections")

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -36,7 +36,10 @@ from tracecat.agent.skill.schemas import (
     SkillVersionRead,
 )
 from tracecat.agent.stream.events import StreamDelta, StreamEnd
-from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
+from tracecat.exceptions import (
+    BuiltinRegistryHasNoSelectionError,
+    TracecatValidationError,
+)
 from tracecat.expressions.common import ExprType
 from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
 from tracecat.tables.service import TablesService
@@ -5617,6 +5620,19 @@ async def test_list_workspaces_returns_multi_org_workspaces(monkeypatch):
 def test_agent_preset_tools_are_registered() -> None:
     assert hasattr(mcp_server, "get_agent_preset")
     assert hasattr(mcp_server, "update_agent_preset")
+    assert hasattr(mcp_server, "list_agent_tree")
+    assert hasattr(mcp_server, "create_agent_folder")
+    assert hasattr(mcp_server, "rename_agent_folder")
+    assert hasattr(mcp_server, "move_agent_folder")
+    assert hasattr(mcp_server, "delete_agent_folder")
+    assert hasattr(mcp_server, "move_agent_presets")
+
+
+def test_workflow_folder_tools_are_registered() -> None:
+    assert hasattr(mcp_server, "create_workflow_folder")
+    assert hasattr(mcp_server, "rename_workflow_folder")
+    assert hasattr(mcp_server, "move_workflow_folder")
+    assert hasattr(mcp_server, "delete_workflow_folder")
 
 
 def test_sync_custom_registry_tool_is_registered() -> None:
@@ -5915,6 +5931,467 @@ async def test_list_workflow_tree_paginates_items(
     assert first_page["has_more"] is True
     assert first_page["next_cursor"] is not None
     assert first_page["root_path"] == "/"
+
+
+@pytest.mark.anyio
+async def test_list_agent_tree_paginates_and_traverses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    calls: list[str] = []
+
+    class _Item:
+        def __init__(self, payload: dict[str, Any]) -> None:
+            self._payload = payload
+
+        def model_dump(self, *, mode: str = "json") -> dict[str, Any]:
+            assert mode == "json"
+            return self._payload
+
+    class _FolderService:
+        async def get_directory_items(
+            self, path: str, order_by: str = "desc"
+        ) -> list[_Item]:
+            assert order_by == "desc"
+            calls.append(path)
+            if path == "/":
+                return [
+                    _Item({"type": "folder", "path": "/soc/", "name": "soc"}),
+                    _Item(
+                        {
+                            "type": "preset",
+                            "slug": "root-agent",
+                            "name": "Root agent",
+                            "model_provider": "openai",
+                            "model_name": "gpt-4o-mini",
+                            "tags": [],
+                        }
+                    ),
+                ]
+            if path == "/soc/":
+                return [
+                    _Item(
+                        {
+                            "type": "preset",
+                            "slug": "soc-agent",
+                            "name": "SOC agent",
+                            "model_provider": "openai",
+                            "model_name": "gpt-4o",
+                            "tags": [{"name": "triage"}],
+                        }
+                    )
+                ]
+            return []
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentFolderService,
+        "with_session",
+        lambda role: _AsyncContext(_FolderService()),
+    )
+
+    first_page = _payload(
+        await _tool(mcp_server.list_agent_tree)(
+            workspace_id=str(workspace_id),
+            depth=2,
+            limit=1,
+        )
+    )
+    assert len(first_page["items"]) == 1
+    assert first_page["has_more"] is True
+    assert first_page["next_cursor"] is not None
+    assert first_page["items"][0]["type"] == "folder"
+    assert calls == ["/"]
+
+    full_page = _payload(
+        await _tool(mcp_server.list_agent_tree)(
+            workspace_id=str(workspace_id),
+            depth=2,
+            limit=10,
+        )
+    )
+    assert [item["type"] for item in full_page["items"]] == [
+        "folder",
+        "preset",
+        "preset",
+    ]
+    assert full_page["items"][2]["preset_slug"] == "soc-agent"
+    assert full_page["items"][2]["folder_path"] == "/soc/"
+    assert calls == ["/", "/", "/soc/"]
+
+
+@pytest.mark.anyio
+async def test_create_agent_folder_creates_missing_parents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    created_paths: list[str] = []
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _FolderService:
+        def __init__(self) -> None:
+            self.folders: dict[str, SimpleNamespace] = {}
+
+        async def get_folder_by_path(self, path: str) -> SimpleNamespace | None:
+            return self.folders.get(path)
+
+        async def create_folder(
+            self, name: str, parent_path: str = "/", commit: bool = True
+        ) -> SimpleNamespace:
+            _ = commit
+            path = f"{parent_path}{name}/" if parent_path != "/" else f"/{name}/"
+            folder = SimpleNamespace(id=uuid.uuid4(), name=name, path=path)
+            self.folders[path] = folder
+            created_paths.append(path)
+            return folder
+
+    folder_service = _FolderService()
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentFolderService,
+        "with_session",
+        lambda role: _AsyncContext(folder_service),
+    )
+
+    result = _payload(
+        await _tool(mcp_server.create_agent_folder)(
+            workspace_id=str(workspace_id),
+            path="/soc/triage/",
+            parents=True,
+        )
+    )
+
+    assert result["path"] == "/soc/triage/"
+    assert result["created_paths"] == ["/soc/", "/soc/triage/"]
+    assert result["already_existed"] is False
+    assert created_paths == ["/soc/", "/soc/triage/"]
+
+
+@pytest.mark.anyio
+async def test_create_agent_folder_without_parents_requires_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _FolderService:
+        async def get_folder_by_path(self, _path: str) -> None:
+            return None
+
+        async def create_folder(
+            self, name: str, parent_path: str = "/", commit: bool = True
+        ) -> None:
+            _ = name, parent_path, commit
+            raise TracecatValidationError("Parent path /soc/ not found")
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentFolderService,
+        "with_session",
+        lambda role: _AsyncContext(_FolderService()),
+    )
+
+    with pytest.raises(ToolError, match="Parent path /soc/ not found"):
+        await _tool(mcp_server.create_agent_folder)(
+            workspace_id=str(workspace_id),
+            path="/soc/triage/",
+            parents=False,
+        )
+
+
+@pytest.mark.anyio
+async def test_move_agent_presets_dry_run_reports_invalid_and_missing_slugs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    destination_folder = SimpleNamespace(id=uuid.uuid4(), path="/soc/")
+    preset_id = uuid.uuid4()
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _FolderService:
+        session = SimpleNamespace(rollback=AsyncMock())
+
+        async def get_folder_by_path(self, path: str) -> SimpleNamespace | None:
+            return destination_folder if path == "/soc/" else None
+
+    class _PresetService:
+        async def get_preset_by_slug(self, slug: str) -> SimpleNamespace | None:
+            if slug == "triage":
+                return SimpleNamespace(id=preset_id, slug=slug, name="Triage")
+            return None
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentFolderService,
+        "with_session",
+        lambda role: _AsyncContext(_FolderService()),
+    )
+    monkeypatch.setattr(
+        mcp_server.AgentPresetService,
+        "with_session",
+        lambda role: _AsyncContext(_PresetService()),
+    )
+
+    result = _payload(
+        await _tool(mcp_server.move_agent_presets)(
+            workspace_id=str(workspace_id),
+            preset_slugs=["triage", "", "missing"],
+            destination_path="/soc/",
+            dry_run=True,
+        )
+    )
+
+    assert result["destination_path"] == "/soc/"
+    assert result["requested_count"] == 3
+    assert result["movable_count"] == 1
+    assert result["movable_presets"] == [{"preset_slug": "triage", "name": "Triage"}]
+    assert [error["preset_slug"] for error in result["errors"]] == ["", "missing"]
+
+
+@pytest.mark.anyio
+async def test_move_agent_presets_to_root_moves_with_none_folder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    preset_id = uuid.uuid4()
+    moved: dict[str, Any] = {}
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _FolderService:
+        session = SimpleNamespace(rollback=AsyncMock())
+
+        async def move_preset(
+            self, requested_preset_id: uuid.UUID, folder: Any | None = None
+        ) -> None:
+            moved["preset_id"] = requested_preset_id
+            moved["folder"] = folder
+
+    class _PresetService:
+        async def get_preset_by_slug(self, slug: str) -> SimpleNamespace | None:
+            return SimpleNamespace(id=preset_id, slug=slug, name="Triage")
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentFolderService,
+        "with_session",
+        lambda role: _AsyncContext(_FolderService()),
+    )
+    monkeypatch.setattr(
+        mcp_server.AgentPresetService,
+        "with_session",
+        lambda role: _AsyncContext(_PresetService()),
+    )
+
+    result = _payload(
+        await _tool(mcp_server.move_agent_presets)(
+            workspace_id=str(workspace_id),
+            preset_slugs=["triage"],
+            destination_path="/",
+        )
+    )
+
+    assert moved == {"preset_id": preset_id, "folder": None}
+    assert result["moved_count"] == 1
+    assert result["moved_presets"][0]["preset_slug"] == "triage"
+
+
+@pytest.mark.anyio
+async def test_move_agent_presets_rejects_missing_destination(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _FolderService:
+        async def get_folder_by_path(self, _path: str) -> None:
+            return None
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server.AgentFolderService,
+        "with_session",
+        lambda role: _AsyncContext(_FolderService()),
+    )
+
+    with pytest.raises(ToolError, match="Folder /missing/ not found"):
+        await _tool(mcp_server.move_agent_presets)(
+            workspace_id=str(workspace_id),
+            preset_slugs=["triage"],
+            destination_path="/missing/",
+        )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("tool_name", "service_name", "expected_path"),
+    [
+        ("rename_agent_folder", "AgentFolderService", "/renamed/"),
+        ("rename_workflow_folder", "WorkflowFolderService", "/renamed/"),
+    ],
+)
+async def test_mcp_rename_folder_tools_delegate_by_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_name: str,
+    service_name: str,
+    expected_path: str,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    folder = SimpleNamespace(id=uuid.uuid4(), path="/old/")
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _FolderService:
+        async def get_folder_by_path(self, path: str) -> SimpleNamespace | None:
+            assert path == "/old/"
+            return folder
+
+        async def rename_folder(
+            self, folder_id: uuid.UUID, new_name: str
+        ) -> SimpleNamespace:
+            assert folder_id == folder.id
+            assert new_name == "renamed"
+            return SimpleNamespace(id=folder.id, path=expected_path)
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        getattr(mcp_server, service_name),
+        "with_session",
+        lambda role: _AsyncContext(_FolderService()),
+    )
+
+    result = _payload(
+        await _tool(getattr(mcp_server, tool_name))(
+            workspace_id=str(workspace_id),
+            path="/old/",
+            new_name="renamed",
+        )
+    )
+
+    assert result["folder_id"] == str(folder.id)
+    assert result["path"] == expected_path
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("tool_name", "service_name"),
+    [
+        ("move_agent_folder", "AgentFolderService"),
+        ("move_workflow_folder", "WorkflowFolderService"),
+    ],
+)
+async def test_mcp_move_folder_tools_delegate_by_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_name: str,
+    service_name: str,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    folder = SimpleNamespace(id=uuid.uuid4(), path="/old/")
+    parent = SimpleNamespace(id=uuid.uuid4(), path="/parent/")
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _FolderService:
+        async def get_folder_by_path(self, path: str) -> SimpleNamespace | None:
+            return {"/old/": folder, "/parent/": parent}.get(path)
+
+        async def move_folder(
+            self, folder_id: uuid.UUID, new_parent_id: uuid.UUID | None
+        ) -> SimpleNamespace:
+            assert folder_id == folder.id
+            assert new_parent_id == parent.id
+            return SimpleNamespace(id=folder.id, path="/parent/old/")
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        getattr(mcp_server, service_name),
+        "with_session",
+        lambda role: _AsyncContext(_FolderService()),
+    )
+
+    result = _payload(
+        await _tool(getattr(mcp_server, tool_name))(
+            workspace_id=str(workspace_id),
+            path="/old/",
+            destination_parent_path="/parent/",
+        )
+    )
+
+    assert result["folder_id"] == str(folder.id)
+    assert result["path"] == "/parent/old/"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("tool_name", "service_name"),
+    [
+        ("delete_agent_folder", "AgentFolderService"),
+        ("delete_workflow_folder", "WorkflowFolderService"),
+    ],
+)
+async def test_mcp_delete_folder_tools_delegate_by_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_name: str,
+    service_name: str,
+) -> None:
+    workspace_id = uuid.uuid4()
+    role = SimpleNamespace(workspace_id=workspace_id)
+    folder = SimpleNamespace(id=uuid.uuid4(), path="/old/")
+    deleted: dict[str, Any] = {}
+
+    async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
+        return workspace_id, role
+
+    class _FolderService:
+        async def get_folder_by_path(self, path: str) -> SimpleNamespace | None:
+            assert path == "/old/"
+            return folder
+
+        async def delete_folder(self, folder_id: uuid.UUID, recursive: bool) -> None:
+            deleted["folder_id"] = folder_id
+            deleted["recursive"] = recursive
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        getattr(mcp_server, service_name),
+        "with_session",
+        lambda role: _AsyncContext(_FolderService()),
+    )
+
+    result = _payload(
+        await _tool(getattr(mcp_server, tool_name))(
+            workspace_id=str(workspace_id),
+            path="/old/",
+            recursive=True,
+        )
+    )
+
+    assert deleted == {"folder_id": folder.id, "recursive": True}
+    assert result["folder_id"] == str(folder.id)
+    assert result["recursive"] is True
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_workflow_folders_service.py
+++ b/tests/unit/test_workflow_folders_service.py
@@ -1,10 +1,11 @@
 from collections.abc import AsyncGenerator
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.types import Role
-from tracecat.db.models import Workflow, Workspace
+from tracecat.db.models import Workflow, WorkflowFolder, Workspace
 from tracecat.exceptions import TracecatValidationError
 from tracecat.identifiers.workflow import WorkflowID
 from tracecat.workflow.management.folders.schemas import WorkflowFolderCreate
@@ -118,6 +119,20 @@ class TestWorkflowFolderService:
         assert parent.path == "/parent/"
         assert child.path == "/parent/child/"
 
+    async def test_create_folder_trims_name_and_rejects_blank(
+        self, folder_service: WorkflowFolderService
+    ) -> None:
+        """Test folder names are normalized before persistence."""
+        folder = await folder_service.create_folder(name="  trimmed  ", parent_path="/")
+
+        assert folder.name == "trimmed"
+        assert folder.path == "/trimmed/"
+
+        with pytest.raises(
+            TracecatValidationError, match="Folder name cannot be empty"
+        ):
+            await folder_service.create_folder(name="   ", parent_path="/")
+
     async def test_list_folders(self, folder_service: WorkflowFolderService) -> None:
         """Test listing folders in a hierarchy."""
         # Create multiple folders
@@ -176,6 +191,20 @@ class TestWorkflowFolderService:
         updated_child = await folder_service.get_folder(child.id)
         assert updated_child is not None
         assert updated_child.path == "/new-name/child/"
+
+    async def test_rename_folder_conflict_fails(
+        self, folder_service: WorkflowFolderService
+    ) -> None:
+        """Test renaming onto an existing sibling path fails."""
+        folder = await folder_service.create_folder(name="old-name", parent_path="/")
+        await folder_service.create_folder(name="existing", parent_path="/")
+
+        with pytest.raises(TracecatValidationError, match="already exists"):
+            await folder_service.rename_folder(folder.id, "existing")
+
+        unchanged = await folder_service.get_folder(folder.id)
+        assert unchanged is not None
+        assert unchanged.path == "/old-name/"
 
     async def test_move_folder(self, folder_service: WorkflowFolderService) -> None:
         """Test moving a folder to a new parent."""
@@ -277,6 +306,29 @@ class TestWorkflowFolderService:
         assert await folder_service.get_folder(parent_id) is None
         assert await folder_service.get_folder(child_id) is None
         assert await folder_service.get_folder(grandchild_id) is None
+
+    async def test_delete_folder_recursive_clears_workflows(
+        self,
+        folder_service: WorkflowFolderService,
+        workflow_id: WorkflowID,
+        session: AsyncSession,
+    ) -> None:
+        """Test recursive folder delete moves contained workflows to root."""
+        parent = await folder_service.create_folder(name="parent", parent_path="/")
+        child = await folder_service.create_folder(name="child", parent_path="/parent/")
+        workflow = await folder_service.move_workflow(workflow_id, child)
+        assert workflow.folder_id == child.id
+
+        await folder_service.delete_folder(parent.id, recursive=True)
+
+        workflow_folder_id = await session.scalar(
+            select(Workflow.folder_id).where(Workflow.id == workflow_id)
+        )
+        remaining_child = await session.scalar(
+            select(WorkflowFolder.id).where(WorkflowFolder.id == child.id)
+        )
+        assert workflow_folder_id is None
+        assert remaining_child is None
 
     async def test_workflows_in_folder(
         self,

--- a/tests/unit/test_workflow_folders_service.py
+++ b/tests/unit/test_workflow_folders_service.py
@@ -9,7 +9,10 @@ from tracecat.db.models import Workflow, WorkflowFolder, Workspace
 from tracecat.exceptions import TracecatValidationError
 from tracecat.identifiers.workflow import WorkflowID
 from tracecat.workflow.management.folders.schemas import WorkflowFolderCreate
-from tracecat.workflow.management.folders.service import WorkflowFolderService
+from tracecat.workflow.management.folders.service import (
+    WorkflowFolderErrorCode,
+    WorkflowFolderService,
+)
 
 pytestmark = pytest.mark.usefixtures("db")
 
@@ -199,9 +202,10 @@ class TestWorkflowFolderService:
         folder = await folder_service.create_folder(name="old-name", parent_path="/")
         await folder_service.create_folder(name="existing", parent_path="/")
 
-        with pytest.raises(TracecatValidationError, match="already exists"):
+        with pytest.raises(TracecatValidationError) as exc_info:
             await folder_service.rename_folder(folder.id, "existing")
 
+        assert exc_info.value.detail == {"code": WorkflowFolderErrorCode.CONFLICT.value}
         unchanged = await folder_service.get_folder(folder.id)
         assert unchanged is not None
         assert unchanged.path == "/old-name/"

--- a/tracecat/AGENTS.md
+++ b/tracecat/AGENTS.md
@@ -39,6 +39,10 @@ Keep type layers separate to avoid circular imports and make reviews easier.
   role fallback, and `with_session()` lifecycle handling.
 - Request-scoped state lives in `tracecat/contexts.py`; use existing context
   variables instead of threading ad hoc state through unrelated layers.
+- Never inspect exception or error-message strings to decide API behavior,
+  status codes, retries, or control flow. Use explicit exception types,
+  `StrEnum`/`Literal` error codes in exception details, or typed structured
+  errors instead.
 - Keep router, service, schema, and type responsibilities separate:
   router for transport, service for business logic, schema for API contracts,
   and `types.py` for domain typing.

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -55,6 +55,7 @@ from tracecat_registry import RegistryOAuthSecret, RegistrySecret
 from tracecat import config
 from tracecat.agent.access.service import AgentModelAccessService
 from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
+from tracecat.agent.folders.service import AgentFolderService
 from tracecat.agent.preset.schemas import (
     AgentPresetCreate,
     AgentPresetRead,
@@ -864,6 +865,90 @@ class WorkflowMoveResponse(BaseModel):
     moved_workflows: list[WorkflowMoveItem] = Field(default_factory=list)
     movable_workflows: list[WorkflowMoveItem] = Field(default_factory=list)
     errors: list[WorkflowMoveError] = Field(default_factory=list)
+
+
+class FolderOperationResponse(BaseModel):
+    """Folder lifecycle operation response."""
+
+    folder_id: uuid.UUID
+    path: str
+    message: str
+
+
+class FolderDeleteResponse(BaseModel):
+    """Folder delete operation response."""
+
+    folder_id: uuid.UUID
+    path: str
+    recursive: bool
+    message: str
+
+
+class AgentFolderCreatedResponse(BaseModel):
+    """Created agent folder response."""
+
+    path: str
+    folder_id: uuid.UUID
+    created_paths: list[str]
+    already_existed: bool
+
+
+class AgentTreeFolderItem(BaseModel):
+    """Folder item in the agent tree response."""
+
+    type: Literal["folder"]
+    path: str
+    name: str
+    depth: int
+
+
+class AgentTreePresetItem(BaseModel):
+    """Agent preset item in the agent tree response."""
+
+    type: Literal["preset"]
+    preset_slug: str
+    name: str
+    folder_path: str
+    depth: int
+    model_provider: str | None = None
+    model_name: str | None = None
+    tags: list[dict[str, Any]] = Field(default_factory=list)
+
+
+AgentTreeItem = AgentTreeFolderItem | AgentTreePresetItem
+
+
+class AgentTreeResponse(MCPPaginatedResponse[AgentTreeItem]):
+    """Paginated agent tree response."""
+
+    root_path: str
+    depth: int | Literal["unlimited"]
+
+
+class AgentPresetMoveItem(BaseModel):
+    """Agent preset move candidate/result item."""
+
+    preset_slug: str
+    name: str
+
+
+class AgentPresetMoveError(BaseModel):
+    """Per-agent-preset move error."""
+
+    preset_slug: str
+    error: str
+
+
+class AgentPresetMoveResponse(BaseModel):
+    """Bulk agent preset move response."""
+
+    destination_path: str
+    requested_count: int
+    moved_count: int | None = None
+    movable_count: int | None = None
+    moved_presets: list[AgentPresetMoveItem] = Field(default_factory=list)
+    movable_presets: list[AgentPresetMoveItem] = Field(default_factory=list)
+    errors: list[AgentPresetMoveError] = Field(default_factory=list)
 
 
 class WorkflowPublishResponse(BaseModel):
@@ -4323,6 +4408,113 @@ async def create_workflow_folder(
     except Exception as e:
         logger.error("Failed to create workflow folder", error=str(e))
         raise ToolError(f"Failed to create workflow folder: {e}") from None
+
+
+@mcp.tool()
+async def rename_workflow_folder(
+    workspace_id: uuid.UUID,
+    path: str,
+    new_name: str,
+) -> FolderOperationResponse:
+    """Rename a workflow folder by absolute path."""
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        normalized_path = _normalize_folder_path_arg(path, allow_root=False)
+
+        async with WorkflowFolderService.with_session(role=role) as svc:
+            folder = await svc.get_folder_by_path(normalized_path)
+            if folder is None:
+                raise ToolError(f"Folder {normalized_path} not found")
+            renamed = await svc.rename_folder(folder.id, new_name)
+            return FolderOperationResponse(
+                folder_id=renamed.id,
+                path=renamed.path,
+                message=f"Workflow folder {normalized_path} renamed to {renamed.path}",
+            )
+    except ToolError:
+        raise
+    except (ValueError, TracecatValidationError) as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to rename workflow folder", error=str(e))
+        raise ToolError(f"Failed to rename workflow folder: {e}") from None
+
+
+@mcp.tool()
+async def move_workflow_folder(
+    workspace_id: uuid.UUID,
+    path: str,
+    destination_parent_path: str = "/",
+) -> FolderOperationResponse:
+    """Move a workflow folder under a new parent path."""
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        normalized_path = _normalize_folder_path_arg(path, allow_root=False)
+        normalized_parent_path = _normalize_folder_path_arg(destination_parent_path)
+
+        async with WorkflowFolderService.with_session(role=role) as svc:
+            folder = await svc.get_folder_by_path(normalized_path)
+            if folder is None:
+                raise ToolError(f"Folder {normalized_path} not found")
+
+            new_parent_id = None
+            if normalized_parent_path != "/":
+                parent_folder = await svc.get_folder_by_path(normalized_parent_path)
+                if parent_folder is None:
+                    raise ToolError(f"Folder {normalized_parent_path} not found")
+                new_parent_id = parent_folder.id
+
+            moved = await svc.move_folder(folder.id, new_parent_id)
+            return FolderOperationResponse(
+                folder_id=moved.id,
+                path=moved.path,
+                message=(
+                    f"Workflow folder {normalized_path} moved under "
+                    f"{normalized_parent_path}"
+                ),
+            )
+    except ToolError:
+        raise
+    except (ValueError, TracecatValidationError) as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to move workflow folder", error=str(e))
+        raise ToolError(f"Failed to move workflow folder: {e}") from None
+
+
+@mcp.tool()
+async def delete_workflow_folder(
+    workspace_id: uuid.UUID,
+    path: str,
+    recursive: bool = False,
+) -> FolderDeleteResponse:
+    """Delete a workflow folder by absolute path."""
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        normalized_path = _normalize_folder_path_arg(path, allow_root=False)
+
+        async with WorkflowFolderService.with_session(role=role) as svc:
+            folder = await svc.get_folder_by_path(normalized_path)
+            if folder is None:
+                raise ToolError(f"Folder {normalized_path} not found")
+            folder_id = folder.id
+            await svc.delete_folder(folder_id, recursive=recursive)
+            return FolderDeleteResponse(
+                folder_id=folder_id,
+                path=normalized_path,
+                recursive=recursive,
+                message=f"Workflow folder {normalized_path} deleted",
+            )
+    except ToolError:
+        raise
+    except (ValueError, TracecatValidationError) as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to delete workflow folder", error=str(e))
+        raise ToolError(f"Failed to delete workflow folder: {e}") from None
 
 
 @mcp.tool()
@@ -8069,6 +8261,373 @@ async def update_agent_preset(
             "Failed to update agent preset", error=str(e), preset_slug=preset_slug
         )
         raise ToolError(f"Failed to update agent preset: {e}") from None
+
+
+@mcp.tool()
+async def list_agent_tree(
+    workspace_id: uuid.UUID,
+    path: str = "/",
+    depth: int = 1,
+    include_presets: bool = True,
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
+) -> AgentTreeResponse:
+    """List agent folders and presets under a path."""
+
+    try:
+        if depth < 0:
+            raise ToolError("depth must be >= 0")
+
+        _, role = await _resolve_workspace_role(workspace_id)
+        root_path = _normalize_folder_path_arg(path)
+        limit = _normalize_limit(
+            limit,
+            default=config.TRACECAT__LIMIT_DEFAULT,
+            max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+        )
+        filters = {
+            "path": root_path,
+            "depth": depth,
+            "include_presets": include_presets,
+        }
+        fingerprint = _pagination_fingerprint("list_agent_tree", **filters)
+        start = (
+            _decode_offset_cursor(cursor, expected_fingerprint=fingerprint)
+            if cursor is not None
+            else 0
+        )
+        end = start + limit
+
+        async with AgentFolderService.with_session(role=role) as svc:
+            queue: deque[tuple[str, int]] = deque([(root_path, 1)])
+            items: list[AgentTreeItem] = []
+            seen_items = 0
+            has_more = False
+
+            def collect_item(item: AgentTreeItem) -> None:
+                nonlocal seen_items, has_more
+                if seen_items >= end:
+                    has_more = True
+                    return
+                if seen_items >= start:
+                    items.append(item)
+                seen_items += 1
+
+            while queue and not has_more:
+                current_path, current_depth = queue.popleft()
+                for item in await svc.get_directory_items(
+                    current_path, order_by="desc"
+                ):
+                    payload = item.model_dump(mode="json")
+                    if payload["type"] == "folder":
+                        collect_item(
+                            AgentTreeFolderItem(
+                                type="folder",
+                                path=payload["path"],
+                                name=payload["name"],
+                                depth=current_depth,
+                            )
+                        )
+                        if depth == 0 or current_depth < depth:
+                            queue.append((payload["path"], current_depth + 1))
+                    elif include_presets:
+                        collect_item(
+                            AgentTreePresetItem(
+                                type="preset",
+                                preset_slug=payload["slug"],
+                                name=payload["name"],
+                                folder_path=current_path,
+                                depth=current_depth,
+                                model_provider=payload.get("model_provider"),
+                                model_name=payload.get("model_name"),
+                                tags=payload.get("tags") or [],
+                            )
+                        )
+                    if has_more:
+                        break
+
+            next_cursor = _encode_offset_cursor(end, fingerprint) if has_more else None
+            prev_start = max(0, start - limit)
+            prev_cursor = (
+                _encode_offset_cursor(prev_start, fingerprint) if start > 0 else None
+            )
+            return AgentTreeResponse(
+                items=items,
+                next_cursor=next_cursor,
+                prev_cursor=prev_cursor,
+                has_more=next_cursor is not None,
+                has_previous=start > 0,
+                root_path=root_path,
+                depth="unlimited" if depth == 0 else depth,
+            )
+    except ToolError:
+        raise
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to list agent tree", error=str(e))
+        raise ToolError(f"Failed to list agent tree: {e}") from None
+
+
+@mcp.tool()
+async def create_agent_folder(
+    workspace_id: uuid.UUID,
+    path: str,
+    parents: bool = False,
+) -> AgentFolderCreatedResponse:
+    """Create an agent folder by absolute path."""
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        normalized_path = _normalize_folder_path_arg(path, allow_root=False)
+        parts = [part for part in normalized_path.strip("/").split("/") if part]
+
+        async with AgentFolderService.with_session(role=role) as svc:
+            if not parents:
+                parent_parts = parts[:-1]
+                parent_path = f"/{'/'.join(parent_parts)}/" if parent_parts else "/"
+                if existing := await svc.get_folder_by_path(normalized_path):
+                    folder = existing
+                    created_paths = []
+                else:
+                    folder = await svc.create_folder(
+                        name=parts[-1], parent_path=parent_path
+                    )
+                    created_paths = [normalized_path]
+            else:
+                current_path = "/"
+                created_paths: list[str] = []
+                folder = None
+                for part in parts:
+                    next_path = (
+                        f"{current_path}{part}/" if current_path != "/" else f"/{part}/"
+                    )
+                    if existing := await svc.get_folder_by_path(next_path):
+                        folder = existing
+                    else:
+                        folder = await svc.create_folder(
+                            name=part,
+                            parent_path=current_path,
+                        )
+                        created_paths.append(next_path)
+                    current_path = next_path
+
+                if folder is None:
+                    raise ToolError(f"Failed to create folder {normalized_path}")
+
+            return AgentFolderCreatedResponse(
+                path=normalized_path,
+                folder_id=folder.id,
+                created_paths=created_paths,
+                already_existed=not created_paths,
+            )
+    except ToolError:
+        raise
+    except (ValueError, TracecatValidationError) as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to create agent folder", error=str(e))
+        raise ToolError(f"Failed to create agent folder: {e}") from None
+
+
+@mcp.tool()
+async def rename_agent_folder(
+    workspace_id: uuid.UUID,
+    path: str,
+    new_name: str,
+) -> FolderOperationResponse:
+    """Rename an agent folder by absolute path."""
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        normalized_path = _normalize_folder_path_arg(path, allow_root=False)
+
+        async with AgentFolderService.with_session(role=role) as svc:
+            folder = await svc.get_folder_by_path(normalized_path)
+            if folder is None:
+                raise ToolError(f"Folder {normalized_path} not found")
+            renamed = await svc.rename_folder(folder.id, new_name)
+            return FolderOperationResponse(
+                folder_id=renamed.id,
+                path=renamed.path,
+                message=f"Agent folder {normalized_path} renamed to {renamed.path}",
+            )
+    except ToolError:
+        raise
+    except (ValueError, TracecatValidationError) as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to rename agent folder", error=str(e))
+        raise ToolError(f"Failed to rename agent folder: {e}") from None
+
+
+@mcp.tool()
+async def move_agent_folder(
+    workspace_id: uuid.UUID,
+    path: str,
+    destination_parent_path: str = "/",
+) -> FolderOperationResponse:
+    """Move an agent folder under a new parent path."""
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        normalized_path = _normalize_folder_path_arg(path, allow_root=False)
+        normalized_parent_path = _normalize_folder_path_arg(destination_parent_path)
+
+        async with AgentFolderService.with_session(role=role) as svc:
+            folder = await svc.get_folder_by_path(normalized_path)
+            if folder is None:
+                raise ToolError(f"Folder {normalized_path} not found")
+
+            new_parent_id = None
+            if normalized_parent_path != "/":
+                parent_folder = await svc.get_folder_by_path(normalized_parent_path)
+                if parent_folder is None:
+                    raise ToolError(f"Folder {normalized_parent_path} not found")
+                new_parent_id = parent_folder.id
+
+            moved = await svc.move_folder(folder.id, new_parent_id)
+            return FolderOperationResponse(
+                folder_id=moved.id,
+                path=moved.path,
+                message=(
+                    f"Agent folder {normalized_path} moved under "
+                    f"{normalized_parent_path}"
+                ),
+            )
+    except ToolError:
+        raise
+    except (ValueError, TracecatValidationError) as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to move agent folder", error=str(e))
+        raise ToolError(f"Failed to move agent folder: {e}") from None
+
+
+@mcp.tool()
+async def delete_agent_folder(
+    workspace_id: uuid.UUID,
+    path: str,
+    recursive: bool = False,
+) -> FolderDeleteResponse:
+    """Delete an agent folder by absolute path."""
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        normalized_path = _normalize_folder_path_arg(path, allow_root=False)
+
+        async with AgentFolderService.with_session(role=role) as svc:
+            folder = await svc.get_folder_by_path(normalized_path)
+            if folder is None:
+                raise ToolError(f"Folder {normalized_path} not found")
+            folder_id = folder.id
+            await svc.delete_folder(folder_id, recursive=recursive)
+            return FolderDeleteResponse(
+                folder_id=folder_id,
+                path=normalized_path,
+                recursive=recursive,
+                message=f"Agent folder {normalized_path} deleted",
+            )
+    except ToolError:
+        raise
+    except (ValueError, TracecatValidationError) as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to delete agent folder", error=str(e))
+        raise ToolError(f"Failed to delete agent folder: {e}") from None
+
+
+@mcp.tool()
+async def move_agent_presets(
+    workspace_id: uuid.UUID,
+    preset_slugs: list[str],
+    destination_path: str = "/",
+    dry_run: bool = False,
+) -> AgentPresetMoveResponse:
+    """Move agent presets into or out of a folder by preset slug."""
+
+    try:
+        if not preset_slugs:
+            raise ToolError("preset_slugs must not be empty")
+
+        _, role = await _resolve_workspace_role(workspace_id)
+        normalized_destination = _normalize_folder_path_arg(destination_path)
+
+        async with AgentFolderService.with_session(role=role) as folder_svc:
+            folder = None
+            if normalized_destination != "/":
+                folder = await folder_svc.get_folder_by_path(normalized_destination)
+                if folder is None:
+                    raise ToolError(f"Folder {normalized_destination} not found")
+
+            validated: list[tuple[uuid.UUID, AgentPresetMoveItem]] = []
+            errors: list[AgentPresetMoveError] = []
+            async with AgentPresetService.with_session(role=role) as preset_svc:
+                for preset_slug in preset_slugs:
+                    if not preset_slug.strip():
+                        errors.append(
+                            AgentPresetMoveError(
+                                preset_slug=preset_slug,
+                                error="Preset slug cannot be empty",
+                            )
+                        )
+                        continue
+                    preset = await preset_svc.get_preset_by_slug(preset_slug)
+                    if preset is None:
+                        errors.append(
+                            AgentPresetMoveError(
+                                preset_slug=preset_slug,
+                                error=f"Agent preset '{preset_slug}' not found",
+                            )
+                        )
+                        continue
+                    validated.append(
+                        (
+                            preset.id,
+                            AgentPresetMoveItem(
+                                preset_slug=preset.slug,
+                                name=preset.name,
+                            ),
+                        )
+                    )
+
+            if dry_run:
+                return AgentPresetMoveResponse(
+                    destination_path=normalized_destination,
+                    requested_count=len(preset_slugs),
+                    movable_count=len(validated),
+                    movable_presets=[item for _, item in validated],
+                    errors=errors,
+                )
+
+            moved: list[AgentPresetMoveItem] = []
+            for preset_id, preset_info in validated:
+                try:
+                    await folder_svc.move_preset(preset_id, folder)
+                    moved.append(preset_info)
+                except Exception as e:
+                    await folder_svc.session.rollback()
+                    errors.append(
+                        AgentPresetMoveError(
+                            preset_slug=preset_info.preset_slug,
+                            error=str(e),
+                        )
+                    )
+
+            return AgentPresetMoveResponse(
+                destination_path=normalized_destination,
+                requested_count=len(preset_slugs),
+                moved_count=len(moved),
+                moved_presets=moved,
+                errors=errors,
+            )
+    except ToolError:
+        raise
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to move agent presets", error=str(e))
+        raise ToolError(f"Failed to move agent presets: {e}") from None
 
 
 @mcp.tool()

--- a/tracecat/workflow/management/folders/router.py
+++ b/tracecat/workflow/management/folders/router.py
@@ -20,6 +20,15 @@ from tracecat.workflow.management.folders.service import WorkflowFolderService
 router = APIRouter(prefix="/folders", tags=["folders"])
 
 
+def _folder_http_exception(err: TracecatValidationError) -> HTTPException:
+    message = str(err)
+    if "not found" in message.lower():
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message)
+    if "already exists" in message:
+        return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message)
+    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message)
+
+
 @router.get("/directory")
 @require_scope("workflow:read")
 async def get_directory(
@@ -126,6 +135,8 @@ async def update_folder(
             status_code=status.HTTP_409_CONFLICT,
             detail="A folder with this name already exists at this location",
         ) from e
+    except TracecatValidationError as e:
+        raise _folder_http_exception(e) from e
 
 
 @router.delete("/{folder_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -187,3 +198,5 @@ async def move_folder(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
         ) from e
+    except TracecatValidationError as e:
+        raise _folder_http_exception(e) from e

--- a/tracecat/workflow/management/folders/router.py
+++ b/tracecat/workflow/management/folders/router.py
@@ -15,18 +15,30 @@ from tracecat.workflow.management.folders.schemas import (
     WorkflowFolderRead,
     WorkflowFolderUpdate,
 )
-from tracecat.workflow.management.folders.service import WorkflowFolderService
+from tracecat.workflow.management.folders.service import (
+    WorkflowFolderErrorCode,
+    WorkflowFolderService,
+)
 
 router = APIRouter(prefix="/folders", tags=["folders"])
 
 
 def _folder_http_exception(err: TracecatValidationError) -> HTTPException:
-    message = str(err)
-    if "not found" in message.lower():
-        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message)
-    if "already exists" in message:
-        return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message)
-    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message)
+    detail = err.detail if isinstance(err.detail, dict) else {}
+    raw_code = detail.get("code") if isinstance(detail, dict) else None
+    try:
+        code = WorkflowFolderErrorCode(raw_code)
+    except (TypeError, ValueError):
+        code = None
+
+    if code in {
+        WorkflowFolderErrorCode.NOT_FOUND,
+        WorkflowFolderErrorCode.PARENT_NOT_FOUND,
+    }:
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(err))
+    if code == WorkflowFolderErrorCode.CONFLICT:
+        return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(err))
+    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(err))
 
 
 @router.get("/directory")
@@ -83,10 +95,7 @@ async def create_folder(
         )
         return WorkflowFolderRead.model_validate(folder, from_attributes=True)
     except TracecatValidationError as e:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="A folder with this name already exists at this location",
-        ) from e
+        raise _folder_http_exception(e) from e
 
 
 @router.get("/{folder_id}")
@@ -160,9 +169,7 @@ async def delete_folder(
             status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found"
         ) from e
     except TracecatValidationError as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
-        ) from e
+        raise _folder_http_exception(e) from e
 
 
 @router.post("/{folder_id}/move")

--- a/tracecat/workflow/management/folders/service.py
+++ b/tracecat/workflow/management/folders/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Sequence
+from enum import StrEnum
 from typing import Literal
 
 import sqlalchemy as sa
@@ -35,6 +36,15 @@ from tracecat.workflow.management.schemas import (
 from tracecat.workflow.management.types import build_workflow_trigger_summary
 
 
+class WorkflowFolderErrorCode(StrEnum):
+    """Machine-readable workflow folder validation error codes."""
+
+    CONFLICT = "workflow_folder_conflict"
+    NOT_FOUND = "workflow_folder_not_found"
+    PARENT_NOT_FOUND = "workflow_folder_parent_not_found"
+    INVALID = "workflow_folder_invalid"
+
+
 class WorkflowFolderService(BaseWorkspaceService):
     """Service for managing workflow folders using materialized path pattern."""
 
@@ -48,13 +58,27 @@ class WorkflowFolderService(BaseWorkspaceService):
         return path if path.endswith("/") else f"{path}/"
 
     @staticmethod
+    def _folder_validation_error(
+        message: str,
+        *,
+        code: WorkflowFolderErrorCode,
+    ) -> TracecatValidationError:
+        return TracecatValidationError(message, detail={"code": code.value})
+
+    @staticmethod
     def _normalize_folder_name(name: str) -> str:
         """Trim folder names and reject blank values."""
         normalized_name = name.strip()
         if not normalized_name:
-            raise TracecatValidationError("Folder name cannot be empty")
+            raise WorkflowFolderService._folder_validation_error(
+                "Folder name cannot be empty",
+                code=WorkflowFolderErrorCode.INVALID,
+            )
         if "/" in normalized_name:
-            raise TracecatValidationError("Folder name cannot contain slashes")
+            raise WorkflowFolderService._folder_validation_error(
+                "Folder name cannot contain slashes",
+                code=WorkflowFolderErrorCode.INVALID,
+            )
         return normalized_name
 
     @classmethod
@@ -81,8 +105,9 @@ class WorkflowFolderService(BaseWorkspaceService):
                 await self.session.flush()
         except IntegrityError as exc:
             await self.session.rollback()
-            raise TracecatValidationError(
-                f"Folder {conflict_path} already exists"
+            raise self._folder_validation_error(
+                f"Folder {conflict_path} already exists",
+                code=WorkflowFolderErrorCode.CONFLICT,
             ) from exc
 
     @require_scope("workflow:create")
@@ -107,7 +132,10 @@ class WorkflowFolderService(BaseWorkspaceService):
             # We want to create the nested folders if not
             parent_exists = await self._folder_path_exists(parent_path)
             if not parent_exists:
-                raise TracecatValidationError(f"Parent path {parent_path} not found")
+                raise self._folder_validation_error(
+                    f"Parent path {parent_path} not found",
+                    code=WorkflowFolderErrorCode.PARENT_NOT_FOUND,
+                )
 
         # Create full path
         full_path = (
@@ -119,7 +147,10 @@ class WorkflowFolderService(BaseWorkspaceService):
         # Check if path already exists
         path_exists = await self._folder_path_exists(full_path)
         if path_exists:
-            raise TracecatValidationError(f"Folder {full_path} already exists")
+            raise self._folder_validation_error(
+                f"Folder {full_path} already exists",
+                code=WorkflowFolderErrorCode.CONFLICT,
+            )
 
         folder = WorkflowFolder(
             name=normalized_name,
@@ -253,7 +284,10 @@ class WorkflowFolderService(BaseWorkspaceService):
 
         folder = await self.get_folder(folder_id)
         if not folder:
-            raise TracecatValidationError(f"Folder {folder_id} not found")
+            raise self._folder_validation_error(
+                f"Folder {folder_id} not found",
+                code=WorkflowFolderErrorCode.NOT_FOUND,
+            )
 
         old_path = folder.path
         parent_path = self._get_parent_path(folder.path)
@@ -269,7 +303,10 @@ class WorkflowFolderService(BaseWorkspaceService):
         if new_path != old_path:
             path_exists = await self._folder_path_exists(new_path)
             if path_exists:
-                raise TracecatValidationError(f"Folder {new_path} already exists")
+                raise self._folder_validation_error(
+                    f"Folder {new_path} already exists",
+                    code=WorkflowFolderErrorCode.CONFLICT,
+                )
 
         # Update this folder
         folder.name = normalized_name
@@ -298,25 +335,35 @@ class WorkflowFolderService(BaseWorkspaceService):
         """
         folder = await self.get_folder(folder_id)
         if not folder:
-            raise TracecatValidationError(f"Folder {folder_id} not found")
+            raise self._folder_validation_error(
+                f"Folder {folder_id} not found",
+                code=WorkflowFolderErrorCode.NOT_FOUND,
+            )
 
         # Determine new parent path
         new_parent_path = "/"
         if new_parent_id is not None:
             new_parent = await self.get_folder(new_parent_id)
             if not new_parent:
-                raise TracecatValidationError(
-                    f"Parent folder {new_parent_id} not found"
+                raise self._folder_validation_error(
+                    f"Parent folder {new_parent_id} not found",
+                    code=WorkflowFolderErrorCode.PARENT_NOT_FOUND,
                 )
             new_parent_path = new_parent.path
 
             # Check if we're trying to make a folder its own descendant
             if folder.path == new_parent_path:
-                raise TracecatValidationError("Cannot make a folder its own child")
+                raise self._folder_validation_error(
+                    "Cannot make a folder its own child",
+                    code=WorkflowFolderErrorCode.INVALID,
+                )
 
             # Check if new parent is a descendant of the folder (would create a cycle)
             if new_parent.path.startswith(folder.path):
-                raise TracecatValidationError("Cannot create cyclic folder structure")
+                raise self._folder_validation_error(
+                    "Cannot create cyclic folder structure",
+                    code=WorkflowFolderErrorCode.INVALID,
+                )
 
         old_path = folder.path
         old_name = folder.name
@@ -332,7 +379,10 @@ class WorkflowFolderService(BaseWorkspaceService):
         if new_path != old_path:
             path_exists = await self._folder_path_exists(new_path)
             if path_exists:
-                raise TracecatValidationError(f"Folder {new_path} already exists")
+                raise self._folder_validation_error(
+                    f"Folder {new_path} already exists",
+                    code=WorkflowFolderErrorCode.CONFLICT,
+                )
 
         # Update this folder
         folder.path = new_path
@@ -358,11 +408,17 @@ class WorkflowFolderService(BaseWorkspaceService):
         """
         folder = await self.get_folder(folder_id)
         if not folder:
-            raise TracecatValidationError(f"Folder {folder_id} not found")
+            raise self._folder_validation_error(
+                f"Folder {folder_id} not found",
+                code=WorkflowFolderErrorCode.NOT_FOUND,
+            )
 
         # Prevent deletion of root folder
         if folder.path == "/":
-            raise TracecatValidationError("Cannot delete root folder")
+            raise self._folder_validation_error(
+                "Cannot delete root folder",
+                code=WorkflowFolderErrorCode.INVALID,
+            )
 
         if not recursive:
             # Check if folder has children or workflows
@@ -370,8 +426,9 @@ class WorkflowFolderService(BaseWorkspaceService):
             has_workflows = await self._has_workflows(folder_id)
 
             if has_children or has_workflows:
-                raise TracecatValidationError(
-                    "Folder is not empty. Please move or delete its contents first."
+                raise self._folder_validation_error(
+                    "Folder is not empty. Please move or delete its contents first.",
+                    code=WorkflowFolderErrorCode.INVALID,
                 )
         else:
             folder_ids = select(WorkflowFolder.id).where(

--- a/tracecat/workflow/management/folders/service.py
+++ b/tracecat/workflow/management/folders/service.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 import sqlalchemy as sa
 from sqlalchemy import and_, cast, func, or_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
 from tracecat.authz.controls import require_scope
@@ -42,9 +43,47 @@ class WorkflowFolderService(BaseWorkspaceService):
     @staticmethod
     def _normalize_folder_path(path: str) -> str:
         """Normalize folder paths to materialized-path format."""
-        if path == "/":
-            return path
+        if not path or path == "/":
+            return "/"
         return path if path.endswith("/") else f"{path}/"
+
+    @staticmethod
+    def _normalize_folder_name(name: str) -> str:
+        """Trim folder names and reject blank values."""
+        normalized_name = name.strip()
+        if not normalized_name:
+            raise TracecatValidationError("Folder name cannot be empty")
+        if "/" in normalized_name:
+            raise TracecatValidationError("Folder name cannot contain slashes")
+        return normalized_name
+
+    @classmethod
+    def _get_parent_path(cls, path: str) -> str:
+        """Return the immediate parent path for a normalized folder path."""
+        path = cls._normalize_folder_path(path)
+        if path == "/":
+            return "/"
+
+        parent_path, _, _ = path.rstrip("/").rpartition("/")
+        return f"{parent_path}/" if parent_path else "/"
+
+    async def _write_folder_change(
+        self,
+        *,
+        conflict_path: str,
+        commit: bool,
+    ) -> None:
+        """Persist a folder write and translate unique conflicts cleanly."""
+        try:
+            if commit:
+                await self.session.commit()
+            else:
+                await self.session.flush()
+        except IntegrityError as exc:
+            await self.session.rollback()
+            raise TracecatValidationError(
+                f"Folder {conflict_path} already exists"
+            ) from exc
 
     @require_scope("workflow:create")
     async def create_folder(
@@ -59,9 +98,7 @@ class WorkflowFolderService(BaseWorkspaceService):
         Returns:
             The created folder
         """
-        # Validate name - no slashes allowed
-        if "/" in name:
-            raise TracecatValidationError("Folder name cannot contain slashes")
+        normalized_name = self._normalize_folder_name(name)
 
         parent_path = self._normalize_folder_path(parent_path)
 
@@ -73,7 +110,11 @@ class WorkflowFolderService(BaseWorkspaceService):
                 raise TracecatValidationError(f"Parent path {parent_path} not found")
 
         # Create full path
-        full_path = f"{parent_path}{name}/" if parent_path != "/" else f"/{name}/"
+        full_path = (
+            f"{parent_path}{normalized_name}/"
+            if parent_path != "/"
+            else f"/{normalized_name}/"
+        )
 
         # Check if path already exists
         path_exists = await self._folder_path_exists(full_path)
@@ -81,15 +122,12 @@ class WorkflowFolderService(BaseWorkspaceService):
             raise TracecatValidationError(f"Folder {full_path} already exists")
 
         folder = WorkflowFolder(
-            name=name,
+            name=normalized_name,
             path=full_path,
             workspace_id=self.workspace_id,
         )
         self.session.add(folder)
-        if commit:
-            await self.session.commit()
-        else:
-            await self.session.flush()
+        await self._write_folder_change(conflict_path=full_path, commit=commit)
         await self.session.refresh(folder)
         return folder
 
@@ -118,9 +156,7 @@ class WorkflowFolderService(BaseWorkspaceService):
         Returns:
             The folder or None if not found
         """
-        # Ensure path has trailing slash
-        if not path.endswith("/") and path != "/":
-            path += "/"
+        path = self._normalize_folder_path(path)
 
         statement = select(WorkflowFolder).where(
             WorkflowFolder.workspace_id == self.workspace_id,
@@ -139,11 +175,11 @@ class WorkflowFolderService(BaseWorkspaceService):
         Returns:
             List of folders within the specified subtree or all folders.
         """
-        # Base statement selecting folders for the current workspace
+        parent_path = self._normalize_folder_path(parent_path)
 
         statement = select(WorkflowFolder).where(
             WorkflowFolder.workspace_id == self.workspace_id,
-            WorkflowFolder.path.like(f"{parent_path}%"),
+            WorkflowFolder.path.startswith(parent_path, autoescape=True),
         )
 
         # Execute the query and return all matching folders
@@ -213,46 +249,37 @@ class WorkflowFolderService(BaseWorkspaceService):
         Returns:
             The updated folder
         """
-        # Validate name - no slashes allowed
-        if "/" in new_name:
-            raise TracecatValidationError("Folder name cannot contain slashes")
+        normalized_name = self._normalize_folder_name(new_name)
 
         folder = await self.get_folder(folder_id)
         if not folder:
             raise TracecatValidationError(f"Folder {folder_id} not found")
 
         old_path = folder.path
-        parent_path = folder.parent_path
+        parent_path = self._get_parent_path(folder.path)
 
         # Create the new path
         new_path = (
-            f"{parent_path}{new_name}/" if parent_path != "/" else f"/{new_name}/"
+            f"{parent_path}{normalized_name}/"
+            if parent_path != "/"
+            else f"/{normalized_name}/"
         )
 
         # Check if new path already exists
         if new_path != old_path:
             path_exists = await self._folder_path_exists(new_path)
-            if not path_exists:
-                # TODO: Create the folder
-                pass
-            # if path_exists:
-            #     raise TracecatValidationError(f"Folder {new_path} already exists")
-
-        # Get all descendants to update their paths
-        descendants = await self._get_descendants(old_path)
+            if path_exists:
+                raise TracecatValidationError(f"Folder {new_path} already exists")
 
         # Update this folder
-        folder.name = new_name
+        folder.name = normalized_name
         folder.path = new_path
         self.session.add(folder)
 
-        # Update all descendant paths
-        for descendant in descendants:
-            # Replace the old path prefix with the new one
-            descendant.path = descendant.path.replace(old_path, new_path, 1)
-            self.session.add(descendant)
+        if new_path != old_path:
+            await self._update_descendant_paths(old_path, new_path)
 
-        await self.session.commit()
+        await self._write_folder_change(conflict_path=new_path, commit=True)
         await self.session.refresh(folder)
         return folder
 
@@ -307,20 +334,14 @@ class WorkflowFolderService(BaseWorkspaceService):
             if path_exists:
                 raise TracecatValidationError(f"Folder {new_path} already exists")
 
-        # Get all descendants to update their paths
-        descendants = await self._get_descendants(old_path)
-
         # Update this folder
         folder.path = new_path
         self.session.add(folder)
 
-        # Update all descendant paths
-        for descendant in descendants:
-            # Replace the old path prefix with the new one
-            descendant.path = descendant.path.replace(old_path, new_path, 1)
-            self.session.add(descendant)
+        if new_path != old_path:
+            await self._update_descendant_paths(old_path, new_path)
 
-        await self.session.commit()
+        await self._write_folder_change(conflict_path=new_path, commit=True)
         await self.session.refresh(folder)
         return folder
 
@@ -353,33 +374,28 @@ class WorkflowFolderService(BaseWorkspaceService):
                     "Folder is not empty. Please move or delete its contents first."
                 )
         else:
-            # If recursive, delete all subfolders first
-            descendants = await self._get_descendants(folder.path)
-            for descendant in descendants:
-                # Delete workflows in each subfolder
-                statement = select(Workflow).where(
-                    Workflow.workspace_id == self.workspace_id,
-                    Workflow.folder_id == descendant.id,
-                )
-                result = await self.session.execute(statement)
-                workflows = result.scalars().all()
-                for workflow in workflows:
-                    workflow.folder_id = None
-                    self.session.add(workflow)
-
-                # Delete the subfolder
-                await self.session.delete(descendant)
-
-            # Delete workflows in the main folder
-            statement = select(Workflow).where(
-                Workflow.workspace_id == self.workspace_id,
-                Workflow.folder_id == folder.id,
+            folder_ids = select(WorkflowFolder.id).where(
+                WorkflowFolder.workspace_id == self.workspace_id,
+                WorkflowFolder.path.startswith(folder.path, autoescape=True),
             )
-            result = await self.session.execute(statement)
-            workflows = result.scalars().all()
-            for workflow in workflows:
-                workflow.folder_id = None
-                self.session.add(workflow)
+            await self.session.execute(
+                sa.update(Workflow)
+                .where(
+                    Workflow.workspace_id == self.workspace_id,
+                    Workflow.folder_id.in_(folder_ids),
+                )
+                .values(folder_id=None)
+                .execution_options(synchronize_session=False)
+            )
+            await self.session.execute(
+                sa.delete(WorkflowFolder)
+                .where(
+                    WorkflowFolder.workspace_id == self.workspace_id,
+                    WorkflowFolder.path.startswith(folder.path, autoescape=True),
+                    WorkflowFolder.path != folder.path,
+                )
+                .execution_options(synchronize_session=False)
+            )
 
         # Delete the folder
         await self.session.delete(folder)
@@ -394,16 +410,14 @@ class WorkflowFolderService(BaseWorkspaceService):
         Returns:
             List of folders in the tree
         """
-        # Ensure root_path has trailing slash
-        if not root_path.endswith("/") and root_path != "/":
-            root_path += "/"
+        root_path = self._normalize_folder_path(root_path)
 
         statement = (
             select(WorkflowFolder)
             .where(
                 WorkflowFolder.workspace_id == self.workspace_id,
                 or_(
-                    WorkflowFolder.path.startswith(root_path),
+                    WorkflowFolder.path.startswith(root_path, autoescape=True),
                     WorkflowFolder.path == root_path,
                 ),
             )
@@ -416,34 +430,25 @@ class WorkflowFolderService(BaseWorkspaceService):
     async def _folder_path_exists(self, path: str) -> bool:
         """Check if a folder path exists."""
         path = self._normalize_folder_path(path)
-        statement = (
-            select(func.count())
-            .select_from(WorkflowFolder)
-            .where(
-                WorkflowFolder.workspace_id == self.workspace_id,
-                WorkflowFolder.path == path,
-            )
+        exists_clause = sa.exists().where(
+            WorkflowFolder.workspace_id == self.workspace_id,
+            WorkflowFolder.path == path,
         )
-        result = await self.session.execute(statement)
-        return result.scalar_one() > 0
+        return bool(await self.session.scalar(select(exists_clause)))
 
     async def _has_children(self, path: str) -> bool:
         """Check if a folder has any child folders."""
-        # Ensure path has trailing slash
-        if not path.endswith("/") and path != "/":
-            path += "/"
+        path = self._normalize_folder_path(path)
 
-        statement = (
-            select(func.count())
-            .select_from(WorkflowFolder)
-            .where(
+        statement = select(
+            sa.exists().where(
                 WorkflowFolder.workspace_id == self.workspace_id,
-                WorkflowFolder.path.startswith(path),
+                WorkflowFolder.path.startswith(path, autoescape=True),
                 WorkflowFolder.path != path,
             )
         )
         result = await self.session.execute(statement)
-        return result.scalar_one() > 0
+        return bool(result.scalar_one())
 
     async def _has_workflows(self, folder_id: uuid.UUID) -> bool:
         """Check if a folder contains any workflows."""
@@ -460,17 +465,35 @@ class WorkflowFolderService(BaseWorkspaceService):
 
     async def _get_descendants(self, path: str) -> Sequence[WorkflowFolder]:
         """Get all descendant folders of a given path."""
-        # Ensure path has trailing slash
-        if not path.endswith("/") and path != "/":
-            path += "/"
+        path = self._normalize_folder_path(path)
 
         statement = select(WorkflowFolder).where(
             WorkflowFolder.workspace_id == self.workspace_id,
-            WorkflowFolder.path.startswith(path),
+            WorkflowFolder.path.startswith(path, autoescape=True),
             WorkflowFolder.path != path,
         )
         result = await self.session.execute(statement)
         return result.scalars().all()
+
+    async def _update_descendant_paths(self, old_path: str, new_path: str) -> None:
+        """Update all descendant materialized paths after a folder path changes."""
+        old_path = self._normalize_folder_path(old_path)
+        new_path = self._normalize_folder_path(new_path)
+        await self.session.execute(
+            sa.update(WorkflowFolder)
+            .where(
+                WorkflowFolder.workspace_id == self.workspace_id,
+                WorkflowFolder.path.startswith(old_path, autoescape=True),
+                WorkflowFolder.path != old_path,
+            )
+            .values(
+                path=func.concat(
+                    new_path,
+                    func.substring(WorkflowFolder.path, len(old_path) + 1),
+                )
+            )
+            .execution_options(synchronize_session="fetch")
+        )
 
     async def get_directory_items(
         self, path: str = "/", *, order_by: Literal["asc", "desc"] = "desc"
@@ -483,9 +506,7 @@ class WorkflowFolderService(BaseWorkspaceService):
         Returns:
             Sequence of DirectoryItems (workflows and folders) in the path
         """
-        # Ensure path has trailing slash
-        if not path.endswith("/") and path != "/":
-            path += "/"
+        path = self._normalize_folder_path(path)
 
         # Subquery to get the latest definition for each workflow
         latest_defn_subq = (
@@ -617,7 +638,7 @@ class WorkflowFolderService(BaseWorkspaceService):
             # Get direct child folders
             folder_statement = select(WorkflowFolder).where(
                 WorkflowFolder.workspace_id == self.workspace_id,
-                WorkflowFolder.path.startswith(path),
+                WorkflowFolder.path.startswith(path, autoescape=True),
                 WorkflowFolder.path != path,
                 ~WorkflowFolder.path.like(f"{path}%/%/"),  # Exclude nested folders
             )


### PR DESCRIPTION
## Summary
- Add MCP tools for agent folder tree/create/rename/move/delete and moving agent presets by slug.
- Add workflow folder rename/move/delete MCP tools for symmetry.
- Harden workflow folder service behavior to match agent folders: trimmed names, blank-name rejection, rename conflict checks, bulk descendant path updates, and bulk recursive delete cleanup.
- Regenerate MCP tool docs.

## Validation
- `uv run pytest tests/unit/test_mcp_server.py`
- `uv run pytest tests/unit/test_mcp_server.py -k "agent_folder or workflow_folder or workflow_tree or move_workflows or move_agent_presets or agent_tree"`
- `uv run pytest tests/unit/test_agent_folders_service.py tests/unit/test_workflow_folders_service.py`
- `uv run ruff check tracecat/mcp/server.py tracecat/workflow/management/folders/service.py tests/unit/test_mcp_server.py tests/unit/test_workflow_folders_service.py`
- `uv run ruff format --check tracecat/mcp/server.py tracecat/workflow/management/folders/service.py tests/unit/test_mcp_server.py tests/unit/test_workflow_folders_service.py`
- `cubic review --json` -> no issues after addressing its pagination finding.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MCP tools to manage agent folders and presets, plus matching tools for workflow folders. Adds machine-readable error codes and stricter validation; the API now maps folder errors to 404/409/400 reliably and the UI shows detailed folder create errors.

- New Features
  - Agent tools: `list_agent_tree`, `create_agent_folder`, `rename_agent_folder`, `move_agent_folder`, `delete_agent_folder`, `move_agent_presets` (by slug). `list_agent_tree` supports depth and cursor pagination; `move_agent_presets` supports dry-run and moving to root.
  - Workflow tools: `rename_workflow_folder`, `move_workflow_folder`, `delete_workflow_folder`. Docs regenerated to include all tools.

- Refactors
  - Introduced `WorkflowFolderErrorCode` with structured error details; API maps codes to 404/409/400 without string matching, and the create-folder dialog surfaces server error detail via `getApiErrorDetail`.
  - Workflow folder service: trim names, reject blank/slashed names, conflict checks on rename/move, bulk descendant path updates, recursive delete clears workflows to root. Safer path normalization and prefix matching; DB conflicts surfaced via `IntegrityError` with clear messages.

<sup>Written for commit 19ac89b485872504209470a30d3a4b58f038d5eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

