### PR TITLE
fix(mcp): don't mark actions unconfigured for optional secrets

### DIFF
--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -2888,6 +2888,80 @@ def test_evaluate_configuration_skips_optional_oauth_integration():
     assert missing == []
 
 
+def test_evaluate_configuration_skips_optional_secret_with_keys():
+    # Regression: a wholly-optional secret that declares keys (e.g. the mtls /
+    # ca_cert secrets inherited from core.http_request) must not block readiness.
+    requirements: list[mcp_server.ActionRequirementPayload] = [
+        {
+            "type": "secret",
+            "name": "mtls",
+            "required_keys": ["TLS_CERTIFICATE", "TLS_PRIVATE_KEY"],
+            "optional_keys": [],
+            "optional": True,
+        }
+    ]
+
+    configured, missing = mcp_server._evaluate_configuration(requirements, {})
+
+    assert configured is True
+    assert missing == []
+
+
+def test_evaluate_configuration_required_present_with_optional_absent():
+    # An action that wraps core.http_request: required urlscan secret present,
+    # optional mtls/ca_cert absent -> configured, nothing missing.
+    requirements: list[mcp_server.ActionRequirementPayload] = [
+        {
+            "type": "secret",
+            "name": "urlscan",
+            "required_keys": ["URLSCAN_API_KEY"],
+            "optional_keys": [],
+            "optional": False,
+        },
+        {
+            "type": "secret",
+            "name": "mtls",
+            "required_keys": ["TLS_CERTIFICATE", "TLS_PRIVATE_KEY"],
+            "optional_keys": [],
+            "optional": True,
+        },
+    ]
+    workspace_inventory = {"urlscan": {"URLSCAN_API_KEY"}}
+
+    configured, missing = mcp_server._evaluate_configuration(
+        requirements, workspace_inventory
+    )
+
+    assert configured is True
+    assert missing == []
+
+
+def test_evaluate_configuration_reports_required_but_not_optional():
+    # Required secret absent, optional secret absent -> unconfigured, and only the
+    # required secret is reported as missing.
+    requirements: list[mcp_server.ActionRequirementPayload] = [
+        {
+            "type": "secret",
+            "name": "urlscan",
+            "required_keys": ["URLSCAN_API_KEY"],
+            "optional_keys": [],
+            "optional": False,
+        },
+        {
+            "type": "secret",
+            "name": "mtls",
+            "required_keys": ["TLS_CERTIFICATE", "TLS_PRIVATE_KEY"],
+            "optional_keys": [],
+            "optional": True,
+        },
+    ]
+
+    configured, missing = mcp_server._evaluate_configuration(requirements, {})
+
+    assert configured is False
+    assert missing == ["missing secret: urlscan"]
+
+
 @pytest.mark.anyio
 async def test_load_oauth_inventory_includes_only_connected(monkeypatch):
     # Only CONNECTED integrations can inject a token at runtime; a
@@ -2970,7 +3044,12 @@ async def test_get_action_context_includes_configuration(monkeypatch):
     )
     registry_service = SimpleNamespace(
         aggregate_secrets_from_manifest=lambda _manifest, _action_name: [
-            RegistrySecret(name="slack", keys=["SLACK_BOT_TOKEN"])
+            RegistrySecret(name="slack", keys=["SLACK_BOT_TOKEN"]),
+            RegistrySecret(
+                name="mtls",
+                keys=["TLS_CERTIFICATE", "TLS_PRIVATE_KEY"],
+                optional=True,
+            ),
         ],
     )
 
@@ -3015,9 +3094,11 @@ async def test_get_action_context_includes_configuration(monkeypatch):
     )
     payload = _payload(result)
     assert payload["action_name"] == "tools.slack.post_message"
+    # The optional mtls secret is absent but must not block configuration.
     assert payload["configured"] is True
     assert payload["missing_requirements"] == []
     assert payload["required_secrets"][0]["name"] == "slack"
+    assert payload["optional_secrets"] == ["mtls"]
 
 
 def _github_oauth_registry_service() -> SimpleNamespace:
@@ -5670,6 +5751,75 @@ async def test_list_actions_browse_without_query(monkeypatch):
     assert payload["items"][0]["action_name"] == "core.http_request"
     assert payload["items"][1]["action_name"] == "tools.slack.post_message"
     assert payload["has_more"] is False
