### PR TITLE
fix(ui): default json viewer to nested and show result tab first

### DIFF
--- a/frontend/src/components/agents/agent-approvals-dialog.tsx
+++ b/frontend/src/components/agents/agent-approvals-dialog.tsx
@@ -349,7 +349,6 @@ export function AgentApprovalsDialog({
                       <JsonViewWithControls
                         src={parsedArgs}
                         defaultExpanded
-                        defaultTab="nested"
                         showControls={false}
                         className="text-xs"
                       />

--- a/frontend/src/components/agents/agents-dashboard.tsx
+++ b/frontend/src/components/agents/agents-dashboard.tsx
@@ -690,7 +690,6 @@ function AgentSessionCard({
                                   <JsonViewWithControls
                                     src={toolArgsValue}
                                     defaultExpanded={true}
-                                    defaultTab="nested"
                                     showControls={false}
                                     className="text-xs"
                                   />
@@ -708,7 +707,6 @@ function AgentSessionCard({
                                   <JsonViewWithControls
                                     src={decisionValue}
                                     defaultExpanded={true}
-                                    defaultTab="nested"
                                     showControls={false}
                                     className="text-xs"
                                   />

--- a/frontend/src/components/builder/events/events-selected-action.tsx
+++ b/frontend/src/components/builder/events/events-selected-action.tsx
@@ -204,7 +204,6 @@ export function SuccessEvent({
   executionId,
   eventId,
   defaultExpanded = true,
-  defaultTab = "nested",
 }: {
   event: WorkflowExecutionEventCompact
   type: Omit<TabType, "interaction">
@@ -212,7 +211,6 @@ export function SuccessEvent({
   executionId: string
   eventId: number
   defaultExpanded?: boolean
-  defaultTab?: "nested" | "flat"
 }) {
   const shouldShowTriggerInput =
     type === "result" && eventRef === WF_TRIGGER_EVENT_REF
@@ -223,7 +221,6 @@ export function SuccessEvent({
         <JsonViewWithControls
           src={event.action_input}
           defaultExpanded={defaultExpanded}
-          defaultTab={defaultTab}
           copyPrefix={getEventCopyPrefix(eventRef, "input")}
           copyMode="jsonpath-and-payload"
         />
@@ -234,7 +231,6 @@ export function SuccessEvent({
           <JsonViewWithControls
             src={event.action_input}
             defaultExpanded={defaultExpanded}
-            defaultTab={defaultTab}
             copyPrefix={getEventCopyPrefix(eventRef, "input")}
             copyMode="jsonpath-and-payload"
           />
@@ -247,7 +243,6 @@ export function SuccessEvent({
           executionId={executionId}
           eventId={eventId}
           defaultExpanded={defaultExpanded}
-          defaultTab={defaultTab}
         />
       )
   }
@@ -260,14 +255,12 @@ function ActionResultViewer({
   executionId,
   eventId,
   defaultExpanded = true,
-  defaultTab = "nested",
 }: {
   result: unknown
   eventRef: string
   executionId: string
   eventId: number
   defaultExpanded?: boolean
-  defaultTab?: "nested" | "flat"
 }) {
   if (result === null || result === undefined) {
     return (
@@ -304,7 +297,6 @@ function ActionResultViewer({
     <JsonViewWithControls
       src={result}
       defaultExpanded={defaultExpanded}
-      defaultTab={defaultTab}
       copyPrefix={getEventCopyPrefix(eventRef, "result")}
       copyMode="jsonpath-and-payload"
     />
@@ -454,7 +446,6 @@ function ActionEventContent({
                 executionId={executionId}
                 eventId={actionEvent.source_event_id}
                 defaultExpanded={true}
-                defaultTab="nested"
               />
             </TabsContent>
           </Tabs>

--- a/frontend/src/components/cases/case-payload-section.tsx
+++ b/frontend/src/components/cases/case-payload-section.tsx
@@ -8,7 +8,6 @@ export function CasePayloadSection({ caseData }: { caseData: CaseRead }) {
       {caseData.payload && Object.keys(caseData.payload).length > 0 ? (
         <JsonViewWithControls
           src={caseData.payload}
-          defaultTab="nested"
           defaultExpanded={true}
           showControls={true}
         />

--- a/frontend/src/components/cases/workflow-trigger-dialog.tsx
+++ b/frontend/src/components/cases/workflow-trigger-dialog.tsx
@@ -224,7 +224,6 @@ export function WorkflowTriggerDialog({
                 <JsonViewWithControls
                   src={fallbackInputs}
                   showControls={false}
-                  defaultTab="nested"
                   defaultExpanded
                 />
               </TooltipProvider>

--- a/frontend/src/components/cases/workflow-trigger-form.tsx
+++ b/frontend/src/components/cases/workflow-trigger-form.tsx
@@ -581,7 +581,6 @@ export function WorkflowTriggerForm({
             <JsonViewWithControls
               src={previewValues}
               showControls={false}
-              defaultTab="nested"
               defaultExpanded
             />
           </TooltipProvider>

--- a/frontend/src/components/executions/event-details.tsx
+++ b/frontend/src/components/executions/event-details.tsx
@@ -49,7 +49,7 @@ export function WorkflowExecutionEventDetailView({
     })
   }
 
-  const initialTab = tabItems[0]?.value
+  const initialTab = hasResult ? "result" : tabItems[0]?.value
   const [activeTab, setActiveTab] = React.useState<"input" | "result" | null>(
     initialTab ?? null
   )

--- a/frontend/src/components/json-viewer.tsx
+++ b/frontend/src/components/json-viewer.tsx
@@ -105,7 +105,7 @@ interface JsonViewWithControlsProps {
 export function JsonViewWithControls({
   src,
   defaultExpanded = false,
-  defaultTab = "flat",
+  defaultTab = "nested",
   showControls = true,
   copyPrefix,
   copyMode = "jsonpath-only",
@@ -133,8 +133,8 @@ export function JsonViewWithControls({
   const tabItems = React.useMemo(
     () =>
       [
-        { value: "flat", label: "Flat", src: flattenedSrc },
         { value: "nested", label: "Nested", src: originalSrc },
+        { value: "flat", label: "Flat", src: flattenedSrc },
       ] as { value: JsonViewWithControlsTabs; label: string; src: unknown }[],
     [flattenedSrc, originalSrc]
   )

--- a/frontend/src/components/watchtower/watchtower-monitor.tsx
+++ b/frontend/src/components/watchtower/watchtower-monitor.tsx
@@ -1122,7 +1122,6 @@ function ToolCallRow({ toolCall }: { toolCall: WatchtowerAgentToolCallRead }) {
           <JsonViewWithControls
             src={toolCall.args_redacted}
             defaultExpanded
-            defaultTab="nested"
             className="max-h-[60vh] overflow-auto"
           />
         </DialogContent>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set the JSON viewer to show the Nested view by default and open the Result tab first on execution events. This makes payloads easier to read and surfaces results faster.

- **Refactors**
  - `JsonViewWithControls`: default tab is now "nested" and tabs are ordered Nested → Flat; removed redundant `defaultTab="nested"` props.
  - Event details: initial tab is "result" when available; falls back to the first tab otherwise.

<sup>Written for commit a4c20dfba6d4a666e779c58d7f4c1e35939dded7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

