### PR TITLE
fix(ui): manually copy service account api key

### DIFF
--- a/frontend/src/components/organization/service-accounts-manager.tsx
+++ b/frontend/src/components/organization/service-accounts-manager.tsx
@@ -196,8 +196,6 @@ function getServiceAccountGroup(
   return "active"
 }
 
-const API_KEY_PREVIEW_LENGTH = 4
-
 const SERVICE_ACCOUNT_STATUS_FILTERS: Array<{
   value: ServiceAccountStatusFilter
   label: string
@@ -217,15 +215,6 @@ const SERVICE_ACCOUNT_CREATOR_COLUMN_CLASS =
   "w-[180px] shrink-0 truncate text-xs text-muted-foreground"
 const INLINE_NAME_HIGHLIGHT_CLASS =
   "mx-1 inline-flex rounded bg-secondary px-1.5 py-0.5 align-middle font-mono text-xs font-normal text-foreground"
-
-function deriveApiKeyPreview(rawKey: string): string {
-  const prefixMatch = rawKey.match(/^(tc_(?:org_|ws_)?sk_)/)
-  const prefix = prefixMatch?.[1]
-  if (!prefix || rawKey.length < prefix.length + API_KEY_PREVIEW_LENGTH) {
-    return rawKey
-  }
-  return `${prefix}...${rawKey.slice(-API_KEY_PREVIEW_LENGTH)}`
-}
 
 function formatUserIdLabel(userId: string): string {
   if (userId.length <= 12) {
@@ -1328,30 +1317,17 @@ export function ServiceAccountsManager({
             </DialogDescription>
           </DialogHeader>
           {issuedCredential ? (
-            <div className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="service-account-key-preview">Key preview</Label>
-                <div className="flex items-center gap-2">
-                  <Input
-                    id="service-account-key-preview"
-                    name="service-account-key-preview"
-                    value={
-                      issuedCredential.issued_api_key.api_key.preview ??
-                      deriveApiKeyPreview(
-                        issuedCredential.issued_api_key.raw_key
-                      )
-                    }
-                    readOnly={true}
-                    disabled={true}
-                    className="select-none font-mono text-xs"
-                  />
-                  <CopyButton
-                    value={issuedCredential.issued_api_key.raw_key}
-                    toastMessage="API key copied"
-                    tooltipMessage="Copy raw key"
-                  />
-                </div>
-              </div>
+            <div className="flex min-w-0 max-w-full items-center gap-3 rounded-lg bg-muted/60 px-4 py-3.5">
+              <code className="min-w-0 flex-1 truncate font-mono text-sm text-foreground/90 select-all">
+                {issuedCredential.issued_api_key.raw_key}
+              </code>
+              <CopyButton
+                value={issuedCredential.issued_api_key.raw_key}
+                toastMessage="API key copied"
+                tooltipMessage="Copy raw key"
+                className="size-6 shrink-0"
+                iconClassName="size-4 text-foreground/70"
+              />
             </div>
           ) : null}
           <DialogFooter>


### PR DESCRIPTION
## Summary
- Show the raw service account API key directly in the one-time issuance dialog.
- Keep the copy button beside the raw key, with the same compact styling used by the MCP PAT dialog.
- Remove the now-unused masked preview fallback helper from the service account manager.

## Why
`CopyButton` relies on `navigator.clipboard`, which is unavailable in insecure contexts such as self-hosted HTTP deployments on non-localhost hosts. Because service account API keys are only shown once, the previous disabled preview input left users without a manual way to recover the raw key if clipboard copy failed.

This mirrors the manual fallback added in PR #2866 for MCP personal access tokens.

## Validation
- `pnpm exec biome check --write src/components/organization/service-accounts-manager.tsx`
- `pnpm run typecheck`
- Browser QA against a temporary local route verified the raw key is present in a selectable code block, the old preview input is absent, and no disabled input remains in the Copy API key dialog.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the raw service account API key in the one-time issuance dialog with a compact copy button, so users can manually copy the key when `navigator.clipboard` isn’t available. Removed the masked preview input and its helper, matching the MCP PAT dialog styling.

<sup>Written for commit f4377687996f86e9ad96a839e9ddb42ae5778d19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

