### PR TITLE
[codex] fix(fargate): wire LiteLLM URL into managed AI runtimes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,11 +169,14 @@ just gen-functions
   range-based constraints.
 - Do not bypass commit signing with `--no-gpg-sign` or `--no-verify`. If
   signing is broken, stop and ask the user to fix it.
-- Never copy customer-provided identifiers, URLs, tenant IDs, subscription IDs,
-  workspace names, resource group names, incident IDs, emails, domains, tokens,
-  or other potentially sensitive values into tests, docs, fixtures, snapshots,
-  examples, logs, or committed code. Replace them with clearly synthetic values
-  before writing files, and search for the original strings before committing.
+- Never copy customer-provided identifiers, customer names, URLs, tenant IDs,
+  subscription IDs, workspace names, resource group names, incident IDs, emails,
+  domains, tokens, or other potentially sensitive values into tests, docs,
+  fixtures, snapshots, examples, logs, committed code, commit messages, PR or
+  issue titles/bodies, PR comments, issue comments, review comments, or any
+  other published repository text. Use generic phrasing such as "affected
+  customer" or clearly synthetic placeholders instead, and search for the
+  original strings before committing, pushing, or publishing PR/issue text.
 - Do not assume PostgreSQL superuser access in migrations, queries, or scripts.
 - Never add methods to `tracecat/db/models.py`; keep database models minimal.
 - Never branch on exception or error-message strings to choose behavior, status

--- a/deployments/fargate/modules/ecs/locals.tf
+++ b/deployments/fargate/modules/ecs/locals.tf
@@ -24,6 +24,10 @@ locals {
   allow_origins          = "https://${var.domain_name},http://ui-service:3000"
   internal_litellm_url   = "http://litellm-service:4000"
 
+  tracecat_litellm_env = {
+    TRACECAT__LITELLM_BASE_URL = local.internal_litellm_url
+  }
+
   # Tracecat Postgres env vars
   tracecat_db_configs = {
     TRACECAT__DB_USER         = "postgres"
@@ -50,7 +54,6 @@ locals {
     TRACECAT__AWS_ASSUME_ROLE_PRINCIPAL_ARN          = aws_iam_role.executor_task.arn
     TRACECAT__FEATURE_FLAGS                          = var.feature_flags # Requires Tracecat Enterprise license to modify.
     TRACECAT__EE_MULTI_TENANT                        = var.ee_multi_tenant
-    TRACECAT__LITELLM_BASE_URL                       = local.internal_litellm_url
     TRACECAT__CONTEXT_COMPRESSION_ENABLED            = var.context_compression_enabled
     TRACECAT__CONTEXT_COMPRESSION_THRESHOLD_KB       = var.context_compression_threshold_kb
     TRACECAT__RESULT_EXTERNALIZATION_ENABLED         = var.result_externalization_enabled
@@ -77,6 +80,7 @@ locals {
   api_env = [
     for k, v in merge(
       local.tracecat_common_env,
+      local.tracecat_litellm_env,
       local.tracecat_temporal_payload_encryption_env,
       local.tracecat_blob_storage_env,
       local.tracecat_db_configs,
@@ -168,6 +172,7 @@ locals {
   agent_executor_env = [
     for k, v in merge(
       local.tracecat_common_env,
+      local.tracecat_litellm_env,
       local.tracecat_temporal_payload_encryption_env,
       local.tracecat_blob_storage_env,
       local.tracecat_db_configs,
@@ -192,7 +197,6 @@ locals {
         TRACECAT__LLM_GATEWAY_POOL_TIMEOUT_SECONDS         = var.llm_gateway_healthcheck_pool_timeout_seconds
         TRACECAT__LLM_GATEWAY_FAILURE_THRESHOLD            = var.llm_gateway_healthcheck_failure_threshold
         TRACECAT__LLM_GATEWAY_STATUS_LOG_INTERVAL_SECONDS  = var.llm_gateway_status_log_interval_seconds
-        TRACECAT__LITELLM_BASE_URL                         = local.internal_litellm_url
         TRACECAT__UNSAFE_DISABLE_SM_MASKING                = "false"
         TRACECAT__DISABLE_NSJAIL                           = "true"
         TRACECAT__SANDBOX_NSJAIL_PATH                      = "/usr/local/bin/nsjail"
@@ -206,12 +210,12 @@ locals {
   litellm_env = [
     for k, v in merge(
       local.tracecat_common_env,
+      local.tracecat_litellm_env,
       local.tracecat_db_configs,
       {
         TRACECAT__DB_ENDPOINT         = local.core_db_hostname
         TRACECAT__LITELLM_PORT        = "4000"
         TRACECAT__LITELLM_NUM_WORKERS = var.litellm_num_workers
-        TRACECAT__LITELLM_BASE_URL    = local.internal_litellm_url
       }
     ) :
     { name = k, value = tostring(v) } if v != null


### PR DESCRIPTION
## Summary

- Make the managed LiteLLM base URL an explicit Fargate ECS env map.
- Merge `TRACECAT__LITELLM_BASE_URL=http://litellm-service:4000` into API, agent-executor, and LiteLLM task definitions.
- Tighten `AGENTS.md` so customer identifiers are prohibited in PR descriptions, issue/PR comments, review comments, commit messages, and other published repository text.

## Why this scope

The other deployment targets do not put this env var on every runtime:

- `~/repos/k8s` Helm wires it into `agent-executor` and `litellm`.
- Docker Compose wires it into `api`, `agent-worker`, `litellm`, and `agent-executor`, but not the normal `worker` or `executor`.
- Code search shows direct `TRACECAT__LITELLM_BASE_URL` callers in API-side session title generation and agent-executor's LLM proxy path. The normal worker and executor do not directly call the managed LiteLLM client path.

So this PR keeps the Fargate fix targeted to API, agent-executor, and LiteLLM instead of broadly adding the variable to worker/executor task definitions.

## RCA

A production customer Fargate deployment had managed AI failures pointing at runtime connectivity to LiteLLM, while the LiteLLM ECS service and Service Connect registration were healthy. The Fargate stack should explicitly wire the Service Connect URL into the runtimes that make managed AI calls rather than relying on broad shared env inheritance.

## Validation

- `terraform -chdir=/Users/chris/repos/tracecat/deployments/fargate fmt -check`
- `terraform -chdir=/Users/chris/repos/tracecat/deployments/fargate validate`
- `git diff --check`
- pre-commit hooks during commits

## Rollout note

After merge, run a Terraform Cloud plan for the affected production Fargate workspace and verify it registers new ECS task definitions containing `TRACECAT__LITELLM_BASE_URL` for API, agent-executor, and LiteLLM, with no destructive RDS/S3/Secrets Manager changes before applying.