### PR TITLE
feat(webhooks): add include_headers toggle to webhook trigger

### DIFF
--- a/alembic/versions/c9d2e7a4f1b3_add_webhook_include_headers.py
+++ b/alembic/versions/c9d2e7a4f1b3_add_webhook_include_headers.py
@@ -1,0 +1,35 @@
+"""add webhook include_headers
+
+Revision ID: c9d2e7a4f1b3
+Revises: 0f18bea0c115
+Create Date: 2026-06-09 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c9d2e7a4f1b3"
+down_revision: str | None = "0f18bea0c115"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "webhook",
+        sa.Column(
+            "include_headers",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("webhook", "include_headers")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -27229,6 +27229,11 @@ export const $WebhookCreate = {
       type: "array",
       title: "Allowlisted Cidrs",
     },
+    include_headers: {
+      type: "boolean",
+      title: "Include Headers",
+      default: false,
+    },
   },
   type: "object",
   title: "WebhookCreate",
@@ -27283,6 +27288,11 @@ export const $WebhookRead = {
       type: "array",
       title: "Methods",
       description: "Methods to allow",
+    },
+    include_headers: {
+      type: "boolean",
+      title: "Include Headers",
+      default: false,
     },
     workflow_id: {
       type: "string",
@@ -27414,6 +27424,17 @@ export const $WebhookUpdate = {
         },
       ],
       title: "Allowlisted Cidrs",
+    },
+    include_headers: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Include Headers",
     },
   },
   type: "object",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -8140,6 +8140,7 @@ export type WebhookCreate = {
   methods?: Array<WebhookMethod>
   entrypoint_ref?: string | null
   allowlisted_cidrs?: Array<string>
+  include_headers?: boolean
 }
 
 export type WebhookMethod = "GET" | "POST"
@@ -8157,6 +8158,7 @@ export type WebhookRead = {
    * Methods to allow
    */
   methods?: Array<WebhookMethod>
+  include_headers?: boolean
   workflow_id: string
   url: string
   api_key?: WebhookApiKeyRead | null
@@ -8184,6 +8186,7 @@ export type WebhookUpdate = {
   methods?: Array<WebhookMethod> | null
   entrypoint_ref?: string | null
   allowlisted_cidrs?: Array<string> | null
+  include_headers?: boolean | null
 }
 
 export type WorkflowAlias = {

--- a/frontend/src/components/builder/panel/trigger-panel.tsx
+++ b/frontend/src/components/builder/panel/trigger-panel.tsx
@@ -212,6 +212,7 @@ const webhookFormSchema = z.object({
       return Array.from(normalized.values())
     })
     .default([]),
+  include_headers: z.boolean().default(false),
 })
 
 type WebhookForm = z.infer<typeof webhookFormSchema>
@@ -394,6 +395,7 @@ export function WebhookControls({
           id: cidr,
           text: cidr,
         })) ?? [],
+      include_headers: webhook.include_headers ?? false,
     },
   })
 
@@ -495,6 +497,31 @@ export function WebhookControls({
           error,
           "An error occurred while updating the webhook status."
         ),
+      })
+    }
+  }
+
+  const handleIncludeHeadersChange = async (checked: boolean) => {
+    form.setValue("include_headers", checked)
+
+    try {
+      await mutateAsync({ include_headers: checked })
+      toast({
+        title: "Webhook trigger payload updated",
+        description: checked
+          ? "TRIGGER will include request headers and metadata"
+          : "TRIGGER will receive the request body only",
+      })
+    } catch (error) {
+      console.error("Failed to update webhook include_headers", error)
+      form.setValue("include_headers", webhook.include_headers ?? false)
+      toast({
+        title: "Failed to update trigger payload",
+        description: extractApiErrorMessage(
+          error,
+          "An error occurred while updating the webhook trigger payload."
+        ),
+        variant: "destructive",
       })
     }
   }
@@ -608,6 +635,35 @@ export function WebhookControls({
                   <Switch
                     checked={field.value === "online"}
                     onCheckedChange={handleStatusChange}
+                    className="data-[state=checked]:bg-emerald-500"
+                    disabled={isUpdatingWebhook}
+                  />
+                </FormControl>
+              </div>
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="include_headers"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex items-center justify-between gap-4 rounded-md border p-3">
+                <div className="space-y-1">
+                  <Label className="text-xs font-semibold">
+                    Include request headers
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Pass request headers and metadata to TRIGGER as{" "}
+                    <code>{"{ status_code, headers, data }"}</code> instead of
+                    just the body
+                  </p>
+                </div>
+                <FormControl>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={handleIncludeHeadersChange}
                     className="data-[state=checked]:bg-emerald-500"
                     disabled={isUpdatingWebhook}
                   />

--- a/frontend/src/components/builder/panel/trigger-panel.tsx
+++ b/frontend/src/components/builder/panel/trigger-panel.tsx
@@ -514,7 +514,8 @@ export function WebhookControls({
       })
     } catch (error) {
       console.error("Failed to update webhook include_headers", error)
-      form.setValue("include_headers", webhook.include_headers ?? false)
+      // Restore the value from before this toggle, not the (possibly stale) prop
+      form.setValue("include_headers", !checked)
       toast({
         title: "Failed to update trigger payload",
         description: extractApiErrorMessage(

--- a/tests/unit/test_webhook_execution_path.py
+++ b/tests/unit/test_webhook_execution_path.py
@@ -36,8 +36,13 @@ from tracecat.storage.object import (
     ObjectRef,
 )
 from tracecat.storage.utils import deserialize_object
-from tracecat.webhooks.router import _incoming_webhook, incoming_webhook_wait
+from tracecat.webhooks.router import (
+    _incoming_webhook,
+    _wrapped_payload,
+    incoming_webhook_wait,
+)
 from tracecat.webhooks.router import router as webhook_router
+from tracecat.webhooks.schemas import WebhookRead
 from tracecat.workflow.executions.enums import (
     ExecutionType,
     TemporalSearchAttr,
@@ -1386,3 +1391,103 @@ class TestWebhookDispatchWorkflowInvariants:
             )
 
         assert response["result"] == inline_result
+
+
+# ---------------------------------------------------------------------------
+# _wrapped_payload dependency (shared by /wait and /draft endpoints)
+# ---------------------------------------------------------------------------
+
+
+class TestWrappedPayloadDependency:
+    """The /wait and /draft endpoints honor include_headers via _wrapped_payload.
+
+    This is the same envelope the root POST/GET path produces, so TRIGGER has a
+    consistent shape across all webhook trigger endpoints.
+    """
+
+    @staticmethod
+    def _request(
+        *, include_headers: bool, headers: dict[str, str] | None = None
+    ) -> Request:
+        request = MagicMock(spec=Request)
+        request.headers = headers or {}
+        request.state.webhook_include_headers = include_headers
+        return request
+
+    @pytest.mark.anyio
+    async def test_passthrough_when_flag_off(self):
+        request = self._request(
+            include_headers=False, headers={"content-type": "application/json"}
+        )
+        payload = {"alert": "x"}
+        result = await _wrapped_payload(request=request, payload=payload)
+        assert result == payload
+
+    @pytest.mark.anyio
+    async def test_wraps_when_flag_on(self):
+        request = self._request(
+            include_headers=True,
+            headers={"content-type": "application/json", "x-custom-source": "siem"},
+        )
+        payload = {"alert": "x"}
+        result = await _wrapped_payload(request=request, payload=payload)
+        assert result == {
+            "status_code": 200,
+            "headers": {
+                "content-type": "application/json",
+                "x-custom-source": "siem",
+            },
+            "data": payload,
+        }
+
+    @pytest.mark.anyio
+    async def test_strips_api_key_when_flag_on(self):
+        request = self._request(
+            include_headers=True,
+            headers={
+                "content-type": "application/json",
+                "x-tracecat-api-key": "super-secret",
+            },
+        )
+        result = await _wrapped_payload(request=request, payload={"a": 1})
+        assert result is not None
+        assert "x-tracecat-api-key" not in result["headers"]
+        assert result["headers"] == {"content-type": "application/json"}
+
+
+class TestWebhookReadIncludeHeaders:
+    """WebhookRead must tolerate a NULL include_headers on unflushed ORM objects."""
+
+    def test_none_include_headers_coerced_to_false(self):
+        obj = SimpleNamespace(
+            id=uuid.uuid4(),
+            secret="secret",
+            status="online",
+            entrypoint_ref=None,
+            allowlisted_cidrs=None,
+            filters=None,
+            methods=None,
+            include_headers=None,
+            workflow_id=_WF_ID,
+            url="http://localhost/webhooks/x/y",
+            api_key=None,
+        )
+        read = WebhookRead.model_validate(obj, from_attributes=True)
+        assert read.include_headers is False
+
+    def test_true_include_headers_preserved(self):
+        obj = SimpleNamespace(
+            id=uuid.uuid4(),
+            secret="secret",
+            status="online",
+            entrypoint_ref=None,
+            allowlisted_cidrs=[],
+            filters={},
+            methods=["POST"],
+            include_headers=True,
+            workflow_id=_WF_ID,
+            url="http://localhost/webhooks/x/y",
+            api_key=None,
+        )
+        read = WebhookRead.model_validate(obj, from_attributes=True)
+        assert read.include_headers is True

--- a/tests/unit/test_webhook_execution_path.py
+++ b/tests/unit/test_webhook_execution_path.py
@@ -506,6 +506,183 @@ class TestWebhookRouterExecutionPath:
         assert call_kwargs["payload"] == payload
 
     @pytest.mark.anyio
+    async def test_include_headers_off_passes_raw_body(self):
+        """With include_headers=False, TRIGGER is the raw parsed body (default)."""
+        workflow_id = WorkflowUUID.new_uuid4()
+        payload = {"event": "test"}
+        mock_service = AsyncMock()
+        mock_service.create_workflow_execution_wait_for_start = AsyncMock(
+            return_value={
+                "message": "Workflow execution started",
+                "wf_id": workflow_id,
+                "wf_exec_id": f"{workflow_id.short()}/exec_1",
+            }
+        )
+
+        request = MagicMock(spec=Request)
+        request.headers = {"content-type": "application/json"}
+
+        with patch(
+            "tracecat.webhooks.router.WorkflowExecutionsService.connect",
+            AsyncMock(return_value=mock_service),
+        ):
+            await _incoming_webhook(
+                workflow_id=workflow_id,
+                defn=_definition(),
+                payload=payload,
+                echo=False,
+                empty_echo=False,
+                vendor=None,
+                request=request,
+                content_type="application/json",
+                include_headers=False,
+            )
+
+        call_kwargs = (
+            mock_service.create_workflow_execution_wait_for_start.call_args.kwargs
+        )
+        assert call_kwargs["payload"] == payload
+
+    @pytest.mark.anyio
+    async def test_include_headers_on_wraps_body_with_envelope(self):
+        """With include_headers=True, TRIGGER is {status_code, headers, data}.
+
+        The synthetic status_code mirrors core.http.request and the original
+        body is preserved under `data`.
+        """
+        workflow_id = WorkflowUUID.new_uuid4()
+        payload = {"event": "test"}
+        mock_service = AsyncMock()
+        mock_service.create_workflow_execution_wait_for_start = AsyncMock(
+            return_value={
+                "message": "Workflow execution started",
+                "wf_id": workflow_id,
+                "wf_exec_id": f"{workflow_id.short()}/exec_1",
+            }
+        )
+
+        request = MagicMock(spec=Request)
+        request.headers = {
+            "content-type": "application/json",
+            "x-custom-header": "abc",
+        }
+
+        with patch(
+            "tracecat.webhooks.router.WorkflowExecutionsService.connect",
+            AsyncMock(return_value=mock_service),
+        ):
+            await _incoming_webhook(
+                workflow_id=workflow_id,
+                defn=_definition(),
+                payload=payload,
+                echo=False,
+                empty_echo=False,
+                vendor=None,
+                request=request,
+                content_type="application/json",
+                include_headers=True,
+            )
+
+        call_kwargs = (
+            mock_service.create_workflow_execution_wait_for_start.call_args.kwargs
+        )
+        wrapped = call_kwargs["payload"]
+        assert wrapped == {
+            "status_code": 200,
+            "headers": {
+                "content-type": "application/json",
+                "x-custom-header": "abc",
+            },
+            "data": payload,
+        }
+
+    @pytest.mark.anyio
+    async def test_include_headers_on_strips_api_key_header(self):
+        """The webhook's own API key header must never reach the workflow."""
+        workflow_id = WorkflowUUID.new_uuid4()
+        payload = {"event": "test"}
+        mock_service = AsyncMock()
+        mock_service.create_workflow_execution_wait_for_start = AsyncMock(
+            return_value={
+                "message": "Workflow execution started",
+                "wf_id": workflow_id,
+                "wf_exec_id": f"{workflow_id.short()}/exec_1",
+            }
+        )
+
+        request = MagicMock(spec=Request)
+        request.headers = {
+            "content-type": "application/json",
+            "x-tracecat-api-key": "super-secret",
+        }
+
+        with patch(
+            "tracecat.webhooks.router.WorkflowExecutionsService.connect",
+            AsyncMock(return_value=mock_service),
+        ):
+            await _incoming_webhook(
+                workflow_id=workflow_id,
+                defn=_definition(),
+                payload=payload,
+                echo=False,
+                empty_echo=False,
+                vendor=None,
+                request=request,
+                content_type="application/json",
+                include_headers=True,
+            )
+
+        call_kwargs = (
+            mock_service.create_workflow_execution_wait_for_start.call_args.kwargs
+        )
+        wrapped = call_kwargs["payload"]
+        assert "x-tracecat-api-key" not in wrapped["headers"]
+        assert wrapped["headers"] == {"content-type": "application/json"}
+
+    @pytest.mark.anyio
+    async def test_include_headers_on_wraps_each_ndjson_batch_item(self):
+        """NDJSON batches: each execution gets its own wrapped envelope."""
+        workflow_id = WorkflowUUID.new_uuid4()
+        payload = [{"event": "a"}, {"event": "b"}]
+        mock_service = AsyncMock()
+        mock_service.create_workflow_execution_wait_for_start = AsyncMock(
+            return_value={
+                "message": "Workflow execution started",
+                "wf_id": workflow_id,
+                "wf_exec_id": f"{workflow_id.short()}/exec_1",
+            }
+        )
+
+        request = MagicMock(spec=Request)
+        request.headers = {"content-type": "application/x-ndjson"}
+
+        with patch(
+            "tracecat.webhooks.router.WorkflowExecutionsService.connect",
+            AsyncMock(return_value=mock_service),
+        ):
+            await _incoming_webhook(
+                workflow_id=workflow_id,
+                defn=_definition(),
+                payload=payload,
+                echo=False,
+                empty_echo=False,
+                vendor=None,
+                request=request,
+                content_type="application/x-ndjson",
+                include_headers=True,
+            )
+
+        # NDJSON batches of 8 -> both items land in a single batch list payload
+        call_kwargs = (
+            mock_service.create_workflow_execution_wait_for_start.call_args.kwargs
+        )
+        wrapped = call_kwargs["payload"]
+        assert wrapped["status_code"] == 200
+        assert wrapped["headers"] == {"content-type": "application/x-ndjson"}
+        # batched() yields tuples; the whole batch is wrapped as one envelope
+        assert list(wrapped["data"]) == payload
+
+    @pytest.mark.anyio
     async def test_webhook_constructs_dsl_input_from_definition_content(self):
         """The router must build DSLInput from defn.content, not pass it raw."""
         workflow_id = WorkflowUUID.new_uuid4()

