### PR TITLE
fix(sync): best effort correlate model catalog entries

### DIFF
--- a/tests/unit/test_agent_catalog_service.py
+++ b/tests/unit/test_agent_catalog_service.py
@@ -640,3 +640,101 @@ def test_bedrock_update_rejects_both_refs_explicitly_null() -> None:
             inference_profile_id=None,
             model_id=None,
         )
+
+
+@pytest.mark.anyio
+async def test_resolve_catalog_id_by_model_returns_org_row(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    service = AgentCatalogService(session=session)
+    row = AgentCatalog(
+        organization_id=svc_organization.id,
+        custom_provider_id=None,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+        model_metadata={},
+    )
+    session.add(row)
+    await session.commit()
+
+    resolved = await service.resolve_catalog_id_by_model(
+        org_id=svc_organization.id,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+    )
+
+    assert resolved == row.id
+
+
+@pytest.mark.anyio
+async def test_resolve_catalog_id_by_model_prefers_org_over_platform(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    service = AgentCatalogService(session=session)
+    platform_row = AgentCatalog(
+        organization_id=None,
+        custom_provider_id=None,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+        model_metadata={},
+    )
+    org_row = AgentCatalog(
+        organization_id=svc_organization.id,
+        custom_provider_id=None,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+        model_metadata={},
+    )
+    session.add_all([platform_row, org_row])
+    await session.commit()
+
+    resolved = await service.resolve_catalog_id_by_model(
+        org_id=svc_organization.id,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+    )
+
+    assert resolved == org_row.id
+
+
+@pytest.mark.anyio
+async def test_resolve_catalog_id_by_model_falls_back_to_platform(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    service = AgentCatalogService(session=session)
+    platform_row = AgentCatalog(
+        organization_id=None,
+        custom_provider_id=None,
+        model_provider="openai",
+        model_name="gpt-4.1",
+        model_metadata={},
+    )
+    session.add(platform_row)
+    await session.commit()
+
+    resolved = await service.resolve_catalog_id_by_model(
+        org_id=svc_organization.id,
+        model_provider="openai",
+        model_name="gpt-4.1",
+    )
+
+    assert resolved == platform_row.id
+
+
+@pytest.mark.anyio
+async def test_resolve_catalog_id_by_model_no_match(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    service = AgentCatalogService(session=session)
+
+    resolved = await service.resolve_catalog_id_by_model(
+        org_id=svc_organization.id,
+        model_provider="anthropic",
+        model_name="does-not-exist",
+    )
+
+    assert resolved is None

--- a/tests/unit/test_agent_catalog_service.py
+++ b/tests/unit/test_agent_catalog_service.py
@@ -947,3 +947,149 @@ async def test_resolve_catalog_id_by_model_multiple_rows_best_effort(
         model_name="shared-model",
     )
     assert again == resolved
+
+
+@pytest.mark.anyio
+async def test_is_catalog_id_enabled_true_for_enabled_row(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    """An org row that is enabled at org level reports as enabled."""
+    service = AgentCatalogService(session=session)
+    row = AgentCatalog(
+        organization_id=svc_organization.id,
+        custom_provider_id=None,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+        model_metadata={},
+    )
+    session.add(row)
+    await session.flush()
+    session.add(_enable(org_id=svc_organization.id, catalog_id=row.id))
+    await session.commit()
+
+    assert (
+        await service.is_catalog_id_enabled(
+            org_id=svc_organization.id,
+            catalog_id=row.id,
+        )
+        is True
+    )
+
+
+@pytest.mark.anyio
+async def test_is_catalog_id_enabled_false_for_disabled_row(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    """A visible row with no access row reports as not enabled."""
+    service = AgentCatalogService(session=session)
+    row = AgentCatalog(
+        organization_id=svc_organization.id,
+        custom_provider_id=None,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+        model_metadata={},
+    )
+    session.add(row)
+    await session.commit()
+
+    assert (
+        await service.is_catalog_id_enabled(
+            org_id=svc_organization.id,
+            catalog_id=row.id,
+        )
+        is False
+    )
+
+
+@pytest.mark.anyio
+async def test_is_catalog_id_enabled_false_for_foreign_org_row(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    """A row owned by another org is not visible, even if enabled there."""
+    service = AgentCatalogService(session=session)
+    other_org_id = uuid.uuid4()
+    other_org = Organization(
+        id=other_org_id,
+        name="Other Org",
+        slug=f"other-org-{other_org_id.hex[:8]}",
+        is_active=True,
+    )
+    session.add(other_org)
+    await session.flush()
+    row = AgentCatalog(
+        organization_id=other_org.id,
+        custom_provider_id=None,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+        model_metadata={},
+    )
+    session.add(row)
+    await session.flush()
+    session.add(_enable(org_id=other_org.id, catalog_id=row.id))
+    await session.commit()
+
+    assert (
+        await service.is_catalog_id_enabled(
+            org_id=svc_organization.id,
+            catalog_id=row.id,
+        )
+        is False
+    )
+
+
+@pytest.mark.anyio
+async def test_is_catalog_id_enabled_respects_workspace_override(
+    session: AsyncSession,
+    svc_organization: Organization,
+    svc_workspace,
+) -> None:
+    """A workspace override replaces the org-level set for the enabled check."""
+    service = AgentCatalogService(session=session)
+    org_row = AgentCatalog(
+        organization_id=svc_organization.id,
+        custom_provider_id=None,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+        model_metadata={},
+    )
+    ws_row = AgentCatalog(
+        organization_id=svc_organization.id,
+        custom_provider_id=None,
+        model_provider="openai",
+        model_name="gpt-4.1",
+        model_metadata={},
+    )
+    session.add_all([org_row, ws_row])
+    await session.flush()
+    # Org level enables org_row; the workspace override enables only ws_row.
+    session.add(_enable(org_id=svc_organization.id, catalog_id=org_row.id))
+    session.add(
+        _enable(
+            org_id=svc_organization.id,
+            catalog_id=ws_row.id,
+            workspace_id=svc_workspace.id,
+        )
+    )
+    await session.commit()
+
+    # org_row is org-enabled but the workspace override hides it.
+    assert (
+        await service.is_catalog_id_enabled(
+            org_id=svc_organization.id,
+            catalog_id=org_row.id,
+            workspace_id=svc_workspace.id,
+        )
+        is False
+    )
+    # ws_row is enabled via the override.
+    assert (
+        await service.is_catalog_id_enabled(
+            org_id=svc_organization.id,
+            catalog_id=ws_row.id,
+            workspace_id=svc_workspace.id,
+        )
+        is True
+    )

--- a/tests/unit/test_agent_catalog_service.py
+++ b/tests/unit/test_agent_catalog_service.py
@@ -15,11 +15,30 @@ from tracecat.agent.catalog.schemas import (
 from tracecat.agent.catalog.service import AgentCatalogService
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
-from tracecat.db.models import AgentCatalog, AgentCustomProvider, Organization
+from tracecat.db.models import (
+    AgentCatalog,
+    AgentCustomProvider,
+    AgentModelAccess,
+    Organization,
+)
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.pagination import CursorPaginationParams
 
 pytestmark = pytest.mark.usefixtures("db")
+
+
+def _enable(
+    *,
+    org_id: uuid.UUID,
+    catalog_id: uuid.UUID,
+    workspace_id: uuid.UUID | None = None,
+) -> AgentModelAccess:
+    """Build an AgentModelAccess row (org-level when workspace_id is None)."""
+    return AgentModelAccess(
+        organization_id=org_id,
+        workspace_id=workspace_id,
+        catalog_id=catalog_id,
+    )
 
 
 def _user_role(organization_id: uuid.UUID) -> Role:
@@ -656,6 +675,8 @@ async def test_resolve_catalog_id_by_model_returns_org_row(
         model_metadata={},
     )
     session.add(row)
+    await session.flush()
+    session.add(_enable(org_id=svc_organization.id, catalog_id=row.id))
     await session.commit()
 
     resolved = await service.resolve_catalog_id_by_model(
@@ -688,6 +709,14 @@ async def test_resolve_catalog_id_by_model_prefers_org_over_platform(
         model_metadata={},
     )
     session.add_all([platform_row, org_row])
+    await session.flush()
+    # Both enabled at org level; the org-owned row wins.
+    session.add_all(
+        [
+            _enable(org_id=svc_organization.id, catalog_id=platform_row.id),
+            _enable(org_id=svc_organization.id, catalog_id=org_row.id),
+        ]
+    )
     await session.commit()
 
     resolved = await service.resolve_catalog_id_by_model(
@@ -713,6 +742,8 @@ async def test_resolve_catalog_id_by_model_falls_back_to_platform(
         model_metadata={},
     )
     session.add(platform_row)
+    await session.flush()
+    session.add(_enable(org_id=svc_organization.id, catalog_id=platform_row.id))
     await session.commit()
 
     resolved = await service.resolve_catalog_id_by_model(
@@ -738,3 +769,181 @@ async def test_resolve_catalog_id_by_model_no_match(
     )
 
     assert resolved is None
+
+
+@pytest.mark.anyio
+async def test_resolve_catalog_id_by_model_skips_disabled_row(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    """An org row that exists but is not enabled is not selected."""
+    service = AgentCatalogService(session=session)
+    row = AgentCatalog(
+        organization_id=svc_organization.id,
+        custom_provider_id=None,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+        model_metadata={},
+    )
+    session.add(row)
+    await session.commit()  # no AgentModelAccess row -> not enabled
+
+    resolved = await service.resolve_catalog_id_by_model(
+        org_id=svc_organization.id,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+    )
+
+    assert resolved is None
+
+
+@pytest.mark.anyio
+async def test_resolve_catalog_id_by_model_prefers_enabled_platform_over_disabled_org(
+    session: AsyncSession,
+    svc_organization: Organization,
+    svc_workspace,
+) -> None:
+    """When the org row is disabled but a platform row is enabled, pick platform.
+
+    This is the runtime-rejection case: rewriting to the disabled org row would
+    make get_catalog_credentials raise even though an enabled model exists.
+    """
+    service = AgentCatalogService(session=session)
+    org_row = AgentCatalog(
+        organization_id=svc_organization.id,
+        custom_provider_id=None,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+        model_metadata={},
+    )
+    platform_row = AgentCatalog(
+        organization_id=None,
+        custom_provider_id=None,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+        model_metadata={},
+    )
+    session.add_all([org_row, platform_row])
+    await session.flush()
+    # Only the platform row is enabled (org level); org row is NOT enabled.
+    session.add(_enable(org_id=svc_organization.id, catalog_id=platform_row.id))
+    await session.commit()
+
+    resolved = await service.resolve_catalog_id_by_model(
+        org_id=svc_organization.id,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+        workspace_id=svc_workspace.id,
+    )
+
+    assert resolved == platform_row.id
+
+
+@pytest.mark.anyio
+async def test_resolve_catalog_id_by_model_workspace_override_replaces_org(
+    session: AsyncSession,
+    svc_organization: Organization,
+    svc_workspace,
+) -> None:
+    """A workspace override fully replaces the org-level enabled set."""
+    service = AgentCatalogService(session=session)
+    row_a = AgentCatalog(
+        organization_id=svc_organization.id,
+        custom_provider_id=None,
+        model_provider="anthropic",
+        model_name="claude-opus-4-8",
+        model_metadata={},
+    )
+    row_b = AgentCatalog(
+        organization_id=svc_organization.id,
+        custom_provider_id=None,
+        model_provider="openai",
+        model_name="gpt-4.1",
+        model_metadata={},
+    )
+    session.add_all([row_a, row_b])
+    await session.flush()
+    # Org level enables A; the workspace override enables only B.
+    session.add(_enable(org_id=svc_organization.id, catalog_id=row_a.id))
+    session.add(
+        _enable(
+            org_id=svc_organization.id,
+            catalog_id=row_b.id,
+            workspace_id=svc_workspace.id,
+        )
+    )
+    await session.commit()
+
+    # A is org-enabled but the workspace override hides it.
+    assert (
+        await service.resolve_catalog_id_by_model(
+            org_id=svc_organization.id,
+            model_provider="anthropic",
+            model_name="claude-opus-4-8",
+            workspace_id=svc_workspace.id,
+        )
+        is None
+    )
+    # B is enabled via the override.
+    assert (
+        await service.resolve_catalog_id_by_model(
+            org_id=svc_organization.id,
+            model_provider="openai",
+            model_name="gpt-4.1",
+            workspace_id=svc_workspace.id,
+        )
+        == row_b.id
+    )
+
+
+@pytest.mark.anyio
+async def test_resolve_catalog_id_by_model_multiple_rows_best_effort(
+    session: AsyncSession,
+    svc_organization: Organization,
+) -> None:
+    """Same (provider, name) on multiple custom providers: best-effort pick.
+
+    The information needed to pick the exact row (custom_provider_id) is
+    environment-specific and unrecoverable, so we deterministically pick one
+    matching row rather than skip the remap.
+    """
+    service = AgentCatalogService(session=session)
+    rows = []
+    for name in ("Provider A", "Provider B"):
+        p = AgentCustomProvider(
+            organization_id=svc_organization.id,
+            display_name=name,
+            base_url="https://api.example.com",
+        )
+        session.add(p)
+        await session.flush()
+        row = AgentCatalog(
+            organization_id=svc_organization.id,
+            custom_provider_id=p.id,
+            model_provider="custom-model-provider",
+            model_name="shared-model",
+            model_metadata={},
+        )
+        session.add(row)
+        rows.append(row)
+    await session.flush()
+    for row in rows:
+        session.add(_enable(org_id=svc_organization.id, catalog_id=row.id))
+    await session.commit()
+    candidate_ids = {row.id for row in rows}
+
+    resolved = await service.resolve_catalog_id_by_model(
+        org_id=svc_organization.id,
+        model_provider="custom-model-provider",
+        model_name="shared-model",
+    )
+
+    # Picks one of the matching org rows (deterministically), never None.
+    assert resolved in candidate_ids
+    # Stable across calls.
+    again = await service.resolve_catalog_id_by_model(
+        org_id=svc_organization.id,
+        model_provider="custom-model-provider",
+        model_name="shared-model",
+    )
+    assert again == resolved

--- a/tests/unit/test_workflow_import_service.py
+++ b/tests/unit/test_workflow_import_service.py
@@ -538,6 +538,42 @@ class TestWorkflowImportService:
         assert inputs2 == {"url": "https://example.com", "method": "GET"}
 
     @pytest.mark.anyio
+    async def test_import_runs_agent_catalog_correlation(
+        self,
+        import_service: WorkflowImportService,
+        remote_workflow_definition: RemoteWorkflowDefinition,
+    ):
+        """Git-sync import routes the definition through catalog correlation.
+
+        The remap logic itself is covered in test_workflow_management; here we
+        verify _import_single_workflow (the create/update chokepoint) invokes
+        it on the remote definition so synced workflows self-heal on pull. The
+        downstream create/update is stubbed to isolate the wiring.
+        """
+        seen: dict[str, object] = {}
+
+        async def fake_correlate(dsl):
+            seen["dsl"] = dsl
+            return dsl
+
+        with (
+            patch.object(
+                import_service.wf_mgmt,
+                "correlate_agent_catalog_ids",
+                side_effect=fake_correlate,
+            ) as correlate_mock,
+            patch.object(import_service.wf_mgmt, "get_workflow", return_value=None),
+            patch.object(
+                import_service, "_create_new_workflow", new=AsyncMock()
+            ) as create_mock,
+        ):
+            await import_service._import_single_workflow(remote_workflow_definition)
+
+        correlate_mock.assert_awaited_once()
+        assert seen["dsl"] is remote_workflow_definition.definition
+        create_mock.assert_awaited_once()
+
+    @pytest.mark.anyio
     async def test_schedule_handling_improvements(
         self,
         import_service: WorkflowImportService,

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -201,10 +201,17 @@ class _FakeCatalogService:
         mapping: dict[tuple[str, str], uuid.UUID] | None = None,
     ):
         self._mapping = mapping or {}
+        self.calls: list[tuple[str, str]] = []
 
     async def resolve_catalog_id_by_model(
-        self, *, org_id: uuid.UUID, model_provider: str, model_name: str
+        self,
+        *,
+        org_id: uuid.UUID,
+        model_provider: str,
+        model_name: str,
+        workspace_id: uuid.UUID | None = None,
     ) -> uuid.UUID | None:
+        self.calls.append((model_provider, model_name))
         return self._mapping.get((model_provider, model_name))
 
 
@@ -360,4 +367,85 @@ async def test_correlate_agent_catalog_ids_skips_when_no_catalog_id(
 
     out = await _service(_role()).correlate_agent_catalog_ids(dsl)
 
+    assert "catalog_id" not in out.actions[0].args["model"]
+
+
+@pytest.mark.anyio
+async def test_correlate_agent_catalog_ids_caches_duplicate_tuples(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated (provider, name) across actions resolves with a single query."""
+    local_id = uuid.uuid4()
+    fake = _FakeCatalogService(mapping={("anthropic", "claude-opus-4-8"): local_id})
+    monkeypatch.setattr(management, "AgentCatalogService", lambda session: fake)
+
+    def _agent(ref: str, foreign: str) -> dict[str, Any]:
+        return {
+            "ref": ref,
+            "action": "ai.agent",
+            "args": {
+                "user_prompt": "hi",
+                "model": {
+                    "model_name": "claude-opus-4-8",
+                    "model_provider": "anthropic",
+                    "catalog_id": foreign,
+                },
+            },
+        }
+
+    dsl = DSLInput(
+        **{
+            "title": "multi agent wf",
+            "description": "",
+            "entrypoint": {"ref": "a1", "expects": {}},
+            "actions": [
+                _agent("a1", str(uuid.uuid4())),
+                _agent("a2", str(uuid.uuid4())),
+                _agent("a3", str(uuid.uuid4())),
+            ],
+        }
+    )
+
+    out = await _service(_role()).correlate_agent_catalog_ids(dsl)
+
+    # Three agent actions, same model -> resolver queried exactly once.
+    assert fake.calls == [("anthropic", "claude-opus-4-8")]
+    for action in out.actions:
+        assert action.args["model"]["catalog_id"] == str(local_id)
+
+
+@pytest.mark.anyio
+async def test_correlate_agent_catalog_ids_mixed_nested_and_flat_catalog_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nested provider/name + a top-level catalog_id: the flat id is remapped.
+
+    AgentActionArgs merges nested over flat per-key, so a missing nested
+    catalog_id leaves the top-level one in force. The correlation must read and
+    rewrite it instead of skipping.
+    """
+    old_id = uuid.uuid4()
+    local_id = uuid.uuid4()
+    mapping = {("anthropic", "claude-opus-4-8"): local_id}
+    monkeypatch.setattr(
+        management,
+        "AgentCatalogService",
+        lambda session: _FakeCatalogService(session=session, mapping=mapping),
+    )
+    dsl = _agent_dsl(
+        {
+            "user_prompt": "hi",
+            "model": {
+                "model_name": "claude-opus-4-8",
+                "model_provider": "anthropic",
+            },
+            "catalog_id": str(old_id),
+        }
+    )
+
+    out = await _service(_role()).correlate_agent_catalog_ids(dsl)
+
+    # The effective (top-level) catalog_id is remapped.
+    assert out.actions[0].args["catalog_id"] == str(local_id)
+    # Nested block had no catalog_id; it is left without one.
     assert "catalog_id" not in out.actions[0].args["model"]

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -189,3 +189,175 @@ async def test_restore_workflow_definition_serializes_expected_fields(
         },
     }
     json.dumps(restored.expects)
+
+
+class _FakeCatalogService:
+    """Stub catalog service returning a fixed (provider, name) -> id map."""
+
+    def __init__(
+        self,
+        *,
+        session: Any = None,
+        mapping: dict[tuple[str, str], uuid.UUID] | None = None,
+    ):
+        self._mapping = mapping or {}
+
+    async def resolve_catalog_id_by_model(
+        self, *, org_id: uuid.UUID, model_provider: str, model_name: str
+    ) -> uuid.UUID | None:
+        return self._mapping.get((model_provider, model_name))
+
+
+def _agent_dsl(args: dict[str, Any], *, action: str = "ai.agent") -> DSLInput:
+    return DSLInput(
+        **{
+            "title": "agent wf",
+            "description": "",
+            "entrypoint": {"ref": "agent", "expects": {}},
+            "actions": [
+                {
+                    "ref": "agent",
+                    "action": action,
+                    "args": args,
+                }
+            ],
+        }
+    )
+
+
+def _service(role: Role) -> WorkflowsManagementService:
+    return WorkflowsManagementService(cast(Any, object()), role=role)
+
+
+def _role() -> Role:
+    return Role(
+        type="service",
+        service_id="tracecat-api",
+        organization_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        scopes=frozenset({"*"}),
+    )
+
+
+@pytest.mark.anyio
+async def test_correlate_agent_catalog_ids_rewrites_nested_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_id = uuid.uuid4()
+    local_id = uuid.uuid4()
+    mapping = {("anthropic", "claude-opus-4-8"): local_id}
+    monkeypatch.setattr(
+        management,
+        "AgentCatalogService",
+        lambda session: _FakeCatalogService(session=session, mapping=mapping),
+    )
+    dsl = _agent_dsl(
+        {
+            "user_prompt": "hi",
+            "model": {
+                "model_name": "claude-opus-4-8",
+                "model_provider": "anthropic",
+                "catalog_id": str(old_id),
+            },
+        }
+    )
+
+    out = await _service(_role()).correlate_agent_catalog_ids(dsl)
+
+    assert out.actions[0].args["model"]["catalog_id"] == str(local_id)
+
+
+@pytest.mark.anyio
+async def test_correlate_agent_catalog_ids_rewrites_flat_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_id = uuid.uuid4()
+    local_id = uuid.uuid4()
+    mapping = {("openai", "gpt-4.1"): local_id}
+    monkeypatch.setattr(
+        management,
+        "AgentCatalogService",
+        lambda session: _FakeCatalogService(session=session, mapping=mapping),
+    )
+    dsl = _agent_dsl(
+        {
+            "user_prompt": "hi",
+            "model_name": "gpt-4.1",
+            "model_provider": "openai",
+            "catalog_id": str(old_id),
+        }
+    )
+
+    out = await _service(_role()).correlate_agent_catalog_ids(dsl)
+
+    assert out.actions[0].args["catalog_id"] == str(local_id)
+
+
+@pytest.mark.anyio
+async def test_correlate_agent_catalog_ids_keeps_id_on_no_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_id = uuid.uuid4()
+    monkeypatch.setattr(
+        management,
+        "AgentCatalogService",
+        lambda session: _FakeCatalogService(session=session, mapping={}),
+    )
+    dsl = _agent_dsl(
+        {
+            "user_prompt": "hi",
+            "model": {
+                "model_name": "claude-opus-4-8",
+                "model_provider": "anthropic",
+                "catalog_id": str(old_id),
+            },
+        }
+    )
+
+    out = await _service(_role()).correlate_agent_catalog_ids(dsl)
+
+    assert out.actions[0].args["model"]["catalog_id"] == str(old_id)
+
+
+@pytest.mark.anyio
+async def test_correlate_agent_catalog_ids_ignores_non_agent_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        management,
+        "AgentCatalogService",
+        lambda session: _FakeCatalogService(
+            session=session, mapping={("anthropic", "claude-opus-4-8"): uuid.uuid4()}
+        ),
+    )
+    dsl = _agent_dsl({"value": "ok"}, action="core.transform.reshape")
+
+    out = await _service(_role()).correlate_agent_catalog_ids(dsl)
+
+    assert out is dsl
+
+
+@pytest.mark.anyio
+async def test_correlate_agent_catalog_ids_skips_when_no_catalog_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        management,
+        "AgentCatalogService",
+        lambda session: _FakeCatalogService(
+            session=session, mapping={("anthropic", "claude-opus-4-8"): uuid.uuid4()}
+        ),
+    )
+    dsl = _agent_dsl(
+        {
+            "user_prompt": "hi",
+            "model": {
+                "model_name": "claude-opus-4-8",
+                "model_provider": "anthropic",
+            },
+        }
+    )
+
+    out = await _service(_role()).correlate_agent_catalog_ids(dsl)
+
+    assert "catalog_id" not in out.actions[0].args["model"]

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -199,9 +199,13 @@ class _FakeCatalogService:
         *,
         session: Any = None,
         mapping: dict[tuple[str, str], uuid.UUID] | None = None,
+        enabled_ids: set[uuid.UUID] | None = None,
     ):
         self._mapping = mapping or {}
+        # Incoming catalog_ids treated as already visible+enabled locally.
+        self._enabled_ids = enabled_ids or set()
         self.calls: list[tuple[str, str]] = []
+        self.enabled_calls: list[uuid.UUID] = []
 
     async def resolve_catalog_id_by_model(
         self,
@@ -213,6 +217,16 @@ class _FakeCatalogService:
     ) -> uuid.UUID | None:
         self.calls.append((model_provider, model_name))
         return self._mapping.get((model_provider, model_name))
+
+    async def is_catalog_id_enabled(
+        self,
+        *,
+        org_id: uuid.UUID,
+        catalog_id: uuid.UUID,
+        workspace_id: uuid.UUID | None = None,
+    ) -> bool:
+        self.enabled_calls.append(catalog_id)
+        return catalog_id in self._enabled_ids
 
 
 def _agent_dsl(args: dict[str, Any], *, action: str = "ai.agent") -> DSLInput:
@@ -449,3 +463,65 @@ async def test_correlate_agent_catalog_ids_mixed_nested_and_flat_catalog_id(
     assert out.actions[0].args["catalog_id"] == str(local_id)
     # Nested block had no catalog_id; it is left without one.
     assert "catalog_id" not in out.actions[0].args["model"]
+
+
+@pytest.mark.anyio
+async def test_correlate_agent_catalog_ids_rewrites_ai_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``ai.action`` uses the same model selection and must be correlated too."""
+    old_id = uuid.uuid4()
+    local_id = uuid.uuid4()
+    mapping = {("anthropic", "claude-opus-4-8"): local_id}
+    fake = _FakeCatalogService(mapping=mapping)
+    monkeypatch.setattr(management, "AgentCatalogService", lambda session: fake)
+    dsl = _agent_dsl(
+        {
+            "user_prompt": "hi",
+            "model": {
+                "model_name": "claude-opus-4-8",
+                "model_provider": "anthropic",
+                "catalog_id": str(old_id),
+            },
+        },
+        action="ai.action",
+    )
+
+    out = await _service(_role()).correlate_agent_catalog_ids(dsl)
+
+    assert fake.calls == [("anthropic", "claude-opus-4-8")]
+    assert out.actions[0].args["model"]["catalog_id"] == str(local_id)
+
+
+@pytest.mark.anyio
+async def test_correlate_agent_catalog_ids_preserves_already_local_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An incoming catalog_id already enabled here is kept, not re-resolved.
+
+    A same-environment pull must not rewrite the user's selected row to another
+    enabled duplicate that merely wins the (provider, name) tuple resolver.
+    """
+    selected_id = uuid.uuid4()
+    other_enabled_id = uuid.uuid4()
+    # Tuple resolver would prefer a *different* enabled row.
+    mapping = {("anthropic", "claude-opus-4-8"): other_enabled_id}
+    fake = _FakeCatalogService(mapping=mapping, enabled_ids={selected_id})
+    monkeypatch.setattr(management, "AgentCatalogService", lambda session: fake)
+    dsl = _agent_dsl(
+        {
+            "user_prompt": "hi",
+            "model": {
+                "model_name": "claude-opus-4-8",
+                "model_provider": "anthropic",
+                "catalog_id": str(selected_id),
+            },
+        }
+    )
+
+    out = await _service(_role()).correlate_agent_catalog_ids(dsl)
+
+    # The selected id is preserved and the tuple resolver was never queried.
+    assert out.actions[0].args["model"]["catalog_id"] == str(selected_id)
+    assert fake.enabled_calls == [selected_id]
+    assert fake.calls == []

--- a/tracecat/agent/catalog/service.py
+++ b/tracecat/agent/catalog/service.py
@@ -115,6 +115,70 @@ class AgentCatalogService(BaseService):
             raise TracecatNotFoundError(f"Catalog entry {catalog_id} not found")
         return row
 
+    async def _enabled_catalog_ids_subquery(
+        self,
+        *,
+        org_id: UUID,
+        workspace_id: UUID | None,
+    ) -> Any:
+        """Subquery of catalog ids enabled for the importing workspace.
+
+        Mirrors ``is_catalog_enabled``: a workspace's explicit access rows fully
+        override the org-level set; otherwise the org-level (``workspace_id IS
+        NULL``) set applies.
+        """
+        effective_workspace_id: UUID | None = None
+        if workspace_id is not None:
+            override_exists = await self.session.scalar(
+                select(
+                    exists().where(
+                        AgentModelAccess.organization_id == org_id,
+                        AgentModelAccess.workspace_id == workspace_id,
+                    )
+                )
+            )
+            if override_exists:
+                effective_workspace_id = workspace_id
+        access_workspace_condition = (
+            AgentModelAccess.workspace_id == effective_workspace_id
+            if effective_workspace_id is not None
+            else AgentModelAccess.workspace_id.is_(None)
+        )
+        return select(AgentModelAccess.catalog_id).where(
+            AgentModelAccess.organization_id == org_id,
+            access_workspace_condition,
+        )
+
+    async def is_catalog_id_enabled(
+        self,
+        *,
+        org_id: UUID,
+        catalog_id: UUID,
+        workspace_id: UUID | None = None,
+    ) -> bool:
+        """Return whether ``catalog_id`` is visible to the org and enabled here.
+
+        Used on import to short-circuit re-mapping when the incoming
+        ``catalog_id`` already points at a row that is both visible to the org
+        and enabled for the importing workspace — a same-environment pull must
+        not rewrite the user's selected row to another enabled row that happens
+        to win the ``(provider, name)`` tuple resolver's ordering.
+        """
+        enabled_catalog_ids = await self._enabled_catalog_ids_subquery(
+            org_id=org_id, workspace_id=workspace_id
+        )
+        stmt = select(
+            exists().where(
+                AgentCatalog.id == catalog_id,
+                AgentCatalog.id.in_(enabled_catalog_ids),
+                sa.or_(
+                    AgentCatalog.organization_id == org_id,
+                    AgentCatalog.organization_id.is_(None),
+                ),
+            )
+        )
+        return bool(await self.session.scalar(stmt))
+
     async def resolve_catalog_id_by_model(
         self,
         *,
@@ -152,29 +216,8 @@ class AgentCatalogService(BaseService):
         deterministically rather than skip; an imported agent resolving to a
         plausible enabled model beats leaving it dangling.
         """
-        # Mirror is_catalog_enabled: a workspace override fully replaces the
-        # org-level access set; otherwise the org-level (workspace_id IS NULL)
-        # set applies.
-        effective_workspace_id: UUID | None = None
-        if workspace_id is not None:
-            override_exists = await self.session.scalar(
-                select(
-                    exists().where(
-                        AgentModelAccess.organization_id == org_id,
-                        AgentModelAccess.workspace_id == workspace_id,
-                    )
-                )
-            )
-            if override_exists:
-                effective_workspace_id = workspace_id
-        access_workspace_condition = (
-            AgentModelAccess.workspace_id == effective_workspace_id
-            if effective_workspace_id is not None
-            else AgentModelAccess.workspace_id.is_(None)
-        )
-        enabled_catalog_ids = select(AgentModelAccess.catalog_id).where(
-            AgentModelAccess.organization_id == org_id,
-            access_workspace_condition,
+        enabled_catalog_ids = await self._enabled_catalog_ids_subquery(
+            org_id=org_id, workspace_id=workspace_id
         )
 
         stmt = (

--- a/tracecat/agent/catalog/service.py
+++ b/tracecat/agent/catalog/service.py
@@ -7,14 +7,14 @@ from typing import Any, TypedDict
 from uuid import UUID
 
 import sqlalchemy as sa
-from sqlalchemy import and_, select
+from sqlalchemy import and_, exists, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
 
 from tracecat.agent.catalog.schemas import AgentCatalogRead
 from tracecat.audit.logger import audit_log
 from tracecat.authz.controls import require_scope
-from tracecat.db.models import AgentCatalog
+from tracecat.db.models import AgentCatalog, AgentModelAccess
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.pagination import BaseCursorPaginator, CursorPaginationParams
 from tracecat.service import BaseService
@@ -121,39 +121,85 @@ class AgentCatalogService(BaseService):
         org_id: UUID,
         model_provider: str,
         model_name: str,
+        workspace_id: UUID | None = None,
     ) -> UUID | None:
-        """Best-effort: find the catalog row id for a (provider, name) visible to org.
+        """Best-effort: find the local catalog row id for a (provider, name).
 
         The stable identifier for a model across environments is the
         ``(model_provider, model_name)`` tuple — ``catalog_id`` is a random
         per-environment UUID. This resolves that tuple to the local catalog row
         so an imported workflow can be re-pointed at the equivalent model.
 
-        Prefers an org-owned row over a platform row when both exist. Returns
-        ``None`` when no row matches.
+        Candidates are restricted to the rows **enabled for the importing
+        workspace** under the same effective-access rules the runtime enforces
+        (``AgentManagementService.get_catalog_credentials`` →
+        ``is_catalog_enabled``): a workspace's explicit access rows fully
+        override the org-level set, otherwise the org-level set applies. This
+        prevents rewriting to an org-owned row that isn't enabled here when an
+        enabled platform row with the same model exists — which would otherwise
+        make the agent fail immediately at execution.
+
+        Among enabled candidates, prefers an org-owned row over a platform row.
+        Returns ``None`` when no enabled row matches.
+
+        Best-effort by design: the unique key includes ``custom_provider_id``,
+        so one org can hold several enabled rows for the same
+        ``(model_provider, model_name)`` backed by different custom providers.
+        ``(model_provider, model_name)`` alone can't disambiguate, and the
+        source ``custom_provider_id`` is itself environment-specific so it
+        can't be matched either — the information needed to pick the exact row
+        is genuinely unrecoverable. In that (rare) case we pick one
+        deterministically rather than skip; an imported agent resolving to a
+        plausible enabled model beats leaving it dangling.
         """
+        # Mirror is_catalog_enabled: a workspace override fully replaces the
+        # org-level access set; otherwise the org-level (workspace_id IS NULL)
+        # set applies.
+        effective_workspace_id: UUID | None = None
+        if workspace_id is not None:
+            override_exists = await self.session.scalar(
+                select(
+                    exists().where(
+                        AgentModelAccess.organization_id == org_id,
+                        AgentModelAccess.workspace_id == workspace_id,
+                    )
+                )
+            )
+            if override_exists:
+                effective_workspace_id = workspace_id
+        access_workspace_condition = (
+            AgentModelAccess.workspace_id == effective_workspace_id
+            if effective_workspace_id is not None
+            else AgentModelAccess.workspace_id.is_(None)
+        )
+        enabled_catalog_ids = select(AgentModelAccess.catalog_id).where(
+            AgentModelAccess.organization_id == org_id,
+            access_workspace_condition,
+        )
+
         stmt = (
             select(AgentCatalog.id)
             .where(
                 AgentCatalog.model_provider == model_provider,
                 AgentCatalog.model_name == model_name,
+                AgentCatalog.id.in_(enabled_catalog_ids),
                 sa.or_(
                     AgentCatalog.organization_id == org_id,
                     AgentCatalog.organization_id.is_(None),
                 ),
             )
-            # Org-owned rows win over platform rows (NULL org).
-            .order_by(AgentCatalog.organization_id.desc().nulls_last())
+            # Org-owned rows win over platform rows (NULL org). ``id`` is the
+            # tiebreaker so the choice is stable across calls/replays.
+            .order_by(
+                AgentCatalog.organization_id.desc().nulls_last(),
+                AgentCatalog.id.asc(),
+            )
             .limit(1)
         )
         row_id = (await self.session.execute(stmt)).scalar_one_or_none()
         if row_id is None:
             return None
-        # Coerce to a stdlib UUID: the driver may hand back a non-stdlib UUID
-        # (e.g. asyncpg's ``pgproto.UUID``) which ``yaml.dump`` later serializes
-        # with a Python object tag that ``yaml.safe_load`` can't read back when
-        # the workflow is exported.
-        return UUID(str(row_id))
+        return row_id
 
     async def list_catalog(
         self,

--- a/tracecat/agent/catalog/service.py
+++ b/tracecat/agent/catalog/service.py
@@ -115,6 +115,46 @@ class AgentCatalogService(BaseService):
             raise TracecatNotFoundError(f"Catalog entry {catalog_id} not found")
         return row
 
+    async def resolve_catalog_id_by_model(
+        self,
+        *,
+        org_id: UUID,
+        model_provider: str,
+        model_name: str,
+    ) -> UUID | None:
+        """Best-effort: find the catalog row id for a (provider, name) visible to org.
+
+        The stable identifier for a model across environments is the
+        ``(model_provider, model_name)`` tuple — ``catalog_id`` is a random
+        per-environment UUID. This resolves that tuple to the local catalog row
+        so an imported workflow can be re-pointed at the equivalent model.
+
+        Prefers an org-owned row over a platform row when both exist. Returns
+        ``None`` when no row matches.
+        """
+        stmt = (
+            select(AgentCatalog.id)
+            .where(
+                AgentCatalog.model_provider == model_provider,
+                AgentCatalog.model_name == model_name,
+                sa.or_(
+                    AgentCatalog.organization_id == org_id,
+                    AgentCatalog.organization_id.is_(None),
+                ),
+            )
+            # Org-owned rows win over platform rows (NULL org).
+            .order_by(AgentCatalog.organization_id.desc().nulls_last())
+            .limit(1)
+        )
+        row_id = (await self.session.execute(stmt)).scalar_one_or_none()
+        if row_id is None:
+            return None
+        # Coerce to a stdlib UUID: the driver may hand back a non-stdlib UUID
+        # (e.g. asyncpg's ``pgproto.UUID``) which ``yaml.dump`` later serializes
+        # with a Python object tag that ``yaml.safe_load`` can't read back when
+        # the workflow is exported.
+        return UUID(str(row_id))
+
     async def list_catalog(
         self,
         org_id: UUID | None = None,

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -1026,6 +1026,10 @@ class WorkflowsManagementService(BaseWorkspaceService):
             return dsl
 
         catalog_svc = AgentCatalogService(session=self.session)
+        # Cache resolutions by (provider, name) — a synced workflow may have
+        # many agent actions on the same model; this avoids repeat DB queries.
+        # ``None`` results (no match / ambiguous) are cached too.
+        resolved: dict[tuple[str, str], uuid.UUID | None] = {}
         rewritten = False
         new_actions = list(dsl.actions)
         for idx, act_stmt in enumerate(dsl.actions):
@@ -1033,23 +1037,34 @@ class WorkflowsManagementService(BaseWorkspaceService):
                 continue
 
             args = act_stmt.args
-            # Model selection arrives either nested under ``model`` or as flat
-            # ``model_name`` / ``model_provider`` / ``catalog_id`` fields, the
-            # same dual shape ``AgentActionArgs`` accepts.
+            # Model selection arrives nested under ``model`` and/or as flat
+            # ``model_name`` / ``model_provider`` / ``catalog_id`` fields.
+            # ``AgentActionArgs`` merges nested over flat per-key, so a mixed
+            # shape (e.g. nested provider/name but a top-level ``catalog_id``)
+            # keeps the flat ``catalog_id``. Mirror that merge here: read each
+            # field from nested when present, else fall back to flat.
             nested = args.get("model")
-            source = nested if isinstance(nested, dict) else args
+            nested = nested if isinstance(nested, dict) else None
+            # Per-key merge of nested over flat, matching AgentActionArgs.
+            merged = {**args, **nested} if nested is not None else args
 
-            catalog_id = source.get("catalog_id")
-            model_provider = source.get("model_provider")
-            model_name = source.get("model_name")
+            catalog_id = merged.get("catalog_id")
+            model_provider = merged.get("model_provider")
+            model_name = merged.get("model_name")
             if not catalog_id or not model_provider or not model_name:
                 continue
 
-            local_id = await catalog_svc.resolve_catalog_id_by_model(
-                org_id=org_id,
-                model_provider=str(model_provider),
-                model_name=str(model_name),
-            )
+            key = (str(model_provider), str(model_name))
+            if key in resolved:
+                local_id = resolved[key]
+            else:
+                local_id = await catalog_svc.resolve_catalog_id_by_model(
+                    org_id=org_id,
+                    model_provider=key[0],
+                    model_name=key[1],
+                    workspace_id=self.workspace_id,
+                )
+                resolved[key] = local_id
             if local_id is None or str(local_id) == str(catalog_id):
                 continue
 
@@ -1058,12 +1073,15 @@ class WorkflowsManagementService(BaseWorkspaceService):
             # object tag that ``yaml.safe_load`` rejects on export).
             new_catalog_id = str(local_id)
             new_args = dict(args)
-            if isinstance(nested, dict):
+            # Always set the flat ``catalog_id`` and, when the nested block
+            # carries one, update it too. The runtime merges nested over flat
+            # per-key, so keeping both copies in sync means the effective id is
+            # correct whichever one wins.
+            new_args["catalog_id"] = new_catalog_id
+            if nested is not None and "catalog_id" in nested:
                 new_model = dict(nested)
                 new_model["catalog_id"] = new_catalog_id
                 new_args["model"] = new_model
-            else:
-                new_args["catalog_id"] = new_catalog_id
             new_actions[idx] = act_stmt.model_copy(update={"args": new_args})
             rewritten = True
             self.logger.info(

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import selectinload
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
+from tracecat.agent.catalog.service import AgentCatalogService
 from tracecat.audit.logger import audit_log
 from tracecat.authz.controls import require_scope
 from tracecat.contexts import ctx_logical_time
@@ -34,6 +35,7 @@ from tracecat.dsl.common import (
     build_action_statements_from_actions,
     edge_components_from_dep,
 )
+from tracecat.dsl.enums import PlatformAction
 from tracecat.dsl.schemas import DSLConfig, ExecutionContext, RunContext
 from tracecat.dsl.view import RFGraph
 from tracecat.exceptions import TracecatValidationError
@@ -996,6 +998,87 @@ class WorkflowsManagementService(BaseWorkspaceService):
         await self.session.refresh(workflow, ["actions", "webhook", "schedules"])
         return workflow
 
+    async def correlate_agent_catalog_ids(self, dsl: DSLInput) -> DSLInput:
+        """Re-map ``ai.agent`` model ``catalog_id``s to local catalog rows.
+
+        A model selection's ``catalog_id`` is a per-environment UUID, but the
+        ``(model_provider, model_name)`` tuple is stable across environments.
+        On import we look up the local catalog row for that tuple and rewrite
+        the ``catalog_id`` so the agent resolves credentials here.
+
+        This is purely additive: when no local row matches, the stored
+        ``catalog_id`` is left untouched (the workflow still imports). Non-
+        ``ai.agent`` actions and selections without a ``catalog_id`` are
+        skipped.
+
+        Runs only on the import/sync boundaries (manual import and git-sync
+        pull) where a ``catalog_id`` may have come from another environment —
+        not on ordinary workflow saves, where the id is already local.
+        """
+        org_id = self.role.organization_id
+        if org_id is None:
+            return dsl
+
+        # Cheap early-out: no DB work unless an ``ai.agent`` action exists.
+        if not any(
+            act_stmt.action == PlatformAction.AI_AGENT for act_stmt in dsl.actions
+        ):
+            return dsl
+
+        catalog_svc = AgentCatalogService(session=self.session)
+        rewritten = False
+        new_actions = list(dsl.actions)
+        for idx, act_stmt in enumerate(dsl.actions):
+            if act_stmt.action != PlatformAction.AI_AGENT:
+                continue
+
+            args = act_stmt.args
+            # Model selection arrives either nested under ``model`` or as flat
+            # ``model_name`` / ``model_provider`` / ``catalog_id`` fields, the
+            # same dual shape ``AgentActionArgs`` accepts.
+            nested = args.get("model")
+            source = nested if isinstance(nested, dict) else args
+
+            catalog_id = source.get("catalog_id")
+            model_provider = source.get("model_provider")
+            model_name = source.get("model_name")
+            if not catalog_id or not model_provider or not model_name:
+                continue
+
+            local_id = await catalog_svc.resolve_catalog_id_by_model(
+                org_id=org_id,
+                model_provider=str(model_provider),
+                model_name=str(model_name),
+            )
+            if local_id is None or str(local_id) == str(catalog_id):
+                continue
+
+            # Store the id as a string so it survives ``yaml.dump`` of the
+            # action inputs (a ``uuid.UUID`` object serializes to a Python
+            # object tag that ``yaml.safe_load`` rejects on export).
+            new_catalog_id = str(local_id)
+            new_args = dict(args)
+            if isinstance(nested, dict):
+                new_model = dict(nested)
+                new_model["catalog_id"] = new_catalog_id
+                new_args["model"] = new_model
+            else:
+                new_args["catalog_id"] = new_catalog_id
+            new_actions[idx] = act_stmt.model_copy(update={"args": new_args})
+            rewritten = True
+            self.logger.info(
+                "Re-mapped agent catalog_id on import",
+                action_ref=act_stmt.ref,
+                model_provider=model_provider,
+                model_name=model_name,
+                old_catalog_id=str(catalog_id),
+                new_catalog_id=str(local_id),
+            )
+
+        if not rewritten:
+            return dsl
+        return dsl.model_copy(update={"actions": new_actions})
+
     @require_scope("workflow:create")
     async def create_workflow_from_external_definition(
         self,
@@ -1015,6 +1098,10 @@ class WorkflowsManagementService(BaseWorkspaceService):
         # NOTE: We do not support adding invalid workflows
 
         dsl = external_defn.definition
+        # `ai.agent` model selections carry a per-environment ``catalog_id``.
+        # Best-effort re-map it to the equivalent local model so imported
+        # workflows resolve credentials in this environment.
+        dsl = await self.correlate_agent_catalog_ids(dsl)
         imported_trigger_position, imported_viewport, imported_action_positions = (
             external_defn.extract_layout_positions()
         )

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import uuid
 from datetime import datetime
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 import sqlalchemy as sa
 import yaml
@@ -85,6 +85,18 @@ from tracecat.workflow.management.types import (
 )
 from tracecat.workflow.schedules import bridge
 from tracecat.workflow.schedules.service import WorkflowSchedulesService
+
+
+class _ModelKey(NamedTuple):
+    """Stable cross-environment identity of a model selection.
+
+    ``catalog_id`` is a per-environment UUID; this ``(provider, name)`` pair is
+    what correlates the same model across environments. Used as the cache key
+    when re-mapping catalog ids on import.
+    """
+
+    provider: str
+    name: str
 
 
 class WorkflowsManagementService(BaseWorkspaceService):
@@ -999,17 +1011,23 @@ class WorkflowsManagementService(BaseWorkspaceService):
         return workflow
 
     async def correlate_agent_catalog_ids(self, dsl: DSLInput) -> DSLInput:
-        """Re-map ``ai.agent`` model ``catalog_id``s to local catalog rows.
+        """Re-map agent action model ``catalog_id``s to local catalog rows.
 
         A model selection's ``catalog_id`` is a per-environment UUID, but the
         ``(model_provider, model_name)`` tuple is stable across environments.
         On import we look up the local catalog row for that tuple and rewrite
-        the ``catalog_id`` so the agent resolves credentials here.
+        the ``catalog_id`` so the action resolves credentials here.
+
+        Covers both ``ai.agent`` and ``ai.action`` — both carry the same
+        ``AgentActionArgs`` model selection and pass ``catalog_id`` into
+        execution.
 
         This is purely additive: when no local row matches, the stored
-        ``catalog_id`` is left untouched (the workflow still imports). Non-
-        ``ai.agent`` actions and selections without a ``catalog_id`` are
-        skipped.
+        ``catalog_id`` is left untouched (the workflow still imports). Other
+        actions and selections without a ``catalog_id`` are skipped. When the
+        incoming ``catalog_id`` is already visible and enabled locally it is
+        kept as-is — a same-environment pull must not rewrite the user's
+        selected row to another enabled row that wins the tuple resolver.
 
         Runs only on the import/sync boundaries (manual import and git-sync
         pull) where a ``catalog_id`` may have come from another environment —
@@ -1019,21 +1037,24 @@ class WorkflowsManagementService(BaseWorkspaceService):
         if org_id is None:
             return dsl
 
-        # Cheap early-out: no DB work unless an ``ai.agent`` action exists.
-        if not any(
-            act_stmt.action == PlatformAction.AI_AGENT for act_stmt in dsl.actions
-        ):
+        # Both action types carry the same ``AgentActionArgs`` model selection.
+        correlated_actions = (PlatformAction.AI_AGENT, PlatformAction.AI_ACTION)
+
+        # Cheap early-out: no DB work unless a correlated action exists.
+        if not any(act_stmt.action in correlated_actions for act_stmt in dsl.actions):
             return dsl
 
         catalog_svc = AgentCatalogService(session=self.session)
         # Cache resolutions by (provider, name) — a synced workflow may have
         # many agent actions on the same model; this avoids repeat DB queries.
         # ``None`` results (no match / ambiguous) are cached too.
-        resolved: dict[tuple[str, str], uuid.UUID | None] = {}
+        resolved: dict[_ModelKey, uuid.UUID | None] = {}
+        # Cache whether an incoming catalog_id is already enabled locally.
+        already_local: dict[str, bool] = {}
         rewritten = False
         new_actions = list(dsl.actions)
         for idx, act_stmt in enumerate(dsl.actions):
-            if act_stmt.action != PlatformAction.AI_AGENT:
+            if act_stmt.action not in correlated_actions:
                 continue
 
             args = act_stmt.args
@@ -1054,14 +1075,36 @@ class WorkflowsManagementService(BaseWorkspaceService):
             if not catalog_id or not model_provider or not model_name:
                 continue
 
-            key = (str(model_provider), str(model_name))
+            # Preserve an already-local selection: if the incoming catalog_id is
+            # itself visible and enabled here, keep it. Otherwise a
+            # same-environment pull could rewrite the user's chosen row to a
+            # different enabled row (e.g. an org vs platform duplicate) that
+            # merely wins the (provider, name) tuple resolver's ordering.
+            catalog_id_str = str(catalog_id)
+            if catalog_id_str not in already_local:
+                try:
+                    parsed_id = uuid.UUID(catalog_id_str)
+                except (ValueError, TypeError):
+                    already_local[catalog_id_str] = False
+                else:
+                    already_local[
+                        catalog_id_str
+                    ] = await catalog_svc.is_catalog_id_enabled(
+                        org_id=org_id,
+                        catalog_id=parsed_id,
+                        workspace_id=self.workspace_id,
+                    )
+            if already_local[catalog_id_str]:
+                continue
+
+            key = _ModelKey(provider=str(model_provider), name=str(model_name))
             if key in resolved:
                 local_id = resolved[key]
             else:
                 local_id = await catalog_svc.resolve_catalog_id_by_model(
                     org_id=org_id,
-                    model_provider=key[0],
-                    model_name=key[1],
+                    model_provider=key.provider,
+                    model_name=key.name,
                     workspace_id=self.workspace_id,
                 )
                 resolved[key] = local_id

--- a/tracecat/workflow/store/import_service.py
+++ b/tracecat/workflow/store/import_service.py
@@ -282,6 +282,15 @@ class WorkflowImportService(BaseWorkspaceService):
 
         Existing workflows will be overwritten with new definitions.
         """
+        # `ai.agent` model selections carry a per-environment ``catalog_id``.
+        # Best-effort re-map it to the equivalent local model so synced
+        # workflows resolve credentials in this environment. Running it here
+        # (the single create/update chokepoint) means existing git-synced
+        # workflows self-heal on the next pull.
+        remote_workflow.definition = await self.wf_mgmt.correlate_agent_catalog_ids(
+            remote_workflow.definition
+        )
+
         wf_id = WorkflowUUID.new(remote_workflow.id)
         if existing_workflow := await self.wf_mgmt.get_workflow(wf_id):
             await self._update_existing_workflow(existing_workflow, remote_workflow)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Best-effort remaps `ai.agent` and `ai.action` model `catalog_id`s on import and git sync so workflows use the correct local model and credentials. Matches by `(model_provider, model_name)`, only rewrites to models enabled for the org/workspace, and keeps already-local IDs unchanged.

- **Bug Fixes**
  - Added `AgentCatalogService.resolve_catalog_id_by_model` and `is_catalog_id_enabled`; resolves among enabled rows via `AgentModelAccess` with workspace overrides, prefers org over platform, picks deterministically, and skips remap when the incoming `catalog_id` is already visible+enabled locally.
  - Extended `WorkflowsManagementService.correlate_agent_catalog_ids` to rewrite `catalog_id` for `ai.agent` and `ai.action`; handles nested/flat/mixed shapes, updates both copies when present, caches by `(provider, name)`, stringifies IDs for YAML, and early-outs on non-agent/no-id cases while preserving already-local IDs.
  - Hooked correlation into manual import (`create_workflow_from_external_definition`) and the git-sync chokepoint (`_import_single_workflow`) so workflows self-heal on pull; added tests for org vs. platform (incl. disabled rows), workspace overrides, duplicate tuples, mixed shapes, caching, `ai.action`, and preserving local IDs.

<sup>Written for commit 7430c02f3221e1998f0d4d6c56a77d346ff76508. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

