### PR TITLE
fix(ui): remove unused isSuperuser/eeMultiTenant params from post-auth redirect

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -12,28 +12,18 @@ import PrivacyPolicy from "@/components/privacy-policy"
 import { buttonVariants } from "@/components/ui/button"
 import { useAuth } from "@/hooks/use-auth"
 import { getPostAuthRedirectPath } from "@/lib/auth-redirect"
-import { useAppInfo } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 
 export default function HomePage() {
   const { user, userIsLoading } = useAuth()
-  const { appInfo, appInfoIsLoading } = useAppInfo()
   const router = useRouter()
 
   useEffect(() => {
     if (!user || userIsLoading) {
       return
     }
-    if (user.isSuperuser && appInfoIsLoading) {
-      return
-    }
-    router.push(
-      getPostAuthRedirectPath({
-        isSuperuser: user.isSuperuser,
-        eeMultiTenant: appInfo?.ee_multi_tenant ?? false,
-      })
-    )
-  }, [appInfo?.ee_multi_tenant, appInfoIsLoading, user, router, userIsLoading])
+    router.push(getPostAuthRedirectPath({}))
+  }, [user, router, userIsLoading])
 
   if (userIsLoading || user) {
     return <CenteredSpinner />

--- a/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -7,11 +7,9 @@ import { CenteredSpinner } from "@/components/loading/spinner"
 import { useAuth } from "@/hooks/use-auth"
 import { getPostAuthRedirectPath } from "@/lib/auth-redirect"
 import { sanitizeReturnUrl } from "@/lib/auth-return-url"
-import { useAppInfo } from "@/lib/hooks"
 
 function SignInContent() {
   const { user, userIsLoading } = useAuth()
-  const { appInfo, appInfoIsLoading } = useAppInfo()
   const router = useRouter()
   const searchParams = useSearchParams()
   const returnUrl = sanitizeReturnUrl(searchParams?.get("returnUrl") ?? null)
@@ -21,17 +19,8 @@ function SignInContent() {
     if (!user) {
       return
     }
-    if (user.isSuperuser && appInfoIsLoading) {
-      return
-    }
-    router.replace(
-      getPostAuthRedirectPath({
-        isSuperuser: user.isSuperuser,
-        eeMultiTenant: appInfo?.ee_multi_tenant ?? false,
-        returnUrl,
-      })
-    )
-  }, [appInfo?.ee_multi_tenant, appInfoIsLoading, user, router, returnUrl])
+    router.replace(getPostAuthRedirectPath({ returnUrl }))
+  }, [user, router, returnUrl])
 
   if (userIsLoading || user) {
     return <CenteredSpinner />

--- a/frontend/src/components/auth/sign-up.tsx
+++ b/frontend/src/components/auth/sign-up.tsx
@@ -90,17 +90,9 @@ export function SignUp({
     if (!user) {
       return
     }
-    if (user.isSuperuser && appInfoIsLoading) {
-      return
-    }
     // Invitation acceptance is handled atomically during registration.
-    router.push(
-      getPostAuthRedirectPath({
-        isSuperuser: user.isSuperuser,
-        eeMultiTenant: appInfo?.ee_multi_tenant ?? true,
-      })
-    )
-  }, [appInfo?.ee_multi_tenant, appInfoIsLoading, user, router])
+    router.push(getPostAuthRedirectPath({}))
+  }, [user, router])
 
   if (appInfoIsLoading) {
     return <CenteredSpinner />

--- a/frontend/src/lib/auth-redirect.test.ts
+++ b/frontend/src/lib/auth-redirect.test.ts
@@ -4,63 +4,40 @@ import {
 } from "@/lib/auth-redirect"
 
 describe("getPostAuthRedirectPath", () => {
-  it("keeps multi-tenant superusers on normal app routes", () => {
+  it("passes through a normal returnUrl", () => {
     expect(
-      getPostAuthRedirectPath({
-        isSuperuser: true,
-        eeMultiTenant: true,
-        returnUrl: "/workspaces/tenant-path",
-      })
+      getPostAuthRedirectPath({ returnUrl: "/workspaces/tenant-path" })
     ).toBe("/workspaces/tenant-path")
   })
 
-  it("honors MCP OAuth continuation paths for multi-tenant superusers", () => {
+  it("honors MCP OAuth continuation paths", () => {
     expect(
-      getPostAuthRedirectPath({
-        isSuperuser: true,
-        eeMultiTenant: true,
-        returnUrl: "/oauth/mcp/continue?txn=abc123",
-      })
+      getPostAuthRedirectPath({ returnUrl: "/oauth/mcp/continue?txn=abc123" })
     ).toBe("/oauth/mcp/continue?txn=abc123")
   })
 
   it("rewrites legacy MCP OAuth org-selection paths", () => {
     expect(
-      getPostAuthRedirectPath({
-        isSuperuser: true,
-        eeMultiTenant: true,
-        returnUrl: "/oauth/mcp/select-org?txn=abc123",
-      })
+      getPostAuthRedirectPath({ returnUrl: "/oauth/mcp/select-org?txn=abc123" })
     ).toBe("/oauth/mcp/continue?txn=abc123")
   })
 
   it("does not treat similar MCP paths as continuation paths", () => {
     expect(
       getPostAuthRedirectPath({
-        isSuperuser: true,
-        eeMultiTenant: true,
         returnUrl: "/oauth/mcp/continue-later?txn=abc123",
       })
     ).toBe("/oauth/mcp/continue-later?txn=abc123")
   })
 
-  it("keeps single-tenant superusers on normal app routes", () => {
-    expect(
-      getPostAuthRedirectPath({
-        isSuperuser: true,
-        eeMultiTenant: false,
-        returnUrl: "/workspaces/default",
-      })
-    ).toBe("/workspaces/default")
+  it("passes through a workspace returnUrl", () => {
+    expect(getPostAuthRedirectPath({ returnUrl: "/workspaces/default" })).toBe(
+      "/workspaces/default"
+    )
   })
 
-  it("uses workspaces as the default app route", () => {
-    expect(
-      getPostAuthRedirectPath({
-        isSuperuser: false,
-        eeMultiTenant: true,
-      })
-    ).toBe("/workspaces")
+  it("defaults to /workspaces when no returnUrl is given", () => {
+    expect(getPostAuthRedirectPath({})).toBe("/workspaces")
   })
 })
 

--- a/frontend/src/lib/auth-redirect.ts
+++ b/frontend/src/lib/auth-redirect.ts
@@ -4,8 +4,6 @@ import {
 } from "@/lib/auth-return-url"
 
 type PostAuthRedirectPathParams = {
-  isSuperuser: boolean
-  eeMultiTenant: boolean
   returnUrl?: string | null
 }
 


### PR DESCRIPTION
## Summary

- `getPostAuthRedirectPath` accepted `isSuperuser` and `eeMultiTenant` params but never used either — both were destructured and silently ignored while the function always resolved to `returnUrl ?? "/workspaces"`
- Removed both params from `PostAuthRedirectPathParams` and all three call sites (`app/page.tsx`, `sign-in/page.tsx`, `sign-up.tsx`)
- Dropped the `user.isSuperuser && appInfoIsLoading` guard that existed solely to defer the redirect until `appInfo` loaded — since those params are gone the guard is meaningless
- Removed the now-unnecessary `useAppInfo` hook from `page.tsx` and `sign-in/page.tsx` (still needed in `sign-up.tsx` for `auth_allowed_types`)
- Updated test names to describe actual behaviour instead of referencing the removed params

## Test plan

- [ ] All 12 `auth-redirect` unit tests pass (`pnpm test -- auth-redirect`)
- [ ] TypeScript clean (`pnpm typecheck`)
- [ ] Sign-in → workspace redirect still works end-to-end
- [ ] Sign-up → workspace redirect still works end-to-end
- [ ] MCP OAuth `returnUrl` continuation path still honoured


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `isSuperuser` and `eeMultiTenant` params from post-auth redirect and simplified call sites. Redirect behavior is unchanged: honors `returnUrl` and defaults to `/workspaces`.

- **Refactors**
  - Dropped `isSuperuser` and `eeMultiTenant` from `getPostAuthRedirectPath` and all call sites.
  - Removed the superuser/appInfo loading guard and `useAppInfo` from home and sign-in pages; kept `useAppInfo` in sign-up for `auth_allowed_types`.
  - Simplified effects and calls to `getPostAuthRedirectPath({ returnUrl })` or `{}`.
  - Updated tests to reflect actual behavior, including MCP OAuth path handling and default redirect.

<sup>Written for commit 690f22550eca76a9d1cc115b3298a2c4184c05f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

