### PR TITLE
docs: clarify local development setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,16 @@ We will only accept bug reports that met the following criteria:
 
 Install the required tools before starting the stack:
 
+- `bash`
 - Docker with Compose
+- `curl`
 - `git`
-- `uv`
-- `pnpm`
-- `just`
 - `jq`
+- `node`
+- `openssl`
+- `pnpm`
+- `uv`
+- `just`
 
 On Windows, run the commands from WSL2 and enable Docker Desktop's WSL
 integration for your Linux distribution. If PowerShell reports that `sh` is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,20 +27,62 @@ We will only accept bug reports that met the following criteria:
 ## Development Setup
 
 > [!NOTE]
-> Check our our [development setup guide](/docs/development-setup) in the docs for more information.
+> Local development requires a Unix-like environment. Use Linux, macOS, or WSL2
+> on Windows. Native Windows shells such as PowerShell and Git Bash are not
+> supported for the full setup because Tracecat depends on Python packages that
+> do not support Windows, such as `uvloop`.
 
-We use `docker compose` and the `docker-compose.dev.yml` files for development.
+Install the required tools before starting the stack:
+
+- Docker with Compose
+- `git`
+- `uv`
+- `pnpm`
+- `just`
+- `jq`
+
+On Windows, run the commands from WSL2 and enable Docker Desktop's WSL
+integration for your Linux distribution. If PowerShell reports that `sh` is
+missing, open WSL2 and run the commands there.
+
+We use `just cluster` to manage the Docker Compose development stack.
+Check your environment first:
+
+```bash
+just doctor
+```
 
 To set up your development environment, run:
+
 ```bash
 just cluster up -d --seed
 ```
 
-This starts the development environment and seeds a test user (`test@tracecat.com` / `password1234`).
-You can then access the application at [http://localhost:80](http://localhost:80).
+This creates `.env` if needed, syncs Python dependencies, installs frontend
+dependencies, starts the `docker-compose.dev.yml` stack, and seeds local users.
+
+Default seeded users:
+
+- `test@tracecat.com` / `password1234`
+- `dev@tracecat.com` / `password1234`
 
 > [!IMPORTANT]
-> `--seed` creates a test user only. Superadmin is determined by `TRACECAT__AUTH_SUPERADMIN_EMAIL` in `.env` (set via `./env.sh`), and the first signup/login with that email becomes the organization owner.
+> `--seed` creates local development users directly. The seeded platform
+> superuser defaults to `test@tracecat.com` and can be changed with
+> `TRACECAT__DEV_SUPERUSER_EMAIL`. `TRACECAT__AUTH_SUPERADMIN_EMAIL` in `.env`
+> controls the first-user bootstrap flow when users sign up normally.
+
+You can then access the application at [http://localhost:80](http://localhost:80).
+
+Useful commands:
+
+```bash
+just cluster ps
+just cluster ports
+just cluster logs api
+just cluster restart api
+just cluster down
+```
 
 ## PR and Commit Message Guidelines
 

--- a/justfile
+++ b/justfile
@@ -3,6 +3,11 @@ set dotenv-load
 
 default:
   @just --list
+
+# Check local development prerequisites
+doctor:
+	@bash ./scripts/dev-doctor
+
 test:
 	pytest --cache-clear tests/registry tests/unit tests/playbooks -x
 

--- a/scripts/dev-doctor
+++ b/scripts/dev-doctor
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -u
+
+failures=0
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    GREEN='\033[32m'
+    RED='\033[31m'
+    RESET='\033[0m'
+else
+    GREEN=''
+    RED=''
+    RESET=''
+fi
+
+ok() {
+    printf '%bOK%b   %s\n' "$GREEN" "$RESET" "$1"
+}
+
+fail() {
+    printf '%bFAIL%b %s\n' "$RED" "$RESET" "$1"
+    failures=$((failures + 1))
+}
+
+info() {
+    printf 'INFO %s\n' "$1"
+}
+
+check_command() {
+    local name=$1
+    if command -v "$name" >/dev/null 2>&1; then
+        ok "$name"
+    else
+        fail "$name is not installed or is not on PATH"
+    fi
+}
+
+echo "Tracecat development environment"
+echo ""
+
+uname_s=$(uname -s 2>/dev/null || echo unknown)
+case "$uname_s" in
+    Linux*)
+        if grep -qi microsoft /proc/version 2>/dev/null; then
+            ok "OS: WSL2/Linux"
+        else
+            ok "OS: Linux"
+        fi
+        ;;
+    Darwin*)
+        ok "OS: macOS"
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        fail "OS: native Windows shell detected"
+        info "Use WSL2 on Windows for the full development setup."
+        ;;
+    *)
+        fail "OS: unsupported or unknown (${uname_s})"
+        ;;
+esac
+
+check_command git
+check_command jq
+check_command uv
+check_command pnpm
+check_command just
+
+if command -v docker >/dev/null 2>&1; then
+    ok "docker"
+    if docker compose version >/dev/null 2>&1; then
+        ok "docker compose"
+    else
+        fail "docker compose is not available"
+    fi
+
+    if docker info >/dev/null 2>&1; then
+        ok "Docker daemon"
+    else
+        fail "Docker daemon is not reachable"
+        info "Start Docker Desktop or your Docker service, then rerun this check."
+    fi
+else
+    fail "docker is not installed or is not on PATH"
+fi
+
+echo ""
+if [ "$failures" -eq 0 ]; then
+    echo "Ready. Run:"
+    echo "  just cluster up -d --seed"
+else
+    echo "Fix the failed checks, then rerun:"
+    echo "  just doctor"
+fi
+
+exit "$failures"

