### PR TITLE
fix(agents): custom model name resolution 

### DIFF
--- a/tests/unit/test_agent_management_service.py
+++ b/tests/unit/test_agent_management_service.py
@@ -378,10 +378,14 @@ async def test_get_catalog_credentials_preserves_migrated_custom_provider_base_u
 
     credentials = await service.get_catalog_credentials(catalog.id)
 
+    # The selected catalog row's model_name wins over the shared provider-level
+    # CUSTOM_MODEL_PROVIDER_MODEL_NAME baked into the migrated blob
+    # ("provider/custom-model"), so per-model selections aren't all collapsed
+    # onto one model.
     assert credentials == {
         "CUSTOM_MODEL_PROVIDER_BASE_URL": "https://llm.example.com/v1",
         "CUSTOM_MODEL_PROVIDER_API_KEY": "sk-custom",
-        "CUSTOM_MODEL_PROVIDER_MODEL_NAME": "provider/custom-model",
+        "CUSTOM_MODEL_PROVIDER_MODEL_NAME": "custom-model-provider",
         "CUSTOM_MODEL_PROVIDER_PASSTHROUGH": "false",
     }
 
@@ -393,6 +397,172 @@ async def test_get_catalog_credentials_preserves_migrated_custom_provider_base_u
     assert credentials is not None
     assert credentials["CUSTOM_MODEL_PROVIDER_BASE_URL"] == (
         "https://column.example.com/v1"
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("db")
+async def test_get_catalog_credentials_distinct_models_share_one_custom_provider(
+    session: AsyncSession,
+    svc_organization: Organization,
+    svc_workspace: Workspace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each catalog row resolves to its own model_name even when several rows
+    share one custom provider whose blob carries a stale, provider-wide
+    CUSTOM_MODEL_PROVIDER_MODEL_NAME (regression: every selection collapsing
+    onto the single legacy model name).
+    """
+    encryption_key = Fernet.generate_key().decode()
+    monkeypatch.setattr(
+        tracecat_config,
+        "TRACECAT__DB_ENCRYPTION_KEY",
+        encryption_key,
+    )
+    # Migrated/legacy blob carrying one shared model name for the provider.
+    migrated_blob = encrypt_keyvalues(
+        [
+            SecretKeyValue(
+                key="CUSTOM_MODEL_PROVIDER_BASE_URL",
+                value=SecretStr("https://llm.example.com/v1"),
+            ),
+            SecretKeyValue(
+                key="CUSTOM_MODEL_PROVIDER_API_KEY",
+                value=SecretStr("sk-custom"),
+            ),
+            SecretKeyValue(
+                key="CUSTOM_MODEL_PROVIDER_MODEL_NAME",
+                value=SecretStr("stale/opus-4-6"),
+            ),
+        ],
+        key=encryption_key,
+    )
+    provider = AgentCustomProvider(
+        organization_id=svc_organization.id,
+        display_name="Shared provider",
+        base_url="https://llm.example.com/v1",
+        passthrough=False,
+        encrypted_config=migrated_blob,
+    )
+    session.add(provider)
+    await session.flush()
+
+    gemini = await _seed_catalog(
+        session,
+        org_id=svc_organization.id,
+        provider="custom-model-provider",
+        model_name="custom-gemini",
+        custom_provider_id=provider.id,
+    )
+    opus = await _seed_catalog(
+        session,
+        org_id=svc_organization.id,
+        provider="custom-model-provider",
+        model_name="custom-opus-4-8",
+        custom_provider_id=provider.id,
+    )
+    for catalog_row in (gemini, opus):
+        await _grant_access(
+            session,
+            org_id=svc_organization.id,
+            catalog_id=catalog_row.id,
+        )
+    await session.commit()
+
+    service = AgentManagementService(
+        session=session,
+        role=_db_role(svc_organization, svc_workspace),
+    )
+
+    gemini_creds = await service.get_catalog_credentials(gemini.id)
+    opus_creds = await service.get_catalog_credentials(opus.id)
+
+    assert gemini_creds is not None
+    assert opus_creds is not None
+    # The selected row's model_name wins; the shared "stale/opus-4-6" never leaks.
+    assert gemini_creds["CUSTOM_MODEL_PROVIDER_MODEL_NAME"] == "custom-gemini"
+    assert opus_creds["CUSTOM_MODEL_PROVIDER_MODEL_NAME"] == "custom-opus-4-8"
+    assert (
+        gemini_creds["CUSTOM_MODEL_PROVIDER_MODEL_NAME"]
+        != opus_creds["CUSTOM_MODEL_PROVIDER_MODEL_NAME"]
+    )
+    # Shared provider-level credentials still resolve as expected.
+    assert gemini_creds["CUSTOM_MODEL_PROVIDER_API_KEY"] == "sk-custom"
+    assert opus_creds["CUSTOM_MODEL_PROVIDER_BASE_URL"] == "https://llm.example.com/v1"
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("db")
+async def test_get_catalog_credentials_legacy_placeholder_row_keeps_blob_model_name(
+    session: AsyncSession,
+    svc_organization: Organization,
+    svc_workspace: Workspace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The single legacy backfill catalog row carries the "custom" placeholder
+    model_name; the real upstream model name lives in the provider blob. For
+    that row the blob's model name must stay authoritative (the per-row pin is
+    only for real, discovered per-model rows).
+    """
+    encryption_key = Fernet.generate_key().decode()
+    monkeypatch.setattr(
+        tracecat_config,
+        "TRACECAT__DB_ENCRYPTION_KEY",
+        encryption_key,
+    )
+    migrated_blob = encrypt_keyvalues(
+        [
+            SecretKeyValue(
+                key="CUSTOM_MODEL_PROVIDER_BASE_URL",
+                value=SecretStr("https://llm.example.com/v1"),
+            ),
+            SecretKeyValue(
+                key="CUSTOM_MODEL_PROVIDER_API_KEY",
+                value=SecretStr("sk-custom"),
+            ),
+            SecretKeyValue(
+                key="CUSTOM_MODEL_PROVIDER_MODEL_NAME",
+                value=SecretStr("provider/real-upstream-model"),
+            ),
+        ],
+        key=encryption_key,
+    )
+    provider = AgentCustomProvider(
+        organization_id=svc_organization.id,
+        display_name="Migrated provider",
+        base_url="https://llm.example.com/v1",
+        passthrough=False,
+        encrypted_config=migrated_blob,
+    )
+    session.add(provider)
+    await session.flush()
+    # The backfill writes the "custom" placeholder on the legacy linked row.
+    catalog = await _seed_catalog(
+        session,
+        org_id=svc_organization.id,
+        provider="custom-model-provider",
+        model_name="custom",
+        custom_provider_id=provider.id,
+    )
+    await _grant_access(
+        session,
+        org_id=svc_organization.id,
+        catalog_id=catalog.id,
+    )
+    await session.commit()
+
+    service = AgentManagementService(
+        session=session,
+        role=_db_role(svc_organization, svc_workspace),
+    )
+
+    credentials = await service.get_catalog_credentials(catalog.id)
+
+    assert credentials is not None
+    # The placeholder must NOT overwrite the blob's real model name.
+    assert (
+        credentials["CUSTOM_MODEL_PROVIDER_MODEL_NAME"]
+        == "provider/real-upstream-model"
     )
 
 
@@ -447,6 +617,9 @@ async def test_load_custom_model_provider_creds_requires_catalog_access(
     assert credentials == {
         "CUSTOM_MODEL_PROVIDER_BASE_URL": "https://llm.example.com/v1",
         "CUSTOM_MODEL_PROVIDER_PASSTHROUGH": "true",
+        # The selected row's model_name is pinned (it's a real, non-placeholder
+        # name) so the provider blob can't override the per-row selection.
+        "CUSTOM_MODEL_PROVIDER_MODEL_NAME": "custom-model-provider",
     }
 
 

--- a/tracecat/agent/service.py
+++ b/tracecat/agent/service.py
@@ -86,6 +86,12 @@ _LEGACY_CUSTOM_PROVIDER_CONFIG_KEYS = frozenset(
         "CUSTOM_MODEL_PROVIDER_PASSTHROUGH",
     }
 )
+# Placeholder ``model_name`` the v2 backfill writes on the single legacy
+# custom-provider catalog row (see
+# ``96470fdcc686_v2_backfill_catalog_and_access`` / ``CUSTOM_PROVIDER_MODEL_NAME``).
+# The row is a stand-in for the migrated provider, so its real upstream model
+# name lives in the provider blob, not on the row.
+_LEGACY_CUSTOM_PROVIDER_PLACEHOLDER_MODEL_NAME = "custom"
 
 
 def _is_cloud_provider(slug: str) -> TypeGuard[CloudProviderSlug]:
@@ -584,10 +590,17 @@ class AgentManagementService(BaseOrgService):
         - **Custom-model-provider rows** (``custom_provider_id`` set): read
           from the linked ``AgentCustomProvider`` row. Plaintext columns
           (``base_url``, ``passthrough``) are the source of truth; the
-          row's ``encrypted_config`` carries the API key. The v2 backfill
-          migration also writes a legacy-format copy of the blob onto the
-          catalog row itself, but we intentionally ignore that here so
-          post-CRUD rotations aren't shadowed by stale migration state.
+          row's ``encrypted_config`` carries the API key. A real per-model
+          catalog row's ``model_name`` is authoritative and overrides any
+          model name the provider blob carries (legacy backfill blobs share
+          one model name across every row pointing at the provider, which
+          would otherwise collapse all selections to a single model). The one
+          exception is the legacy backfill row, whose ``model_name`` is the
+          ``"custom"`` placeholder — for it the blob's model name stays
+          authoritative. The v2 backfill also writes a legacy-format copy of
+          the blob onto the catalog row itself, but we intentionally ignore
+          that here so post-CRUD rotations aren't shadowed by stale migration
+          state.
 
         - **Cloud rows** (Bedrock / Azure / Vertex): use the live
           ``agent-{provider}-credentials`` secret as the credential source of
@@ -636,6 +649,12 @@ class AgentManagementService(BaseOrgService):
             credentials["CUSTOM_MODEL_PROVIDER_PASSTHROUGH"] = (
                 "true" if provider_row.passthrough else "false"
             )
+            # Pin the selected row's model_name so the shared provider blob
+            # can't override it. The legacy backfill row is the exception: its
+            # "custom" placeholder isn't a real model, so leave the blob's
+            # model name in place for that row.
+            if row.model_name != _LEGACY_CUSTOM_PROVIDER_PLACEHOLDER_MODEL_NAME:
+                credentials["CUSTOM_MODEL_PROVIDER_MODEL_NAME"] = row.model_name
             return credentials or None
 
         if _is_cloud_provider(row.model_provider):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes custom model name resolution for custom providers. Per-model catalog rows now pin their own `model_name`, while the legacy placeholder row keeps the blob’s model name.

- **Bug Fixes**
  - Set `CUSTOM_MODEL_PROVIDER_MODEL_NAME` from the selected catalog row in `get_catalog_credentials`, except when the row’s `model_name` is the legacy placeholder `"custom"` (blob stays authoritative).
  - Added tests to ensure:
    - Distinct catalog rows share provider creds but keep different `model_name` values.
    - The legacy placeholder row uses the blob’s model name and does not override real per-model rows.

<sup>Written for commit 45a963e647fe081c51ed7015fc03ac3c380efdad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

