### PR TITLE
fix(mcp): report OAuth-backed registry actions as configured

### DIFF
--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -20,7 +20,7 @@ from fastmcp.server.middleware.middleware import MiddlewareContext
 from fastmcp.tools import ToolResult
 from mcp.types import CallToolRequestParams
 from pydantic import ValidationError
-from tracecat_registry import RegistrySecret
+from tracecat_registry import RegistryOAuthSecret, RegistrySecret
 
 import tracecat.mcp.auth as mcp_auth
 from tracecat.agent.common.stream_types import (
@@ -41,7 +41,12 @@ from tracecat.exceptions import (
     TracecatValidationError,
 )
 from tracecat.expressions.common import ExprType
-from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
+from tracecat.integrations.enums import (
+    IntegrationStatus,
+    MCPAuthType,
+    OAuthGrantType,
+)
+from tracecat.integrations.schemas import ProviderKey
 from tracecat.tables.service import TablesService
 from tracecat.validation.schemas import (
     ValidationDetail,
@@ -89,6 +94,11 @@ class _AsyncContext:
 
     async def __aexit__(self, exc_type, exc, tb):
         return None
+
+
+async def _empty_oauth_inventory(_role: Any) -> set[ProviderKey]:
+    """Default OAuth inventory stub: no workspace integrations configured."""
+    return set()
 
 
 def _build_preset_read(preset: Any) -> AgentPresetRead:
@@ -2789,8 +2799,9 @@ async def test_publish_workflow_builtin_registry_not_ready_returns_validation_fa
 
 
 def test_evaluate_configuration_reports_missing_workspace_secret_keys():
-    requirements: list[mcp_server.ActionSecretRequirementPayload] = [
+    requirements: list[mcp_server.ActionRequirementPayload] = [
         {
+            "type": "secret",
             "name": "slack",
             "required_keys": ["SLACK_BOT_TOKEN"],
             "optional_keys": [],
@@ -2805,6 +2816,76 @@ def test_evaluate_configuration_reports_missing_workspace_secret_keys():
 
     assert configured is False
     assert missing == ["missing key: slack.SLACK_BOT_TOKEN"]
+
+
+def test_secrets_to_requirements_represents_oauth_as_oauth():
+    requirements = mcp_server._secrets_to_requirements(
+        [RegistryOAuthSecret(provider_id="github", grant_type="authorization_code")]
+    )
+
+    assert requirements == [
+        {
+            "type": "oauth",
+            "name": "github_oauth",
+            "provider_id": "github",
+            "grant_type": "authorization_code",
+            "optional": False,
+        }
+    ]
+
+
+def test_evaluate_configuration_oauth_configured_when_integration_exists():
+    requirements = mcp_server._secrets_to_requirements(
+        [RegistryOAuthSecret(provider_id="github", grant_type="authorization_code")]
+    )
+    oauth_inventory = {
+        ProviderKey(id="github", grant_type=OAuthGrantType.AUTHORIZATION_CODE)
+    }
+
+    configured, missing = mcp_server._evaluate_configuration(
+        requirements,
+        {},
+        oauth_inventory,
+    )
+
+    assert configured is True
+    assert missing == []
+
+
+def test_evaluate_configuration_reports_missing_oauth_integration():
+    requirements = mcp_server._secrets_to_requirements(
+        [RegistryOAuthSecret(provider_id="github", grant_type="authorization_code")]
+    )
+
+    configured, missing = mcp_server._evaluate_configuration(
+        requirements,
+        {},
+        set(),
+    )
+
+    assert configured is False
+    assert missing == ["missing oauth integration: github (authorization_code)"]
+
+
+def test_evaluate_configuration_skips_optional_oauth_integration():
+    requirements = mcp_server._secrets_to_requirements(
+        [
+            RegistryOAuthSecret(
+                provider_id="github",
+                grant_type="authorization_code",
+                optional=True,
+            )
+        ]
+    )
+
+    configured, missing = mcp_server._evaluate_configuration(
+        requirements,
+        {},
+        set(),
+    )
+
+    assert configured is True
+    assert missing == []
 
 
 @pytest.mark.anyio
@@ -2876,11 +2957,15 @@ async def test_get_action_context_includes_configuration(monkeypatch):
     async def _secret_inventory(_role):
         return {"slack": {"SLACK_BOT_TOKEN"}}
 
+    async def _oauth_inventory(_role):
+        return set()
+
     monkeypatch.setattr(
         mcp_server,
         "_load_secret_inventory",
         _secret_inventory,
     )
+    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _oauth_inventory)
     monkeypatch.setattr(
         "tracecat.registry.actions.service.RegistryActionsService.with_session",
         lambda role: _AsyncContext(registry_service),
@@ -2896,6 +2981,109 @@ async def test_get_action_context_includes_configuration(monkeypatch):
     assert payload["configured"] is True
     assert payload["missing_requirements"] == []
     assert payload["required_secrets"][0]["name"] == "slack"
+
+
+def _github_oauth_registry_service() -> SimpleNamespace:
+    """Registry service stub for a GitHub OAuth-backed REST action."""
+    indexed_action = SimpleNamespace(
+        manifest=SimpleNamespace(),
+        index_entry=SimpleNamespace(options=None),
+    )
+    registry_service = SimpleNamespace(
+        aggregate_secrets_from_manifest=lambda _manifest, _action_name: [
+            RegistryOAuthSecret(provider_id="github", grant_type="authorization_code")
+        ],
+    )
+
+    async def _get_indexed(_action_name):
+        return indexed_action
+
+    registry_service.get_action_from_index = _get_indexed
+    return registry_service
+
+
+@pytest.mark.anyio
+async def test_get_action_context_oauth_configured_when_integration_exists(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    async def _create_tool(_action_name, _indexed):
+        return SimpleNamespace(
+            description="Get a GitHub issue",
+            parameters_json_schema={
+                "type": "object",
+                "properties": {"issue_number": {"type": "integer"}},
+                "required": ["issue_number"],
+            },
+        )
+
+    async def _secret_inventory(_role):
+        return {}
+
+    async def _oauth_inventory(_role):
+        return {ProviderKey(id="github", grant_type=OAuthGrantType.AUTHORIZATION_CODE)}
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _oauth_inventory)
+    monkeypatch.setattr(
+        "tracecat.registry.actions.service.RegistryActionsService.with_session",
+        lambda role: _AsyncContext(_github_oauth_registry_service()),
+    )
+    monkeypatch.setattr(mcp_server, "create_tool_from_registry", _create_tool)
+
+    result = await _tool(mcp_server.get_action_context)(
+        workspace_id=str(uuid.uuid4()),
+        action_name="tools.github.get_issue",
+    )
+    payload = _payload(result)
+    assert payload["configured"] is True
+    assert payload["missing_requirements"] == []
+    oauth_req = payload["required_secrets"][0]
+    assert oauth_req["type"] == "oauth"
+    assert oauth_req["provider_id"] == "github"
+    assert oauth_req["grant_type"] == "authorization_code"
+    # Regression: OAuth requirements must not be reported as workspace secrets.
+    assert "missing secret: github_oauth" not in payload["missing_requirements"]
+
+
+@pytest.mark.anyio
+async def test_get_action_context_reports_missing_oauth_integration(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    async def _create_tool(_action_name, _indexed):
+        return SimpleNamespace(
+            description="Get a GitHub issue",
+            parameters_json_schema={"type": "object", "properties": {}},
+        )
+
+    async def _secret_inventory(_role):
+        return {}
+
+    async def _oauth_inventory(_role):
+        return set()
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _oauth_inventory)
+    monkeypatch.setattr(
+        "tracecat.registry.actions.service.RegistryActionsService.with_session",
+        lambda role: _AsyncContext(_github_oauth_registry_service()),
+    )
+    monkeypatch.setattr(mcp_server, "create_tool_from_registry", _create_tool)
+
+    result = await _tool(mcp_server.get_action_context)(
+        workspace_id=str(uuid.uuid4()),
+        action_name="tools.github.get_issue",
+    )
+    payload = _payload(result)
+    assert payload["configured"] is False
+    assert payload["missing_requirements"] == [
+        "missing oauth integration: github (authorization_code)"
+    ]
+    # Regression: never reported as a missing workspace secret.
+    assert "missing secret: github_oauth" not in payload["missing_requirements"]
 
 
 @pytest.mark.anyio
@@ -5367,6 +5555,7 @@ async def test_action_catalog_resource(monkeypatch):
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
     monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _empty_oauth_inventory)
     monkeypatch.setattr(
         "tracecat.registry.actions.service.RegistryActionsService.with_session",
         lambda role: _AsyncContext(_RegistryService()),
@@ -5430,6 +5619,7 @@ async def test_list_actions_browse_without_query(monkeypatch):
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
     monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _empty_oauth_inventory)
     monkeypatch.setattr(
         "tracecat.registry.actions.service.RegistryActionsService.with_session",
         lambda role: _AsyncContext(_RegistryService()),
@@ -5484,6 +5674,7 @@ async def test_list_actions_browse_with_namespace(monkeypatch):
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
     monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _empty_oauth_inventory)
     monkeypatch.setattr(
         "tracecat.registry.actions.service.RegistryActionsService.with_session",
         lambda role: _AsyncContext(_RegistryService()),
@@ -5538,6 +5729,7 @@ async def test_list_actions_paginates_and_rejects_mismatched_cursor(monkeypatch)
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
     monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _empty_oauth_inventory)
     monkeypatch.setattr(
         "tracecat.registry.actions.service.RegistryActionsService.with_session",
         lambda role: _AsyncContext(_RegistryService()),
@@ -7013,17 +7205,21 @@ async def test_list_integrations_returns_mcp_and_provider_inventory(
     workspace_id = uuid.uuid4()
     current_user_id = uuid.uuid4()
     role = SimpleNamespace(workspace_id=workspace_id, user_id=current_user_id)
-    oauth_integration = SimpleNamespace(
-        provider_id="slack",
-        grant_type=OAuthGrantType.AUTHORIZATION_CODE,
-        user_id=current_user_id,
-        status=SimpleNamespace(value="connected"),
-    )
+    # An authorization_code integration connected by another workspace member.
+    # Public MCP must report workspace-level status, not the caller's own row.
     other_user_integration = SimpleNamespace(
         provider_id="slack",
         grant_type=OAuthGrantType.AUTHORIZATION_CODE,
         user_id=uuid.uuid4(),
-        status=SimpleNamespace(value="configured"),
+        status=IntegrationStatus.CONNECTED,
+    )
+    # The caller's own row is only configured; listed last to prove the most
+    # progressed status wins deterministically regardless of ordering.
+    oauth_integration = SimpleNamespace(
+        provider_id="slack",
+        grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        user_id=current_user_id,
+        status=IntegrationStatus.CONFIGURED,
     )
     mcp_integration_id = uuid.uuid4()
     mcp_integration = SimpleNamespace(
@@ -7147,6 +7343,7 @@ async def test_get_workflow_authoring_context_truncates_embedded_collections(
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
     monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _empty_oauth_inventory)
     monkeypatch.setattr(mcp_server, "_MCP_EMBEDDED_COLLECTION_LIMIT", 1)
     monkeypatch.setattr(mcp_server, "create_tool_from_registry", _create_tool)
     monkeypatch.setattr(

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -2889,6 +2889,43 @@ def test_evaluate_configuration_skips_optional_oauth_integration():
 
 
 @pytest.mark.anyio
+async def test_load_oauth_inventory_includes_only_connected(monkeypatch):
+    # Only CONNECTED integrations can inject a token at runtime; a
+    # configured-but-not-connected provider must be excluded from readiness.
+    connected = SimpleNamespace(
+        provider_id="github",
+        grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        status=IntegrationStatus.CONNECTED,
+    )
+    configured_only = SimpleNamespace(
+        provider_id="slack",
+        grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        status=IntegrationStatus.CONFIGURED,
+    )
+    not_configured = SimpleNamespace(
+        provider_id="notion",
+        grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        status=IntegrationStatus.NOT_CONFIGURED,
+    )
+
+    class _IntegrationService:
+        async def list_integrations(self):
+            return [connected, configured_only, not_configured]
+
+    monkeypatch.setattr(
+        mcp_server.IntegrationService,
+        "with_session",
+        lambda role: _AsyncContext(_IntegrationService()),
+    )
+
+    inventory = await mcp_server._load_oauth_inventory(cast(Any, SimpleNamespace()))
+
+    assert inventory == {
+        ProviderKey(id="github", grant_type=OAuthGrantType.AUTHORIZATION_CODE)
+    }
+
+
+@pytest.mark.anyio
 async def test_create_table_accepts_columns(monkeypatch):
     async def _resolve(_workspace_id):
         return uuid.uuid4(), SimpleNamespace()

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -153,8 +153,9 @@ from tracecat.identifiers.workflow import (
     WorkflowUUID,
     exec_id_to_parts,
 )
-from tracecat.integrations.enums import IntegrationStatus
+from tracecat.integrations.enums import IntegrationStatus, OAuthGrantType
 from tracecat.integrations.providers import all_providers
+from tracecat.integrations.schemas import ProviderKey
 from tracecat.integrations.service import IntegrationService
 from tracecat.logger import logger
 from tracecat.mcp.auth import (
@@ -458,13 +459,19 @@ def _build_example_from_schema(schema: dict[str, Any]) -> dict[str, Any]:
 
 def _secrets_to_requirements(
     secrets: Sequence[RegistrySecret | RegistryOAuthSecret],
-) -> list[ActionSecretRequirementPayload]:
-    """Convert registry secret objects to public requirement metadata."""
-    requirements: list[ActionSecretRequirementPayload] = []
+) -> list[ActionRequirementPayload]:
+    """Convert registry secret objects to public requirement metadata.
+
+    OAuth requirements are represented as OAuth requirements (provider_id +
+    grant_type), not as workspace secret/key pairs, so readiness can be checked
+    against the workspace's configured OAuth integrations.
+    """
+    requirements: list[ActionRequirementPayload] = []
     for secret in secrets:
         if isinstance(secret, RegistrySecret):
             requirements.append(
                 {
+                    "type": "secret",
                     "name": secret.name,
                     "required_keys": list(secret.keys or []),
                     "optional_keys": list(secret.optional_keys or []),
@@ -474,9 +481,10 @@ def _secrets_to_requirements(
         elif isinstance(secret, RegistryOAuthSecret):
             requirements.append(
                 {
+                    "type": "oauth",
                     "name": secret.name,
-                    "required_keys": [secret.token_name],
-                    "optional_keys": [],
+                    "provider_id": secret.provider_id,
+                    "grant_type": secret.grant_type,
                     "optional": secret.optional,
                 }
             )
@@ -501,16 +509,49 @@ async def _load_secret_inventory(
         return workspace_inventory
 
 
+async def _load_oauth_inventory(role: Role) -> set[ProviderKey]:
+    """Load configured workspace OAuth integrations.
+
+    Mirrors runtime secret injection and workflow validation, which key OAuth
+    readiness on workspace-level ``(provider_id, grant_type)`` integrations
+    rather than per-user rows.
+    """
+    async with IntegrationService.with_session(role=role) as svc:
+        integrations = await svc.list_integrations()
+    return {
+        ProviderKey(id=integration.provider_id, grant_type=integration.grant_type)
+        for integration in integrations
+    }
+
+
 def _evaluate_configuration(
-    requirements: Sequence[ActionSecretRequirementPayload],
+    requirements: Sequence[ActionRequirementPayload],
     workspace_inventory: dict[str, set[str]],
+    oauth_inventory: set[ProviderKey] | None = None,
 ) -> tuple[bool, list[str]]:
-    """Evaluate whether required secret names/keys are configured."""
+    """Evaluate whether required secrets and OAuth integrations are configured."""
+    oauth_inventory = oauth_inventory or set()
     missing: list[str] = []
     for req in requirements:
-        secret_name = req["name"]
-        required_keys = set(req["required_keys"])
-        if not required_keys and req.get("optional", False):
+        if req.get("type") == "oauth":
+            oauth_req = cast(ActionOAuthRequirementPayload, req)
+            if oauth_req.get("optional", False):
+                continue
+            provider_key = ProviderKey(
+                id=oauth_req["provider_id"],
+                grant_type=OAuthGrantType(oauth_req["grant_type"]),
+            )
+            if provider_key not in oauth_inventory:
+                missing.append(
+                    "missing oauth integration: "
+                    f"{provider_key.id} ({provider_key.grant_type.value})"
+                )
+            continue
+
+        secret_req = cast(ActionSecretRequirementPayload, req)
+        secret_name = secret_req["name"]
+        required_keys = set(secret_req["required_keys"])
+        if not required_keys and secret_req.get("optional", False):
             continue
         available_keys = workspace_inventory.get(secret_name)
         if available_keys is None:
@@ -558,18 +599,25 @@ def _build_output_type_context() -> dict[str, Any]:
 async def _build_integrations_inventory(role: Role) -> IntegrationsInventoryResponse:
     """Build integration inventory for workflow and preset authoring."""
     async with IntegrationService.with_session(role=role) as svc:
-        user_id = getattr(role, "user_id", None)
+        # Report workspace-level integration status (matching the /integrations
+        # UI and runtime/validation readiness checks), not per-user rows. An
+        # OAuth provider configured by any workspace member counts as available.
+        # authorization_code integrations are per-user, so multiple rows can
+        # share a provider key; keep the most-progressed status deterministically.
         integrations = await svc.list_integrations()
-        if user_id is not None:
-            integrations = [
-                integration
-                for integration in integrations
-                if getattr(integration, "user_id", None) == user_id
-            ]
-        existing = {
-            (integration.provider_id, integration.grant_type): integration
-            for integration in integrations
+        status_rank = {
+            IntegrationStatus.NOT_CONFIGURED: 0,
+            IntegrationStatus.CONFIGURED: 1,
+            IntegrationStatus.CONNECTED: 2,
         }
+        existing: dict[tuple[str, OAuthGrantType], Any] = {}
+        for integration in integrations:
+            key = (integration.provider_id, integration.grant_type)
+            current = existing.get(key)
+            if current is None or status_rank.get(
+                integration.status, 0
+            ) > status_rank.get(current.status, 0):
+                existing[key] = integration
         mcp_integrations = await svc.list_mcp_integrations()
         oauth_providers: list[OAuthProviderInventoryItem] = []
         for provider_impl in all_providers():
@@ -744,12 +792,35 @@ class MCPValidationErrorPayload(TypedDict, total=False):
 
 
 class ActionSecretRequirementPayload(TypedDict):
-    """Secret requirements needed by an action."""
+    """Workspace secret requirement needed by an action."""
 
+    type: Literal["secret"]
     name: str
     required_keys: list[str]
     optional_keys: list[str]
     optional: bool
+
+
+class ActionOAuthRequirementPayload(TypedDict):
+    """OAuth integration requirement needed by an action.
+
+    OAuth requirements are backed by workspace integrations (configured under
+    /integrations), not by workspace secrets. ``name`` is the synthetic secret
+    name (e.g. ``github_oauth``) used in ``${{ SECRETS.<name>.<token> }}``
+    expressions at runtime, but readiness is evaluated against the workspace's
+    configured OAuth integrations keyed by ``(provider_id, grant_type)``.
+    """
+
+    type: Literal["oauth"]
+    name: str
+    provider_id: str
+    grant_type: str
+    optional: bool
+
+
+ActionRequirementPayload = (
+    ActionSecretRequirementPayload | ActionOAuthRequirementPayload
+)
 
 
 class WorkflowSummaryResponse(BaseModel):
@@ -974,7 +1045,7 @@ class ActionContextResponse(ActionDiscoveryResponse):
     """Full action authoring context response."""
 
     parameters_json_schema: dict[str, Any]
-    required_secrets: list[ActionSecretRequirementPayload] = Field(default_factory=list)
+    required_secrets: list[ActionRequirementPayload] = Field(default_factory=list)
     examples: list[dict[str, Any]] = Field(default_factory=list)
 
 
@@ -3471,6 +3542,7 @@ async def _build_action_catalog(workspace_id: uuid.UUID) -> ActionCatalogRespons
 
     ws_id, role = await _resolve_workspace_role(workspace_id)
     workspace_inventory = await _load_secret_inventory(role)
+    oauth_inventory = await _load_oauth_inventory(role)
 
     async with RegistryActionsService.with_session(role=role) as svc:
         entries = await svc.list_actions_from_index()
@@ -3512,7 +3584,7 @@ async def _build_action_catalog(workspace_id: uuid.UUID) -> ActionCatalogRespons
                 if secrets:
                     requirements = _secrets_to_requirements(secrets)
                     configured, missing = _evaluate_configuration(
-                        requirements, workspace_inventory
+                        requirements, workspace_inventory, oauth_inventory
                     )
                     if not configured:
                         ns_configured = False
@@ -4659,6 +4731,7 @@ async def list_actions(
         _, role = await _resolve_workspace_role(workspace_id)
         limit = _normalize_limit(limit, default=50, max_limit=200)
         workspace_inventory = await _load_secret_inventory(role)
+        oauth_inventory = await _load_oauth_inventory(role)
         async with RegistryActionsService.with_session(role=role) as svc:
             if query:
                 entries = await svc.search_actions_from_index(query, limit=None)
@@ -4677,7 +4750,7 @@ async def list_actions(
                 )
                 requirements = _secrets_to_requirements(secrets)
                 configured, missing = _evaluate_configuration(
-                    requirements, workspace_inventory
+                    requirements, workspace_inventory, oauth_inventory
                 )
                 items.append(
                     ActionDiscoveryResponse(
@@ -4833,15 +4906,18 @@ async def get_action_context(
     - description: What the action does
     - parameters_json_schema: JSON Schema for the action's args (map these to the
       YAML `args:` block in a workflow action definition)
-    - required_secrets: List of secrets the action needs ({name, required_keys, optional_keys})
-    - configured: Whether all required secrets are present
-    - missing_requirements: List of missing secret names/keys
+    - required_secrets: List of requirements the action needs. Workspace secrets
+      are {type: "secret", name, required_keys, optional_keys}; OAuth-backed
+      integrations are {type: "oauth", name, provider_id, grant_type}.
+    - configured: Whether all required secrets and OAuth integrations are present
+    - missing_requirements: List of missing secrets/keys or OAuth integrations
     - examples: Example args payload based on the schema
     """
 
     try:
         _, role = await _resolve_workspace_role(workspace_id)
         workspace_inventory = await _load_secret_inventory(role)
+        oauth_inventory = await _load_oauth_inventory(role)
         async with RegistryActionsService.with_session(role=role) as svc:
             indexed = await svc.get_action_from_index(action_name)
             if indexed is None:
@@ -4850,7 +4926,7 @@ async def get_action_context(
             secrets = svc.aggregate_secrets_from_manifest(indexed.manifest, action_name)
             requirements = _secrets_to_requirements(secrets)
             configured, missing = _evaluate_configuration(
-                requirements, workspace_inventory
+                requirements, workspace_inventory, oauth_inventory
             )
             schema = tool.parameters_json_schema
             return ActionContextResponse(
@@ -4904,6 +4980,7 @@ async def get_workflow_authoring_context(
         action_names = list(actions.action_names) if actions is not None else []
 
         workspace_inventory = await _load_secret_inventory(role)
+        oauth_inventory = await _load_oauth_inventory(role)
         action_contexts: list[ActionContextResponse] = []
         async with RegistryActionsService.with_session(role=role) as registry_svc:
             if not action_names and query:
@@ -4922,7 +4999,7 @@ async def get_workflow_authoring_context(
                     )
                 )
                 configured, missing = _evaluate_configuration(
-                    requirements, workspace_inventory
+                    requirements, workspace_inventory, oauth_inventory
                 )
                 action_contexts.append(
                     ActionContextResponse(
@@ -4975,7 +5052,9 @@ async def get_workflow_authoring_context(
             variable_hints=truncated_sections["variable_hints"],
             secret_hints=truncated_sections["secret_hints"],
             notes=[
-                "configured means required secret names and required key names exist in the default environment",
+                "configured means required secret names and keys exist in the "
+                "default environment, and any required OAuth integrations are "
+                "configured for the workspace",
             ],
             truncation=truncation,
         )

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -510,17 +510,22 @@ async def _load_secret_inventory(
 
 
 async def _load_oauth_inventory(role: Role) -> set[ProviderKey]:
-    """Load configured workspace OAuth integrations.
+    """Load connected workspace OAuth integrations keyed by provider.
 
-    Mirrors runtime secret injection and workflow validation, which key OAuth
-    readiness on workspace-level ``(provider_id, grant_type)`` integrations
-    rather than per-user rows.
+    Only integrations that have completed authentication (``CONNECTED`` status,
+    i.e. an access token is stored) can have
+    ``${{ SECRETS.<provider>_oauth.*_TOKEN }}`` injected at runtime. A
+    configured-but-not-connected provider (client credentials saved but the
+    OAuth flow not completed) yields no token at runtime, so it must not count
+    as configured for action readiness. Keys are workspace-level
+    ``(provider_id, grant_type)`` pairs, not per-user rows.
     """
     async with IntegrationService.with_session(role=role) as svc:
         integrations = await svc.list_integrations()
     return {
         ProviderKey(id=integration.provider_id, grant_type=integration.grant_type)
         for integration in integrations
+        if integration.status == IntegrationStatus.CONNECTED
     }
 
 


### PR DESCRIPTION
## Summary

Public MCP authoring helpers reported OAuth-backed registry actions (e.g. `tools.github.*` REST templates) as misconfigured. A `RegistryOAuthSecret(provider_id="github", grant_type="authorization_code")` was converted into a fake workspace-secret requirement (`github_oauth.GITHUB_USER_TOKEN`) and checked only against `SecretsService.list_secrets()`, so these actions always surfaced `missing secret: github_oauth` — even when the `/integrations` GitHub Delegated OAuth row was configured.

This makes public MCP configuration checks OAuth-aware, matching how agent internal tools, workflow validation, and runtime secret injection already evaluate OAuth requirements (by `ProviderKey(id, grant_type)`).

## Changes

- Represent OAuth requirements as OAuth requirements (`type: "oauth"`, `provider_id`, `grant_type`) instead of fake secret/key pairs. Added `ActionOAuthRequirementPayload` and a `ActionRequirementPayload` union; `ActionContextResponse.required_secrets` uses the union.
- Added `_load_oauth_inventory(role)` to load workspace OAuth integrations as `set[ProviderKey]` via `IntegrationService.list_integrations()` (workspace-scoped, no per-user filter).
- `_evaluate_configuration()` now checks OAuth requirements against the inventory and reports `missing oauth integration: github (authorization_code)`. Existing workspace-secret evaluation is unchanged.
- Applied at every readiness call site: `list_actions`, `get_action_context`, `get_workflow_authoring_context`, and the action catalog namespaces.
- Removed the suspicious `role.user_id` filter in `_build_integrations_inventory` so it reports workspace-level status like the `/integrations` UI, deterministically keeping the most-progressed status (connected > configured > not_configured) when per-user `authorization_code` rows share a provider key.

## Out of scope (intentionally unchanged)

- GitHub REST templates: still use `/integrations` GitHub Delegated OAuth and resolve `${{ SECRETS.github_oauth.GITHUB_USER_TOKEN }}` at runtime. No `GITHUB_TOKEN`, static PATs, or the separate GitHub MCP integration.

## Test plan

- New unit tests: `_secrets_to_requirements` represents OAuth as OAuth; `_evaluate_configuration` configured / missing / optional OAuth cases; `get_action_context` configured when the integration exists; `get_action_context` reports a missing OAuth integration. Both tool-level tests assert `missing secret: github_oauth` never appears (the regression).
- Updated `test_list_integrations_returns_mcp_and_provider_inventory` to prove workspace-level reporting (another member's connected integration counts; best status wins regardless of ordering).
- Existing workspace-secret tests still pass.

Verification: `ruff check`, `ruff format`, `basedpyright --warnings` clean; full `tests/unit/test_mcp_server.py` (211 tests) passes; `cubic review` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP authoring to mark OAuth-backed registry actions as configured by checking workspace OAuth integrations instead of fake secrets, and only counting CONNECTED integrations. Removes false "missing secret: github_oauth" warnings and aligns readiness with runtime.

- **Bug Fixes**
  - Represent OAuth requirements as `{ type: "oauth", provider_id, grant_type }` via `ActionRequirementPayload`.
  - Add `_load_oauth_inventory()` to include only `IntegrationStatus.CONNECTED` rows from `IntegrationService.list_integrations()`.
  - Update `_evaluate_configuration()` to validate secrets and OAuth, reporting `missing oauth integration: <provider> (<grant_type>)` when absent.
  - Apply checks across `list_actions`, `get_action_context`, `get_workflow_authoring_context`, and the action catalog.
  - Report integration status at the workspace level and keep the most-progressed status when rows share a provider key.

<sup>Written for commit d0e19f3cd9d410f83e7270842dc74922643318dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

