### PR TITLE
fix(cluster): avoid portless port collision

### DIFF
--- a/scripts/cluster
+++ b/scripts/cluster
@@ -222,6 +222,15 @@ portless_docs_alias_name() {
     echo "docs.${WORKTREE_ID}.tracecat"
 }
 
+source_env_file() {
+    if [[ -f "$ENV_FILE" ]]; then
+        set -a
+        # shellcheck disable=SC1090
+        source "$ENV_FILE"
+        set +a
+    fi
+}
+
 # Get list of running cluster numbers for this worktree (used for auto-selection)
 get_running_clusters() {
     local prefix="tracecat-${WORKTREE_ID}-"
@@ -613,6 +622,8 @@ if [[ $# -lt 1 ]]; then
     usage
 fi
 
+source_env_file
+
 # Handle 'list' command specially
 if [[ "$1" == "list" ]]; then
     list_clusters
@@ -877,14 +888,6 @@ if [[ "$COMMAND" == "db" ]]; then
         exit 1
     fi
 
-    # Source .env for credentials if it exists
-    if [[ -f "$ENV_FILE" ]]; then
-        set -a
-        # shellcheck disable=SC1090
-        source "$ENV_FILE"
-        set +a
-    fi
-
     calculate_ports "$CLUSTER_NUM"
     pg_user="${TRACECAT__POSTGRES_USER:-postgres}"
     pg_pass="${TRACECAT__POSTGRES_PASSWORD:-postgres}"
@@ -1096,10 +1099,7 @@ fi
 
 # Source the .env file for other variables (but our exports take precedence)
 if [[ -f "$ENV_FILE" ]]; then
-    set -a
-    # shellcheck disable=SC1090
-    source "$ENV_FILE"
-    set +a
+    source_env_file
     # Re-apply our overrides (source may have overwritten them)
     build_env "$CLUSTER_NUM"
 fi

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -29,6 +29,9 @@
 #   Cluster 2: 180, 3100, 5532, 6479, 7333, 8100, 8181, 9100, 9101
 #   Cluster 3: 280, 3200, 5632, 6579, 7433, 8200, 8281, 9200, 9201
 #   ...
+#
+#   With portless enabled, the Caddy/public app port starts at 10080 instead
+#   of 80 because portless itself owns ports 80 and 443.
 
 set -euo pipefail
 
@@ -332,6 +335,7 @@ auto_select_cluster() {
 
 # Base ports (cluster 1 defaults)
 BASE_PUBLIC_APP_PORT=80
+BASE_PORTLESS_PUBLIC_APP_PORT=10080
 BASE_UI_PORT=3000
 BASE_PG_PORT=5432
 BASE_REDIS_PORT=6379
@@ -475,8 +479,13 @@ normalize_bool() {
 calculate_ports() {
     local cluster_num=$1
     local offset=$(( (cluster_num - 1) * 100 ))
+    local public_app_base=$BASE_PUBLIC_APP_PORT
 
-    PUBLIC_APP_PORT=$(( BASE_PUBLIC_APP_PORT + offset ))
+    if portless_enabled; then
+        public_app_base=$BASE_PORTLESS_PUBLIC_APP_PORT
+    fi
+
+    PUBLIC_APP_PORT=$(( public_app_base + offset ))
     UI_PORT=$(( BASE_UI_PORT + offset ))
     PG_PORT=$(( BASE_PG_PORT + offset ))
     REDIS_PORT_HOST=$(( BASE_REDIS_PORT + offset ))


### PR DESCRIPTION
## Summary
- avoid routing Tracecat Caddy through portless-owned port 80 when portless is enabled
- move the portless-enabled public Caddy base port to 10080 so the stable `.localhost` alias reaches Caddy directly

## Testing
- `bash -n scripts/cluster`
- `git diff --check origin/main...HEAD -- scripts/cluster`
- `just cluster up -d`
- `curl -skS -D - --max-time 15 https://fix-admin-user-delete.tracecat.localhost/api/ready`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid port collisions with `portless` by switching the public Caddy base port from 80 to 10080 when `portless` is enabled, and load `.env` before checks so the right ports are chosen and clusters start cleanly.

- **Bug Fixes**
  - Added `BASE_PORTLESS_PUBLIC_APP_PORT=10080` and switched to it when `portless_enabled` (since `portless` owns 80/443).
  - Updated `calculate_ports` to compute `PUBLIC_APP_PORT` from the selected base with per-cluster offsets.
  - Load `.env` early via `source_env_file` before `portless` checks; removed duplicate sourcing.

<sup>Written for commit c4635db16a3be4800af1102817f23498b8c47179. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

