### PR TITLE
fix(chat): 5 tab limit LRU pop

### DIFF
--- a/frontend/src/components/chat/chat-interface.tsx
+++ b/frontend/src/components/chat/chat-interface.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useQueryClient } from "@tanstack/react-query"
-import type { ChatOnDataCallback, UIMessage } from "ai"
+import type { ChatOnDataCallback, ChatStatus, UIMessage } from "ai"
 import { ArrowRight, ChevronDown, Plus } from "lucide-react"
 import Link from "next/link"
 import { type ReactNode, useEffect, useState } from "react"
@@ -72,6 +72,8 @@ interface ChatInterfaceProps {
   onMessagesChange?: (messages: UIMessage[]) => void
   /** Called for data stream parts as soon as the chat transport receives them. */
   onData?: ChatOnDataCallback<UIMessage>
+  /** Called whenever the chat transport status changes. */
+  onStatusChange?: (status: ChatStatus) => void
   /** Called when the selected chat payload changes. */
   onChatChange?: (
     chat: AgentSessionsGetSessionVercelResponse | undefined
@@ -103,6 +105,7 @@ export function ChatInterface({
   surface = "regular",
   onMessagesChange,
   onData,
+  onStatusChange,
   onChatChange,
   headerActions,
 }: ChatInterfaceProps) {
@@ -471,6 +474,7 @@ export function ChatInterface({
           surface={surface}
           onMessagesChange={onMessagesChange}
           onData={onData}
+          onStatusChange={onStatusChange}
         />
       </div>
     </div>
@@ -514,6 +518,7 @@ interface ChatBodyProps {
   surface: ChatSurface
   onMessagesChange?: (messages: UIMessage[]) => void
   onData?: ChatOnDataCallback<UIMessage>
+  onStatusChange?: (status: ChatStatus) => void
 }
 
 function ChatBody({
@@ -539,6 +544,7 @@ function ChatBody({
   surface,
   onMessagesChange,
   onData,
+  onStatusChange,
 }: ChatBodyProps) {
   const {
     ready: chatReady,
@@ -650,6 +656,7 @@ function ChatBody({
         surface={surface}
         onMessagesChange={onMessagesChange}
         onData={onData}
+        onStatusChange={onStatusChange}
       />
     )
   }
@@ -680,6 +687,7 @@ function ChatBody({
       surface={surface}
       onMessagesChange={onMessagesChange}
       onData={onData}
+      onStatusChange={onStatusChange}
     />
   )
 }

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -231,6 +231,8 @@ export interface ChatSessionPaneProps {
   placeholder?: string
   onMessagesChange?: (messages: UIMessage[]) => void
   onData?: ChatOnDataCallback<UIMessage>
+  /** Called whenever the underlying chat transport status changes. */
+  onStatusChange?: (status: ChatStatus) => void
   modelInfo: ModelInfo
   toolsEnabled?: boolean
   agentAddonsEnabled?: boolean
@@ -289,6 +291,7 @@ export function ChatSessionPane({
   placeholder = "Ask your question...",
   onMessagesChange,
   onData,
+  onStatusChange,
   modelInfo,
   toolsEnabled = true,
   agentAddonsEnabled = true,
@@ -360,6 +363,10 @@ export function ChatSessionPane({
       modelInfo,
       onData,
     })
+
+  useEffect(() => {
+    onStatusChange?.(status)
+  }, [status, onStatusChange])
 
   const hasOptimisticMessageInStream = useMemo(
     () =>

--- a/frontend/src/components/workspace-chat/workspace-chat-view.tsx
+++ b/frontend/src/components/workspace-chat/workspace-chat-view.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useQueryClient } from "@tanstack/react-query"
-import type { ChatOnDataCallback, UIMessage } from "ai"
+import type { ChatOnDataCallback, ChatStatus, UIMessage } from "ai"
 import { PanelLeftIcon } from "lucide-react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
@@ -109,6 +109,7 @@ export function WorkspaceChatView({ chatId }: { chatId?: string }) {
   const workspaceChatEnabled = hasEntitlement("workspace_chat")
 
   const [messages, setMessages] = useState<UIMessage[]>(EMPTY_MESSAGES)
+  const [chatStatus, setChatStatus] = useState<ChatStatus>("ready")
   const [chat, setChat] = useState<
     AgentSessionsGetSessionVercelResponse | undefined
   >()
@@ -159,6 +160,7 @@ export function WorkspaceChatView({ chatId }: { chatId?: string }) {
     enabled: true,
     initialActiveArtifactKey: initialArtifactKeyRef.current,
     persistedArtifacts,
+    isStreaming: chatStatus === "submitted" || chatStatus === "streaming",
     onArtifactStreamPart: handleArtifactStreamPart,
     onCloseArtifact: closePersistedArtifact,
   })
@@ -261,6 +263,7 @@ export function WorkspaceChatView({ chatId }: { chatId?: string }) {
             surface="workspace-chat"
             onMessagesChange={setMessages}
             onData={handleStreamData}
+            onStatusChange={setChatStatus}
             onChatChange={setChat}
             headerActions={
               showExpandButton ? (

--- a/frontend/src/hooks/use-workspace-chat-artifacts.test.tsx
+++ b/frontend/src/hooks/use-workspace-chat-artifacts.test.tsx
@@ -1,5 +1,8 @@
-import { renderHook, waitFor } from "@testing-library/react"
-import { useWorkspaceChatArtifacts } from "@/hooks/use-workspace-chat-artifacts"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import {
+  MAX_OPEN_ARTIFACT_TABS,
+  useWorkspaceChatArtifacts,
+} from "@/hooks/use-workspace-chat-artifacts"
 import {
   parseWorkspaceChatArtifactStreamPart,
   type WorkspaceChatArtifact,
@@ -71,5 +74,103 @@ describe("useWorkspaceChatArtifacts", () => {
         artifact: agentArtifact,
       },
     })
+  })
+
+  it("evicts the oldest artifact tabs past the open tab limit", () => {
+    const { result } = renderHook(() => useWorkspaceChatArtifacts([]))
+
+    const total = MAX_OPEN_ARTIFACT_TABS + 2
+    act(() => {
+      for (let i = 0; i < total; i++) {
+        result.current.applyStreamPart({
+          type: "data-artifact",
+          data: {
+            op: "upsert",
+            artifact: {
+              id: `case-${i}`,
+              type: "case",
+              title: `Case ${i}`,
+              severity: "medium",
+              status: "new",
+            },
+          },
+        })
+      }
+    })
+
+    expect(result.current.artifacts).toHaveLength(MAX_OPEN_ARTIFACT_TABS)
+    expect(result.current.artifacts.map((artifact) => artifact.id)).toEqual(
+      Array.from(
+        { length: MAX_OPEN_ARTIFACT_TABS },
+        (_, i) => `case-${total - MAX_OPEN_ARTIFACT_TABS + i}`
+      )
+    )
+    expect(result.current.activeArtifactKey).toBe(`case:case-${total - 1}`)
+  })
+
+  it("defers focus changes until streaming ends", async () => {
+    const { result, rerender } = renderHook(
+      ({ isStreaming }: { isStreaming: boolean }) =>
+        useWorkspaceChatArtifacts([], { isStreaming }),
+      { initialProps: { isStreaming: true } }
+    )
+
+    const upsertCase = (i: number) =>
+      result.current.applyStreamPart({
+        type: "data-artifact",
+        data: {
+          op: "upsert",
+          artifact: {
+            id: `case-${i}`,
+            type: "case",
+            title: `Case ${i}`,
+            severity: "medium",
+            status: "new",
+          },
+        },
+      })
+
+    act(() => {
+      upsertCase(0)
+    })
+    // First artifact of a run still gets selected so the panel isn't empty.
+    await waitFor(() =>
+      expect(result.current.activeArtifactKey).toBe("case:case-0")
+    )
+
+    act(() => {
+      upsertCase(1)
+      upsertCase(2)
+    })
+    // Later artifacts open in the background while streaming.
+    expect(result.current.activeArtifactKey).toBe("case:case-0")
+
+    rerender({ isStreaming: false })
+    // Focus moves once to the last streamed artifact when the run ends.
+    await waitFor(() =>
+      expect(result.current.activeArtifactKey).toBe("case:case-2")
+    )
+  })
+
+  it("caps persisted artifacts to the open tab limit", () => {
+    const persistedArtifacts: WorkspaceChatArtifact[] = Array.from(
+      { length: MAX_OPEN_ARTIFACT_TABS + 3 },
+      (_, i) => ({
+        id: `case-${i}`,
+        type: "case",
+        title: `Case ${i}`,
+        severity: "medium",
+        status: "new",
+      })
+    )
+
+    const { result } = renderHook(() =>
+      useWorkspaceChatArtifacts([], { persistedArtifacts })
+    )
+
+    expect(result.current.artifacts).toHaveLength(MAX_OPEN_ARTIFACT_TABS)
+    expect(result.current.artifacts.at(-1)?.id).toBe(
+      `case-${MAX_OPEN_ARTIFACT_TABS + 2}`
+    )
   })
 })

--- a/frontend/src/hooks/use-workspace-chat-artifacts.ts
+++ b/frontend/src/hooks/use-workspace-chat-artifacts.ts
@@ -26,6 +26,11 @@ export type UseWorkspaceChatArtifactsOptions = {
   enabled?: boolean
   initialActiveArtifactKey?: string | null
   persistedArtifacts?: WorkspaceChatArtifact[]
+  /**
+   * While true, new artifacts open in the background instead of stealing
+   * focus; the last streamed artifact is focused once streaming ends.
+   */
+  isStreaming?: boolean
   onArtifactStreamPart?: (part: WorkspaceChatArtifactStreamPart) => void
   onCloseArtifact?: (type: ArtifactType, id: string) => void | Promise<void>
 }
@@ -37,6 +42,23 @@ type WorkspaceChatArtifactMessageStreamPart = {
 
 const EMPTY_ARTIFACTS: WorkspaceChatArtifact[] = []
 
+/**
+ * Maximum artifact tabs kept open; the oldest tabs are evicted first.
+ * Must match MAX_OPEN_ARTIFACTS in tracecat/artifacts/projection.py so the
+ * live panel and the persisted session projection agree after a reload.
+ */
+export const MAX_OPEN_ARTIFACT_TABS = 5
+
+function evictOldestArtifacts(next: Map<string, WorkspaceChatArtifact>): void {
+  while (next.size > MAX_OPEN_ARTIFACT_TABS) {
+    const oldestKey = next.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    next.delete(oldestKey)
+  }
+}
+
 function reduceArtifactPayload(
   next: Map<string, WorkspaceChatArtifact>,
   payload: ArtifactDataPayload
@@ -44,7 +66,11 @@ function reduceArtifactPayload(
   const key = artifactKey(payload.artifact)
   switch (payload.op) {
     case "upsert":
+      // Delete first so re-upserting an open artifact refreshes its recency
+      // instead of keeping its original tab position.
+      next.delete(key)
       next.set(key, payload.artifact)
+      evictOldestArtifacts(next)
       return
     case "remove":
       next.delete(key)
@@ -118,6 +144,7 @@ function artifactMapFromArtifacts(
   for (const artifact of artifacts) {
     next.set(artifactKey(artifact), artifact)
   }
+  evictOldestArtifacts(next)
   return next
 }
 
@@ -193,6 +220,7 @@ export function useWorkspaceChatArtifacts(
   const enabled = options.enabled ?? true
   const initialActiveArtifactKey = options.initialActiveArtifactKey ?? null
   const persistedArtifacts = options.persistedArtifacts ?? EMPTY_ARTIFACTS
+  const isStreaming = options.isStreaming ?? false
   const onArtifactStreamPart = options.onArtifactStreamPart
   const onCloseArtifact = options.onCloseArtifact
   const persistedArtifactSignature = useMemo(
@@ -208,6 +236,7 @@ export function useWorkspaceChatArtifacts(
     persistedArtifactSignature
   )
   const initialActiveArtifactKeyRef = useRef(initialActiveArtifactKey)
+  const deferredActiveArtifactKeyRef = useRef<string | null>(null)
   const [activeArtifactKey, setActiveArtifactKey] = useState<string | null>(
     () => {
       if (!enabled) {
@@ -264,6 +293,7 @@ export function useWorkspaceChatArtifacts(
 
     if (!enabled) {
       processedMessagePartKeysRef.current.clear()
+      deferredActiveArtifactKeyRef.current = null
       setStreamArtifacts((current) =>
         current.size === 0 ? current : new Map()
       )
@@ -314,6 +344,12 @@ export function useWorkspaceChatArtifacts(
       setStreamArtifacts(nextArtifacts)
       const nextActiveArtifactKey =
         lastUpsertKey(pendingParts) ?? lastArtifactKey(persistedArtifacts)
+      if (isStreaming) {
+        if (nextActiveArtifactKey) {
+          deferredActiveArtifactKeyRef.current = nextActiveArtifactKey
+        }
+        return
+      }
       setActiveArtifactKey(
         selectActiveArtifactKey(
           Array.from(nextArtifacts.values()),
@@ -342,11 +378,16 @@ export function useWorkspaceChatArtifacts(
 
     const nextActiveArtifactKey = lastUpsertKey(pendingParts)
     if (nextActiveArtifactKey) {
-      initialActiveArtifactKeyRef.current = null
-      setActiveArtifactKey(nextActiveArtifactKey)
+      if (isStreaming) {
+        deferredActiveArtifactKeyRef.current = nextActiveArtifactKey
+      } else {
+        initialActiveArtifactKeyRef.current = null
+        setActiveArtifactKey(nextActiveArtifactKey)
+      }
     }
   }, [
     enabled,
+    isStreaming,
     messages,
     onArtifactStreamPart,
     persistedArtifactSignature,
@@ -376,14 +417,37 @@ export function useWorkspaceChatArtifacts(
       switch (part.type) {
         case ARTIFACT_DATA_PART_TYPE:
           if (part.data.op === "upsert") {
-            initialActiveArtifactKeyRef.current = null
-            setActiveArtifactKey(artifactKey(part.data.artifact))
+            if (isStreaming) {
+              deferredActiveArtifactKeyRef.current = artifactKey(
+                part.data.artifact
+              )
+            } else {
+              initialActiveArtifactKeyRef.current = null
+              setActiveArtifactKey(artifactKey(part.data.artifact))
+            }
           }
           return
       }
     },
-    [enabled, onArtifactStreamPart]
+    [enabled, isStreaming, onArtifactStreamPart]
   )
+
+  // Focus deferred artifacts once the stream settles so a multi-artifact run
+  // switches the panel content once instead of chasing every upsert.
+  useEffect(() => {
+    if (isStreaming) {
+      return
+    }
+    const deferredKey = deferredActiveArtifactKeyRef.current
+    if (!deferredKey) {
+      return
+    }
+    deferredActiveArtifactKeyRef.current = null
+    if (artifacts.some((artifact) => artifactKey(artifact) === deferredKey)) {
+      initialActiveArtifactKeyRef.current = null
+      setActiveArtifactKey(deferredKey)
+    }
+  }, [isStreaming, artifacts])
 
   const lanes = useMemo(() => {
     const next = new Map<string, ArtifactLane>()

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -4,11 +4,13 @@ from types import SimpleNamespace
 
 from tracecat.artifacts.bindings import (
     ARTIFACT_BINDINGS,
+    MAX_LIST_ARTIFACTS,
     ArtifactIdentityRef,
     ArtifactSideEffect,
     artifact_side_effects_for_tool_result,
 )
 from tracecat.artifacts.projection import (
+    MAX_OPEN_ARTIFACTS,
     apply_artifact_side_effects,
     remove_artifact,
     serialize_artifacts,
@@ -92,6 +94,51 @@ def test_artifact_projection_applies_upsert_and_remove_operations() -> None:
     )
 
     assert projected == [second]
+
+
+def test_artifact_projection_evicts_oldest_past_open_limit() -> None:
+    def case(i: int) -> CaseArtifact:
+        return CaseArtifact(
+            id=f"case_{i}",
+            title=f"Case {i}",
+            severity=CaseSeverity.LOW,
+            status=CaseStatus.NEW,
+        )
+
+    total = MAX_OPEN_ARTIFACTS + 2
+    projected = apply_artifact_side_effects(
+        [],
+        [ArtifactSideEffect(op="upsert", artifact=case(i)) for i in range(total)],
+    )
+
+    assert [artifact.id for artifact in projected] == [
+        f"case_{i}" for i in range(total - MAX_OPEN_ARTIFACTS, total)
+    ]
+
+
+def test_artifact_projection_upsert_refreshes_recency() -> None:
+    def case(i: int) -> CaseArtifact:
+        return CaseArtifact(
+            id=f"case_{i}",
+            title=f"Case {i}",
+            severity=CaseSeverity.LOW,
+            status=CaseStatus.NEW,
+        )
+
+    initial = [case(i) for i in range(MAX_OPEN_ARTIFACTS)]
+    projected = apply_artifact_side_effects(
+        initial,
+        [
+            # Touch the oldest artifact, then add one more: the second-oldest
+            # should be evicted instead of the refreshed one.
+            ArtifactSideEffect(op="upsert", artifact=case(0)),
+            ArtifactSideEffect(op="upsert", artifact=case(MAX_OPEN_ARTIFACTS)),
+        ],
+    )
+
+    assert [artifact.id for artifact in projected] == [
+        f"case_{i}" for i in range(2, MAX_OPEN_ARTIFACTS)
+    ] + ["case_0", f"case_{MAX_OPEN_ARTIFACTS}"]
 
 
 def test_artifact_projection_serializes_and_validates_jsonb_payload() -> None:
@@ -433,6 +480,31 @@ def test_case_list_tool_result_emits_upsert_side_effects() -> None:
     assert [effect.artifact.id for effect in effects] == ["case_123", "case_456"]
 
 
+def test_case_list_tool_result_above_limit_emits_no_side_effects() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.cases.list_cases",
+            tool_input={"limit": 10},
+            tool_output={
+                "items": [
+                    {
+                        "id": f"case_{i}",
+                        "summary": f"Case {i}",
+                        "severity": "low",
+                        "status": "new",
+                    }
+                    for i in range(MAX_LIST_ARTIFACTS + 1)
+                ],
+                "has_more": False,
+            },
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert effects == []
+
+
 def test_table_list_tool_result_emits_upsert_side_effects() -> None:
     effects = list(
         artifact_side_effects_for_tool_result(
@@ -449,6 +521,23 @@ def test_table_list_tool_result_emits_upsert_side_effects() -> None:
 
     assert [effect.op for effect in effects] == ["upsert", "upsert"]
     assert [effect.artifact.id for effect in effects] == ["table_123", "table_456"]
+
+
+def test_table_list_tool_result_above_limit_emits_no_side_effects() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.table.list_tables",
+            tool_input=None,
+            tool_output=[
+                {"id": f"table_{i}", "name": f"table-{i}"}
+                for i in range(MAX_LIST_ARTIFACTS + 1)
+            ],
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert effects == []
 
 
 def test_table_search_tool_result_emits_upsert_side_effect_from_input() -> None:
@@ -552,6 +641,23 @@ def test_agent_preset_list_tool_result_emits_upsert_side_effects() -> None:
         "preset_123",
         "preset_456",
     ]
+
+
+def test_agent_preset_list_tool_result_above_limit_emits_no_side_effects() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="ai.agent.list_presets",
+            tool_input=None,
+            tool_output=[
+                {"id": f"preset_{i}", "name": f"Preset {i}"}
+                for i in range(MAX_LIST_ARTIFACTS + 1)
+            ],
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert effects == []
 
 
 def test_table_tool_result_mapping_content_emits_upsert_side_effect() -> None:

--- a/tracecat/artifacts/bindings.py
+++ b/tracecat/artifacts/bindings.py
@@ -213,6 +213,12 @@ class ArtifactBinding:
     op: ArtifactOp
     build: ArtifactBuilder
     identity: ArtifactIdentityBuilder | None = None
+    max_artifacts: int | None = None
+
+
+# List-style tools (list/search) skip artifact emission past this count so a
+# broad listing answers in chat text instead of opening one tab per item.
+MAX_LIST_ARTIFACTS = 3
 
 
 def _build_case_artifact(ctx: ArtifactProjectionContext) -> Artifact | None:
@@ -289,6 +295,7 @@ ARTIFACT_BINDINGS: tuple[ArtifactBinding, ...] = (
         tool_names=("core.cases.list_cases", "core.cases.search_cases"),
         op="upsert",
         build=_build_case_artifacts,
+        max_artifacts=MAX_LIST_ARTIFACTS,
     ),
     ArtifactBinding(
         tool_names=("core.cases.delete_case",),
@@ -312,6 +319,7 @@ ARTIFACT_BINDINGS: tuple[ArtifactBinding, ...] = (
         tool_names=("core.table.list_tables",),
         op="upsert",
         build=_build_table_artifacts,
+        max_artifacts=MAX_LIST_ARTIFACTS,
     ),
     ArtifactBinding(
         tool_names=(
@@ -342,6 +350,7 @@ ARTIFACT_BINDINGS: tuple[ArtifactBinding, ...] = (
         tool_names=("ai.agent.list_presets",),
         op="upsert",
         build=_build_agent_artifacts,
+        max_artifacts=MAX_LIST_ARTIFACTS,
     ),
     ArtifactBinding(
         tool_names=("core.workflow.execute", "core.workflow.get_status"),
@@ -418,6 +427,8 @@ def artifact_side_effects_for_tool_result(
 
     artifacts = _artifact_tuple(binding.build(ctx))
     if not artifacts:
+        return
+    if binding.max_artifacts is not None and len(artifacts) > binding.max_artifacts:
         return
 
     identity_ref = binding.identity(ctx) if binding.identity else None

--- a/tracecat/artifacts/projection.py
+++ b/tracecat/artifacts/projection.py
@@ -12,6 +12,12 @@ from tracecat.artifacts.schemas import Artifact, ArtifactAdapter, ArtifactType
 
 ArtifactsAdapter: TypeAdapter[list[Artifact]] = TypeAdapter(list[Artifact])
 
+# Maximum artifacts retained in the panel projection. Oldest entries are
+# evicted first so repeated tool calls don't accumulate unbounded tabs.
+# Must match MAX_OPEN_ARTIFACT_TABS in
+# frontend/src/hooks/use-workspace-chat-artifacts.ts.
+MAX_OPEN_ARTIFACTS = 5
+
 
 def artifact_key(artifact: Artifact) -> str:
     """Return the stable projection key for an artifact."""
@@ -45,16 +51,22 @@ def apply_artifact_side_effects(
     artifacts: Iterable[Artifact],
     effects: Iterable[ArtifactSideEffect],
 ) -> list[Artifact]:
-    """Apply artifact operations while preserving existing panel order."""
+    """Apply artifact operations, keeping at most the most recent artifacts."""
     projected = {artifact_key(artifact): artifact for artifact in artifacts}
     for effect in effects:
         key = artifact_key(effect.artifact)
         match effect.op:
             case "upsert":
+                # Pop first so re-upserting an open artifact refreshes its
+                # recency instead of keeping its original panel position.
+                projected.pop(key, None)
                 projected[key] = effect.artifact
             case "remove":
                 projected.pop(key, None)
-    return list(projected.values())
+    result = list(projected.values())
+    if len(result) > MAX_OPEN_ARTIFACTS:
+        result = result[-MAX_OPEN_ARTIFACTS:]
+    return result
 
 
 def remove_artifact(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces a 5-tab limit for workspace chat artifacts with LRU eviction, keeping the panel stable during streams and matching frontend and backend behavior. Also caps list tool emissions to avoid opening excessive tabs.

- **Bug Fixes**
  - Enforce 5-tab LRU in frontend (`MAX_OPEN_ARTIFACT_TABS = 5`) and backend (`MAX_OPEN_ARTIFACTS = 5`); upserts refresh recency and persisted tabs are capped.
  - Defer tab focus while streaming; focus the last streamed artifact when done. Plumb `onStatusChange` through `ChatInterface`/`ChatSessionPane` and set `isStreaming` in `WorkspaceChatView`.
  - Cap list/search tool artifact emissions to `MAX_LIST_ARTIFACTS = 3` to prevent tab explosions.
  - Add unit tests for eviction, recency refresh, streaming focus behavior, and list caps.

<sup>Written for commit 509e6e58ebfbcdc50d708223d8273624a44bd279. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

