### PR TITLE
feat(mcp): add case dropdown management tools

### DIFF
--- a/docs/snippets/mcp-tools.mdx
+++ b/docs/snippets/mcp-tools.mdx
@@ -295,6 +295,40 @@
   Update a case field definition.
 </ResponseField>
 
+<ResponseField name="list_case_dropdowns" type="tool">
+  List case dropdown definitions in a workspace. Requires the case add-ons entitlement.
+
+  Returns a paginated JSON array of dropdown objects with `id`, `name`, `ref`, `icon_name`, `is_ordered`, `required_on_closure`, `position`, and embedded `options`.
+</ResponseField>
+
+<ResponseField name="create_case_dropdown" type="tool">
+  Create a case dropdown definition with optional initial options. Requires the case add-ons entitlement.
+</ResponseField>
+
+<ResponseField name="update_case_dropdown" type="tool">
+  Update a case dropdown definition. Only provided fields are changed. Requires the case add-ons entitlement.
+</ResponseField>
+
+<ResponseField name="delete_case_dropdown" type="tool">
+  Delete a case dropdown definition along with all its options and per-case values. Requires the case add-ons entitlement.
+</ResponseField>
+
+<ResponseField name="add_case_dropdown_option" type="tool">
+  Add an option to a case dropdown definition. Requires the case add-ons entitlement.
+</ResponseField>
+
+<ResponseField name="update_case_dropdown_option" type="tool">
+  Update an option within a case dropdown definition. Only provided fields are changed. Requires the case add-ons entitlement.
+</ResponseField>
+
+<ResponseField name="delete_case_dropdown_option" type="tool">
+  Delete an option from a case dropdown definition. Requires the case add-ons entitlement.
+</ResponseField>
+
+<ResponseField name="set_case_dropdown_value" type="tool">
+  Set or clear a dropdown value on a case. Provide exactly one of `definition_id` or `definition_ref`, and at most one of `option_id` or `option_ref`; omit both option arguments to clear the value. Requires the case add-ons entitlement.
+</ResponseField>
+
 <ResponseField name="list_tables" type="tool">
   List workspace tables.
 </ResponseField>

--- a/tests/unit/test_case_dropdown_service.py
+++ b/tests/unit/test_case_dropdown_service.py
@@ -262,3 +262,17 @@ class TestCaseDropdownDefinitionsService:
         )
         definitions = await viewer_service.list_definitions()
         assert [d.id for d in definitions] == [definition.id]
+
+        # Write-only roles can fetch a definition (mutation flows look it up
+        # first) but cannot list the read surface. case:create is used here
+        # because case:update implies case:read platform-wide.
+        create_only_role = dropdown_service.role.model_copy(
+            update={"scopes": frozenset({"case:create"})}
+        )
+        create_only_service = CaseDropdownDefinitionsService(
+            session=session, role=create_only_role
+        )
+        fetched = await create_only_service.get_definition(definition.id)
+        assert fetched.id == definition.id
+        with pytest.raises(ScopeDeniedError):
+            await create_only_service.list_definitions()

--- a/tests/unit/test_case_dropdown_service.py
+++ b/tests/unit/test_case_dropdown_service.py
@@ -221,6 +221,19 @@ class TestCaseDropdownDefinitionsService:
         with pytest.raises(TracecatNotFoundError):
             await values_service.apply_values(uuid.uuid4(), [])
 
+    async def test_list_definitions_order_is_deterministic(
+        self, dropdown_service: CaseDropdownDefinitionsService
+    ) -> None:
+        """Position ties should fall back to creation order, stable across calls."""
+        refs = ["first", "second", "third"]
+        for ref in refs:
+            await _create_definition(dropdown_service, name=ref.title(), ref=ref)
+
+        listed = await dropdown_service.list_definitions()
+        assert [d.ref for d in listed] == refs
+        relisted = await dropdown_service.list_definitions()
+        assert [d.id for d in relisted] == [d.id for d in listed]
+
     async def test_reads_require_case_read_scope(
         self,
         session: AsyncSession,

--- a/tests/unit/test_case_dropdown_service.py
+++ b/tests/unit/test_case_dropdown_service.py
@@ -10,6 +10,7 @@ from tracecat.cases.dropdowns.schemas import (
     CaseDropdownDefinitionUpdate,
     CaseDropdownOptionCreate,
     CaseDropdownOptionUpdate,
+    CaseDropdownValueInput,
 )
 from tracecat.cases.dropdowns.service import (
     CaseDropdownDefinitionsService,
@@ -190,3 +191,32 @@ class TestCaseDropdownDefinitionsService:
         )
         with pytest.raises(ScopeDeniedError):
             await viewer_values_service.apply_values(uuid.uuid4(), [])
+        with pytest.raises(ScopeDeniedError):
+            await viewer_values_service.set_value_from_input(
+                uuid.uuid4(),
+                CaseDropdownValueInput(definition_ref="analyst_verdict"),
+            )
+
+    async def test_set_value_requires_update_scope(
+        self,
+        session: AsyncSession,
+        dropdown_service: CaseDropdownDefinitionsService,
+    ) -> None:
+        """A create-only role may not set dropdown values on existing cases."""
+        create_only_role = dropdown_service.role.model_copy(
+            update={"scopes": VIEWER_SCOPES | {"case:create"}}
+        )
+        values_service = CaseDropdownValuesService(
+            session=session, role=create_only_role
+        )
+
+        with pytest.raises(ScopeDeniedError):
+            await values_service.set_value_from_input(
+                uuid.uuid4(),
+                CaseDropdownValueInput(definition_ref="analyst_verdict"),
+            )
+
+        # apply_values serves the scope-guarded CasesService create path, so a
+        # create-only role passes its scope gate (and fails later on lookup).
+        with pytest.raises(TracecatNotFoundError):
+            await values_service.apply_values(uuid.uuid4(), [])

--- a/tests/unit/test_case_dropdown_service.py
+++ b/tests/unit/test_case_dropdown_service.py
@@ -1,15 +1,25 @@
+import uuid
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.types import Role
+from tracecat.authz.scopes import VIEWER_SCOPES
 from tracecat.cases.dropdowns.schemas import (
     CaseDropdownDefinitionCreate,
     CaseDropdownDefinitionUpdate,
     CaseDropdownOptionCreate,
     CaseDropdownOptionUpdate,
 )
-from tracecat.cases.dropdowns.service import CaseDropdownDefinitionsService
-from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.cases.dropdowns.service import (
+    CaseDropdownDefinitionsService,
+    CaseDropdownValuesService,
+)
+from tracecat.exceptions import (
+    ScopeDeniedError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
 
 pytestmark = pytest.mark.usefixtures("db")
 
@@ -136,3 +146,47 @@ class TestCaseDropdownDefinitionsService:
         await dropdown_service.delete_option(definition_b.id, option_b.id)
         with pytest.raises(TracecatNotFoundError, match="not found for definition"):
             await dropdown_service.delete_option(definition_b.id, option_b.id)
+
+    async def test_mutations_require_case_scopes(
+        self,
+        session: AsyncSession,
+        dropdown_service: CaseDropdownDefinitionsService,
+    ) -> None:
+        """Mutation methods should reject roles without case mutation scopes."""
+        definition = await _create_definition(dropdown_service)
+        option = await dropdown_service.add_option(
+            definition.id,
+            CaseDropdownOptionCreate(label="High", ref="high"),
+        )
+
+        viewer_role = dropdown_service.role.model_copy(update={"scopes": VIEWER_SCOPES})
+        viewer_service = CaseDropdownDefinitionsService(
+            session=session, role=viewer_role
+        )
+
+        with pytest.raises(ScopeDeniedError):
+            await viewer_service.create_definition(
+                CaseDropdownDefinitionCreate(name="Blocked", ref="blocked", options=[])
+            )
+        with pytest.raises(ScopeDeniedError):
+            await viewer_service.update_definition(
+                definition, CaseDropdownDefinitionUpdate(name="Blocked")
+            )
+        with pytest.raises(ScopeDeniedError):
+            await viewer_service.delete_definition(definition)
+        with pytest.raises(ScopeDeniedError):
+            await viewer_service.add_option(
+                definition.id, CaseDropdownOptionCreate(label="Low", ref="low")
+            )
+        with pytest.raises(ScopeDeniedError):
+            await viewer_service.update_option(
+                definition.id, option.id, CaseDropdownOptionUpdate(label="Blocked")
+            )
+        with pytest.raises(ScopeDeniedError):
+            await viewer_service.delete_option(definition.id, option.id)
+
+        viewer_values_service = CaseDropdownValuesService(
+            session=session, role=viewer_role
+        )
+        with pytest.raises(ScopeDeniedError):
+            await viewer_values_service.apply_values(uuid.uuid4(), [])

--- a/tests/unit/test_case_dropdown_service.py
+++ b/tests/unit/test_case_dropdown_service.py
@@ -5,9 +5,11 @@ from tracecat.auth.types import Role
 from tracecat.cases.dropdowns.schemas import (
     CaseDropdownDefinitionCreate,
     CaseDropdownDefinitionUpdate,
+    CaseDropdownOptionCreate,
+    CaseDropdownOptionUpdate,
 )
 from tracecat.cases.dropdowns.service import CaseDropdownDefinitionsService
-from tracecat.exceptions import TracecatValidationError
+from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 
 pytestmark = pytest.mark.usefixtures("db")
 
@@ -81,3 +83,56 @@ class TestCaseDropdownDefinitionsService:
                 definition,
                 CaseDropdownDefinitionUpdate(name="!!!"),
             )
+
+    async def test_update_option_scoped_to_definition(
+        self, dropdown_service: CaseDropdownDefinitionsService
+    ) -> None:
+        """Updating an option through a different definition should fail."""
+        definition_a = await _create_definition(
+            dropdown_service, name="Analyst Verdict", ref="analyst_verdict"
+        )
+        definition_b = await _create_definition(
+            dropdown_service, name="Threat Level", ref="threat_level"
+        )
+        option_b = await dropdown_service.add_option(
+            definition_b.id,
+            CaseDropdownOptionCreate(label="High", ref="high"),
+        )
+
+        with pytest.raises(TracecatNotFoundError, match="not found for definition"):
+            await dropdown_service.update_option(
+                definition_a.id,
+                option_b.id,
+                CaseDropdownOptionUpdate(label="Hijacked"),
+            )
+
+        updated = await dropdown_service.update_option(
+            definition_b.id,
+            option_b.id,
+            CaseDropdownOptionUpdate(label="Very High"),
+        )
+        assert updated.label == "Very High"
+
+    async def test_delete_option_scoped_to_definition(
+        self, dropdown_service: CaseDropdownDefinitionsService
+    ) -> None:
+        """Deleting an option through a different definition should fail."""
+        definition_a = await _create_definition(
+            dropdown_service, name="Analyst Verdict", ref="analyst_verdict"
+        )
+        definition_b = await _create_definition(
+            dropdown_service, name="Threat Level", ref="threat_level"
+        )
+        option_b = await dropdown_service.add_option(
+            definition_b.id,
+            CaseDropdownOptionCreate(label="High", ref="high"),
+        )
+
+        with pytest.raises(TracecatNotFoundError, match="not found for definition"):
+            await dropdown_service.delete_option(definition_a.id, option_b.id)
+
+        # The option survives the mismatched delete and is removable through
+        # its own definition exactly once.
+        await dropdown_service.delete_option(definition_b.id, option_b.id)
+        with pytest.raises(TracecatNotFoundError, match="not found for definition"):
+            await dropdown_service.delete_option(definition_b.id, option_b.id)

--- a/tests/unit/test_case_dropdown_service.py
+++ b/tests/unit/test_case_dropdown_service.py
@@ -220,3 +220,32 @@ class TestCaseDropdownDefinitionsService:
         # create-only role passes its scope gate (and fails later on lookup).
         with pytest.raises(TracecatNotFoundError):
             await values_service.apply_values(uuid.uuid4(), [])
+
+    async def test_reads_require_case_read_scope(
+        self,
+        session: AsyncSession,
+        dropdown_service: CaseDropdownDefinitionsService,
+    ) -> None:
+        """Definition reads should reject roles without case:read."""
+        definition = await _create_definition(dropdown_service)
+
+        scopeless_role = dropdown_service.role.model_copy(
+            update={"scopes": frozenset()}
+        )
+        scopeless_service = CaseDropdownDefinitionsService(
+            session=session, role=scopeless_role
+        )
+
+        with pytest.raises(ScopeDeniedError):
+            await scopeless_service.list_definitions()
+        with pytest.raises(ScopeDeniedError):
+            await scopeless_service.get_definition(definition.id)
+        with pytest.raises(ScopeDeniedError):
+            await scopeless_service.get_definition_by_ref(definition.ref)
+
+        viewer_role = dropdown_service.role.model_copy(update={"scopes": VIEWER_SCOPES})
+        viewer_service = CaseDropdownDefinitionsService(
+            session=session, role=viewer_role
+        )
+        definitions = await viewer_service.list_definitions()
+        assert [d.id for d in definitions] == [definition.id]

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -4352,7 +4352,8 @@ async def test_update_case_dropdown_option(monkeypatch):
     async def _get_definition(definition_id):
         return definition
 
-    async def _update_option(oid, params):
+    async def _update_option(did, oid, params):
+        captured["definition_id"] = did
         captured["option_id"] = oid
         captured["params"] = params
         return _fake_dropdown_option(id=oid, label="Renamed", color="red")
@@ -4371,6 +4372,7 @@ async def test_update_case_dropdown_option(monkeypatch):
         color="red",
     )
     payload = _payload(result)
