### PR TITLE
feat(skills): Restructure Tracecat best practices

### DIFF
--- a/.agents/skills/LEARNINGS_INBOX.md
+++ b/.agents/skills/LEARNINGS_INBOX.md
@@ -1,0 +1,39 @@
+# Skill learnings inbox
+
+Append-only buffer for the **build → feedback → distill** loop. This file is **not** linked
+from any `SKILL.md`, so it never auto-loads into context — it is a staging area, not policy.
+
+## How to use it
+
+- **Capture (after a build session):** append a raw, dated candidate learning below — what
+  happened, what the user's feedback was, and the *generic* rule it might imply. Cheap and
+  unbounded; do not edit the skills yet.
+- **Also capture from evals:** after an eval run, mine `report.json` `key_failures` and
+  `improvements` (under `.tracecat/evals/tracecat_authoring/<timestamp>/`) and drop candidate
+  learnings here.
+- **Distill (periodically):** fold entries into the skills as the **smallest edit that
+  generalizes** — sharpen an existing rule > add a Common-Mistakes bullet > add detail to a
+  `references/*.md` > (last resort) add a new `references/` file. Keep `SKILL.md` lean and
+  under its eval char budget; route detail to `references/`. Then **delete the distilled
+  entry** from this file.
+
+## Rules
+
+- Only **generic, cross-tenant** lessons may enter a skill. Tenant/tool specifics stay in the
+  owning tenant tree. Slack craft is the sole tool-specific exception → it belongs in
+  `tracecat-slackbot-best-practices`.
+- Before committing a skill edit, run the eval static checks as a regression gate (budget,
+  fenced-block parse, action-literal validity).
+- Follow the Agent Skills spec for structure/naming: <https://agentskills.io/specification>.
+
+---
+
+## Pending learnings
+
+<!-- Append entries below. Format:
+### YYYY-MM-DD — short title
+- Context:
+- Feedback / signal:
+- Candidate generic rule:
+- Target (skill + section, or references/<file>):
+-->

--- a/.agents/skills/tracecat-automation-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-automation-best-practices/SKILL.md
@@ -5,6 +5,10 @@ description: Use when building, editing, validating, or debugging generic Tracec
 
 # Tracecat Automation Best Practices
 
+For Slack-facing automations, use `$tracecat-slackbot-best-practices`. Detailed guidance
+lives in on-demand references: [run-python](references/run-python.md),
+[workflow-editing](references/workflow-editing.md), [tables](references/tables.md).
+
 ## Workflow
 
 Start from live MCP context rather than guessing:
@@ -12,29 +16,99 @@ Start from live MCP context rather than guessing:
 1. Discover the workspace with `list_workspaces`.
 2. Read `tracecat://platform/dsl-reference` when DSL syntax or examples are needed.
 3. Use `get_workflow_authoring_context` for action schemas, variables, and secrets.
-4. For existing workflows, use `get_workflow`, then targeted `edit_workflow` patches against `draft_document` and `draft_revision`.
-5. Validate with `validate_workflow`, run a draft or published execution when appropriate, then inspect failures with `list_workflow_executions` and `get_workflow_execution`.
+4. For existing workflows, use `get_workflow`, then targeted `edit_workflow` patches — see
+   [workflow-editing](references/workflow-editing.md).
+5. Validate with `validate_workflow`, run a draft or published execution when appropriate,
+   then inspect failures with `list_workflow_executions` and `get_workflow_execution`.
 
-Clarify production choices that change the workflow contract: workspace, integration/provider, secret source, publish/run behavior, destructive side effects, approvals, or acceptance criteria. If the request is already specific enough, proceed.
+Clarify production choices that change the workflow contract: workspace, integration/provider,
+secret source, publish/run behavior, destructive side effects, approvals, or acceptance
+criteria. If the request is already specific enough, proceed.
 
