### PR TITLE
fix(mcp): expire stale schedules during update_workflow YAML updates

### DIFF
--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -20,6 +20,8 @@ from fastmcp.server.middleware.middleware import MiddlewareContext
 from fastmcp.tools import ToolResult
 from mcp.types import CallToolRequestParams
 from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat_registry import RegistryOAuthSecret, RegistrySecret
 
 import tracecat.mcp.auth as mcp_auth
@@ -36,6 +38,8 @@ from tracecat.agent.skill.schemas import (
     SkillVersionRead,
 )
 from tracecat.agent.stream.events import StreamDelta, StreamEnd
+from tracecat.auth.types import Role
+from tracecat.db.models import Schedule, Workflow
 from tracecat.exceptions import (
     BuiltinRegistryHasNoSelectionError,
     EntitlementRequired,
@@ -57,6 +61,7 @@ from tracecat.validation.schemas import (
     ValidationResultType,
 )
 from tracecat.workflow.management import layout as layout_module
+from tracecat.workflow.schedules import bridge as schedules_bridge
 
 _original_create_mcp_auth = mcp_auth.create_mcp_auth
 try:
@@ -2360,6 +2365,80 @@ async def test_replace_workflow_schedules_creates_schedules_with_payload_status(
 
     assert deleted_ids == [existing_schedule_id]
     assert [params.status for params in created_params] == ["offline", "online"]
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("db")
+async def test_apply_workflow_yaml_update_replaces_schedules_without_stale_state(
+    session: AsyncSession, svc_role: Role, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression test: replacing schedules must not leave deleted Schedule
+    instances in the eagerly-loaded workflow.schedules collection, where the
+    save-update cascade from session.add(workflow) raises
+    "Instance '<Schedule ...>' has been deleted".
+    """
+
+    async def _create_schedule(**kwargs: Any) -> Any:
+        _ = kwargs
+        return SimpleNamespace(id="fake-temporal-handle")
+
+    async def _delete_schedule(schedule_id: Any) -> None:
+        _ = schedule_id
+
+    monkeypatch.setattr(schedules_bridge, "create_schedule", _create_schedule)
+    monkeypatch.setattr(schedules_bridge, "delete_schedule", _delete_schedule)
+
+    workflow = Workflow(
+        title="Scheduled workflow",
+        description="Schedule replacement regression test",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+    )
+    session.add(workflow)
+    await session.flush()
+    schedule = Schedule(
+        workspace_id=svc_role.workspace_id,
+        workflow_id=workflow.id,
+        every=timedelta(hours=1),
+        inputs={},
+        status="offline",
+        timeout=0,
+    )
+    session.add(schedule)
+    await session.commit()
+    old_schedule_id = schedule.id
+
+    service = mcp_server.WorkflowsManagementService(session, role=svc_role)
+    workflow_id = mcp_server.WorkflowUUID.new(workflow.id)
+    loaded = await service.get_workflow(workflow_id, for_update=True)
+    assert loaded is not None
+
+    await mcp_server._apply_workflow_yaml_update(
+        role=svc_role,
+        service=service,
+        workflow=loaded,
+        workflow_id=workflow_id,
+        update_params=mcp_server.WorkflowUpdate(),
+        yaml_payload=mcp_server.WorkflowYamlPayload(
+            schedules=[
+                mcp_server.WorkflowSchedule(
+                    every=timedelta(hours=2),
+                    status="offline",
+                    inputs={},
+                    timeout=0,
+                )
+            ]
+        ),
+        definition_yaml=None,
+        update_mode="replace",
+    )
+
+    result = await session.execute(
+        select(Schedule).where(Schedule.workflow_id == workflow.id)
+    )
+    persisted = result.scalars().all()
+    assert [s.every for s in persisted] == [timedelta(hours=2)]
+    assert old_schedule_id not in {s.id for s in persisted}
 
 
 @pytest.mark.anyio

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -2796,6 +2796,11 @@ async def _apply_workflow_yaml_update(
             workflow_id=workflow_id,
             schedules=yaml_payload.schedules,
         )
+        # The deleted Schedule rows are already flushed, but the eagerly-loaded
+        # workflow.schedules collection still references them; expire it so the
+        # save-update cascade from session.add(workflow) below does not touch
+        # deleted instances.
+        service.session.expire(workflow, ["schedules"])
 
     if yaml_payload is not None and yaml_payload.case_trigger is not None:
         case_trigger_service = CaseTriggersService(service.session, role=role)


### PR DESCRIPTION
## Summary

The MCP `update_workflow` tool failed whenever the `definition_yaml` payload replaced schedules on a workflow that already had schedules:

```
Internal error: Failed to update workflow: Instance '<Schedule at 0xffff41b88410>' has been
deleted.  Use the make_transient() function to send this object back to the transient state.
```

## Root cause

- `update_workflow` loads the workflow with `get_workflow(for_update=True)`, which eagerly loads `workflow.schedules` (`lazy="selectin"`).
- `_apply_workflow_yaml_update` calls `_replace_workflow_schedules`, which deletes the existing `Schedule` rows via `session.delete()` + flush, putting those instances into SQLAlchemy's deleted state.
- The in-memory `workflow.schedules` collection still references the deleted instances (sessions run with `expire_on_commit=False`, and deleting a child never updates the parent collection in memory).
- The subsequent `session.add(workflow)` cascades save-update (`cascade="all, delete"`) over the stale collection, and SQLAlchemy raises `InvalidRequestError`.

The `edit_workflow` path is unaffected because its `session.add(workflow)` calls happen before schedule replacement.

## Fix

Expire the `schedules` relationship on the workflow right after `_replace_workflow_schedules` in `_apply_workflow_yaml_update`. Expiring unloads the stale collection so the save-update cascade skips it; the existing post-commit `session.refresh(workflow)` reloads fresh schedules.

## Testing

- Added a DB-backed regression test (`test_apply_workflow_yaml_update_replaces_schedules_without_stale_state`) that creates a workflow with a schedule, loads it the same way the tool does, and replaces the schedule via `_apply_workflow_yaml_update` with the Temporal bridge monkeypatched. Without the fix it reproduces the exact `InvalidRequestError`; with the fix it passes.
- `uv run pytest tests/unit/test_mcp_server.py` (235 passed) and `uv run pytest tests/unit/test_workflow_schedules_service.py` pass.
- `ruff check`, `ruff format --check`, and `basedpyright --warnings` are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in MCP `update_workflow` when a YAML update replaces existing schedules by expiring the stale `schedules` relationship after replacement. Adds a DB-backed regression test to prevent regressions.

- **Bug Fixes**
  - After `_replace_workflow_schedules`, call `service.session.expire(workflow, ["schedules"])` so the subsequent `session.add(workflow)` doesn’t cascade over deleted `Schedule` instances.
  - Root cause: eagerly-loaded `workflow.schedules` held deleted objects, leading to `InvalidRequestError` during save-update cascade.
  - Adds `test_apply_workflow_yaml_update_replaces_schedules_without_stale_state` to reproduce the failure without the fix and verify the fix.

<sup>Written for commit e2bdc3b6a8233c992dda10d55d33ab030f1a728b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