+    assert captured["definition_id"] == definition.id
     assert captured["option_id"] == option_id
     assert captured["params"].model_dump(exclude_unset=True) == {
         "label": "Renamed",
@@ -4386,13 +4388,13 @@ async def test_delete_case_dropdown_option(monkeypatch):
 
     definition = _fake_dropdown_definition()
     option_id = uuid.uuid4()
-    deleted: list[uuid.UUID] = []
+    deleted: list[tuple[uuid.UUID, uuid.UUID]] = []
 
     async def _get_definition(definition_id):
         return definition
 
-    async def _delete_option(oid):
-        deleted.append(oid)
+    async def _delete_option(did, oid):
+        deleted.append((did, oid))
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
     _patch_dropdown_definitions_service(
@@ -4407,7 +4409,7 @@ async def test_delete_case_dropdown_option(monkeypatch):
     )
     payload = _payload(result)
     assert "deleted successfully" in payload["message"]
-    assert deleted == [option_id]
+    assert deleted == [(definition.id, option_id)]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -4352,10 +4352,12 @@ async def test_add_case_dropdown_option_defaults(monkeypatch):
     async def _resolve(_workspace_id):
         return uuid.uuid4(), SimpleNamespace()
 
+    # Sparse positions (e.g. after deletions): default must append after the
+    # max position, not at the option count.
     definition = _fake_dropdown_definition(
         options=[
             _fake_dropdown_option(label="Low", ref="low", position=0),
-            _fake_dropdown_option(label="Medium", ref="medium", position=1),
+            _fake_dropdown_option(label="Medium", ref="medium", position=5),
         ]
     )
     captured: dict[str, Any] = {}
@@ -4385,7 +4387,7 @@ async def test_add_case_dropdown_option_defaults(monkeypatch):
     params = captured["params"]
     assert captured["definition_id"] == definition.id
     assert params.ref == "very_high"
-    assert params.position == 2
+    assert params.position == 6
     assert payload["label"] == "Very High!"
     assert payload["ref"] == "very_high"
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -4460,14 +4460,14 @@ async def test_set_case_dropdown_value_by_ref(monkeypatch):
         option_ref="high",
     )
 
-    async def _apply_values(cid, values):
+    async def _set_value_from_input(cid, value):
         captured["case_id"] = cid
-        captured["values"] = values
-        return [value_read]
+        captured["value"] = value
+        return value_read
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
     _patch_dropdown_values_service(
-        monkeypatch, SimpleNamespace(apply_values=_apply_values)
+        monkeypatch, SimpleNamespace(set_value_from_input=_set_value_from_input)
     )
 
     result = await _tool(mcp_server.set_case_dropdown_value)(
@@ -4478,8 +4478,7 @@ async def test_set_case_dropdown_value_by_ref(monkeypatch):
     )
     payload = _payload(result)
     assert captured["case_id"] == case_id
-    assert len(captured["values"]) == 1
-    value_input = captured["values"][0]
+    value_input = captured["value"]
     assert value_input.definition_ref == "threat_level"
     assert value_input.option_ref == "high"
     assert value_input.definition_id is None
@@ -4502,13 +4501,13 @@ async def test_set_case_dropdown_value_clears(monkeypatch):
         definition_name="Threat Level",
     )
 
-    async def _apply_values(cid, values):
-        captured["values"] = values
-        return [value_read]
+    async def _set_value_from_input(cid, value):
+        captured["value"] = value
+        return value_read
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
     _patch_dropdown_values_service(
-        monkeypatch, SimpleNamespace(apply_values=_apply_values)
+        monkeypatch, SimpleNamespace(set_value_from_input=_set_value_from_input)
     )
 
     result = await _tool(mcp_server.set_case_dropdown_value)(
@@ -4517,7 +4516,7 @@ async def test_set_case_dropdown_value_clears(monkeypatch):
         definition_ref="threat_level",
     )
     payload = _payload(result)
-    value_input = captured["values"][0]
+    value_input = captured["value"]
     assert value_input.option_id is None
     assert value_input.option_ref is None
     assert payload["option_id"] is None
@@ -4529,12 +4528,12 @@ async def test_set_case_dropdown_value_requires_definition(monkeypatch):
     async def _resolve(_workspace_id):
         return uuid.uuid4(), SimpleNamespace()
 
-    async def _apply_values(cid, values):
-        raise AssertionError("apply_values should not be called")
+    async def _set_value_from_input(cid, value):
+        raise AssertionError("set_value_from_input should not be called")
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
     _patch_dropdown_values_service(
-        monkeypatch, SimpleNamespace(apply_values=_apply_values)
+        monkeypatch, SimpleNamespace(set_value_from_input=_set_value_from_input)
     )
 
     with pytest.raises(ToolError, match="exactly one of definition_id"):
@@ -4550,12 +4549,12 @@ async def test_set_case_dropdown_value_not_entitled(monkeypatch):
     async def _resolve(_workspace_id):
         return uuid.uuid4(), SimpleNamespace()
 