--- a/tests/unit/test_workflow_import_service.py
+++ b/tests/unit/test_workflow_import_service.py
@@ -86,9 +86,17 @@ def remote_workflow_definition(sample_dsl: DSLInput) -> RemoteWorkflowDefinition
                 timeout=300.0,
             )
         ],
-        webhook=RemoteWebhook(methods=["POST", "PUT"], status="online"),
+        webhook=RemoteWebhook(
+            methods=["POST", "PUT"], status="online", include_headers=True
+        ),
         definition=sample_dsl,
     )
+
+
+def test_remote_webhook_defaults_include_headers_false():
+    """Store exports predating include_headers must import as False."""
+    rw = RemoteWebhook.model_validate({"methods": ["POST"], "status": "online"})
+    assert rw.include_headers is False
 
 
 class TestWorkflowImportService:
@@ -158,6 +166,7 @@ class TestWorkflowImportService:
         webhook = workflow.webhook
         assert webhook.methods == ["POST", "PUT"]
         assert webhook.status == "online"
+        assert webhook.include_headers is True
 
         # Verify workflow definition was created
         stmt = select(WorkflowDefinition).where(WorkflowDefinition.workflow_id == wf_id)

--- a/tests/unit/test_workflow_store_service.py
+++ b/tests/unit/test_workflow_store_service.py
@@ -60,7 +60,9 @@ def _workflow_fixture(
         tags=[],
         folder=None,
         schedules=[],
-        webhook=SimpleNamespace(methods=["POST"], status="online"),
+        webhook=SimpleNamespace(
+            methods=["POST"], status="online", include_headers=True
+        ),
         case_trigger=case_trigger,
         git_sync_branch=None,
     )
