### PR TITLE
feat(integrations): per-tool agent approvals for remote mcp servers

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
@@ -782,7 +782,11 @@ function McpCatalogCard({
     canConfigure = canCreate
   }
   const configureLabel = "Configure"
-  const verifiedToolCount = entry.tools?.length ?? null
+  const totalToolCount = entry.tools?.length ?? null
+  const activeToolCount =
+    entry.tools?.filter(
+      (tool) => tool.status !== "missing" && tool.enabled !== false
+    ).length ?? null
   const unverifiedBadge = UNVERIFIED_BADGE
   let statusLabel = "Not connected"
   let statusClassName = "border-muted bg-muted/30 text-muted-foreground"
@@ -793,10 +797,15 @@ function McpCatalogCard({
     statusLabel = "Locked"
     statusClassName = "border-muted bg-muted/30 text-muted-foreground"
   } else if (connected) {
-    statusLabel =
-      isHttpServer && verifiedToolCount !== null
-        ? `Connected · ${verifiedToolCount} ${verifiedToolCount === 1 ? "tool" : "tools"}`
-        : "Connected"
+    if (isHttpServer && activeToolCount !== null && totalToolCount !== null) {
+      const toolCountLabel =
+        activeToolCount === totalToolCount
+          ? `${activeToolCount}`
+          : `${activeToolCount}/${totalToolCount}`
+      statusLabel = `Connected · ${toolCountLabel} ${activeToolCount === 1 ? "tool" : "tools"}`
+    } else {
+      statusLabel = "Connected"
+    }
     statusClassName = "border-emerald-200 bg-emerald-50 text-emerald-700"
   } else if (configured) {
     // An HTTP row with config but no verified tool listing is not known to

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -16453,6 +16453,59 @@ export const $MCPStdioServerConfig = {
   description: "Configuration for a stdio MCP server.",
 } as const
 
+export const $MCPToolPolicyUpdate = {
+  properties: {
+    name: {
+      type: "string",
+      minLength: 1,
+      title: "Name",
+    },
+    enabled: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Enabled",
+    },
+    requires_approval: {
+      anyOf: [
+        {
+          type: "boolean",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Requires Approval",
+    },
+  },
+  type: "object",
+  required: ["name"],
+  title: "MCPToolPolicyUpdate",
+  description: "Per-tool policy update for a stored MCP integration tool.",
+} as const
+
+export const $MCPToolPolicyUpdateRequest = {
+  properties: {
+    tools: {
+      items: {
+        $ref: "#/components/schemas/MCPToolPolicyUpdate",
+      },
+      type: "array",
+      minItems: 1,
+      title: "Tools",
+    },
+  },
+  type: "object",
+  required: ["tools"],
+  title: "MCPToolPolicyUpdateRequest",
+  description: "Request to update per-tool MCP integration policy.",
+} as const
+
 export const $MCPToolSummary = {
   properties: {
     name: {
@@ -16469,6 +16522,22 @@ export const $MCPToolSummary = {
         },
       ],
       title: "Description",
+    },
+    enabled: {
+      type: "boolean",
+      title: "Enabled",
+      default: true,
+    },
+    requires_approval: {
+      type: "boolean",
+      title: "Requires Approval",
+      default: false,
+    },
+    status: {
+      type: "string",
+      enum: ["available", "missing"],
+      title: "Status",
+      default: "available",
     },
   },
   type: "object",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -462,6 +462,8 @@ import type {
   McpIntegrationsTestMcpIntegrationConnectionResponse,
   McpIntegrationsUpdateMcpIntegrationData,
   McpIntegrationsUpdateMcpIntegrationResponse,
+  McpIntegrationsUpdateMcpIntegrationToolPoliciesData,
+  McpIntegrationsUpdateMcpIntegrationToolPoliciesResponse,
   McpPersonalAccessTokensCreateMcpPersonalAccessTokenData,
   McpPersonalAccessTokensCreateMcpPersonalAccessTokenResponse,
   McpPersonalAccessTokensListMcpPersonalAccessTokensData,
@@ -11642,6 +11644,34 @@ export const mcpIntegrationsDeleteMcpIntegration = (
       mcp_integration_id: data.mcpIntegrationId,
       workspace_id: data.workspaceId,
     },
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Update Mcp Integration Tool Policies
+ * Update MCP integration tool availability and approval policy.
+ * @param data The data for the request.
+ * @param data.mcpIntegrationId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns MCPIntegrationRead Successful Response
+ * @throws ApiError
+ */
+export const mcpIntegrationsUpdateMcpIntegrationToolPolicies = (
+  data: McpIntegrationsUpdateMcpIntegrationToolPoliciesData
+): CancelablePromise<McpIntegrationsUpdateMcpIntegrationToolPoliciesResponse> => {
+  return __request(OpenAPI, {
+    method: "PATCH",
+    url: "/workspaces/{workspace_id}/mcp-integrations/{mcp_integration_id}/tools",
+    path: {
+      mcp_integration_id: data.mcpIntegrationId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -5014,12 +5014,33 @@ export type MCPStdioServerConfig = {
 }
 
 /**
+ * Per-tool policy update for a stored MCP integration tool.
+ */
+export type MCPToolPolicyUpdate = {
+  name: string
+  enabled?: boolean | null
+  requires_approval?: boolean | null
+}
+
+/**
+ * Request to update per-tool MCP integration policy.
+ */
+export type MCPToolPolicyUpdateRequest = {
+  tools: Array<MCPToolPolicyUpdate>
+}
+
+/**
  * Summary of a tool discovered on a remote MCP server.
  */
 export type MCPToolSummary = {
   name: string
   description?: string | null
+  enabled?: boolean
+  requires_approval?: boolean
+  status?: "available" | "missing"
 }
+
+export type status4 = "available" | "missing"
 
 /**
  * The type/kind of message stored in the chat.
@@ -5427,7 +5448,7 @@ export type PlatformMCPCatalogRead = {
   last_refreshed_at: string | null
 }
 
-export type status4 = "available" | "coming_soon" | "deprecated" | "hidden"
+export type status5 = "available" | "coming_soon" | "deprecated" | "hidden"
 
 /**
  * Platform registry settings response.
@@ -5670,7 +5691,7 @@ export type RateLimitInfo = {
   }
 }
 
-export type status5 = "allowed" | "allowed_warning" | "rejected"
+export type status6 = "allowed" | "allowed_warning" | "rejected"
 
 export type ReadinessResponse = {
   status: string
@@ -6273,7 +6294,7 @@ export type RunArtifact = {
   startedAt: string
 }
 
-export type status6 = "running" | "success" | "failed" | "cancelled"
+export type status7 = "running" | "success" | "failed" | "cancelled"
 
 /**
  * This is the runtime context model for a workflow run. Passed into activities.
@@ -8463,7 +8484,7 @@ export type WorkflowCommitResponse = {
   } | null
 }
 
-export type status7 = "success" | "failure"
+export type status8 = "success" | "failure"
 
 /**
  * API response model for persisted workflow definitions.
@@ -8522,7 +8543,7 @@ export type WorkflowDslPublishResult = {
   message: string
 }
 
-export type status8 = "committed" | "no_op"
+export type status9 = "committed" | "no_op"
 
 export type WorkflowEntrypointValidationRequest = {
   expects?: {
@@ -8840,7 +8861,7 @@ export type WorkflowExecutionRead = {
   interactions?: Array<InteractionRead>
 }
 
-export type status9 =
+export type status10 =
   | "RUNNING"
   | "COMPLETED"
   | "FAILED"
@@ -12786,6 +12807,15 @@ export type McpIntegrationsDeleteMcpIntegrationData = {
 }
 
 export type McpIntegrationsDeleteMcpIntegrationResponse = void
+
+export type McpIntegrationsUpdateMcpIntegrationToolPoliciesData = {
+  mcpIntegrationId: string
+  requestBody: MCPToolPolicyUpdateRequest
+  workspaceId: string
+}
+
+export type McpIntegrationsUpdateMcpIntegrationToolPoliciesResponse =
+  MCPIntegrationRead
 
 export type McpIntegrationsTestMcpConnectionConfigData = {
   requestBody: MCPIntegrationTestConnectionRequest
@@ -18914,6 +18944,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         204: void
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/mcp-integrations/{mcp_integration_id}/tools": {
+    patch: {
+      req: McpIntegrationsUpdateMcpIntegrationToolPoliciesData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: MCPIntegrationRead
         /**
          * Validation Error
          */

--- a/frontend/src/components/integrations/mcp-integration-dialog.tsx
+++ b/frontend/src/components/integrations/mcp-integration-dialog.tsx
@@ -26,6 +26,7 @@ import type {
   MCPIntegrationRead,
   MCPIntegrationUpdate,
   MCPStdioIntegrationCreate,
+  MCPToolSummary,
   PlatformMCPCatalogRead,
 } from "@/client/types.gen"
 import { useScopeCheck } from "@/components/auth/scope-guard"
@@ -94,6 +95,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { toast } from "@/components/ui/use-toast"
 import { getMcpOAuthConnectErrorDetail } from "@/lib/errors"
@@ -106,6 +108,7 @@ import {
   useTestMcpConnectionConfig,
   useTestMcpIntegrationConnection,
   useUpdateMcpIntegration,
+  useUpdateMcpIntegrationToolPolicies,
 } from "@/lib/hooks"
 import { isMcpProvider } from "@/lib/integrations"
 import { cn } from "@/lib/utils"
@@ -270,6 +273,95 @@ function CatalogEntrySummary({
   )
 }
 
+type MCPToolPolicyPatch = {
+  enabled?: boolean
+  requires_approval?: boolean
+}
+
+function MCPToolPolicyList({
+  tools,
+  canUpdate,
+  pendingToolName,
+  onPolicyChange,
+}: {
+  tools: MCPToolSummary[]
+  canUpdate: boolean
+  pendingToolName: string | null
+  onPolicyChange: (tool: MCPToolSummary, patch: MCPToolPolicyPatch) => void
+}) {
+  return (
+    <ul className="divide-y divide-border/50">
+      {tools.map((tool) => {
+        const enabled = tool.enabled !== false
+        const requiresApproval = tool.requires_approval === true
+        const isMissing = tool.status === "missing"
+        const disabled = !canUpdate || isMissing || pendingToolName !== null
+        const rowIsPending = pendingToolName === tool.name
+
+        return (
+          <li
+            key={tool.name}
+            className="grid gap-3 py-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+          >
+            <div className="min-w-0 space-y-1">
+              <div className="flex min-w-0 items-center gap-2">
+                <p className="truncate font-mono text-xs text-foreground">
+                  {tool.name}
+                </p>
+                {rowIsPending ? (
+                  <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
+                ) : null}
+                {isMissing ? (
+                  <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
+                    Missing
+                  </Badge>
+                ) : !enabled ? (
+                  <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
+                    Disabled
+                  </Badge>
+                ) : requiresApproval ? (
+                  <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
+                    Approval
+                  </Badge>
+                ) : null}
+              </div>
+              {tool.description ? (
+                <p className="line-clamp-2 text-xs leading-5 text-muted-foreground">
+                  {tool.description}
+                </p>
+              ) : null}
+            </div>
+            <div className="grid grid-cols-2 gap-4 sm:flex sm:items-center sm:gap-5">
+              <label className="flex items-center justify-between gap-2 text-xs text-muted-foreground sm:justify-start">
+                Enabled
+                <Switch
+                  checked={enabled}
+                  disabled={disabled}
+                  onCheckedChange={(checked) =>
+                    onPolicyChange(tool, { enabled: checked })
+                  }
+                  aria-label={`Enable ${tool.name}`}
+                />
+              </label>
+              <label className="flex items-center justify-between gap-2 text-xs text-muted-foreground sm:justify-start">
+                Approval
+                <Switch
+                  checked={requiresApproval}
+                  disabled={disabled || !enabled}
+                  onCheckedChange={(checked) =>
+                    onPolicyChange(tool, { requires_approval: checked })
+                  }
+                  aria-label={`Require approval for ${tool.name}`}
+                />
+              </label>
+            </div>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
 export function MCPIntegrationDialog({
   triggerProps,
   mcpIntegrationId,
@@ -299,6 +391,8 @@ export function MCPIntegrationDialog({
     useCreateMcpIntegration(workspaceId)
   const { updateMcpIntegration, updateMcpIntegrationIsPending } =
     useUpdateMcpIntegration(workspaceId)
+  const { updateMcpIntegrationToolPolicies } =
+    useUpdateMcpIntegrationToolPolicies(workspaceId)
   const { deleteMcpIntegration, deleteMcpIntegrationIsPending } =
     useDeleteMcpIntegration(workspaceId)
   const { integrations, providers, integrationsIsLoading } =
@@ -321,6 +415,9 @@ export function MCPIntegrationDialog({
   const [isEditHydrated, setIsEditHydrated] = useState(false)
   const [catalogOAuthClientIsPending, setCatalogOAuthClientIsPending] =
     useState(false)
+  const [pendingToolPolicyName, setPendingToolPolicyName] = useState<
+    string | null
+  >(null)
   const open = controlledOpen ?? internalOpen
   const { className: triggerClassName, ...restTriggerProps } =
     triggerProps ?? {}
@@ -402,6 +499,32 @@ export function MCPIntegrationDialog({
       timeout: values.timeout ?? null,
     })
   }
+
+  async function handleToolPolicyChange(
+    tool: MCPToolSummary,
+    patch: MCPToolPolicyPatch
+  ) {
+    if (!mcpIntegrationId) {
+      return
+    }
+    setPendingToolPolicyName(tool.name)
+    try {
+      await updateMcpIntegrationToolPolicies({
+        mcpIntegrationId,
+        tools: [
+          {
+            name: tool.name,
+            ...patch,
+          },
+        ],
+      })
+    } catch {
+      // The mutation hook logs and surfaces the API error.
+    } finally {
+      setPendingToolPolicyName(null)
+    }
+  }
+
   const selectedCatalogSpec = catalogSpecForOption(
     catalogEntry,
     connectionOptionId
@@ -804,6 +927,9 @@ export function MCPIntegrationDialog({
         </DropdownMenuContent>
       </DropdownMenu>
     ) : null
+  const availableToolCount =
+    mcpIntegration?.tools?.filter((tool) => tool.status !== "missing").length ??
+    0
   const dialogTitle = catalogEntry
     ? `Configure ${catalogEntry.name}`
     : isEditMode
@@ -1316,23 +1442,28 @@ export function MCPIntegrationDialog({
                     mcpIntegration?.tools?.length ? (
                       <AccordionItem value="tools" className="border-t">
                         <AccordionTrigger className="py-3 hover:no-underline">
-                          Tools ({mcpIntegration.tools.length})
+                          <span className="flex items-center gap-2">
+                            Tools ({mcpIntegration.tools.length})
+                            {availableToolCount !==
+                            mcpIntegration.tools.length ? (
+                              <Badge
+                                variant="outline"
+                                className="h-5 px-1.5 text-[10px]"
+                              >
+                                {availableToolCount} available
+                              </Badge>
+                            ) : null}
+                          </span>
                         </AccordionTrigger>
                         <AccordionContent>
-                          <ul className="divide-y divide-border/50">
-                            {mcpIntegration.tools.map((tool) => (
-                              <li key={tool.name} className="py-2">
-                                <p className="font-mono text-xs text-foreground">
-                                  {tool.name}
-                                </p>
-                                {tool.description ? (
-                                  <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
-                                    {tool.description}
-                                  </p>
-                                ) : null}
-                              </li>
-                            ))}
-                          </ul>
+                          <MCPToolPolicyList
+                            tools={mcpIntegration.tools}
+                            canUpdate={canUpdate}
+                            pendingToolName={pendingToolPolicyName}
+                            onPolicyChange={(tool, patch) =>
+                              void handleToolPolicyChange(tool, patch)
+                            }
+                          />
                         </AccordionContent>
                       </AccordionItem>
                     ) : null}

--- a/frontend/src/components/integrations/mcp-integration-dialog.tsx
+++ b/frontend/src/components/integrations/mcp-integration-dialog.tsx
@@ -281,12 +281,10 @@ type MCPToolPolicyPatch = {
 function MCPToolPolicyList({
   tools,
   canUpdate,
-  pendingToolName,
   onPolicyChange,
 }: {
   tools: MCPToolSummary[]
   canUpdate: boolean
-  pendingToolName: string | null
   onPolicyChange: (tool: MCPToolSummary, patch: MCPToolPolicyPatch) => void
 }) {
   return (
@@ -295,8 +293,7 @@ function MCPToolPolicyList({
         const enabled = tool.enabled !== false
         const requiresApproval = tool.requires_approval === true
         const isMissing = tool.status === "missing"
-        const disabled = !canUpdate || isMissing || pendingToolName !== null
-        const rowIsPending = pendingToolName === tool.name
+        const disabled = !canUpdate || isMissing
 
         return (
           <li
@@ -308,9 +305,6 @@ function MCPToolPolicyList({
                 <p className="truncate font-mono text-xs text-foreground">
                   {tool.name}
                 </p>
-                {rowIsPending ? (
-                  <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
-                ) : null}
                 {isMissing ? (
                   <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
                     Missing
@@ -415,9 +409,6 @@ export function MCPIntegrationDialog({
   const [isEditHydrated, setIsEditHydrated] = useState(false)
   const [catalogOAuthClientIsPending, setCatalogOAuthClientIsPending] =
     useState(false)
-  const [pendingToolPolicyName, setPendingToolPolicyName] = useState<
-    string | null
-  >(null)
   const open = controlledOpen ?? internalOpen
   const { className: triggerClassName, ...restTriggerProps } =
     triggerProps ?? {}
@@ -507,7 +498,8 @@ export function MCPIntegrationDialog({
     if (!mcpIntegrationId) {
       return
     }
-    setPendingToolPolicyName(tool.name)
+    // The switch flips optimistically; the mutation hook rolls back the
+    // cached integration and surfaces the API error on failure.
     try {
       await updateMcpIntegrationToolPolicies({
         mcpIntegrationId,
@@ -519,9 +511,7 @@ export function MCPIntegrationDialog({
         ],
       })
     } catch {
-      // The mutation hook logs and surfaces the API error.
-    } finally {
-      setPendingToolPolicyName(null)
+      // Handled by the mutation hook.
     }
   }
 
@@ -1459,7 +1449,6 @@ export function MCPIntegrationDialog({
                           <MCPToolPolicyList
                             tools={mcpIntegration.tools}
                             canUpdate={canUpdate}
-                            pendingToolName={pendingToolPolicyName}
                             onPolicyChange={(tool, patch) =>
                               void handleToolPolicyChange(tool, patch)
                             }

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -143,6 +143,7 @@ import {
   type MCPIntegrationRead,
   type MCPIntegrationTestConnectionRequest,
   type MCPIntegrationUpdate,
+  type MCPToolPolicyUpdate,
   type McpIntegrationsListMcpIntegrationsData,
   type ModelCredentialCreate,
   type ModelCredentialUpdate,
@@ -154,6 +155,7 @@ import {
   mcpIntegrationsTestMcpConnectionConfig,
   mcpIntegrationsTestMcpIntegrationConnection,
   mcpIntegrationsUpdateMcpIntegration,
+  mcpIntegrationsUpdateMcpIntegrationToolPolicies,
   type OAuthGrantType,
   type OrganizationDeleteOrgMemberData,
   type OrganizationDeleteSessionData,
@@ -4774,6 +4776,52 @@ export function useUpdateMcpIntegration(workspaceId: string) {
   }
 }
 
+export function useUpdateMcpIntegrationToolPolicies(workspaceId: string) {
+  const queryClient = useQueryClient()
+
+  const {
+    mutateAsync: updateMcpIntegrationToolPolicies,
+    isPending: updateMcpIntegrationToolPoliciesIsPending,
+    error: updateMcpIntegrationToolPoliciesError,
+  } = useMutation({
+    mutationFn: async ({
+      mcpIntegrationId,
+      tools,
+    }: {
+      mcpIntegrationId: string
+      tools: MCPToolPolicyUpdate[]
+    }) => {
+      return await mcpIntegrationsUpdateMcpIntegrationToolPolicies({
+        workspaceId,
+        mcpIntegrationId,
+        requestBody: { tools },
+      })
+    },
+    onSuccess: (integration) => {
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-integrations", workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-integration", workspaceId, integration.id],
+      })
+    },
+    onError: (error: TracecatApiError) => {
+      console.error("Failed to update MCP tool policy:", error)
+      toast({
+        title: "Failed to update tool policy",
+        description: `${error.body?.detail || error.message}`,
+        variant: "destructive",
+      })
+    },
+  })
+
+  return {
+    updateMcpIntegrationToolPolicies,
+    updateMcpIntegrationToolPoliciesIsPending,
+    updateMcpIntegrationToolPoliciesError,
+  }
+}
+
 /**
  * Test connectivity against an unsaved (possibly edited) HTTP MCP
  * configuration. Fully ephemeral: nothing is persisted server-side and no
@@ -4853,7 +4901,7 @@ export function useTestMcpIntegrationConnection(workspaceId: string) {
       })
     },
     onSuccess: (result, mcpIntegrationId) => {
-      // Tools are persisted on success or cleared on failure, so refresh the
+      // Tools are refreshed on success and preserved on failure, so refresh the
       // integration regardless of outcome.
       queryClient.invalidateQueries({
         queryKey: ["mcp-integration", workspaceId, mcpIntegrationId],

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -4784,6 +4784,7 @@ export function useUpdateMcpIntegrationToolPolicies(workspaceId: string) {
     isPending: updateMcpIntegrationToolPoliciesIsPending,
     error: updateMcpIntegrationToolPoliciesError,
   } = useMutation({
+    mutationKey: ["update-mcp-integration-tool-policies", workspaceId],
     mutationFn: async ({
       mcpIntegrationId,
       tools,
@@ -4797,13 +4798,30 @@ export function useUpdateMcpIntegrationToolPolicies(workspaceId: string) {
         requestBody: { tools },
       })
     },
-    onSuccess: (integration) => {
-      queryClient.invalidateQueries({
-        queryKey: ["mcp-integrations", workspaceId],
-      })
-      queryClient.invalidateQueries({
-        queryKey: ["mcp-integration", workspaceId, integration.id],
-      })
+    // Optimistically patch the cached integration so policy switches flip
+    // immediately instead of waiting for the round-trip and refetch.
+    onMutate: async ({ mcpIntegrationId, tools }) => {
+      const queryKey = ["mcp-integration", workspaceId, mcpIntegrationId]
+      await queryClient.cancelQueries({ queryKey })
+      const previous = queryClient.getQueryData<MCPIntegrationRead>(queryKey)
+      if (previous?.tools) {
+        const patches = new Map(tools.map((tool) => [tool.name, tool]))
+        queryClient.setQueryData<MCPIntegrationRead>(queryKey, {
+          ...previous,
+          tools: previous.tools.map((tool) => {
+            const patch = patches.get(tool.name)
+            if (!patch) {
+              return tool
+            }
+            return {
+              ...tool,
+              enabled: patch.enabled ?? tool.enabled,
+              requires_approval:
+                patch.requires_approval ?? tool.requires_approval,
+            }
+          }),
+        })
+      }
     },
     onError: (error: TracecatApiError) => {
       console.error("Failed to update MCP tool policy:", error)
@@ -4811,6 +4829,27 @@ export function useUpdateMcpIntegrationToolPolicies(workspaceId: string) {
         title: "Failed to update tool policy",
         description: `${error.body?.detail || error.message}`,
         variant: "destructive",
+      })
+    },
+    // Reconcile against the server once toggles settle instead of restoring a
+    // per-mutation snapshot. Toggles run concurrently (no disable-all gating),
+    // so restoring a stale snapshot on error would clobber a sibling toggle
+    // that already succeeded. Refetching re-syncs to server truth — a failed
+    // tool reverts, succeeded siblings stay. Only invalidate once this is the
+    // last in-flight toggle (isMutating counts the current one as 1), so a
+    // refetch can't overwrite siblings' still-pending optimistic patches.
+    onSettled: (_data, _error, { mcpIntegrationId }) => {
+      const stillInFlight = queryClient.isMutating({
+        mutationKey: ["update-mcp-integration-tool-policies", workspaceId],
+      })
+      if (stillInFlight > 1) {
+        return
+      }
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-integration", workspaceId, mcpIntegrationId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["mcp-integrations", workspaceId],
       })
     },
   })

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -228,7 +228,10 @@ class AgentActivities:
         # Discover user MCP tools if configured
         user_mcp_claims: list[UserMCPServerClaim] | None = None
         if args.mcp_servers:
-            from tracecat.agent.mcp.user_client import discover_user_mcp_tools
+            from tracecat.agent.mcp.user_client import (
+                UserMCPClient,
+                discover_user_mcp_tools,
+            )
             from tracecat.agent.preset.service import AgentPresetService
 
             http_servers = [cfg for cfg in args.mcp_servers if is_http_mcp_server(cfg)]
@@ -294,6 +297,8 @@ class AgentActivities:
                 # disabled or missing tools are dropped, approval-gated tools
                 # are recorded in the effective approval map.
                 for tool_name, tool_def in user_mcp_tools.items():
+                    parsed = UserMCPClient.parse_user_mcp_tool_name(tool_name)
+                    has_dotted_remote_name = parsed is not None and "." in parsed[1]
                     policy = _stored_user_mcp_tool_policy(
                         tool_name,
                         integration_id_by_server_name=integration_id_by_server_name,
@@ -306,6 +311,21 @@ class AgentActivities:
                             )
                             continue
                         if policy.requires_approval:
+                            # Approval keys are stored as ``mcp.{server}.{tool}``
+                            # and converted back by replacing every dot, so a
+                            # dotted remote name (e.g. ``issue.get``) can't
+                            # round-trip to its router name and would resolve to
+                            # an unexecutable tool after approval. Non-approval
+                            # calls are unaffected: they route through the proxy
+                            # with the original name, so only drop on approval.
+                            if has_dotted_remote_name:
+                                logger.warning(
+                                    "Skipping approval-gated user MCP tool with "
+                                    "unsupported dotted name",
+                                    tool_name=tool_name,
+                                    remote_tool_name=parsed[1] if parsed else None,
+                                )
+                                continue
                             approval_key = normalize_mcp_tool_name(
                                 f"mcp__{REGISTRY_MCP_SERVER_NAME}__{tool_name}"
                             )

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import (
     UUID4,
     BaseModel,
+    Field,
 )
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
@@ -22,6 +23,10 @@ from tracecat.agent.mcp.internal_tools import (
     BUILDER_INTERNAL_TOOL_NAMES,
     get_builder_internal_tool_definitions,
 )
+from tracecat.agent.mcp.utils import (
+    REGISTRY_MCP_SERVER_NAME,
+    normalize_mcp_tool_name,
+)
 from tracecat.agent.schemas import ToolFilters
 from tracecat.agent.stream.connector import AgentStream
 from tracecat.agent.tokens import InternalToolContext, UserMCPServerClaim
@@ -35,6 +40,9 @@ from tracecat.registry.lock.service import RegistryLockService
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.tiers.entitlements import Entitlement, EntitlementService
 from tracecat.tiers.service import TierService
+
+if TYPE_CHECKING:
+    from tracecat.integrations.schemas import MCPToolSummary
 
 
 class BuildToolDefsArgs(BaseModel):
@@ -68,6 +76,8 @@ class BuildToolDefsResult(BaseModel):
     """Resolved user MCP server configs for JWT claims."""
     allowed_internal_tools: list[str] | None = None
     """List of allowed internal tool names for JWT claims."""
+    tool_approvals: dict[str, bool] | None = None
+    """Effective tool approval policy for the compiled scope."""
 
 
 class BuildAgentToolDefsArgs(BaseModel):
@@ -84,6 +94,12 @@ class ToolApprovalPayload(BaseModel):
     tool_name: str
     args: dict[str, Any] | str | None = None
     metadata: dict[str, Any] | None = None
+
+
+class ExecuteRemoteMCPToolArgs(BaseModel):
+    mcp_auth_token: str
+    tool_name: str
+    args: dict[str, Any] = Field(default_factory=dict)
 
 
 class PersistApprovalsActivityInputs(BaseModel):
@@ -113,6 +129,29 @@ class EmitSessionErrorInputs(BaseModel):
     message: str
 
 
+def _stored_user_mcp_tool_policy(
+    tool_name: str,
+    *,
+    integration_id_by_server_name: dict[str, uuid.UUID],
+    policies_by_integration_id: dict[uuid.UUID, dict[str, MCPToolSummary]],
+) -> MCPToolSummary | None:
+    """Look up the stored per-tool policy for a discovered user MCP tool.
+
+    Returns None when the tool name is not a user MCP tool, its server has no
+    backing integration, or the integration has no stored policy for the tool.
+    """
+    from tracecat.agent.mcp.user_client import UserMCPClient
+
+    parsed = UserMCPClient.parse_user_mcp_tool_name(tool_name)
+    if parsed is None:
+        return None
+    server_name, remote_tool_name = parsed
+    integration_id = integration_id_by_server_name.get(server_name)
+    if integration_id is None:
+        return None
+    return policies_by_integration_id.get(integration_id, {}).get(remote_tool_name)
+
+
 class AgentActivities:
     """Activities for agent execution."""
 
@@ -135,6 +174,8 @@ class AgentActivities:
         *,
         role: Role,
     ) -> BuildToolDefsResult:
+        effective_tool_approvals = dict(args.tool_approvals or {})
+
         # Check if this is a builder assistant session
         is_builder = (
             args.internal_tool_context is not None
@@ -204,16 +245,40 @@ class AgentActivities:
             hydrated_servers: list[MCPHttpServerConfig] = [
                 {**cfg} for cfg in http_servers
             ]
-            configs_with_integration_id: list[tuple[MCPHttpServerConfig, str]] = []
+            configs_with_integration_id: list[
+                tuple[MCPHttpServerConfig, uuid.UUID]
+            ] = []
+            integration_id_by_server_name: dict[str, uuid.UUID] = {}
             for hydrated in hydrated_servers:
                 if integration_id_str := hydrated.get("id"):
-                    configs_with_integration_id.append((hydrated, integration_id_str))
+                    try:
+                        integration_id = uuid.UUID(integration_id_str)
+                    except ValueError:
+                        logger.warning(
+                            "Invalid MCP integration id on server config",
+                            server_name=hydrated["name"],
+                            integration_id=integration_id_str,
+                        )
+                        continue
+                    configs_with_integration_id.append((hydrated, integration_id))
+                    integration_id_by_server_name[hydrated["name"]] = integration_id
+            tool_policies_by_integration_id: dict[
+                uuid.UUID, dict[str, MCPToolSummary]
+            ] = {}
             if configs_with_integration_id:
                 async with AgentPresetService.with_session(role=role) as svc:
-                    for hydrated, integration_id_str in configs_with_integration_id:
+                    tool_policies_by_integration_id = (
+                        await svc.resolve_mcp_integration_tool_policies(
+                            [
+                                integration_id
+                                for _, integration_id in configs_with_integration_id
+                            ]
+                        )
+                    )
+                    for hydrated, integration_id in configs_with_integration_id:
                         try:
                             secrets = await svc.resolve_mcp_integration_secrets(
-                                uuid.UUID(integration_id_str)
+                                integration_id
                             )
                         except ValueError:
                             secrets = None
@@ -225,8 +290,26 @@ class AgentActivities:
                     hydrated_servers,
                     fail_on_error=args.fail_on_mcp_discovery_error,
                 )
-                # Add user MCP tools to definitions
+                # Add user MCP tools to definitions, honoring stored policy:
+                # disabled or missing tools are dropped, approval-gated tools
+                # are recorded in the effective approval map.
                 for tool_name, tool_def in user_mcp_tools.items():
+                    policy = _stored_user_mcp_tool_policy(
+                        tool_name,
+                        integration_id_by_server_name=integration_id_by_server_name,
+                        policies_by_integration_id=tool_policies_by_integration_id,
+                    )
+                    if policy is not None:
+                        if not policy.enabled or policy.status != "available":
+                            logger.info(
+                                "Skipping disabled MCP tool", tool_name=tool_name
+                            )
+                            continue
+                        if policy.requires_approval:
+                            approval_key = normalize_mcp_tool_name(
+                                f"mcp__{REGISTRY_MCP_SERVER_NAME}__{tool_name}"
+                            )
+                            effective_tool_approvals[approval_key] = True
                     defs[tool_name] = tool_def
 
                 # JWT claims carry the source integration id when available so
@@ -284,6 +367,9 @@ class AgentActivities:
                 # is documentation more than enforcement.
                 hydrated_servers = []
 
+        if any(effective_tool_approvals.values()):
+            await self._check_tool_approval_entitlement(role)
+
         # Resolve registry lock for these actions
         # This provides origin→version mappings needed for action execution
         # Note: User MCP tools and internal tools don't need registry lock resolution
@@ -309,6 +395,7 @@ class AgentActivities:
             registry_lock=registry_lock,
             user_mcp_claims=user_mcp_claims,
             allowed_internal_tools=allowed_internal_tools,
+            tool_approvals=effective_tool_approvals or None,
         )
 
     @activity.defn
@@ -373,3 +460,29 @@ class AgentActivities:
         )
         await stream.error(args.message)
         await stream.done()
+
+    @activity.defn
+    async def execute_remote_mcp_tool(self, args: ExecuteRemoteMCPToolArgs) -> str:
+        """Execute an approved remote MCP tool through the trusted MCP router."""
+        from fastmcp.exceptions import ToolError
+
+        from tracecat.agent.mcp.trusted_server import call_token_scoped_tool
+        from tracecat.agent.tokens import verify_mcp_token
+
+        try:
+            claims = verify_mcp_token(args.mcp_auth_token)
+        except ValueError as e:
+            raise ApplicationError(
+                "MCP token verification failed",
+                type="AgentToolExecutionError",
+                non_retryable=True,
+            ) from e
+
+        try:
+            return await call_token_scoped_tool(args.tool_name, args.args, claims)
+        except ToolError as e:
+            raise ApplicationError(
+                str(e),
+                type="AgentToolExecutionError",
+                non_retryable=True,
+            ) from e

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -299,6 +299,23 @@ class AgentActivities:
                 for tool_name, tool_def in user_mcp_tools.items():
                     parsed = UserMCPClient.parse_user_mcp_tool_name(tool_name)
                     has_dotted_remote_name = parsed is not None and "." in parsed[1]
+                    # Unlike registry/internal tools, user MCP tool names are
+                    # registered with the trusted MCP server verbatim (see
+                    # ``build_token_scoped_tools``), so a dotted remote name
+                    # (e.g. ``issue.get``) reaches the model provider as
+                    # ``mcp__{server}__issue.get``. Provider tool-name
+                    # constraints reject dots, so an otherwise-valid tool would
+                    # make the agent fail to start. Drop these regardless of
+                    # approval status; approval-gated ones also can't round-trip
+                    # their ``mcp.{server}.{tool}`` approval key back to a
+                    # router name.
+                    if has_dotted_remote_name:
+                        logger.warning(
+                            "Skipping user MCP tool with unsupported dotted name",
+                            tool_name=tool_name,
+                            remote_tool_name=parsed[1] if parsed else None,
+                        )
+                        continue
                     policy = _stored_user_mcp_tool_policy(
                         tool_name,
                         integration_id_by_server_name=integration_id_by_server_name,
@@ -311,21 +328,6 @@ class AgentActivities:
                             )
                             continue
                         if policy.requires_approval:
-                            # Approval keys are stored as ``mcp.{server}.{tool}``
-                            # and converted back by replacing every dot, so a
-                            # dotted remote name (e.g. ``issue.get``) can't
-                            # round-trip to its router name and would resolve to
-                            # an unexecutable tool after approval. Non-approval
-                            # calls are unaffected: they route through the proxy
-                            # with the original name, so only drop on approval.
-                            if has_dotted_remote_name:
-                                logger.warning(
-                                    "Skipping approval-gated user MCP tool with "
-                                    "unsupported dotted name",
-                                    tool_name=tool_name,
-                                    remote_tool_name=parsed[1] if parsed else None,
-                                )
-                                continue
                             approval_key = normalize_mcp_tool_name(
                                 f"mcp__{REGISTRY_MCP_SERVER_NAME}__{tool_name}"
                             )

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -36,7 +36,12 @@ with workflow.unsafe.imports_passed_through():
         build_tracecat_mcp_role,
     )
     from tracecat.agent.mcp.metadata import strip_proxy_tool_metadata
-    from tracecat.agent.mcp.utils import normalize_mcp_tool_name
+    from tracecat.agent.mcp.utils import (
+        LEGACY_REGISTRY_MCP_SERVER_NAME,
+        REGISTRY_MCP_SERVER_NAME,
+        action_name_to_mcp_tool_name,
+        normalize_mcp_tool_name,
+    )
     from tracecat.agent.parsers import try_parse_json
     from tracecat.agent.preset.activities import (
         ResolveAgentPresetConfigActivityInput,
@@ -93,6 +98,7 @@ with workflow.unsafe.imports_passed_through():
         BuildToolDefsArgs,
         BuildToolDefsResult,
         EmitSessionErrorInputs,
+        ExecuteRemoteMCPToolArgs,
     )
     from tracecat_ee.agent.approvals.service import ApprovalManager, ApprovalMap
     from tracecat_ee.agent.context import AgentContext
@@ -142,6 +148,106 @@ def _build_approved_tool_run_input(
         run_id=run_id,
         execution_id=execution_id,
         logical_time=logical_time,
+    )
+
+
+def _approved_user_mcp_tool_name(tool_name: str) -> str | None:
+    """Resolve an approved tool call to the tool name on its user MCP server.
+
+    Approved user MCP tool calls arrive in one of two shapes: the normalized
+    approval key (``mcp.{server}.{tool}``) or the raw proxy-routed runtime name
+    (``mcp__tracecat-registry__mcp__{server}__{tool}``). Both map to the
+    ``mcp__{server}__{tool}`` name expected by the trusted MCP router. Returns
+    None for registry actions, which execute through the executor instead.
+    """
+    server, _, remote_tool = tool_name.removeprefix("mcp.").partition(".")
+    is_normalized_user_mcp = (
+        tool_name.startswith("mcp.")
+        and bool(server and remote_tool)
+        and server not in (REGISTRY_MCP_SERVER_NAME, LEGACY_REGISTRY_MCP_SERVER_NAME)
+    )
+    if not is_normalized_user_mcp:
+        action_name = normalize_mcp_tool_name(tool_name)
+        if not action_name.startswith("mcp."):
+            return None
+        server, _, remote_tool = action_name.removeprefix("mcp.").partition(".")
+        if not server or not remote_tool:
+            return None
+        tool_name = action_name
+    return action_name_to_mcp_tool_name(tool_name)
+
+
+def _apply_tool_approvals(
+    spec: AgentScopeSpec, build_result: BuildToolDefsResult
+) -> None:
+    """Adopt the effective approval policy computed during tool compilation."""
+    if build_result.tool_approvals is not None:
+        spec.config.tool_approvals = build_result.tool_approvals
+
+
+async def _execute_remote_mcp_tool_call(
+    tool_call: ApprovedToolCall,
+    *,
+    remote_tool_name: str,
+    mcp_auth_token: str,
+) -> PendingToolResult:
+    """Route an approved user MCP tool call through the trusted MCP router."""
+    raw_result = await workflow.execute_activity_method(
+        AgentActivities.execute_remote_mcp_tool,
+        arg=ExecuteRemoteMCPToolArgs(
+            mcp_auth_token=mcp_auth_token,
+            tool_name=remote_tool_name,
+            args=tool_call.args,
+        ),
+        start_to_close_timeout=timedelta(
+            seconds=int(config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT)
+        ),
+        retry_policy=RETRY_POLICIES["activity:fail_fast"],
+    )
+    return PendingToolResult(
+        tool_call_id=tool_call.tool_call_id,
+        tool_name=tool_call.tool_name,
+        tool_input=tool_call.args,
+        raw_result=raw_result,
+    )
+
+
+async def _execute_registry_tool_call(
+    tool_call: ApprovedToolCall,
+    *,
+    registry_lock: RegistryLock,
+    service_role: Role,
+    logical_time: datetime,
+) -> PendingToolResult:
+    """Execute an approved registry action on the executor task queue."""
+    stored = await workflow.execute_activity(
+        ExecutorActivities.execute_action_activity,
+        args=[
+            _build_approved_tool_run_input(
+                tool_call=tool_call,
+                registry_lock=registry_lock,
+                workflow_id=workflow.uuid4(),
+                run_id=workflow.uuid4(),
+                execution_id=workflow.uuid4(),
+                logical_time=logical_time,
+            ),
+            service_role,
+        ],
+        task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+        start_to_close_timeout=timedelta(
+            seconds=int(config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT)
+        ),
+        heartbeat_timeout=timedelta(seconds=config.TRACECAT__ACTIVITY_HEARTBEAT_TIMEOUT)
+        if config.TRACECAT__ACTIVITY_HEARTBEAT_TIMEOUT > 0
+        else None,
+        retry_policy=RETRY_POLICIES["activity:fail_fast"],
+        priority=AGENT_TOOL_PRIORITY,
+    )
+    return PendingToolResult(
+        tool_call_id=tool_call.tool_call_id,
+        tool_name=tool_call.tool_name,
+        tool_input=tool_call.args,
+        stored_result=stored,
     )
 
 
@@ -544,6 +650,7 @@ class DurableAgentWorkflow:
                     raise e.cause from e
                 raise
 
+            _apply_tool_approvals(root_spec, legacy_build_result)
             root_scope = CompiledAgentScope(
                 spec=root_spec,
                 build_result=legacy_build_result,
@@ -607,6 +714,7 @@ class DurableAgentWorkflow:
                 non_retryable=True,
             )
 
+        _apply_tool_approvals(root_spec, root_build_result)
         root_scope = CompiledAgentScope(
             spec=root_spec,
             build_result=root_build_result,
@@ -626,6 +734,13 @@ class DurableAgentWorkflow:
                     f"Batched agent tool compilation did not return scope '{scope_spec.name}'",
                     non_retryable=True,
                 )
+            if has_manual_tool_approvals(child_build_result.tool_approvals):
+                raise ApplicationError(
+                    f"Subagent preset '{subagent_spec.resolved.binding.preset}' uses manual approvals, "
+                    "which are not supported for subagents yet.",
+                    non_retryable=True,
+                )
+            _apply_tool_approvals(scope_spec, child_build_result)
             route_resolution = _llm_route_for_config(
                 scope_spec.config,
             )
@@ -928,6 +1043,7 @@ class DurableAgentWorkflow:
                         approved_tools=approved_tools,
                         denied_tools=denied_tools,
                         registry_lock=root_registry_lock,
+                        mcp_auth_token=compiled_run.root.mcp_auth_token,
                     )
                     logger.info(
                         "Tool execution completed",
@@ -1107,6 +1223,7 @@ class DurableAgentWorkflow:
         approved_tools: list[ApprovedToolCall],
         denied_tools: list[DeniedToolCall],
         registry_lock: RegistryLock,
+        mcp_auth_token: str,
     ) -> list:
         logical_time = workflow.now()
         service_role = build_tracecat_mcp_role(
@@ -1116,40 +1233,22 @@ class DurableAgentWorkflow:
         )
         pending_results: list[PendingToolResult] = []
         for tool_call in approved_tools:
+            remote_mcp_tool_name = _approved_user_mcp_tool_name(tool_call.tool_name)
             try:
-                stored = await workflow.execute_activity(
-                    ExecutorActivities.execute_action_activity,
-                    args=[
-                        _build_approved_tool_run_input(
-                            tool_call=tool_call,
-                            registry_lock=registry_lock,
-                            workflow_id=workflow.uuid4(),
-                            run_id=workflow.uuid4(),
-                            execution_id=workflow.uuid4(),
-                            logical_time=logical_time,
-                        ),
-                        service_role,
-                    ],
-                    task_queue=config.TRACECAT__EXECUTOR_QUEUE,
-                    start_to_close_timeout=timedelta(
-                        seconds=int(config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT)
-                    ),
-                    heartbeat_timeout=timedelta(
-                        seconds=config.TRACECAT__ACTIVITY_HEARTBEAT_TIMEOUT
+                if remote_mcp_tool_name is not None:
+                    result = await _execute_remote_mcp_tool_call(
+                        tool_call,
+                        remote_tool_name=remote_mcp_tool_name,
+                        mcp_auth_token=mcp_auth_token,
                     )
-                    if config.TRACECAT__ACTIVITY_HEARTBEAT_TIMEOUT > 0
-                    else None,
-                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
-                    priority=AGENT_TOOL_PRIORITY,
-                )
-                pending_results.append(
-                    PendingToolResult(
-                        tool_call_id=tool_call.tool_call_id,
-                        tool_name=tool_call.tool_name,
-                        tool_input=tool_call.args,
-                        stored_result=stored,
+                else:
+                    result = await _execute_registry_tool_call(
+                        tool_call,
+                        registry_lock=registry_lock,
+                        service_role=service_role,
+                        logical_time=logical_time,
                     )
-                )
+                pending_results.append(result)
             except ActivityError as e:
                 pending_results.append(
                     PendingToolResult(

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -36,6 +36,7 @@ from tracecat_ee.agent.activities import (
     BuildAgentToolDefsResult,
     BuildToolDefsResult,
     EmitSessionErrorInputs,
+    ExecuteRemoteMCPToolArgs,
     PersistApprovalsActivityInputs,
 )
 from tracecat_ee.agent.approvals.service import (
@@ -76,6 +77,7 @@ from tracecat.agent.session.activities import (
 )
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.tokens import UserMCPServerClaim
 from tracecat.agent.types import AgentConfig
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
@@ -1395,6 +1397,209 @@ async def test_agent_workflow_plumbs_forked_session_through_approval_continuatio
     }
     assert decisions_by_tool_call_id["call_risky"].approved is False
     assert decisions_by_tool_call_id["call_risky"].reason == "too risky"
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
+async def test_agent_workflow_routes_approved_user_mcp_tool_to_remote_activity(
+    svc_role: Role,
+    temporal_client: Client,
+    agent_worker_factory,
+    mock_session_id: uuid.UUID,
+) -> None:
+    """An approved user MCP tool must execute via execute_remote_mcp_tool, not
+    the registry executor, and the workflow must replay before and after the
+    approval signal."""
+    queue = f"test-agent-queue-{mock_session_id}"
+    integration_id = uuid.uuid4()
+    approval_request_recorded = asyncio.Event()
+    agent_inputs: list[AgentExecutorInput] = []
+    remote_activity_inputs: list[ExecuteRemoteMCPToolArgs] = []
+    registry_activity_inputs: list[RunActionInput] = []
+    reconcile_inputs: list[ReconcileToolResultsInput] = []
+
+    @activity.defn(name="load_session_activity")
+    async def mock_load_session_activity(
+        input: LoadSessionInput,
+    ) -> LoadSessionResult:
+        assert input.session_id == mock_session_id
+        return LoadSessionResult(
+            found=bool(agent_inputs),
+            sdk_session_id="sdk-session" if agent_inputs else None,
+            sdk_session_data=None,
+            is_fork=False,
+        )
+
+    @activity.defn(name="build_agent_tool_definitions")
+    async def mock_build_tool_definitions(
+        args: BuildAgentToolDefsArgs,
+    ) -> BuildAgentToolDefsResult:
+        tool_result = BuildToolDefsResult(
+            tool_definitions={
+                "mcp__Jira__getIssue": MCPToolDefinition(
+                    name="mcp__Jira__getIssue",
+                    description="Get an issue",
+                    parameters_json_schema={
+                        "type": "object",
+                        "properties": {"issue_key": {"type": "string"}},
+                        "required": ["issue_key"],
+                        "additionalProperties": False,
+                    },
+                )
+            },
+            registry_lock=RegistryLock(origins={}, actions={}),
+            user_mcp_claims=[UserMCPServerClaim(name="Jira", id=integration_id)],
+            tool_approvals={"mcp.Jira.getIssue": True},
+        )
+        return BuildAgentToolDefsResult(
+            scopes={scope.scope: tool_result for scope in args.scopes}
+        )
+
+    @activity.defn(name="run_agent_activity")
+    async def mock_run_agent_activity(
+        input: AgentExecutorInput,
+    ) -> AgentExecutorResult:
+        agent_inputs.append(input)
+        if len(agent_inputs) == 1:
+            assert input.is_approval_continuation is False
+            return AgentExecutorResult(
+                success=True,
+                approval_requested=True,
+                approval_items=[
+                    ToolCallContent(
+                        id="call-user-mcp",
+                        name="mcp__tracecat-registry__mcp__Jira__getIssue",
+                        input={"issue_key": "ISSUE-1"},
+                    )
+                ],
+            )
+
+        assert input.is_approval_continuation is True
+        return AgentExecutorResult(
+            success=True,
+            approval_requested=False,
+            output={"continued": True},
+        )
+
+    @activity.defn(name="record_approval_requests")
+    async def mock_record_approval_requests(
+        input: PersistApprovalsActivityInputs,
+    ) -> None:
+        assert [approval.tool_call_id for approval in input.approvals] == [
+            "call-user-mcp"
+        ]
+        approval_request_recorded.set()
+
+    @activity.defn(name="apply_approval_decisions")
+    async def mock_apply_approval_decisions(
+        input: ApplyApprovalResultsActivityInputs,
+    ) -> None:
+        assert [decision.tool_call_id for decision in input.decisions] == [
+            "call-user-mcp"
+        ]
+        assert input.decisions[0].approved is True
+
+    @activity.defn(name="execute_remote_mcp_tool")
+    async def mock_execute_remote_mcp_tool(args: ExecuteRemoteMCPToolArgs) -> str:
+        remote_activity_inputs.append(args)
+        assert args.tool_name == "mcp__Jira__getIssue"
+        assert args.args == {"issue_key": "ISSUE-1"}
+        assert args.mcp_auth_token
+        return '{"ok": true}'
+
+    @activity.defn(name="execute_action_activity")
+    async def mock_execute_action_activity(
+        input: RunActionInput,
+        role: Role,
+    ) -> InlineObject[dict[str, str]]:
+        del role
+        registry_activity_inputs.append(input)
+        return InlineObject(data={"unexpected": "registry path"})
+
+    @activity.defn(name="reconcile_tool_results_activity")
+    async def mock_reconcile_tool_results_activity(
+        input: ReconcileToolResultsInput,
+    ) -> ReconcileToolResultsResult:
+        reconcile_inputs.append(input)
+        return ReconcileToolResultsResult(
+            results=[
+                ToolExecutionResult(
+                    tool_call_id=pending.tool_call_id,
+                    tool_name=pending.tool_name,
+                    result=pending.raw_result,
+                    is_error=pending.is_error,
+                )
+                for pending in input.pending_results
+            ]
+        )
+
+    workflow_args = AgentWorkflowArgs(
+        role=svc_role,
+        agent_args=RunAgentArgs(
+            session_id=mock_session_id,
+            user_prompt="Validate remote MCP approval continuation",
+            config=AgentConfig(
+                model_name="claude-3-5-sonnet-20241022",
+                model_provider="anthropic",
+                actions=[],
+                tool_approvals={"mcp.Jira.getIssue": True},
+            ),
+        ),
+        entity_type=AgentSessionEntity.WORKFLOW,
+        entity_id=uuid.uuid4(),
+    )
+
+    activities = [
+        create_mock_create_session_activity(),
+        mock_load_session_activity,
+        create_mock_load_session_messages_activity(),
+        mock_build_tool_definitions,
+        mock_run_agent_activity,
+        mock_record_approval_requests,
+        mock_apply_approval_decisions,
+        mock_execute_remote_mcp_tool,
+        mock_execute_action_activity,
+        mock_reconcile_tool_results_activity,
+    ]
+
+    async with agent_worker_factory(
+        temporal_client, task_queue=queue, custom_activities=activities
+    ):
+        wf_handle = await temporal_client.start_workflow(
+            DurableAgentWorkflow.run,
+            workflow_args,
+            id=AgentWorkflowID(mock_session_id),
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+            execution_timeout=timedelta(seconds=30),
+        )
+
+        await asyncio.wait_for(approval_request_recorded.wait(), timeout=10)
+        suspended_history = await fetch_history_after_completed_workflow_task(wf_handle)
+        await replay_durable_agent_workflow_history(temporal_client, suspended_history)
+
+        await wf_handle.execute_update(
+            DurableAgentWorkflow.set_approvals,
+            WorkflowApprovalSubmission(
+                approvals={"call-user-mcp": True},
+                approved_by=svc_role.user_id,
+            ),
+        )
+
+        result = await wf_handle.result()
+        completed_history = await wf_handle.fetch_history()
+        await replay_durable_agent_workflow_history(temporal_client, completed_history)
+
+    assert result.output == {"continued": True}
+    assert len(remote_activity_inputs) == 1
+    assert remote_activity_inputs[0].tool_name == "mcp__Jira__getIssue"
+    assert remote_activity_inputs[0].args == {"issue_key": "ISSUE-1"}
+    # The approved user MCP tool must NOT fall through to the registry executor.
+    assert registry_activity_inputs == []
+    assert len(reconcile_inputs) == 1
+    assert len(reconcile_inputs[0].pending_results) == 1
+    assert reconcile_inputs[0].pending_results[0].raw_result == '{"ok": true}'
+    assert [input.is_approval_continuation for input in agent_inputs] == [False, True]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -28,6 +28,7 @@ from tracecat_ee.agent.activities import (
 
 from tracecat.agent.common.protocol import RuntimeInitPayload
 from tracecat.agent.common.stream_types import HarnessType
+from tracecat.agent.common.types import MCPToolDefinition
 from tracecat.agent.executor.activity import (
     AgentExecutorInput,
     AgentExecutorResult,
@@ -59,6 +60,7 @@ from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.chat.schemas import ChatMessage
 from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
+from tracecat.integrations.schemas import MCPToolSummary
 from tracecat.registry.lock.service import RegistryLockService
 from tracecat.registry.lock.types import RegistryLock
 
@@ -264,6 +266,142 @@ class TestBuildToolDefinitionsActivity:
         )
         assert exc_info.value.type == "AgentToolDefinitionError"
         assert exc_info.value.non_retryable is True
+
+    @pytest.mark.anyio
+    async def test_mcp_tool_policy_filters_and_maps_approvals(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_role: Role,
+    ) -> None:
+        from tracecat.agent.mcp import user_client
+        from tracecat.agent.preset.service import AgentPresetService
+
+        integration_id = uuid.uuid4()
+
+        async def mock_build_agent_tools(**_kwargs: Any) -> BuildToolsResult:
+            return BuildToolsResult(tools=[], collected_secrets=set())
+
+        async def mock_discover_user_mcp_tools(
+            configs: list[dict[str, Any]],
+            *,
+            fail_on_error: bool = False,
+        ) -> dict[str, MCPToolDefinition]:
+            assert fail_on_error is False
+            assert configs[0]["headers"] == {"authorization": "Bearer test-token"}
+            return {
+                "mcp__Jira__getIssue": MCPToolDefinition(
+                    name="mcp__Jira__getIssue",
+                    description="Get issue",
+                    parameters_json_schema={"type": "object"},
+                ),
+                "mcp__Jira__deleteIssue": MCPToolDefinition(
+                    name="mcp__Jira__deleteIssue",
+                    description="Delete issue",
+                    parameters_json_schema={"type": "object"},
+                ),
+            }
+
+        class _PresetService:
+            async def resolve_mcp_integration_tool_policies(
+                self,
+                mcp_integration_ids: list[uuid.UUID],
+            ) -> dict[uuid.UUID, dict[str, MCPToolSummary]]:
+                assert mcp_integration_ids == [integration_id]
+                return {
+                    integration_id: {
+                        "getIssue": MCPToolSummary(
+                            name="getIssue",
+                            requires_approval=True,
+                        ),
+                        "deleteIssue": MCPToolSummary(
+                            name="deleteIssue",
+                            enabled=False,
+                        ),
+                    }
+                }
+
+            async def resolve_mcp_integration_secrets(
+                self,
+                mcp_integration_id: uuid.UUID,
+            ) -> dict[str, str]:
+                assert mcp_integration_id == integration_id
+                return {"authorization": "Bearer test-token"}
+
+        class _PresetContext:
+            async def __aenter__(self) -> _PresetService:
+                return _PresetService()
+
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
+                return None
+
+        class _LockService:
+            async def resolve_lock_with_bindings(
+                self,
+                actions: set[str],
+            ) -> RegistryLock:
+                assert actions == set()
+                return RegistryLock(origins={}, actions={})
+
+        class _LockContext:
+            async def __aenter__(self) -> _LockService:
+                return _LockService()
+
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
+                return None
+
+        entitlement_roles: list[Role] = []
+
+        async def mock_check_tool_approval_entitlement(role: Role) -> None:
+            entitlement_roles.append(role)
+
+        monkeypatch.setattr(
+            agent_activities, "build_agent_tools", mock_build_agent_tools
+        )
+        monkeypatch.setattr(
+            user_client,
+            "discover_user_mcp_tools",
+            mock_discover_user_mcp_tools,
+        )
+        monkeypatch.setattr(
+            AgentPresetService,
+            "with_session",
+            staticmethod(lambda **_kwargs: _PresetContext()),
+        )
+        monkeypatch.setattr(
+            RegistryLockService,
+            "with_session",
+            lambda: _LockContext(),
+        )
+        monkeypatch.setattr(
+            AgentActivities,
+            "_check_tool_approval_entitlement",
+            staticmethod(mock_check_tool_approval_entitlement),
+        )
+
+        result = await AgentActivities().build_tool_definitions(
+            BuildToolDefsArgs(
+                role=mock_role,
+                tool_filters=ToolFilters(actions=[]),
+                mcp_servers=[
+                    {
+                        "type": "http",
+                        "name": "Jira",
+                        "url": "https://mcp.example.com/mcp",
+                        "id": str(integration_id),
+                    }
+                ],
+            )
+        )
+
+        assert set(result.tool_definitions) == {"mcp__Jira__getIssue"}
+        assert result.tool_approvals == {"mcp.Jira.getIssue": True}
+        assert result.user_mcp_claims is not None
+        assert result.user_mcp_claims[0].id == integration_id
+        assert entitlement_roles == [mock_role]
 
     @pytest.mark.anyio
     async def test_build_agent_tool_definitions_returns_partitioned_scopes(

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -404,6 +404,127 @@ class TestBuildToolDefinitionsActivity:
         assert entitlement_roles == [mock_role]
 
     @pytest.mark.anyio
+    async def test_mcp_tool_with_dotted_remote_name_kept_unless_approval_gated(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_role: Role,
+    ) -> None:
+        """Dotted remote names execute fine via the proxy, so they're kept; only
+        an approval-gated dotted tool is dropped since its approval key can't
+        round-trip back to the router name."""
+        from tracecat.agent.mcp import user_client
+        from tracecat.agent.preset.service import AgentPresetService
+
+        integration_id = uuid.uuid4()
+
+        async def mock_build_agent_tools(**_kwargs: Any) -> BuildToolsResult:
+            return BuildToolsResult(tools=[], collected_secrets=set())
+
+        async def mock_discover_user_mcp_tools(
+            configs: list[dict[str, Any]],
+            *,
+            fail_on_error: bool = False,
+        ) -> dict[str, MCPToolDefinition]:
+            return {
+                # Dotted, no approval -> kept (routes via proxy verbatim).
+                "mcp__Jira__issue.get": MCPToolDefinition(
+                    name="mcp__Jira__issue.get",
+                    description="Dotted, no approval",
+                    parameters_json_schema={"type": "object"},
+                ),
+                # Dotted, approval-gated -> dropped (lossy approval round-trip).
+                "mcp__Jira__issue.delete": MCPToolDefinition(
+                    name="mcp__Jira__issue.delete",
+                    description="Dotted, approval-gated",
+                    parameters_json_schema={"type": "object"},
+                ),
+            }
+
+        class _PresetService:
+            async def resolve_mcp_integration_tool_policies(
+                self,
+                mcp_integration_ids: list[uuid.UUID],
+            ) -> dict[uuid.UUID, dict[str, MCPToolSummary]]:
+                return {
+                    integration_id: {
+                        "issue.delete": MCPToolSummary(
+                            name="issue.delete",
+                            requires_approval=True,
+                        ),
+                    }
+                }
+
+            async def resolve_mcp_integration_secrets(
+                self,
+                mcp_integration_id: uuid.UUID,
+            ) -> dict[str, str]:
+                return {}
+
+        class _PresetContext:
+            async def __aenter__(self) -> _PresetService:
+                return _PresetService()
+
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
+                return None
+
+        class _LockService:
+            async def resolve_lock_with_bindings(
+                self, actions: set[str]
+            ) -> RegistryLock:
+                return RegistryLock(origins={}, actions={})
+
+        class _LockContext:
+            async def __aenter__(self) -> _LockService:
+                return _LockService()
+
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
+                return None
+
+        async def mock_check_tool_approval_entitlement(role: Role) -> None:
+            return None
+
+        monkeypatch.setattr(
+            agent_activities, "build_agent_tools", mock_build_agent_tools
+        )
+        monkeypatch.setattr(
+            user_client, "discover_user_mcp_tools", mock_discover_user_mcp_tools
+        )
+        monkeypatch.setattr(
+            AgentPresetService,
+            "with_session",
+            staticmethod(lambda **_kwargs: _PresetContext()),
+        )
+        monkeypatch.setattr(RegistryLockService, "with_session", lambda: _LockContext())
+        monkeypatch.setattr(
+            AgentActivities,
+            "_check_tool_approval_entitlement",
+            staticmethod(mock_check_tool_approval_entitlement),
+        )
+
+        result = await AgentActivities().build_tool_definitions(
+            BuildToolDefsArgs(
+                role=mock_role,
+                tool_filters=ToolFilters(actions=[]),
+                mcp_servers=[
+                    {
+                        "type": "http",
+                        "name": "Jira",
+                        "url": "https://mcp.example.com/mcp",
+                        "id": str(integration_id),
+                    }
+                ],
+            )
+        )
+
+        assert set(result.tool_definitions) == {"mcp__Jira__issue.get"}
+        # The kept dotted tool has no approval requirement.
+        assert not (result.tool_approvals or {})
+
+    @pytest.mark.anyio
     async def test_build_agent_tool_definitions_returns_partitioned_scopes(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -404,14 +404,15 @@ class TestBuildToolDefinitionsActivity:
         assert entitlement_roles == [mock_role]
 
     @pytest.mark.anyio
-    async def test_mcp_tool_with_dotted_remote_name_kept_unless_approval_gated(
+    async def test_mcp_tool_with_dotted_remote_name_always_dropped(
         self,
         monkeypatch: pytest.MonkeyPatch,
         mock_role: Role,
     ) -> None:
-        """Dotted remote names execute fine via the proxy, so they're kept; only
-        an approval-gated dotted tool is dropped since its approval key can't
-        round-trip back to the router name."""
+        """User MCP tool names reach the provider verbatim (registered on the
+        trusted server without dot-to-underscore conversion). Provider tool-name
+        constraints reject dots, so a dotted remote name is dropped regardless of
+        approval status - otherwise the agent would fail to start."""
         from tracecat.agent.mcp import user_client
         from tracecat.agent.preset.service import AgentPresetService
 
@@ -426,16 +427,23 @@ class TestBuildToolDefinitionsActivity:
             fail_on_error: bool = False,
         ) -> dict[str, MCPToolDefinition]:
             return {
-                # Dotted, no approval -> kept (routes via proxy verbatim).
+                # Dotted, no approval -> dropped (dot reaches provider verbatim).
                 "mcp__Jira__issue.get": MCPToolDefinition(
                     name="mcp__Jira__issue.get",
                     description="Dotted, no approval",
                     parameters_json_schema={"type": "object"},
                 ),
-                # Dotted, approval-gated -> dropped (lossy approval round-trip).
+                # Dotted, approval-gated -> dropped (dot reaches provider verbatim
+                # and approval key can't round-trip back to the router name).
                 "mcp__Jira__issue.delete": MCPToolDefinition(
                     name="mcp__Jira__issue.delete",
                     description="Dotted, approval-gated",
+                    parameters_json_schema={"type": "object"},
+                ),
+                # Non-dotted -> kept.
+                "mcp__Jira__list_issues": MCPToolDefinition(
+                    name="mcp__Jira__list_issues",
+                    description="Non-dotted, no approval",
                     parameters_json_schema={"type": "object"},
                 ),
             }
@@ -520,8 +528,9 @@ class TestBuildToolDefinitionsActivity:
             )
         )
 
-        assert set(result.tool_definitions) == {"mcp__Jira__issue.get"}
-        # The kept dotted tool has no approval requirement.
+        # Both dotted tools are dropped; only the non-dotted tool survives.
+        assert set(result.tool_definitions) == {"mcp__Jira__list_issues"}
+        # No approval entry is recorded for the dropped approval-gated dotted tool.
         assert not (result.tool_approvals or {})
 
     @pytest.mark.anyio

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -2132,6 +2132,36 @@ class TestClaudeAgentRuntimePreToolUseHook:
         runtime.client.interrupt.assert_awaited()
 
     @pytest.mark.anyio
+    async def test_proxy_routed_user_mcp_tool_requires_approval(
+        self,
+        mock_socket_writer: MagicMock,
+    ) -> None:
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer, transport_factory=lambda _: MagicMock()
+        )
+        runtime.tool_approvals = {"mcp.Jira.getIssue": True}
+        runtime.client = MagicMock()
+        runtime.client.interrupt = AsyncMock()
+
+        result = await runtime._pre_tool_use_hook(
+            input_data=make_hook_input(
+                tool_name="mcp__tracecat-registry__mcp__Jira__getIssue",
+                tool_input={"issue_key": "ISSUE-1"},
+                tool_use_id="call-user-mcp",
+            ),
+            tool_use_id="call-user-mcp",
+            context=make_hook_context(),
+        )
+
+        hook_output = get_hook_output(result)
+        assert hook_output.get("permissionDecision") == "deny"
+        assert "mcp.Jira.getIssue" in (
+            hook_output.get("permissionDecisionReason") or ""
+        )
+        mock_socket_writer.send_stream_event.assert_awaited()
+        runtime.client.interrupt.assert_awaited()
+
+    @pytest.mark.anyio
     async def test_agent_tool_denies_child_delegation(
         self,
         mock_socket_writer: MagicMock,

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -19,6 +19,7 @@ from tracecat_ee.agent.workflows.durable import (
     UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH,
     AgentWorkflowArgs,
     DurableAgentWorkflow,
+    _approved_user_mcp_tool_name,
     _build_approved_tool_run_input,
 )
 
@@ -416,6 +417,15 @@ async def test_build_config_prefers_pinned_preset_version_id() -> None:
     assert cfg.model_provider == pinned_config.model_provider
     assert cfg.actions == ["core.http_request"]
     assert cfg.instructions == "base instructions\nappend this"
+
+
+def test_approved_user_mcp_tool_name_from_normalized_approval() -> None:
+    assert _approved_user_mcp_tool_name("mcp.Jira.getIssue") == ("mcp__Jira__getIssue")
+    assert (
+        _approved_user_mcp_tool_name("mcp__tracecat-registry__mcp__Jira__getIssue")
+        == "mcp__Jira__getIssue"
+    )
+    assert _approved_user_mcp_tool_name("core.http_request") is None
 
 
 def test_build_approved_tool_run_input_is_deterministic() -> None:

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -60,6 +60,8 @@ from tracecat.integrations.schemas import (
     MCPIntegrationTestConnectionRequest,
     MCPIntegrationUpdate,
     MCPStdioIntegrationCreate,
+    MCPToolPolicyUpdate,
+    MCPToolSummary,
     ProviderConfig,
     ProviderKey,
     ProviderMetadata,
@@ -4264,6 +4266,81 @@ class TestMCPConnectionVerification:
         assert result.success is False
         assert result.message == "MCP integration is not configured correctly"
         assert stdio_integration.tools is None
+
+    def test_merge_mcp_tool_summaries_preserves_policy_and_marks_missing(self) -> None:
+        stored = [
+            {
+                "name": "search",
+                "description": "Old search",
+                "enabled": False,
+                "requires_approval": True,
+                "status": "available",
+            },
+            {
+                "name": "delete",
+                "description": "Delete issue",
+                "enabled": True,
+                "requires_approval": True,
+                "status": "available",
+            },
+        ]
+
+        merged = IntegrationService._merge_mcp_tool_summaries(
+            [
+                MCPToolSummary(name="search", description="New search"),
+                MCPToolSummary(name="create", description="Create issue"),
+            ],
+            stored,
+        )
+
+        assert [tool.name for tool in merged] == ["search", "create", "delete"]
+        assert merged[0].description == "New search"
+        assert merged[0].enabled is False
+        assert merged[0].requires_approval is True
+        assert merged[0].status == "available"
+        assert merged[1].enabled is True
+        assert merged[1].requires_approval is False
+        assert merged[1].status == "available"
+        assert merged[2].status == "missing"
+        assert merged[2].enabled is True
+        assert merged[2].requires_approval is True
+
+    async def test_update_mcp_tool_policies(
+        self, integration_service: IntegrationService
+    ) -> None:
+        integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Tool Policy MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        integration.tools = [
+            MCPToolSummary(name="search", description="Search").model_dump(),
+            MCPToolSummary(name="delete", description="Delete").model_dump(),
+        ]
+        integration_service.session.add(integration)
+        await integration_service.session.commit()
+
+        updated = await integration_service.update_mcp_tool_policies(
+            mcp_integration_id=integration.id,
+            tools=[
+                MCPToolPolicyUpdate(
+                    name="delete",
+                    enabled=False,
+                    requires_approval=True,
+                )
+            ],
+        )
+
+        assert updated is not None
+        tools = MCPToolSummary.validate_stored(updated.tools)
+        assert tools is not None
+        by_name = {tool.name: tool for tool in tools}
+        assert by_name["search"].enabled is True
+        assert by_name["search"].requires_approval is False
+        assert by_name["delete"].enabled is False
+        assert by_name["delete"].requires_approval is True
 
 
 class TestMCPTestConnectionRequestSchema:

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -4342,6 +4342,54 @@ class TestMCPConnectionVerification:
         assert by_name["delete"].enabled is False
         assert by_name["delete"].requires_approval is True
 
+    async def test_update_mcp_tool_policies_rejects_approval_without_entitlement(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Enabling approval needs AGENT_ADDONS; disabling/availability do not."""
+        monkeypatch.setattr(
+            tier_defaults,
+            "DEFAULT_ENTITLEMENTS",
+            tier_defaults.DEFAULT_ENTITLEMENTS.model_copy(
+                update={"agent_addons": False}
+            ),
+        )
+        integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name="Unentitled Tool Policy MCP",
+                server_uri="https://api.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        integration.tools = [
+            MCPToolSummary(name="search", description="Search").model_dump(),
+            MCPToolSummary(name="delete", description="Delete").model_dump(),
+        ]
+        integration_service.session.add(integration)
+        await integration_service.session.commit()
+
+        with pytest.raises(EntitlementRequired, match="agent_addons"):
+            await integration_service.update_mcp_tool_policies(
+                mcp_integration_id=integration.id,
+                tools=[MCPToolPolicyUpdate(name="delete", requires_approval=True)],
+            )
+
+        # Disabling availability and turning approval back off stay allowed.
+        updated = await integration_service.update_mcp_tool_policies(
+            mcp_integration_id=integration.id,
+            tools=[
+                MCPToolPolicyUpdate(name="search", enabled=False),
+                MCPToolPolicyUpdate(name="delete", requires_approval=False),
+            ],
+        )
+        assert updated is not None
+        tools = MCPToolSummary.validate_stored(updated.tools)
+        assert tools is not None
+        by_name = {tool.name: tool for tool in tools}
+        assert by_name["search"].enabled is False
+        assert by_name["delete"].requires_approval is False
+
 
 class TestMCPTestConnectionRequestSchema:
     """Input validation for ``MCPIntegrationTestConnectionRequest.server_uri``."""

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -60,6 +60,7 @@ from tracecat.integrations.mcp_validation import (
     MCPValidationError,
     validate_mcp_command_config,
 )
+from tracecat.integrations.schemas import MCPToolSummary
 from tracecat.integrations.service import IntegrationService
 from tracecat.logger import logger
 from tracecat.pagination import (
@@ -912,6 +913,31 @@ class AgentPresetService(BaseWorkspaceService):
             )
 
         return refs
+
+    async def resolve_mcp_integration_tool_policies(
+        self, mcp_integration_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, dict[str, MCPToolSummary]]:
+        """Resolve stored MCP tool policy by integration id and tool name."""
+        if not mcp_integration_ids:
+            return {}
+
+        requested_ids = set(mcp_integration_ids)
+        integrations_service = IntegrationService(self.session, role=self.role)
+        available = await integrations_service.list_mcp_integrations()
+
+        policies: dict[uuid.UUID, dict[str, MCPToolSummary]] = {}
+        for mcp_integration in available:
+            if mcp_integration.id not in requested_ids:
+                continue
+            tools = MCPToolSummary.validate_stored(
+                mcp_integration.tools,
+                mcp_integration_id=mcp_integration.id,
+            )
+            if tools is None:
+                continue
+            policies[mcp_integration.id] = {tool.name: tool for tool in tools}
+
+        return policies
 
     async def resolve_mcp_integration_secrets(
         self, mcp_integration_id: uuid.UUID

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -4578,7 +4578,8 @@ class MCPIntegration(TimestampMixin, Base):
         JSONB,
         nullable=True,
         doc="Tools discovered at the last successful connection verification "
-        "([{name, description}]); null means the server is unverified",
+        "([{name, description, enabled, requires_approval, status}]); null means "
+        "the server is unverified",
     )
 
     oauth_integration: Mapped[OAuthIntegration | None] = relationship(

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -50,6 +50,7 @@ from tracecat.integrations.schemas import (
     MCPIntegrationTestConnectionRequest,
     MCPIntegrationTestConnectionResponse,
     MCPIntegrationUpdate,
+    MCPToolPolicyUpdateRequest,
     MCPToolSummary,
     PlatformMCPCatalogListResponse,
     PlatformMCPCatalogState,
@@ -123,9 +124,9 @@ async def _gate_mcp_connect_verification(
     When the row was created by this request, a failed verification deletes it
     so that retries don't accumulate orphaned rows. Pre-existing rows returned
     by idempotent connects are kept (``delete_on_failure=False``) so a
-    transient outage doesn't destroy a saved integration; the failed
-    verification has already cleared its stored tools. Either way the failure
-    surfaces as an HTTP error so the connect/save does not report success.
+    transient outage doesn't destroy a saved integration. Either way the
+    failure surfaces as an HTTP error so the connect/save does not report
+    success.
     """
     if mcp_integration.server_type != "http":
         return
@@ -1189,6 +1190,44 @@ async def update_mcp_integration(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),
         ) from exc
+
+    return _mcp_integration_read(
+        integration,
+        state=await svc.mcp_integration_state(mcp_integration=integration),
+    )
+
+
+@mcp_router.patch("/{mcp_integration_id}/tools")
+@require_scope("integration:update")
+async def update_mcp_integration_tool_policies(
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    mcp_integration_id: uuid.UUID,
+    params: Annotated[MCPToolPolicyUpdateRequest, Body(...)],
+) -> MCPIntegrationRead:
+    """Update MCP integration tool availability and approval policy."""
+    if role.workspace_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Workspace ID is required",
+        )
+
+    svc = IntegrationService(session, role=role)
+    try:
+        integration = await svc.update_mcp_tool_policies(
+            mcp_integration_id=mcp_integration_id,
+            tools=params.tools,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    if integration is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="MCP integration not found",
+        )
 
     return _mcp_integration_read(
         integration,

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -567,6 +567,7 @@ PlatformMCPCatalogState = Literal[
     "connected",
     "error",
 ]
+MCPToolStatus = Literal["available", "missing"]
 
 
 class MCPConnectionCredential(BaseModel):
@@ -699,6 +700,12 @@ class MCPToolSummary(BaseModel):
 
     name: str
     description: str | None = None
+    enabled: bool = True
+    """Whether the tool is available to agents that use this MCP integration."""
+    requires_approval: bool = False
+    """Whether this tool requires HITL approval before execution."""
+    status: MCPToolStatus = "available"
+    """Whether the tool was present in the latest successful discovery."""
 
     @classmethod
     def validate_stored(
@@ -724,6 +731,20 @@ class MCPToolSummary(BaseModel):
                     else None,
                 )
         return validated
+
+
+class MCPToolPolicyUpdate(BaseModel):
+    """Per-tool policy update for a stored MCP integration tool."""
+
+    name: str = Field(..., min_length=1)
+    enabled: bool | None = None
+    requires_approval: bool | None = None
+
+
+class MCPToolPolicyUpdateRequest(BaseModel):
+    """Request to update per-tool MCP integration policy."""
+
+    tools: list[MCPToolPolicyUpdate] = Field(..., min_length=1)
 
 
 class MCPConnectionOption(BaseModel):

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -3068,13 +3068,22 @@ class IntegrationService(BaseWorkspaceService):
         return items
 
     async def get_mcp_integration(
-        self, *, mcp_integration_id: uuid.UUID
+        self, *, mcp_integration_id: uuid.UUID, for_update: bool = False
     ) -> MCPIntegration | None:
-        """Get an MCP integration by ID."""
+        """Get an MCP integration by ID.
+
+        Pass ``for_update=True`` to lock the row (``SELECT ... FOR UPDATE``)
+        before a read-modify-write of the ``tools`` JSON blob. The blob is
+        rewritten wholesale, so concurrent writers (e.g. a policy toggle racing
+        connection verification) must serialize or one commit silently drops the
+        other's changes to unrelated tools.
+        """
         statement = select(MCPIntegration).where(
             MCPIntegration.id == mcp_integration_id,
             MCPIntegration.workspace_id == self.workspace_id,
         )
+        if for_update:
+            statement = statement.with_for_update()
         result = await self.session.execute(statement)
         return result.scalars().first()
 
@@ -3215,6 +3224,13 @@ class IntegrationService(BaseWorkspaceService):
                 message=e.message,
                 error=e.error or e.message,
             )
+
+        # Lock and reload the row before merging: the probe runs unlocked (it's a
+        # network call), and merging rewrites the full tools blob, which races
+        # read-modify-write policy toggles. refresh(with_for_update) takes the
+        # row lock AND reloads tools to the latest committed value, so the merge
+        # serializes against and sees concurrent mutations.
+        await self.session.refresh(mcp_integration, with_for_update=True)
 
         merged_tools = self._merge_mcp_tool_summaries(
             tools,
@@ -3595,9 +3611,23 @@ class IntegrationService(BaseWorkspaceService):
                 mcp_integration.encrypted_headers = None
 
         if verified_tools is not None:
+            # Lock the row and read its latest committed tools before merging: the
+            # verify probe ran unlocked (network call), so merging against the
+            # in-memory snapshot would clobber policy toggles committed since.
+            # Fetch just the tools column FOR UPDATE — a full refresh() would
+            # discard this method's pending field mutations on mcp_integration.
+            current_tools_result = await self.session.execute(
+                select(MCPIntegration.tools)
+                .where(
+                    MCPIntegration.id == mcp_integration.id,
+                    MCPIntegration.workspace_id == self.workspace_id,
+                )
+                .with_for_update()
+            )
+            current_tools = current_tools_result.scalar_one_or_none()
             merged_tools = self._merge_mcp_tool_summaries(
                 verified_tools,
-                mcp_integration.tools,
+                current_tools,
                 mcp_integration_id=mcp_integration.id,
             )
             mcp_integration.tools = [tool.model_dump() for tool in merged_tools]
@@ -3621,8 +3651,10 @@ class IntegrationService(BaseWorkspaceService):
         tools: Sequence[MCPToolPolicyUpdate],
     ) -> MCPIntegration | None:
         """Update per-tool availability and approval policy for an MCP integration."""
+        # Lock the row: this is a read-modify-write of the full tools blob, so a
+        # concurrent toggle or verification commit would otherwise clobber it.
         mcp_integration = await self.get_mcp_integration(
-            mcp_integration_id=mcp_integration_id
+            mcp_integration_id=mcp_integration_id, for_update=True
         )
         if not mcp_integration:
             return None
@@ -3644,6 +3676,18 @@ class IntegrationService(BaseWorkspaceService):
             if tool.name not in stored_by_name:
                 raise ValueError(f"MCP tool not found on integration: {tool.name}")
             updates_by_name[tool.name] = tool
+
+        # Turning on approval for a tool only takes effect at agent compile time,
+        # which gates on AGENT_ADDONS. Without the entitlement the stored policy
+        # would silently brick the MCP-backed agent, so reject approval-enabling
+        # updates here. Disabling approval and availability changes stay allowed.
+        enables_approval = any(
+            update.requires_approval is True
+            and not stored_by_name[name].requires_approval
+            for name, update in updates_by_name.items()
+        )
+        if enables_approval:
+            await self.require_entitlement(Entitlement.AGENT_ADDONS)
 
         updated_tools: list[MCPToolSummary] = []
         for stored_tool in stored_tools:

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -73,6 +73,7 @@ from tracecat.integrations.schemas import (
     MCPIntegrationTestConnectionResponse,
     MCPIntegrationUpdate,
     MCPStdioIntegrationCreate,
+    MCPToolPolicyUpdate,
     MCPToolSummary,
     PlatformMCPCatalogState,
     ProviderConfig,
@@ -215,6 +216,51 @@ class IntegrationService(BaseWorkspaceService):
             )
         except MCPValidationError as exc:
             raise ValueError(str(exc)) from exc
+
+    @staticmethod
+    def _merge_mcp_tool_summaries(
+        discovered_tools: Sequence[MCPToolSummary],
+        stored_tools: list[dict[str, Any]] | None,
+        *,
+        mcp_integration_id: object | None = None,
+    ) -> list[MCPToolSummary]:
+        """Merge fresh discovery into stored tool policy.
+
+        Discovery owns the tool name, description, and availability status.
+        Stored rows own user policy fields (enabled and requires_approval).
+        Tools that disappeared remain in the snapshot as disabled-by-status
+        entries so the UI can show what changed without silently losing policy.
+        """
+        stored = (
+            MCPToolSummary.validate_stored(
+                stored_tools, mcp_integration_id=mcp_integration_id
+            )
+            or []
+        )
+        stored_by_name = {tool.name: tool for tool in stored}
+        merged: list[MCPToolSummary] = []
+        discovered_names: set[str] = set()
+
+        for discovered in discovered_tools:
+            previous = stored_by_name.get(discovered.name)
+            merged.append(
+                MCPToolSummary(
+                    name=discovered.name,
+                    description=discovered.description,
+                    enabled=previous.enabled if previous is not None else True,
+                    requires_approval=previous.requires_approval
+                    if previous is not None
+                    else False,
+                    status="available",
+                )
+            )
+            discovered_names.add(discovered.name)
+
+        for previous in stored:
+            if previous.name not in discovered_names:
+                merged.append(previous.model_copy(update={"status": "missing"}))
+
+        return merged
 
     async def _provider_identifier_taken(
         self, provider_id: str, grant_type: OAuthGrantType
@@ -3157,9 +3203,9 @@ class IntegrationService(BaseWorkspaceService):
     ) -> MCPIntegrationTestConnectionResponse:
         """Verify connectivity to an HTTP MCP server and persist its tools.
 
-        Last attempt wins: a successful verification stores the discovered
-        tools on the integration; any failure clears previously stored tools
-        so the integration no longer reports as verified.
+        A successful verification refreshes the discovered tool set while
+        preserving stored per-tool policy. A failed verification is reported to
+        the caller without mutating the last known tool snapshot.
         """
         try:
             tools = await self._probe_mcp_http_server(mcp_integration)
@@ -3170,7 +3216,12 @@ class IntegrationService(BaseWorkspaceService):
                 error=e.error or e.message,
             )
 
-        mcp_integration.tools = [tool.model_dump() for tool in tools]
+        merged_tools = self._merge_mcp_tool_summaries(
+            tools,
+            mcp_integration.tools,
+            mcp_integration_id=mcp_integration.id,
+        )
+        mcp_integration.tools = [tool.model_dump() for tool in merged_tools]
         self.session.add(mcp_integration)
         await self.session.commit()
         await self.session.refresh(mcp_integration)
@@ -3182,7 +3233,7 @@ class IntegrationService(BaseWorkspaceService):
         return MCPIntegrationTestConnectionResponse(
             success=True,
             mcp_integration_id=mcp_integration.id,
-            tools=tools,
+            tools=merged_tools,
             message=f"Connected successfully — {len(tools)} tools available",
         )
 
@@ -3193,18 +3244,13 @@ class IntegrationService(BaseWorkspaceService):
         message: str,
         error: str,
     ) -> MCPIntegrationTestConnectionResponse:
-        """Clear stored tools after a failed verification and build the response."""
+        """Record a failed verification response without mutating stored policy."""
         self.logger.warning(
             "MCP integration verification failed",
             mcp_integration_id=str(mcp_integration.id),
             message=message,
             error=error,
         )
-        if mcp_integration.tools is not None:
-            mcp_integration.tools = None
-            self.session.add(mcp_integration)
-            await self.session.commit()
-            await self.session.refresh(mcp_integration)
         return MCPIntegrationTestConnectionResponse(
             success=False,
             mcp_integration_id=mcp_integration.id,
@@ -3549,7 +3595,12 @@ class IntegrationService(BaseWorkspaceService):
                 mcp_integration.encrypted_headers = None
 
         if verified_tools is not None:
-            mcp_integration.tools = [tool.model_dump() for tool in verified_tools]
+            merged_tools = self._merge_mcp_tool_summaries(
+                verified_tools,
+                mcp_integration.tools,
+                mcp_integration_id=mcp_integration.id,
+            )
+            mcp_integration.tools = [tool.model_dump() for tool in merged_tools]
 
         self.session.add(mcp_integration)
         await self.session.commit()
@@ -3558,6 +3609,65 @@ class IntegrationService(BaseWorkspaceService):
         self.logger.info(
             "Updated MCP integration",
             mcp_integration_id=mcp_integration.id,
+        )
+
+        return mcp_integration
+
+    @require_scope("integration:update")
+    async def update_mcp_tool_policies(
+        self,
+        *,
+        mcp_integration_id: uuid.UUID,
+        tools: Sequence[MCPToolPolicyUpdate],
+    ) -> MCPIntegration | None:
+        """Update per-tool availability and approval policy for an MCP integration."""
+        mcp_integration = await self.get_mcp_integration(
+            mcp_integration_id=mcp_integration_id
+        )
+        if not mcp_integration:
+            return None
+        if mcp_integration.tools is None:
+            raise ValueError("MCP integration has no discovered tools to update")
+
+        stored_tools = (
+            MCPToolSummary.validate_stored(
+                mcp_integration.tools, mcp_integration_id=mcp_integration.id
+            )
+            or []
+        )
+        stored_by_name = {tool.name: tool for tool in stored_tools}
+
+        updates_by_name: dict[str, MCPToolPolicyUpdate] = {}
+        for tool in tools:
+            if tool.name in updates_by_name:
+                raise ValueError(f"Duplicate MCP tool policy update: {tool.name}")
+            if tool.name not in stored_by_name:
+                raise ValueError(f"MCP tool not found on integration: {tool.name}")
+            updates_by_name[tool.name] = tool
+
+        updated_tools: list[MCPToolSummary] = []
+        for stored_tool in stored_tools:
+            policy_update = updates_by_name.get(stored_tool.name)
+            if policy_update is None:
+                updated_tools.append(stored_tool)
+                continue
+
+            update_fields: dict[str, bool] = {}
+            if policy_update.enabled is not None:
+                update_fields["enabled"] = policy_update.enabled
+            if policy_update.requires_approval is not None:
+                update_fields["requires_approval"] = policy_update.requires_approval
+            updated_tools.append(stored_tool.model_copy(update=update_fields))
+
+        mcp_integration.tools = [tool.model_dump() for tool in updated_tools]
+        self.session.add(mcp_integration)
+        await self.session.commit()
+        await self.session.refresh(mcp_integration)
+
+        self.logger.info(
+            "Updated MCP integration tool policies",
+            mcp_integration_id=mcp_integration.id,
+            tool_count=len(updates_by_name),
         )
 
         return mcp_integration


### PR DESCRIPTION
  ## Core change

  - **`mcpintegration.tools` column schema extended** — each stored tool entry now carries
    per-tool policy: `enabled` (default `true`), `requires_approval` (default `false`), and
    `status` (`available` | `missing`). No migration needed: old `[{name, description}]` rows
    self-heal on read via `MCPToolSummary` defaults, and the next successful verification
    rewrites them in the new shape.
  - **Re-verification merges instead of overwrites** — discovery owns name/description/status;
    stored rows own user policy. Tools that disappear from the server are kept as
    `status: "missing"` (policy preserved) instead of silently dropped, and a failed
    verification no longer clears the stored tool snapshot.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-tool enable/approval policies for remote MCP servers, enforced by agents, with approved user MCP tool calls routed through a trusted router. Discovery now merges with stored policy and the UI exposes per-tool switches with clear active/total tool counts.

- **New Features**
  - API: PATCH `/workspaces/{workspace_id}/mcp-integrations/{mcp_integration_id}/tools` to update per-tool policy; adds `MCPToolPolicyUpdate`, `MCPToolPolicyUpdateRequest`; `MCPToolSummary` includes `enabled`, `requires_approval`, `status`.
  - Integrations: verification merges discovery with stored policy, marks missing tools, locks rows to avoid clobbering concurrent updates; failures don’t clear stored snapshots.
  - Agent/Workflow: compile effective `tool_approvals`, gate unapproved calls, and execute approved user MCP tools via `execute_remote_mcp_tool` (token-scoped trusted router) from normalized approval keys or proxy names; manual approvals are disallowed for subagents.
  - Frontend: per-tool “Enabled” and “Approval” switches with optimistic updates and error toasts; catalog cards show “Connected · {active}/{total} tools” and an “available” badge in the tools accordion.

- **Bug Fixes**
  - Enforce entitlement when enabling approvals (`agent_addons` required); disabling and availability changes remain allowed.
  - Drop remote MCP tools with dotted names, regardless of approval state.
  - Ensure approved user MCP tools never fall through to the registry executor.

<sup>Written for commit e959d35e221875b23725d40c014bf34e7808f2e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<img width="931" height="906" alt="image" src="https://github.com/user-attachments/assets/9780c6bd-e038-47ff-a256-4bea4ba9f118" />
