### PR TITLE
refactor(api): narrow workspace-scoped role deps to WorkspaceRole

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
@@ -96,13 +96,6 @@ async def submit_approvals(
         HTTPException 404: If the agent session/workflow is not found.
         HTTPException 500: For unexpected errors.
     """
-    workspace_id = role.workspace_id
-    if workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Workspace access required",
-        )
-
     # Verify the session belongs to the caller's workspace
     # This prevents cross-workspace access if an attacker knows another workspace's session_id
     session_service = AgentSessionService(session, role)
@@ -165,13 +158,6 @@ async def delete_approval(
     agent step. If the workflow is already gone, delete the approval records
     directly. The session itself is left intact in both cases.
     """
-    workspace_id = role.workspace_id
-    if workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Workspace access required",
-        )
-
     session_service = AgentSessionService(session, role)
     approval_service = ApprovalService(session=session, role=role)
 

--- a/packages/tracecat-ee/tracecat_ee/agent/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/router.py
@@ -93,13 +93,6 @@ async def submit_approvals(
         HTTPException 404: If the agent session/workflow is not found.
         HTTPException 500: For unexpected errors.
     """
-    workspace_id = role.workspace_id
-    if workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Workspace access required",
-        )
-
     # Verify the session belongs to the caller's workspace
     # This prevents cross-workspace access if an attacker knows another workspace's session_id
     session_service = AgentSessionService(session, role)

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -23,7 +23,7 @@ from tracecat.auth.dependencies import (
     WorkspaceUserRole,
     WorkspaceUserRouteRole,
 )
-from tracecat.auth.types import Role
+from tracecat.auth.types import Role, WorkspaceRole
 from tracecat.authz.scopes import (
     ADMIN_SCOPES,
     ORG_ADMIN_SCOPES,
@@ -122,9 +122,9 @@ def client(request: FixtureRequest) -> Generator[TestClient, None, None]:
 @pytest.fixture
 def test_admin_role(
     test_workspace: Workspace, mock_org_id: uuid.UUID
-) -> Generator[Role, None, None]:
+) -> Generator[WorkspaceRole, None, None]:
     global _FALLBACK_ROLE
-    role = Role(
+    role = WorkspaceRole(
         type="user",
         user_id=uuid.uuid4(),
         organization_id=mock_org_id,
@@ -145,9 +145,9 @@ def test_admin_role(
 @pytest.fixture
 def test_role(
     test_workspace: Workspace, mock_org_id: uuid.UUID
-) -> Generator[Role, None, None]:
+) -> Generator[WorkspaceRole, None, None]:
     global _FALLBACK_ROLE
-    role = Role(
+    role = WorkspaceRole(
         type="service",
         user_id=mock_org_id,
         organization_id=mock_org_id,

--- a/tests/unit/api/test_api_agent_folders.py
+++ b/tests/unit/api/test_api_agent_folders.py
@@ -14,7 +14,7 @@ from tracecat.agent.folders.service import (
 )
 from tracecat.agent.preset import router as agent_preset_router
 from tracecat.agent.preset.schemas import AgentPresetMoveToFolder
-from tracecat.auth.types import Role
+from tracecat.auth.types import WorkspaceRole
 from tracecat.exceptions import EntitlementRequired, TracecatValidationError
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
 
@@ -42,7 +42,7 @@ def _mock_service_with_async_method(
 @pytest.mark.anyio
 async def test_create_folder_conflict_returns_409(
     client: TestClient,
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     """Duplicate folder paths should surface as conflicts."""
     with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
@@ -67,7 +67,7 @@ async def test_create_folder_conflict_returns_409(
 @pytest.mark.anyio
 async def test_create_folder_missing_parent_returns_404(
     client: TestClient,
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     """Missing parent paths should not be misreported as conflicts."""
     with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
@@ -92,7 +92,7 @@ async def test_create_folder_missing_parent_returns_404(
 @pytest.mark.anyio
 async def test_list_folders_missing_parent_returns_404(
     client: TestClient,
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     """Listing a missing folder path should not look like an empty folder."""
     with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
@@ -117,7 +117,7 @@ async def test_list_folders_missing_parent_returns_404(
 @pytest.mark.anyio
 async def test_list_folders_returns_paginated_response(
     client: TestClient,
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     """Folder listing should use the cursor-paginated API shape."""
     with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
@@ -159,7 +159,7 @@ async def test_list_folders_returns_paginated_response(
 @pytest.mark.anyio
 async def test_get_directory_returns_directory_items(
     client: TestClient,
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     """Directory listing should return the full directory array."""
     with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
@@ -184,7 +184,7 @@ async def test_get_directory_returns_directory_items(
 @pytest.mark.anyio
 async def test_create_folder_blank_name_returns_400(
     client: TestClient,
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     """Blank folder names should be rejected before path construction."""
     with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
@@ -209,7 +209,7 @@ async def test_create_folder_blank_name_returns_400(
 @pytest.mark.anyio
 async def test_update_folder_validation_returns_400(
     client: TestClient,
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     """Invalid rename requests should stay in the 4xx range."""
     with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
@@ -234,7 +234,7 @@ async def test_update_folder_validation_returns_400(
 @pytest.mark.anyio
 async def test_update_folder_blank_name_returns_400(
     client: TestClient,
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     """Blank folder renames should stay in the 4xx range."""
     with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
@@ -259,7 +259,7 @@ async def test_update_folder_blank_name_returns_400(
 @pytest.mark.anyio
 async def test_move_folder_validation_returns_400(
     client: TestClient,
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     """Cyclic folder moves should not fall through as 500s."""
     with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
@@ -283,7 +283,7 @@ async def test_move_folder_validation_returns_400(
 
 @pytest.mark.anyio
 async def test_move_agent_preset_to_root_skips_folder_lookup(
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     """Moving to '/' should clear the folder instead of trying to resolve a root row."""
     preset_id = uuid.uuid4()
@@ -309,7 +309,7 @@ async def test_move_agent_preset_to_root_skips_folder_lookup(
 @pytest.mark.anyio
 async def test_move_agent_preset_requires_agent_addons_entitlement(
     client: TestClient,
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     """Preset moves should surface AGENT_ADDONS entitlement failures as 403s."""
     preset_id = uuid.uuid4()
@@ -336,7 +336,7 @@ async def test_move_agent_preset_requires_agent_addons_entitlement(
 @pytest.mark.anyio
 async def test_get_directory_requires_agent_addons_entitlement(
     client: TestClient,
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     """Folder directory reads should preserve the AGENT_ADDONS gate at HTTP level."""
     with patch.object(agent_folder_router, "AgentFolderService") as mock_service_cls:
@@ -357,7 +357,7 @@ async def test_get_directory_requires_agent_addons_entitlement(
 @pytest.mark.anyio
 async def test_delete_folder_without_body_defaults_to_non_recursive(
     client: TestClient,
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     """Non-recursive folder deletes should not require a request body."""
     folder_id = uuid.uuid4()
@@ -411,7 +411,7 @@ async def test_delete_folder_without_body_defaults_to_non_recursive(
 )
 async def test_folder_management_routes_require_agent_addons_entitlement(
     client: TestClient,
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
     method: str,
     path: str,
     kwargs: dict[str, Any],

--- a/tests/unit/api/test_api_agent_presets.py
+++ b/tests/unit/api/test_api_agent_presets.py
@@ -9,13 +9,13 @@ from fastapi import HTTPException, status
 
 from tracecat.agent.preset import internal_router as agent_preset_internal_router
 from tracecat.agent.preset import router as agent_preset_router
-from tracecat.auth.types import Role
+from tracecat.auth.types import Role, WorkspaceRole
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 
 
 @pytest.mark.anyio
 async def test_create_preset_payload_backfills_legacy_model_fields(
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     catalog_id = uuid.uuid4()
@@ -54,7 +54,7 @@ async def test_create_preset_payload_backfills_legacy_model_fields(
 
 @pytest.mark.anyio
 async def test_create_preset_payload_requires_default_model_selection(
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class FakeAgentManagementService:
@@ -80,7 +80,7 @@ async def test_create_preset_payload_requires_default_model_selection(
 
 @pytest.mark.anyio
 async def test_create_preset_payload_resolves_catalog_id_without_default_model(
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     expected_catalog_id = uuid.uuid4()
@@ -126,7 +126,7 @@ async def test_create_preset_payload_resolves_catalog_id_without_default_model(
 
 @pytest.mark.anyio
 async def test_create_preset_payload_preserves_default_catalog_when_null_supplied(
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     catalog_id = uuid.uuid4()
@@ -167,7 +167,7 @@ async def test_create_preset_payload_preserves_default_catalog_when_null_supplie
 
 @pytest.mark.anyio
 async def test_create_preset_payload_drops_null_defaulted_fields(
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     catalog_id = uuid.uuid4()
@@ -207,7 +207,7 @@ async def test_create_preset_payload_drops_null_defaulted_fields(
 
 @pytest.mark.anyio
 async def test_create_preset_payload_rejects_partial_legacy_model_fields(
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     with pytest.raises(
         TracecatValidationError,
@@ -225,7 +225,7 @@ async def test_create_preset_payload_rejects_partial_legacy_model_fields(
 
 @pytest.mark.anyio
 async def test_restore_agent_preset_version_maps_validation_error(
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Validation failures during restore should remain client errors."""

--- a/tests/unit/api/test_api_case_rows.py
+++ b/tests/unit/api/test_api_case_rows.py
@@ -7,7 +7,7 @@ from fastapi import HTTPException, status
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 
-from tracecat.auth.types import Role
+from tracecat.auth.types import WorkspaceRole
 from tracecat.cases import router as cases_router
 from tracecat.cases.enums import CasePriority, CaseSeverity, CaseStatus
 from tracecat.cases.rows import internal_router as internal_case_rows_router
@@ -48,7 +48,7 @@ def _duplicate_case_row_link_error() -> IntegrityError:
 
 @pytest.mark.anyio
 async def test_list_cases_include_rows_hydration_error_is_sanitized(
-    client: TestClient, test_admin_role: Role
+    client: TestClient, test_admin_role: WorkspaceRole
 ) -> None:
     case_id = uuid.uuid4()
     with (
@@ -85,7 +85,7 @@ async def test_list_cases_include_rows_hydration_error_is_sanitized(
 
 @pytest.mark.anyio
 async def test_link_case_row_returns_400_for_value_error(
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     case_id = uuid.uuid4()
     table_id = uuid.uuid4()
@@ -112,7 +112,7 @@ async def test_link_case_row_returns_400_for_value_error(
 
 @pytest.mark.anyio
 async def test_link_case_row_returns_409_for_duplicate_link(
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     case_id = uuid.uuid4()
     table_id = uuid.uuid4()
@@ -142,7 +142,7 @@ async def test_link_case_row_returns_409_for_duplicate_link(
 
 @pytest.mark.anyio
 async def test_internal_link_case_row_returns_404_for_missing_case(
-    client: TestClient, test_admin_role: Role
+    client: TestClient, test_admin_role: WorkspaceRole
 ) -> None:
     case_id = uuid.uuid4()
     table_id = uuid.uuid4()
@@ -168,7 +168,7 @@ async def test_internal_link_case_row_returns_404_for_missing_case(
 
 @pytest.mark.anyio
 async def test_internal_link_case_row_returns_400_for_value_error(
-    client: TestClient, test_admin_role: Role
+    client: TestClient, test_admin_role: WorkspaceRole
 ) -> None:
     case_id = uuid.uuid4()
     table_id = uuid.uuid4()
@@ -195,7 +195,7 @@ async def test_internal_link_case_row_returns_400_for_value_error(
 
 @pytest.mark.anyio
 async def test_internal_link_case_row_returns_409_for_duplicate_link(
-    client: TestClient, test_admin_role: Role
+    client: TestClient, test_admin_role: WorkspaceRole
 ) -> None:
     case_id = uuid.uuid4()
     table_id = uuid.uuid4()

--- a/tests/unit/api/test_api_mcp_personal_access_tokens.py
+++ b/tests/unit/api/test_api_mcp_personal_access_tokens.py
@@ -10,7 +10,7 @@ import pytest
 from fastapi.routing import APIRoute
 
 from tracecat.auth.dependencies import WorkspaceUserPathRole
-from tracecat.auth.types import Role
+from tracecat.auth.types import WorkspaceRole
 from tracecat.mcp.personal_access_tokens import router as mcp_pat_router
 from tracecat.mcp.personal_access_tokens.schemas import MCPPersonalAccessTokenCreate
 from tracecat.pagination import CursorPaginatedResponse
@@ -41,7 +41,7 @@ def _token_read(
     )
 
 
-def _with_workspace_read(role: Role) -> Role:
+def _with_workspace_read(role: WorkspaceRole) -> WorkspaceRole:
     return role.model_copy(
         update={
             "scopes": frozenset(set(role.scopes or frozenset()) | {"workspace:read"})
@@ -51,7 +51,7 @@ def _with_workspace_read(role: Role) -> Role:
 
 @pytest.mark.anyio
 async def test_list_mcp_personal_access_tokens_success(
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     role = _with_workspace_read(test_admin_role)
     organization_id = role.organization_id
@@ -94,7 +94,7 @@ async def test_list_mcp_personal_access_tokens_success(
 
 @pytest.mark.anyio
 async def test_create_mcp_personal_access_token_success(
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     role = _with_workspace_read(test_admin_role)
     organization_id = role.organization_id
@@ -131,7 +131,7 @@ async def test_create_mcp_personal_access_token_success(
 
 @pytest.mark.anyio
 async def test_revoke_mcp_personal_access_token_success(
-    test_admin_role: Role,
+    test_admin_role: WorkspaceRole,
 ) -> None:
     role = _with_workspace_read(test_admin_role)
     token_id = uuid.uuid4()

--- a/tests/unit/test_agent_channel_management_router.py
+++ b/tests/unit/test_agent_channel_management_router.py
@@ -9,12 +9,12 @@ from fastapi import HTTPException
 
 from tracecat.agent.channels.management_router import start_slack_oauth
 from tracecat.agent.channels.schemas import SlackOAuthStartRequest
-from tracecat.auth.types import Role
+from tracecat.auth.types import WorkspaceRole
 
 
 @pytest.mark.anyio
 async def test_start_slack_oauth_rejects_mismatched_token_preset() -> None:
-    role = Role(
+    role = WorkspaceRole(
         type="service",
         service_id="tracecat-api",
         workspace_id=uuid.uuid4(),
@@ -56,7 +56,7 @@ async def test_start_slack_oauth_rejects_mismatched_token_preset() -> None:
 
 @pytest.mark.anyio
 async def test_start_slack_oauth_returns_404_for_missing_token() -> None:
-    role = Role(
+    role = WorkspaceRole(
         type="service",
         service_id="tracecat-api",
         workspace_id=uuid.uuid4(),

--- a/tracecat/agent/channels/management_router.py
+++ b/tracecat/agent/channels/management_router.py
@@ -157,11 +157,6 @@ async def start_slack_oauth(
     role: WorkspaceActorRouteRole,
     session: AsyncDBSession,
 ) -> SlackOAuthStartResponse:
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="workspace_id is required",
-        )
     service = AgentChannelService(session, role=role)
 
     token = None

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -431,14 +431,7 @@ async def send_message(
     3. Streams the response back in Vercel's data protocol format
     """
     try:
-        workspace_id = role.workspace_id
-        if workspace_id is None:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Workspace access required",
-            )
-
-        stream = await AgentStream.new(session_id, workspace_id)
+        stream = await AgentStream.new(session_id, role.workspace_id)
         async with AgentSessionService.with_session(role=role) as svc:
             # Check if this is a legacy chat (read-only)
             if await svc.is_legacy_session(session_id):
@@ -558,15 +551,8 @@ async def stream_session_events(
     using Server-Sent Events. It supports automatic reconnection via the
     Last-Event-ID header.
     """
-    workspace_id = role.workspace_id
-    if workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Workspace access required",
-        )
-
-        # Try to get last_stream_id from session, but don't fail if session doesn't exist yet.
-        # This handles the race condition where frontend connects before session is created.
+    # Try to get last_stream_id from session, but don't fail if session doesn't exist yet.
+    # This handles the race condition where frontend connects before session is created.
     last_stream_id: str | None = None
     async with AgentSessionService.with_session(role=role) as svc:
         agent_session = await svc.get_session(session_id)
@@ -598,7 +584,7 @@ async def stream_session_events(
         session_id=session_id,
     )
 
-    stream = await AgentStream.new(session_id, workspace_id)
+    stream = await AgentStream.new(session_id, role.workspace_id)
     headers = {
         "Cache-Control": "no-cache, no-transform",
         "Connection": "keep-alive",

--- a/tracecat/auth/credentials.py
+++ b/tracecat/auth/credentials.py
@@ -38,7 +38,7 @@ from tracecat.auth.api_keys import (
 )
 from tracecat.auth.executor_tokens import verify_executor_token
 from tracecat.auth.secrets import get_service_key
-from tracecat.auth.types import PlatformRole, Role
+from tracecat.auth.types import PlatformRole, Role, WorkspaceRole
 from tracecat.auth.users import (
     current_active_user,
     optional_current_active_user,
@@ -848,7 +848,12 @@ async def _validate_role(
         "Computed effective scopes",
         scope_count=len(scopes),
     )
-    return role.model_copy(update={"scopes": scopes})
+    role = role.model_copy(update={"scopes": scopes})
+    if require_workspace == "yes":
+        # Re-validate into the narrowed type so routes annotated with
+        # WorkspaceRole-based dependencies get a non-optional workspace_id.
+        role = WorkspaceRole.model_validate(role.model_dump())
+    return role
 
 
 # --- Main Auth Orchestrator ---

--- a/tracecat/auth/dependencies.py
+++ b/tracecat/auth/dependencies.py
@@ -11,12 +11,12 @@ from tracecat.auth.credentials import (
     RoleACL,
 )
 from tracecat.auth.enums import AuthType
-from tracecat.auth.types import Role
+from tracecat.auth.types import Role, WorkspaceRole
 from tracecat.settings.constants import AUTH_TYPE_TO_SETTING_KEY
 from tracecat.settings.service import get_setting
 
 WorkspaceUserRole = Annotated[
-    Role,
+    WorkspaceRole,
     RoleACL(
         allow_user=True,
         allow_service=False,
@@ -30,7 +30,7 @@ Sets the `ctx_role` context variable.
 """
 
 WorkspaceActorRole = Annotated[
-    Role,
+    WorkspaceRole,
     RoleACL(
         allow_user=True,
         allow_service=False,
@@ -41,7 +41,7 @@ WorkspaceActorRole = Annotated[
 """Dependency for a user or service-account role for a workspace."""
 
 WorkspaceActorRouteRole = Annotated[
-    Role,
+    WorkspaceRole,
     RoleACL(
         allow_user=True,
         allow_service=False,
@@ -53,7 +53,7 @@ WorkspaceActorRouteRole = Annotated[
 """Dependency for workspace routes that accept path-scoped canonical routes and legacy query-scoped routes."""
 
 WorkspaceUserRouteRole = Annotated[
-    Role,
+    WorkspaceRole,
     RoleACL(
         allow_user=True,
         allow_service=False,
@@ -71,7 +71,7 @@ async def require_workspace_id_path(workspace_id: uuid.UUID = Path(...)) -> uuid
 
 
 WorkspaceServiceAccountRole = Annotated[
-    Role,
+    WorkspaceRole,
     RoleACL(
         allow_user=False,
         allow_service=False,
@@ -82,7 +82,7 @@ WorkspaceServiceAccountRole = Annotated[
 """Dependency for a service-account role for a workspace."""
 
 WorkspaceUserPathRole = Annotated[
-    Role,
+    WorkspaceRole,
     RoleACL(
         allow_user=True,
         allow_service=False,
@@ -97,7 +97,7 @@ Sets the `ctx_role` context variable.
 
 
 ExecutorWorkspaceRole = Annotated[
-    Role,
+    WorkspaceRole,
     RoleACL(
         allow_user=False,
         allow_service=False,

--- a/tracecat/auth/types.py
+++ b/tracecat/auth/types.py
@@ -107,6 +107,18 @@ class Role(BaseModel):
         return headers
 
 
+class WorkspaceRole(Role):
+    """A `Role` guaranteed to be resolved against a workspace.
+
+    Produced by `RoleACL(require_workspace="yes")` dependencies after workspace
+    validation so route handlers get a non-optional `workspace_id` without
+    re-narrowing. Do not construct one directly from unvalidated input.
+    """
+
+    workspace_id: WorkspaceID = Field(frozen=True)  # pyright: ignore[reportIncompatibleVariableOverride, reportGeneralTypeIssues]
+    """The effective workspace context for this request after auth resolution."""
+
+
 class PlatformRole(BaseModel):
     """Role for platform admin (superuser) operations.
 

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -215,7 +215,8 @@ async def oauth_callback(
 
     # Overwrite role with workspace context from validated state
     # This is always authorization code
-    role = role.model_copy(update={"workspace_id": oauth_state_db.workspace_id})
+    workspace_id = oauth_state_db.workspace_id
+    role = role.model_copy(update={"workspace_id": workspace_id})
     ctx_role.set(role)
     if config.TRACECAT__RLS_MODE == config.RLSMode.ENFORCE:
         await set_rls_context_from_role(session, role)
@@ -254,17 +255,12 @@ async def oauth_callback(
                 detail="Could not reach MCP OAuth server",
             ) from exc
 
-        if role.workspace_id is None:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Workspace ID is required",
-            )
         return IntegrationOAuthCallback(
             status="connected",
             provider_id=oauth_state_db.provider_id,
             redirect_url=(
                 f"{config.TRACECAT__PUBLIC_APP_URL}/workspaces/"
-                f"{role.workspace_id}/mcp-servers"
+                f"{workspace_id}/mcp-servers"
             ),
         )
 
@@ -381,15 +377,10 @@ async def oauth_callback(
             detail="Provider returned insecure OAuth endpoints",
         ) from exc
     logger.info("Returning OAuth callback", status="connected", provider=key.id)
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     redirect_url = _oauth_callback_redirect_url(
         provider_impl=provider_impl,
-        workspace_id=role.workspace_id,
+        workspace_id=workspace_id,
     )
     return IntegrationOAuthCallback(
         status="connected",
@@ -405,11 +396,6 @@ async def list_integrations(
     role: WorkspaceUserRouteRole, session: AsyncDBSession
 ) -> list[IntegrationReadMinimal]:
     """List all integrations for the current user."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     integration_service = IntegrationService(session, role=role)
     integrations = await integration_service.list_integrations()
@@ -435,12 +421,6 @@ async def get_integration(
 ) -> IntegrationRead:
     """Get integration for the specified provider."""
     # Verify provider exists (this will raise 400 if not)
-
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     integration = await svc.get_integration(provider_key=provider_info.key)
@@ -514,10 +494,10 @@ async def connect_provider(
     The state is validated on the callback to ensure it was issued by our server.
     """
 
-    if role.workspace_id is None or role.user_id is None:
+    if role.user_id is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace and user ID is required",
+            detail="User ID is required",
         )
     svc = IntegrationService(session, role=role)
     provider_impl = provider_info.impl
@@ -580,11 +560,6 @@ async def disconnect_integration(
     provider_info: ProviderInfoDep,
 ) -> None:
     """Disconnect integration for the specified provider (revokes tokens but keeps configuration)."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     integration = await svc.get_integration(provider_key=provider_info.key)
@@ -605,11 +580,6 @@ async def delete_integration(
     provider_info: ProviderInfoDep,
 ) -> None:
     """Delete integration for the specified provider (removes the integration record completely)."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     integration = await svc.get_integration(provider_key=provider_info.key)
@@ -636,11 +606,6 @@ async def test_connection(
     provider_info: CCProviderInfoDep,
 ) -> IntegrationTestConnectionResponse:
     """Test client credentials connection for the specified provider."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     integration = await svc.get_integration(provider_key=provider_info.key)
@@ -715,11 +680,6 @@ async def update_integration(
     provider_info: ProviderInfoDep,
 ) -> None:
     """Update OAuth client credentials for the specified provider integration."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     # Store the provider configuration
@@ -761,11 +721,6 @@ async def create_custom_provider(
     session: AsyncDBSession,
     params: CustomOAuthProviderCreate,
 ) -> ProviderReadMinimal:
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     try:
@@ -895,11 +850,6 @@ async def create_mcp_integration(
     params: Annotated[MCPIntegrationCreate, Body(...)],
 ) -> MCPIntegrationRead:
     """Create a new MCP integration."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     try:
@@ -932,11 +882,6 @@ async def list_mcp_integrations(
     ] = None,
 ) -> list[MCPIntegrationRead]:
     """List MCP integrations for the workspace, optionally filtered by source."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     integrations = await svc.list_mcp_integrations_with_state(source=source)
@@ -967,11 +912,6 @@ async def list_platform_mcp_catalog(
     limit: Annotated[int, Query(ge=1, le=100)] = 50,
 ) -> PlatformMCPCatalogListResponse:
     """List platform MCP catalog rows with workspace connection state."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
     if role.organization_id is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1001,11 +941,6 @@ async def connect_platform_mcp_catalog(
     catalog_slug: str,
 ) -> MCPCatalogConnectResponse:
     """Create or return a workspace MCP integration from catalog defaults."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     try:
@@ -1026,11 +961,6 @@ async def connect_mcp_integration(
     params: Annotated[MCPIntegrationCreate, Body(...)],
 ) -> MCPCatalogConnectResponse:
     """Create an MCP integration or start generic MCP OAuth discovery."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     try:
@@ -1062,11 +992,6 @@ async def get_mcp_integration(
     mcp_integration_id: uuid.UUID,
 ) -> MCPIntegrationRead:
     """Get an MCP integration by ID."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     integration = await svc.get_mcp_integration(mcp_integration_id=mcp_integration_id)
@@ -1091,11 +1016,6 @@ async def update_mcp_integration(
     params: MCPIntegrationUpdate,
 ) -> MCPIntegrationRead:
     """Update an MCP integration."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     try:
@@ -1129,11 +1049,6 @@ async def disconnect_mcp_integration(
     mcp_integration_id: uuid.UUID,
 ) -> None:
     """Disconnect an MCP integration by deleting the workspace MCP row."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     deleted = await svc.delete_mcp_integration(mcp_integration_id=mcp_integration_id)
@@ -1152,11 +1067,6 @@ async def delete_mcp_integration(
     mcp_integration_id: uuid.UUID,
 ) -> None:
     """Delete an MCP integration."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace ID is required",
-        )
 
     svc = IntegrationService(session, role=role)
     deleted = await svc.delete_mcp_integration(mcp_integration_id=mcp_integration_id)

--- a/tracecat/secrets/router.py
+++ b/tracecat/secrets/router.py
@@ -140,18 +140,11 @@ async def get_aws_assume_role_access(
     role: WorkspaceActorRouteRole,
 ) -> AwsAssumeRoleAccessRead:
     """Get workspace-scoped AWS AssumeRole details for credential setup."""
-    workspace_id = role.workspace_id
-    if workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Workspace context is required",
-        )
-
     try:
         return AwsAssumeRoleAccessRead(
             tracecat_aws_account_id=get_tracecat_aws_account_id(),
             tracecat_aws_principal_arn=get_tracecat_aws_principal_arn(),
-            external_id=build_workspace_external_id(workspace_id),
+            external_id=build_workspace_external_id(role.workspace_id),
         )
     except ValueError as exc:
         raise HTTPException(

--- a/tracecat/service_accounts/router.py
+++ b/tracecat/service_accounts/router.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from tracecat.auth.credentials import RoleACL
 from tracecat.auth.dependencies import OrgUserOnlyRole
 from tracecat.auth.schemas import UserReadMinimal
-from tracecat.auth.types import Role
+from tracecat.auth.types import WorkspaceRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.models import User
@@ -44,7 +44,7 @@ from tracecat.tiers.entitlements import check_entitlement
 from tracecat.tiers.enums import Entitlement
 
 WorkspaceUserOnlyInPath = Annotated[
-    Role,
+    WorkspaceRole,
     RoleACL(
         allow_user=True,
         allow_service=False,

--- a/tracecat/workflow/actions/router.py
+++ b/tracecat/workflow/actions/router.py
@@ -80,10 +80,6 @@ async def create_action(
     session: AsyncDBSession,
 ) -> ActionReadMinimal:
     """Create a new action for a workflow."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Workspace ID is required"
-        )
     svc = WorkflowActionService(session, role=role)
     try:
         action = await svc.create_action(params)

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -18,7 +18,7 @@ from tracecat.auth.dependencies import (
     WorkspaceActorRouteRole,
     WorkspaceUserRouteRole,
 )
-from tracecat.auth.types import Role
+from tracecat.auth.types import WorkspaceRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.db.models import Workflow, WorkflowDefinition
@@ -303,11 +303,9 @@ def _normalize_search_term(search_term: str | None) -> str | None:
 async def _resolve_workflow_ids_by_search_term(
     *,
     session: AsyncSession,
-    role: Role,
+    role: WorkspaceRole,
     search_term: str,
 ) -> list[WorkflowUUID]:
-    if role.workspace_id is None:
-        return []
     like_term = f"%{search_term}%"
     statement = (
         select(Workflow.id)
@@ -327,10 +325,10 @@ async def _resolve_workflow_ids_by_search_term(
 async def _load_workflow_metadata_map(
     *,
     session: AsyncSession,
-    role: Role,
+    role: WorkspaceRole,
     workflow_ids: list[WorkflowUUID],
 ) -> dict[WorkflowIDShort, tuple[str, str | None]]:
-    if role.workspace_id is None or not workflow_ids:
+    if not workflow_ids:
         return {}
 
     statement = select(Workflow).where(

--- a/tracecat/workflow/management/router.py
+++ b/tracecat/workflow/management/router.py
@@ -818,10 +818,6 @@ async def create_webhook(
     params: WebhookCreate,
 ) -> None:
     """Create a webhook for a workflow."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Workspace ID is required"
-        )
 
     webhook = Webhook(
         workspace_id=role.workspace_id,
@@ -847,10 +843,6 @@ async def get_webhook(
     workflow_id: AnyWorkflowIDPath,
 ) -> WebhookRead:
     """Get the webhook from a workflow."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Workspace ID is required"
-        )
     webhook = await webhook_service.get_webhook(
         session=session,
         workspace_id=role.workspace_id,
@@ -985,10 +977,6 @@ async def generate_webhook_api_key(
     workflow_id: AnyWorkflowIDPath,
 ) -> WebhookApiKeyGenerateResponse:
     """Create or rotate the API key for a webhook."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Workspace ID is required"
-        )
     webhook = await webhook_service.get_webhook(
         session=session, workspace_id=role.workspace_id, workflow_id=workflow_id
     )
@@ -1039,10 +1027,6 @@ async def revoke_webhook_api_key(
     workflow_id: AnyWorkflowIDPath,
 ) -> None:
     """Revoke the current API key for a webhook."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Workspace ID is required"
-        )
     webhook = await webhook_service.get_webhook(
         session=session, workspace_id=role.workspace_id, workflow_id=workflow_id
     )
@@ -1075,10 +1059,6 @@ async def delete_webhook_api_key(
     workflow_id: AnyWorkflowIDPath,
 ) -> None:
     """Delete the current API key for a webhook."""
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Workspace ID is required"
-        )
     webhook = await webhook_service.get_webhook(
         session=session, workspace_id=role.workspace_id, workflow_id=workflow_id
     )

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -40,10 +40,6 @@ async def publish_workflow(
     workflow_id: AnyWorkflowIDPath,
     params: WorkflowDslPublish,
 ) -> WorkflowDslPublishResult:
-    if role.workspace_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Workspace ID is required"
-        )
     defn_svc = WorkflowDefinitionsService(session=session)
     defn = await defn_svc.get_definition_by_workflow_id(workflow_id)
     if not defn:

--- a/tracecat/workspaces/router.py
+++ b/tracecat/workspaces/router.py
@@ -10,7 +10,7 @@ from sqlalchemy.exc import IntegrityError, NoResultFound
 
 from tracecat.auth.credentials import RoleACL
 from tracecat.auth.dependencies import OrgActorRole
-from tracecat.auth.types import Role
+from tracecat.auth.types import WorkspaceRole
 from tracecat.authz.controls import require_scope
 from tracecat.authz.service import MembershipService
 from tracecat.db.dependencies import AsyncDBSession
@@ -42,7 +42,7 @@ router = APIRouter(prefix="/workspaces", tags=["workspaces"])
 
 # Workspace role types for path-based workspace access
 WorkspaceUserInPath = Annotated[
-    Role,
+    WorkspaceRole,
     RoleACL(
         allow_user=True,
         allow_service=False,


### PR DESCRIPTION
## What

Introduces `WorkspaceRole`, a `Role` subtype with a non-optional `workspace_id`, and makes all `RoleACL(require_workspace="yes")` dependency aliases produce it. This deletes ~35 repeated route-level guards of the form:

```python
if role.workspace_id is None:
    raise HTTPException(status_code=400, detail="Workspace ID is required")
```

## Why

`_validate_role` already raises 403 before any route body runs when `require_workspace="yes"` and the workspace is missing, so these guards were unreachable at runtime — they existed only to narrow `Role.workspace_id: WorkspaceID | None` for the type checker. Encoding the guarantee in the dependency's return type does the narrowing once instead of per-route.

## Do we lose the HTTP exceptions?

No. FastAPI resolves the `RoleACL(require_workspace="yes")` dependency before the route body runs, and `_validate_role` raises there if the workspace is missing:

```python
if require_workspace == "yes" and role.workspace_id is None:
    logger.warning("User does not have access to this workspace", role=role)
    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
```

The executor-token path has the same 403 check. A request without workspace context still gets an HTTP 403 — it just comes from the dependency, exactly as it always did.

The deleted guards sat *after* that dependency in the same handlers, so they could only run when `workspace_id` was already guaranteed non-None. Their responses (e.g. the secrets route's 400 "Workspace context is required", the agent routes' 403 "Workspace access required") were never reachable, so there is no client-facing behavior change: the real response was always the dependency's `403 Forbidden`.

## How

- `tracecat/auth/types.py`: new `WorkspaceRole(Role)` overriding `workspace_id: WorkspaceID` (non-optional, frozen).
- `tracecat/auth/credentials.py`: `_validate_role` re-validates into `WorkspaceRole` when `require_workspace == "yes"` (after scope computation, so `ctx_role` also carries the narrowed instance).
- `tracecat/auth/dependencies.py`: all workspace-scoped aliases (`WorkspaceUserRole`, `WorkspaceActorRole`, `WorkspaceActorRouteRole`, `WorkspaceUserRouteRole`, `WorkspaceServiceAccountRole`, `WorkspaceUserPathRole`, `ExecutorWorkspaceRole`) plus the inline `WorkspaceUserInPath` / `WorkspaceUserOnlyInPath` aliases now annotate `WorkspaceRole`.
- Routers: redundant guards removed across `integrations`, `workflow/{management,actions,executions,store}`, `agent/channels`, `agent/session`, `secrets`, and the EE `tracecat_ee/agent` routers (approvals + agent). In `workflow/executions/router.py`, the two private search helpers now take `WorkspaceRole` directly.
- `oauth_callback` (a `require_workspace="no"` route) now binds the workspace from the validated OAuth state row to a local instead of re-narrowing the role.

## What is intentionally unchanged

- `BaseWorkspaceService.__init__`'s runtime guard: services are also constructed from Temporal activities, the executor, and `system_role()`, where no `RoleACL` guarantee exists.
- All `workspace_id is None` checks in engine/runtime code (`dsl/`, `executor/`, `agent/`), which receive roles deserialized from payloads/headers — there, no `RoleACL` guarantee exists, so the runtime checks still matter.

Since `WorkspaceRole` subclasses `Role`, every service signature taking `role: Role` is unaffected.

## Testing

- `uv run basedpyright --warnings`: 0 errors.
- `uv run ruff check` / `ruff format`: clean.
- Targeted auth/router unit tests (`test_role_acl`, `test_auth_scope_resolution`, `test_role_headers`, `test_workspace_scoped_routes`, `test_api_actor_roles`, plus the touched routers' tests): 88 passed.
- Routes covered by the follow-up sweep (`test_api_secrets`, `test_agent_session_router`, `test_approvals_delete`): 46 passed.
- Full `tests/unit` sweep: identical failure set (222) on this branch and on clean `main` in my environment — zero regressions introduced.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce `WorkspaceRole` (a `Role` with a non-optional `workspace_id`) and update all workspace-scoped auth dependencies to return it. This removes ~30 unreachable guards and tightens typing with no runtime behavior changes.

- **Refactors**
  - Added `WorkspaceRole(Role)` in `tracecat/auth/types.py`.
  - `_validate_role` now returns `WorkspaceRole` when `require_workspace="yes"` after computing scopes.
  - Annotated all workspace-scoped dependency aliases to `WorkspaceRole` (e.g., `WorkspaceUserRole`, `WorkspaceActorRole`, `WorkspaceActorRouteRole`, `WorkspaceUserRouteRole`, `WorkspaceServiceAccountRole`, `WorkspaceUserPathRole`, `ExecutorWorkspaceRole`, `WorkspaceUserInPath`, `WorkspaceUserOnlyInPath`).
  - Removed redundant `workspace_id is None` checks across `integrations`, `workflow/*`, and `agent/channels`; `oauth_callback` now uses a local `workspace_id`.
  - Kept service-layer/runtime guards for untrusted contexts unchanged; `WorkspaceRole` subclasses `Role`, so existing service signatures remain compatible.

<sup>Written for commit 07f2c623f19fec478fc7141fe113dd191159c41d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
