### PR TITLE
fix(infra): Fargate LiteLLM Service Connect ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,17 @@ Use this file for repo-wide guidance. Prefer the more specific notes in nested
 - `alembic/`: Database migrations.
 - `deployments/`: Docker, Fargate, EKS, and Helm deployment targets.
 
+## Fargate Deployment Notes
+
+- ECS Service Connect clients should explicitly depend on the ECS services that
+  publish the Service Connect aliases they resolve. This avoids startup and
+  rollout races where a client task starts before the provider alias is
+  registered or stable. Follow the existing UI-to-API ordering pattern; for
+  example, an agent-executor service that calls the managed LiteLLM alias should
+  depend on the LiteLLM ECS service unless that would create a dependency cycle.
+- When a cycle appears, prefer breaking the unnecessary provider dependency
+  rather than leaving the Service Connect client unordered.
+
 ## Setup and verification
 
 Use `uv` for Python commands and `pnpm` for frontend commands.

--- a/deployments/fargate/modules/ecs/ecs-agent-executor.tf
+++ b/deployments/fargate/modules/ecs/ecs-agent-executor.tf
@@ -65,6 +65,7 @@ resource "aws_ecs_service" "tracecat_agent_executor" {
 
   depends_on = [
     aws_ecs_service.temporal_service,
-    aws_ecs_service.tracecat_api
+    aws_ecs_service.tracecat_api,
+    aws_ecs_service.tracecat_litellm
   ]
 }


### PR DESCRIPTION
## Summary
- Make the Fargate agent-executor ECS service depend on the managed LiteLLM ECS service before it starts or rolls.
- Add repo guidance for Service Connect client/provider ordering in Fargate deployments.

## Why
ECS Service Connect clients can race provider alias registration during startup or rollout. The agent-executor resolves the managed LiteLLM alias, so Terraform should order it after the service that publishes that alias. This mirrors the existing UI-to-API ordering pattern.

## Validation
- `terraform -chdir=/Users/chris/repos/tracecat/deployments/fargate fmt -check`
- `terraform -chdir=/Users/chris/repos/tracecat/deployments/fargate validate`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the Fargate agent-executor starts after the managed `LiteLLM` service to prevent `Service Connect` alias races. Adds repo guidance on client/provider ordering for Fargate.

- **Bug Fixes**
  - Added `aws_ecs_service.tracecat_litellm` to `depends_on` for `aws_ecs_service.tracecat_agent_executor` in `deployments/fargate/modules/ecs/ecs-agent-executor.tf` to avoid startup/rollout races.
  - Documented Fargate `Service Connect` client/provider ordering in `AGENTS.md`, including guidance on breaking dependency cycles.

<sup>Written for commit 0e75299040d6889738566db482e2ec7db1252271. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

