### PR TITLE
fix(docs): update LeakCheck secret name

### DIFF
--- a/docs/tools/leakcheck.mdx
+++ b/docs/tools/leakcheck.mdx
@@ -16,7 +16,7 @@ Reference: [https://wiki.leakcheck.io/en/api](https://wiki.leakcheck.io/en/api)
 
 Required secrets:
 
-- `leakcheck_api`: required values `API_KEY`.
+- `leakcheck`: required values `LEAKCHECK_API_KEY`.
 
 ### Input fields
 
@@ -38,7 +38,7 @@ Reference: [https://wiki.leakcheck.io/en/api](https://wiki.leakcheck.io/en/api)
 
 Required secrets:
 
-- `leakcheck_api`: required values `API_KEY`.
+- `leakcheck`: required values `LEAKCHECK_API_KEY`.
 
 ### Input fields
 


### PR DESCRIPTION
## Summary
- Regenerate the generated LeakCheck tool docs after the secret rename in #2830
- Update the documented secret from `leakcheck_api.API_KEY` to `leakcheck.LEAKCHECK_API_KEY`

## Validation
- `uv run python scripts/generate_tool_docs.py --check`
- `git diff --check`
- `rg -n "leakcheck_api|\\bAPI_KEY\\b" docs/tools/leakcheck.mdx` returned no matches

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update LeakCheck tool docs to use the new secret name: `leakcheck.LEAKCHECK_API_KEY` instead of `leakcheck_api.API_KEY`. Ensures users configure the correct secret after the rename.

<sup>Written for commit cbd76f1a26e62223b29e4e7160c149173aa445ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

