### PR TITLE
fix(agent): disable thinking for default-model chat sessions

### DIFF
--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -1533,6 +1533,10 @@ class AgentSessionService(BaseWorkspaceService):
                     model_provider=model_config.provider,
                     catalog_id=model_config.catalog_id,
                     actions=agent_session.tools,
+                    # Raw default-model sessions (no preset) keep thinking off:
+                    # opus-4-8 rejects the legacy enabled block. Preset-backed
+                    # configs carry their own enable_thinking and are untouched.
+                    enable_thinking=False,
                 )
             return
 
@@ -1561,6 +1565,7 @@ class AgentSessionService(BaseWorkspaceService):
                         model_provider=model_config.provider,
                         catalog_id=model_config.catalog_id,
                         actions=agent_session.tools,
+                        enable_thinking=False,
                     )
         elif session_entity is AgentSessionEntity.AGENT_PRESET:
             async with agent_svc.with_preset_config(
@@ -1590,6 +1595,7 @@ class AgentSessionService(BaseWorkspaceService):
                         model_provider=model_config.provider,
                         catalog_id=model_config.catalog_id,
                         actions=None,
+                        enable_thinking=False,
                     )
             except TracecatNotFoundError as exc:
                 raise ValueError(
@@ -1627,6 +1633,7 @@ class AgentSessionService(BaseWorkspaceService):
                         catalog_id=model_config.catalog_id,
                         actions=actions,
                         mcp_servers=mcp_servers,
+                        enable_thinking=False,
                     )
         elif session_entity in (
             AgentSessionEntity.WORKFLOW,
@@ -1671,6 +1678,7 @@ class AgentSessionService(BaseWorkspaceService):
                             model_provider=model_config.provider,
                             catalog_id=model_config.catalog_id,
                             actions=[],  # No tools for forked sessions
+                            enable_thinking=False,
                         )
             elif agent_session.agent_preset_id:
                 # Workflow sessions with preset use the preset config
@@ -1688,6 +1696,7 @@ class AgentSessionService(BaseWorkspaceService):
                         model_provider=model_config.provider,
                         catalog_id=model_config.catalog_id,
                         actions=agent_session.tools,
+                        enable_thinking=False,
                     )
         else:
             raise ValueError(


### PR DESCRIPTION
## Why

Opus 4.8 is only supported officially in litellm starting from 1.88.x >=, which requires a breaking update to starlette >= 1.0X, so in the meanwhile we drop thinking by default for agent contexts dependant on the organization default model.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable “thinking” for default-model chat sessions to prevent `opus-4-8` rejecting the legacy thinking parameter and breaking chats. Preset-backed sessions are unchanged.

- **Bug Fixes**
  - Set `enable_thinking=False` when building agent configs for non-preset sessions (chat, tool-backed, forks, workflow tasks).
  - Leave preset-driven configs untouched so they use their own `enable_thinking`.

<sup>Written for commit abe267257fb34f762c9f6fa584a75462137f23a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

