### PR TITLE
fix(case-triggers): stop stale trigger replays

### DIFF
--- a/tests/unit/test_case_trigger_consumer.py
+++ b/tests/unit/test_case_trigger_consumer.py
@@ -383,6 +383,72 @@ async def test_dispatch_workflow_skips_non_current_definition(
     workflow_service_connect.assert_not_called()
 
 
+@pytest.mark.anyio
+async def test_dispatch_workflow_disables_structurally_invalid_definition(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    workflow_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    consumer = CaseTriggerConsumer(client=AsyncMock())
+    consumer._disable_invalid_case_trigger = AsyncMock()
+    workflow_service_connect = AsyncMock()
+
+    monkeypatch.setattr(
+        "tracecat.cases.triggers.consumer.WorkflowDefinitionsService.get_definition_by_workflow_id",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                workflow=SimpleNamespace(version=1),
+                version=1,
+                content={
+                    "title": "invalid",
+                    "description": "",
+                    "entrypoint": {"ref": "start"},
+                    "actions": [],
+                },
+                registry_lock=None,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "tracecat.cases.triggers.consumer.WorkflowExecutionsService.connect",
+        workflow_service_connect,
+    )
+
+    trigger = cast(
+        CaseTrigger,
+        SimpleNamespace(workflow_id=workflow_id, status="online"),
+    )
+    event = cast(
+        CaseEvent,
+        SimpleNamespace(
+            id=uuid.uuid4(),
+            created_at=None,
+            type="case_closed",
+            user_id=None,
+        ),
+    )
+    dispatched = await consumer._dispatch_workflow(
+        session=AsyncMock(),
+        role=_build_role(workspace_id),
+        trigger=trigger,
+        case=cast(
+            Case,
+            SimpleNamespace(id=uuid.uuid4(), workspace_id=workspace_id, tags=[]),
+        ),
+        event=event,
+    )
+
+    assert dispatched is True
+    consumer._disable_invalid_case_trigger.assert_awaited_once()
+    disable_call = consumer._disable_invalid_case_trigger.await_args
+    assert disable_call is not None
+    disable_kwargs = disable_call.kwargs
+    assert disable_kwargs["trigger"] is trigger
+    assert disable_kwargs["event"] is event
+    assert disable_kwargs["reason"] == "invalid workflow definition content"
+    workflow_service_connect.assert_not_called()
+
+
 def _nogroup_retry_error() -> RetryError:
     future = Future(1)
     future.set_exception(

--- a/tests/unit/test_case_trigger_consumer.py
+++ b/tests/unit/test_case_trigger_consumer.py
@@ -2,7 +2,7 @@ import asyncio
 import uuid
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from redis.exceptions import ResponseError
@@ -258,7 +258,7 @@ async def test_case_trigger_consumer_done_allows_ack():
 
 
 @pytest.mark.anyio
-async def test_case_trigger_consumer_missing_definition_no_ack():
+async def test_case_trigger_consumer_missing_definition_allows_ack():
     event_id = uuid.uuid4()
     case_id = uuid.uuid4()
     workspace_id = uuid.uuid4()
@@ -285,6 +285,7 @@ async def test_case_trigger_consumer_missing_definition_no_ack():
     client.exists = AsyncMock(return_value=False)
     client.set_if_not_exists = AsyncMock(return_value=True)
     client.delete = AsyncMock(return_value=1)
+    client.set = AsyncMock(return_value=True)
 
     consumer = _build_consumer_with_mocks(
         client,
@@ -293,6 +294,7 @@ async def test_case_trigger_consumer_missing_definition_no_ack():
         triggers=[trigger],
         role=_build_role(workspace_id),
     )
+    consumer._disable_invalid_case_trigger = AsyncMock()
 
     fields = {
         "event_id": str(event_id),
@@ -301,7 +303,84 @@ async def test_case_trigger_consumer_missing_definition_no_ack():
         "event_type": "case_created",
     }
     should_ack = await consumer._process_message(fields)
-    assert should_ack is False
+    assert should_ack is True
+    client.set.assert_awaited_once_with(
+        f"case-trigger:done:{event_id}:{workflow_id}",
+        value="1",
+        expire_seconds=consumer.dedup_ttl,
+    )
+    consumer._disable_invalid_case_trigger.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_disable_invalid_case_trigger_sets_trigger_offline():
+    trigger = SimpleNamespace(workflow_id=uuid.uuid4(), status="online")
+    event = SimpleNamespace(id=uuid.uuid4())
+    session = SimpleNamespace(add=MagicMock(), flush=AsyncMock())
+
+    await CaseTriggerConsumer(client=AsyncMock())._disable_invalid_case_trigger(
+        session=session,
+        trigger=cast(CaseTrigger, trigger),
+        event=cast(CaseEvent, event),
+        reason="missing workflow definition",
+    )
+
+    assert trigger.status == "offline"
+    session.add.assert_called_once_with(trigger)
+    session.flush.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_dispatch_workflow_skips_non_current_definition(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    workflow_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    consumer = CaseTriggerConsumer(client=AsyncMock())
+    consumer._disable_invalid_case_trigger = AsyncMock()
+    workflow_service_connect = AsyncMock()
+
+    monkeypatch.setattr(
+        "tracecat.cases.triggers.consumer.WorkflowDefinitionsService.get_definition_by_workflow_id",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                workflow=SimpleNamespace(version=2),
+                version=1,
+                content={"title": "old"},
+                registry_lock=None,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "tracecat.cases.triggers.consumer.WorkflowExecutionsService.connect",
+        workflow_service_connect,
+    )
+
+    dispatched = await consumer._dispatch_workflow(
+        session=AsyncMock(),
+        role=_build_role(workspace_id),
+        trigger=cast(
+            CaseTrigger,
+            SimpleNamespace(workflow_id=workflow_id, status="online"),
+        ),
+        case=cast(
+            Case,
+            SimpleNamespace(id=uuid.uuid4(), workspace_id=workspace_id, tags=[]),
+        ),
+        event=cast(
+            CaseEvent,
+            SimpleNamespace(
+                id=uuid.uuid4(),
+                created_at=None,
+                type="case_closed",
+                user_id=None,
+            ),
+        ),
+    )
+
+    assert dispatched is True
+    consumer._disable_invalid_case_trigger.assert_awaited_once()
+    workflow_service_connect.assert_not_called()
 
 
 def _nogroup_retry_error() -> RetryError:

--- a/tests/unit/test_case_triggers.py
+++ b/tests/unit/test_case_triggers.py
@@ -1,15 +1,41 @@
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat.cases.enums import CaseEventType
 from tracecat.cases.tags.service import CaseTagsService
-from tracecat.db.models import CaseTrigger, Workflow
+from tracecat.db.models import CaseTrigger, Workflow, WorkflowDefinition
+from tracecat.dsl.common import DSLInput
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.workflow.case_triggers.schemas import CaseTriggerConfig, CaseTriggerUpdate
 from tracecat.workflow.case_triggers.service import CaseTriggersService
 
 pytestmark = pytest.mark.usefixtures("db")
+
+
+def _runnable_definition_content() -> dict[str, Any]:
+    dsl = DSLInput.model_validate(
+        {
+            "title": "Runnable workflow",
+            "description": "Test workflow",
+            "entrypoint": {"ref": "start"},
+            "actions": [
+                {
+                    "ref": "start",
+                    "action": "core.transform.reshape",
+                    "args": {"value": "ok"},
+                }
+            ],
+        }
+    )
+    return dsl.model_dump(exclude_unset=True)
+
+
+def _case_closed_event_types() -> list[CaseEventType]:
+    return [CaseEventType.CASE_CLOSED]
 
 
 @pytest.mark.anyio
@@ -46,6 +72,121 @@ async def test_case_trigger_update_requires_events_when_online(
         await service.update_case_trigger(
             WorkflowUUID.new(workflow.id), CaseTriggerUpdate(status="online")
         )
+
+
+@pytest.mark.anyio
+async def test_case_trigger_update_requires_published_definition_when_online(
+    session: AsyncSession, svc_role
+):
+    workflow = Workflow(
+        title="Case Trigger Draft",
+        description="Test workflow",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+    )
+    session.add(workflow)
+    await session.flush()
+
+    case_trigger = CaseTrigger(
+        workspace_id=svc_role.workspace_id,
+        workflow_id=workflow.id,
+        status="offline",
+        event_types=[],
+        tag_filters=[],
+    )
+    session.add(case_trigger)
+    await session.commit()
+
+    service = CaseTriggersService(session, role=svc_role)
+    with pytest.raises(TracecatValidationError, match="Publish the workflow"):
+        await service.update_case_trigger(
+            WorkflowUUID.new(workflow.id),
+            CaseTriggerUpdate(status="online", event_types=_case_closed_event_types()),
+        )
+
+
+@pytest.mark.anyio
+async def test_case_trigger_update_requires_current_definition_when_online(
+    session: AsyncSession, svc_role
+):
+    workflow = Workflow(
+        title="Case Trigger Missing Current Definition",
+        description="Test workflow",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+        version=2,
+    )
+    session.add(workflow)
+    await session.flush()
+
+    session.add(
+        WorkflowDefinition(
+            workspace_id=svc_role.workspace_id,
+            workflow_id=workflow.id,
+            version=1,
+            content=_runnable_definition_content(),
+        )
+    )
+    session.add(
+        CaseTrigger(
+            workspace_id=svc_role.workspace_id,
+            workflow_id=workflow.id,
+            status="offline",
+            event_types=[],
+            tag_filters=[],
+        )
+    )
+    await session.commit()
+
+    service = CaseTriggersService(session, role=svc_role)
+    with pytest.raises(TracecatValidationError, match="Publish the workflow"):
+        await service.update_case_trigger(
+            WorkflowUUID.new(workflow.id),
+            CaseTriggerUpdate(status="online", event_types=_case_closed_event_types()),
+        )
+
+
+@pytest.mark.anyio
+async def test_case_trigger_update_allows_online_with_current_definition(
+    session: AsyncSession, svc_role
+):
+    workflow = Workflow(
+        title="Case Trigger Published",
+        description="Test workflow",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+        version=1,
+    )
+    session.add(workflow)
+    await session.flush()
+
+    session.add(
+        WorkflowDefinition(
+            workspace_id=svc_role.workspace_id,
+            workflow_id=workflow.id,
+            version=1,
+            content=_runnable_definition_content(),
+        )
+    )
+    session.add(
+        CaseTrigger(
+            workspace_id=svc_role.workspace_id,
+            workflow_id=workflow.id,
+            status="offline",
+            event_types=[],
+            tag_filters=[],
+        )
+    )
+    await session.commit()
+
+    service = CaseTriggersService(session, role=svc_role)
+    updated = await service.update_case_trigger(
+        WorkflowUUID.new(workflow.id),
+        CaseTriggerUpdate(status="online", event_types=_case_closed_event_types()),
+    )
+
+    assert updated.status == "online"
+    assert updated.event_types == ["case_closed"]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_workflow_definitions_service.py
+++ b/tests/unit/test_workflow_definitions_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat.auth.types import Role
 from tracecat.db.models import Workflow, Workspace
 from tracecat.dsl.common import DSLInput
+from tracecat.exceptions import ScopeDeniedError
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 
@@ -188,6 +189,36 @@ async def test_create_workflow_definition_with_datetime_serialization(
     saved_datetime = content["actions"][0]["args"]["date_field"]
     assert isinstance(saved_datetime, str)  # Should be serialized as ISO string
     assert "2024-11-01T00:00:00" in saved_datetime
+
+
+@pytest.mark.anyio
+async def test_create_initial_workflow_definition_uses_create_scope(
+    session: AsyncSession,
+    svc_workspace: Workspace,
+    workflow_id: WorkflowUUID,
+):
+    create_only_role = Role(
+        type="service",
+        service_id="tracecat-api",
+        organization_id=svc_workspace.organization_id,
+        workspace_id=svc_workspace.id,
+        scopes=frozenset({"workflow:create"}),
+    )
+    service = WorkflowDefinitionsService(session=session, role=create_only_role)
+
+    definition = await service.create_initial_workflow_definition(
+        workflow_id=workflow_id,
+        dsl=_dsl_input("initial"),
+        commit=True,
+    )
+
+    assert definition.version == 1
+    with pytest.raises(ScopeDeniedError):
+        await service.create_workflow_definition(
+            workflow_id=workflow_id,
+            dsl=_dsl_input("v2"),
+            commit=True,
+        )
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_workflow_import_service.py
+++ b/tests/unit/test_workflow_import_service.py
@@ -99,6 +99,22 @@ def test_remote_webhook_defaults_include_headers_false():
     assert rw.include_headers is False
 
 
+async def _publish_workflow(
+    session: AsyncSession, workflow: Workflow, dsl: DSLInput
+) -> None:
+    definition = WorkflowDefinition(
+        workspace_id=workflow.workspace_id,
+        workflow_id=workflow.id,
+        version=1,
+        content=dsl.model_dump(exclude_unset=True),
+    )
+    session.add(definition)
+    workflow.version = definition.version
+    session.add(workflow)
+    await session.commit()
+    await session.refresh(workflow)
+
+
 class TestWorkflowImportService:
     """Test WorkflowImportService functionality."""
 
@@ -208,6 +224,7 @@ class TestWorkflowImportService:
         workflow = await import_service.wf_mgmt.create_db_workflow_from_dsl(
             sample_dsl, workflow_id=WorkflowUUID.new_uuid4()
         )
+        await _publish_workflow(import_service.session, workflow, sample_dsl)
         case_trigger_service = CaseTriggersService(
             import_service.session, role=import_service.role
         )
@@ -237,6 +254,7 @@ class TestWorkflowImportService:
         workflow = await import_service.wf_mgmt.create_db_workflow_from_dsl(
             sample_dsl, workflow_id=WorkflowUUID.new_uuid4()
         )
+        await _publish_workflow(import_service.session, workflow, sample_dsl)
         case_trigger_service = CaseTriggersService(
             import_service.session, role=import_service.role
         )

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -10,6 +10,7 @@ from tracecat.auth.types import Role
 from tracecat.db.models import Action, Workflow, WorkflowDefinition
 from tracecat.dsl.common import DSLInput
 from tracecat.expressions.expectations import ExpectedField
+from tracecat.registry.lock.types import RegistryLock
 from tracecat.workflow.management import management
 from tracecat.workflow.management.management import WorkflowsManagementService
 
@@ -321,7 +322,17 @@ async def test_external_import_publishes_before_online_case_trigger(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     role = _role()
-    workflow = SimpleNamespace(id=uuid.uuid4(), version=None)
+    registry_lock = {
+        "origins": {"tracecat_registry": "test-version"},
+        "actions": {"core.transform.reshape": "tracecat_registry"},
+        "origin_fingerprints": {},
+    }
+    workflow = SimpleNamespace(
+        id=uuid.uuid4(),
+        version=None,
+        alias="imported-case-trigger",
+        registry_lock=registry_lock,
+    )
     session = SimpleNamespace(add=MagicMock(), flush=AsyncMock(), commit=AsyncMock())
     service = WorkflowsManagementService(cast(Any, session), role=role)
     dsl = DSLInput(
@@ -351,10 +362,18 @@ async def test_external_import_publishes_before_online_case_trigger(
             workflow_id: uuid.UUID,
             dsl: DSLInput,
             *,
+            alias: str | None = None,
+            registry_lock: RegistryLock | None = None,
             commit: bool = True,
         ) -> SimpleNamespace:
             definition_calls.append(
-                {"workflow_id": workflow_id, "dsl": dsl, "commit": commit}
+                {
+                    "workflow_id": workflow_id,
+                    "dsl": dsl,
+                    "alias": alias,
+                    "registry_lock": registry_lock,
+                    "commit": commit,
+                }
             )
             return SimpleNamespace(version=1)
 
@@ -414,6 +433,8 @@ async def test_external_import_publishes_before_online_case_trigger(
         {
             "workflow_id": workflow.id,
             "dsl": dsl,
+            "alias": "imported-case-trigger",
+            "registry_lock": RegistryLock.model_validate(registry_lock),
             "commit": False,
         }
     ]

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -346,7 +346,7 @@ async def test_external_import_publishes_before_online_case_trigger(
             self.session = session
             self.role = role
 
-        async def create_workflow_definition(
+        async def create_initial_workflow_definition(
             self,
             workflow_id: uuid.UUID,
             dsl: DSLInput,

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -1,6 +1,8 @@
 import json
 import uuid
+from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -312,6 +314,119 @@ async def test_correlate_agent_catalog_ids_rewrites_flat_fields(
     out = await _service(_role()).correlate_agent_catalog_ids(dsl)
 
     assert out.actions[0].args["catalog_id"] == str(local_id)
+
+
+@pytest.mark.anyio
+async def test_external_import_publishes_before_online_case_trigger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    role = _role()
+    workflow = SimpleNamespace(id=uuid.uuid4(), version=None)
+    session = SimpleNamespace(add=MagicMock(), flush=AsyncMock(), commit=AsyncMock())
+    service = WorkflowsManagementService(cast(Any, session), role=role)
+    dsl = DSLInput(
+        **{
+            "title": "online case trigger import",
+            "description": "",
+            "entrypoint": {"ref": "start", "expects": {}},
+            "actions": [
+                {
+                    "ref": "start",
+                    "action": "core.transform.reshape",
+                    "args": {"value": "ok"},
+                }
+            ],
+        }
+    )
+    definition_calls: list[dict[str, Any]] = []
+    case_trigger_calls: list[dict[str, Any]] = []
+
+    class FakeWorkflowDefinitionsService:
+        def __init__(self, session: Any, role: Role) -> None:
+            self.session = session
+            self.role = role
+
+        async def create_workflow_definition(
+            self,
+            workflow_id: uuid.UUID,
+            dsl: DSLInput,
+            *,
+            commit: bool = True,
+        ) -> SimpleNamespace:
+            definition_calls.append(
+                {"workflow_id": workflow_id, "dsl": dsl, "commit": commit}
+            )
+            return SimpleNamespace(version=1)
+
+    class FakeCaseTriggersService:
+        def __init__(self, session: Any, role: Role) -> None:
+            self.session = session
+            self.role = role
+
+        async def upsert_case_trigger(
+            self,
+            workflow_id: uuid.UUID,
+            params: Any,
+            *,
+            create_missing_tags: bool = False,
+            commit: bool = True,
+        ) -> None:
+            case_trigger_calls.append(
+                {
+                    "workflow_id": workflow_id,
+                    "params": params,
+                    "create_missing_tags": create_missing_tags,
+                    "commit": commit,
+                }
+            )
+
+    monkeypatch.setattr(
+        service,
+        "create_db_workflow_from_dsl",
+        AsyncMock(return_value=workflow),
+    )
+    monkeypatch.setattr(
+        service,
+        "correlate_agent_catalog_ids",
+        AsyncMock(return_value=dsl),
+    )
+    monkeypatch.setattr(
+        management,
+        "WorkflowDefinitionsService",
+        FakeWorkflowDefinitionsService,
+    )
+    monkeypatch.setattr(management, "CaseTriggersService", FakeCaseTriggersService)
+
+    imported = await service.create_workflow_from_external_definition(
+        {
+            "definition": dsl.model_dump(mode="json"),
+            "case_trigger": {
+                "status": "online",
+                "event_types": ["case_created"],
+                "tag_filters": ["phishing"],
+            },
+        }
+    )
+
+    assert imported is workflow
+    assert workflow.version == 1
+    assert definition_calls == [
+        {
+            "workflow_id": workflow.id,
+            "dsl": dsl,
+            "commit": False,
+        }
+    ]
+    session.add.assert_called_once_with(workflow)
+    session.flush.assert_awaited_once()
+    session.commit.assert_awaited_once()
+    assert len(case_trigger_calls) == 1
+    assert case_trigger_calls[0]["workflow_id"] == workflow.id
+    assert case_trigger_calls[0]["params"].status == "online"
+    assert case_trigger_calls[0]["params"].event_types == ["case_created"]
+    assert case_trigger_calls[0]["params"].tag_filters == ["phishing"]
+    assert case_trigger_calls[0]["create_missing_tags"] is True
+    assert case_trigger_calls[0]["commit"] is False
 
 
 @pytest.mark.anyio

--- a/tracecat/cases/triggers/consumer.py
+++ b/tracecat/cases/triggers/consumer.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from time import monotonic
 from typing import Any
 
+from pydantic import ValidationError
 from redis.exceptions import ResponseError
 from sqlalchemy import or_, select, update
 from sqlalchemy.orm import selectinload
@@ -557,16 +558,57 @@ class CaseTriggerConsumer:
                 workflow_id=str(trigger.workflow_id),
                 event_id=str(event.id),
             )
-            return False
+            await self._disable_invalid_case_trigger(
+                session=session,
+                trigger=trigger,
+                event=event,
+                reason="missing workflow definition",
+            )
+            return True
+        if defn.workflow is None or defn.workflow.version != defn.version:
+            logger.warning(
+                "Current workflow definition missing for case trigger",
+                workflow_id=str(trigger.workflow_id),
+                event_id=str(event.id),
+                definition_version=defn.version,
+                workflow_version=defn.workflow.version if defn.workflow else None,
+            )
+            await self._disable_invalid_case_trigger(
+                session=session,
+                trigger=trigger,
+                event=event,
+                reason="current workflow definition missing",
+            )
+            return True
         if not defn.content:
             logger.warning(
                 "Workflow definition content missing",
                 workflow_id=str(trigger.workflow_id),
                 event_id=str(event.id),
             )
-            return False
+            await self._disable_invalid_case_trigger(
+                session=session,
+                trigger=trigger,
+                event=event,
+                reason="missing workflow definition content",
+            )
+            return True
 
-        dsl = DSLInput.model_validate(defn.content)
+        try:
+            dsl = DSLInput.model_validate(defn.content)
+        except ValidationError:
+            logger.warning(
+                "Workflow definition content invalid",
+                workflow_id=str(trigger.workflow_id),
+                event_id=str(event.id),
+            )
+            await self._disable_invalid_case_trigger(
+                session=session,
+                trigger=trigger,
+                event=event,
+                reason="invalid workflow definition content",
+            )
+            return True
         workflow_service = await WorkflowExecutionsService.connect(role=role)
 
         workflow_service.create_workflow_execution_nowait(
@@ -579,6 +621,24 @@ class CaseTriggerConsumer:
             else None,
         )
         return True
+
+    async def _disable_invalid_case_trigger(
+        self,
+        *,
+        session,
+        trigger: CaseTrigger,
+        event: CaseEvent,
+        reason: str,
+    ) -> None:
+        logger.warning(
+            "Disabling invalid case trigger",
+            workflow_id=str(trigger.workflow_id),
+            event_id=str(event.id),
+            reason=reason,
+        )
+        trigger.status = "offline"
+        session.add(trigger)
+        await session.flush()
 
     async def _dispatch_selected_workflow(
         self,

--- a/tracecat/cases/triggers/consumer.py
+++ b/tracecat/cases/triggers/consumer.py
@@ -25,6 +25,7 @@ from tracecat.cases.schemas import CaseCommentWorkflowStatus
 from tracecat.db.engine import get_async_session_bypass_rls_context_manager
 from tracecat.db.models import Case, CaseComment, CaseEvent, CaseTrigger, Workspace
 from tracecat.dsl.common import DSLInput
+from tracecat.exceptions import TracecatDSLError
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
 from tracecat.redis.client import RedisClient, get_redis_client
@@ -596,7 +597,7 @@ class CaseTriggerConsumer:
 
         try:
             dsl = DSLInput.model_validate(defn.content)
-        except ValidationError:
+        except (ValidationError, TracecatDSLError):
             logger.warning(
                 "Workflow definition content invalid",
                 workflow_id=str(trigger.workflow_id),

--- a/tracecat/workflow/case_triggers/service.py
+++ b/tracecat/workflow/case_triggers/service.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 
-from tracecat.db.models import CaseTag, CaseTrigger, Workflow
+from tracecat.db.models import CaseTag, CaseTrigger, Workflow, WorkflowDefinition
+from tracecat.dsl.common import DSLInput
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.identifiers.workflow import WorkflowID, WorkflowUUID
 from tracecat.service import BaseWorkspaceService, requires_entitlement
@@ -70,6 +72,37 @@ class CaseTriggersService(BaseWorkspaceService):
         if case_trigger := result.scalar_one_or_none():
             return case_trigger
         raise TracecatValidationError("Failed to ensure case trigger")
+
+    async def _ensure_workflow_has_runnable_definition(
+        self, workflow_id: WorkflowID
+    ) -> None:
+        workflow_uuid = WorkflowUUID.new(workflow_id)
+        version_stmt = select(Workflow.version).where(
+            Workflow.workspace_id == self.workspace_id,
+            Workflow.id == workflow_uuid,
+        )
+        workflow_version = await self.session.scalar(version_stmt)
+        if workflow_version is None:
+            raise TracecatValidationError(
+                "Publish the workflow before enabling case triggers"
+            )
+
+        definition_stmt = select(WorkflowDefinition.content).where(
+            WorkflowDefinition.workspace_id == self.workspace_id,
+            WorkflowDefinition.workflow_id == workflow_uuid,
+            WorkflowDefinition.version == workflow_version,
+        )
+        content = await self.session.scalar(definition_stmt)
+        if not content:
+            raise TracecatValidationError(
+                "Publish the workflow before enabling case triggers"
+            )
+        try:
+            DSLInput.model_validate(content)
+        except ValidationError as e:
+            raise TracecatValidationError(
+                "Publish the workflow before enabling case triggers"
+            ) from e
 
     @requires_entitlement(Entitlement.CASE_ADDONS)
     async def get_case_trigger(self, workflow_id: WorkflowID) -> CaseTrigger:
@@ -143,6 +176,8 @@ class CaseTriggersService(BaseWorkspaceService):
             raise TracecatValidationError(
                 "event_types must be non-empty when status is online"
             )
+        if status == "online":
+            await self._ensure_workflow_has_runnable_definition(workflow_id)
 
         tag_filters = updates.get("tag_filters", case_trigger.tag_filters)
         if tag_filters is None:

--- a/tracecat/workflow/management/definitions.py
+++ b/tracecat/workflow/management/definitions.py
@@ -8,7 +8,11 @@ from temporalio.exceptions import ApplicationError
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import Workflow, WorkflowDefinition
 from tracecat.dsl.common import DSLInput
-from tracecat.exceptions import BuiltinRegistryHasNoSelectionError, EntitlementRequired
+from tracecat.exceptions import (
+    BuiltinRegistryHasNoSelectionError,
+    EntitlementRequired,
+    TracecatValidationError,
+)
 from tracecat.identifiers.workflow import WorkflowID
 from tracecat.logger import logger
 from tracecat.registry.lock.service import RegistryLockService
@@ -70,6 +74,46 @@ class WorkflowDefinitionsService(BaseWorkspaceService):
         result = await self.session.execute(statement)
         return list(result.scalars().all())
 
+    async def _create_workflow_definition(
+        self,
+        workflow_id: WorkflowID,
+        dsl: DSLInput,
+        *,
+        alias: str | None = None,
+        registry_lock: RegistryLock | None = None,
+        commit: bool = True,
+        require_initial: bool = False,
+    ) -> WorkflowDefinition:
+        statement = (
+            select(WorkflowDefinition)
+            .where(
+                WorkflowDefinition.workspace_id == self.workspace_id,
+                WorkflowDefinition.workflow_id == workflow_id,
+            )
+            .order_by(WorkflowDefinition.version.desc())
+        )
+        result = await self.session.execute(statement)
+        latest_defn = result.scalars().first()
+        if require_initial and latest_defn is not None:
+            raise TracecatValidationError("Initial workflow definition already exists")
+
+        version = latest_defn.version + 1 if latest_defn else 1
+        defn = WorkflowDefinition(
+            workspace_id=self.workspace_id,
+            workflow_id=workflow_id,
+            content=dsl.model_dump(exclude_unset=True),
+            version=version,
+            alias=alias,
+            registry_lock=registry_lock.model_dump() if registry_lock else None,
+        )
+        self.session.add(defn)
+        if commit:
+            await self.session.commit()
+        else:
+            await self.session.flush()
+        await self.session.refresh(defn)
+        return defn
+
     @require_scope("workflow:update")
     async def create_workflow_definition(
         self,
@@ -92,33 +136,33 @@ class WorkflowDefinitionsService(BaseWorkspaceService):
         Returns:
             The created WorkflowDefinition.
         """
-        statement = (
-            select(WorkflowDefinition)
-            .where(
-                WorkflowDefinition.workspace_id == self.workspace_id,
-                WorkflowDefinition.workflow_id == workflow_id,
-            )
-            .order_by(WorkflowDefinition.version.desc())
-        )
-        result = await self.session.execute(statement)
-        latest_defn = result.scalars().first()
-
-        version = latest_defn.version + 1 if latest_defn else 1
-        defn = WorkflowDefinition(
-            workspace_id=self.workspace_id,
-            workflow_id=workflow_id,
-            content=dsl.model_dump(exclude_unset=True),
-            version=version,
+        return await self._create_workflow_definition(
+            workflow_id,
+            dsl,
             alias=alias,
-            registry_lock=registry_lock.model_dump() if registry_lock else None,
+            registry_lock=registry_lock,
+            commit=commit,
         )
-        self.session.add(defn)
-        if commit:
-            await self.session.commit()
-        else:
-            await self.session.flush()
-        await self.session.refresh(defn)
-        return defn
+
+    @require_scope("workflow:create")
+    async def create_initial_workflow_definition(
+        self,
+        workflow_id: WorkflowID,
+        dsl: DSLInput,
+        *,
+        alias: str | None = None,
+        registry_lock: RegistryLock | None = None,
+        commit: bool = True,
+    ) -> WorkflowDefinition:
+        """Create the first committed definition for a newly created workflow."""
+        return await self._create_workflow_definition(
+            workflow_id,
+            dsl,
+            alias=alias,
+            registry_lock=registry_lock,
+            commit=commit,
+            require_initial=True,
+        )
 
 
 @activity.defn

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -1195,6 +1195,19 @@ class WorkflowsManagementService(BaseWorkspaceService):
         if external_defn.case_trigger is not None and (
             external_defn.case_trigger.is_configured()
         ):
+            if external_defn.case_trigger.status == "online":
+                defn_service = WorkflowDefinitionsService(
+                    session=self.session, role=self.role
+                )
+                defn = await defn_service.create_workflow_definition(
+                    WorkflowUUID.new(workflow.id),
+                    dsl,
+                    commit=False,
+                )
+                workflow.version = defn.version
+                self.session.add(workflow)
+                await self.session.flush()
+
             case_trigger_service = CaseTriggersService(self.session, role=self.role)
             await case_trigger_service.upsert_case_trigger(
                 WorkflowUUID.new(workflow.id),

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -52,6 +52,7 @@ from tracecat.pagination import (
     CursorPaginationParams,
 )
 from tracecat.registry.lock.service import RegistryLockService
+from tracecat.registry.lock.types import RegistryLock
 from tracecat.service import BaseWorkspaceService
 from tracecat.validation.schemas import (
     DSLValidationResult,
@@ -1202,6 +1203,12 @@ class WorkflowsManagementService(BaseWorkspaceService):
                 defn = await defn_service.create_initial_workflow_definition(
                     WorkflowUUID.new(workflow.id),
                     dsl,
+                    alias=workflow.alias,
+                    registry_lock=(
+                        RegistryLock.model_validate(workflow.registry_lock)
+                        if workflow.registry_lock
+                        else None
+                    ),
                     commit=False,
                 )
                 workflow.version = defn.version

--- a/tracecat/workflow/management/management.py
+++ b/tracecat/workflow/management/management.py
@@ -1199,7 +1199,7 @@ class WorkflowsManagementService(BaseWorkspaceService):
                 defn_service = WorkflowDefinitionsService(
                     session=self.session, role=self.role
                 )
-                defn = await defn_service.create_workflow_definition(
+                defn = await defn_service.create_initial_workflow_definition(
                     WorkflowUUID.new(workflow.id),
                     dsl,
                     commit=False,


### PR DESCRIPTION
## Summary
- require online case triggers to target the workflow's current committed, runnable definition
- self-heal stale invalid case triggers by setting them offline when the consumer encounters missing, empty, invalid, or non-current definitions
- treat those invalid trigger configs as terminal skips so one bad trigger cannot keep a Redis case event pending after valid triggers already dispatched

## Root Cause
A stale online case trigger can point at a workflow without a usable current definition. The consumer previously treated that as a retryable dispatch failure, returned `should_ack=false`, and left the Redis stream message pending. Valid triggers for the same case event could still dispatch and write a temporary dedupe key; after that key expired, the still-pending event could replay the valid workflow.

## Validation
- `uv run ruff check --fix tracecat/workflow/case_triggers/service.py tracecat/cases/triggers/consumer.py tests/unit/test_case_trigger_consumer.py tests/unit/test_case_triggers.py tests/unit/test_workflow_import_service.py`
- `uv run ruff format --check tracecat/workflow/case_triggers/service.py tracecat/cases/triggers/consumer.py tests/unit/test_case_trigger_consumer.py tests/unit/test_case_triggers.py tests/unit/test_workflow_import_service.py`
- `uv run basedpyright tracecat/workflow/case_triggers/service.py tracecat/cases/triggers/consumer.py tests/unit/test_case_trigger_consumer.py tests/unit/test_case_triggers.py tests/unit/test_workflow_import_service.py`
- `uv run pytest tests/unit/test_case_trigger_consumer.py tests/unit/test_case_triggers.py tests/unit/test_workflow_import_service.py -k 'case_trigger'`
- `uv run pytest tests/unit/test_workflow_import_service.py`

Pre-commit also passed during commit after installing frontend dependencies for the generated-client hook.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale case trigger replays by forcing online triggers to use the workflow’s current runnable definition, and by ACKing and auto‑disabling invalid triggers to clear pending replays. External imports with online triggers now publish a create‑scoped, version‑locked initial definition so the trigger stays online.

- **Bug Fixes**
  - Consumer: If a trigger’s workflow definition is missing, non‑current, empty, or has invalid DSL, set the trigger offline, treat as a terminal skip, write the done key, and ACK the event to stop replays.
  - Service: When enabling a trigger, require the workflow’s current, published, valid definition; otherwise reject with “Publish the workflow…”.
  - Management: For external imports with an online trigger, publish the initial definition via create scope, freeze with the workflow’s `registry_lock`, set `workflow.version`, then upsert the trigger (keeps it online).

<sup>Written for commit bf096312c39e519bd2cd30d5fa81e3ca60e20534. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