-Sketch the workflow shape before authoring. Prefer readable left-to-right or top-to-bottom flows, human-readable refs, few branches, and layout refs aligned with definition refs. Use the live DSL reference for exact syntax.
+Sketch the workflow shape before authoring. Prefer readable left-to-right or top-to-bottom
+flows, human-readable refs, few branches, and layout refs aligned with definition refs.
+
+## Choosing between an agent and Python
+
+Decide by the *kind* of work, and optimize the whole workflow for maintainability and
+readability — **the fewest actions and the least code that does the job.**
+
+- **Agentic work → use an agent** (`ai.agent` / `ai.preset_agent`). Anything needing
+  judgment, investigation, routing, enrichment choices, summarization, composing a message,
+  or posting to Slack. Give the agent the tools and trust it. Prefer agents, prompts, and
+  skills — they carry the creative thinking with far fewer moving parts than a graph of
+  deterministic nodes.
+- **Deterministic data plumbing → use Python** (`core.script.run_python`). Transforming,
+  normalizing, redacting, loading or upserting rows into tables, forwarding data between
+  systems. This is exactly what Python is for — it is **not** a smell. One clear `run_python`
+  action beats scattering the same work across many nodes.
+
+The smell is using Python for the *agentic* part — for example composing or sending an
+agent's Slack message from a script instead of giving the agent the Slack tool.
+
+**Prompt-size guardrail:** push behavior into the prompt up to a reasonable size. When a
+single prompt grows too large to stay readable, decompose into **subagents or a skill**
+rather than inflating one mega-prompt.
+
+## Agent-First Automation
+
+When the user asks for an agentic workflow, an agent preset, or says to use agents, make the
+agent the primary owner of the work. Give it the tools it needs and trust it to investigate,
+decide, route, compose messages, and act. Default to a thin shape:
+`trigger -> reshape/redact -> upsert event record -> ai.agent` (or `ai.preset_agent`).
+
+Persist the normalized event before the agent runs. When events originate in a SIEM, log
+platform, SaaS webhook stream, audit trail, or cloud service, store the normalized payload
+and review state in a Tracecat table first, with a deterministic upsert. That gives retries,
+duplicate webhooks, and replay a durable source of truth. Point the agent at the saved row,
+so the workflow — not the agent — owns the first durable record of the event.
+
+A deterministic node earns its place by being thin, direct, and easy to audit, and by doing
+work the agent should not own: redact secrets before the agent sees data, normalize schema,
+upsert the event row, enforce hard approval or authorization boundaries, guard expensive
+agent runs with a dedupe check, prepare bounded batches, or checkpoint durable state. Keep
+judgment, routing, enrichment, message composition, soft approval decisions, and final
+notification behavior in the agent. When an approval question itself needs judgment, let the
+agent decide or draft the request, and reserve deterministic gates for explicit safety or
+authorization boundaries.
+
+Favor one well-instructed agent or reusable preset over many small deterministic nodes. Put
+output contracts, Slack style, dedupe rules, tenant boundaries, tool permissions, and
+permitted side effects directly in the preset instructions — the agent reads those, not repo
+files. When the agent needs a tool, grant it the narrow tool directly rather than wrapping
+the same call in a workflow action.
+
+A preset's runtime has more capability than `list_actions` shows. The agent runs inside a
+sandbox with a real shell and file tools (`Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`),
+plus CLI utilities: Python and `uv`, `curl`, `jq`, and the DuckDB CLI for local SQL over CSV,
+JSON, and Parquet. So an agent can shape data, parse JSON, and run tabular queries without a
+workflow node for it. Before adding a workflow helper or preprocessing step to compensate for
+a presumed limitation, inspect the preset/runtime context. When the agent can safely do the
+bounded work itself, keep it in the preset instructions.
 
 ## Authoring Defaults
 
-- Prefer linear, readable graphs. Keep ordinary workflows around 20 nodes or fewer and agentic workflows around 6 nodes or fewer.
-- Consolidate deterministic work with `core.script.run_python`: data shaping, API loops, retries, batching, dedupe, joins, sorting, chunked table writes, and per-item error handling.
-- Prefer `ai.agent` or `ai.preset_agent` for investigation, judgment, summarization, and tool-using decisions. Use `core.http_request` for deterministic API calls.
-- Do not give `core.http_request` to an agent unless the user explicitly accepts the broad network capability. Put deterministic HTTP in the workflow graph or a tightly scoped subflow.
-- Use HTTP pagination actions for paginated APIs. Keep paginated results bounded before storing or returning them.
-- Prefer `core.script.run_python` loops over action-level `for_each`, even for bounded lists. `for_each` can create enough scheduled work to hurt the scheduler. Use it only when the user explicitly needs separate workflow action runs per item and accepts the concurrency tradeoff.
-- Prefer `core.script.run_python` loops over `core.transform.scatter` / `core.transform.gather`. Scatter/gather has the same scheduler/concurrency risk and should be reserved for explicit workflow-stream fan-out/fan-in requirements.
-- Use `core.loop.start` / `core.loop.end` only when each iteration depends on prior action output.
-- Split into subflows only when there is a real orchestration boundary, reusable child workflow, separate execution history, approvals, long-running actions, retries, or independent checkpointing.
-- Use `core.workflow.execute` for subflows and prefer `workflow_alias` over hard-coded workflow IDs.
-- For subflow bulk work, default to `loop_strategy: batch`, `batch_size: 32`, `fail_strategy: isolated`, and `wait_strategy: wait`. Use `wait_strategy: detach` only when the parent does not need child results.
-- Keep run-python and agent outputs small: downstream rows, summary counts, and bounded error samples.
-- Prefer agent presets when reusable behavior already exists. Use inline `ai.agent` only when the prompt should live with one workflow.
-- Prefer the `model` object for inline `ai.agent`; top-level `model_name` and `model_provider` are deprecated unless the user asks for the legacy shape.
+- Prefer linear, readable graphs. Keep ordinary workflows around 20 nodes or fewer and
+  agentic workflows around 6 nodes or fewer.
+- For agentic workflows, push most behavior into the agent prompt/preset. For event-driven
+  workflows, a single reshape/redact/upsert action before the agent is usually the right
+  deterministic boundary.
+- Use `ai.agent` / `ai.preset_agent` for the agentic work; `core.http_request` for
+  deterministic API calls; `core.script.run_python` for deterministic data work — details and
+  loop/concurrency rules in [run-python](references/run-python.md).
+- Do not give `core.http_request` to an agent unless the user explicitly accepts the broad
+  network capability. Put deterministic HTTP in the workflow graph or a tightly scoped subflow.
+- Split into subflows only when there is a real orchestration boundary, reusable child
+  workflow, separate execution history, approvals, long-running actions, or independent
+  checkpointing. Use `core.workflow.execute` and prefer `workflow_alias` over hard-coded IDs.
+  Subflow bulk defaults: `loop_strategy: batch`, `batch_size: 32`, `fail_strategy: isolated`,
+  `wait_strategy: wait` (use `detach` only when the parent does not need child results).
+- Keep run-python and agent outputs small: downstream rows, summary counts, bounded error
+  samples.
+- Prefer agent presets when reusable behavior already exists. Use inline `ai.agent` only when
+  the prompt should live with one workflow.
+- Prefer the `model` object for inline `ai.agent`; top-level `model_name`/`model_provider` are
+  deprecated unless the user asks for the legacy shape.
 
 ```yaml
 args:
@@ -43,65 +117,28 @@ args:
     model_provider: anthropic
 ```
 
