### PR TITLE
feat(integrations): test http mcp integrations

### DIFF
--- a/alembic/versions/290137982547_add_mcp_integration_tools.py
+++ b/alembic/versions/290137982547_add_mcp_integration_tools.py
@@ -1,0 +1,31 @@
+"""add mcp integration tools
+
+Revision ID: 290137982547
+Revises: 9b52f7f18a31
+Create Date: 2026-06-10 15:03:58.463176
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "290137982547"
+down_revision: str | None = "9b52f7f18a31"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "mcp_integration",
+        sa.Column("tools", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("mcp_integration", "tools")

--- a/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
@@ -740,7 +740,11 @@ function McpCatalogCard({
   const { entry } = item
   const locked = entry.locked === true
   const hasMcpRow = Boolean(entry.mcp_integration_id)
-  const connected = entry.state === "connected"
+  const isHttpServer = entry.mcp_server_type === "http"
+  // An HTTP row with no tool listing hasn't been successfully verified yet;
+  // treat it as "configured" so the unverified badge branch is reachable.
+  const connected =
+    entry.state === "connected" && !(isHttpServer && entry.tools === null)
   const configured = !connected && (entry.state === "configured" || hasMcpRow)
   const hasWorkspaceConfig = configured || connected
   const connectable = isCatalogEntryConnectable(entry)
@@ -783,7 +787,6 @@ function McpCatalogCard({
     canConfigure = canCreate
   }
   const configureLabel = "Configure"
-  const isHttpServer = entry.mcp_server_type === "http"
   const verifiedToolCount = entry.tools?.length ?? null
   const unverifiedBadge = UNVERIFIED_BADGE_VARIANTS[UNVERIFIED_BADGE_VARIANT]
   let statusLabel = "Not connected"

--- a/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
@@ -40,25 +40,13 @@ const MCP_VERIFY_ERROR_PARAM = "mcp_verify_error"
 const ALL_CATEGORY = "All"
 
 /**
- * Badge treatments for an HTTP server whose connection has not been verified
- * (never tested, or the last test failed). Trial variants — pick one at review.
+ * Badge treatment for an HTTP server whose connection has not been verified
+ * (never tested, or the last test failed).
  */
-const UNVERIFIED_BADGE_VARIANTS = {
-  unverified: {
-    label: "Unverified",
-    className: "border-amber-200 bg-amber-50 text-amber-700",
-  },
-  "connection-failed": {
-    label: "Connection failed",
-    className: "border-red-200 bg-red-50 text-red-700",
-  },
-  "needs-verification": {
-    label: "Needs verification",
-    className: "border-amber-200 bg-amber-50 text-amber-700",
-  },
+const UNVERIFIED_BADGE = {
+  label: "Unverified",
+  className: "border-amber-200 bg-amber-50 text-amber-700",
 } as const
-const UNVERIFIED_BADGE_VARIANT: keyof typeof UNVERIFIED_BADGE_VARIANTS =
-  "unverified"
 const CUSTOM_CATEGORY = "Custom"
 const MCP_CATEGORIES = [
   "SIEM / Datalake",
@@ -389,10 +377,11 @@ export default function McpServersPage() {
     if (!verifyErrorSignal || !pathname) {
       return
     }
+    // Not `destructive`: a verification failure is a remote/config issue
+    // (unreachable server, bad credentials), not a platform fault.
     toast({
       title: "Connection failed",
       description: verifyErrorSignal,
-      variant: "destructive",
     })
     const params = new URLSearchParams(searchParams?.toString() ?? "")
     params.delete(MCP_VERIFY_ERROR_PARAM)
@@ -466,7 +455,13 @@ export default function McpServersPage() {
       setLockedCatalogEntry(entry)
       return
     }
-    const connected = entry.state === "connected"
+    // Mirror McpCatalogCard's derivation: an HTTP row with no tool listing
+    // hasn't been verified yet, so it is "configured"/reconnect, not a
+    // connected disconnect. Keeping this in sync avoids showing "Reconnect"
+    // while routing through the disconnect/no-op path.
+    const isHttpServer = entry.mcp_server_type === "http"
+    const connected =
+      entry.state === "connected" && !(isHttpServer && entry.tools === null)
     const connectable = isCatalogEntryConnectable(entry)
 
     if (entry.mcp_integration_id && connected) {
@@ -788,7 +783,7 @@ function McpCatalogCard({
   }
   const configureLabel = "Configure"
   const verifiedToolCount = entry.tools?.length ?? null
-  const unverifiedBadge = UNVERIFIED_BADGE_VARIANTS[UNVERIFIED_BADGE_VARIANT]
+  const unverifiedBadge = UNVERIFIED_BADGE
   let statusLabel = "Not connected"
   let statusClassName = "border-muted bg-muted/30 text-muted-foreground"
   if (isActionPending) {

--- a/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
@@ -36,7 +36,29 @@ import { cn } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
 const CREATE_MCP_SERVER_PARAM = "createMcpServer"
+const MCP_VERIFY_ERROR_PARAM = "mcp_verify_error"
 const ALL_CATEGORY = "All"
+
+/**
+ * Badge treatments for an HTTP server whose connection has not been verified
+ * (never tested, or the last test failed). Trial variants — pick one at review.
+ */
+const UNVERIFIED_BADGE_VARIANTS = {
+  unverified: {
+    label: "Unverified",
+    className: "border-amber-200 bg-amber-50 text-amber-700",
+  },
+  "connection-failed": {
+    label: "Connection failed",
+    className: "border-red-200 bg-red-50 text-red-700",
+  },
+  "needs-verification": {
+    label: "Needs verification",
+    className: "border-amber-200 bg-amber-50 text-amber-700",
+  },
+} as const
+const UNVERIFIED_BADGE_VARIANT: keyof typeof UNVERIFIED_BADGE_VARIANTS =
+  "unverified"
 const CUSTOM_CATEGORY = "Custom"
 const MCP_CATEGORIES = [
   "SIEM / Datalake",
@@ -140,6 +162,7 @@ function workspaceIntegrationToCatalogEntry(
     mcp_integration_id: integration.id,
     mcp_server_type: integration.server_type,
     mcp_auth_type: integration.auth_type,
+    tools: integration.tools ?? null,
     created_at: integration.created_at,
     updated_at: integration.updated_at,
     last_refreshed_at: null,
@@ -358,6 +381,25 @@ export default function McpServersPage() {
     router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canCreate, createSignal, pathname, router])
+
+  // Surface a connection verification failure carried back from the MCP
+  // OAuth callback redirect, then strip the param from the URL.
+  const verifyErrorSignal = searchParams?.get(MCP_VERIFY_ERROR_PARAM) ?? null
+  useEffect(() => {
+    if (!verifyErrorSignal || !pathname) {
+      return
+    }
+    toast({
+      title: "Connection failed",
+      description: verifyErrorSignal,
+      variant: "destructive",
+    })
+    const params = new URLSearchParams(searchParams?.toString() ?? "")
+    params.delete(MCP_VERIFY_ERROR_PARAM)
+    const next = params.toString()
+    router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [verifyErrorSignal, pathname, router])
 
   const items = useMemo<CatalogItem[]>(() => {
     const catalogMcpIntegrationIds = new Set(
@@ -741,6 +783,9 @@ function McpCatalogCard({
     canConfigure = canCreate
   }
   const configureLabel = "Configure"
+  const isHttpServer = entry.mcp_server_type === "http"
+  const verifiedToolCount = entry.tools?.length ?? null
+  const unverifiedBadge = UNVERIFIED_BADGE_VARIANTS[UNVERIFIED_BADGE_VARIANT]
   let statusLabel = "Not connected"
   let statusClassName = "border-muted bg-muted/30 text-muted-foreground"
   if (isActionPending) {
@@ -750,11 +795,21 @@ function McpCatalogCard({
     statusLabel = "Locked"
     statusClassName = "border-muted bg-muted/30 text-muted-foreground"
   } else if (connected) {
-    statusLabel = "Connected"
+    statusLabel =
+      isHttpServer && verifiedToolCount !== null
+        ? `Connected · ${verifiedToolCount} ${verifiedToolCount === 1 ? "tool" : "tools"}`
+        : "Connected"
     statusClassName = "border-emerald-200 bg-emerald-50 text-emerald-700"
   } else if (configured) {
-    statusLabel = "Configured"
-    statusClassName = "border-blue-200 bg-blue-50 text-blue-700"
+    // An HTTP row with config but no verified tool listing is not known to
+    // work — show it as a problem rather than a neutral setup state.
+    if (isHttpServer && hasMcpRow) {
+      statusLabel = unverifiedBadge.label
+      statusClassName = unverifiedBadge.className
+    } else {
+      statusLabel = "Configured"
+      statusClassName = "border-blue-200 bg-blue-50 text-blue-700"
+    }
   } else if (comingSoon) {
     statusLabel = "Coming soon"
     statusClassName = "border-muted bg-muted/30 text-muted-foreground"

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -15622,6 +15622,20 @@ export const $MCPIntegrationRead = {
       ],
       title: "Timeout",
     },
+    tools: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/MCPToolSummary",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Tools",
+    },
     created_at: {
       type: "string",
       format: "date-time",
@@ -15653,6 +15667,135 @@ export const $MCPIntegrationRead = {
   ],
   title: "MCPIntegrationRead",
   description: "Response model for MCP integration.",
+} as const
+
+export const $MCPIntegrationTestConnectionRequest = {
+  properties: {
+    mcp_integration_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid4",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Mcp Integration Id",
+    },
+    server_uri: {
+      type: "string",
+      maxLength: 2048,
+      minLength: 1,
+      title: "Server Uri",
+    },
+    auth_type: {
+      $ref: "#/components/schemas/MCPAuthType",
+      default: "NONE",
+    },
+    oauth_integration_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid4",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Oauth Integration Id",
+    },
+    custom_credentials: {
+      anyOf: [
+        {
+          type: "string",
+          format: "password",
+          writeOnly: true,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Custom Credentials",
+      description:
+        "JSON object of custom headers; falls back to stored headers when omitted",
+    },
+    timeout: {
+      anyOf: [
+        {
+          type: "integer",
+          maximum: 300,
+          minimum: 1,
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Timeout",
+    },
+  },
+  type: "object",
+  required: ["server_uri"],
+  title: "MCPIntegrationTestConnectionRequest",
+  description: `Request to test connectivity against an unsaved HTTP MCP configuration.
+
+Carries the (possibly edited, not yet persisted) form values. When
+\`\`mcp_integration_id\`\` is set, stored secrets from that row are used as a
+fallback for fields the caller leaves blank (e.g. unchanged credentials).`,
+} as const
+
+export const $MCPIntegrationTestConnectionResponse = {
+  properties: {
+    success: {
+      type: "boolean",
+      title: "Success",
+    },
+    mcp_integration_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid4",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Mcp Integration Id",
+    },
+    tools: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/MCPToolSummary",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Tools",
+    },
+    message: {
+      type: "string",
+      title: "Message",
+    },
+    error: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Error",
+    },
+  },
+  type: "object",
+  required: ["success", "message"],
+  title: "MCPIntegrationTestConnectionResponse",
+  description: "Response for testing connectivity to an MCP server.",
 } as const
 
 export const $MCPIntegrationUpdate = {
@@ -16308,6 +16451,30 @@ export const $MCPStdioServerConfig = {
   required: ["type", "name", "command"],
   title: "MCPStdioServerConfig",
   description: "Configuration for a stdio MCP server.",
+} as const
+
+export const $MCPToolSummary = {
+  properties: {
+    name: {
+      type: "string",
+      title: "Name",
+    },
+    description: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Description",
+    },
+  },
+  type: "object",
+  required: ["name"],
+  title: "MCPToolSummary",
+  description: "Summary of a tool discovered on a remote MCP server.",
 } as const
 
 export const $MessageKind = {
@@ -17925,6 +18092,20 @@ export const $PlatformMCPCatalogRead = {
           type: "null",
         },
       ],
+    },
+    tools: {
+      anyOf: [
+        {
+          items: {
+            $ref: "#/components/schemas/MCPToolSummary",
+          },
+          type: "array",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Tools",
     },
     created_at: {
       type: "string",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -456,6 +456,10 @@ import type {
   McpIntegrationsListMcpIntegrationsResponse,
   McpIntegrationsListPlatformMcpCatalogData,
   McpIntegrationsListPlatformMcpCatalogResponse,
+  McpIntegrationsTestMcpConnectionConfigData,
+  McpIntegrationsTestMcpConnectionConfigResponse,
+  McpIntegrationsTestMcpIntegrationConnectionData,
+  McpIntegrationsTestMcpIntegrationConnectionResponse,
   McpIntegrationsUpdateMcpIntegrationData,
   McpIntegrationsUpdateMcpIntegrationResponse,
   McpPersonalAccessTokensCreateMcpPersonalAccessTokenData,
@@ -11634,6 +11638,60 @@ export const mcpIntegrationsDeleteMcpIntegration = (
   return __request(OpenAPI, {
     method: "DELETE",
     url: "/workspaces/{workspace_id}/mcp-integrations/{mcp_integration_id}",
+    path: {
+      mcp_integration_id: data.mcpIntegrationId,
+      workspace_id: data.workspaceId,
+    },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Test Mcp Connection Config
+ * Test connectivity against an unsaved HTTP MCP configuration.
+ *
+ * Ephemeral: nothing is persisted and stored verification state is never
+ * touched — use this for testing edited form values before saving.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns MCPIntegrationTestConnectionResponse Successful Response
+ * @throws ApiError
+ */
+export const mcpIntegrationsTestMcpConnectionConfig = (
+  data: McpIntegrationsTestMcpConnectionConfigData
+): CancelablePromise<McpIntegrationsTestMcpConnectionConfigResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/mcp-integrations/test",
+    path: {
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Test Mcp Integration Connection
+ * Test connectivity to an HTTP MCP server and refresh its tool listing.
+ * @param data The data for the request.
+ * @param data.mcpIntegrationId
+ * @param data.workspaceId
+ * @returns MCPIntegrationTestConnectionResponse Successful Response
+ * @throws ApiError
+ */
+export const mcpIntegrationsTestMcpIntegrationConnection = (
+  data: McpIntegrationsTestMcpIntegrationConnectionData
+): CancelablePromise<McpIntegrationsTestMcpIntegrationConnectionResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/mcp-integrations/{mcp_integration_id}/test",
     path: {
       mcp_integration_id: data.mcpIntegrationId,
       workspace_id: data.workspaceId,

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4811,11 +4811,42 @@ export type MCPIntegrationRead = {
   stdio_args: Array<string> | null
   has_stdio_env?: boolean
   timeout: number | null
+  tools?: Array<MCPToolSummary> | null
   created_at: string
   updated_at: string
 }
 
 export type state = "not_configured" | "configured" | "connected" | "error"
+
+/**
+ * Request to test connectivity against an unsaved HTTP MCP configuration.
+ *
+ * Carries the (possibly edited, not yet persisted) form values. When
+ * ``mcp_integration_id`` is set, stored secrets from that row are used as a
+ * fallback for fields the caller leaves blank (e.g. unchanged credentials).
+ */
+export type MCPIntegrationTestConnectionRequest = {
+  mcp_integration_id?: string | null
+  server_uri: string
+  auth_type?: MCPAuthType
+  oauth_integration_id?: string | null
+  /**
+   * JSON object of custom headers; falls back to stored headers when omitted
+   */
+  custom_credentials?: string | null
+  timeout?: number | null
+}
+
+/**
+ * Response for testing connectivity to an MCP server.
+ */
+export type MCPIntegrationTestConnectionResponse = {
+  success: boolean
+  mcp_integration_id?: string | null
+  tools?: Array<MCPToolSummary> | null
+  message: string
+  error?: string | null
+}
 
 /**
  * Request model for updating an MCP integration.
@@ -4980,6 +5011,14 @@ export type MCPStdioServerConfig = {
   }
   timeout?: number
   id?: string
+}
+
+/**
+ * Summary of a tool discovered on a remote MCP server.
+ */
+export type MCPToolSummary = {
+  name: string
+  description?: string | null
 }
 
 /**
@@ -5382,6 +5421,7 @@ export type PlatformMCPCatalogRead = {
   mcp_integration_id: string | null
   mcp_server_type?: MCPServerType | null
   mcp_auth_type?: MCPAuthType | null
+  tools?: Array<MCPToolSummary> | null
   created_at: string
   updated_at: string
   last_refreshed_at: string | null
@@ -12747,6 +12787,22 @@ export type McpIntegrationsDeleteMcpIntegrationData = {
 
 export type McpIntegrationsDeleteMcpIntegrationResponse = void
 
+export type McpIntegrationsTestMcpConnectionConfigData = {
+  requestBody: MCPIntegrationTestConnectionRequest
+  workspaceId: string
+}
+
+export type McpIntegrationsTestMcpConnectionConfigResponse =
+  MCPIntegrationTestConnectionResponse
+
+export type McpIntegrationsTestMcpIntegrationConnectionData = {
+  mcpIntegrationId: string
+  workspaceId: string
+}
+
+export type McpIntegrationsTestMcpIntegrationConnectionResponse =
+  MCPIntegrationTestConnectionResponse
+
 export type McpIntegrationsDisconnectMcpIntegrationData = {
   mcpIntegrationId: string
   workspaceId: string
@@ -18858,6 +18914,36 @@ export type $OpenApiTs = {
          * Successful Response
          */
         204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/mcp-integrations/test": {
+    post: {
+      req: McpIntegrationsTestMcpConnectionConfigData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: MCPIntegrationTestConnectionResponse
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/mcp-integrations/{mcp_integration_id}/test": {
+    post: {
+      req: McpIntegrationsTestMcpIntegrationConnectionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: MCPIntegrationTestConnectionResponse
         /**
          * Validation Error
          */

--- a/frontend/src/components/integrations/mcp-integration-dialog.tsx
+++ b/frontend/src/components/integrations/mcp-integration-dialog.tsx
@@ -6,6 +6,8 @@ import {
   ExternalLink,
   Globe2,
   Loader2,
+  MoreHorizontal,
+  PlayCircle,
   Plus,
   Server,
   Trash2,
@@ -70,6 +72,12 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog"
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
   Form,
   FormControl,
   FormDescription,
@@ -95,6 +103,7 @@ import {
   useDeleteMcpIntegration,
   useGetMcpIntegration,
   useIntegrations,
+  useTestMcpConnectionConfig,
   useUpdateMcpIntegration,
 } from "@/lib/hooks"
 import { isMcpProvider } from "@/lib/integrations"
@@ -203,7 +212,13 @@ function catalogMcpProviderId(
   return `custom_mcp_${entry.slug}${suffix}`.replace(/[^a-zA-Z0-9_]+/g, "_")
 }
 
-function CatalogEntrySummary({ entry }: { entry: PlatformMCPCatalogRead }) {
+function CatalogEntrySummary({
+  entry,
+  actions,
+}: {
+  entry: PlatformMCPCatalogRead
+  actions?: React.ReactNode
+}) {
   const providerId = entry.slug.replace(/-/g, "_")
   const transports = Array.from(
     new Set(
@@ -249,6 +264,7 @@ function CatalogEntrySummary({ entry }: { entry: PlatformMCPCatalogRead }) {
           </a>
         ) : null}
       </div>
+      {actions}
     </div>
   )
 }
@@ -290,7 +306,10 @@ export function MCPIntegrationDialog({
     workspaceId,
     mcpIntegrationId ?? null
   )
+  const { testMcpConnectionConfig, testMcpConnectionConfigIsPending } =
+    useTestMcpConnectionConfig(workspaceId)
   const canDelete = useScopeCheck("integration:delete") === true
+  const canUpdate = useScopeCheck("integration:update") === true
   const [internalOpen, setInternalOpen] = useState(false)
   const [isEditHydrated, setIsEditHydrated] = useState(false)
   const [catalogOAuthClientIsPending, setCatalogOAuthClientIsPending] =
@@ -324,6 +343,31 @@ export function MCPIntegrationDialog({
   const authType = form.watch("auth_type")
   const oauthSetup = form.watch("oauth_setup")
   const connectionOptionId = form.watch("connection_option_id")
+
+  /**
+   * Test the form's current (possibly unsaved) values against the server.
+   * Ephemeral — nothing is persisted; saving runs its own verification.
+   */
+  async function handleTestConnection() {
+    const values = form.getValues()
+    const serverUri = values.server_uri?.trim()
+    if (values.server_type !== "http" || !serverUri) {
+      void form.trigger("server_uri")
+      return
+    }
+    const customCredentials = values.custom_credentials?.trim()
+    await testMcpConnectionConfig({
+      mcp_integration_id: mcpIntegrationId ?? null,
+      server_uri: serverUri,
+      auth_type: values.auth_type,
+      oauth_integration_id:
+        values.oauth_integration_id ||
+        mcpIntegration?.oauth_integration_id ||
+        null,
+      custom_credentials: customCredentials || null,
+      timeout: values.timeout ?? null,
+    })
+  }
   const selectedCatalogSpec = catalogSpecForOption(
     catalogEntry,
     connectionOptionId
@@ -687,6 +731,46 @@ export function MCPIntegrationDialog({
     connectMcpIntegrationIsPending ||
     createMcpIntegrationIsPending ||
     updateMcpIntegrationIsPending
+
+  // Connection actions menu mirroring the OAuth integration details dialog.
+  // Tests the form's current (possibly unsaved) values without persisting.
+  const connectionActions =
+    isEditMode && mcpIntegrationId && canUpdate ? (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-8 shrink-0 text-muted-foreground"
+            disabled={testMcpConnectionConfigIsPending}
+            aria-label="Connection actions"
+          >
+            {testMcpConnectionConfigIsPending ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <MoreHorizontal className="size-4" />
+            )}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-44">
+          <DropdownMenuItem
+            disabled={
+              serverType === "stdio" || testMcpConnectionConfigIsPending
+            }
+            title={
+              serverType === "stdio"
+                ? "Stdio servers can't be tested"
+                : undefined
+            }
+            onClick={() => void handleTestConnection()}
+          >
+            <PlayCircle className="mr-2 size-4 text-muted-foreground" />
+            Test
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    ) : null
   const dialogTitle = catalogEntry
     ? `Configure ${catalogEntry.name}`
     : isEditMode
@@ -721,7 +805,34 @@ export function MCPIntegrationDialog({
         <div className="max-h-[calc(88vh-92px)] overflow-y-auto px-6 py-5">
           {catalogEntry ? (
             <div className="mb-6">
-              <CatalogEntrySummary entry={catalogEntry} />
+              <CatalogEntrySummary
+                entry={catalogEntry}
+                actions={connectionActions}
+              />
+            </div>
+          ) : null}
+          {!catalogEntry && isEditMode && mcpIntegration ? (
+            <div className="mb-6 flex items-start gap-3 rounded-md border bg-muted/30 p-3">
+              <ProviderIcon providerId="custom" className="size-9 shrink-0" />
+              <div className="min-w-0 flex-1 space-y-1">
+                <div className="flex min-w-0 items-center gap-2">
+                  <div className="truncate text-sm font-medium text-foreground">
+                    {mcpIntegration.name}
+                  </div>
+                  <Badge
+                    variant="outline"
+                    className="h-4 px-1.5 text-[10px] uppercase tracking-wide"
+                  >
+                    {mcpIntegration.server_type}
+                  </Badge>
+                </div>
+                <p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
+                  {mcpIntegration.server_uri ??
+                    mcpIntegration.stdio_command ??
+                    "Custom MCP server"}
+                </p>
+              </div>
+              {connectionActions}
             </div>
           ) : null}
           {(integrationsIsLoading ||
@@ -1157,8 +1268,52 @@ export function MCPIntegrationDialog({
                     </>
                   )}
 
-                  <Accordion type="single" collapsible>
-                    <AccordionItem value="advanced" className="border-b-0">
+                  {isEditMode &&
+                  serverType === "http" &&
+                  !mcpIntegration?.tools?.length ? (
+                    <p className="text-xs text-muted-foreground">
+                      Connection not verified — test the connection to discover
+                      tools.
+                    </p>
+                  ) : null}
+
+                  <Accordion type="multiple">
+                    {isEditMode &&
+                    serverType === "http" &&
+                    mcpIntegration?.tools?.length ? (
+                      <AccordionItem value="tools" className="border-t">
+                        <AccordionTrigger className="py-3 hover:no-underline">
+                          Tools ({mcpIntegration.tools.length})
+                        </AccordionTrigger>
+                        <AccordionContent>
+                          <ul className="divide-y divide-border/50">
+                            {mcpIntegration.tools.map((tool) => (
+                              <li key={tool.name} className="py-2">
+                                <p className="font-mono text-xs text-foreground">
+                                  {tool.name}
+                                </p>
+                                {tool.description ? (
+                                  <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                                    {tool.description}
+                                  </p>
+                                ) : null}
+                              </li>
+                            ))}
+                          </ul>
+                        </AccordionContent>
+                      </AccordionItem>
+                    ) : null}
+                    <AccordionItem
+                      value="advanced"
+                      className={cn(
+                        "border-b-0",
+                        isEditMode &&
+                          serverType === "http" &&
+                          mcpIntegration?.tools?.length
+                          ? undefined
+                          : "border-t"
+                      )}
+                    >
                       <AccordionTrigger className="py-3 hover:no-underline">
                         Advanced
                       </AccordionTrigger>
@@ -1435,56 +1590,56 @@ export function MCPIntegrationDialog({
                   )}
 
                   <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-between">
-                    {isEditMode && mcpIntegrationId && canDelete ? (
-                      <AlertDialog>
-                        <AlertDialogTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-                            disabled={
-                              isPending || deleteMcpIntegrationIsPending
-                            }
-                          >
-                            <Trash2 className="mr-1.5 h-3.5 w-3.5" />
-                            Delete
-                          </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>
-                              Remove MCP server?
-                            </AlertDialogTitle>
-                            <AlertDialogDescription>
-                              Agents will no longer be able to call{" "}
-                              <span className="font-medium">
-                                {mcpIntegration?.name ?? "this server"}
-                              </span>
-                              .
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>Cancel</AlertDialogCancel>
-                            <AlertDialogAction
-                              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                              disabled={deleteMcpIntegrationIsPending}
-                              onClick={async (event) => {
-                                event.preventDefault()
-                                await deleteMcpIntegration(mcpIntegrationId)
-                                handleOpenChange(false)
-                              }}
+                    <div className="flex items-center gap-2">
+                      {isEditMode && mcpIntegrationId && canDelete ? (
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                              disabled={
+                                isPending || deleteMcpIntegrationIsPending
+                              }
                             >
-                              {deleteMcpIntegrationIsPending && (
-                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                              )}
-                              Remove
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                    ) : (
-                      <span />
-                    )}
+                              <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+                              Delete
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>
+                                Remove MCP server?
+                              </AlertDialogTitle>
+                              <AlertDialogDescription>
+                                Agents will no longer be able to call{" "}
+                                <span className="font-medium">
+                                  {mcpIntegration?.name ?? "this server"}
+                                </span>
+                                .
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Cancel</AlertDialogCancel>
+                              <AlertDialogAction
+                                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                                disabled={deleteMcpIntegrationIsPending}
+                                onClick={async (event) => {
+                                  event.preventDefault()
+                                  await deleteMcpIntegration(mcpIntegrationId)
+                                  handleOpenChange(false)
+                                }}
+                              >
+                                {deleteMcpIntegrationIsPending && (
+                                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                )}
+                                Remove
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      ) : null}
+                    </div>
                     <div className="flex items-center justify-end gap-2">
                       <Button
                         type="button"

--- a/frontend/src/components/integrations/mcp-integration-dialog.tsx
+++ b/frontend/src/components/integrations/mcp-integration-dialog.tsx
@@ -104,6 +104,7 @@ import {
   useGetMcpIntegration,
   useIntegrations,
   useTestMcpConnectionConfig,
+  useTestMcpIntegrationConnection,
   useUpdateMcpIntegration,
 } from "@/lib/hooks"
 import { isMcpProvider } from "@/lib/integrations"
@@ -308,6 +309,12 @@ export function MCPIntegrationDialog({
   )
   const { testMcpConnectionConfig, testMcpConnectionConfigIsPending } =
     useTestMcpConnectionConfig(workspaceId)
+  const {
+    testMcpIntegrationConnection,
+    testMcpIntegrationConnectionIsPending,
+  } = useTestMcpIntegrationConnection(workspaceId)
+  const testConnectionIsPending =
+    testMcpConnectionConfigIsPending || testMcpIntegrationConnectionIsPending
   const canDelete = useScopeCheck("integration:delete") === true
   const canUpdate = useScopeCheck("integration:update") === true
   const [internalOpen, setInternalOpen] = useState(false)
@@ -355,7 +362,34 @@ export function MCPIntegrationDialog({
       void form.trigger("server_uri")
       return
     }
-    const customCredentials = values.custom_credentials?.trim()
+    // For a saved integration without unsaved connection edits, test through
+    // the integration-scoped endpoint so a successful probe persists the
+    // discovered tools and refreshes the Tools list (matching the "test the
+    // connection to discover tools" copy). With dirty connection fields, the
+    // stored config no longer reflects what would be saved, so test the form
+    // values through the ephemeral config-test endpoint instead; it back-fills
+    // secrets the form leaves blank from the saved integration.
+    const dirtyFields = form.formState.dirtyFields
+    const connectionFieldsAreDirty = Boolean(
+      dirtyFields.server_uri ||
+        dirtyFields.auth_type ||
+        dirtyFields.oauth_setup ||
+        dirtyFields.oauth_integration_id ||
+        dirtyFields.custom_credentials ||
+        dirtyFields.timeout
+    )
+    if (isEditMode && mcpIntegrationId && !connectionFieldsAreDirty) {
+      await testMcpIntegrationConnection(mcpIntegrationId)
+      return
+    }
+    // Mirror the save path: an edited-but-empty editor means the user cleared
+    // the credentials, so send "" (test without headers) rather than null,
+    // which the backend back-fills from the stored secret.
+    const trimmedCredentials = values.custom_credentials?.trim() ?? ""
+    let customCredentials: string | null = trimmedCredentials || null
+    if (!trimmedCredentials && dirtyFields.custom_credentials) {
+      customCredentials = ""
+    }
     await testMcpConnectionConfig({
       mcp_integration_id: mcpIntegrationId ?? null,
       server_uri: serverUri,
@@ -364,7 +398,7 @@ export function MCPIntegrationDialog({
         values.oauth_integration_id ||
         mcpIntegration?.oauth_integration_id ||
         null,
-      custom_credentials: customCredentials || null,
+      custom_credentials: customCredentials,
       timeout: values.timeout ?? null,
     })
   }
@@ -733,7 +767,8 @@ export function MCPIntegrationDialog({
     updateMcpIntegrationIsPending
 
   // Connection actions menu mirroring the OAuth integration details dialog.
-  // Tests the form's current (possibly unsaved) values without persisting.
+  // Tests the form's current values; with unsaved connection edits the probe
+  // is ephemeral, otherwise it persists the discovered tools.
   const connectionActions =
     isEditMode && mcpIntegrationId && canUpdate ? (
       <DropdownMenu>
@@ -743,10 +778,10 @@ export function MCPIntegrationDialog({
             variant="ghost"
             size="icon"
             className="size-8 shrink-0 text-muted-foreground"
-            disabled={testMcpConnectionConfigIsPending}
+            disabled={testConnectionIsPending}
             aria-label="Connection actions"
           >
-            {testMcpConnectionConfigIsPending ? (
+            {testConnectionIsPending ? (
               <Loader2 className="size-4 animate-spin" />
             ) : (
               <MoreHorizontal className="size-4" />
@@ -755,9 +790,7 @@ export function MCPIntegrationDialog({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">
           <DropdownMenuItem
-            disabled={
-              serverType === "stdio" || testMcpConnectionConfigIsPending
-            }
+            disabled={serverType === "stdio" || testConnectionIsPending}
             title={
               serverType === "stdio"
                 ? "Stdio servers can't be tested"

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -66,6 +66,33 @@ export function getApiErrorDetail(error: unknown): string | null {
   return error.message
 }
 
+/**
+ * Strip credentials and query parameters from any URLs embedded in free text.
+ *
+ * Backend connection errors can echo a user-supplied server URI, which may
+ * carry secrets in its userinfo (`user:pass@`) or query string. Sanitize before
+ * surfacing such text in toasts or the console so those values are not leaked
+ * into UI output or logs. Non-URL text is returned unchanged.
+ */
+export function sanitizeUrlsInText(text: string): string {
+  return text.replace(/\bhttps?:\/\/[^\s]+/gi, (match) => {
+    try {
+      const url = new URL(match)
+      url.username = ""
+      url.password = ""
+      url.search = ""
+      url.hash = ""
+      return url.toString()
+    } catch {
+      // Not a parseable URL (e.g. trailing punctuation captured); fall back to
+      // dropping everything from the first `?` and any `userinfo@` segment.
+      return match
+        .replace(/^(https?:\/\/)[^/@]*@/i, "$1")
+        .replace(/[?#].*$/, "")
+    }
+  })
+}
+
 const MCP_OAUTH_DISCOVERY_ERROR_PATTERNS = [
   "dynamic registration",
   "discover oauth",

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -141,6 +141,7 @@ import {
   listEnabledModels,
   type MCPIntegrationCreate,
   type MCPIntegrationRead,
+  type MCPIntegrationTestConnectionRequest,
   type MCPIntegrationUpdate,
   type McpIntegrationsListMcpIntegrationsData,
   type ModelCredentialCreate,
@@ -150,6 +151,7 @@ import {
   mcpIntegrationsDeleteMcpIntegration,
   mcpIntegrationsGetMcpIntegration,
   mcpIntegrationsListMcpIntegrations,
+  mcpIntegrationsTestMcpConnectionConfig,
   mcpIntegrationsUpdateMcpIntegration,
   type OAuthGrantType,
   type OrganizationDeleteOrgMemberData,
@@ -4766,6 +4768,56 @@ export function useUpdateMcpIntegration(workspaceId: string) {
     updateMcpIntegration,
     updateMcpIntegrationIsPending,
     updateMcpIntegrationError,
+  }
+}
+
+/**
+ * Test connectivity against an unsaved (possibly edited) HTTP MCP
+ * configuration. Fully ephemeral: nothing is persisted server-side and no
+ * queries are invalidated — saving via connect/update runs its own
+ * verification.
+ */
+export function useTestMcpConnectionConfig(workspaceId: string) {
+  const {
+    mutateAsync: testMcpConnectionConfig,
+    isPending: testMcpConnectionConfigIsPending,
+    error: testMcpConnectionConfigError,
+  } = useMutation({
+    mutationFn: async (params: MCPIntegrationTestConnectionRequest) => {
+      return await mcpIntegrationsTestMcpConnectionConfig({
+        workspaceId,
+        requestBody: params,
+      })
+    },
+    onSuccess: (result) => {
+      if (result.success) {
+        const toolCount = result.tools?.length ?? 0
+        toast({
+          title: "Connection verified",
+          description: `${toolCount} ${toolCount === 1 ? "tool" : "tools"} available`,
+        })
+      } else {
+        toast({
+          title: "Connection failed",
+          description: result.error || result.message,
+          variant: "destructive",
+        })
+      }
+    },
+    onError: (error: TracecatApiError) => {
+      console.error("Failed to test MCP connection:", error)
+      toast({
+        title: "Test failed",
+        description: `Could not test connection: ${error.body?.detail || error.message}`,
+        variant: "destructive",
+      })
+    },
+  })
+
+  return {
+    testMcpConnectionConfig,
+    testMcpConnectionConfigIsPending,
+    testMcpConnectionConfigError,
   }
 }
 

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -152,6 +152,7 @@ import {
   mcpIntegrationsGetMcpIntegration,
   mcpIntegrationsListMcpIntegrations,
   mcpIntegrationsTestMcpConnectionConfig,
+  mcpIntegrationsTestMcpIntegrationConnection,
   mcpIntegrationsUpdateMcpIntegration,
   type OAuthGrantType,
   type OrganizationDeleteOrgMemberData,
@@ -367,8 +368,10 @@ import {
 import { invalidateCaseActivityQueries } from "@/lib/cases/invalidation"
 import type { ModelInfo } from "@/lib/chat"
 import {
+  getApiErrorDetail,
   getMcpOAuthConnectErrorDetail,
   retryHandler,
+  sanitizeUrlsInText,
   type TracecatApiError,
 } from "@/lib/errors"
 import type { WorkflowExecutionReadCompact } from "@/lib/event-history"
@@ -4799,16 +4802,21 @@ export function useTestMcpConnectionConfig(workspaceId: string) {
       } else {
         toast({
           title: "Connection failed",
-          description: result.error || result.message,
+          description: sanitizeUrlsInText(result.error || result.message),
           variant: "destructive",
         })
       }
     },
     onError: (error: TracecatApiError) => {
-      console.error("Failed to test MCP connection:", error)
+      // The server URI is caller-controlled and may carry credentials in its
+      // userinfo/query; strip those from any URLs before logging or surfacing.
+      const detail = sanitizeUrlsInText(
+        getApiErrorDetail(error) ?? error.message
+      )
+      console.error("Failed to test MCP connection:", detail)
       toast({
         title: "Test failed",
-        description: `Could not test connection: ${error.body?.detail || error.message}`,
+        description: `Could not test connection: ${detail}`,
         variant: "destructive",
       })
     },
@@ -4818,6 +4826,72 @@ export function useTestMcpConnectionConfig(workspaceId: string) {
     testMcpConnectionConfig,
     testMcpConnectionConfigIsPending,
     testMcpConnectionConfigError,
+  }
+}
+
+/**
+ * Test connectivity to a saved MCP integration and persist its tool listing.
+ *
+ * Unlike {@link useTestMcpConnectionConfig} (which hits the ephemeral
+ * config-test endpoint and never persists), this calls the integration-scoped
+ * endpoint that refreshes and stores the discovered tools. On success it
+ * invalidates the integration query so the Tools list reflects the new
+ * verification result.
+ */
+export function useTestMcpIntegrationConnection(workspaceId: string) {
+  const queryClient = useQueryClient()
+
+  const {
+    mutateAsync: testMcpIntegrationConnection,
+    isPending: testMcpIntegrationConnectionIsPending,
+    error: testMcpIntegrationConnectionError,
+  } = useMutation({
+    mutationFn: async (mcpIntegrationId: string) => {
+      return await mcpIntegrationsTestMcpIntegrationConnection({
+        workspaceId,
+        mcpIntegrationId,
+      })
+    },
+    onSuccess: (result, mcpIntegrationId) => {
+      // Tools are persisted on success or cleared on failure, so refresh the
+      // integration regardless of outcome.
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-integration", workspaceId, mcpIntegrationId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-integrations", workspaceId],
+      })
+      if (result.success) {
+        const toolCount = result.tools?.length ?? 0
+        toast({
+          title: "Connection verified",
+          description: `${toolCount} ${toolCount === 1 ? "tool" : "tools"} available`,
+        })
+      } else {
+        toast({
+          title: "Connection failed",
+          description: sanitizeUrlsInText(result.error || result.message),
+          variant: "destructive",
+        })
+      }
+    },
+    onError: (error: TracecatApiError) => {
+      const detail = sanitizeUrlsInText(
+        getApiErrorDetail(error) ?? error.message
+      )
+      console.error("Failed to test MCP connection:", detail)
+      toast({
+        title: "Test failed",
+        description: `Could not test connection: ${detail}`,
+        variant: "destructive",
+      })
+    },
+  })
+
+  return {
+    testMcpIntegrationConnection,
+    testMcpIntegrationConnectionIsPending,
+    testMcpIntegrationConnectionError,
   }
 }
 

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -41,7 +41,6 @@ from tracecat.integrations.catalog.service import PlatformMCPCatalogService
 from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
 from tracecat.integrations.mcp_validation import (
     MCPConfigurationError,
-    MCPConnectionVerificationError,
 )
 from tracecat.integrations.providers.base import (
     DynamicRegistrationResult,
@@ -61,7 +60,6 @@ from tracecat.integrations.schemas import (
     MCPIntegrationTestConnectionRequest,
     MCPIntegrationUpdate,
     MCPStdioIntegrationCreate,
-    MCPToolSummary,
     ProviderConfig,
     ProviderKey,
     ProviderMetadata,
@@ -380,7 +378,6 @@ class TestMCPIntegrationCRUD:
             server_type="http",
             server_uri="https://mcp.example.com/mcp",
             auth_type=MCPAuthType.NONE,
-            tools=[{"name": "ping", "description": "Ping tool"}],
         )
         session.add(existing_mcp)
         await session.flush()
@@ -446,10 +443,6 @@ class TestMCPIntegrationCRUD:
                 oauth_integration_id=oauth_integration.id,
             )
         )
-        # Mark the row as verified so it reports as connected.
-        mcp_integration.tools = [{"name": "ping", "description": "Ping tool"}]
-        session.add(mcp_integration)
-        await session.flush()
         catalog_service = PlatformMCPCatalogService(session=session)
 
         connected_items, _ = await catalog_service.list_catalog(
@@ -543,7 +536,6 @@ class TestMCPIntegrationCRUD:
             server_uri="https://mcp.example.com/mcp",
             auth_type=MCPAuthType.OAUTH2,
             oauth_integration_id=live_oauth.id,
-            tools=[{"name": "ping", "description": "Ping tool"}],
             created_at=now,
         )
         session.add_all([stale_row, live_row])
@@ -863,11 +855,6 @@ class TestMCPIntegrationCRUD:
         assert created.id != custom.id
         assert created.slug == f"{catalog.slug}-1"
         assert created.catalog_slug == catalog.slug
-
-        # Mark the new row as verified so it reports as connected.
-        created.tools = [{"name": "ping", "description": "Ping tool"}]
-        session.add(created)
-        await session.flush()
 
         items, _ = await catalog_service.list_catalog(
             workspace_id=integration_service.workspace_id,
@@ -1740,13 +1727,6 @@ class TestMCPIntegrationCRUD:
                 auth_type=MCPAuthType.NONE,
             )
         )
-        # Mark rows with working credentials as verified; HTTP rows only count
-        # as connected once a tool listing has been stored.
-        verified_tools = [{"name": "ping", "description": "Ping tool"}]
-        connected_mcp.tools = verified_tools
-        none_mcp.tools = verified_tools
-        integration_service.session.add_all([connected_mcp, none_mcp])
-        await integration_service.session.flush()
 
         rows = await integration_service.list_mcp_integrations_with_state()
         state_by_id = {row.integration.id: row.state for row in rows}
@@ -4265,112 +4245,6 @@ class TestMCPConnectionVerification:
                 custom_without_headers
             )
 
-    async def test_verify_success_persists_tools(
-        self,
-        integration_service: IntegrationService,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """A successful verification stores the discovered tools."""
-        mcp_integration = await integration_service.create_mcp_integration(
-            params=MCPHttpIntegrationCreate(
-                name="Verified MCP",
-                server_uri="https://verified.example.com/mcp",
-                auth_type=MCPAuthType.NONE,
-            )
-        )
-
-        async def fake_list_tools(server_config):
-            assert server_config["url"] == "https://verified.example.com/mcp"
-            return [
-                MCPToolSummary(name="search", description="Search things"),
-                MCPToolSummary(name="fetch", description=None),
-            ]
-
-        monkeypatch.setattr(
-            integration_service_module, "list_remote_mcp_tools", fake_list_tools
-        )
-
-        result = await integration_service.verify_mcp_integration(
-            mcp_integration=mcp_integration
-        )
-
-        assert result.success is True
-        assert result.tools is not None
-        assert [tool.name for tool in result.tools] == ["search", "fetch"]
-        assert mcp_integration.tools == [
-            {"name": "search", "description": "Search things"},
-            {"name": "fetch", "description": None},
-        ]
-        state = await integration_service.mcp_integration_state(
-            mcp_integration=mcp_integration
-        )
-        assert state == "connected"
-
-    async def test_verify_failure_clears_tools(
-        self,
-        integration_service: IntegrationService,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Last attempt wins: a failed verification clears stored tools."""
-        mcp_integration = await integration_service.create_mcp_integration(
-            params=MCPHttpIntegrationCreate(
-                name="Broken MCP",
-                server_uri="https://broken.example.com/mcp",
-                auth_type=MCPAuthType.NONE,
-            )
-        )
-        mcp_integration.tools = [{"name": "old", "description": "Stale"}]
-        integration_service.session.add(mcp_integration)
-        await integration_service.session.flush()
-
-        async def fake_list_tools(server_config):
-            raise RuntimeError("connection refused")
-
-        monkeypatch.setattr(
-            integration_service_module, "list_remote_mcp_tools", fake_list_tools
-        )
-
-        result = await integration_service.verify_mcp_integration(
-            mcp_integration=mcp_integration
-        )
-
-        assert result.success is False
-        assert result.error == "connection refused"
-        assert result.tools is None
-        assert mcp_integration.tools is None
-        state = await integration_service.mcp_integration_state(
-            mcp_integration=mcp_integration
-        )
-        assert state == "configured"
-
-    async def test_verify_timeout_reports_timeout_message(
-        self,
-        integration_service: IntegrationService,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Timeouts produce the dedicated timeout message."""
-        mcp_integration = await integration_service.create_mcp_integration(
-            params=MCPHttpIntegrationCreate(
-                name="Slow MCP",
-                server_uri="https://slow.example.com/mcp",
-                auth_type=MCPAuthType.NONE,
-            )
-        )
-
-        async def fake_list_tools(server_config):
-            raise TimeoutError
-
-        monkeypatch.setattr(
-            integration_service_module, "list_remote_mcp_tools", fake_list_tools
-        )
-
-        result = await integration_service.verify_mcp_integration(
-            mcp_integration=mcp_integration
-        )
-
-        assert result.success is False
-        assert result.message == "Connection to the MCP server timed out"
-
     async def test_verify_stdio_is_configuration_error(
         self, integration_service: IntegrationService
     ) -> None:
@@ -4391,166 +4265,151 @@ class TestMCPConnectionVerification:
         assert result.message == "MCP integration is not configured correctly"
         assert stdio_integration.tools is None
 
-    async def test_ephemeral_test_does_not_touch_stored_tools(
+
+class TestMCPTestConnectionRequestSchema:
+    """Input validation for ``MCPIntegrationTestConnectionRequest.server_uri``."""
+
+    @pytest.mark.parametrize(
+        "server_uri",
+        [
+            "ftp://api.example.com/mcp",
+            "file:///etc/passwd",
+            "api.example.com/mcp",  # no scheme
+            "https:///mcp",  # no host
+        ],
+    )
+    def test_rejects_invalid_server_uri(self, server_uri: str) -> None:
+        with pytest.raises(ValueError):
+            MCPIntegrationTestConnectionRequest(server_uri=server_uri)
+
+    def test_strips_and_accepts_valid_uri(self) -> None:
+        request = MCPIntegrationTestConnectionRequest(
+            server_uri="  https://api.example.com/mcp  "
+        )
+        assert request.server_uri == "https://api.example.com/mcp"
+
+    @pytest.mark.parametrize(
+        "server_uri",
+        [
+            "http://localhost:8080/mcp",
+            "http://127.0.0.1/mcp",
+            "https://api.example.com/mcp",
+        ],
+    )
+    def test_accepts_localhost_for_self_hosted(self, server_uri: str) -> None:
+        """Loopback hosts are valid so self-hosted MCP servers can connect."""
+        request = MCPIntegrationTestConnectionRequest(server_uri=server_uri)
+        assert request.server_uri == server_uri
+
+
+class TestCatalogToolsGuard:
+    """A single malformed stored tool must not crash catalog listing."""
+
+    def test_skips_malformed_tool_entries(self) -> None:
+        integration = MCPIntegration(
+            id=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
+            name="Catalog MCP",
+            slug="catalog-mcp",
+            server_type="http",
+            server_uri="https://api.example.com/mcp",
+            auth_type=MCPAuthType.NONE,
+            tools=[
+                {"name": "good", "description": "ok"},
+                {"description": "missing required name"},  # invalid
+                {"name": "also_good", "description": None},
+            ],
+        )
+
+        tools = PlatformMCPCatalogService._catalog_tools(integration)
+
+        assert tools is not None
+        assert [t.name for t in tools] == ["good", "also_good"]
+
+    def test_returns_none_when_unverified(self) -> None:
+        integration = MCPIntegration(
+            id=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
+            name="Catalog MCP",
+            slug="catalog-mcp",
+            server_type="http",
+            server_uri="https://api.example.com/mcp",
+            auth_type=MCPAuthType.NONE,
+            tools=None,
+        )
+
+        assert PlatformMCPCatalogService._catalog_tools(integration) is None
+        assert PlatformMCPCatalogService._catalog_tools(None) is None
+
+
+@pytest.mark.anyio
+class TestMCPOAuthAuthorizationPending:
+    """The connect/save verification gate must skip pre-authorization OAuth."""
+
+    async def test_pending_when_oauth_token_absent(
         self,
         integration_service: IntegrationService,
-        monkeypatch: pytest.MonkeyPatch,
+        oauth_integration: OAuthIntegration,
     ) -> None:
-        """Testing an unsaved config never clears a row's stored verification."""
+        """A linked-but-unauthorized OAuth integration reads as pending."""
+        oauth_integration.encrypted_access_token = b""
+        integration_service.session.add(oauth_integration)
+        await integration_service.session.commit()
+
         mcp_integration = await integration_service.create_mcp_integration(
             params=MCPHttpIntegrationCreate(
-                name="Dirty Form MCP",
-                server_uri="https://saved.example.com/mcp",
-                auth_type=MCPAuthType.NONE,
-            )
-        )
-        stored_tools = [{"name": "saved", "description": "Saved tool"}]
-        mcp_integration.tools = stored_tools
-        integration_service.session.add(mcp_integration)
-        await integration_service.session.flush()
-
-        seen_urls: list[str] = []
-
-        async def fake_list_tools(server_config):
-            seen_urls.append(server_config["url"])
-            raise RuntimeError("edited server unreachable")
-
-        monkeypatch.setattr(
-            integration_service_module, "list_remote_mcp_tools", fake_list_tools
-        )
-
-        result = await integration_service.test_mcp_http_connection(
-            params=MCPIntegrationTestConnectionRequest(
-                mcp_integration_id=mcp_integration.id,
-                server_uri="https://edited.example.com/mcp",
-                auth_type=MCPAuthType.NONE,
+                name="Pending OAuth MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
             )
         )
 
-        assert result.success is False
-        # The edited (dirty) URL was probed, not the persisted one.
-        assert seen_urls == ["https://edited.example.com/mcp"]
-        # Stored verification state is untouched.
-        assert mcp_integration.tools == stored_tools
-        assert mcp_integration.server_uri == "https://saved.example.com/mcp"
+        assert (
+            await integration_service.mcp_oauth_authorization_pending(
+                mcp_integration=mcp_integration
+            )
+            is True
+        )
 
-    async def test_ephemeral_test_uses_form_credentials_with_stored_fallback(
+    async def test_not_pending_when_oauth_token_present(
         self,
         integration_service: IntegrationService,
-        monkeypatch: pytest.MonkeyPatch,
+        oauth_integration: OAuthIntegration,
     ) -> None:
-        """Edited credentials are used directly; blank ones fall back to stored."""
+        """An authorized OAuth integration (token stored) is not pending."""
         mcp_integration = await integration_service.create_mcp_integration(
             params=MCPHttpIntegrationCreate(
-                name="Custom Fallback MCP",
-                server_uri="https://custom.example.com/mcp",
-                auth_type=MCPAuthType.CUSTOM,
-                custom_credentials=SecretStr('{"X-API-Key": "stored-key"}'),
+                name="Authorized OAuth MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
             )
         )
 
-        seen_headers: list[dict[str, str] | None] = []
-
-        async def fake_list_tools(server_config):
-            seen_headers.append(server_config.get("headers"))
-            return [MCPToolSummary(name="ping", description=None)]
-
-        monkeypatch.setattr(
-            integration_service_module, "list_remote_mcp_tools", fake_list_tools
-        )
-
-        # Blank credentials in the form: fall back to the stored secret.
-        fallback = await integration_service.test_mcp_http_connection(
-            params=MCPIntegrationTestConnectionRequest(
-                mcp_integration_id=mcp_integration.id,
-                server_uri="https://custom.example.com/mcp",
-                auth_type=MCPAuthType.CUSTOM,
+        assert (
+            await integration_service.mcp_oauth_authorization_pending(
+                mcp_integration=mcp_integration
             )
+            is False
         )
-        assert fallback.success is True
-        assert seen_headers[-1] == {"X-API-Key": "stored-key"}
 
-        # Edited credentials win without being persisted.
-        edited = await integration_service.test_mcp_http_connection(
-            params=MCPIntegrationTestConnectionRequest(
-                mcp_integration_id=mcp_integration.id,
-                server_uri="https://custom.example.com/mcp",
-                auth_type=MCPAuthType.CUSTOM,
-                custom_credentials=SecretStr('{"X-API-Key": "edited-key"}'),
-            )
-        )
-        assert edited.success is True
-        assert seen_headers[-1] == {"X-API-Key": "edited-key"}
-        decrypted = integration_service._decrypt_mcp_custom_headers(mcp_integration)
-        assert decrypted == {"X-API-Key": "stored-key"}
-
-    async def test_update_with_failed_verification_preserves_existing_connection(
+    async def test_non_oauth_never_pending(
         self,
         integration_service: IntegrationService,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A failed verified update is rejected without disturbing the row."""
+        """NONE/CUSTOM auth integrations are never gated on a token."""
         mcp_integration = await integration_service.create_mcp_integration(
             params=MCPHttpIntegrationCreate(
-                name="Stable MCP",
-                server_uri="https://stable.example.com/mcp",
-                auth_type=MCPAuthType.NONE,
-            )
-        )
-        stored_tools = [{"name": "saved", "description": "Saved tool"}]
-        mcp_integration.tools = stored_tools
-        integration_service.session.add(mcp_integration)
-        await integration_service.session.flush()
-
-        async def failing_list_tools(server_config):
-            assert server_config["url"] == "https://broken.example.com/mcp"
-            raise RuntimeError("connection refused")
-
-        monkeypatch.setattr(
-            integration_service_module, "list_remote_mcp_tools", failing_list_tools
-        )
-
-        with pytest.raises(MCPConnectionVerificationError):
-            await integration_service.update_mcp_integration(
-                mcp_integration_id=mcp_integration.id,
-                params=MCPIntegrationUpdate(
-                    server_uri="https://broken.example.com/mcp"
-                ),
-                verify_connection=True,
-            )
-
-        await integration_service.session.refresh(mcp_integration)
-        assert mcp_integration.server_uri == "https://stable.example.com/mcp"
-        assert mcp_integration.tools == stored_tools
-
-    async def test_update_with_successful_verification_stores_fresh_tools(
-        self,
-        integration_service: IntegrationService,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """A verified update persists the new config with its tool listing."""
-        mcp_integration = await integration_service.create_mcp_integration(
-            params=MCPHttpIntegrationCreate(
-                name="Movable MCP",
-                server_uri="https://old.example.com/mcp",
+                name="No Auth MCP",
+                server_uri="https://api.example.com/mcp",
                 auth_type=MCPAuthType.NONE,
             )
         )
 
-        async def fake_list_tools(server_config):
-            assert server_config["url"] == "https://new.example.com/mcp"
-            return [MCPToolSummary(name="ping", description=None)]
-
-        monkeypatch.setattr(
-            integration_service_module, "list_remote_mcp_tools", fake_list_tools
+        assert (
+            await integration_service.mcp_oauth_authorization_pending(
+                mcp_integration=mcp_integration
+            )
+            is False
         )
-
-        updated = await integration_service.update_mcp_integration(
-            mcp_integration_id=mcp_integration.id,
-            params=MCPIntegrationUpdate(server_uri="https://new.example.com/mcp"),
-            verify_connection=True,
-        )
-
-        assert updated is not None
-        assert updated.server_uri == "https://new.example.com/mcp"
-        assert updated.tools == [{"name": "ping", "description": None}]

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -39,6 +39,10 @@ from tracecat.exceptions import EntitlementRequired
 from tracecat.integrations.catalog.loader import catalog_id_for_slug
 from tracecat.integrations.catalog.service import PlatformMCPCatalogService
 from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
+from tracecat.integrations.mcp_validation import (
+    MCPConfigurationError,
+    MCPConnectionVerificationError,
+)
 from tracecat.integrations.providers.base import (
     DynamicRegistrationResult,
     MCPAuthProvider,
@@ -54,8 +58,10 @@ from tracecat.integrations.schemas import (
     MCPHttpIntegrationCreate,
     MCPHTTPOAuth2ConnectionSpec,
     MCPIntegrationCreate,
+    MCPIntegrationTestConnectionRequest,
     MCPIntegrationUpdate,
     MCPStdioIntegrationCreate,
+    MCPToolSummary,
     ProviderConfig,
     ProviderKey,
     ProviderMetadata,
@@ -374,6 +380,7 @@ class TestMCPIntegrationCRUD:
             server_type="http",
             server_uri="https://mcp.example.com/mcp",
             auth_type=MCPAuthType.NONE,
+            tools=[{"name": "ping", "description": "Ping tool"}],
         )
         session.add(existing_mcp)
         await session.flush()
@@ -439,6 +446,10 @@ class TestMCPIntegrationCRUD:
                 oauth_integration_id=oauth_integration.id,
             )
         )
+        # Mark the row as verified so it reports as connected.
+        mcp_integration.tools = [{"name": "ping", "description": "Ping tool"}]
+        session.add(mcp_integration)
+        await session.flush()
         catalog_service = PlatformMCPCatalogService(session=session)
 
         connected_items, _ = await catalog_service.list_catalog(
@@ -532,6 +543,7 @@ class TestMCPIntegrationCRUD:
             server_uri="https://mcp.example.com/mcp",
             auth_type=MCPAuthType.OAUTH2,
             oauth_integration_id=live_oauth.id,
+            tools=[{"name": "ping", "description": "Ping tool"}],
             created_at=now,
         )
         session.add_all([stale_row, live_row])
@@ -851,6 +863,11 @@ class TestMCPIntegrationCRUD:
         assert created.id != custom.id
         assert created.slug == f"{catalog.slug}-1"
         assert created.catalog_slug == catalog.slug
+
+        # Mark the new row as verified so it reports as connected.
+        created.tools = [{"name": "ping", "description": "Ping tool"}]
+        session.add(created)
+        await session.flush()
 
         items, _ = await catalog_service.list_catalog(
             workspace_id=integration_service.workspace_id,
@@ -1723,6 +1740,13 @@ class TestMCPIntegrationCRUD:
                 auth_type=MCPAuthType.NONE,
             )
         )
+        # Mark rows with working credentials as verified; HTTP rows only count
+        # as connected once a tool listing has been stored.
+        verified_tools = [{"name": "ping", "description": "Ping tool"}]
+        connected_mcp.tools = verified_tools
+        none_mcp.tools = verified_tools
+        integration_service.session.add_all([connected_mcp, none_mcp])
+        await integration_service.session.flush()
 
         rows = await integration_service.list_mcp_integrations_with_state()
         state_by_id = {row.integration.id: row.state for row in rows}
@@ -4113,3 +4137,420 @@ class TestMCPProviderOAuth:
             provider._get_additional_token_params()["resource"]
             == SentryMCPProvider.mcp_server_uri
         )
+
+
+@pytest.mark.anyio
+class TestMCPConnectionVerification:
+    """Tests for HTTP MCP config resolution and connection verification."""
+
+    async def test_resolve_http_config_none_auth(
+        self, integration_service: IntegrationService
+    ) -> None:
+        """NONE-auth HTTP integrations resolve with empty headers."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="No Auth MCP",
+                server_uri="https://none.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+                timeout=30,
+            )
+        )
+
+        server_config = await integration_service.resolve_mcp_http_server_config(
+            mcp_integration
+        )
+
+        assert server_config["url"] == "https://none.example.com/mcp"
+        assert server_config.get("headers") == {}
+        assert server_config.get("timeout") == 30
+        assert server_config.get("id") == str(mcp_integration.id)
+
+    async def test_resolve_http_config_custom_headers(
+        self, integration_service: IntegrationService
+    ) -> None:
+        """CUSTOM-auth integrations resolve their decrypted headers."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Custom Auth MCP",
+                server_uri="https://custom.example.com/mcp",
+                auth_type=MCPAuthType.CUSTOM,
+                custom_credentials=SecretStr('{"X-API-Key": "secret-key"}'),
+            )
+        )
+
+        server_config = await integration_service.resolve_mcp_http_server_config(
+            mcp_integration
+        )
+
+        assert server_config.get("headers") == {"X-API-Key": "secret-key"}
+
+    async def test_resolve_http_config_oauth2_drops_custom_authorization(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+    ) -> None:
+        """OAuth2 resolution attaches the access token; custom Authorization loses."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="OAuth MCP",
+                server_uri="https://oauth.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+                custom_credentials=SecretStr(
+                    '{"authorization": "Bearer attacker", "X-Tenant": "t1"}'
+                ),
+            )
+        )
+
+        server_config = await integration_service.resolve_mcp_http_server_config(
+            mcp_integration
+        )
+
+        headers = server_config.get("headers")
+        assert headers is not None
+        assert headers["Authorization"] == "Bearer test_access_token"
+        assert "authorization" not in headers
+        assert headers["X-Tenant"] == "t1"
+
+    async def test_resolve_http_config_errors(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+    ) -> None:
+        """Unresolvable integrations raise MCPConfigurationError."""
+        stdio_integration = await integration_service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name="Stdio MCP",
+                stdio_command="npx",
+                stdio_args=["@example/mcp-server"],
+            )
+        )
+        with pytest.raises(MCPConfigurationError):
+            await integration_service.resolve_mcp_http_server_config(stdio_integration)
+
+        missing_uri = MCPIntegration(
+            workspace_id=integration_service.workspace_id,
+            name="Missing URI MCP",
+            slug="missing-uri-mcp",
+            server_type="http",
+            server_uri=None,
+            auth_type=MCPAuthType.NONE,
+        )
+        with pytest.raises(MCPConfigurationError):
+            await integration_service.resolve_mcp_http_server_config(missing_uri)
+
+        unlinked_oauth = MCPIntegration(
+            workspace_id=integration_service.workspace_id,
+            name="Unlinked OAuth MCP",
+            slug="unlinked-oauth-mcp",
+            server_type="http",
+            server_uri="https://oauth.example.com/mcp",
+            auth_type=MCPAuthType.OAUTH2,
+            oauth_integration_id=None,
+        )
+        with pytest.raises(MCPConfigurationError):
+            await integration_service.resolve_mcp_http_server_config(unlinked_oauth)
+
+        custom_without_headers = MCPIntegration(
+            workspace_id=integration_service.workspace_id,
+            name="Custom No Headers MCP",
+            slug="custom-no-headers-mcp",
+            server_type="http",
+            server_uri="https://custom.example.com/mcp",
+            auth_type=MCPAuthType.CUSTOM,
+            encrypted_headers=None,
+        )
+        with pytest.raises(MCPConfigurationError):
+            await integration_service.resolve_mcp_http_server_config(
+                custom_without_headers
+            )
+
+    async def test_verify_success_persists_tools(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A successful verification stores the discovered tools."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Verified MCP",
+                server_uri="https://verified.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+
+        async def fake_list_tools(server_config):
+            assert server_config["url"] == "https://verified.example.com/mcp"
+            return [
+                MCPToolSummary(name="search", description="Search things"),
+                MCPToolSummary(name="fetch", description=None),
+            ]
+
+        monkeypatch.setattr(
+            integration_service_module, "list_remote_mcp_tools", fake_list_tools
+        )
+
+        result = await integration_service.verify_mcp_integration(
+            mcp_integration=mcp_integration
+        )
+
+        assert result.success is True
+        assert result.tools is not None
+        assert [tool.name for tool in result.tools] == ["search", "fetch"]
+        assert mcp_integration.tools == [
+            {"name": "search", "description": "Search things"},
+            {"name": "fetch", "description": None},
+        ]
+        state = await integration_service.mcp_integration_state(
+            mcp_integration=mcp_integration
+        )
+        assert state == "connected"
+
+    async def test_verify_failure_clears_tools(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Last attempt wins: a failed verification clears stored tools."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Broken MCP",
+                server_uri="https://broken.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        mcp_integration.tools = [{"name": "old", "description": "Stale"}]
+        integration_service.session.add(mcp_integration)
+        await integration_service.session.flush()
+
+        async def fake_list_tools(server_config):
+            raise RuntimeError("connection refused")
+
+        monkeypatch.setattr(
+            integration_service_module, "list_remote_mcp_tools", fake_list_tools
+        )
+
+        result = await integration_service.verify_mcp_integration(
+            mcp_integration=mcp_integration
+        )
+
+        assert result.success is False
+        assert result.error == "connection refused"
+        assert result.tools is None
+        assert mcp_integration.tools is None
+        state = await integration_service.mcp_integration_state(
+            mcp_integration=mcp_integration
+        )
+        assert state == "configured"
+
+    async def test_verify_timeout_reports_timeout_message(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Timeouts produce the dedicated timeout message."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Slow MCP",
+                server_uri="https://slow.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+
+        async def fake_list_tools(server_config):
+            raise TimeoutError
+
+        monkeypatch.setattr(
+            integration_service_module, "list_remote_mcp_tools", fake_list_tools
+        )
+
+        result = await integration_service.verify_mcp_integration(
+            mcp_integration=mcp_integration
+        )
+
+        assert result.success is False
+        assert result.message == "Connection to the MCP server timed out"
+
+    async def test_verify_stdio_is_configuration_error(
+        self, integration_service: IntegrationService
+    ) -> None:
+        """Stdio integrations cannot be verified."""
+        stdio_integration = await integration_service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name="Stdio Verify MCP",
+                stdio_command="npx",
+                stdio_args=["@example/mcp-server"],
+            )
+        )
+
+        result = await integration_service.verify_mcp_integration(
+            mcp_integration=stdio_integration
+        )
+
+        assert result.success is False
+        assert result.message == "MCP integration is not configured correctly"
+        assert stdio_integration.tools is None
+
+    async def test_ephemeral_test_does_not_touch_stored_tools(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Testing an unsaved config never clears a row's stored verification."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Dirty Form MCP",
+                server_uri="https://saved.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        stored_tools = [{"name": "saved", "description": "Saved tool"}]
+        mcp_integration.tools = stored_tools
+        integration_service.session.add(mcp_integration)
+        await integration_service.session.flush()
+
+        seen_urls: list[str] = []
+
+        async def fake_list_tools(server_config):
+            seen_urls.append(server_config["url"])
+            raise RuntimeError("edited server unreachable")
+
+        monkeypatch.setattr(
+            integration_service_module, "list_remote_mcp_tools", fake_list_tools
+        )
+
+        result = await integration_service.test_mcp_http_connection(
+            params=MCPIntegrationTestConnectionRequest(
+                mcp_integration_id=mcp_integration.id,
+                server_uri="https://edited.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+
+        assert result.success is False
+        # The edited (dirty) URL was probed, not the persisted one.
+        assert seen_urls == ["https://edited.example.com/mcp"]
+        # Stored verification state is untouched.
+        assert mcp_integration.tools == stored_tools
+        assert mcp_integration.server_uri == "https://saved.example.com/mcp"
+
+    async def test_ephemeral_test_uses_form_credentials_with_stored_fallback(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Edited credentials are used directly; blank ones fall back to stored."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Custom Fallback MCP",
+                server_uri="https://custom.example.com/mcp",
+                auth_type=MCPAuthType.CUSTOM,
+                custom_credentials=SecretStr('{"X-API-Key": "stored-key"}'),
+            )
+        )
+
+        seen_headers: list[dict[str, str] | None] = []
+
+        async def fake_list_tools(server_config):
+            seen_headers.append(server_config.get("headers"))
+            return [MCPToolSummary(name="ping", description=None)]
+
+        monkeypatch.setattr(
+            integration_service_module, "list_remote_mcp_tools", fake_list_tools
+        )
+
+        # Blank credentials in the form: fall back to the stored secret.
+        fallback = await integration_service.test_mcp_http_connection(
+            params=MCPIntegrationTestConnectionRequest(
+                mcp_integration_id=mcp_integration.id,
+                server_uri="https://custom.example.com/mcp",
+                auth_type=MCPAuthType.CUSTOM,
+            )
+        )
+        assert fallback.success is True
+        assert seen_headers[-1] == {"X-API-Key": "stored-key"}
+
+        # Edited credentials win without being persisted.
+        edited = await integration_service.test_mcp_http_connection(
+            params=MCPIntegrationTestConnectionRequest(
+                mcp_integration_id=mcp_integration.id,
+                server_uri="https://custom.example.com/mcp",
+                auth_type=MCPAuthType.CUSTOM,
+                custom_credentials=SecretStr('{"X-API-Key": "edited-key"}'),
+            )
+        )
+        assert edited.success is True
+        assert seen_headers[-1] == {"X-API-Key": "edited-key"}
+        decrypted = integration_service._decrypt_mcp_custom_headers(mcp_integration)
+        assert decrypted == {"X-API-Key": "stored-key"}
+
+    async def test_update_with_failed_verification_preserves_existing_connection(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failed verified update is rejected without disturbing the row."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Stable MCP",
+                server_uri="https://stable.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        stored_tools = [{"name": "saved", "description": "Saved tool"}]
+        mcp_integration.tools = stored_tools
+        integration_service.session.add(mcp_integration)
+        await integration_service.session.flush()
+
+        async def failing_list_tools(server_config):
+            assert server_config["url"] == "https://broken.example.com/mcp"
+            raise RuntimeError("connection refused")
+
+        monkeypatch.setattr(
+            integration_service_module, "list_remote_mcp_tools", failing_list_tools
+        )
+
+        with pytest.raises(MCPConnectionVerificationError):
+            await integration_service.update_mcp_integration(
+                mcp_integration_id=mcp_integration.id,
+                params=MCPIntegrationUpdate(
+                    server_uri="https://broken.example.com/mcp"
+                ),
+                verify_connection=True,
+            )
+
+        await integration_service.session.refresh(mcp_integration)
+        assert mcp_integration.server_uri == "https://stable.example.com/mcp"
+        assert mcp_integration.tools == stored_tools
+
+    async def test_update_with_successful_verification_stores_fresh_tools(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A verified update persists the new config with its tool listing."""
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Movable MCP",
+                server_uri="https://old.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+
+        async def fake_list_tools(server_config):
+            assert server_config["url"] == "https://new.example.com/mcp"
+            return [MCPToolSummary(name="ping", description=None)]
+
+        monkeypatch.setattr(
+            integration_service_module, "list_remote_mcp_tools", fake_list_tools
+        )
+
+        updated = await integration_service.update_mcp_integration(
+            mcp_integration_id=mcp_integration.id,
+            params=MCPIntegrationUpdate(server_uri="https://new.example.com/mcp"),
+            verify_connection=True,
+        )
+
+        assert updated is not None
+        assert updated.server_uri == "https://new.example.com/mcp"
+        assert updated.tools == [{"name": "ping", "description": None}]

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -4413,3 +4413,42 @@ class TestMCPOAuthAuthorizationPending:
             )
             is False
         )
+
+    async def test_update_skips_verification_when_oauth_pending(
+        self,
+        integration_service: IntegrationService,
+        oauth_integration: OAuthIntegration,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A benign edit of an unauthorized OAuth MCP server must not be probed.
+
+        The connect/save gate skips verification while OAuth is pending; the
+        update path must do the same, otherwise a rename/timeout bump on an
+        integration awaiting authorization is rejected with a 502.
+        """
+        oauth_integration.encrypted_access_token = b""
+        integration_service.session.add(oauth_integration)
+        await integration_service.session.commit()
+
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Pending OAuth MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=oauth_integration.id,
+            )
+        )
+
+        async def _fail_probe(*args: object, **kwargs: object) -> object:
+            raise AssertionError("probe must be skipped while OAuth is pending")
+
+        monkeypatch.setattr(integration_service, "_probe_mcp_http_server", _fail_probe)
+
+        updated = await integration_service.update_mcp_integration(
+            mcp_integration_id=mcp_integration.id,
+            params=MCPIntegrationUpdate(name="Pending OAuth MCP renamed"),
+            verify_connection=True,
+        )
+
+        assert updated is not None
+        assert updated.name == "Pending OAuth MCP renamed"

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -19,6 +19,7 @@ from tracecat.agent.mcp.utils import (
     LEGACY_REGISTRY_MCP_SERVER_NAME,
     REGISTRY_MCP_SERVER_NAME,
 )
+from tracecat.integrations.schemas import MCPToolSummary
 from tracecat.logger import logger
 
 
@@ -38,6 +39,28 @@ def _create_transport(
         return SSETransport(url=url, headers=headers, sse_read_timeout=timeout)
     # Default to HTTP (Streamable HTTP transport)
     return StreamableHttpTransport(url=url, headers=headers, sse_read_timeout=timeout)
+
+
+async def list_remote_mcp_tools(
+    config: MCPHttpServerConfig,
+) -> list[MCPToolSummary]:
+    """Connect to a remote HTTP/SSE MCP server and list its tools.
+
+    Raises:
+        Exception: If the server is unreachable or the MCP handshake fails.
+    """
+    transport = _create_transport(
+        config["url"],
+        config.get("transport", "http"),
+        config.get("headers"),
+        config.get("timeout"),
+    )
+    async with Client(transport) as client:
+        server_tools = await client.list_tools()
+    return [
+        MCPToolSummary(name=tool.name, description=tool.description)
+        for tool in server_tools
+    ]
 
 
 class UserMCPClient:

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import uuid
 from collections import Counter
 from collections.abc import Sequence
@@ -43,7 +42,6 @@ from tracecat.agent.types import (
     OutputType,
 )
 from tracecat.audit.logger import audit_log
-from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import (
     AgentCatalog,
@@ -51,15 +49,14 @@ from tracecat.db.models import (
     AgentPresetSkill,
     AgentPresetVersion,
     AgentPresetVersionSkill,
-    OAuthIntegration,
     SkillVersion,
 )
 from tracecat.dsl.common import create_default_execution_context
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.executor.service import get_workspace_variables
 from tracecat.expressions.eval import collect_expressions, eval_templated_object
-from tracecat.integrations.enums import MCPAuthType
 from tracecat.integrations.mcp_validation import (
+    MCPConfigurationError,
     MCPValidationError,
     validate_mcp_command_config,
 )
@@ -72,7 +69,6 @@ from tracecat.pagination import (
 )
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.secrets import secrets_manager
-from tracecat.secrets.encryption import decrypt_value
 from tracecat.service import BaseWorkspaceService, requires_entitlement
 from tracecat.tiers.enums import Entitlement
 
@@ -656,58 +652,6 @@ class AgentPresetService(BaseWorkspaceService):
         )
         return resolved.to_agents_binding().model_dump(mode="json")
 
-    def _decrypt_mcp_headers(
-        self,
-        *,
-        encrypted_headers: bytes,
-        encryption_key: str,
-        mcp_integration_id: uuid.UUID,
-        mcp_integration_name: str,
-    ) -> dict[str, str] | None:
-        """Decrypt and validate MCP custom headers from encrypted storage."""
-        try:
-            decrypted_bytes = decrypt_value(encrypted_headers, key=encryption_key)
-            custom_credentials_str = decrypted_bytes.decode("utf-8")
-            parsed_headers = json.loads(custom_credentials_str)
-        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as err:
-            logger.warning(
-                "Failed to parse custom credentials for MCP integration %r: %s",
-                mcp_integration_name,
-                str(err),
-                extra={
-                    "workspace_id": str(self.workspace_id),
-                    "mcp_integration_id": str(mcp_integration_id),
-                },
-            )
-            return None
-
-        if not isinstance(parsed_headers, dict):
-            logger.warning(
-                "Custom credentials for MCP integration %r must be a JSON object",
-                mcp_integration_name,
-                extra={
-                    "workspace_id": str(self.workspace_id),
-                    "mcp_integration_id": str(mcp_integration_id),
-                },
-            )
-            return None
-
-        custom_headers: dict[str, str] = {}
-        for key, value in parsed_headers.items():
-            if not isinstance(key, str) or not isinstance(value, str):
-                logger.warning(
-                    "Custom credentials for MCP integration %r must contain string header values",
-                    mcp_integration_name,
-                    extra={
-                        "workspace_id": str(self.workspace_id),
-                        "mcp_integration_id": str(mcp_integration_id),
-                    },
-                )
-                return None
-            custom_headers[key] = value
-
-        return custom_headers
-
     async def resolve_mcp_integrations(
         self, mcp_integrations: list[str] | None
     ) -> list[MCPServerConfig] | None:
@@ -721,9 +665,6 @@ class AgentPresetService(BaseWorkspaceService):
             mcp_integration.id: mcp_integration
             for mcp_integration in available_mcp_integrations
         }
-
-        # Get encryption key for decrypting custom credentials
-        encryption_key = get_db_encryption_key()
 
         mcp_servers: list[MCPServerConfig] = []
 
@@ -827,156 +768,21 @@ class AgentPresetService(BaseWorkspaceService):
                 continue
 
             # Handle HTTP-type servers (default)
-            if not mcp_integration.server_uri:
+            try:
+                http_config = await integrations_service.resolve_mcp_http_server_config(
+                    mcp_integration
+                )
+            except MCPConfigurationError as e:
                 logger.warning(
-                    "HTTP-type MCP integration %r has no server_uri specified",
+                    "Failed to resolve HTTP MCP integration %r, skipping: %s",
                     mcp_integration.name,
+                    str(e),
                     extra={
                         "workspace_id": str(self.workspace_id),
                         "mcp_integration_id": str(mcp_integration.id),
                     },
                 )
                 continue
-
-            headers: dict[str, str] = {}
-
-            # Resolve headers based on auth type
-            if mcp_integration.auth_type == MCPAuthType.OAUTH2:
-                # OAuth2: Get access token from linked OAuth integration
-                if not mcp_integration.oauth_integration_id:
-                    logger.warning(
-                        "MCP integration %r has OAUTH2 auth type but no oauth_integration_id",
-                        mcp_integration.name,
-                        extra={
-                            "workspace_id": str(self.workspace_id),
-                            "mcp_integration_id": str(mcp_integration.id),
-                        },
-                    )
-                    continue
-
-                # Get OAuth integration by ID
-                stmt = select(OAuthIntegration).where(
-                    OAuthIntegration.id == mcp_integration.oauth_integration_id,
-                    OAuthIntegration.workspace_id == self.workspace_id,
-                )
-                result = await self.session.execute(stmt)
-                oauth_integration = result.scalars().first()
-                if not oauth_integration:
-                    logger.warning(
-                        "OAuth integration not found for MCP integration %r",
-                        mcp_integration.name,
-                        extra={
-                            "workspace_id": str(self.workspace_id),
-                            "mcp_integration_id": str(mcp_integration.id),
-                            "oauth_integration_id": str(
-                                mcp_integration.oauth_integration_id
-                            ),
-                        },
-                    )
-                    continue
-
-                await integrations_service.refresh_token_if_needed(oauth_integration)
-                access_token = await integrations_service.get_access_token(
-                    oauth_integration
-                )
-                if not access_token:
-                    logger.warning(
-                        "No access token for MCP integration %r (likely disconnected)",
-                        mcp_integration.name,
-                        extra={
-                            "workspace_id": str(self.workspace_id),
-                            "mcp_integration_id": str(mcp_integration.id),
-                            "integration_status": oauth_integration.status,
-                        },
-                    )
-                    continue
-
-                token_type = oauth_integration.token_type or "Bearer"
-                headers["Authorization"] = (
-                    f"{token_type} {access_token.get_secret_value()}"
-                )
-
-                if mcp_integration.encrypted_headers:
-                    custom_headers = self._decrypt_mcp_headers(
-                        encrypted_headers=mcp_integration.encrypted_headers,
-                        encryption_key=encryption_key,
-                        mcp_integration_id=mcp_integration.id,
-                        mcp_integration_name=mcp_integration.name,
-                    )
-                    if custom_headers is None:
-                        # OAuth2 additional headers are optional; malformed values should
-                        # not disable the integration when an access token is available.
-                        custom_headers = {}
-
-                    auth_header_keys = [
-                        key
-                        for key in custom_headers
-                        if key.strip().casefold() == "authorization"
-                    ]
-                    if auth_header_keys:
-                        logger.warning(
-                            "Ignoring custom Authorization header variants for OAUTH2 MCP integration %r",
-                            mcp_integration.name,
-                            extra={
-                                "workspace_id": str(self.workspace_id),
-                                "mcp_integration_id": str(mcp_integration.id),
-                                "dropped_header_keys": auth_header_keys,
-                            },
-                        )
-                        for auth_header_key in auth_header_keys:
-                            custom_headers.pop(auth_header_key, None)
-                    headers.update(custom_headers)
-
-            elif mcp_integration.auth_type == MCPAuthType.CUSTOM:
-                # CUSTOM: Decrypt and parse custom credentials (JSON string with headers)
-                if not mcp_integration.encrypted_headers:
-                    logger.warning(
-                        "MCP integration %r has CUSTOM auth type but no encrypted_headers",
-                        mcp_integration.name,
-                        extra={
-                            "workspace_id": str(self.workspace_id),
-                            "mcp_integration_id": str(mcp_integration.id),
-                        },
-                    )
-                    continue
-
-                custom_headers = self._decrypt_mcp_headers(
-                    encrypted_headers=mcp_integration.encrypted_headers,
-                    encryption_key=encryption_key,
-                    mcp_integration_id=mcp_integration.id,
-                    mcp_integration_name=mcp_integration.name,
-                )
-                if custom_headers is None:
-                    continue
-                # Merge custom headers (e.g., {"Authorization": "Bearer ...", "X-API-Key": "..."})
-                headers.update(custom_headers)
-
-            elif mcp_integration.auth_type == MCPAuthType.NONE:
-                pass
-
-            else:
-                logger.warning(
-                    "Unknown auth type for MCP integration %r: %s",
-                    mcp_integration.name,
-                    mcp_integration.auth_type,
-                    extra={
-                        "workspace_id": str(self.workspace_id),
-                        "mcp_integration_id": str(mcp_integration.id),
-                        "auth_type": str(mcp_integration.auth_type),
-                    },
-                )
-                continue
-
-            # Build MCP server config
-            http_config: MCPHttpServerConfig = {
-                "type": "http",
-                "name": mcp_integration.name,
-                "url": mcp_integration.server_uri,
-                "headers": headers,
-                "id": str(mcp_integration.id),
-            }
-            if mcp_integration.timeout is not None:
-                http_config["timeout"] = mcp_integration.timeout
             mcp_servers.append(http_config)
 
         if not mcp_servers:
@@ -1157,64 +963,22 @@ class AgentPresetService(BaseWorkspaceService):
                 return None
 
         # HTTP server — resolve headers per auth type.
-        encryption_key = get_db_encryption_key()
-        headers: dict[str, str] = {}
-
-        if mcp_integration.auth_type == MCPAuthType.OAUTH2:
-            if not mcp_integration.oauth_integration_id:
-                return None
-            stmt = select(OAuthIntegration).where(
-                OAuthIntegration.id == mcp_integration.oauth_integration_id,
-                OAuthIntegration.workspace_id == self.workspace_id,
+        try:
+            server_config = await integrations_service.resolve_mcp_http_server_config(
+                mcp_integration
             )
-            result = await self.session.execute(stmt)
-            oauth_integration = result.scalars().first()
-            if not oauth_integration:
-                return None
-            await integrations_service.refresh_token_if_needed(oauth_integration)
-            access_token = await integrations_service.get_access_token(
-                oauth_integration
+        except MCPConfigurationError as e:
+            logger.warning(
+                "Failed to resolve secrets for HTTP MCP integration %r: %s",
+                mcp_integration.name,
+                str(e),
+                extra={
+                    "workspace_id": str(self.workspace_id),
+                    "mcp_integration_id": str(mcp_integration.id),
+                },
             )
-            if not access_token:
-                return None
-            token_type = oauth_integration.token_type or "Bearer"
-            headers["Authorization"] = f"{token_type} {access_token.get_secret_value()}"
-
-            if mcp_integration.encrypted_headers:
-                custom_headers = self._decrypt_mcp_headers(
-                    encrypted_headers=mcp_integration.encrypted_headers,
-                    encryption_key=encryption_key,
-                    mcp_integration_id=mcp_integration.id,
-                    mcp_integration_name=mcp_integration.name,
-                )
-                if custom_headers:
-                    # Drop any user-supplied Authorization header — the OAuth
-                    # one wins.
-                    for key in list(custom_headers):
-                        if key.strip().casefold() == "authorization":
-                            custom_headers.pop(key, None)
-                    headers.update(custom_headers)
-
-        elif mcp_integration.auth_type == MCPAuthType.CUSTOM:
-            if not mcp_integration.encrypted_headers:
-                return None
-            custom_headers = self._decrypt_mcp_headers(
-                encrypted_headers=mcp_integration.encrypted_headers,
-                encryption_key=encryption_key,
-                mcp_integration_id=mcp_integration.id,
-                mcp_integration_name=mcp_integration.name,
-            )
-            if not custom_headers:
-                return None
-            headers.update(custom_headers)
-
-        elif mcp_integration.auth_type == MCPAuthType.NONE:
-            pass
-
-        else:
             return None
-
-        return headers
+        return server_config.get("headers", {})
 
     async def _resolve_stdio_env(
         self,

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -4574,6 +4574,12 @@ class MCPIntegration(TimestampMixin, Base):
         nullable=True,
         doc="Timeout in seconds (HTTP timeout for http type, process timeout for stdio type)",
     )
+    tools: Mapped[list[dict[str, Any]] | None] = mapped_column(
+        JSONB,
+        nullable=True,
+        doc="Tools discovered at the last successful connection verification "
+        "([{name, description}]); null means the server is unverified",
+    )
 
     oauth_integration: Mapped[OAuthIntegration | None] = relationship(
         "OAuthIntegration",

--- a/tracecat/integrations/catalog/service.py
+++ b/tracecat/integrations/catalog/service.py
@@ -7,7 +7,6 @@ from datetime import UTC, datetime
 from typing import NamedTuple
 
 import sqlalchemy as sa
-from pydantic import ValidationError
 
 from tracecat.db.models import MCPIntegration, OAuthIntegration
 from tracecat.integrations.catalog.loader import get_platform_mcp_catalog_entries
@@ -20,7 +19,6 @@ from tracecat.integrations.schemas import (
     PlatformMCPCatalogStatus,
 )
 from tracecat.integrations.types import MCPServerType
-from tracecat.logger import logger
 from tracecat.pagination import BaseCursorPaginator, CursorPaginationParams
 from tracecat.secrets.encryption import is_set
 from tracecat.service import BaseService
@@ -259,24 +257,12 @@ class PlatformMCPCatalogService(BaseService):
     def _catalog_tools(
         mcp_integration: MCPIntegration | None,
     ) -> list[MCPToolSummary] | None:
-        """Validate stored tool entries, skipping any malformed records.
-
-        Stored tool JSON is best-effort: a single corrupt entry must not crash
-        the entire catalog listing, so invalid records are dropped with a
-        warning instead of raising.
-        """
-        if mcp_integration is None or mcp_integration.tools is None:
+        """Validate stored tool entries, skipping any malformed records."""
+        if mcp_integration is None:
             return None
-        tools: list[MCPToolSummary] = []
-        for tool in mcp_integration.tools:
-            try:
-                tools.append(MCPToolSummary.model_validate(tool))
-            except ValidationError:
-                logger.warning(
-                    "Skipping malformed MCP catalog tool entry",
-                    mcp_integration_id=str(mcp_integration.id),
-                )
-        return tools
+        return MCPToolSummary.validate_stored(
+            mcp_integration.tools, mcp_integration_id=mcp_integration.id
+        )
 
     @staticmethod
     def _mcp_server_type(server_type: str | None) -> MCPServerType | None:

--- a/tracecat/integrations/catalog/service.py
+++ b/tracecat/integrations/catalog/service.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from typing import NamedTuple
 
 import sqlalchemy as sa
+from pydantic import ValidationError
 
 from tracecat.db.models import MCPIntegration, OAuthIntegration
 from tracecat.integrations.catalog.loader import get_platform_mcp_catalog_entries
@@ -19,6 +20,7 @@ from tracecat.integrations.schemas import (
     PlatformMCPCatalogStatus,
 )
 from tracecat.integrations.types import MCPServerType
+from tracecat.logger import logger
 from tracecat.pagination import BaseCursorPaginator, CursorPaginationParams
 from tracecat.secrets.encryption import is_set
 from tracecat.service import BaseService
@@ -245,10 +247,6 @@ class PlatformMCPCatalogService(BaseService):
             encrypted_access_token is not None and is_set(encrypted_access_token)
         ):
             return "configured"
-        # HTTP servers must also have a verified tool listing to count as
-        # connected; stdio servers cannot be verified and rely on config alone.
-        if mcp_integration.server_type == "http" and mcp_integration.tools is None:
-            return "configured"
         return "connected"
 
     @staticmethod
@@ -256,6 +254,29 @@ class PlatformMCPCatalogService(BaseService):
         if status in _CATALOG_STATUSES:
             return status
         return "coming_soon"
+
+    @staticmethod
+    def _catalog_tools(
+        mcp_integration: MCPIntegration | None,
+    ) -> list[MCPToolSummary] | None:
+        """Validate stored tool entries, skipping any malformed records.
+
+        Stored tool JSON is best-effort: a single corrupt entry must not crash
+        the entire catalog listing, so invalid records are dropped with a
+        warning instead of raising.
+        """
+        if mcp_integration is None or mcp_integration.tools is None:
+            return None
+        tools: list[MCPToolSummary] = []
+        for tool in mcp_integration.tools:
+            try:
+                tools.append(MCPToolSummary.model_validate(tool))
+            except ValidationError:
+                logger.warning(
+                    "Skipping malformed MCP catalog tool entry",
+                    mcp_integration_id=str(mcp_integration.id),
+                )
+        return tools
 
     @staticmethod
     def _mcp_server_type(server_type: str | None) -> MCPServerType | None:
@@ -303,11 +324,7 @@ class PlatformMCPCatalogService(BaseService):
                 mcp_integration.server_type if mcp_integration else None
             ),
             mcp_auth_type=mcp_integration.auth_type if mcp_integration else None,
-            tools=(
-                [MCPToolSummary.model_validate(tool) for tool in mcp_integration.tools]
-                if mcp_integration and mcp_integration.tools is not None
-                else None
-            ),
+            tools=cls._catalog_tools(mcp_integration),
             created_at=mcp_integration.created_at if mcp_integration else now,
             updated_at=mcp_integration.updated_at if mcp_integration else now,
             last_refreshed_at=None,

--- a/tracecat/integrations/catalog/service.py
+++ b/tracecat/integrations/catalog/service.py
@@ -13,6 +13,7 @@ from tracecat.integrations.catalog.loader import get_platform_mcp_catalog_entrie
 from tracecat.integrations.catalog.types import PlatformMCPCatalogEntry
 from tracecat.integrations.enums import MCPAuthType
 from tracecat.integrations.schemas import (
+    MCPToolSummary,
     PlatformMCPCatalogRead,
     PlatformMCPCatalogState,
     PlatformMCPCatalogStatus,
@@ -240,15 +241,15 @@ class PlatformMCPCatalogService(BaseService):
     ) -> PlatformMCPCatalogState:
         if mcp_integration is None:
             return "not_configured"
-        if (
-            mcp_integration.auth_type == MCPAuthType.OAUTH2
-            and encrypted_access_token is not None
-            and is_set(encrypted_access_token)
+        if mcp_integration.auth_type == MCPAuthType.OAUTH2 and not (
+            encrypted_access_token is not None and is_set(encrypted_access_token)
         ):
-            return "connected"
-        if mcp_integration.auth_type != MCPAuthType.OAUTH2:
-            return "connected"
-        return "configured"
+            return "configured"
+        # HTTP servers must also have a verified tool listing to count as
+        # connected; stdio servers cannot be verified and rely on config alone.
+        if mcp_integration.server_type == "http" and mcp_integration.tools is None:
+            return "configured"
+        return "connected"
 
     @staticmethod
     def _catalog_status(status: str) -> PlatformMCPCatalogStatus:
@@ -302,6 +303,11 @@ class PlatformMCPCatalogService(BaseService):
                 mcp_integration.server_type if mcp_integration else None
             ),
             mcp_auth_type=mcp_integration.auth_type if mcp_integration else None,
+            tools=(
+                [MCPToolSummary.model_validate(tool) for tool in mcp_integration.tools]
+                if mcp_integration and mcp_integration.tools is not None
+                else None
+            ),
             created_at=mcp_integration.created_at if mcp_integration else now,
             updated_at=mcp_integration.updated_at if mcp_integration else now,
             last_refreshed_at=None,

--- a/tracecat/integrations/mcp_validation.py
+++ b/tracecat/integrations/mcp_validation.py
@@ -53,6 +53,26 @@ class MCPConfigurationError(Exception):
     pass
 
 
+_URL_PATTERN = re.compile(r"\bhttps?://\S+", re.IGNORECASE)
+_URL_USERINFO_PATTERN = re.compile(r"^(https?://)[^/@]*@", re.IGNORECASE)
+
+
+def sanitize_urls_in_text(text: str) -> str:
+    """Strip credentials and query strings from any URLs embedded in free text.
+
+    Transport errors can echo a user-supplied server URI, which may carry
+    secrets in its userinfo (``user:pass@``) or query string. Sanitize before
+    storing such text in errors, logs, or API responses. Non-URL text is
+    returned unchanged.
+    """
+
+    def _sanitize(match: re.Match[str]) -> str:
+        url = _URL_USERINFO_PATTERN.sub(r"\1", match.group(0))
+        return re.sub(r"[?#].*$", "", url)
+
+    return _URL_PATTERN.sub(_sanitize, text)
+
+
 class MCPConnectionVerificationError(Exception):
     """Raised when connectivity verification against an MCP server fails."""
 

--- a/tracecat/integrations/mcp_validation.py
+++ b/tracecat/integrations/mcp_validation.py
@@ -47,6 +47,21 @@ class MCPValidationError(ValueError):
     pass
 
 
+class MCPConfigurationError(Exception):
+    """Raised when an MCP integration cannot be resolved into a usable server config."""
+
+    pass
+
+
+class MCPConnectionVerificationError(Exception):
+    """Raised when connectivity verification against an MCP server fails."""
+
+    def __init__(self, message: str, error: str | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.error = error
+
+
 def validate_mcp_command(command: str) -> None:
     """Validate that a command is in the allowlist.
 

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -2,6 +2,7 @@ import json
 import uuid
 from datetime import UTC, datetime
 from typing import Annotated, NoReturn, cast
+from urllib.parse import urlencode
 
 import httpx
 from fastapi import APIRouter, Body, HTTPException, Query, status
@@ -26,6 +27,7 @@ from tracecat.integrations.dependencies import (
     ProviderInfoDep,
 )
 from tracecat.integrations.enums import IntegrationStatus, OAuthGrantType
+from tracecat.integrations.mcp_validation import MCPConnectionVerificationError
 from tracecat.integrations.providers import all_providers
 from tracecat.integrations.providers.base import (
     AuthorizationCodeOAuthProvider,
@@ -45,7 +47,10 @@ from tracecat.integrations.schemas import (
     MCPIntegrationCreate,
     MCPIntegrationRead,
     MCPIntegrationSource,
+    MCPIntegrationTestConnectionRequest,
+    MCPIntegrationTestConnectionResponse,
     MCPIntegrationUpdate,
+    MCPToolSummary,
     PlatformMCPCatalogListResponse,
     PlatformMCPCatalogState,
     PlatformMCPCatalogStatus,
@@ -101,7 +106,32 @@ def _mcp_integration_read(
         stdio_args=mcp_integration.stdio_args,
         has_stdio_env=bool(mcp_integration.encrypted_stdio_env),
         timeout=mcp_integration.timeout,
+        tools=(
+            [MCPToolSummary.model_validate(tool) for tool in mcp_integration.tools]
+            if mcp_integration.tools is not None
+            else None
+        ),
     )
+
+
+async def _gate_mcp_connect_verification(
+    svc: IntegrationService, mcp_integration: MCPIntegration
+) -> None:
+    """Verify HTTP MCP connectivity as part of connect/save.
+
+    The row is already persisted; a failed verification clears its stored
+    tools (demoting the connection state) and surfaces the failure as an
+    HTTP error so the connect/save does not report success.
+    """
+    if mcp_integration.server_type != "http":
+        return
+    result = await svc.verify_mcp_integration(mcp_integration=mcp_integration)
+    if not result.success:
+        detail = f"{result.message}: {result.error}" if result.error else result.message
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=detail,
+        )
 
 
 async def _mcp_catalog_connect_response(
@@ -117,6 +147,8 @@ async def _mcp_catalog_connect_response(
     mcp_integration = connect_result.mcp_integration
     mcp_read = None
     if mcp_integration:
+        if not oauth_connect:
+            await _gate_mcp_connect_verification(svc, mcp_integration)
         mcp_read = _mcp_integration_read(
             mcp_integration,
             state=await svc.mcp_integration_state(mcp_integration=mcp_integration),
@@ -232,7 +264,7 @@ async def oauth_callback(
 
     if svc._is_custom_mcp_oauth_provider(oauth_state_db.provider_id):
         try:
-            await svc.complete_mcp_oauth_discovery_callback(
+            oauth_integration = await svc.complete_mcp_oauth_discovery_callback(
                 provider_id=oauth_state_db.provider_id,
                 code=code,
                 state=str(state),
@@ -259,13 +291,31 @@ async def oauth_callback(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Workspace ID is required",
             )
+
+        # Verify connectivity now that the token is stored. Failure must not
+        # block the redirect — it clears stored tools so the integration
+        # lands demoted, and the error is surfaced via the redirect URL.
+        verification_error: str | None = None
+        mcp_integration = await svc._mcp_integration_for_oauth_integration(
+            oauth_integration_id=oauth_integration.id
+        )
+        if mcp_integration is not None and mcp_integration.server_type == "http":
+            result = await svc.verify_mcp_integration(mcp_integration=mcp_integration)
+            if not result.success:
+                verification_error = result.error or result.message
+
+        redirect_url = (
+            f"{config.TRACECAT__PUBLIC_APP_URL}/workspaces/"
+            f"{role.workspace_id}/mcp-servers"
+        )
+        if verification_error:
+            redirect_url += "?" + urlencode(
+                {"mcp_verify_error": verification_error[:500]}
+            )
         return IntegrationOAuthCallback(
             status="connected",
             provider_id=oauth_state_db.provider_id,
-            redirect_url=(
-                f"{config.TRACECAT__PUBLIC_APP_URL}/workspaces/"
-                f"{role.workspace_id}/mcp-servers"
-            ),
+            redirect_url=redirect_url,
         )
 
     key = ProviderKey(
@@ -910,6 +960,7 @@ async def create_mcp_integration(
             detail=str(exc),
         ) from exc
 
+    await _gate_mcp_connect_verification(svc, mcp_integration)
     return _mcp_integration_read(
         mcp_integration,
         state=await svc.mcp_integration_state(mcp_integration=mcp_integration),
@@ -1043,15 +1094,17 @@ async def connect_mcp_integration(
             return await _mcp_catalog_connect_response(svc, connect_result)
 
         mcp_integration = await svc.create_mcp_integration(params=params)
-        return MCPCatalogConnectResponse(
-            status="connected",
-            mcp_integration=_mcp_integration_read(
-                mcp_integration,
-                state=await svc.mcp_integration_state(mcp_integration=mcp_integration),
-            ),
-        )
     except Exception as exc:
         _raise_mcp_connect_http_error(exc)
+
+    await _gate_mcp_connect_verification(svc, mcp_integration)
+    return MCPCatalogConnectResponse(
+        status="connected",
+        mcp_integration=_mcp_integration_read(
+            mcp_integration,
+            state=await svc.mcp_integration_state(mcp_integration=mcp_integration),
+        ),
+    )
 
 
 @mcp_router.get("/{mcp_integration_id}")
@@ -1099,14 +1152,24 @@ async def update_mcp_integration(
 
     svc = IntegrationService(session, role=role)
     try:
+        # Verification runs against the merged config BEFORE anything is
+        # persisted — a failed update never disturbs the existing connection.
         integration = await svc.update_mcp_integration(
-            mcp_integration_id=mcp_integration_id, params=params
+            mcp_integration_id=mcp_integration_id,
+            params=params,
+            verify_connection=True,
         )
         if integration is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="MCP integration not found",
             )
+    except MCPConnectionVerificationError as exc:
+        detail = f"{exc.message}: {exc.error}" if exc.error else exc.message
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=detail,
+        ) from exc
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1117,6 +1180,58 @@ async def update_mcp_integration(
         integration,
         state=await svc.mcp_integration_state(mcp_integration=integration),
     )
+
+
+@mcp_router.post("/test")
+@require_scope("integration:create", "integration:update", require_all=False)
+async def test_mcp_connection_config(
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    params: Annotated[MCPIntegrationTestConnectionRequest, Body(...)],
+) -> MCPIntegrationTestConnectionResponse:
+    """Test connectivity against an unsaved HTTP MCP configuration.
+
+    Ephemeral: nothing is persisted and stored verification state is never
+    touched — use this for testing edited form values before saving.
+    """
+    if role.workspace_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Workspace ID is required",
+        )
+
+    svc = IntegrationService(session, role=role)
+    return await svc.test_mcp_http_connection(params=params)
+
+
+@mcp_router.post("/{mcp_integration_id}/test")
+@require_scope("integration:update")
+async def test_mcp_integration_connection(
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    mcp_integration_id: uuid.UUID,
+) -> MCPIntegrationTestConnectionResponse:
+    """Test connectivity to an HTTP MCP server and refresh its tool listing."""
+    if role.workspace_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Workspace ID is required",
+        )
+
+    svc = IntegrationService(session, role=role)
+    integration = await svc.get_mcp_integration(mcp_integration_id=mcp_integration_id)
+    if integration is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="MCP integration not found",
+        )
+    if integration.server_type != "http":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Connection testing is only supported for HTTP MCP servers",
+        )
+
+    return await svc.verify_mcp_integration(mcp_integration=integration)
 
 
 @mcp_router.post(

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -106,10 +106,8 @@ def _mcp_integration_read(
         stdio_args=mcp_integration.stdio_args,
         has_stdio_env=bool(mcp_integration.encrypted_stdio_env),
         timeout=mcp_integration.timeout,
-        tools=(
-            [MCPToolSummary.model_validate(tool) for tool in mcp_integration.tools]
-            if mcp_integration.tools is not None
-            else None
+        tools=MCPToolSummary.validate_stored(
+            mcp_integration.tools, mcp_integration_id=mcp_integration.id
         ),
     )
 
@@ -1199,7 +1197,7 @@ async def update_mcp_integration(
 
 
 @mcp_router.post("/test")
-@require_scope("integration:create", "integration:update", require_all=False)
+@require_scope("integration:update")
 async def test_mcp_connection_config(
     role: WorkspaceActorRouteRole,
     session: AsyncDBSession,

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -115,18 +115,30 @@ def _mcp_integration_read(
 
 
 async def _gate_mcp_connect_verification(
-    svc: IntegrationService, mcp_integration: MCPIntegration
+    svc: IntegrationService,
+    mcp_integration: MCPIntegration,
+    *,
+    delete_on_failure: bool = True,
 ) -> None:
     """Verify HTTP MCP connectivity as part of connect/save.
 
-    The row is already persisted; a failed verification clears its stored
-    tools (demoting the connection state) and surfaces the failure as an
-    HTTP error so the connect/save does not report success.
+    When the row was created by this request, a failed verification deletes it
+    so that retries don't accumulate orphaned rows. Pre-existing rows returned
+    by idempotent connects are kept (``delete_on_failure=False``) so a
+    transient outage doesn't destroy a saved integration; the failed
+    verification has already cleared its stored tools. Either way the failure
+    surfaces as an HTTP error so the connect/save does not report success.
     """
     if mcp_integration.server_type != "http":
         return
+    if await svc.mcp_oauth_authorization_pending(mcp_integration=mcp_integration):
+        # No access token exists until the user completes the OAuth redirect;
+        # the OAuth callback runs its own verification after token exchange.
+        return
     result = await svc.verify_mcp_integration(mcp_integration=mcp_integration)
     if not result.success:
+        if delete_on_failure:
+            await svc._delete_mcp_integration_row(mcp_integration)
         detail = f"{result.message}: {result.error}" if result.error else result.message
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -148,7 +160,11 @@ async def _mcp_catalog_connect_response(
     mcp_read = None
     if mcp_integration:
         if not oauth_connect:
-            await _gate_mcp_connect_verification(svc, mcp_integration)
+            await _gate_mcp_connect_verification(
+                svc,
+                mcp_integration,
+                delete_on_failure=connect_result.created,
+            )
         mcp_read = _mcp_integration_read(
             mcp_integration,
             state=await svc.mcp_integration_state(mcp_integration=mcp_integration),

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -692,6 +692,13 @@ type MCPConnectionSpec = Annotated[
 ]
 
 
+class MCPToolSummary(BaseModel):
+    """Summary of a tool discovered on a remote MCP server."""
+
+    name: str
+    description: str | None = None
+
+
 class MCPConnectionOption(BaseModel):
     """A connectable transport/auth option for one catalog provider."""
 
@@ -723,6 +730,8 @@ class PlatformMCPCatalogRead(BaseModel):
     mcp_integration_id: UUID4 | None
     mcp_server_type: MCPServerType | None = None
     mcp_auth_type: MCPAuthType | None = None
+    tools: list[MCPToolSummary] | None = None
+    """Tools discovered at the last successful verification; null means unverified."""
     created_at: datetime
     updated_at: datetime
     last_refreshed_at: datetime | None
@@ -758,8 +767,39 @@ class MCPIntegrationRead(BaseModel):
     """Whether stdio_env is configured (actual values are not exposed)."""
     # General fields
     timeout: int | None
+    tools: list[MCPToolSummary] | None = None
+    """Tools discovered at the last successful verification; null means unverified."""
     created_at: datetime
     updated_at: datetime
+
+
+class MCPIntegrationTestConnectionRequest(BaseModel):
+    """Request to test connectivity against an unsaved HTTP MCP configuration.
+
+    Carries the (possibly edited, not yet persisted) form values. When
+    ``mcp_integration_id`` is set, stored secrets from that row are used as a
+    fallback for fields the caller leaves blank (e.g. unchanged credentials).
+    """
+
+    mcp_integration_id: UUID4 | None = None
+    server_uri: str = Field(..., min_length=1, max_length=2048)
+    auth_type: MCPAuthType = MCPAuthType.NONE
+    oauth_integration_id: UUID4 | None = None
+    custom_credentials: SecretStr | None = Field(
+        default=None,
+        description="JSON object of custom headers; falls back to stored headers when omitted",
+    )
+    timeout: int | None = Field(default=None, ge=1, le=300)
+
+
+class MCPIntegrationTestConnectionResponse(BaseModel):
+    """Response for testing connectivity to an MCP server."""
+
+    success: bool
+    mcp_integration_id: UUID4 | None = None
+    tools: list[MCPToolSummary] | None = None
+    message: str
+    error: str | None = None
 
 
 class MCPCatalogConnectResponse(BaseModel):

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -17,6 +17,7 @@ from pydantic import (
     Field,
     SecretStr,
     Tag,
+    ValidationError,
     computed_field,
     field_validator,
 )
@@ -24,6 +25,7 @@ from pydantic import (
 from tracecat.identifiers import UserID, WorkspaceID
 from tracecat.integrations.enums import IntegrationStatus, MCPAuthType, OAuthGrantType
 from tracecat.integrations.types import MCPServerType
+from tracecat.logger import logger
 
 
 # Pydantic models for API responses
@@ -697,6 +699,31 @@ class MCPToolSummary(BaseModel):
 
     name: str
     description: str | None = None
+
+    @classmethod
+    def validate_stored(
+        cls, tools: list[Any] | None, *, mcp_integration_id: object | None = None
+    ) -> list[Self] | None:
+        """Validate stored tool entries, skipping any malformed records.
+
+        Stored tool JSON is best-effort: a single corrupt entry (manual DB
+        edit, future schema drift) must not crash listing or read responses,
+        so invalid records are dropped with a warning instead of raising.
+        """
+        if tools is None:
+            return None
+        validated: list[Self] = []
+        for tool in tools:
+            try:
+                validated.append(cls.model_validate(tool))
+            except ValidationError:
+                logger.warning(
+                    "Skipping malformed MCP tool entry",
+                    mcp_integration_id=str(mcp_integration_id)
+                    if mcp_integration_id is not None
+                    else None,
+                )
+        return validated
 
 
 class MCPConnectionOption(BaseModel):

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -791,6 +791,30 @@ class MCPIntegrationTestConnectionRequest(BaseModel):
     )
     timeout: int | None = Field(default=None, ge=1, le=300)
 
+    @field_validator("server_uri", mode="before")
+    @classmethod
+    def _validate_server_uri(cls, value: str | None) -> str:
+        """Validate and sanitize the MCP server URI.
+
+        Input-only validation that mirrors ``MCPHttpIntegrationCreate``. It does
+        NOT perform DNS resolution; the runtime SSRF block at probe time is the
+        real defense against private/loopback/link-local targets.
+        """
+        if value is None:
+            raise ValueError("server_uri is required")
+        if isinstance(value, str):
+            value = value.strip()
+        if not value:
+            raise ValueError("server_uri is required")
+
+        parsed = urlparse(value)
+        if not parsed.netloc:
+            raise ValueError("Server URI must include a hostname")
+        if parsed.scheme.lower() not in ("http", "https"):
+            raise ValueError("Server URI must use HTTP or HTTPS")
+
+        return value
+
 
 class MCPIntegrationTestConnectionResponse(BaseModel):
     """Response for testing connectivity to an MCP server."""

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -3113,12 +3113,7 @@ class IntegrationService(BaseWorkspaceService):
             # path, which maps "" to no headers rather than back-filling.
             raw_credentials = params.custom_credentials.get_secret_value()
             encrypted_headers = (
-                encrypt_value(
-                    raw_credentials.encode("utf-8"),
-                    key=get_db_encryption_key(),
-                )
-                if raw_credentials
-                else None
+                self._encrypt_token(raw_credentials) if raw_credentials else None
             )
         else:
             encrypted_headers = reusable.encrypted_headers if reusable else None
@@ -3452,7 +3447,15 @@ class IntegrationService(BaseWorkspaceService):
                     target_auth_type=target_auth_type,
                     target_oauth_integration_id=target_oauth_integration_id,
                 )
-                verified_tools = await self._probe_mcp_http_server(update_target)
+                # Skip the probe while an OAuth2 target still lacks an access
+                # token: the user hasn't completed (or has lost) authorization,
+                # so a benign edit must not be rejected. Mirrors the connect/save
+                # gate (_gate_mcp_connect_verification); the OAuth callback runs
+                # its own verification after token exchange.
+                if not await self.mcp_oauth_authorization_pending(
+                    mcp_integration=update_target
+                ):
+                    verified_tools = await self._probe_mcp_http_server(update_target)
         elif target_server_type == "stdio" and (
             server_type_changed
             or params.stdio_command is not None

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -22,9 +22,8 @@ from sqlalchemy import and_, delete, or_, select, update
 
 from tracecat import config
 from tracecat.agent.common.types import MCPHttpServerConfig
-from tracecat.agent.mcp.user_client import list_remote_mcp_tools
 from tracecat.auth.secrets import get_db_encryption_key
-from tracecat.authz.controls import require_scope
+from tracecat.authz.controls import has_scope, require_scope
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import (
     AgentPreset,
@@ -48,6 +47,7 @@ from tracecat.integrations.mcp_validation import (
     MCPConfigurationError,
     MCPConnectionVerificationError,
     MCPValidationError,
+    sanitize_urls_in_text,
     validate_mcp_command_config,
 )
 from tracecat.integrations.providers import get_provider_class
@@ -100,6 +100,10 @@ class PlatformMCPCatalogConnectResult:
 
     mcp_integration: MCPIntegration | None = None
     oauth_connect: IntegrationOAuthConnect | None = None
+    # True when this request created the MCP row. A failed connect-time
+    # verification may delete the row only in that case; pre-existing rows
+    # returned by idempotent connects must survive transient failures.
+    created: bool = False
 
 
 @dataclass(frozen=True)
@@ -1009,7 +1013,8 @@ class IntegrationService(BaseWorkspaceService):
             raise ValueError("MCP OAuth discovery requires an HTTP OAuth MCP server")
         if params.oauth_integration_id is not None:
             return PlatformMCPCatalogConnectResult(
-                mcp_integration=await self.create_mcp_integration(params=params)
+                mcp_integration=await self.create_mcp_integration(params=params),
+                created=True,
             )
 
         scopes: list[str] | None = None
@@ -1091,6 +1096,7 @@ class IntegrationService(BaseWorkspaceService):
         return PlatformMCPCatalogConnectResult(
             mcp_integration=mcp_integration,
             oauth_connect=oauth_connect,
+            created=existing_mcp_integration is None,
         )
 
     @classmethod
@@ -2622,7 +2628,8 @@ class IntegrationService(BaseWorkspaceService):
         if spec is not None:
             params = self._catalog_connect_create_params(catalog=catalog, spec=spec)
             return PlatformMCPCatalogConnectResult(
-                mcp_integration=await self.create_mcp_integration(params=params)
+                mcp_integration=await self.create_mcp_integration(params=params),
+                created=True,
             )
 
         if provider_connect := await self._start_catalog_provider_oauth(
@@ -2929,10 +2936,6 @@ class IntegrationService(BaseWorkspaceService):
             encrypted_access_token is not None and is_set(encrypted_access_token)
         ):
             return "configured"
-        # HTTP servers must also have a verified tool listing to count as
-        # connected; stdio servers cannot be verified and rely on config alone.
-        if mcp_integration.server_type == "http" and mcp_integration.tools is None:
-            return "configured"
         return "connected"
 
     async def _mcp_oauth_access_tokens_by_id(
@@ -2956,6 +2959,27 @@ class IntegrationService(BaseWorkspaceService):
         )
         rows = result.tuples().all()
         return dict(rows)
+
+    async def mcp_oauth_authorization_pending(
+        self, *, mcp_integration: MCPIntegration
+    ) -> bool:
+        """Whether an OAUTH2 MCP integration is still awaiting its OAuth callback.
+
+        True when the linked OAuth integration has no stored access token yet,
+        i.e. the user has not completed the authorization redirect. Used to skip
+        connect/save verification until a token exists; the OAuth callback runs
+        its own verification after the token exchange.
+        """
+        if mcp_integration.auth_type != MCPAuthType.OAUTH2:
+            return False
+        oauth_integration_id = mcp_integration.oauth_integration_id
+        if oauth_integration_id is None:
+            return True
+        tokens_by_id = await self._mcp_oauth_access_tokens_by_id([mcp_integration])
+        encrypted_access_token = tokens_by_id.get(oauth_integration_id)
+        return not (
+            encrypted_access_token is not None and is_set(encrypted_access_token)
+        )
 
     async def mcp_integration_state(
         self, *, mcp_integration: MCPIntegration
@@ -3019,6 +3043,11 @@ class IntegrationService(BaseWorkspaceService):
             MCPConnectionVerificationError: If the config cannot be resolved,
                 the connection times out, or the server is unreachable.
         """
+        # Imported lazily: fastmcp's dependencies install a global beartype
+        # import hook that breaks Temporal's workflow sandbox in processes
+        # that import this module (e.g. the executor worker).
+        from tracecat.agent.mcp.user_client import list_remote_mcp_tools
+
         try:
             server_config = await self.resolve_mcp_http_server_config(mcp_integration)
             timeout = mcp_integration.timeout or MCP_TEST_CONNECTION_TIMEOUT_CAP
@@ -3029,15 +3058,21 @@ class IntegrationService(BaseWorkspaceService):
                 return await list_remote_mcp_tools(server_config)
         except MCPConfigurationError as e:
             raise MCPConnectionVerificationError(
-                "MCP integration is not configured correctly", str(e)
+                "MCP integration is not configured correctly",
+                sanitize_urls_in_text(str(e)),
             ) from e
         except TimeoutError as e:
             raise MCPConnectionVerificationError(
-                "Connection to the MCP server timed out", str(e) or "Timed out"
+                "Connection to the MCP server timed out",
+                sanitize_urls_in_text(str(e)) or "Timed out",
             ) from e
         except Exception as e:
+            # Transport errors can echo the full request URL, including
+            # userinfo or query-string secrets — sanitize before this text
+            # reaches logs or API error responses.
             raise MCPConnectionVerificationError(
-                "Failed to connect to the MCP server", str(e)
+                "Failed to connect to the MCP server",
+                sanitize_urls_in_text(str(e)),
             ) from e
 
     async def test_mcp_http_connection(
@@ -3048,7 +3083,13 @@ class IntegrationService(BaseWorkspaceService):
         Fully ephemeral: nothing is persisted and a failure never touches the
         stored verification state of any existing integration. When
         ``params.mcp_integration_id`` references an existing row, its stored
-        secrets back-fill fields the caller left blank.
+        secrets back-fill fields the caller left blank — but only for callers
+        with ``integration:update``. This route is reachable with
+        ``integration:create`` alone; without the back-fill guard a create-only
+        caller could pair a saved integration id with an attacker-controlled
+        ``server_uri`` and have the probe send the stored API key or OAuth
+        bearer token to that host, bypassing the update permission that guards
+        reuse of stored credentials.
         """
         existing: MCPIntegration | None = None
         if params.mcp_integration_id is not None:
@@ -3056,15 +3097,33 @@ class IntegrationService(BaseWorkspaceService):
                 mcp_integration_id=params.mcp_integration_id
             )
 
+        # Reusing a saved integration's stored secrets is an update-scoped
+        # operation. Without integration:update, ignore the existing row's
+        # secrets so the probe runs with only caller-supplied credentials.
+        can_reuse_stored_secrets = (
+            existing is not None
+            and self.role.scopes is not None
+            and has_scope(self.role.scopes, "integration:update")
+        )
+        reusable = existing if can_reuse_stored_secrets else None
+
         if params.custom_credentials is not None:
-            encrypted_headers = encrypt_value(
-                params.custom_credentials.get_secret_value().encode("utf-8"),
-                key=get_db_encryption_key(),
+            # An explicit empty string means "test without stored headers"
+            # (the user cleared the credentials editor) — mirror the update
+            # path, which maps "" to no headers rather than back-filling.
+            raw_credentials = params.custom_credentials.get_secret_value()
+            encrypted_headers = (
+                encrypt_value(
+                    raw_credentials.encode("utf-8"),
+                    key=get_db_encryption_key(),
+                )
+                if raw_credentials
+                else None
             )
         else:
-            encrypted_headers = existing.encrypted_headers if existing else None
+            encrypted_headers = reusable.encrypted_headers if reusable else None
         oauth_integration_id = params.oauth_integration_id or (
-            existing.oauth_integration_id if existing else None
+            reusable.oauth_integration_id if reusable else None
         )
         # Transient row used purely for config resolution — never added to the
         # session, so it is never persisted.
@@ -3508,7 +3567,18 @@ class IntegrationService(BaseWorkspaceService):
         )
         if not mcp_integration:
             return False
+        return await self._delete_mcp_integration_row(mcp_integration)
 
+    async def _delete_mcp_integration_row(
+        self, mcp_integration: MCPIntegration
+    ) -> bool:
+        """Delete an MCP integration row and clean up references.
+
+        Called by delete_mcp_integration (scope-checked) and by the connect/save
+        cleanup path which rolls back a freshly created row on verification failure
+        without requiring the caller to hold integration:delete.
+        """
+        mcp_integration_id = mcp_integration.id
         id_str = str(mcp_integration_id)
 
         try:

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1,5 +1,6 @@
 """Service for managing user integrations with external services."""
 
+import asyncio
 import re
 import secrets
 import uuid
@@ -20,6 +21,8 @@ from slugify import slugify
 from sqlalchemy import and_, delete, or_, select, update
 
 from tracecat import config
+from tracecat.agent.common.types import MCPHttpServerConfig
+from tracecat.agent.mcp.user_client import list_remote_mcp_tools
 from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.authz.controls import require_scope
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
@@ -42,6 +45,8 @@ from tracecat.integrations.enums import MCPAuthType, OAuthGrantType
 from tracecat.integrations.mcp_validation import (
     ALLOWED_MCP_COMMANDS,
     MAX_SERVER_NAME_LENGTH,
+    MCPConfigurationError,
+    MCPConnectionVerificationError,
     MCPValidationError,
     validate_mcp_command_config,
 )
@@ -64,8 +69,11 @@ from tracecat.integrations.schemas import (
     MCPHTTPOAuth2ConnectionSpec,
     MCPIntegrationCreate,
     MCPIntegrationSource,
+    MCPIntegrationTestConnectionRequest,
+    MCPIntegrationTestConnectionResponse,
     MCPIntegrationUpdate,
     MCPStdioIntegrationCreate,
+    MCPToolSummary,
     PlatformMCPCatalogState,
     ProviderConfig,
     ProviderKey,
@@ -81,6 +89,9 @@ from tracecat.integrations.types import (
 from tracecat.secrets.encryption import decrypt_value, encrypt_value, is_set
 from tracecat.service import BaseWorkspaceService
 from tracecat.tiers.enums import Entitlement
+
+MCP_TEST_CONNECTION_TIMEOUT_CAP = 15
+"""Maximum seconds an MCP connection verification may take."""
 
 
 @dataclass(frozen=True)
@@ -2914,11 +2925,15 @@ class IntegrationService(BaseWorkspaceService):
         mcp_integration: MCPIntegration,
         encrypted_access_token: bytes | None,
     ) -> PlatformMCPCatalogState:
-        if mcp_integration.auth_type != MCPAuthType.OAUTH2:
-            return "connected"
-        if encrypted_access_token is not None and is_set(encrypted_access_token):
-            return "connected"
-        return "configured"
+        if mcp_integration.auth_type == MCPAuthType.OAUTH2 and not (
+            encrypted_access_token is not None and is_set(encrypted_access_token)
+        ):
+            return "configured"
+        # HTTP servers must also have a verified tool listing to count as
+        # connected; stdio servers cannot be verified and rely on config alone.
+        if mcp_integration.server_type == "http" and mcp_integration.tools is None:
+            return "configured"
+        return "connected"
 
     async def _mcp_oauth_access_tokens_by_id(
         self, mcp_integrations: Sequence[MCPIntegration]
@@ -2993,16 +3008,333 @@ class IntegrationService(BaseWorkspaceService):
         result = await self.session.execute(statement)
         return result.scalars().first()
 
+    async def _probe_mcp_http_server(
+        self, mcp_integration: MCPIntegration
+    ) -> list[MCPToolSummary]:
+        """Resolve an HTTP MCP config and list the server's tools.
+
+        Side-effect free.
+
+        Raises:
+            MCPConnectionVerificationError: If the config cannot be resolved,
+                the connection times out, or the server is unreachable.
+        """
+        try:
+            server_config = await self.resolve_mcp_http_server_config(mcp_integration)
+            timeout = mcp_integration.timeout or MCP_TEST_CONNECTION_TIMEOUT_CAP
+            server_config["timeout"] = min(timeout, MCP_TEST_CONNECTION_TIMEOUT_CAP)
+            # The transport timeout only covers reads; the outer timeout guards
+            # connect-phase hangs as well.
+            async with asyncio.timeout(MCP_TEST_CONNECTION_TIMEOUT_CAP + 5):
+                return await list_remote_mcp_tools(server_config)
+        except MCPConfigurationError as e:
+            raise MCPConnectionVerificationError(
+                "MCP integration is not configured correctly", str(e)
+            ) from e
+        except TimeoutError as e:
+            raise MCPConnectionVerificationError(
+                "Connection to the MCP server timed out", str(e) or "Timed out"
+            ) from e
+        except Exception as e:
+            raise MCPConnectionVerificationError(
+                "Failed to connect to the MCP server", str(e)
+            ) from e
+
+    async def test_mcp_http_connection(
+        self, *, params: MCPIntegrationTestConnectionRequest
+    ) -> MCPIntegrationTestConnectionResponse:
+        """Test connectivity against an unsaved HTTP MCP configuration.
+
+        Fully ephemeral: nothing is persisted and a failure never touches the
+        stored verification state of any existing integration. When
+        ``params.mcp_integration_id`` references an existing row, its stored
+        secrets back-fill fields the caller left blank.
+        """
+        existing: MCPIntegration | None = None
+        if params.mcp_integration_id is not None:
+            existing = await self.get_mcp_integration(
+                mcp_integration_id=params.mcp_integration_id
+            )
+
+        if params.custom_credentials is not None:
+            encrypted_headers = encrypt_value(
+                params.custom_credentials.get_secret_value().encode("utf-8"),
+                key=get_db_encryption_key(),
+            )
+        else:
+            encrypted_headers = existing.encrypted_headers if existing else None
+        oauth_integration_id = params.oauth_integration_id or (
+            existing.oauth_integration_id if existing else None
+        )
+        # Transient row used purely for config resolution — never added to the
+        # session, so it is never persisted.
+        transient = MCPIntegration(
+            id=uuid4(),
+            workspace_id=self.workspace_id,
+            name=existing.name if existing else "MCP connection test",
+            slug=existing.slug if existing else "mcp-connection-test",
+            server_type="http",
+            server_uri=params.server_uri,
+            auth_type=params.auth_type,
+            oauth_integration_id=oauth_integration_id,
+            encrypted_headers=encrypted_headers,
+            timeout=params.timeout,
+        )
+
+        try:
+            tools = await self._probe_mcp_http_server(transient)
+        except MCPConnectionVerificationError as e:
+            return MCPIntegrationTestConnectionResponse(
+                success=False,
+                mcp_integration_id=params.mcp_integration_id,
+                message=e.message,
+                error=e.error,
+            )
+
+        return MCPIntegrationTestConnectionResponse(
+            success=True,
+            mcp_integration_id=params.mcp_integration_id,
+            tools=tools,
+            message=f"Connected successfully — {len(tools)} tools available",
+        )
+
+    async def verify_mcp_integration(
+        self, *, mcp_integration: MCPIntegration
+    ) -> MCPIntegrationTestConnectionResponse:
+        """Verify connectivity to an HTTP MCP server and persist its tools.
+
+        Last attempt wins: a successful verification stores the discovered
+        tools on the integration; any failure clears previously stored tools
+        so the integration no longer reports as verified.
+        """
+        try:
+            tools = await self._probe_mcp_http_server(mcp_integration)
+        except MCPConnectionVerificationError as e:
+            return await self._record_mcp_verification_failure(
+                mcp_integration,
+                message=e.message,
+                error=e.error or e.message,
+            )
+
+        mcp_integration.tools = [tool.model_dump() for tool in tools]
+        self.session.add(mcp_integration)
+        await self.session.commit()
+        await self.session.refresh(mcp_integration)
+        self.logger.info(
+            "MCP integration verified",
+            mcp_integration_id=str(mcp_integration.id),
+            tool_count=len(tools),
+        )
+        return MCPIntegrationTestConnectionResponse(
+            success=True,
+            mcp_integration_id=mcp_integration.id,
+            tools=tools,
+            message=f"Connected successfully — {len(tools)} tools available",
+        )
+
+    async def _record_mcp_verification_failure(
+        self,
+        mcp_integration: MCPIntegration,
+        *,
+        message: str,
+        error: str,
+    ) -> MCPIntegrationTestConnectionResponse:
+        """Clear stored tools after a failed verification and build the response."""
+        self.logger.warning(
+            "MCP integration verification failed",
+            mcp_integration_id=str(mcp_integration.id),
+            message=message,
+            error=error,
+        )
+        if mcp_integration.tools is not None:
+            mcp_integration.tools = None
+            self.session.add(mcp_integration)
+            await self.session.commit()
+            await self.session.refresh(mcp_integration)
+        return MCPIntegrationTestConnectionResponse(
+            success=False,
+            mcp_integration_id=mcp_integration.id,
+            message=message,
+            error=error,
+        )
+
+    def _decrypt_mcp_custom_headers(
+        self, mcp_integration: MCPIntegration
+    ) -> dict[str, str]:
+        """Decrypt and validate custom headers stored on an MCP integration.
+
+        Raises:
+            MCPConfigurationError: If headers are missing, malformed, or not a
+                JSON object of string keys to string values.
+        """
+        if not mcp_integration.encrypted_headers:
+            raise MCPConfigurationError(
+                "MCP integration has no custom headers configured"
+            )
+        encryption_key = get_db_encryption_key()
+        try:
+            decrypted = decrypt_value(
+                mcp_integration.encrypted_headers, key=encryption_key
+            )
+            parsed = orjson.loads(decrypted)
+        except (orjson.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
+            raise MCPConfigurationError("Custom headers are malformed") from e
+        if not isinstance(parsed, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in parsed.items()
+        ):
+            raise MCPConfigurationError(
+                "Custom headers must be a JSON object of string header values"
+            )
+        return cast(dict[str, str], parsed)
+
+    async def resolve_mcp_http_server_config(
+        self, mcp_integration: MCPIntegration
+    ) -> MCPHttpServerConfig:
+        """Resolve an HTTP MCP integration into a connectable server config.
+
+        Decrypts custom headers and refreshes/attaches the OAuth access token
+        as needed. Secrets are resolved at call time — never persist or send
+        the result across a Temporal boundary.
+
+        Raises:
+            MCPConfigurationError: If the integration is stdio-type or its
+                configuration/credentials cannot be resolved.
+        """
+        if mcp_integration.server_type != "http":
+            raise MCPConfigurationError(
+                "Only HTTP MCP servers can be resolved into an HTTP config"
+            )
+        if not mcp_integration.server_uri:
+            raise MCPConfigurationError("HTTP MCP integration has no server URI")
+
+        headers: dict[str, str] = {}
+        if mcp_integration.auth_type == MCPAuthType.OAUTH2:
+            if not mcp_integration.oauth_integration_id:
+                raise MCPConfigurationError(
+                    "OAuth MCP integration has no linked OAuth integration"
+                )
+            stmt = select(OAuthIntegration).where(
+                OAuthIntegration.id == mcp_integration.oauth_integration_id,
+                OAuthIntegration.workspace_id == self.workspace_id,
+            )
+            result = await self.session.execute(stmt)
+            oauth_integration = result.scalars().first()
+            if not oauth_integration:
+                raise MCPConfigurationError("Linked OAuth integration not found")
+            await self.refresh_token_if_needed(oauth_integration)
+            access_token = await self.get_access_token(oauth_integration)
+            if not access_token:
+                raise MCPConfigurationError(
+                    "OAuth integration has no access token (likely disconnected)"
+                )
+            token_type = oauth_integration.token_type or "Bearer"
+            headers["Authorization"] = f"{token_type} {access_token.get_secret_value()}"
+            if mcp_integration.encrypted_headers:
+                try:
+                    custom_headers = self._decrypt_mcp_custom_headers(mcp_integration)
+                except MCPConfigurationError:
+                    # Extra headers are optional for OAuth2; malformed values must
+                    # not disable an integration that has a valid access token.
+                    self.logger.warning(
+                        "Ignoring malformed custom headers for OAUTH2 MCP integration",
+                        mcp_integration_id=str(mcp_integration.id),
+                    )
+                    custom_headers = {}
+                for key in list(custom_headers):
+                    # The OAuth Authorization header always wins.
+                    if key.strip().casefold() == "authorization":
+                        custom_headers.pop(key, None)
+                headers.update(custom_headers)
+        elif mcp_integration.auth_type == MCPAuthType.CUSTOM:
+            headers.update(self._decrypt_mcp_custom_headers(mcp_integration))
+        elif mcp_integration.auth_type == MCPAuthType.NONE:
+            pass
+        else:
+            raise MCPConfigurationError(
+                f"Unsupported MCP auth type: {mcp_integration.auth_type}"
+            )
+
+        server_config: MCPHttpServerConfig = {
+            "type": "http",
+            "name": mcp_integration.name,
+            "url": mcp_integration.server_uri,
+            "headers": headers,
+            "id": str(mcp_integration.id),
+        }
+        if mcp_integration.timeout is not None:
+            server_config["timeout"] = mcp_integration.timeout
+        return server_config
+
+    def _build_mcp_update_target(
+        self,
+        *,
+        mcp_integration: MCPIntegration,
+        params: MCPIntegrationUpdate,
+        previous_auth_type: MCPAuthType,
+        target_server_uri: str,
+        target_auth_type: MCPAuthType,
+        target_oauth_integration_id: uuid.UUID | None,
+    ) -> MCPIntegration:
+        """Build a transient row representing the merged (post-update) HTTP config.
+
+        Never added to the session; mirrors the credential-merge rules applied
+        later in ``update_mcp_integration``.
+        """
+        if params.custom_credentials is not None:
+            raw_credentials = params.custom_credentials.get_secret_value()
+            target_encrypted_headers = (
+                self._encrypt_token(raw_credentials) if raw_credentials else None
+            )
+        elif params.auth_type == MCPAuthType.NONE:
+            target_encrypted_headers = None
+        elif (
+            previous_auth_type == MCPAuthType.CUSTOM
+            and params.auth_type == MCPAuthType.OAUTH2
+        ):
+            target_encrypted_headers = None
+        else:
+            target_encrypted_headers = mcp_integration.encrypted_headers
+
+        return MCPIntegration(
+            id=mcp_integration.id,
+            workspace_id=self.workspace_id,
+            name=mcp_integration.name,
+            slug=mcp_integration.slug,
+            server_type="http",
+            server_uri=target_server_uri,
+            auth_type=target_auth_type,
+            oauth_integration_id=target_oauth_integration_id,
+            encrypted_headers=target_encrypted_headers,
+            timeout=(
+                params.timeout
+                if params.timeout is not None
+                else mcp_integration.timeout
+            ),
+        )
+
     @require_scope("integration:update")
     async def update_mcp_integration(
-        self, *, mcp_integration_id: uuid.UUID, params: MCPIntegrationUpdate
+        self,
+        *,
+        mcp_integration_id: uuid.UUID,
+        params: MCPIntegrationUpdate,
+        verify_connection: bool = False,
     ) -> MCPIntegration | None:
-        """Update an MCP integration."""
+        """Update an MCP integration.
+
+        With ``verify_connection``, HTTP targets are probed with the merged
+        (post-update) configuration BEFORE anything is persisted: a failed
+        probe raises ``MCPConnectionVerificationError`` and leaves the stored
+        configuration and verification state untouched; a successful probe
+        stores the fresh tool listing alongside the update.
+        """
         mcp_integration = await self.get_mcp_integration(
             mcp_integration_id=mcp_integration_id
         )
         if not mcp_integration:
             return None
+        verified_tools: list[MCPToolSummary] | None = None
         previous_auth_type = mcp_integration.auth_type
         previous_server_type = cast(MCPServerType, mcp_integration.server_type)
         target_server_type = params.server_type or previous_server_type
@@ -3051,6 +3383,17 @@ class IntegrationService(BaseWorkspaceService):
                 raise ValueError(
                     "oauth_integration_id is required for OAuth 2.0 authentication"
                 )
+
+            if verify_connection:
+                update_target = self._build_mcp_update_target(
+                    mcp_integration=mcp_integration,
+                    params=params,
+                    previous_auth_type=previous_auth_type,
+                    target_server_uri=target_server_uri,
+                    target_auth_type=target_auth_type,
+                    target_oauth_integration_id=target_oauth_integration_id,
+                )
+                verified_tools = await self._probe_mcp_http_server(update_target)
         elif target_server_type == "stdio" and (
             server_type_changed
             or params.stdio_command is not None
@@ -3094,6 +3437,8 @@ class IntegrationService(BaseWorkspaceService):
                 mcp_integration.auth_type = MCPAuthType.NONE
                 mcp_integration.oauth_integration_id = None
                 mcp_integration.encrypted_headers = None
+                # Stdio servers cannot be verified.
+                mcp_integration.tools = None
 
         if target_server_type == "http" and params.server_uri is not None:
             mcp_integration.server_uri = params.server_uri.strip()
@@ -3140,6 +3485,9 @@ class IntegrationService(BaseWorkspaceService):
             ):
                 # Avoid carrying CUSTOM credentials into OAuth unless explicitly set.
                 mcp_integration.encrypted_headers = None
+
+        if verified_tools is not None:
+            mcp_integration.tools = [tool.model_dump() for tool in verified_tools]
 
         self.session.add(mcp_integration)
         await self.session.commit()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds APIs and UI to test HTTP MCP connections for draft configs and existing integrations, saving discovered tools on success. Fixes MCP update 502s, read 500s, and UI glitches; also unblocks the MCP catalog OAuth-client connect flow.

- **New Features**
  - Test endpoints for ephemeral configs and existing integrations; resolve stored secrets when `mcp_integration_id` is provided; return discovered tools and sanitized error details.
  - On success, persist tool summaries to `mcp_integration.tools`; expose `tools` on `MCPIntegrationRead` and `PlatformMCPCatalogRead` (null when unverified).
  - Frontend adds “Test connection”, Unverified/Failed badges, hooks (`useTestMcpConnectionConfig`, `useTestMcpIntegrationConnection`), and sanitizes URLs in error text; surfaces OAuth verify errors via `mcp_verify_error`. OAuth flow supports `oauth_endpoint_allowed_hosts`.

- **Migration**
  - Run Alembic to add `mcp_integration.tools` (JSONB).

<sup>Written for commit ad071d17fd4638d1cae566a62383fcf6e9ccbb38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

