### PR TITLE
fix(integrations): LeakCheck secret name

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/templates/tools/leakcheck/search_domain_leak.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/leakcheck/search_domain_leak.yml
@@ -8,9 +8,9 @@ definition:
   doc_url: https://wiki.leakcheck.io/en/api
   author: y0no
   secrets:
-    - name: leakcheck_api
+    - name: leakcheck
       keys:
-        - API_KEY
+        - LEAKCHECK_API_KEY
   expects:
     domain_name:
       type: str
@@ -24,5 +24,5 @@ definition:
           type: domain
         method: GET
         headers:
-          x-api-key: ${{ SECRETS.leakcheck_api.API_KEY }}
+          x-api-key: ${{ SECRETS.leakcheck.LEAKCHECK_API_KEY }}
   returns: ${{ steps.search_domain_leak.result.data }}

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/leakcheck/search_email_leak.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/leakcheck/search_email_leak.yml
@@ -8,9 +8,9 @@ definition:
   doc_url: https://wiki.leakcheck.io/en/api
   author: y0no
   secrets:
-    - name: leakcheck_api
+    - name: leakcheck
       keys:
-        - API_KEY
+        - LEAKCHECK_API_KEY
   expects:
     email_address:
       type: str
@@ -22,5 +22,5 @@ definition:
         url: https://leakcheck.io/api/v2/query/${{ FN.url_encode(inputs.email_address) }}
         method: GET
         headers:
-          x-api-key: ${{ SECRETS.leakcheck_api.API_KEY }}
+          x-api-key: ${{ SECRETS.leakcheck.LEAKCHECK_API_KEY }}
   returns: ${{ steps.search_email_leak.result.data }}


### PR DESCRIPTION
## Summary
- Rename the built-in LeakCheck secret group from `leakcheck_api` to `leakcheck`
- Rename the required key from `API_KEY` to `LEAKCHECK_API_KEY`
- Update both LeakCheck templates to read `SECRETS.leakcheck.LEAKCHECK_API_KEY`

## Root Cause
The built-in LeakCheck templates used a generic key name and an awkward provider-specific secret group (`leakcheck_api.API_KEY`) instead of the clearer provider namespace and explicit key name.

## Validation
- `git diff --check`
- `rg -n "leakcheck_api|SECRETS\\.leakcheck_api|\\bAPI_KEY\\b" packages/tracecat-registry/tracecat_registry/templates/tools/leakcheck` returned no matches
- `uv run pytest tests/registry/test_templates.py -q` passed: 353 passed, 8 warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized LeakCheck secret naming: the secret group is now `leakcheck` and the key is `LEAKCHECK_API_KEY`. Updated both LeakCheck templates to use `SECRETS.leakcheck.LEAKCHECK_API_KEY` for the `x-api-key` header.

- **Migration**
  - Rename your secret group from `leakcheck_api` to `leakcheck`.
  - Rename the key from `API_KEY` to `LEAKCHECK_API_KEY`.

<sup>Written for commit 4aadf37d5f22422e6332132c523084a23c63cdd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