-## Existing Workflow Edits
-
-- Prefer `edit_workflow` over replacing full YAML for focused changes.
-- Patch against the `draft_document` returned by `get_workflow`; action paths start under `/definition/actions/...`, not `/actions/...`.
-- For nontrivial edits, call `edit_workflow` with `validate_only: true`, then apply the same patch with `validate_only: false` against the same `base_revision`.
-- Treat `draft_revision` as sequential state. After a successful write, use the returned revision before the next patch.
-- When adding or renaming actions, update `depends_on` and matching layout action refs in the same edit.
-
-## Run-Python Imports
-
-Use direct Tracecat imports inside `core.script.run_python` when consolidating table or HTTP side effects reduces graph noise:
-
-```python
-from tracecat_registry.core.http import http_request, http_paginate
-from tracecat_registry.core.table import create_table, insert_rows, lookup, update_row
-
-async def main(rows):
-    await create_table(
-        name="automation_inventory",
-        columns=[
-            {"name": "external_id", "type": "TEXT"},
-            {"name": "payload", "type": "JSONB"},
-        ],
-        raise_on_duplicate=False,
-    )
-
-    inserted = 0
-    for start in range(0, len(rows), 1000):
-        inserted += await insert_rows(
-            table="automation_inventory",
-            rows_data=rows[start:start + 1000],
-            upsert=False,
-        )
-    return {"input_rows": len(rows), "inserted": inserted}
-```
-
-Use `async def main(...)`, `await` imported actions, pass named arguments, and chunk writes. Catch expected per-item failures inside bulk actions and return counts plus a few examples instead of failing the whole workflow.
-
-## Tables
-
-- `core.table.create_table` creates columns but not unique indexes.
-- Before using `insert_rows(..., upsert=True)`, create a unique index on the intended key column.
-- Keep `insert_rows` batches at or below 1000 rows.
-- Use table storage for durable workflow state, checkpoints between stages and subflows, per-item status, run IDs, timestamps, and bounded error samples.
-- Keep opaque identifiers as strings, especially numeric-looking IDs that may exceed integer limits.
-- Keep table names, column names, and case field names under 63 characters.
-
-For MCP table operations, use `list_tables`, `get_table`, `create_column_index`, `search_table_rows`, and `export_csv`. For workflow YAML, use `core.table.*` actions or `tracecat_registry.core.table` imports inside run-python.
-
 ## Common Mistakes
 
-- Workflow action names are not MCP tool names. Use MCP tools such as `create_workflow` to manage workflows, and use action names such as `core.http_request` only inside workflow YAML.
-- Do not invent `tools.*` action names. Discover actions with `list_actions`, then inspect exact schemas with `get_action_context`.
-- Use `core.script.run_python` for ordinary collection processing; avoid `for_each` and scatter/gather for normal loops, batching, filtering, joins, or table writes.
-- Do not use table `insert_rows(..., upsert=True)` unless the table has a unique index on the key column used to match existing rows.
-- Do not grant `core.http_request` to an agent unless the user explicitly approves broad network access.
+- Using Python for the *agentic* part — composing or posting an agent's Slack message, or
+  making routing/judgment calls in a script. The agent owns message composition, posting (via
+  a Slack tool), and judgment; Python owns deterministic data plumbing.
+- Workflow action names are not MCP tool names. Use MCP tools such as `create_workflow` to
+  manage workflows, and action names such as `core.http_request` only inside workflow YAML.
+- Inventing `tools.*` action names. Discover actions with `list_actions`, then inspect exact
+  schemas with `get_action_context`.
+- Using `for_each` or scatter/gather for normal loops, batching, filtering, joins, or table
+  writes — prefer a `core.script.run_python` loop (see [run-python](references/run-python.md)).
+- Using `insert_rows(..., upsert=True)` without a unique index on the key column (see
+  [tables](references/tables.md)).
+- Granting `core.http_request` to an agent without explicit user approval of broad network
+  access.
 
 ## Agent Presets
 