+
+
+@pytest.mark.anyio
+async def test_list_actions_surfaces_optional_secrets(monkeypatch):
+    """Optional secrets appear under optional_secrets, not missing_requirements."""
+
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    async def _secret_inventory(_role):
+        # Only the required urlscan secret is configured.
+        return {"urlscan": {"URLSCAN_API_KEY"}}
+
+    class _IndexEntry:
+        def __init__(self, namespace, name, description):
+            self.namespace = namespace
+            self.name = name
+            self.description = description
+
+    entries = [
+        (_IndexEntry("tools.urlscan", "lookup_url", "Lookup a URL"), "platform"),
+    ]
+    indexed_action = SimpleNamespace(
+        manifest=SimpleNamespace(),
+        index_entry=SimpleNamespace(options=None),
+    )
+
+    class _RegistryService:
+        async def list_actions_from_index(self, **_kwargs):
+            return entries
+
+        async def search_actions_from_index(self, _query, *, limit=None):
+            _ = limit
+            return entries
+
+        async def get_action_from_index(self, _action_name):
+            return indexed_action
+
+        def aggregate_secrets_from_manifest(self, _manifest, _action_name):
+            # Mirrors lookup_url: required urlscan secret plus the optional
+            # mtls/ca_cert secrets inherited from core.http_request.
+            return [
+                RegistrySecret(name="urlscan", keys=["URLSCAN_API_KEY"]),
+                RegistrySecret(
+                    name="mtls",
+                    keys=["TLS_CERTIFICATE", "TLS_PRIVATE_KEY"],
+                    optional=True,
+                ),
+                RegistrySecret(name="ca_cert", keys=["CA_CERTIFICATE"], optional=True),
+            ]
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _empty_oauth_inventory)
+    monkeypatch.setattr(
+        "tracecat.registry.actions.service.RegistryActionsService.with_session",
+        lambda role: _AsyncContext(_RegistryService()),
+    )
+
+    result = await _tool(mcp_server.list_actions)(
+        workspace_id=str(uuid.uuid4()),
+    )
+    payload = _payload(result)
+    assert len(payload["items"]) == 1
+    item = payload["items"][0]
+    assert item["action_name"] == "tools.urlscan.lookup_url"
+    assert item["configured"] is True
+    assert item["missing_requirements"] == []
+    assert item["optional_secrets"] == ["mtls", "ca_cert"]
 
 
 @pytest.mark.anyio

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -491,6 +491,21 @@ def _secrets_to_requirements(
     return requirements
 
 
+def _optional_secret_names(
+    requirements: Sequence[ActionRequirementPayload],
+) -> list[str]:
+    """Names of optional secret requirements (e.g. mtls/ca_cert).
+
+    These are credentials an action *may* use but does not require to run, so
+    their absence never makes an action unconfigured.
+    """
+    return [
+        req["name"]
+        for req in requirements
+        if req["type"] == "secret" and req.get("optional", False)
+    ]
+
+
 async def _load_secret_inventory(
     role: Role,
 ) -> dict[str, set[str]]:
@@ -554,10 +569,14 @@ def _evaluate_configuration(
             continue
 
         secret_req = cast(ActionSecretRequirementPayload, req)
+        if secret_req.get("optional", False):
+            # A wholly-optional secret never blocks readiness, even when it
+            # declares keys (e.g. the mtls/ca_cert secrets inherited from
+            # core.http_request). At runtime these are absent-by-default, so an
+            # action that only "needs" optional secrets is still usable.
+            continue
         secret_name = secret_req["name"]
         required_keys = set(secret_req["required_keys"])
-        if not required_keys and secret_req.get("optional", False):
-            continue
         available_keys = workspace_inventory.get(secret_name)
         if available_keys is None:
             missing.append(f"missing secret: {secret_name}")
@@ -1044,6 +1063,7 @@ class ActionDiscoveryResponse(BaseModel):
     description: str | None = None
     configured: bool
     missing_requirements: list[str] = Field(default_factory=list)
+    optional_secrets: list[str] = Field(default_factory=list)
 
 
 class ActionContextResponse(ActionDiscoveryResponse):
@@ -4730,6 +4750,9 @@ async def list_actions(
     - description: One-line description of the action
     - configured: Whether required secrets are present in the workspace
     - missing_requirements: List of missing secret names/keys (if any)
+    - optional_secrets: Credentials you *may* supply (e.g. mtls/ca_cert for
+      mTLS targets) but are not required to run the action. Their absence never
+      makes an action unconfigured.
     """
 
     try:
@@ -4763,6 +4786,7 @@ async def list_actions(
                         description=entry.description,
                         configured=configured,
                         missing_requirements=missing,
+                        optional_secrets=_optional_secret_names(requirements),
                     )
                 )
             page = _paginate_items(
@@ -4916,6 +4940,9 @@ async def get_action_context(
       integrations are {type: "oauth", name, provider_id, grant_type}.
     - configured: Whether all required secrets and OAuth integrations are present
     - missing_requirements: List of missing secrets/keys or OAuth integrations
+    - optional_secrets: Credentials you *may* supply (e.g. mtls/ca_cert for mTLS
+      targets) but are not required to run the action; their absence never makes
+      an action unconfigured.
     - examples: Example args payload based on the schema
     """
 
@@ -4941,6 +4968,7 @@ async def get_action_context(
                 required_secrets=requirements,
                 configured=configured,
                 missing_requirements=missing,
+                optional_secrets=_optional_secret_names(requirements),
                 examples=[_build_example_from_schema(schema)],
             )
     except ToolError:
@@ -5014,6 +5042,7 @@ async def get_workflow_authoring_context(
                         required_secrets=requirements,
                         configured=configured,
                         missing_requirements=missing,
+                        optional_secrets=_optional_secret_names(requirements),
                         examples=[
                             _build_example_from_schema(tool.parameters_json_schema)
                         ],


### PR DESCRIPTION
## Problem

In a workspace, an agent refused to use `tools.urlscan.lookup_url`, believing it was blocked because the workspace "only" had the `urlscan` credential and was "missing" `mtls` / `ca_cert`.

Those two secrets are **optional**. They come from the `core.http_request` / `core.http_poll` steps the template wraps, and are pulled in by recursive secret aggregation. But `_evaluate_configuration` honored the `optional` flag only for OAuth requirements and for *keyless* secrets — not for optional secrets that declare `keys`. Since `mtls` (`TLS_CERTIFICATE`, `TLS_PRIVATE_KEY`) and `ca_cert` (`CA_CERTIFICATE`) declare keys, they fell through and were reported as missing:

```
configured: false
missing_requirements: ["missing secret: mtls", "missing secret: ca_cert"]
```

Any template that wraps a core HTTP action was affected. The agent read it as a hard block.

## Fix

1. **`_evaluate_configuration`** now skips any wholly-optional secret before the presence check, mirroring the existing optional-OAuth handling. Optional credentials never make an action unconfigured — matching runtime, where `core.http_request` runs fine without mTLS/CA. This propagates to every agent-facing surface (`list_actions`, `get_action_context`, `get_workflow_authoring_context`, the action catalog, agent internal tools).

2. **Surface optionality to callers**: new `optional_secrets: list[str]` field on `ActionDiscoveryResponse` (inherited by `ActionContextResponse`), populated via a shared `_optional_secret_names` helper in `list_actions`, `get_action_context`, and `get_workflow_authoring_context`. Docstrings updated so agents know these are creds they *may* supply (e.g. mtls/ca_cert for mTLS targets), not required to run.

## Why the custom registry templates were never affected

Secret aggregation (`aggregate_secrets_from_manifest`) only recurses into a step action if it exists in the *same registry version's manifest*. `lookup_url` ships in the base registry, whose manifest contains `core.http_request`/`core.http_poll`, so it inherits their optional secrets. Equivalent custom-registry urlscan templates live in a custom registry whose manifest has no `core.*`, so aggregation finds nothing and they only carry the `urlscan` secret. This PR fixes the scoring bug — the part that actually harmed agents.

## Tests

- `test_evaluate_configuration_skips_optional_secret_with_keys` — regression guard.
- `test_evaluate_configuration_required_present_with_optional_absent` — required present + optional absent → configured.
- `test_evaluate_configuration_reports_required_but_not_optional` — only the genuinely-required missing secret is reported.
- `test_list_actions_surfaces_optional_secrets` — `optional_secrets` populated, `missing_requirements` empty, `configured: true`.
- Extended `test_get_action_context_includes_configuration` to assert `optional_secrets`.

## Verification

- 16 relevant `test_mcp_server.py` tests pass.
- `ruff check`, `ruff format --check`, `basedpyright --warnings` on changed files: clean.
- `cubic review --base main`: no issues.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP configuration scoring so actions aren’t marked unconfigured when only optional secrets are missing, and surfaces which secrets are optional to callers for clarity.

- **Bug Fixes**
  - `_evaluate_configuration` now skips optional secret requirements even if they declare keys, matching runtime behavior for `core.http_request`/`core.http_poll`. This prevents false blocks like on `tools.urlscan.lookup_url` (no more “missing secret: mtls/ca_cert” when absent-by-default).

- **New Features**
  - Added `optional_secrets` to `ActionDiscoveryResponse` and `ActionContextResponse`, listing credentials like `mtls` and `ca_cert` that may be provided but aren’t required.
  - Populated via `_optional_secret_names` and returned by `list_actions`, `get_action_context`, and `get_workflow_authoring_context`.

<sup>Written for commit 048bf1c48ac0b0873b6618fe8162714b7cf0fb66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

