### PR TITLE
fix(ui): workspace model selection scroll

### DIFF
--- a/frontend/src/components/settings/settings-modal.tsx
+++ b/frontend/src/components/settings/settings-modal.tsx
@@ -175,7 +175,7 @@ function SettingsModalContent() {
   const showSyncNav = hasEntitlement("git_sync")
 
   return (
-    <DialogContent className="h-[600px] max-w-[900px] gap-0 overflow-hidden p-0">
+    <DialogContent className="h-[600px] max-w-[900px] grid-rows-[100%] gap-0 overflow-hidden p-0">
       <TooltipProvider>
         <DialogTitle className="sr-only">Settings</DialogTitle>
         <DialogDescription className="sr-only">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores scrolling in the Workspace model selection panel by making the Settings modal content a single full-height grid row. Adds `grid-rows-[100%]` to `DialogContent` to prevent content from being clipped.

<sup>Written for commit fd69b8eb3fe2a1fc89c584ad306a787b4e3bea64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