-Before creating or updating presets, call `get_agent_preset_authoring_context` and `list_integrations`. Check workspace model credentials, attachable MCP integrations, output type options, variables, and available tools.
+Before creating or updating presets, call `get_agent_preset_authoring_context` and
+`list_integrations`. Check workspace model credentials, attachable MCP integrations, output
+type options, variables, and available tools.
 
-Give presets only the tools they need. Encode routing, table names, output style, and production action rules directly in the preset instructions; the agent reads its own instructions, not repo files.
+Give presets only the tools they need. Encode routing, table names, output style, and
+production action rules directly in the preset instructions; the agent reads its own
+instructions, not repo files.

--- a/.agents/skills/tracecat-automation-best-practices/references/run-python.md
+++ b/.agents/skills/tracecat-automation-best-practices/references/run-python.md
@@ -1,0 +1,80 @@
+# Run-Python and deterministic data work
+
+Use `core.script.run_python` for deterministic data plumbing: transforming, normalizing,
+redacting, loading/upserting table rows, forwarding data, batching, retries, joins, sorting,
+simple dedupe guards, and per-item error handling. Consolidate this work into one clear action
+rather than scattering it across many nodes.
+
+## Loops and concurrency
+
+- Prefer `core.script.run_python` loops over action-level `for_each`, even for bounded lists.
+  `for_each` can create enough scheduled work to hurt the scheduler. Use it only when the user
+  explicitly needs separate workflow action runs per item and accepts the concurrency tradeoff.
+- Prefer `core.script.run_python` loops over `core.transform.scatter` / `core.transform.gather`.
+  Scatter/gather has the same scheduler/concurrency risk; reserve it for explicit
+  workflow-stream fan-out/fan-in requirements.
+- Use `core.loop.start` / `core.loop.end` only when each iteration depends on prior action
+  output.
+- Use bounded async concurrency inside `core.script.run_python` for bulk HTTP or table
+  operations.
+
+## Imports
+
+Use direct Tracecat imports inside `core.script.run_python` when consolidating table or HTTP
+side effects reduces graph noise:
+
+```python
+from tracecat_registry.core.http import http_request, http_paginate
+from tracecat_registry.core.table import create_table, insert_rows, lookup, update_row
+
+async def main(rows):
+    await create_table(
+        name="automation_inventory",
+        columns=[
+            {"name": "external_id", "type": "TEXT"},
+            {"name": "payload", "type": "JSONB"},
+        ],
+        raise_on_duplicate=False,
+    )
+
+    inserted = 0
+    for start in range(0, len(rows), 1000):
+        inserted += await insert_rows(
+            table="automation_inventory",
+            rows_data=rows[start:start + 1000],
+            upsert=False,
+        )
+    return {"input_rows": len(rows), "inserted": inserted}
+```
+
+Use `async def main(...)`, `await` imported actions, pass named arguments, and chunk writes.
+Catch expected per-item failures inside bulk actions and return counts plus a few examples
+instead of failing the whole workflow. Keep outputs small: downstream-required rows, summary
+counts, and bounded error samples — not full intermediate datasets.
+
+## HTTP and pagination
+
+- Prefer `core.http_request` for single generic API calls and `core.http_paginate` for cursor
+  or next-URL APIs when the items and next request can be expressed clearly. Move the work
+  into `core.script.run_python` when pagination, joins, retries, dedupe, or per-item error
+  handling would make the graph noisy.
+- Check `get_workflow_authoring_context` before using `core.http_paginate`; its pagination
+  controls are lambda-string fields (`stop_condition`, `next_request`), not nested request
+  objects.
+- Keep paginated results bounded before storing or returning them.
+
+## Inline expressions vs Python
+
+Use inline expressions for small value shaping only: scalar fallbacks with `||`, simple
+strings with `FN.concat`, CSV-style summaries with `FN.join`, and time windows with
+`FN.to_isoformat(FN.now() - FN.hours(N))`. Use Python for anything that starts to look like
+iteration or branching. Avoid empty-list fallbacks in expressions; use trigger defaults,
+CSV/JSON strings, or Python-side defaults.
+
+## Plain Python vs DuckDB
+
+Default to plain Python for transforms that fit comfortably in memory. Reach for DuckDB only
+for genuinely SQL-shaped work — real joins, multi-key aggregates, window functions, or large
+row counts where vectorized execution is worth the overhead. Do not overstate DuckDB-removal
+speedups without execution data; for low-hundreds-row transforms the win is usually simpler
+dependencies, smaller scripts, and clearer graph review rather than a large runtime gain.

