### PR TITLE
feat(git): add GitHub App PEM upload dropzone

### DIFF
--- a/frontend/src/components/organization/org-vcs-github-manual-form.tsx
+++ b/frontend/src/components/organization/org-vcs-github-manual-form.tsx
@@ -1,7 +1,15 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useState } from "react"
+import { FileTextIcon, UploadCloudIcon } from "lucide-react"
+import {
+  type ChangeEvent,
+  type DragEvent,
+  type KeyboardEvent,
+  useCallback,
+  useRef,
+  useState,
+} from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
@@ -19,6 +27,25 @@ import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { useToast } from "@/components/ui/use-toast"
 import { useGitHubAppCredentials } from "@/lib/hooks"
+import { cn } from "@/lib/utils"
+
+const pemFileExtensionRegex = /\.pem$/i
+
+function getPrivateKeyDropzoneClass({
+  hasError,
+  isDragOver,
+}: {
+  hasError: boolean
+  isDragOver: boolean
+}) {
+  if (hasError) {
+    return "border-destructive/80 bg-destructive/5"
+  }
+  if (isDragOver) {
+    return "border-primary/60 bg-primary/5"
+  }
+  return "border-muted-foreground/30 bg-muted/40 hover:border-muted-foreground/50"
+}
 
 const gitHubAppCredentialsSchema = z.object({
   app_id: z
@@ -56,6 +83,11 @@ export function GitHubAppManualForm({
   const { saveCredentials } = useGitHubAppCredentials()
   const { toast } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [privateKeyFileName, setPrivateKeyFileName] = useState<string | null>(
+    null
+  )
+  const [isPrivateKeyDragOver, setIsPrivateKeyDragOver] = useState(false)
+  const privateKeyFileInputRef = useRef<HTMLInputElement | null>(null)
 
   const form = useForm<GitHubAppCredentialsFormData>({
     resolver: zodResolver(gitHubAppCredentialsSchema),
@@ -66,6 +98,112 @@ export function GitHubAppManualForm({
       client_id: "",
     },
   })
+
+  const resetPrivateKeyFileInput = useCallback(() => {
+    if (privateKeyFileInputRef.current) {
+      privateKeyFileInputRef.current.value = ""
+    }
+  }, [])
+
+  const handlePrivateKeyFile = useCallback(
+    (file: File | undefined) => {
+      if (!file) {
+        return
+      }
+
+      if (!pemFileExtensionRegex.test(file.name)) {
+        setPrivateKeyFileName(null)
+        form.setError("private_key", {
+          type: "manual",
+          message: "Upload a .pem file.",
+        })
+        resetPrivateKeyFileInput()
+        return
+      }
+
+      const reader = new FileReader()
+      reader.onload = () => {
+        const privateKey =
+          typeof reader.result === "string" ? reader.result : ""
+
+        form.clearErrors("private_key")
+        form.setValue("private_key", privateKey, {
+          shouldDirty: true,
+          shouldTouch: true,
+          shouldValidate: true,
+        })
+        setPrivateKeyFileName(file.name)
+        resetPrivateKeyFileInput()
+      }
+      reader.onerror = () => {
+        setPrivateKeyFileName(null)
+        form.setError("private_key", {
+          type: "manual",
+          message: "Failed to read the uploaded PEM file.",
+        })
+        resetPrivateKeyFileInput()
+      }
+
+      reader.readAsText(file)
+    },
+    [form, resetPrivateKeyFileInput]
+  )
+
+  const handlePrivateKeyInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      handlePrivateKeyFile(event.target.files?.[0])
+    },
+    [handlePrivateKeyFile]
+  )
+
+  const handlePrivateKeyDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      setIsPrivateKeyDragOver(false)
+      handlePrivateKeyFile(event.dataTransfer.files?.[0])
+      event.dataTransfer.clearData()
+    },
+    [handlePrivateKeyFile]
+  )
+
+  const handlePrivateKeyDragOver = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      event.dataTransfer.dropEffect = "copy"
+      setIsPrivateKeyDragOver(true)
+    },
+    []
+  )
+
+  const handlePrivateKeyDragLeave = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      const relatedTarget = event.relatedTarget
+      if (
+        relatedTarget instanceof Node &&
+        event.currentTarget.contains(relatedTarget)
+      ) {
+        return
+      }
+      setIsPrivateKeyDragOver(false)
+    },
+    []
+  )
+
+  const handlePrivateKeyDropzoneClick = useCallback(() => {
+    privateKeyFileInputRef.current?.click()
+  }, [])
+
+  const handlePrivateKeyDropzoneKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== "Enter" && event.key !== " ") {
+        return
+      }
+      event.preventDefault()
+      handlePrivateKeyDropzoneClick()
+    },
+    [handlePrivateKeyDropzoneClick]
+  )
 
   const onSubmit = async (data: GitHubAppCredentialsFormData) => {
     try {
@@ -86,6 +224,8 @@ export function GitHubAppManualForm({
 
       // Clear sensitive data from form
       form.setValue("private_key", "")
+      setPrivateKeyFileName(null)
+      resetPrivateKeyFileInput()
       if (data.webhook_secret) {
         form.setValue("webhook_secret", "")
       }
@@ -140,25 +280,98 @@ export function GitHubAppManualForm({
               <FormField
                 control={form.control}
                 name="private_key"
-                render={({ field }) => (
-                  <FormItem className="space-y-2">
-                    <FormLabel>Private Key *</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        {...field}
-                        placeholder="-----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEA...
------END RSA PRIVATE KEY-----"
-                        className="h-32 font-mono text-xs"
+                render={({ field, fieldState }) => {
+                  const dropzoneStateClass = getPrivateKeyDropzoneClass({
+                    hasError: fieldState.invalid,
+                    isDragOver: isPrivateKeyDragOver,
+                  })
+
+                  return (
+                    <FormItem className="space-y-2">
+                      <FormLabel>Private Key *</FormLabel>
+                      <input
+                        ref={privateKeyFileInputRef}
+                        type="file"
+                        accept=".pem"
+                        className="hidden"
+                        onChange={handlePrivateKeyInputChange}
                       />
-                    </FormControl>
-                    <p className="text-xs text-muted-foreground">
-                      Paste the full contents of the PEM file you downloaded
-                      from GitHub
-                    </p>
-                    <FormMessage />
-                  </FormItem>
-                )}
+                      <div
+                        data-testid="github-app-private-key-dropzone"
+                        role="button"
+                        tabIndex={0}
+                        aria-label="Choose GitHub App private key PEM file"
+                        onClick={handlePrivateKeyDropzoneClick}
+                        onKeyDown={handlePrivateKeyDropzoneKeyDown}
+                        onDrop={handlePrivateKeyDrop}
+                        onDragEnter={handlePrivateKeyDragOver}
+                        onDragOver={handlePrivateKeyDragOver}
+                        onDragLeave={handlePrivateKeyDragLeave}
+                        className={cn(
+                          "flex cursor-pointer flex-col items-center justify-center gap-3 rounded-md border border-dashed px-4 py-8 text-center transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
+                          dropzoneStateClass
+                        )}
+                      >
+                        <span
+                          className={cn(
+                            "flex size-10 items-center justify-center rounded-full transition-colors",
+                            isPrivateKeyDragOver
+                              ? "bg-primary/10 text-primary"
+                              : "bg-muted-foreground/10 text-muted-foreground"
+                          )}
+                        >
+                          {privateKeyFileName ? (
+                            <FileTextIcon className="size-5" />
+                          ) : (
+                            <UploadCloudIcon className="size-5" />
+                          )}
+                        </span>
+                        <div className="flex flex-col gap-0.5">
+                          {privateKeyFileName ? (
+                            <>
+                              <p className="text-sm font-medium">
+                                {privateKeyFileName}
+                              </p>
+                              <p className="text-xs text-muted-foreground">
+                                Click to replace, or paste below
+                              </p>
+                            </>
+                          ) : (
+                            <>
+                              <p className="text-sm font-medium">
+                                Drop .pem file here, or{" "}
+                                <span className="text-primary">
+                                  click to browse
+                                </span>
+                              </p>
+                              <p className="text-xs text-muted-foreground">
+                                You can also paste it below
+                              </p>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                      <FormControl>
+                        <Textarea
+                          {...field}
+                          onChange={(event) => {
+                            setPrivateKeyFileName(null)
+                            form.clearErrors("private_key")
+                            field.onChange(event)
+                          }}
+                          placeholder={`-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA1Xq8z2vY3kHnPbW9pJ4rT5sU6wK
+9bV3nHpQ7rTaB4eYhN2dWfL5mC8xR1oZ0gD7uF6iX3c
+…
+hQ4kR2bJ8nVwPzL0aXmS9tE1yU6sJ0oZ4eY7dWfL5mC
+-----END RSA PRIVATE KEY-----`}
+                          className="h-32 font-mono text-xs"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )
+                }}
               />
 
               <FormField

--- a/frontend/src/components/organization/org-vcs-github-manual-form.tsx
+++ b/frontend/src/components/organization/org-vcs-github-manual-form.tsx
@@ -130,6 +130,13 @@ export function GitHubAppManualForm({
         return
       }
 
+      setPrivateKeyFileName(null)
+      form.setValue("private_key", "", {
+        shouldDirty: true,
+        shouldTouch: true,
+        shouldValidate: false,
+      })
+
       const reader = new FileReader()
       reader.onload = () => {
         if (readId !== privateKeyReadIdRef.current) {
@@ -167,6 +174,7 @@ export function GitHubAppManualForm({
       }
 
       reader.readAsText(file)
+      resetPrivateKeyFileInput()
     },
     [form, resetPrivateKeyFileInput]
   )

--- a/frontend/src/components/organization/org-vcs-github-manual-form.tsx
+++ b/frontend/src/components/organization/org-vcs-github-manual-form.tsx
@@ -31,22 +31,6 @@ import { cn } from "@/lib/utils"
 
 const pemFileExtensionRegex = /\.pem$/i
 
-function getPrivateKeyDropzoneClass({
-  hasError,
-  isDragOver,
-}: {
-  hasError: boolean
-  isDragOver: boolean
-}) {
-  if (hasError) {
-    return "border-destructive/80 bg-destructive/5"
-  }
-  if (isDragOver) {
-    return "border-primary/60 bg-primary/5"
-  }
-  return "border-muted-foreground/30 bg-muted/40 hover:border-muted-foreground/50"
-}
-
 const gitHubAppCredentialsSchema = z.object({
   app_id: z
     .string()
@@ -312,11 +296,6 @@ export function GitHubAppManualForm({
                 control={form.control}
                 name="private_key"
                 render={({ field, fieldState }) => {
-                  const dropzoneStateClass = getPrivateKeyDropzoneClass({
-                    hasError: fieldState.invalid,
-                    isDragOver: isPrivateKeyDragOver,
-                  })
-
                   return (
                     <FormItem className="space-y-2">
                       <FormLabel>Private Key *</FormLabel>
@@ -340,7 +319,14 @@ export function GitHubAppManualForm({
                         onDragLeave={handlePrivateKeyDragLeave}
                         className={cn(
                           "flex cursor-pointer flex-col items-center justify-center gap-3 rounded-md border border-dashed px-4 py-8 text-center transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
-                          dropzoneStateClass
+                          fieldState.invalid &&
+                            "border-destructive/80 bg-destructive/5",
+                          !fieldState.invalid &&
+                            isPrivateKeyDragOver &&
+                            "border-primary/60 bg-primary/5",
+                          !fieldState.invalid &&
+                            !isPrivateKeyDragOver &&
+                            "border-muted-foreground/30 bg-muted/40 hover:border-muted-foreground/50"
                         )}
                       >
                         <span

--- a/frontend/src/components/organization/org-vcs-github-manual-form.tsx
+++ b/frontend/src/components/organization/org-vcs-github-manual-form.tsx
@@ -88,6 +88,7 @@ export function GitHubAppManualForm({
   )
   const [isPrivateKeyDragOver, setIsPrivateKeyDragOver] = useState(false)
   const privateKeyFileInputRef = useRef<HTMLInputElement | null>(null)
+  const privateKeyReadIdRef = useRef(0)
 
   const form = useForm<GitHubAppCredentialsFormData>({
     resolver: zodResolver(gitHubAppCredentialsSchema),
@@ -111,6 +112,9 @@ export function GitHubAppManualForm({
         return
       }
 
+      const readId = privateKeyReadIdRef.current + 1
+      privateKeyReadIdRef.current = readId
+
       if (!pemFileExtensionRegex.test(file.name)) {
         setPrivateKeyFileName(null)
         form.setValue("private_key", "", {
@@ -128,6 +132,10 @@ export function GitHubAppManualForm({
 
       const reader = new FileReader()
       reader.onload = () => {
+        if (readId !== privateKeyReadIdRef.current) {
+          return
+        }
+
         const privateKey =
           typeof reader.result === "string" ? reader.result : ""
 
@@ -141,6 +149,10 @@ export function GitHubAppManualForm({
         resetPrivateKeyFileInput()
       }
       reader.onerror = () => {
+        if (readId !== privateKeyReadIdRef.current) {
+          return
+        }
+
         setPrivateKeyFileName(null)
         form.setValue("private_key", "", {
           shouldDirty: true,
@@ -233,6 +245,7 @@ export function GitHubAppManualForm({
       })
 
       // Clear sensitive data from form
+      privateKeyReadIdRef.current += 1
       form.setValue("private_key", "")
       setPrivateKeyFileName(null)
       resetPrivateKeyFileInput()
@@ -365,6 +378,7 @@ export function GitHubAppManualForm({
                         <Textarea
                           {...field}
                           onChange={(event) => {
+                            privateKeyReadIdRef.current += 1
                             setPrivateKeyFileName(null)
                             form.clearErrors("private_key")
                             field.onChange(event)

--- a/frontend/src/components/organization/org-vcs-github-manual-form.tsx
+++ b/frontend/src/components/organization/org-vcs-github-manual-form.tsx
@@ -113,6 +113,11 @@ export function GitHubAppManualForm({
 
       if (!pemFileExtensionRegex.test(file.name)) {
         setPrivateKeyFileName(null)
+        form.setValue("private_key", "", {
+          shouldDirty: true,
+          shouldTouch: true,
+          shouldValidate: false,
+        })
         form.setError("private_key", {
           type: "manual",
           message: "Upload a .pem file.",
@@ -137,6 +142,11 @@ export function GitHubAppManualForm({
       }
       reader.onerror = () => {
         setPrivateKeyFileName(null)
+        form.setValue("private_key", "", {
+          shouldDirty: true,
+          shouldTouch: true,
+          shouldValidate: false,
+        })
         form.setError("private_key", {
           type: "manual",
           message: "Failed to read the uploaded PEM file.",

--- a/frontend/tests/org-vcs-github-manual-form.test.tsx
+++ b/frontend/tests/org-vcs-github-manual-form.test.tsx
@@ -70,17 +70,29 @@ describe("GitHubAppManualForm", () => {
     expect(screen.getByText("github-app.private-key.pem")).toBeInTheDocument()
   })
 
-  it("rejects non-PEM files", () => {
+  it("clears existing private key when rejecting non-PEM files", () => {
+    const existingPem = [
+      "-----BEGIN PRIVATE KEY-----",
+      "MIIEpAIBAAKCAQEA",
+      "-----END PRIVATE KEY-----",
+    ].join("\n")
     const file = new File(["not a pem"], "private-key.txt", {
       type: "text/plain",
     })
 
     render(<GitHubAppManualForm />)
 
+    const privateKeyInput = screen.getByLabelText("Private Key *")
+    fireEvent.change(privateKeyInput, {
+      target: { value: existingPem },
+    })
+    expect(privateKeyInput).toHaveValue(existingPem)
+
     fireEvent.drop(screen.getByTestId("github-app-private-key-dropzone"), {
       dataTransfer: createDataTransfer(file),
     })
 
+    expect(privateKeyInput).toHaveValue("")
     expect(screen.getByText("Upload a .pem file.")).toBeInTheDocument()
   })
 })

--- a/frontend/tests/org-vcs-github-manual-form.test.tsx
+++ b/frontend/tests/org-vcs-github-manual-form.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { GitHubAppManualForm } from "@/components/organization/org-vcs-github-manual-form"
+
+const mockMutateAsync = jest.fn()
+const mockToast = jest.fn()
+
+jest.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
+
+jest.mock("@/lib/hooks", () => ({
+  useGitHubAppCredentials: () => ({
+    saveCredentials: {
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+      isError: false,
+      error: null,
+    },
+  }),
+}))
+
+function createDataTransfer(file: File) {
+  return {
+    files: [file],
+    clearData: jest.fn(),
+  }
+}
+
+describe("GitHubAppManualForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("opens the file picker when the dropzone is clicked", () => {
+    const clickSpy = jest
+      .spyOn(HTMLInputElement.prototype, "click")
+      .mockImplementation(() => {})
+
+    render(<GitHubAppManualForm />)
+
+    fireEvent.click(screen.getByTestId("github-app-private-key-dropzone"))
+
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    clickSpy.mockRestore()
+  })
+
+  it("loads a dropped PEM file into the private key field", async () => {
+    const pem = [
+      "-----BEGIN PRIVATE KEY-----",
+      "MIIEpAIBAAKCAQEA",
+      "-----END PRIVATE KEY-----",
+    ].join("\n")
+    const file = new File([pem], "github-app.private-key.pem", {
+      type: "application/x-pem-file",
+    })
+
+    render(<GitHubAppManualForm />)
+
+    fireEvent.drop(screen.getByTestId("github-app-private-key-dropzone"), {
+      dataTransfer: createDataTransfer(file),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Private Key *")).toHaveValue(pem)
+    })
+    expect(screen.getByText("github-app.private-key.pem")).toBeInTheDocument()
+  })
+
+  it("rejects non-PEM files", () => {
+    const file = new File(["not a pem"], "private-key.txt", {
+      type: "text/plain",
+    })
+
+    render(<GitHubAppManualForm />)
+
+    fireEvent.drop(screen.getByTestId("github-app-private-key-dropzone"), {
+      dataTransfer: createDataTransfer(file),
+    })
+
+    expect(screen.getByText("Upload a .pem file.")).toBeInTheDocument()
+  })
+})

--- a/frontend/tests/org-vcs-github-manual-form.test.tsx
+++ b/frontend/tests/org-vcs-github-manual-form.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { GitHubAppManualForm } from "@/components/organization/org-vcs-github-manual-form"
 
 const mockMutateAsync = jest.fn()
@@ -29,6 +29,10 @@ function createDataTransfer(file: File) {
     clearData: jest.fn(),
   }
 }
+
+type FileReaderEventHandler =
+  | ((this: FileReader, event: ProgressEvent<FileReader>) => unknown)
+  | null
 
 describe("GitHubAppManualForm", () => {
   beforeEach(() => {
@@ -94,5 +98,69 @@ describe("GitHubAppManualForm", () => {
 
     expect(privateKeyInput).toHaveValue("")
     expect(screen.getByText("Upload a .pem file.")).toBeInTheDocument()
+  })
+
+  it("ignores stale PEM reads after a rejected replacement", () => {
+    const stalePem = [
+      "-----BEGIN PRIVATE KEY-----",
+      "MIIEpAIBAAKCAQEA",
+      "-----END PRIVATE KEY-----",
+    ].join("\n")
+    const pemFile = new File([stalePem], "github-app.private-key.pem", {
+      type: "application/x-pem-file",
+    })
+    const invalidFile = new File(["not a pem"], "private-key.txt", {
+      type: "text/plain",
+    })
+    const originalFileReader = window.FileReader
+    const deferredReader = {
+      result: null as string | ArrayBuffer | null,
+      onload: null as FileReaderEventHandler,
+      onerror: null as FileReaderEventHandler,
+      readAsText: jest.fn(),
+    }
+
+    Object.defineProperty(window, "FileReader", {
+      configurable: true,
+      writable: true,
+      value: jest.fn(() => deferredReader as unknown as FileReader),
+    })
+
+    try {
+      render(<GitHubAppManualForm />)
+
+      const dropzone = screen.getByTestId("github-app-private-key-dropzone")
+      const privateKeyInput = screen.getByLabelText("Private Key *")
+
+      fireEvent.drop(dropzone, {
+        dataTransfer: createDataTransfer(pemFile),
+      })
+      expect(deferredReader.readAsText).toHaveBeenCalledWith(pemFile)
+
+      fireEvent.drop(dropzone, {
+        dataTransfer: createDataTransfer(invalidFile),
+      })
+      expect(privateKeyInput).toHaveValue("")
+      expect(screen.getByText("Upload a .pem file.")).toBeInTheDocument()
+
+      deferredReader.result = stalePem
+      act(() => {
+        deferredReader.onload?.call(
+          deferredReader as unknown as FileReader,
+          new ProgressEvent("load") as ProgressEvent<FileReader>
+        )
+      })
+
+      expect(privateKeyInput).toHaveValue("")
+      expect(
+        screen.queryByText("github-app.private-key.pem")
+      ).not.toBeInTheDocument()
+    } finally {
+      Object.defineProperty(window, "FileReader", {
+        configurable: true,
+        writable: true,
+        value: originalFileReader,
+      })
+    }
   })
 })

--- a/frontend/tests/org-vcs-github-manual-form.test.tsx
+++ b/frontend/tests/org-vcs-github-manual-form.test.tsx
@@ -34,6 +34,33 @@ type FileReaderEventHandler =
   | ((this: FileReader, event: ProgressEvent<FileReader>) => unknown)
   | null
 
+function installDeferredFileReader() {
+  const originalFileReader = window.FileReader
+  const deferredReader = {
+    result: null as string | ArrayBuffer | null,
+    onload: null as FileReaderEventHandler,
+    onerror: null as FileReaderEventHandler,
+    readAsText: jest.fn(),
+  }
+
+  Object.defineProperty(window, "FileReader", {
+    configurable: true,
+    writable: true,
+    value: jest.fn(() => deferredReader as unknown as FileReader),
+  })
+
+  return {
+    deferredReader,
+    restoreFileReader: () => {
+      Object.defineProperty(window, "FileReader", {
+        configurable: true,
+        writable: true,
+        value: originalFileReader,
+      })
+    },
+  }
+}
+
 describe("GitHubAppManualForm", () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -112,19 +139,7 @@ describe("GitHubAppManualForm", () => {
     const invalidFile = new File(["not a pem"], "private-key.txt", {
       type: "text/plain",
     })
-    const originalFileReader = window.FileReader
-    const deferredReader = {
-      result: null as string | ArrayBuffer | null,
-      onload: null as FileReaderEventHandler,
-      onerror: null as FileReaderEventHandler,
-      readAsText: jest.fn(),
-    }
-
-    Object.defineProperty(window, "FileReader", {
-      configurable: true,
-      writable: true,
-      value: jest.fn(() => deferredReader as unknown as FileReader),
-    })
+    const { deferredReader, restoreFileReader } = installDeferredFileReader()
 
     try {
       render(<GitHubAppManualForm />)
@@ -156,11 +171,53 @@ describe("GitHubAppManualForm", () => {
         screen.queryByText("github-app.private-key.pem")
       ).not.toBeInTheDocument()
     } finally {
-      Object.defineProperty(window, "FileReader", {
-        configurable: true,
-        writable: true,
-        value: originalFileReader,
+      restoreFileReader()
+    }
+  })
+
+  it("prevents saving an old private key while a PEM is loading", async () => {
+    const existingPem = [
+      "-----BEGIN PRIVATE KEY-----",
+      "MIIEpAIBAAKCAQEA",
+      "-----END PRIVATE KEY-----",
+    ].join("\n")
+    const replacementPem = [
+      "-----BEGIN PRIVATE KEY-----",
+      "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC",
+      "-----END PRIVATE KEY-----",
+    ].join("\n")
+    const file = new File([replacementPem], "replacement.private-key.pem", {
+      type: "application/x-pem-file",
+    })
+    const { deferredReader, restoreFileReader } = installDeferredFileReader()
+
+    try {
+      render(<GitHubAppManualForm />)
+
+      fireEvent.change(screen.getByLabelText("GitHub App ID *"), {
+        target: { value: "123456" },
       })
+      const privateKeyInput = screen.getByLabelText("Private Key *")
+      fireEvent.change(privateKeyInput, {
+        target: { value: existingPem },
+      })
+      expect(privateKeyInput).toHaveValue(existingPem)
+
+      fireEvent.drop(screen.getByTestId("github-app-private-key-dropzone"), {
+        dataTransfer: createDataTransfer(file),
+      })
+
+      expect(deferredReader.readAsText).toHaveBeenCalledWith(file)
+      expect(privateKeyInput).toHaveValue("")
+
+      fireEvent.click(screen.getByRole("button", { name: "Save credentials" }))
+
+      await waitFor(() => {
+        expect(screen.getByText("Private key is required")).toBeInTheDocument()
+      })
+      expect(mockMutateAsync).not.toHaveBeenCalled()
+    } finally {
+      restoreFileReader()
     }
   })
 })


### PR DESCRIPTION
## Summary

- Add a clickable drag-and-drop `.pem` upload target to the GitHub App manual credentials form.
- Read uploaded PEM files into the existing private key textarea while preserving paste input.
- Add focused coverage for click-to-upload, dropped PEM files, and invalid file extensions.

## Screenshots

![Connect GitHub App dialog with PEM dropzone](https://github.com/TracecatHQ/tracecat/releases/download/pr-2879-screenshots/github-app-pem-dialog.png)

![PEM dropzone detail](https://github.com/TracecatHQ/tracecat/releases/download/pr-2879-screenshots/github-app-pem-dropzone.png)

## Validation

- `pnpm -C frontend test -- org-vcs-github-manual-form.test.tsx --runInBand`
- `pnpm -C frontend exec biome check --write src/components/organization/org-vcs-github-manual-form.tsx tests/org-vcs-github-manual-form.test.tsx`
- `pnpm -C frontend run typecheck`
- `uv run ruff check .`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a click-or-drag `.pem` upload dropzone to the GitHub App manual credentials form to make adding the private key faster and less error-prone. Also inlines the dropzone styles for simpler markup.

- **New Features**
  - Keyboard-accessible dropzone with drag-over styling and error states; shows uploaded file name.
  - Accepts only `.pem` files; rejects others with an inline error, clears any existing key and file name, and resets the hidden file input.

- **Bug Fixes**
  - Ignore stale PEM reads so an older FileReader result can’t overwrite a cleared or replaced key; added a focused test.
  - Prevent stale PEM saves by invalidating in-flight reads and blocking submit while the key is empty.

<sup>Written for commit a40d6514a113ebc9ca7b591d573574b6539b39a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

