### PR TITLE
fix(deploy): use liveness health check for API containers

### DIFF
--- a/deployments/fargate/modules/ecs/ecs-api.tf
+++ b/deployments/fargate/modules/ecs/ecs-api.tf
@@ -58,7 +58,7 @@ resource "aws_ecs_task_definition" "api_task_definition" {
       environment = local.api_env
       secrets     = local.tracecat_api_secrets
       healthCheck = {
-        command     = ["CMD", "curl", "-f", "http://localhost:8000/ready"]
+        command     = ["CMD", "curl", "-f", "http://localhost:8000/health"]
         interval    = 30
         timeout     = 5
         retries     = 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -93,7 +93,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/ready"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -98,7 +98,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/ready"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/ready"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -12932,10 +12932,10 @@ export const publicCheckHealth =
 
 /**
  * Check Ready
- * Readiness check - returns 200 only after startup and registry sync complete.
+ * Deep readiness check for platform registry sync state.
  *
- * Use this endpoint for Docker healthchecks to ensure the API has finished
- * initializing and the platform registry is synced before accepting traffic.
+ * Container health checks should use /health so transient registry sync delays
+ * do not cause orchestrators to replace otherwise healthy API tasks.
  *
  * Returns a detailed response including registry sync status.
  * @returns ReadinessResponse Successful Response
@@ -12947,7 +12947,7 @@ export const publicCheckReady =
       method: "GET",
       url: "/ready",
       errors: {
-        503: "API startup or platform registry sync is incomplete.",
+        503: "Platform registry sync is incomplete.",
       },
     })
   }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -19758,7 +19758,7 @@ export type $OpenApiTs = {
          */
         200: ReadinessResponse
         /**
-         * API startup or platform registry sync is incomplete.
+         * Platform registry sync is incomplete.
          */
         503: ReadinessResponse
       }

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -1191,7 +1191,7 @@ seed_dev_user() {
 
     echo "[dev-seed] Waiting for API to be ready (up to 5 minutes)..."
     while [[ $attempt -le $max_attempts ]]; do
-        # Use /ready endpoint which checks full startup completion (not /health which returns immediately)
+        # Use deep readiness so dev seeding waits for registry sync.
         local status_code
         status_code=$(curl -s -o /dev/null -w "%{http_code}" "${api_url}/ready" 2>/dev/null || echo "000")
         if [[ "$status_code" == "200" ]]; then

--- a/tests/unit/api/test_api_readiness.py
+++ b/tests/unit/api/test_api_readiness.py
@@ -53,9 +53,7 @@ def test_check_ready_documents_not_ready_response():
 
     responses = app.openapi()["paths"]["/ready"]["get"]["responses"]
 
-    assert responses["503"]["description"] == (
-        "API startup or platform registry sync is incomplete."
-    )
+    assert responses["503"]["description"] == "Platform registry sync is incomplete."
     assert responses["503"]["content"]["application/json"]["schema"] == {
         "$ref": "#/components/schemas/ReadinessResponse"
     }

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -773,15 +773,15 @@ async def check_health() -> HealthResponse:
     responses={
         status.HTTP_503_SERVICE_UNAVAILABLE: {
             "model": ReadinessResponse,
-            "description": "API startup or platform registry sync is incomplete.",
+            "description": "Platform registry sync is incomplete.",
         },
     },
 )
 async def check_ready(response: Response, session: AsyncDBSession) -> ReadinessResponse:
-    """Readiness check - returns 200 only after startup and registry sync complete.
+    """Deep readiness check for platform registry sync state.
 
-    Use this endpoint for Docker healthchecks to ensure the API has finished
-    initializing and the platform registry is synced before accepting traffic.
+    Container health checks should use /health so transient registry sync delays
+    do not cause orchestrators to replace otherwise healthy API tasks.
 
     Returns a detailed response including registry sync status.
     """


### PR DESCRIPTION
## Summary

- Point Docker Compose API container health checks at `/health` instead of `/ready`.
- Point the Fargate API container health check at `/health` so registry sync delays do not mark the essential API task unhealthy.
- Update `/ready` docs/test wording to describe it as a deep platform registry readiness signal, while keeping dev seeding on `/ready`.

## Why

`/ready` returns `503` while the platform registry is not synced. That is useful for explicit waiters, but it is too deep for container health checks: in ECS, the failed essential container health check can cause task replacement during deployments even though the API process is alive.

## Validation

- `uv run ruff check tracecat/api/app.py tests/unit/api/test_api_readiness.py`
- `uv run ruff format --check tracecat/api/app.py tests/unit/api/test_api_readiness.py`
- `terraform fmt -check deployments/fargate/modules/ecs/ecs-api.tf`
- `uv run python -c 'import yaml; [yaml.safe_load(open(p)) for p in ["docker-compose.yml", "docker-compose.dev.yml", "docker-compose.local.yml"]]; print("compose yaml parsed")'`
- `uv run pytest tests/unit/api/test_api_readiness.py` could not complete locally because Postgres was not running on `localhost:5432`; Docker was also unavailable, so I could not start the local stack for the DB-backed fixture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch API container health checks to /health to avoid ECS task replacements during registry sync. Keep /ready as a deep readiness signal for explicit waiters like dev seeding.

- **Bug Fixes**
  - Fargate API `healthCheck` now queries /health.
  - Docker Compose API service healthchecks now use /health in all compose files.
  - Clarified /ready docs in OpenAPI; regenerated frontend `services.gen.ts` and `types.gen.ts`; updated unit test.
  - Dev seeding continues to wait on /ready.

<sup>Written for commit dbe38ee3773dc7be45c1c0fb6603f61b35985b0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