@@ -113,6 +115,8 @@ async def test_publish_workflow_omits_inert_case_trigger(
 
     push_obj = sync_service.push.call_args.kwargs["objects"][0]
     assert push_obj.data.case_trigger is None
+    # include_headers must be exported so it survives a store round-trip
+    assert push_obj.data.webhook.include_headers is True
 
 
 @pytest.mark.anyio

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -1180,6 +1180,12 @@ class Webhook(WorkspaceModel):
         nullable=False,
         server_default=text("'[]'::jsonb"),
     )
+    include_headers: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        nullable=False,
+        server_default=text("false"),
+    )
 
     workflow: Mapped[Workflow] = relationship(back_populates="webhook")
     api_key: Mapped[WebhookApiKey | None] = relationship(

--- a/tracecat/webhooks/dependencies.py
+++ b/tracecat/webhooks/dependencies.py
@@ -109,6 +109,12 @@ async def validate_incoming_webhook(
                 detail="Request method not allowed",
             ) from None
 
+        # Stash whether the trigger should receive the full request envelope
+        # (headers + body) instead of just the parsed body. Read as a scalar
+        # bool before the session closes so it stays valid once the ORM object
+        # detaches.
+        request.state.webhook_include_headers = webhook.include_headers
+
         updated = False
 
         client_ip = _extract_client_ip(request)

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -470,7 +470,9 @@ async def incoming_webhook_wait(
     The workflow is identified by the `path` parameter, which is equivalent to the workflow id.
     """
     logger.info("Webhook hit", path=workflow_id, role=ctx_role.get())
-    logger.trace("Webhook payload", payload=payload)
+    # Do not log the payload here: it may be wrapped with request headers
+    # (include_headers), which can contain auth/signature values.
+    logger.trace("Webhook payload received")
 
     dsl_input = DSLInput(**defn.content)
 
@@ -509,7 +511,9 @@ async def incoming_webhook_draft(
     Child workflows using aliases will resolve to the latest draft aliases, not committed aliases.
     """
     logger.info("Draft webhook hit", path=workflow_id, role=ctx_role.get())
-    logger.trace("Draft webhook payload", payload=payload)
+    # Do not log the payload here: it may be wrapped with request headers
+    # (include_headers), which can contain auth/signature values.
+    logger.trace("Draft webhook payload received")
 
     service = await WorkflowExecutionsService.connect()
     response = await service.create_draft_workflow_execution_wait_for_start(

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -334,6 +334,23 @@ def _wrap_with_headers(
     return {"status_code": 200, "headers": headers, "data": payload}
 
 
+async def _wrapped_payload(
+    request: Request, payload: PayloadDep
+) -> TriggerInputs | None:
+    """Wrap the parsed body in the request envelope when the webhook opts in.
+
+    Used by trigger endpoints that pass the payload straight through (no NDJSON
+    batching), so the whole payload can be wrapped here. The root POST/GET path
+    wraps per-batch-item inside ``_incoming_webhook`` instead.
+    """
+    if getattr(request.state, "webhook_include_headers", False):
+        return _wrap_with_headers(payload, request)
+    return payload
+
+
+WrappedPayloadDep = Annotated[TriggerInputs | None, Depends(_wrapped_payload)]
+
+
 async def _incoming_webhook(
     *,
     workflow_id: AnyWorkflowIDPath,
@@ -434,7 +451,7 @@ async def _incoming_webhook(
 async def incoming_webhook_wait(
     workflow_id: AnyWorkflowIDPath,
     defn: ValidWorkflowDefinitionDep,
-    payload: PayloadDep,
+    payload: WrappedPayloadDep,
     unwrap: Annotated[
         bool,
         Query(
@@ -484,7 +501,7 @@ async def incoming_webhook_wait(
 async def incoming_webhook_draft(
     workflow_id: AnyWorkflowIDPath,
     draft_ctx: DraftWorkflowDep,
-    payload: PayloadDep,
+    payload: WrappedPayloadDep,
 ) -> WorkflowExecutionCreateResponse:
     """Draft webhook endpoint to trigger a workflow execution using the draft workflow graph.
 

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -320,9 +320,18 @@ async def incoming_webhook_get(
 _REDACTED_HEADERS = frozenset({"x-tracecat-api-key"})
 
 
+class WebhookTriggerEnvelope(TypedDict):
+    """`core.http.request`-style envelope passed to TRIGGER when a webhook opts
+    into ``include_headers``."""
+
+    status_code: int
+    headers: dict[str, str]
+    data: TriggerInputs | None
+
+
 def _wrap_with_headers(
     payload: TriggerInputs | None, request: Request
-) -> dict[str, Any]:
+) -> WebhookTriggerEnvelope:
     """Wrap the parsed body in a `core.http.request`-style envelope.
 
     Strips sensitive auth headers so workflow authors can't read the webhook's
@@ -331,7 +340,7 @@ def _wrap_with_headers(
     headers = {
         k: v for k, v in request.headers.items() if k.lower() not in _REDACTED_HEADERS
     }
-    return {"status_code": 200, "headers": headers, "data": payload}
+    return WebhookTriggerEnvelope(status_code=200, headers=headers, data=payload)
 
 
 async def _wrapped_payload(

--- a/tracecat/webhooks/router.py
+++ b/tracecat/webhooks/router.py
@@ -21,6 +21,7 @@ from tracecat.concurrency import cooperative
 from tracecat.contexts import ctx_role
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import DSLInput
+from tracecat.dsl.schemas import TriggerInputs
 from tracecat.dsl.workflow import DSLWorkflow
 from tracecat.ee.interactions.enums import InteractionCategory
 from tracecat.ee.interactions.schemas import InteractionInput
@@ -274,6 +275,7 @@ async def incoming_webhook_post(
         vendor=vendor,
         request=request,
         content_type=content_type,
+        include_headers=getattr(request.state, "webhook_include_headers", False),
     )
 
 
@@ -310,7 +312,26 @@ async def incoming_webhook_get(
         vendor=vendor,
         request=request,
         content_type=content_type,
+        include_headers=getattr(request.state, "webhook_include_headers", False),
     )
+
+
+# Auth headers that must never be exposed to workflows via the trigger envelope.
+_REDACTED_HEADERS = frozenset({"x-tracecat-api-key"})
+
+
+def _wrap_with_headers(
+    payload: TriggerInputs | None, request: Request
+) -> dict[str, Any]:
+    """Wrap the parsed body in a `core.http.request`-style envelope.
+
+    Strips sensitive auth headers so workflow authors can't read the webhook's
+    own credentials.
+    """
+    headers = {
+        k: v for k, v in request.headers.items() if k.lower() not in _REDACTED_HEADERS
+    }
+    return {"status_code": 200, "headers": headers, "data": payload}
 
 
 async def _incoming_webhook(
@@ -323,6 +344,7 @@ async def _incoming_webhook(
     vendor: str | None,
     request: Request,
     content_type: str | None,
+    include_headers: bool = False,
 ) -> WebhookResponse:
     logger.info("Webhook hit", path=workflow_id, role=ctx_role.get())
     logger.trace("Webhook payload", payload=payload)
@@ -341,7 +363,7 @@ async def _incoming_webhook(
             one_response = await service.create_workflow_execution_wait_for_start(
                 dsl=dsl_input,
                 wf_id=workflow_id,
-                payload=p,
+                payload=_wrap_with_headers(p, request) if include_headers else p,
                 trigger_type=TriggerType.WEBHOOK,
                 registry_lock=RegistryLock.model_validate(defn.registry_lock)
                 if defn.registry_lock
@@ -360,7 +382,9 @@ async def _incoming_webhook(
         response = await service.create_workflow_execution_wait_for_start(
             dsl=dsl_input,
             wf_id=workflow_id,
-            payload=payload,
+            payload=_wrap_with_headers(payload, request)
+            if include_headers
+            else payload,
             trigger_type=TriggerType.WEBHOOK,
             registry_lock=RegistryLock.model_validate(defn.registry_lock)
             if defn.registry_lock

--- a/tracecat/webhooks/schemas.py
+++ b/tracecat/webhooks/schemas.py
@@ -52,6 +52,14 @@ class WebhookRead(Schema):
             return {}
         return v
 
+    @field_validator("include_headers", mode="before")
+    @classmethod
+    def _coerce_none_to_false(cls, v: Any) -> Any:
+        """ORM attribute may be NULL before flush; coerce to False."""
+        if v is None:
+            return False
+        return v
+
 
 class WebhookCreate(BaseModel):
     status: WebhookStatus = "offline"

--- a/tracecat/webhooks/schemas.py
+++ b/tracecat/webhooks/schemas.py
@@ -31,6 +31,7 @@ class WebhookRead(Schema):
     methods: list[WebhookMethod] = Field(
         default_factory=list, description="Methods to allow"
     )
+    include_headers: bool = False
     workflow_id: WorkflowID
     url: str
     api_key: WebhookApiKeyRead | None = None
@@ -59,6 +60,7 @@ class WebhookCreate(BaseModel):
     )
     entrypoint_ref: str | None = None
     allowlisted_cidrs: list[str] = Field(default_factory=list)
+    include_headers: bool = False
 
     @field_validator("allowlisted_cidrs")
     @classmethod
@@ -71,6 +73,7 @@ class WebhookUpdate(BaseModel):
     methods: list[WebhookMethod] | None = None
     entrypoint_ref: str | None = None
     allowlisted_cidrs: list[str] | None = None
+    include_headers: bool | None = None
 
     @field_validator("allowlisted_cidrs")
     @classmethod

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -829,6 +829,7 @@ async def create_webhook(
         workflow_id=workflow_id,
         status=params.status,
         allowlisted_cidrs=params.allowlisted_cidrs,
+        include_headers=params.include_headers,
     )
     session.add(webhook)
     await session.commit()

--- a/tracecat/workflow/store/import_service.py
+++ b/tracecat/workflow/store/import_service.py
@@ -429,6 +429,7 @@ class WorkflowImportService(BaseWorkspaceService):
         # The webhook ID doesn't matter
         webhook.methods = remote_webhook.methods
         webhook.status = remote_webhook.status
+        webhook.include_headers = remote_webhook.include_headers
 
     async def _update_case_trigger(
         self, workflow: Workflow, remote_case_trigger: RemoteCaseTrigger | None

--- a/tracecat/workflow/store/schemas.py
+++ b/tracecat/workflow/store/schemas.py
@@ -125,6 +125,8 @@ class RemoteWebhook(BaseModel):
     """The methods of the webhook."""
     status: Status = Field(default="online")
     """Status of the webhook, either 'online' or 'offline'."""
+    include_headers: bool = False
+    """Whether TRIGGER receives the full request envelope (headers + body)."""
 
 
 class RemoteCaseTrigger(BaseModel):

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -126,6 +126,7 @@ class WorkflowStoreService(BaseWorkspaceService):
             webhook=RemoteWebhook(
                 methods=webhook.methods,
                 status=cast(Status, webhook.status),
+                include_headers=webhook.include_headers,
             ),
             case_trigger=case_trigger,
             definition=dsl,


### PR DESCRIPTION
## Summary

Adds a per-webhook `include_headers` toggle. When enabled, the workflow `TRIGGER` receives the full request envelope — mirroring the shape of `core.http.request` — instead of just the parsed body:

```json
{
  "status_code": 200,
  "headers": { "content-type": "application/json", "x-custom-source": "my-siem" },
  "data": { "...the request body..." }
}
```

When the toggle is off (the default), behavior is unchanged: `TRIGGER` is the parsed body only. This lets workflows read signature headers, custom auth headers, delivery IDs, etc.

The webhook's own `x-tracecat-api-key` header is stripped from the exposed `headers` so workflow authors can't read the webhook's auth secret. NDJSON batches wrap each execution's payload in the same envelope.

## Changes

- DB: add `webhook.include_headers boolean not null default false` + Alembic migration `c9d2e7a4f1b3`.
- API schemas: add `include_headers` to `WebhookRead`/`WebhookCreate`/`WebhookUpdate`.
- Webhook handling: `validate_incoming_webhook` stashes the flag on `request.state`; `_incoming_webhook` wraps the payload via a small `_wrap_with_headers` helper (explicit param, defaults off).
- UI: add an "Include request headers" switch to the webhook trigger panel, mirroring the existing status toggle.
- Tests: cover on/off behavior, `x-tracecat-api-key` stripping, and NDJSON batch wrapping.

The existing `get_webhook`/`update_webhook` handlers surface and persist the field automatically.

## Verification

- `uv run pytest tests/unit/test_webhook_execution_path.py tests/unit/test_webhook.py` — 56 passed.
- `ruff check` / `ruff format --check` / `basedpyright --warnings` clean; `pnpm -C frontend check` + `typecheck` clean.
- Migration applied to a local stack; column confirmed.
- Live curl end-to-end (trigger read back from Temporal):
  - ON -> `{status_code, headers, data}` with the API-key header stripped and a custom header preserved.
  - OFF -> raw body, unchanged.
- UI toggle persisted `include_headers = true` via the real `PATCH` (frontend -> API -> DB).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-webhook `include_headers` toggle to send the full request envelope {status_code, headers, data} to TRIGGER instead of only the body. Also preserves this flag through workflow store export/import and stops logging wrapped headers in `/wait` and `/draft`.

- **New Features**
  - Backend: `include_headers` boolean; when on, TRIGGER receives `{status_code, headers, data}` (mirrors `core.http.request`) and filters sensitive headers (strips `x-tracecat-api-key`).
  - API/UI: added `include_headers` to Webhook Read/Create/Update; added “Include request headers” switch in the webhook trigger panel.
  - DB: adds `webhook.include_headers boolean not null default false`.

- **Bug Fixes**
  - Endpoints: apply the header envelope to `/wait` and `/draft` via a shared payload dependency; stop logging wrapped payloads to avoid leaking headers; typed the trigger envelope as `WebhookTriggerEnvelope` (no behavior change).
  - API: `WebhookRead` coerces NULL `include_headers` to false; `create_webhook` persists `include_headers`.
  - Workflow Store: round-trip `include_headers` via `RemoteWebhook` (export/import); defaults to false for older exports.
  - UI: toggle rolls back to the previous value on update error.

<sup>Written for commit bb1cfebf03cdd6e35c1c1b1e370dc2c488a3c321. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