--- a/scripts/dev-doctor
+++ b/scripts/dev-doctor
@@ -26,12 +26,17 @@ info() {
     printf 'INFO %s\n' "$1"
 }
 
-check_command() {
+check_command_runs() {
     local name=$1
-    if command -v "$name" >/dev/null 2>&1; then
+    shift
+    if ! command -v "$name" >/dev/null 2>&1; then
+        fail "$name is not installed or is not on PATH"
+        return
+    fi
+    if "$name" "$@" >/dev/null 2>&1; then
         ok "$name"
     else
-        fail "$name is not installed or is not on PATH"
+        fail "$name is installed but could not run"
     fi
 }
 
@@ -59,11 +64,21 @@ case "$uname_s" in
         ;;
 esac
 
-check_command git
-check_command jq
-check_command uv
-check_command pnpm
-check_command just
+check_command_runs bash --version
+check_command_runs curl --version
+check_command_runs git --version
+check_command_runs jq --version
+check_command_runs node --version
+if command -v node >/dev/null 2>&1 && ! node --version >/dev/null 2>&1; then
+    info "Install Node.js inside this environment, not only on the host."
+fi
+check_command_runs openssl version
+check_command_runs pnpm --version
+if command -v pnpm >/dev/null 2>&1 && ! pnpm --version >/dev/null 2>&1; then
+    info "Install pnpm inside this environment, not only on the host."
+fi
+check_command_runs uv --version
+check_command_runs just --version
 
 if command -v docker >/dev/null 2>&1; then
     ok "docker"


### PR DESCRIPTION

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic.
- [x] PR only implements a single feature or fixes a single bug.
- [ ] Tests passing (`uv run pytest tests`)?
- [ ] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR improves local development onboarding.

It updates `CONTRIBUTING.md` with supported development environments, required
tools, and the `just doctor` setup check.

It also adds `just doctor`, which checks common local requirements before
contributors start the full development stack.

## Related Issues

Fixes #2827 

## Screenshots / Recordings

Git Bash: 
<img width="438" height="358" alt="image" src="https://github.com/user-attachments/assets/ca76c0fb-e67d-411e-b2d6-6cea70840e16" />

WSL: 
<img width="322" height="303" alt="image" src="https://github.com/user-attachments/assets/4bc30bf1-b624-40d0-ba64-4be69cec45cc" />

 

## Steps to QA

1. Run:

```bash
just doctor
```

2. Confirm it reports available and missing tools.

3. After all checks pass, run:

```bash
just cluster up -d --seed
```

4. Confirm the app is available at `http://localhost:80`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies local development setup and adds a `just doctor` check to catch missing tools early. This reduces setup issues across macOS, Linux, and WSL2.

- New Features
  - Added `just doctor` (via `scripts/dev-doctor`) to validate local prerequisites: OS support, `bash`, `docker` + `docker compose`, `curl`, `git`, `jq`, `node`, `openssl`, `pnpm`, `uv`, `just`, and Docker daemon availability. Prints clear next steps and exits non-zero on failures.
  - Detects native Windows shells and recommends WSL2; supports macOS, Linux, and WSL2.
  - Updated `CONTRIBUTING.md` with supported environments, required tools, WSL2/Docker guidance, quick start using `just doctor` and `just cluster up -d --seed`, seeded users, and helpful `just cluster` commands.
  - Added `doctor` target to `justfile`.

<sup>Written for commit 3e779a06cbd01a3ac27be42024ae3aee8ed60abb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

