### PR TITLE
chore: bump model catalog

### DIFF
--- a/tracecat/agent/llm.py
+++ b/tracecat/agent/llm.py
@@ -134,7 +134,7 @@ async def _call_litellm(
     max_tokens: int | None,
     timeout_seconds: float,
 ) -> str:
-    body: dict[str, Any] = {"messages": messages, "temperature": 0}
+    body: dict[str, Any] = {"messages": messages}
     if max_tokens is not None:
         body["max_tokens"] = max_tokens
     async with httpx.AsyncClient(timeout=timeout_seconds) as client:
@@ -164,7 +164,6 @@ async def _call_passthrough(
     body: dict[str, Any] = {
         "model": model_name,
         "messages": messages,
-        "temperature": 0,
     }
     if max_tokens is not None:
         body["max_tokens"] = max_tokens

--- a/tracecat/agent/platform_catalog.json
+++ b/tracecat/agent/platform_catalog.json
@@ -65,6 +65,43 @@
     },
     {
       "model_provider": "anthropic",
+      "model_name": "claude-fable-5",
+      "metadata": {
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_1hr": 2e-05,
+        "cache_read_input_token_cost": 1e-06,
+        "input_cost_per_token": 1e-05,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "provider_specific_entry": {
+          "us": 1.1
+        },
+        "supports_output_config": true,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
       "model_name": "claude-haiku-4-5",
       "metadata": {
         "cache_creation_input_token_cost": 1.25e-06,
@@ -342,6 +379,44 @@
         },
         "supports_max_reasoning_effort": true,
         "supports_minimal_reasoning_effort": true,
+        "provider": "anthropic"
+      }
+    },
+    {
+      "model_provider": "anthropic",
+      "model_name": "claude-opus-4-8",
+      "metadata": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_1hr": 1e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "output_cost_per_token": 2.5e-05,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.01,
+          "search_context_size_low": 0.01,
+          "search_context_size_medium": 0.01
+        },
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "provider_specific_entry": {
+          "us": 1.1,
+          "fast": 2.0
+        },
+        "supports_output_config": true,
         "provider": "anthropic"
       }
     },
@@ -998,6 +1073,70 @@
         "cache_read_input_token_cost_priority": 3.6e-07,
         "cache_read_input_token_cost_above_200k_tokens_priority": 7.2e-07,
         "supports_service_tier": true,
+        "provider": "gemini"
+      }
+    },
+    {
+      "model_provider": "gemini",
+      "model_name": "gemini-3.5-flash",
+      "metadata": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_audio_token": 1e-06,
+        "input_cost_per_token": 1.5e-06,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65535,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "output_cost_per_reasoning_token": 9e-06,
+        "output_cost_per_token": 9e-06,
+        "rpm": 2000,
+        "source": "https://ai.google.dev/pricing/gemini-3",
+        "supported_endpoints": [
+          "/v1/chat/completions",
+          "/v1/completions",
+          "/v1/batch"
+        ],
+        "supported_modalities": [
+          "text",
+          "image",
+          "audio",
+          "video"
+        ],
+        "supported_output_modalities": [
+          "text"
+        ],
+        "supports_audio_output": false,
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_native_streaming": true,
+        "tpm": 800000,
+        "input_cost_per_token_priority": 2.7e-06,
+        "input_cost_per_audio_token_priority": 1.8e-06,
+        "output_cost_per_token_priority": 1.62e-05,
+        "cache_read_input_token_cost_priority": 2.7e-07,
+        "supports_service_tier": true,
+        "search_context_cost_per_query": {
+          "search_context_size_high": 0.014,
+          "search_context_size_low": 0.014,
+          "search_context_size_medium": 0.014
+        },
+        "web_search_billing_unit": "per_query",
         "provider": "gemini"
       }
     },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Claude Fable 5, Claude Opus 4.8 (with fast tier), and Gemini 3.5 Flash to the model catalog to expand reasoning/vision and enable Gemini web search and native streaming. Also drop the hardcoded temperature in lightweight completions and passthrough so sampling respects caller settings or provider defaults.

<sup>Written for commit 732cf6293afc1d8aeca4f35bb977a1368459385a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