--- a/.agents/skills/tracecat-automation-best-practices/references/tables.md
+++ b/.agents/skills/tracecat-automation-best-practices/references/tables.md
@@ -1,0 +1,19 @@
+# Tables
+
+- `core.table.create_table` creates columns but **not** unique indexes.
+- Before using `insert_rows(..., upsert=True)`, create a unique index on the intended key
+  column. Any workflow action that upserts requires the index to exist first.
+- For event ingestion, create or update the event table before agent review. Prefer upsert
+  keyed by the source's stable event ID, delivery ID, object ID, or a deterministic hash of
+  source, event kind, timestamp, actor, and object. If no stable key exists, insert with a
+  generated run ID, but still store the normalized payload before invoking the agent.
+- Keep `insert_rows` batches at or below 1000 rows.
+- Use table storage for durable workflow state, checkpoints between stages and subflows,
+  per-item status, run IDs, timestamps, and bounded error samples.
+- Keep opaque identifiers as strings, especially numeric-looking IDs that may exceed integer
+  limits.
+- Keep table names, column names, and case field names under 63 characters.
+
+For MCP table operations, use `list_tables`, `get_table`, `create_column_index`,
+`search_table_rows`, and `export_csv`. For workflow YAML, use `core.table.*` actions or
+`tracecat_registry.core.table` imports inside run-python.

--- a/.agents/skills/tracecat-automation-best-practices/references/workflow-editing.md
+++ b/.agents/skills/tracecat-automation-best-practices/references/workflow-editing.md
@@ -1,0 +1,49 @@
+# Editing existing workflows with MCP
+
+Prefer targeted `edit_workflow` patches over replacing full YAML.
+
+- Patch against the `draft_document` returned by `get_workflow`; action paths start under
+  `/definition/actions/...`, not `/actions/...`. Valid targeted paths include
+  `/definition/actions/N/args/script`, `/definition/actions/N/args/dependencies`,
+  `/definition/actions/N/ref`, `/definition/actions/N/depends_on/...`, and
+  `/layout/actions/N/ref`.
+- Before patching, call `get_workflow`, use the returned `draft_revision` as `base_revision`,
+  and build action indexes from the latest returned action list. Do not reuse stale indexes
+  after another edit.
+- For nontrivial edits, call `edit_workflow` with `validate_only: true`, then apply the same
+  patch with `validate_only: false` against the same `base_revision`.
+- Treat `draft_revision` as sequential state. After a successful write, use the returned
+  revision before the next patch. Do not run parallel `edit_workflow` calls against the same
+  draft — each successful edit advances `draft_revision`; apply chunks sequentially,
+  refetching before each chunk when payload size or reviewability argues against one large
+  patch.
+- When adding or renaming actions, update the action `ref`, every dependent `depends_on` edge,
+  and the matching layout action `ref` in the same edit.
+- JSON Patch operations apply in order. RFC 6902 array semantics: `/-` appends, and indexes
+  shift after `add`, `remove`, and `move`.
+- Use `update_workflow(definition_yaml=..., update_mode="replace")` only when a targeted patch
+  is not sufficient. Never broad-replace from local YAML without comparing against the remote
+  draft for production-only values and remote-only improvements.
+- After remote edits, run `validate_workflow`, read back the draft to confirm intended refs
+  and important fields landed, then run a draft execution for nontrivial changes. Publish only
+  when explicitly authorized.
+
+## Definition and trigger inputs
+
+- Complete workflow YAML belongs under top-level `definition:`. A bare top-level `entrypoint:`
+  may parse but will not register trigger inputs for runtime expressions.
+- Declare `definition.entrypoint.expects` for every trigger input used as `TRIGGER.*`;
+  validation can pass even when a later draft run lacks undeclared trigger values.
+
+## Action naming
+
+Name action refs by their externally visible effect: `create_<scope>_tables`, `fetch_<noun>`,
+`aggregate_<noun>`, `build_<noun>`, `update_<noun>_table(s)`. Avoid `sync_*` and `persist_*`
+for table writes because they do not state the write target clearly.
+
+## Static checks before remote updates
+
+Before remote updates, inspect the workspace draft and run applicable static checks on
+generated or exported workflow content: YAML parse, embedded Python `ast.parse`,
+ref/dependency resolution, no accidental scatter/gather, no redundant diamonds, and
+`git diff --check`.

--- a/.agents/skills/tracecat-slackbot-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-slackbot-best-practices/SKILL.md
@@ -21,6 +21,19 @@ Build Slack bots with `ai.agent` or `ai.preset_agent`.
 - Fetch the Slack thread before invoking the agent, and tell the agent that thread context is required input.
 - Post visible replies back to the original channel and thread. Do not answer only in the agent transcript.
 