-    async def _apply_values(cid, values):
+    async def _set_value_from_input(cid, value):
         raise EntitlementRequired("case_addons")
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
     _patch_dropdown_values_service(
-        monkeypatch, SimpleNamespace(apply_values=_apply_values)
+        monkeypatch, SimpleNamespace(set_value_from_input=_set_value_from_input)
     )
 
     with pytest.raises(ToolError, match="requires an upgraded plan"):

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -38,6 +38,8 @@ from tracecat.agent.skill.schemas import (
 from tracecat.agent.stream.events import StreamDelta, StreamEnd
 from tracecat.exceptions import (
     BuiltinRegistryHasNoSelectionError,
+    EntitlementRequired,
+    TracecatNotFoundError,
     TracecatValidationError,
 )
 from tracecat.expressions.common import ExprType
@@ -4027,6 +4029,599 @@ async def test_update_case_field_parses_type_and_options(monkeypatch):
     assert str(captured["type"]) == "MULTI_SELECT"
     assert captured["options"] == ["p1", "p2"]
     assert "updated successfully" in payload["message"]
+
+
+# ---------------------------------------------------------------------------
+# Case dropdown tests
+# ---------------------------------------------------------------------------
+
+
+def _fake_dropdown_definition(**overrides: Any) -> SimpleNamespace:
+    defaults: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "name": "Threat Level",
+        "ref": "threat_level",
+        "icon_name": None,
+        "is_ordered": True,
+        "required_on_closure": False,
+        "position": 0,
+        "options": [],
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _fake_dropdown_option(**overrides: Any) -> SimpleNamespace:
+    defaults: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "label": "High",
+        "ref": "high",
+        "icon_name": None,
+        "color": None,
+        "position": 0,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _patch_dropdown_definitions_service(monkeypatch, service: SimpleNamespace) -> None:
+    monkeypatch.setattr(
+        mcp_server,
+        "CaseDropdownDefinitionsService",
+        SimpleNamespace(with_session=lambda role: _AsyncContext(service)),
+    )
+
+
+def _patch_dropdown_values_service(monkeypatch, service: SimpleNamespace) -> None:
+    monkeypatch.setattr(
+        mcp_server,
+        "CaseDropdownValuesService",
+        SimpleNamespace(with_session=lambda role: _AsyncContext(service)),
+    )
+
+
+@pytest.mark.anyio
+async def test_list_case_dropdowns(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    definitions = [
+        _fake_dropdown_definition(
+            options=[
+                _fake_dropdown_option(label="Low", ref="low", position=0),
+                _fake_dropdown_option(label="High", ref="high", position=1),
+            ]
+        ),
+        _fake_dropdown_definition(name="Disposition", ref="disposition", position=1),
+    ]
+
+    async def _list_definitions():
+        return definitions
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_definitions_service(
+        monkeypatch, SimpleNamespace(list_definitions=_list_definitions)
+    )
+
+    result = await _tool(mcp_server.list_case_dropdowns)(workspace_id=str(uuid.uuid4()))
+    payload = _payload(result)
+    assert payload["has_more"] is False
+    assert len(payload["items"]) == 2
+    assert payload["items"][0]["name"] == "Threat Level"
+    assert payload["items"][0]["ref"] == "threat_level"
+    assert payload["items"][0]["is_ordered"] is True
+    assert payload["items"][0]["required_on_closure"] is False
+    assert payload["items"][0]["options"][0]["label"] == "Low"
+    assert payload["items"][0]["options"][1]["ref"] == "high"
+    assert payload["items"][1]["ref"] == "disposition"
+
+
+@pytest.mark.anyio
+async def test_create_case_dropdown_slugifies_refs(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    captured: dict[str, Any] = {}
+
+    async def _create_definition(params):
+        captured["params"] = params
+        return _fake_dropdown_definition(
+            name=params.name,
+            ref=params.ref,
+            options=[
+                _fake_dropdown_option(
+                    label=opt.label, ref=opt.ref, position=opt.position
+                )
+                for opt in params.options
+            ],
+        )
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_definitions_service(
+        monkeypatch, SimpleNamespace(create_definition=_create_definition)
+    )
+
+    result = await _tool(mcp_server.create_case_dropdown)(
+        workspace_id=str(uuid.uuid4()),
+        name="Threat Level",
+        options=[
+            mcp_server.CaseDropdownOptionInput(label="Very High!"),
+            mcp_server.CaseDropdownOptionInput(label="Low"),
+        ],
+    )
+    payload = _payload(result)
+    params = captured["params"]
+    assert params.ref == "threat_level"
+    assert params.options[0].ref == "very_high"
+    assert params.options[0].position == 0
+    assert params.options[1].ref == "low"
+    assert params.options[1].position == 1
+    assert payload["ref"] == "threat_level"
+    assert payload["options"][0]["ref"] == "very_high"
+
+
+@pytest.mark.anyio
+async def test_create_case_dropdown_explicit_ref_passthrough(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    captured: dict[str, Any] = {}
+
+    async def _create_definition(params):
+        captured["params"] = params
+        return _fake_dropdown_definition(name=params.name, ref=params.ref)
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_definitions_service(
+        monkeypatch, SimpleNamespace(create_definition=_create_definition)
+    )
+
+    await _tool(mcp_server.create_case_dropdown)(
+        workspace_id=str(uuid.uuid4()),
+        name="Threat Level",
+        ref="custom_ref",
+        options=[
+            mcp_server.CaseDropdownOptionInput(
+                label="High", ref="explicit_high", position=7
+            )
+        ],
+    )
+    params = captured["params"]
+    assert params.ref == "custom_ref"
+    assert params.options[0].ref == "explicit_high"
+    assert params.options[0].position == 7
+
+
+@pytest.mark.anyio
+async def test_create_case_dropdown_invalid_name(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    async def _create_definition(params):
+        raise AssertionError("create_definition should not be called")
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_definitions_service(
+        monkeypatch, SimpleNamespace(create_definition=_create_definition)
+    )
+
+    with pytest.raises(ToolError, match="valid reference"):
+        await _tool(mcp_server.create_case_dropdown)(
+            workspace_id=str(uuid.uuid4()),
+            name="!!!",
+        )
+
+
+@pytest.mark.anyio
+async def test_update_case_dropdown_partial(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    definition = _fake_dropdown_definition()
+    captured: dict[str, Any] = {}
+
+    async def _get_definition(definition_id):
+        return definition
+
+    async def _update_definition(defn, params):
+        captured["params"] = params
+        return _fake_dropdown_definition(name="New Name", ref="new_name")
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_definitions_service(
+        monkeypatch,
+        SimpleNamespace(
+            get_definition=_get_definition, update_definition=_update_definition
+        ),
+    )
+
+    result = await _tool(mcp_server.update_case_dropdown)(
+        workspace_id=str(uuid.uuid4()),
+        dropdown_id=str(definition.id),
+        name="New Name",
+    )
+    payload = _payload(result)
+    assert captured["params"].model_dump(exclude_unset=True) == {"name": "New Name"}
+    assert payload["name"] == "New Name"
+
+
+@pytest.mark.anyio
+async def test_update_case_dropdown_not_found(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    async def _get_definition(definition_id):
+        raise TracecatNotFoundError(f"Dropdown definition {definition_id} not found")
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_definitions_service(
+        monkeypatch, SimpleNamespace(get_definition=_get_definition)
+    )
+
+    with pytest.raises(ToolError, match="not found"):
+        await _tool(mcp_server.update_case_dropdown)(
+            workspace_id=str(uuid.uuid4()),
+            dropdown_id=str(uuid.uuid4()),
+            name="New Name",
+        )
+
+
+@pytest.mark.anyio
+async def test_delete_case_dropdown(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    definition = _fake_dropdown_definition()
+    deleted: list[Any] = []
+
+    async def _get_definition(definition_id):
+        return definition
+
+    async def _delete_definition(defn):
+        deleted.append(defn)
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_definitions_service(
+        monkeypatch,
+        SimpleNamespace(
+            get_definition=_get_definition, delete_definition=_delete_definition
+        ),
+    )
+
+    result = await _tool(mcp_server.delete_case_dropdown)(
+        workspace_id=str(uuid.uuid4()),
+        dropdown_id=str(definition.id),
+    )
+    payload = _payload(result)
+    assert "deleted successfully" in payload["message"]
+    assert deleted == [definition]
+
+
+@pytest.mark.anyio
+async def test_add_case_dropdown_option_defaults(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    definition = _fake_dropdown_definition(
+        options=[
+            _fake_dropdown_option(label="Low", ref="low", position=0),
+            _fake_dropdown_option(label="Medium", ref="medium", position=1),
+        ]
+    )
+    captured: dict[str, Any] = {}
+
+    async def _get_definition(definition_id):
+        return definition
+
+    async def _add_option(definition_id, params):
+        captured["definition_id"] = definition_id
+        captured["params"] = params
+        return _fake_dropdown_option(
+            label=params.label, ref=params.ref, position=params.position
+        )
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_definitions_service(
+        monkeypatch,
+        SimpleNamespace(get_definition=_get_definition, add_option=_add_option),
+    )
+
+    result = await _tool(mcp_server.add_case_dropdown_option)(
+        workspace_id=str(uuid.uuid4()),
+        dropdown_id=str(definition.id),
+        label="Very High!",
+    )
+    payload = _payload(result)
+    params = captured["params"]
+    assert captured["definition_id"] == definition.id
+    assert params.ref == "very_high"
+    assert params.position == 2
+    assert payload["label"] == "Very High!"
+    assert payload["ref"] == "very_high"
+
+
+@pytest.mark.anyio
+async def test_update_case_dropdown_option(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    definition = _fake_dropdown_definition()
+    option_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+
+    async def _get_definition(definition_id):
+        return definition
+
+    async def _update_option(oid, params):
+        captured["option_id"] = oid
+        captured["params"] = params
+        return _fake_dropdown_option(id=oid, label="Renamed", color="red")
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_definitions_service(
+        monkeypatch,
+        SimpleNamespace(get_definition=_get_definition, update_option=_update_option),
+    )
+
+    result = await _tool(mcp_server.update_case_dropdown_option)(
+        workspace_id=str(uuid.uuid4()),
+        dropdown_id=str(definition.id),
+        option_id=str(option_id),
+        label="Renamed",
+        color="red",
+    )
+    payload = _payload(result)
+    assert captured["option_id"] == option_id
+    assert captured["params"].model_dump(exclude_unset=True) == {
+        "label": "Renamed",
+        "color": "red",
+    }
+    assert payload["label"] == "Renamed"
+
+
+@pytest.mark.anyio
+async def test_delete_case_dropdown_option(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    definition = _fake_dropdown_definition()
+    option_id = uuid.uuid4()
+    deleted: list[uuid.UUID] = []
+
+    async def _get_definition(definition_id):
+        return definition
+
+    async def _delete_option(oid):
+        deleted.append(oid)
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_definitions_service(
+        monkeypatch,
+        SimpleNamespace(get_definition=_get_definition, delete_option=_delete_option),
+    )
+
+    result = await _tool(mcp_server.delete_case_dropdown_option)(
+        workspace_id=str(uuid.uuid4()),
+        dropdown_id=str(definition.id),
+        option_id=str(option_id),
+    )
+    payload = _payload(result)
+    assert "deleted successfully" in payload["message"]
+    assert deleted == [option_id]
+
+
+@pytest.mark.anyio
+async def test_set_case_dropdown_value_by_ref(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    case_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+    value_read = mcp_server.CaseDropdownValueRead(
+        id=uuid.uuid4(),
+        definition_id=uuid.uuid4(),
+        definition_ref="threat_level",
+        definition_name="Threat Level",
+        option_id=uuid.uuid4(),
+        option_label="High",
+        option_ref="high",
+    )
+
+    async def _apply_values(cid, values):
+        captured["case_id"] = cid
+        captured["values"] = values
+        return [value_read]
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_values_service(
+        monkeypatch, SimpleNamespace(apply_values=_apply_values)
+    )
+
+    result = await _tool(mcp_server.set_case_dropdown_value)(
+        workspace_id=str(uuid.uuid4()),
+        case_id=str(case_id),
+        definition_ref="threat_level",
+        option_ref="high",
+    )
+    payload = _payload(result)
+    assert captured["case_id"] == case_id
+    assert len(captured["values"]) == 1
+    value_input = captured["values"][0]
+    assert value_input.definition_ref == "threat_level"
+    assert value_input.option_ref == "high"
+    assert value_input.definition_id is None
+    assert value_input.option_id is None
+    assert payload["definition_ref"] == "threat_level"
+    assert payload["option_label"] == "High"
+
+
+@pytest.mark.anyio
+async def test_set_case_dropdown_value_clears(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    case_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+    value_read = mcp_server.CaseDropdownValueRead(
+        id=uuid.uuid4(),
+        definition_id=uuid.uuid4(),
+        definition_ref="threat_level",
+        definition_name="Threat Level",
+    )
+
+    async def _apply_values(cid, values):
+        captured["values"] = values
+        return [value_read]
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_values_service(
+        monkeypatch, SimpleNamespace(apply_values=_apply_values)
+    )
+
+    result = await _tool(mcp_server.set_case_dropdown_value)(
+        workspace_id=str(uuid.uuid4()),
+        case_id=str(case_id),
+        definition_ref="threat_level",
+    )
+    payload = _payload(result)
+    value_input = captured["values"][0]
+    assert value_input.option_id is None
+    assert value_input.option_ref is None
+    assert payload["option_id"] is None
+    assert payload["option_label"] is None
+
+
+@pytest.mark.anyio
+async def test_set_case_dropdown_value_requires_definition(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    async def _apply_values(cid, values):
+        raise AssertionError("apply_values should not be called")
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_values_service(
+        monkeypatch, SimpleNamespace(apply_values=_apply_values)
+    )
+
+    with pytest.raises(ToolError, match="exactly one of definition_id"):
+        await _tool(mcp_server.set_case_dropdown_value)(
+            workspace_id=str(uuid.uuid4()),
+            case_id=str(uuid.uuid4()),
+            option_ref="high",
+        )
+
+
+@pytest.mark.anyio
+async def test_set_case_dropdown_value_not_entitled(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    async def _apply_values(cid, values):
+        raise EntitlementRequired("case_addons")
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_values_service(
+        monkeypatch, SimpleNamespace(apply_values=_apply_values)
+    )
+
+    with pytest.raises(ToolError, match="requires an upgraded plan"):
+        await _tool(mcp_server.set_case_dropdown_value)(
+            workspace_id=str(uuid.uuid4()),
+            case_id=str(uuid.uuid4()),
+            definition_ref="threat_level",
+            option_ref="high",
+        )
+
+
+@pytest.mark.anyio
+async def test_create_case_with_dropdown_values(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    case_id = uuid.uuid4()
+    captured: dict[str, Any] = {}
+
+    async def _create_case(params):
+        captured["params"] = params
+        return SimpleNamespace(id=case_id, short_id="CASE-0007")
+
+    cases_service = SimpleNamespace(create_case=_create_case)
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server,
+        "CasesService",
+        SimpleNamespace(with_session=lambda role: _AsyncContext(cases_service)),
+    )
+
+    result = await _tool(mcp_server.create_case)(
+        workspace_id=str(uuid.uuid4()),
+        summary="Dropdown incident",
+        description="With dropdowns",
+        status="new",
+        priority="high",
+        severity="medium",
+        dropdown_values=[
+            mcp_server.CaseDropdownValueInput(
+                definition_ref="threat_level", option_ref="high"
+            )
+        ],
+    )
+    payload = _payload(result)
+    assert "created successfully" in payload["message"]
+    params = captured["params"]
+    assert params.dropdown_values is not None
+    assert params.dropdown_values[0].definition_ref == "threat_level"
+    assert params.dropdown_values[0].option_ref == "high"
+
+
+@pytest.mark.anyio
+async def test_update_case_with_dropdown_values(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    case_id = uuid.uuid4()
+    case = SimpleNamespace(id=case_id)
+    captured: dict[str, Any] = {}
+
+    async def _get_case(parsed_id, **kwargs):
+        return case
+
+    async def _update_case(c, params):
+        captured["params"] = params
+        return c
+
+    cases_service = SimpleNamespace(get_case=_get_case, update_case=_update_case)
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    monkeypatch.setattr(
+        mcp_server,
+        "CasesService",
+        SimpleNamespace(with_session=lambda role: _AsyncContext(cases_service)),
+    )
+
+    await _tool(mcp_server.update_case)(
+        workspace_id=str(uuid.uuid4()),
+        case_id=str(case_id),
+        dropdown_values=[
+            mcp_server.CaseDropdownValueInput(
+                definition_ref="threat_level", option_ref="high"
+            )
+        ],
+    )
+    params = captured["params"]
+    assert params.dropdown_values is not None
+    assert params.dropdown_values[0].definition_ref == "threat_level"
+
+    captured.clear()
+    await _tool(mcp_server.update_case)(
+        workspace_id=str(uuid.uuid4()),
+        case_id=str(case_id),
+        summary="No dropdown change",
+    )
+    params = captured["params"]
+    assert "dropdown_values" not in params.model_dump(exclude_unset=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -39,6 +39,7 @@ from tracecat.agent.stream.events import StreamDelta, StreamEnd
 from tracecat.exceptions import (
     BuiltinRegistryHasNoSelectionError,
     EntitlementRequired,
+    ScopeDeniedError,
     TracecatNotFoundError,
     TracecatValidationError,
 )
@@ -4295,6 +4296,36 @@ async def test_delete_case_dropdown(monkeypatch):
     payload = _payload(result)
     assert "deleted successfully" in payload["message"]
     assert deleted == [definition]
+
+
+@pytest.mark.anyio
+async def test_delete_case_dropdown_missing_scope(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    definition = _fake_dropdown_definition()
+
+    async def _get_definition(definition_id):
+        return definition
+
+    async def _delete_definition(defn):
+        raise ScopeDeniedError(
+            required_scopes=["case:delete"], missing_scopes=["case:delete"]
+        )
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_definitions_service(
+        monkeypatch,
+        SimpleNamespace(
+            get_definition=_get_definition, delete_definition=_delete_definition
+        ),
+    )
+
+    with pytest.raises(ToolError, match="Missing required scope: case:delete"):
+        await _tool(mcp_server.delete_case_dropdown)(
+            workspace_id=str(uuid.uuid4()),
+            dropdown_id=str(definition.id),
+        )
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -4118,6 +4118,25 @@ async def test_list_case_dropdowns(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_list_case_dropdowns_missing_scope(monkeypatch):
+    async def _resolve(_workspace_id):
+        return uuid.uuid4(), SimpleNamespace()
+
+    async def _list_definitions():
+        raise ScopeDeniedError(
+            required_scopes=["case:read"], missing_scopes=["case:read"]
+        )
+
+    monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
+    _patch_dropdown_definitions_service(
+        monkeypatch, SimpleNamespace(list_definitions=_list_definitions)
+    )
+
+    with pytest.raises(ToolError, match="Missing required scope: case:read"):
+        await _tool(mcp_server.list_case_dropdowns)(workspace_id=str(uuid.uuid4()))
+
+
+@pytest.mark.anyio
 async def test_create_case_dropdown_slugifies_refs(monkeypatch):
     async def _resolve(_workspace_id):
         return uuid.uuid4(), SimpleNamespace()

--- a/tracecat/cases/dropdowns/router.py
+++ b/tracecat/cases/dropdowns/router.py
@@ -193,7 +193,7 @@ async def update_dropdown_option(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(err)
         ) from err
     try:
-        option = await service.update_option(option_id, params)
+        option = await service.update_option(definition_id, option_id, params)
     except TracecatNotFoundError as err:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(err)
@@ -228,7 +228,7 @@ async def delete_dropdown_option(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(err)
         ) from err
     try:
-        await service.delete_option(option_id)
+        await service.delete_option(definition_id, option_id)
     except TracecatNotFoundError as err:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(err)

--- a/tracecat/cases/dropdowns/service.py
+++ b/tracecat/cases/dropdowns/service.py
@@ -173,8 +173,10 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
 
     # --- Option CRUD ---
 
-    async def _get_option(self, option_id: uuid.UUID) -> CaseDropdownOption:
-        """Get an option by ID, scoped to the current workspace."""
+    async def _get_option(
+        self, definition_id: uuid.UUID, option_id: uuid.UUID
+    ) -> CaseDropdownOption:
+        """Get an option by ID, scoped to the definition and current workspace."""
         stmt = (
             select(CaseDropdownOption)
             .join(
@@ -183,13 +185,16 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
             )
             .where(
                 CaseDropdownOption.id == option_id,
+                CaseDropdownOption.definition_id == definition_id,
                 CaseDropdownDefinition.workspace_id == self.workspace_id,
             )
         )
         result = await self.session.execute(stmt)
         option = result.scalar_one_or_none()
         if option is None:
-            raise TracecatNotFoundError(f"Dropdown option {option_id} not found")
+            raise TracecatNotFoundError(
+                f"Dropdown option {option_id} not found for definition {definition_id}"
+            )
         return option
 
     @requires_entitlement(Entitlement.CASE_ADDONS)
@@ -221,11 +226,12 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def update_option(
         self,
+        definition_id: uuid.UUID,
         option_id: uuid.UUID,
         params: CaseDropdownOptionUpdate,
     ) -> CaseDropdownOption:
-        """Update a dropdown option."""
-        option = await self._get_option(option_id)
+        """Update a dropdown option belonging to the given definition."""
+        option = await self._get_option(definition_id, option_id)
         for key, value in params.model_dump(exclude_unset=True).items():
             setattr(option, key, value)
         try:
@@ -239,9 +245,11 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
         return option
 
     @requires_entitlement(Entitlement.CASE_ADDONS)
-    async def delete_option(self, option_id: uuid.UUID) -> None:
-        """Delete a dropdown option."""
-        option = await self._get_option(option_id)
+    async def delete_option(
+        self, definition_id: uuid.UUID, option_id: uuid.UUID
+    ) -> None:
+        """Delete a dropdown option belonging to the given definition."""
+        option = await self._get_option(definition_id, option_id)
         await self.session.delete(option)
         await self.session.commit()
 

--- a/tracecat/cases/dropdowns/service.py
+++ b/tracecat/cases/dropdowns/service.py
@@ -515,6 +515,40 @@ class CaseDropdownValuesService(BaseWorkspaceService):
             await self.session.flush()
         return result
 
+    @require_scope("case:update")
+    @requires_entitlement(Entitlement.CASE_ADDONS)
+    async def set_value_from_input(
+        self,
+        case_id: uuid.UUID,
+        value: CaseDropdownValueInput,
+        *,
+        commit: bool = True,
+    ) -> CaseDropdownValueRead:
+        """Resolve identifiers and set or clear a single dropdown value on a case."""
+        case = await self._get_case(case_id)
+        definition_id = await self._resolve_definition_id(
+            definition_id=value.definition_id,
+            definition_ref=value.definition_ref,
+        )
+        option_id = await self._resolve_option_id(
+            definition_id=definition_id,
+            option_id=value.option_id,
+            option_ref=value.option_ref,
+        )
+        result = await self._set_value(
+            case=case,
+            definition_id=definition_id,
+            params=CaseDropdownValueSet(option_id=option_id),
+        )
+        if commit:
+            await self.session.commit()
+        else:
+            await self.session.flush()
+        return result
+
+    # Note: dual create/update scope because this serves both the case-create
+    # and case-update paths, whose CasesService callers enforce the specific
+    # scope. Direct value updates must use set_value or set_value_from_input.
     @require_scope("case:create", "case:update", require_all=False)
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def apply_values(

--- a/tracecat/cases/dropdowns/service.py
+++ b/tracecat/cases/dropdowns/service.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
+from tracecat.authz.controls import require_scope
 from tracecat.cases.dropdowns.schemas import (
     CaseDropdownDefinitionCreate,
     CaseDropdownDefinitionUpdate,
@@ -84,6 +85,7 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
             )
         return definition
 
+    @require_scope("case:create")
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def create_definition(
         self, params: CaseDropdownDefinitionCreate
@@ -122,6 +124,7 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
         await self.session.refresh(definition)
         return definition
 
+    @require_scope("case:update")
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def update_definition(
         self,
@@ -165,6 +168,7 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
         await self.session.refresh(definition)
         return definition
 
+    @require_scope("case:delete")
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def delete_definition(self, definition: CaseDropdownDefinition) -> None:
         """Delete a dropdown definition and all associated options/values."""
@@ -197,6 +201,7 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
             )
         return option
 
+    @require_scope("case:create")
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def add_option(
         self,
@@ -223,6 +228,7 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
         await self.session.refresh(option)
         return option
 
+    @require_scope("case:update")
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def update_option(
         self,
@@ -244,6 +250,7 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
         await self.session.refresh(option)
         return option
 
+    @require_scope("case:delete")
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def delete_option(
         self, definition_id: uuid.UUID, option_id: uuid.UUID
@@ -253,6 +260,7 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
         await self.session.delete(option)
         await self.session.commit()
 
+    @require_scope("case:update")
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def reorder_options(
         self, definition_id: uuid.UUID, option_ids: list[uuid.UUID]
@@ -484,6 +492,7 @@ class CaseDropdownValuesService(BaseWorkspaceService):
             option_color=new_option.color if new_option else None,
         )
 
+    @require_scope("case:update")
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def set_value(
         self,
@@ -506,6 +515,7 @@ class CaseDropdownValuesService(BaseWorkspaceService):
             await self.session.flush()
         return result
 
+    @require_scope("case:create", "case:update", require_all=False)
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def apply_values(
         self,

--- a/tracecat/cases/dropdowns/service.py
+++ b/tracecat/cases/dropdowns/service.py
@@ -35,6 +35,7 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
 
     service_name = "case_dropdown_definitions"
 
+    @require_scope("case:read")
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def list_definitions(self) -> Sequence[CaseDropdownDefinition]:
         """List all dropdown definitions for the workspace, ordered by position."""
@@ -47,6 +48,7 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         return result.scalars().all()
 
+    @require_scope("case:read")
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def get_definition(self, definition_id: uuid.UUID) -> CaseDropdownDefinition:
         """Get a single dropdown definition by ID."""
@@ -66,6 +68,7 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
             )
         return definition
 
+    @require_scope("case:read")
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def get_definition_by_ref(self, ref: str) -> CaseDropdownDefinition:
         """Get a single dropdown definition by its slug ref."""

--- a/tracecat/cases/dropdowns/service.py
+++ b/tracecat/cases/dropdowns/service.py
@@ -55,7 +55,12 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         return result.scalars().all()
 
-    @require_scope("case:read")
+    # Any case scope may fetch a definition: mutation flows (REST handlers and
+    # MCP tools) look up the definition first, so requiring case:read alone
+    # would block write-only roles.
+    @require_scope(
+        "case:read", "case:create", "case:update", "case:delete", require_all=False
+    )
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def get_definition(self, definition_id: uuid.UUID) -> CaseDropdownDefinition:
         """Get a single dropdown definition by ID."""
@@ -75,7 +80,9 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
             )
         return definition
 
-    @require_scope("case:read")
+    @require_scope(
+        "case:read", "case:create", "case:update", "case:delete", require_all=False
+    )
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def get_definition_by_ref(self, ref: str) -> CaseDropdownDefinition:
         """Get a single dropdown definition by its slug ref."""

--- a/tracecat/cases/dropdowns/service.py
+++ b/tracecat/cases/dropdowns/service.py
@@ -43,7 +43,14 @@ class CaseDropdownDefinitionsService(BaseWorkspaceService):
             select(CaseDropdownDefinition)
             .where(CaseDropdownDefinition.workspace_id == self.workspace_id)
             .options(selectinload(CaseDropdownDefinition.options))
-            .order_by(CaseDropdownDefinition.position)
+            # Deterministic insertion-order tiebreaker: position defaults to 0,
+            # and offset pagination over an unstable order can duplicate or
+            # drop items. created_at is unsuitable because now() is pinned
+            # within a transaction.
+            .order_by(
+                CaseDropdownDefinition.position,
+                CaseDropdownDefinition.surrogate_id,
+            )
         )
         result = await self.session.execute(stmt)
         return result.scalars().all()

--- a/tracecat/mcp/README.md
+++ b/tracecat/mcp/README.md
@@ -96,6 +96,28 @@ Case field and table `type` values are:
 - `SELECT`
 - `MULTI_SELECT`
 
+## Case dropdown tools
+
+- `list_case_dropdowns(workspace_id, limit=20, cursor=None)` returns dropdown definitions with embedded `options`
+- `create_case_dropdown(workspace_id, name, ref=None, icon_name=None, is_ordered=False, required_on_closure=False, position=0, options=None)`
+- `update_case_dropdown(workspace_id, dropdown_id, name=None, ref=None, icon_name=None, is_ordered=None, required_on_closure=None, position=None)`
+- `delete_case_dropdown(workspace_id, dropdown_id)` deletes the definition with all its options and per-case values
+- `add_case_dropdown_option(workspace_id, dropdown_id, label, ref=None, icon_name=None, color=None, position=None)`
+- `update_case_dropdown_option(workspace_id, dropdown_id, option_id, label=None, ref=None, icon_name=None, color=None, position=None)`
+- `delete_case_dropdown_option(workspace_id, dropdown_id, option_id)`
+- `set_case_dropdown_value(workspace_id, case_id, definition_id=None, definition_ref=None, option_id=None, option_ref=None)`
+
+Notes:
+
+- All case dropdown tools require the case add-ons entitlement.
+- Dropdown and option `ref` values default to the slugified name or label
+  (e.g. `Threat Level` becomes `threat_level`).
+- `set_case_dropdown_value` takes exactly one of `definition_id` or
+  `definition_ref`, and at most one of `option_id` or `option_ref`; omitting
+  both option arguments clears the value.
+- `create_case` and `update_case` accept a `dropdown_values` list with the
+  same per-item identifier rules to set dropdown values in the same call.
+
 ## Table tools
 
 - `list_tables(workspace_id, limit=20, cursor=None)`

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -82,8 +82,20 @@ from tracecat.agent.types import OutputType
 from tracecat.auth.schemas import UserRead
 from tracecat.auth.types import Role
 from tracecat.auth.users import search_users
-from tracecat.cases.dropdowns.schemas import CaseDropdownValueRead
-from tracecat.cases.dropdowns.service import CaseDropdownValuesService
+from tracecat.cases.dropdowns.schemas import (
+    CaseDropdownDefinitionCreate,
+    CaseDropdownDefinitionRead,
+    CaseDropdownDefinitionUpdate,
+    CaseDropdownOptionCreate,
+    CaseDropdownOptionRead,
+    CaseDropdownOptionUpdate,
+    CaseDropdownValueInput,
+    CaseDropdownValueRead,
+)
+from tracecat.cases.dropdowns.service import (
+    CaseDropdownDefinitionsService,
+    CaseDropdownValuesService,
+)
 from tracecat.cases.enums import (
     CaseEventType,
     CaseFieldKind,
@@ -140,6 +152,7 @@ from tracecat.dsl.validation import (
 )
 from tracecat.exceptions import (
     BuiltinRegistryHasNoSelectionError,
+    EntitlementRequired,
     RegistryActionValidationError,
     RegistryError,
     ScopeDeniedError,
@@ -787,6 +800,23 @@ class MCPMessageResponse(BaseModel):
     """Common message-only MCP response."""
 
     message: str
+
+
+class CaseDropdownOptionInput(BaseModel):
+    """Option payload for MCP case dropdown creation."""
+
+    label: str = Field(min_length=1, max_length=255)
+    ref: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=255,
+        description="Slug identifier. Defaults to the slugified label.",
+    )
+    icon_name: str | None = Field(default=None, max_length=100)
+    color: str | None = Field(default=None, max_length=50)
+    position: int | None = Field(
+        default=None, description="Sort position. Defaults to the list order."
+    )
 
 
 class WorkspaceSummaryResponse(BaseModel):
@@ -3757,6 +3787,24 @@ def _case_tag_payload(tag: Any) -> CaseTagRead:
     return CaseTagRead.model_validate(tag, from_attributes=True)
 
 
+def _case_dropdown_definition_payload(definition: Any) -> CaseDropdownDefinitionRead:
+    """Serialize a case dropdown definition with its options."""
+    return CaseDropdownDefinitionRead.model_validate(definition, from_attributes=True)
+
+
+def _case_dropdown_option_payload(option: Any) -> CaseDropdownOptionRead:
+    """Serialize a case dropdown option."""
+    return CaseDropdownOptionRead.model_validate(option, from_attributes=True)
+
+
+def _slugify_dropdown_ref(value: str, *, field_name: str) -> str:
+    """Slugify a display name into a dropdown ref, matching the UI behavior."""
+    ref = slugify(value, separator="_")
+    if not ref:
+        raise ToolError(f"{field_name} must produce a valid reference")
+    return ref
+
+
 def _case_full_payload(
     case: Any,
     *,
@@ -6345,6 +6393,7 @@ async def create_case(
     payload: dict[str, Any] | None = None,
     tags: list[str] | None = None,
     create_missing_tags: bool = False,
+    dropdown_values: list[CaseDropdownValueInput] | None = None,
 ) -> CaseCreatedResponse:
     """Create a new case.
 
@@ -6365,6 +6414,10 @@ async def create_case(
         tags: Optional tag identifiers (IDs or refs) to add to the case.
         create_missing_tags: If true, automatically create any tags that do
             not already exist. Defaults to false.
+        dropdown_values: Optional dropdown selections. Each item provides
+            exactly one of `definition_id`/`definition_ref` and at most one
+            of `option_id`/`option_ref` (omit both to clear). Requires the
+            case add-ons entitlement.
 
     Returns JSON with a confirmation message and the created case ID.
     """
@@ -6383,6 +6436,7 @@ async def create_case(
             assignee_id=assignee_id,
             fields=fields,
             payload=payload,
+            dropdown_values=dropdown_values,
         )
 
         async with CasesService.with_session(role=role) as svc:
@@ -6401,6 +6455,12 @@ async def create_case(
             )
     except ToolError:
         raise
+    except EntitlementRequired as e:
+        raise ToolError(str(e)) from e
+    except TracecatNotFoundError as e:
+        raise ToolError(str(e)) from e
+    except TracecatValidationError as e:
+        raise ToolError(str(e)) from e
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -6422,6 +6482,7 @@ async def update_case(
     payload: dict[str, Any] | None = None,
     tags: list[str] | None = None,
     create_missing_tags: bool = False,
+    dropdown_values: list[CaseDropdownValueInput] | None = None,
 ) -> MCPMessageResponse:
     """Update a case. Only provided fields are changed.
 
@@ -6443,6 +6504,10 @@ async def update_case(
             Replaces all existing tags.
         create_missing_tags: If true, automatically create any tags that do
             not already exist. Defaults to false.
+        dropdown_values: Optional dropdown selections to apply. Each item
+            provides exactly one of `definition_id`/`definition_ref` and at
+            most one of `option_id`/`option_ref` (omit both to clear).
+            Requires the case add-ons entitlement.
 
     Returns a confirmation message.
     """
@@ -6470,6 +6535,8 @@ async def update_case(
             update_kwargs["fields"] = fields
         if payload is not None:
             update_kwargs["payload"] = payload
+        if dropdown_values is not None:
+            update_kwargs["dropdown_values"] = dropdown_values
 
         params = CaseUpdate(**update_kwargs)
 
@@ -6491,6 +6558,10 @@ async def update_case(
             return MCPMessageResponse(message=f"Case {case_id} updated successfully")
     except ToolError:
         raise
+    except EntitlementRequired as e:
+        raise ToolError(str(e)) from e
+    except TracecatNotFoundError as e:
+        raise ToolError(str(e)) from e
     except TracecatValidationError as e:
         raise ToolError(str(e)) from e
     except ValueError as e:
@@ -7463,6 +7534,434 @@ async def update_case_field(
     except Exception as e:
         logger.error("Failed to update case field", error=str(e))
         raise ToolError(f"Failed to update case field: {e}") from None
+
+
+# ---------------------------------------------------------------------------
+# Case Dropdowns
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def list_case_dropdowns(
+    workspace_id: uuid.UUID,
+    limit: int = config.TRACECAT__LIMIT_DEFAULT,
+    cursor: str | None = None,
+) -> MCPPaginatedResponse[CaseDropdownDefinitionRead]:
+    """List case dropdown definitions in a workspace. Requires the case
+    add-ons entitlement.
+
+    Returns a paginated JSON array of dropdown objects with `id`, `name`,
+    `ref`, `icon_name`, `is_ordered`, `required_on_closure`, `position`, and
+    embedded `options`.
+    """
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        async with CaseDropdownDefinitionsService.with_session(role=role) as svc:
+            definitions = await svc.list_definitions()
+            page = _paginate_items(
+                [_case_dropdown_definition_payload(d) for d in definitions],
+                tool_name="list_case_dropdowns",
+                limit=_normalize_limit(
+                    limit,
+                    default=config.TRACECAT__LIMIT_DEFAULT,
+                    max_limit=config.TRACECAT__LIMIT_CURSOR_MAX,
+                ),
+                cursor=cursor,
+            )
+            return page
+    except ToolError:
+        raise
+    except EntitlementRequired as e:
+        raise ToolError(str(e)) from e
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to list case dropdowns", error=str(e))
+        raise ToolError(f"Failed to list case dropdowns: {e}") from None
+
+
+@mcp.tool()
+async def create_case_dropdown(
+    workspace_id: uuid.UUID,
+    name: str,
+    ref: str | None = None,
+    icon_name: str | None = None,
+    is_ordered: bool = False,
+    required_on_closure: bool = False,
+    position: int = 0,
+    options: list[CaseDropdownOptionInput] | None = None,
+) -> CaseDropdownDefinitionRead:
+    """Create a case dropdown definition with optional initial options.
+    Requires the case add-ons entitlement.
+
+    Args:
+        workspace_id: The workspace ID.
+        name: Display name for the dropdown.
+        ref: Optional slug identifier. Defaults to the slugified name
+            (e.g. "Threat Level" -> "threat_level").
+        icon_name: Optional icon name.
+        is_ordered: Whether option order is semantically meaningful.
+        required_on_closure: Whether a value is required to close a case.
+        position: Sort position among the workspace dropdowns.
+        options: Optional initial options. Each option's `ref` defaults to
+            its slugified label and `position` defaults to its list order.
+
+    Returns JSON with the created dropdown definition and its options.
+    """
+
+    try:
+        _, role = await _resolve_workspace_role(workspace_id)
+        resolved_ref = ref or _slugify_dropdown_ref(name, field_name="name")
+        option_params = [
+            CaseDropdownOptionCreate(
+                label=opt.label,
+                ref=opt.ref or _slugify_dropdown_ref(opt.label, field_name="label"),
+                icon_name=opt.icon_name,
+                color=opt.color,
+                position=opt.position if opt.position is not None else idx,
+            )
+            for idx, opt in enumerate(options or [])
+        ]
+        params = CaseDropdownDefinitionCreate(
+            name=name,
+            ref=resolved_ref,
+            icon_name=icon_name,
+            is_ordered=is_ordered,
+            required_on_closure=required_on_closure,
+            position=position,
+            options=option_params,
+        )
+        async with CaseDropdownDefinitionsService.with_session(role=role) as svc:
+            definition = await svc.create_definition(params)
+            return _case_dropdown_definition_payload(definition)
+    except ToolError:
+        raise
+    except EntitlementRequired as e:
+        raise ToolError(str(e)) from e
+    except TracecatValidationError as e:
+        raise ToolError(str(e)) from e
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to create case dropdown", error=str(e))
+        raise ToolError(f"Failed to create case dropdown: {e}") from None
+
+
+@mcp.tool()
+async def update_case_dropdown(
+    workspace_id: uuid.UUID,
+    dropdown_id: uuid.UUID,
+    name: str | None = None,
+    ref: str | None = None,
+    icon_name: str | None = None,
+    is_ordered: bool | None = None,
+    required_on_closure: bool | None = None,
+    position: int | None = None,
+) -> CaseDropdownDefinitionRead:
+    """Update a case dropdown definition. Only provided fields are changed.
+    Requires the case add-ons entitlement.
+
+    Args:
+        workspace_id: The workspace ID.
+        dropdown_id: Dropdown definition UUID from `list_case_dropdowns`.
+        name: New display name. Renaming without an explicit `ref`
+            regenerates the ref from the new name.
+        ref: New slug identifier.
+        icon_name: New icon name.
+        is_ordered: Whether option order is semantically meaningful.
+        required_on_closure: Whether a value is required to close a case.
+        position: New sort position.
+
+    Returns JSON with the updated dropdown definition and its options.
+    """
+
+    try:
+        dropdown_id = _coerce_uuid_arg(dropdown_id, "dropdown_id")
+        _, role = await _resolve_workspace_role(workspace_id)
+        update_kwargs: dict[str, Any] = {}
+        if name is not None:
+            update_kwargs["name"] = name
+        if ref is not None:
+            update_kwargs["ref"] = ref
+        if icon_name is not None:
+            update_kwargs["icon_name"] = icon_name
+        if is_ordered is not None:
+            update_kwargs["is_ordered"] = is_ordered
+        if required_on_closure is not None:
+            update_kwargs["required_on_closure"] = required_on_closure
+        if position is not None:
+            update_kwargs["position"] = position
+        async with CaseDropdownDefinitionsService.with_session(role=role) as svc:
+            definition = await svc.get_definition(dropdown_id)
+            updated = await svc.update_definition(
+                definition, CaseDropdownDefinitionUpdate(**update_kwargs)
+            )
+            return _case_dropdown_definition_payload(updated)
+    except ToolError:
+        raise
+    except EntitlementRequired as e:
+        raise ToolError(str(e)) from e
+    except TracecatNotFoundError as e:
+        raise ToolError(str(e)) from e
+    except TracecatValidationError as e:
+        raise ToolError(str(e)) from e
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to update case dropdown", error=str(e))
+        raise ToolError(f"Failed to update case dropdown: {e}") from None
+
+
+@mcp.tool()
+async def delete_case_dropdown(
+    workspace_id: uuid.UUID,
+    dropdown_id: uuid.UUID,
+) -> MCPMessageResponse:
+    """Delete a case dropdown definition along with all its options and
+    per-case values. Requires the case add-ons entitlement.
+
+    Args:
+        workspace_id: The workspace ID.
+        dropdown_id: Dropdown definition UUID from `list_case_dropdowns`.
+
+    Returns a confirmation message.
+    """
+
+    try:
+        dropdown_id = _coerce_uuid_arg(dropdown_id, "dropdown_id")
+        _, role = await _resolve_workspace_role(workspace_id)
+        async with CaseDropdownDefinitionsService.with_session(role=role) as svc:
+            definition = await svc.get_definition(dropdown_id)
+            await svc.delete_definition(definition)
+            return MCPMessageResponse(
+                message=f"Case dropdown {dropdown_id} deleted successfully"
+            )
+    except ToolError:
+        raise
+    except EntitlementRequired as e:
+        raise ToolError(str(e)) from e
+    except TracecatNotFoundError as e:
+        raise ToolError(str(e)) from e
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to delete case dropdown", error=str(e))
+        raise ToolError(f"Failed to delete case dropdown: {e}") from None
+
+
+@mcp.tool()
+async def add_case_dropdown_option(
+    workspace_id: uuid.UUID,
+    dropdown_id: uuid.UUID,
+    label: str,
+    ref: str | None = None,
+    icon_name: str | None = None,
+    color: str | None = None,
+    position: int | None = None,
+) -> CaseDropdownOptionRead:
+    """Add an option to a case dropdown definition. Requires the case
+    add-ons entitlement.
+
+    Args:
+        workspace_id: The workspace ID.
+        dropdown_id: Dropdown definition UUID from `list_case_dropdowns`.
+        label: Display label for the option.
+        ref: Optional slug identifier. Defaults to the slugified label.
+        icon_name: Optional icon name.
+        color: Optional display color.
+        position: Sort position. Defaults to the end of the option list.
+
+    Returns JSON with the created option.
+    """
+
+    try:
+        dropdown_id = _coerce_uuid_arg(dropdown_id, "dropdown_id")
+        _, role = await _resolve_workspace_role(workspace_id)
+        async with CaseDropdownDefinitionsService.with_session(role=role) as svc:
+            definition = await svc.get_definition(dropdown_id)
+            params = CaseDropdownOptionCreate(
+                label=label,
+                ref=ref or _slugify_dropdown_ref(label, field_name="label"),
+                icon_name=icon_name,
+                color=color,
+                position=position if position is not None else len(definition.options),
+            )
+            option = await svc.add_option(dropdown_id, params)
+            return _case_dropdown_option_payload(option)
+    except ToolError:
+        raise
+    except EntitlementRequired as e:
+        raise ToolError(str(e)) from e
+    except TracecatNotFoundError as e:
+        raise ToolError(str(e)) from e
+    except TracecatValidationError as e:
+        raise ToolError(str(e)) from e
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to add case dropdown option", error=str(e))
+        raise ToolError(f"Failed to add case dropdown option: {e}") from None
+
+
+@mcp.tool()
+async def update_case_dropdown_option(
+    workspace_id: uuid.UUID,
+    dropdown_id: uuid.UUID,
+    option_id: uuid.UUID,
+    label: str | None = None,
+    ref: str | None = None,
+    icon_name: str | None = None,
+    color: str | None = None,
+    position: int | None = None,
+) -> CaseDropdownOptionRead:
+    """Update an option within a case dropdown definition. Only provided
+    fields are changed. Requires the case add-ons entitlement.
+
+    Args:
+        workspace_id: The workspace ID.
+        dropdown_id: Dropdown definition UUID from `list_case_dropdowns`.
+        option_id: Option UUID within the dropdown definition.
+        label: New display label.
+        ref: New slug identifier.
+        icon_name: New icon name.
+        color: New display color.
+        position: New sort position.
+
+    Returns JSON with the updated option.
+    """
+
+    try:
+        dropdown_id = _coerce_uuid_arg(dropdown_id, "dropdown_id")
+        option_id = _coerce_uuid_arg(option_id, "option_id")
+        _, role = await _resolve_workspace_role(workspace_id)
+        update_kwargs: dict[str, Any] = {}
+        if label is not None:
+            update_kwargs["label"] = label
+        if ref is not None:
+            update_kwargs["ref"] = ref
+        if icon_name is not None:
+            update_kwargs["icon_name"] = icon_name
+        if color is not None:
+            update_kwargs["color"] = color
+        if position is not None:
+            update_kwargs["position"] = position
+        async with CaseDropdownDefinitionsService.with_session(role=role) as svc:
+            await svc.get_definition(dropdown_id)
+            option = await svc.update_option(
+                option_id, CaseDropdownOptionUpdate(**update_kwargs)
+            )
+            return _case_dropdown_option_payload(option)
+    except ToolError:
+        raise
+    except EntitlementRequired as e:
+        raise ToolError(str(e)) from e
+    except TracecatNotFoundError as e:
+        raise ToolError(str(e)) from e
+    except TracecatValidationError as e:
+        raise ToolError(str(e)) from e
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to update case dropdown option", error=str(e))
+        raise ToolError(f"Failed to update case dropdown option: {e}") from None
+
+
+@mcp.tool()
+async def delete_case_dropdown_option(
+    workspace_id: uuid.UUID,
+    dropdown_id: uuid.UUID,
+    option_id: uuid.UUID,
+) -> MCPMessageResponse:
+    """Delete an option from a case dropdown definition. Requires the case
+    add-ons entitlement.
+
+    Args:
+        workspace_id: The workspace ID.
+        dropdown_id: Dropdown definition UUID from `list_case_dropdowns`.
+        option_id: Option UUID within the dropdown definition.
+
+    Returns a confirmation message.
+    """
+
+    try:
+        dropdown_id = _coerce_uuid_arg(dropdown_id, "dropdown_id")
+        option_id = _coerce_uuid_arg(option_id, "option_id")
+        _, role = await _resolve_workspace_role(workspace_id)
+        async with CaseDropdownDefinitionsService.with_session(role=role) as svc:
+            await svc.get_definition(dropdown_id)
+            await svc.delete_option(option_id)
+            return MCPMessageResponse(
+                message=f"Case dropdown option {option_id} deleted successfully"
+            )
+    except ToolError:
+        raise
+    except EntitlementRequired as e:
+        raise ToolError(str(e)) from e
+    except TracecatNotFoundError as e:
+        raise ToolError(str(e)) from e
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to delete case dropdown option", error=str(e))
+        raise ToolError(f"Failed to delete case dropdown option: {e}") from None
+
+
+@mcp.tool()
+async def set_case_dropdown_value(
+    workspace_id: uuid.UUID,
+    case_id: uuid.UUID,
+    definition_id: uuid.UUID | None = None,
+    definition_ref: str | None = None,
+    option_id: uuid.UUID | None = None,
+    option_ref: str | None = None,
+) -> CaseDropdownValueRead:
+    """Set or clear a dropdown value on a case. Provide exactly one of
+    `definition_id` or `definition_ref`, and at most one of `option_id` or
+    `option_ref`; omit both option arguments to clear the value. Requires
+    the case add-ons entitlement.
+
+    Args:
+        workspace_id: The workspace ID.
+        case_id: Case UUID.
+        definition_id: Dropdown definition UUID.
+        definition_ref: Dropdown definition slug ref.
+        option_id: Option UUID to select.
+        option_ref: Option slug ref to select.
+
+    Returns JSON with the resulting value including definition and option
+    info.
+    """
+
+    try:
+        case_id = _coerce_uuid_arg(case_id, "case_id")
+        if definition_id is not None:
+            definition_id = _coerce_uuid_arg(definition_id, "definition_id")
+        if option_id is not None:
+            option_id = _coerce_uuid_arg(option_id, "option_id")
+        _, role = await _resolve_workspace_role(workspace_id)
+        value_input = CaseDropdownValueInput(
+            definition_id=definition_id,
+            definition_ref=definition_ref,
+            option_id=option_id,
+            option_ref=option_ref,
+        )
+        async with CaseDropdownValuesService.with_session(role=role) as svc:
+            results = await svc.apply_values(case_id, [value_input])
+            return results[0]
+    except ToolError:
+        raise
+    except EntitlementRequired as e:
+        raise ToolError(str(e)) from e
+    except TracecatNotFoundError as e:
+        raise ToolError(str(e)) from e
+    except TracecatValidationError as e:
+        raise ToolError(str(e)) from e
+    except ValueError as e:
+        raise ToolError(str(e)) from e
+    except Exception as e:
+        logger.error("Failed to set case dropdown value", error=str(e))
+        raise ToolError(f"Failed to set case dropdown value: {e}") from None
 
 
 @mcp.tool()

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -7849,7 +7849,7 @@ async def update_case_dropdown_option(
         async with CaseDropdownDefinitionsService.with_session(role=role) as svc:
             await svc.get_definition(dropdown_id)
             option = await svc.update_option(
-                option_id, CaseDropdownOptionUpdate(**update_kwargs)
+                dropdown_id, option_id, CaseDropdownOptionUpdate(**update_kwargs)
             )
             return _case_dropdown_option_payload(option)
     except ToolError:
@@ -7890,7 +7890,7 @@ async def delete_case_dropdown_option(
         _, role = await _resolve_workspace_role(workspace_id)
         async with CaseDropdownDefinitionsService.with_session(role=role) as svc:
             await svc.get_definition(dropdown_id)
-            await svc.delete_option(option_id)
+            await svc.delete_option(dropdown_id, option_id)
             return MCPMessageResponse(
                 message=f"Case dropdown option {option_id} deleted successfully"
             )

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -7974,8 +7974,7 @@ async def set_case_dropdown_value(
             option_ref=option_ref,
         )
         async with CaseDropdownValuesService.with_session(role=role) as svc:
-            results = await svc.apply_values(case_id, [value_input])
-            return results[0]
+            return await svc.set_value_from_input(case_id, value_input)
     except ToolError:
         raise
     except ScopeDeniedError as e:

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -7798,12 +7798,18 @@ async def add_case_dropdown_option(
         _, role = await _resolve_workspace_role(workspace_id)
         async with CaseDropdownDefinitionsService.with_session(role=role) as svc:
             definition = await svc.get_definition(dropdown_id)
+            if position is None:
+                # Append after the highest position; deletions leave gaps, so
+                # the option count can collide with an existing position.
+                position = (
+                    max((opt.position for opt in definition.options), default=-1) + 1
+                )
             params = CaseDropdownOptionCreate(
                 label=label,
                 ref=ref or _slugify_dropdown_ref(label, field_name="label"),
                 icon_name=icon_name,
                 color=color,
-                position=position if position is not None else len(definition.options),
+                position=position,
             )
             option = await svc.add_option(dropdown_id, params)
             return _case_dropdown_option_payload(option)

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -6455,6 +6455,9 @@ async def create_case(
             )
     except ToolError:
         raise
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except EntitlementRequired as e:
         raise ToolError(str(e)) from e
     except TracecatNotFoundError as e:
@@ -6558,6 +6561,9 @@ async def update_case(
             return MCPMessageResponse(message=f"Case {case_id} updated successfully")
     except ToolError:
         raise
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except EntitlementRequired as e:
         raise ToolError(str(e)) from e
     except TracecatNotFoundError as e:
@@ -7572,6 +7578,9 @@ async def list_case_dropdowns(
             return page
     except ToolError:
         raise
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except EntitlementRequired as e:
         raise ToolError(str(e)) from e
     except ValueError as e:
@@ -7637,6 +7646,9 @@ async def create_case_dropdown(
             return _case_dropdown_definition_payload(definition)
     except ToolError:
         raise
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except EntitlementRequired as e:
         raise ToolError(str(e)) from e
     except TracecatValidationError as e:
@@ -7700,6 +7712,9 @@ async def update_case_dropdown(
             return _case_dropdown_definition_payload(updated)
     except ToolError:
         raise
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except EntitlementRequired as e:
         raise ToolError(str(e)) from e
     except TracecatNotFoundError as e:
@@ -7739,6 +7754,9 @@ async def delete_case_dropdown(
             )
     except ToolError:
         raise
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except EntitlementRequired as e:
         raise ToolError(str(e)) from e
     except TracecatNotFoundError as e:
@@ -7791,6 +7809,9 @@ async def add_case_dropdown_option(
             return _case_dropdown_option_payload(option)
     except ToolError:
         raise
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except EntitlementRequired as e:
         raise ToolError(str(e)) from e
     except TracecatNotFoundError as e:
@@ -7854,6 +7875,9 @@ async def update_case_dropdown_option(
             return _case_dropdown_option_payload(option)
     except ToolError:
         raise
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except EntitlementRequired as e:
         raise ToolError(str(e)) from e
     except TracecatNotFoundError as e:
@@ -7896,6 +7920,9 @@ async def delete_case_dropdown_option(
             )
     except ToolError:
         raise
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except EntitlementRequired as e:
         raise ToolError(str(e)) from e
     except TracecatNotFoundError as e:
@@ -7951,6 +7978,9 @@ async def set_case_dropdown_value(
             return results[0]
     except ToolError:
         raise
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except EntitlementRequired as e:
         raise ToolError(str(e)) from e
     except TracecatNotFoundError as e:


### PR DESCRIPTION
## Summary

The case dropdowns feature (workspace-scoped dropdown definitions, options, and per-case values, gated by the case add-ons entitlement) has a full REST API but no MCP coverage — agents could see `dropdown_values` in `get_case` output but couldn't manage dropdowns or set values.

This PR adds 8 MCP tools mirroring the REST API (minus redundant endpoints):

- `list_case_dropdowns`, `create_case_dropdown`, `update_case_dropdown`, `delete_case_dropdown`
- `add_case_dropdown_option`, `update_case_dropdown_option`, `delete_case_dropdown_option`
- `set_case_dropdown_value` — set or clear via `definition_id`/`definition_ref` + `option_id`/`option_ref`

It also extends `create_case` and `update_case` with a `dropdown_values` parameter, reusing the existing `CaseDropdownValueInput` schema that `CaseCreate`/`CaseUpdate` already support.

## Details

- Dropdown and option `ref` values default to the slugified name/label (e.g. `Threat Level` -> `threat_level`), matching the frontend dialog behavior
- `set_case_dropdown_value` routes through the public `CaseDropdownValuesService.apply_values`, so id/ref resolution, validation, and case events work the same as the REST API
- `EntitlementRequired`, `TracecatNotFoundError`, and `TracecatValidationError` surface as clear `ToolError` messages

## Testing

- 16 new unit tests in `tests/unit/test_mcp_server.py` (slugify defaults, exclude-unset partial updates, value clearing, identifier validation, not-entitled errors); full file passes (232 tests)
- `ruff check`/`format` clean, `basedpyright --warnings` clean on `server.py`
- `tracecat/mcp/README.md` updated; `docs/snippets/mcp-tools.mdx` regenerated via `just gen-mcp-docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP tools to manage case dropdowns (definitions, options, and per-case values) and lets you set dropdown selections during `create_case` and `update_case`. Tightens RBAC to match REST and improves ordering and option handling.

- **New Features**
  - Tools: `list_case_dropdowns`, `create_case_dropdown`, `update_case_dropdown`, `delete_case_dropdown`, `add_case_dropdown_option`, `update_case_dropdown_option`, `delete_case_dropdown_option`, `set_case_dropdown_value`.
  - `create_case` and `update_case` accept `dropdown_values` to set selections.
  - Default `ref` values slugify names/labels; clear `ToolError` messages for entitlement, missing-scope, not-found, and validation errors.

- **Bug Fixes**
  - Option update/delete are scoped to their definition across REST and MCP; mismatched IDs raise `TracecatNotFoundError`.
  - Service-layer RBAC: `case:create/update/delete` for dropdown mutations; require `case:update` for direct value writes; `list_case_dropdowns` requires `case:read`, while `get_definition`/`get_definition_by_ref` allow any case scope to unblock mutation flows.
  - Deterministic dropdown ordering (position + insertion order) for stable pagination.
  - New option `position` defaults to append after the max existing position (not the option count).

<sup>Written for commit deb4c0e6b5061e3c4f5fc0010c42062122eea6b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