+**The agent owns the message — composition and posting.** Composing or sending a Slack
+message is agentic work, not data plumbing. Reserve deterministic nodes for data plumbing
+around the agent (fetching the thread, redacting, upserting state).
+
+- WRONG: a `core.script.run_python` or `core.http_request` node formats the text and posts to
+  Slack, and the agent only returns a string. This buries the wording in a script, makes
+  Block Kit and tone hard to iterate, and splits responsibility.
+- RIGHT: the agent is given the Slack send/reply tool and owns both composing the message
+  (mrkdwn/Block Kit, tone) and posting it to the original thread, per its instructions.
+
+If a deterministic step formats the agent's output for Slack, that is the smell — move the
+formatting and posting into the agent.
+
 Prefer the `model` object for `ai.agent`; top-level `model_name` and `model_provider` are deprecated unless the user explicitly asks for the legacy shape.
 
 ```yaml

--- a/.agents/skills/tracecat-slackbot-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-slackbot-best-practices/SKILL.md
@@ -77,7 +77,9 @@ Slack-facing agents need explicit production posting rules in their own instruct
 - Always post to the original Slack channel and thread.
 - Use Slack mrkdwn, not generic Markdown, when posting text.
 - Use Block Kit only when the response needs buttons, links, compact review layout, or structured blocks.
-- Use a reasonable, calm, critical tone. Do not be alarmist, speculate about compromise, or inflate severity without evidence.
+- Use a reasonable, calm, critical tone. Keep risk language grounded in evidence rather than inflated.
+- Prefer positive, preferred-vocabulary instructions over avoid-word blocklists. Naming the exact words to avoid (e.g. "suspicious", "critical", "breach") seeds those tokens into context and can prime them; instead state the phrasing you want and require risk claims to be evidence-backed.
+- State each rule once. Don't restate rules in a large end-of-prompt validation checklist — duplication bloats the prompt and drifts out of sync.
 - Avoid emojis unless they make the point clearer or are part of a deliberate lightweight status convention.
 - Keep style rules in the preset or `ai.agent` instructions. The agent reads its own instructions, not repo files.
 - If a Slack post fails, return a concise failure reason and enough context for workflow debugging.

--- a/scripts/evals/tracecat_authoring/run_local.py
+++ b/scripts/evals/tracecat_authoring/run_local.py
@@ -521,11 +521,11 @@ async def choose_workspace(mcp: TracecatMCP) -> str:
 
 def isolated_workspace(case_dir: Path) -> Path:
     workspace = case_dir / "workspace"
-    skill_target = (
-        workspace / ".agents/skills/tracecat-automation-best-practices/SKILL.md"
-    )
+    skill_target = workspace / ".agents/skills/tracecat-automation-best-practices"
     skill_target.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(SKILL_SOURCE, skill_target)
+    # Copy the whole skill directory so progressive-disclosure references/ files
+    # (loaded on demand by SKILL.md links) are present in the workspace too.
+    shutil.copytree(SKILL_SOURCE.parent, skill_target, dirs_exist_ok=True)
     return workspace
 
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -2888,6 +2888,80 @@ def test_evaluate_configuration_skips_optional_oauth_integration():
     assert missing == []
 
 
+def test_evaluate_configuration_skips_optional_secret_with_keys():
+    # Regression: a wholly-optional secret that declares keys (e.g. the mtls /
+    # ca_cert secrets inherited from core.http_request) must not block readiness.
+    requirements: list[mcp_server.ActionRequirementPayload] = [
+        {
+            "type": "secret",
+            "name": "mtls",
+            "required_keys": ["TLS_CERTIFICATE", "TLS_PRIVATE_KEY"],
+            "optional_keys": [],
+            "optional": True,
+        }
+    ]
+
+    configured, missing = mcp_server._evaluate_configuration(requirements, {})
+
+    assert configured is True
+    assert missing == []
+
+
+def test_evaluate_configuration_required_present_with_optional_absent():
+    # An action that wraps core.http_request: required urlscan secret present,
+    # optional mtls/ca_cert absent -> configured, nothing missing.
+    requirements: list[mcp_server.ActionRequirementPayload] = [
+        {
+            "type": "secret",
+            "name": "urlscan",
+            "required_keys": ["URLSCAN_API_KEY"],
+            "optional_keys": [],
+            "optional": False,
+        },
+        {
+            "type": "secret",
+            "name": "mtls",
+            "required_keys": ["TLS_CERTIFICATE", "TLS_PRIVATE_KEY"],
+            "optional_keys": [],
+            "optional": True,
+        },
+    ]
+    workspace_inventory = {"urlscan": {"URLSCAN_API_KEY"}}
+
+    configured, missing = mcp_server._evaluate_configuration(
+        requirements, workspace_inventory
+    )
+
+    assert configured is True
+    assert missing == []
+
+
+def test_evaluate_configuration_reports_required_but_not_optional():
+    # Required secret absent, optional secret absent -> unconfigured, and only the
+    # required secret is reported as missing.
+    requirements: list[mcp_server.ActionRequirementPayload] = [
+        {
+            "type": "secret",
+            "name": "urlscan",
+            "required_keys": ["URLSCAN_API_KEY"],
+            "optional_keys": [],
+            "optional": False,
+        },
+        {
+            "type": "secret",
+            "name": "mtls",
+            "required_keys": ["TLS_CERTIFICATE", "TLS_PRIVATE_KEY"],
+            "optional_keys": [],
+            "optional": True,
+        },
+    ]
+
+    configured, missing = mcp_server._evaluate_configuration(requirements, {})
+
+    assert configured is False
+    assert missing == ["missing secret: urlscan"]
+
+
 @pytest.mark.anyio
 async def test_load_oauth_inventory_includes_only_connected(monkeypatch):
     # Only CONNECTED integrations can inject a token at runtime; a
@@ -2970,7 +3044,12 @@ async def test_get_action_context_includes_configuration(monkeypatch):
     )
     registry_service = SimpleNamespace(
         aggregate_secrets_from_manifest=lambda _manifest, _action_name: [
-            RegistrySecret(name="slack", keys=["SLACK_BOT_TOKEN"])
+            RegistrySecret(name="slack", keys=["SLACK_BOT_TOKEN"]),
+            RegistrySecret(
+                name="mtls",
+                keys=["TLS_CERTIFICATE", "TLS_PRIVATE_KEY"],
+                optional=True,
+            ),
         ],
     )
 
@@ -3015,9 +3094,11 @@ async def test_get_action_context_includes_configuration(monkeypatch):
     )
     payload = _payload(result)
     assert payload["action_name"] == "tools.slack.post_message"
+    # The optional mtls secret is absent but must not block configuration.
     assert payload["configured"] is True
     assert payload["missing_requirements"] == []
     assert payload["required_secrets"][0]["name"] == "slack"
+    assert payload["optional_secrets"] == ["mtls"]
 
 
 def _github_oauth_registry_service() -> SimpleNamespace:
@@ -5670,6 +5751,75 @@ async def test_list_actions_browse_without_query(monkeypatch):
     assert payload["items"][0]["action_name"] == "core.http_request"
     assert payload["items"][1]["action_name"] == "tools.slack.post_message"
     assert payload["has_more"] is False
+
+
+@pytest.mark.anyio
+async def test_list_actions_surfaces_optional_secrets(monkeypatch):
+    """Optional secrets appear under optional_secrets, not missing_requirements."""
+
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    async def _secret_inventory(_role):
+        # Only the required urlscan secret is configured.
+        return {"urlscan": {"URLSCAN_API_KEY"}}
+
+    class _IndexEntry:
+        def __init__(self, namespace, name, description):
+            self.namespace = namespace
+            self.name = name
+            self.description = description
+
+    entries = [
+        (_IndexEntry("tools.urlscan", "lookup_url", "Lookup a URL"), "platform"),
+    ]
+    indexed_action = SimpleNamespace(
+        manifest=SimpleNamespace(),
+        index_entry=SimpleNamespace(options=None),
+    )
+
+    class _RegistryService:
+        async def list_actions_from_index(self, **_kwargs):
+            return entries
+
+        async def search_actions_from_index(self, _query, *, limit=None):
+            _ = limit
+            return entries
+
+        async def get_action_from_index(self, _action_name):
+            return indexed_action
+
+        def aggregate_secrets_from_manifest(self, _manifest, _action_name):
+            # Mirrors lookup_url: required urlscan secret plus the optional
+            # mtls/ca_cert secrets inherited from core.http_request.
+            return [
+                RegistrySecret(name="urlscan", keys=["URLSCAN_API_KEY"]),
+                RegistrySecret(
+                    name="mtls",
+                    keys=["TLS_CERTIFICATE", "TLS_PRIVATE_KEY"],
+                    optional=True,
+                ),
+                RegistrySecret(name="ca_cert", keys=["CA_CERTIFICATE"], optional=True),
+            ]
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _empty_oauth_inventory)
+    monkeypatch.setattr(
+        "tracecat.registry.actions.service.RegistryActionsService.with_session",
+        lambda role: _AsyncContext(_RegistryService()),
+    )
+
+    result = await _tool(mcp_server.list_actions)(
+        workspace_id=str(uuid.uuid4()),
+    )
+    payload = _payload(result)
+    assert len(payload["items"]) == 1
+    item = payload["items"][0]
+    assert item["action_name"] == "tools.urlscan.lookup_url"
+    assert item["configured"] is True
+    assert item["missing_requirements"] == []
+    assert item["optional_secrets"] == ["mtls", "ca_cert"]
 
 
 @pytest.mark.anyio

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -491,6 +491,21 @@ def _secrets_to_requirements(
     return requirements
 
 
+def _optional_secret_names(
+    requirements: Sequence[ActionRequirementPayload],
+) -> list[str]:
+    """Names of optional secret requirements (e.g. mtls/ca_cert).
+
+    These are credentials an action *may* use but does not require to run, so
+    their absence never makes an action unconfigured.
+    """
+    return [
+        req["name"]
+        for req in requirements
+        if req["type"] == "secret" and req.get("optional", False)
+    ]
+
+
 async def _load_secret_inventory(
     role: Role,
 ) -> dict[str, set[str]]:
@@ -554,10 +569,14 @@ def _evaluate_configuration(
             continue
 
         secret_req = cast(ActionSecretRequirementPayload, req)
+        if secret_req.get("optional", False):
+            # A wholly-optional secret never blocks readiness, even when it
+            # declares keys (e.g. the mtls/ca_cert secrets inherited from
+            # core.http_request). At runtime these are absent-by-default, so an
+            # action that only "needs" optional secrets is still usable.
+            continue
         secret_name = secret_req["name"]
         required_keys = set(secret_req["required_keys"])
-        if not required_keys and secret_req.get("optional", False):
-            continue
         available_keys = workspace_inventory.get(secret_name)
         if available_keys is None:
             missing.append(f"missing secret: {secret_name}")
@@ -1044,6 +1063,7 @@ class ActionDiscoveryResponse(BaseModel):
     description: str | None = None
     configured: bool
     missing_requirements: list[str] = Field(default_factory=list)
+    optional_secrets: list[str] = Field(default_factory=list)
 
 
 class ActionContextResponse(ActionDiscoveryResponse):
@@ -4730,6 +4750,9 @@ async def list_actions(
     - description: One-line description of the action
     - configured: Whether required secrets are present in the workspace
     - missing_requirements: List of missing secret names/keys (if any)
+    - optional_secrets: Credentials you *may* supply (e.g. mtls/ca_cert for
+      mTLS targets) but are not required to run the action. Their absence never
+      makes an action unconfigured.
     """
 
     try:
@@ -4763,6 +4786,7 @@ async def list_actions(
                         description=entry.description,
                         configured=configured,
                         missing_requirements=missing,
+                        optional_secrets=_optional_secret_names(requirements),
                     )
                 )
             page = _paginate_items(
@@ -4916,6 +4940,9 @@ async def get_action_context(
       integrations are {type: "oauth", name, provider_id, grant_type}.
     - configured: Whether all required secrets and OAuth integrations are present
     - missing_requirements: List of missing secrets/keys or OAuth integrations
+    - optional_secrets: Credentials you *may* supply (e.g. mtls/ca_cert for mTLS
+      targets) but are not required to run the action; their absence never makes
+      an action unconfigured.
     - examples: Example args payload based on the schema
     """
 
@@ -4941,6 +4968,7 @@ async def get_action_context(
                 required_secrets=requirements,
                 configured=configured,
                 missing_requirements=missing,
+                optional_secrets=_optional_secret_names(requirements),
                 examples=[_build_example_from_schema(schema)],
             )
     except ToolError:
@@ -5014,6 +5042,7 @@ async def get_workflow_authoring_context(
                         required_secrets=requirements,
                         configured=configured,
                         missing_requirements=missing,
+                        optional_secrets=_optional_secret_names(requirements),
                         examples=[
                             _build_example_from_schema(tool.parameters_json_schema)
                         ],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reworked Tracecat best-practices with agent‑first guidance and progressive‑disclosure references, and fixed MCP configuration so optional secrets never block actions. Also added `optional_secrets` to discovery/context APIs and updated eval tooling to include reference files.

- **Refactors**
  - Split `tracecat-automation-best-practices` into a lean `SKILL.md` with on-demand references: `references/run-python.md`, `references/workflow-editing.md`, `references/tables.md`.
  - Added clear agent vs Python guidance: agentic work → `ai.agent`/`ai.preset_agent`; deterministic data plumbing → `core.script.run_python`; keep fewest actions/least code; decompose oversized prompts into subagents/skills.
  - New “Agent-First Automation” guidance: thin deterministic boundary (reshape/redact/upsert) before the agent; persist normalized events; keep judgment, routing, and Slack composition in the agent.
  - Slackbot skill: the agent owns message composition and posting via Slack tools (WRONG/RIGHT examples); tightened tone/style rules.
  - Added `LEARNINGS_INBOX.md` for the build → feedback → distill loop.
  - Eval runner (`scripts/evals/tracecat_authoring/run_local.py`) now copies the whole skill directory so `references/` files are available in isolated workspaces.

- **Bug Fixes**
  - Optional secrets with keys (e.g., `mtls`, `ca_cert`) no longer mark actions unconfigured; `_evaluate_configuration` skips wholly optional secrets.
  - Surfaced optionality via `optional_secrets` in `list_actions`, `get_action_context`, and `get_workflow_authoring_context` responses.
  - Added unit tests to cover optional-secret handling and ensure required vs optional behavior is reported correctly.

<sup>Written for commit a339e0a8e928aea796f310a1172380d983585182. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

