### PR TITLE
fix(integrations): route discovery MCP catalog entries to the MCP dialog

### DIFF
--- a/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
+++ b/frontend/src/app/workspaces/[workspaceId]/mcp-servers/page.tsx
@@ -20,7 +20,6 @@ import { useScopeCheck } from "@/components/auth/scope-guard"
 import { CatalogHeader } from "@/components/catalog/catalog-header"
 import { getMcpProviderIconId, ProviderIcon } from "@/components/icons"
 import { MCPIntegrationDialog } from "@/components/integrations/mcp-integration-dialog"
-import { OAuthIntegrationDialog } from "@/components/integrations/oauth-integration-dialog"
 import { LockedFeatureModal } from "@/components/locked-feature-modal"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
@@ -191,13 +190,6 @@ function catalogTransports(entry: PlatformMCPCatalogRead) {
   )
 }
 
-function isProviderBackedOAuth(entry: PlatformMCPCatalogRead) {
-  return Boolean(
-    entry.provider_id &&
-      catalogConnectionSpecs(entry).some((spec) => spec.auth_type === "OAUTH2")
-  )
-}
-
 function requiresCatalogConfig(entry: PlatformMCPCatalogRead) {
   return catalogConnectionSpecs(entry).some((spec) => spec.requires_config)
 }
@@ -205,8 +197,7 @@ function requiresCatalogConfig(entry: PlatformMCPCatalogRead) {
 function isCatalogEntryConnectable(entry: PlatformMCPCatalogRead) {
   return Boolean(
     entry.connection_spec ||
-      (entry.connection_options && entry.connection_options.length > 0) ||
-      isProviderBackedOAuth(entry)
+      (entry.connection_options && entry.connection_options.length > 0)
   )
 }
 
@@ -229,8 +220,6 @@ export default function McpServersPage() {
     null
   )
   const [lockedCatalogEntry, setLockedCatalogEntry] =
-    useState<PlatformMCPCatalogRead | null>(null)
-  const [providerConfigEntry, setProviderConfigEntry] =
     useState<PlatformMCPCatalogRead | null>(null)
   const [editingItem, setEditingItem] = useState<CatalogItem | null>(null)
 
@@ -525,10 +514,9 @@ export default function McpServersPage() {
       setConfigEntry(entry)
       return
     }
-    if (isProviderBackedOAuth(entry) && entry.provider_id && canCreateMcp) {
-      setProviderConfigEntry(entry)
-      return
-    }
+    // Provider-backed entries (e.g. GitHub, Atlassian) carry a connection_spec
+    // and are configured through the MCP dialog — its discovery / OAuth-client
+    // flow — not the standalone OAuth provider form.
     if (entry.connection_spec && canCreateMcp) {
       setConfigEntry(entry)
       return
@@ -670,21 +658,6 @@ export default function McpServersPage() {
           }}
           catalogEntry={configEntry}
           hideTrigger
-        />
-      ) : null}
-
-      {providerConfigEntry?.provider_id ? (
-        <OAuthIntegrationDialog
-          open
-          onOpenChange={(next) => {
-            if (!next) {
-              setProviderConfigEntry(null)
-              queryClient.invalidateQueries({ queryKey: catalogQueryKey })
-              queryClient.invalidateQueries({ queryKey: workspaceMcpQueryKey })
-            }
-          }}
-          providerId={providerConfigEntry.provider_id}
-          grantType="authorization_code"
         />
       ) : null}
 

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -11600,11 +11600,15 @@ export const mcpIntegrationsGetMcpIntegration = (
 /**
  * Update Mcp Integration
  * Update an MCP integration.
+ *
+ * Returns an ``MCPCatalogConnectResponse`` when the edit triggers MCP OAuth
+ * discovery (an OAuth2 target with ``oauth_integration_id`` explicitly
+ * cleared): the caller must follow ``auth_url`` to finish authorization.
  * @param data The data for the request.
  * @param data.mcpIntegrationId
  * @param data.workspaceId
  * @param data.requestBody
- * @returns MCPIntegrationRead Successful Response
+ * @returns unknown Successful Response
  * @throws ApiError
  */
 export const mcpIntegrationsUpdateMcpIntegration = (

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -12802,7 +12802,9 @@ export type McpIntegrationsUpdateMcpIntegrationData = {
   workspaceId: string
 }
 
-export type McpIntegrationsUpdateMcpIntegrationResponse = MCPIntegrationRead
+export type McpIntegrationsUpdateMcpIntegrationResponse =
+  | MCPIntegrationRead
+  | MCPCatalogConnectResponse
 
 export type McpIntegrationsDeleteMcpIntegrationData = {
   mcpIntegrationId: string
@@ -18933,7 +18935,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: MCPIntegrationRead
+        200: MCPIntegrationRead | MCPCatalogConnectResponse
         /**
          * Validation Error
          */

--- a/frontend/src/components/integrations/mcp-integration-dialog.tsx
+++ b/frontend/src/components/integrations/mcp-integration-dialog.tsx
@@ -14,13 +14,7 @@ import {
 } from "lucide-react"
 import React, { useState } from "react"
 import { useFieldArray, useForm } from "react-hook-form"
-import {
-  integrationsGetIntegration,
-  mcpIntegrationsConnectPlatformMcpCatalog,
-  providersCreateCustomProvider,
-} from "@/client/services.gen"
 import type {
-  MCPCatalogConnectResponse,
   MCPConnectionSpec,
   MCPHttpIntegrationCreate,
   MCPIntegrationRead,
@@ -41,7 +35,6 @@ import {
   type MCPIntegrationFormValues,
   mcpIntegrationFormSchema,
   missingRequiredOAuthClientCredentials,
-  normalizeOAuthClientKey,
   SERVER_TYPES,
 } from "@/components/integrations/mcp-integration-schema"
 import {
@@ -174,47 +167,6 @@ function hasOAuthClientConfig(spec: MCPConnectionSpec | null | undefined) {
       (credential) => credential.target === "oauth_client"
     )
   )
-}
-
-function isClientSecretKey(key: string) {
-  const normalized = normalizeOAuthClientKey(key)
-  return (
-    normalized === "client_secret" ||
-    normalized === "oauth_client_secret" ||
-    normalized.endsWith("_client_secret")
-  )
-}
-
-function isClientIdKey(key: string) {
-  const normalized = normalizeOAuthClientKey(key)
-  return (
-    normalized === "client_id" ||
-    normalized === "oauth_client_id" ||
-    normalized.endsWith("_client_id")
-  )
-}
-
-function readOAuthClientCredentials(value: string) {
-  const parsed = JSON.parse(value) as Record<string, string>
-  const entries = Object.entries(parsed)
-  const clientIdEntry =
-    entries.find(([key]) => isClientIdKey(key)) ??
-    entries.find(([key]) => !isClientSecretKey(key))
-  const clientSecretEntry = entries.find(([key]) => isClientSecretKey(key))
-  const clientId = clientIdEntry?.[1]?.trim() ?? ""
-  const clientSecret = clientSecretEntry?.[1]?.trim() ?? ""
-  if (!clientId) {
-    throw new Error("OAuth client ID is required")
-  }
-  return { clientId, clientSecret: clientSecret || undefined }
-}
-
-function catalogMcpProviderId(
-  entry: PlatformMCPCatalogRead,
-  optionId: string | null | undefined
-) {
-  const suffix = optionId ? `-${optionId}` : ""
-  return `custom_mcp_${entry.slug}${suffix}`.replace(/[^a-zA-Z0-9_]+/g, "_")
 }
 
 function CatalogEntrySummary({
@@ -438,6 +390,7 @@ export function MCPIntegrationDialog({
   const serverType = form.watch("server_type")
   const authType = form.watch("auth_type")
   const oauthSetup = form.watch("oauth_setup")
+  const oauthIntegrationId = form.watch("oauth_integration_id")
   const connectionOptionId = form.watch("connection_option_id")
 
   /**
@@ -783,59 +736,19 @@ export function MCPIntegrationDialog({
               return
             }
             setCatalogOAuthClientIsPending(true)
-            // Without advertised endpoints, the backend does dynamic registration
-            // from the pasted credentials; otherwise create the OAuth client here.
-            let result: MCPCatalogConnectResponse
-            if (
-              !spec.oauth_authorization_endpoint ||
-              !spec.oauth_token_endpoint
-            ) {
-              hookHandledError = true
-              result = await connectMcpIntegration({
-                ...params,
-                custom_credentials: oauthClientCredentials,
-              })
-              hookHandledError = false
-            } else {
-              const { clientId, clientSecret } = readOAuthClientCredentials(
-                oauthClientCredentials
-              )
-              const provider = await providersCreateCustomProvider({
-                workspaceId,
-                requestBody: {
-                  provider_id: catalogMcpProviderId(
-                    catalogEntry,
-                    values.connection_option_id
-                  ),
-                  name: `${values.name} OAuth`,
-                  description:
-                    values.description?.trim() ||
-                    `OAuth client for ${values.name}`,
-                  grant_type: "authorization_code",
-                  authorization_endpoint: spec.oauth_authorization_endpoint,
-                  token_endpoint: spec.oauth_token_endpoint,
-                  scopes: spec.scopes ?? [],
-                  client_id: clientId,
-                  client_secret: clientSecret,
-                },
-              })
-              const oauthIntegration = await integrationsGetIntegration({
-                workspaceId,
-                providerId: provider.id,
-                grantType: "authorization_code",
-              })
-              params = {
-                ...params,
-                oauth_integration_id: oauthIntegration.id,
-              }
-              hookHandledError = true
-              await createMcpIntegration(params)
-              hookHandledError = false
-              result = await mcpIntegrationsConnectPlatformMcpCatalog({
-                workspaceId,
-                catalogSlug: catalogEntry.slug,
-              })
-            }
+            // The backend MCP OAuth discovery flow owns OAuth client setup for
+            // both cases: when the spec advertises endpoints it pins them as
+            // trusted discovery hosts, and either way it builds the OAuth client
+            // from the pasted credentials (or DCR when none are supplied). The
+            // generated `custom_mcp_*` provider id is reserved and rejected by
+            // the public providers endpoint, so route credentials through the
+            // discovery connect path rather than creating a provider here.
+            hookHandledError = true
+            const result = await connectMcpIntegration({
+              ...params,
+              custom_credentials: oauthClientCredentials,
+            })
+            hookHandledError = false
             if (result.auth_url) {
               window.location.href = result.auth_url
               return
@@ -886,13 +799,26 @@ export function MCPIntegrationDialog({
     updateMcpIntegrationIsPending
 
   // An OAuth2 server can only be probed once authorization has produced an
-  // access token. Until the integration is connected (discovery row awaiting
-  // its OAuth redirect, or a lost token), a probe has no bearer token and is a
-  // guaranteed 401 — so disable Test and point the user at OAuth instead.
+  // access token. A probe has a usable bearer token only when the form's active
+  // OAuth selection resolves to a connected existing integration:
+  //   - "existing_integration": resolve the in-form selection (or the saved
+  //     client when untouched) and require it to be connected. A discovery row
+  //     awaiting its redirect or a lost/stale token is not connected -> pending.
+  //   - "mcp_discovery"/"oauth_client": no client exists yet (the OAuth client
+  //     is created on save), so a probe is a guaranteed 401 -> always pending.
+  // Driven by the active form state, not the saved row, so an unsaved switch to
+  // discovery correctly disables Test instead of probing the old token.
+  const resolvedOAuthIntegrationId =
+    oauthSetup === "existing_integration"
+      ? oauthIntegrationId || mcpIntegration?.oauth_integration_id || null
+      : null
+  const resolvedOAuthIsConnected =
+    resolvedOAuthIntegrationId != null &&
+    connectedOAuthIntegrations.some(
+      (int) => int.id === resolvedOAuthIntegrationId
+    )
   const oauthAuthorizationPending =
-    serverType === "http" &&
-    authType === "OAUTH2" &&
-    mcpIntegration?.state !== "connected"
+    serverType === "http" && authType === "OAUTH2" && !resolvedOAuthIsConnected
   const testDisabledReason =
     serverType === "stdio"
       ? "Stdio servers can't be tested"
@@ -1115,38 +1041,42 @@ export function MCPIntegrationDialog({
                     />
                   ) : null}
 
-                  <FormField
-                    control={form.control}
-                    name="name"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Integration name</FormLabel>
-                        <FormControl>
-                          <Input placeholder="My MCP Server" {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="description"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Description</FormLabel>
-                        <FormControl>
-                          <Textarea
-                            placeholder="Optional description for this MCP integration"
-                            {...field}
-                          />
-                        </FormControl>
-                        <FormDescription className="text-xs">
-                          Appears in the integrations list for this workspace.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
+                  {/* Catalog entries are not renameable, so the name and
+                      description come from the repo-owned catalog and these
+                      fields are hidden. */}
+                  {!catalogEntry ? (
+                    <>
+                      <FormField
+                        control={form.control}
+                        name="name"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Integration name</FormLabel>
+                            <FormControl>
+                              <Input placeholder="My MCP Server" {...field} />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name="description"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Description</FormLabel>
+                            <FormControl>
+                              <Textarea
+                                placeholder="Optional description for this MCP integration"
+                                {...field}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </>
+                  ) : null}
 
                   {!catalogEntry ? (
                     <FormField

--- a/frontend/src/components/integrations/mcp-integration-dialog.tsx
+++ b/frontend/src/components/integrations/mcp-integration-dialog.tsx
@@ -711,11 +711,16 @@ export function MCPIntegrationDialog({
                 custom_credentials: customCredentialsForUpdate,
               }
         hookHandledError = true
-        await updateMcpIntegration({
+        const result = await updateMcpIntegration({
           mcpIntegrationId,
           params,
         })
         hookHandledError = false
+        // An OAuth-discovery edit returns a connect response with a redirect.
+        if ("auth_url" in result && result.auth_url) {
+          window.location.href = result.auth_url
+          return
+        }
       } else {
         if (values.server_type === "stdio") {
           const params: MCPStdioIntegrationCreate = {
@@ -880,6 +885,21 @@ export function MCPIntegrationDialog({
     createMcpIntegrationIsPending ||
     updateMcpIntegrationIsPending
 
+  // An OAuth2 server can only be probed once authorization has produced an
+  // access token. Until the integration is connected (discovery row awaiting
+  // its OAuth redirect, or a lost token), a probe has no bearer token and is a
+  // guaranteed 401 — so disable Test and point the user at OAuth instead.
+  const oauthAuthorizationPending =
+    serverType === "http" &&
+    authType === "OAUTH2" &&
+    mcpIntegration?.state !== "connected"
+  const testDisabledReason =
+    serverType === "stdio"
+      ? "Stdio servers can't be tested"
+      : oauthAuthorizationPending
+        ? "Connect via OAuth to test"
+        : undefined
+
   // Connection actions menu mirroring the OAuth integration details dialog.
   // Tests the form's current values; with unsaved connection edits the probe
   // is ephemeral, otherwise it persists the discovered tools.
@@ -904,12 +924,12 @@ export function MCPIntegrationDialog({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">
           <DropdownMenuItem
-            disabled={serverType === "stdio" || testConnectionIsPending}
-            title={
-              serverType === "stdio"
-                ? "Stdio servers can't be tested"
-                : undefined
+            disabled={
+              serverType === "stdio" ||
+              oauthAuthorizationPending ||
+              testConnectionIsPending
             }
+            title={testDisabledReason}
             onClick={() => void handleTestConnection()}
           >
             <PlayCircle className="mr-2 size-4 text-muted-foreground" />

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -139,6 +139,7 @@ import {
   listCatalog,
   listCustomProviders,
   listEnabledModels,
+  type MCPCatalogConnectResponse,
   type MCPIntegrationCreate,
   type MCPIntegrationRead,
   type MCPIntegrationTestConnectionRequest,
@@ -4726,6 +4727,19 @@ export function useGetMcpIntegration(
   }
 }
 
+/**
+ * Narrow an MCP update response to the OAuth-discovery connect result.
+ *
+ * A plain update returns {@link MCPIntegrationRead}; an edit that triggers MCP
+ * OAuth discovery returns {@link MCPCatalogConnectResponse}, identified by its
+ * `status` field, and may carry an `auth_url` redirect.
+ */
+function isMcpCatalogConnectResponse(
+  result: MCPIntegrationRead | MCPCatalogConnectResponse
+): result is MCPCatalogConnectResponse {
+  return "status" in result
+}
+
 export function useUpdateMcpIntegration(workspaceId: string) {
   const queryClient = useQueryClient()
 
@@ -4747,16 +4761,27 @@ export function useUpdateMcpIntegration(workspaceId: string) {
         requestBody: params,
       })
     },
-    onSuccess: (integration) => {
+    onSuccess: (result) => {
+      const integration = isMcpCatalogConnectResponse(result)
+        ? result.mcp_integration
+        : result
+      const awaitingOAuth =
+        isMcpCatalogConnectResponse(result) && Boolean(result.auth_url)
       queryClient.invalidateQueries({
         queryKey: ["mcp-integrations", workspaceId],
       })
-      queryClient.invalidateQueries({
-        queryKey: ["mcp-integration", workspaceId, integration.id],
-      })
+      if (integration) {
+        queryClient.invalidateQueries({
+          queryKey: ["mcp-integration", workspaceId, integration.id],
+        })
+      }
       toast({
-        title: "MCP integration updated",
-        description: `Updated ${integration.name}`,
+        title: awaitingOAuth
+          ? "Continue OAuth authorization"
+          : "MCP integration updated",
+        description: integration
+          ? `Updated ${integration.name}`
+          : "Redirecting to finish OAuth authorization.",
       })
     },
     onError: (error: TracecatApiError) => {

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -52,6 +52,7 @@ from tracecat.integrations.providers.sentry.mcp import SentryMCPProvider
 from tracecat.integrations.providers.wiz.mcp import WizMCPProvider
 from tracecat.integrations.schemas import (
     CustomOAuthProviderCreate,
+    IntegrationOAuthConnect,
     MCPConnectionOption,
     MCPConnectionSpec,
     MCPHttpIntegrationCreate,
@@ -67,7 +68,10 @@ from tracecat.integrations.schemas import (
     ProviderMetadata,
     ProviderScopes,
 )
-from tracecat.integrations.service import IntegrationService
+from tracecat.integrations.service import (
+    IntegrationService,
+    PlatformMCPCatalogConnectResult,
+)
 from tracecat.integrations.types import OAuthServerMetadata
 from tracecat.tiers import defaults as tier_defaults
 
@@ -76,6 +80,19 @@ pytestmark = pytest.mark.usefixtures("db")
 _MCP_CONNECTION_SPEC_ADAPTER: TypeAdapter[MCPConnectionSpec] = TypeAdapter(
     MCPConnectionSpec
 )
+
+
+def _as_mcp_integration(
+    result: MCPIntegration | PlatformMCPCatalogConnectResult | None,
+) -> MCPIntegration:
+    """Narrow a plain (non-discovery) update result to the persisted row.
+
+    ``update_mcp_integration`` returns a ``PlatformMCPCatalogConnectResult`` only
+    when an edit starts OAuth discovery; the non-discovery cases asserted here
+    always return the row.
+    """
+    assert isinstance(result, MCPIntegration)
+    return result
 
 
 class _TestCatalogEntry(dict):
@@ -399,6 +416,60 @@ class TestMCPIntegrationCRUD:
         assert unlocked.mcp_server_type == "http"
         assert unlocked.mcp_auth_type == MCPAuthType.NONE
         assert unlocked.state == "connected"
+
+    async def test_platform_mcp_catalog_uses_workspace_row_name_and_description(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A renamed workspace row's name/description win over catalog defaults.
+
+        The catalog_slug binds the row to the entry, so the user's rename must
+        persist in the catalog listing rather than being overridden by the
+        repo-owned catalog name/description.
+        """
+        catalog = _catalog_entry(
+            slug="renamable-mcp",
+            name="Catalog Default Name",
+            description="Catalog default description",
+            connection_spec={
+                "kind": "http_none",
+                "server_type": "http",
+                "auth_type": "NONE",
+                "requires_config": False,
+                "config_fields": [],
+                "credentials": [],
+                "server_uri": "https://mcp.example.com/mcp",
+            },
+            sort_key="0000:renamable-mcp",
+        )
+        _install_catalog_entry(monkeypatch, catalog)
+
+        session.add(
+            MCPIntegration(
+                workspace_id=integration_service.workspace_id,
+                name="My Renamed Server",
+                description="My own notes",
+                slug=catalog.slug,
+                catalog_slug=catalog.slug,
+                server_type="http",
+                server_uri="https://mcp.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        await session.flush()
+
+        catalog_service = PlatformMCPCatalogService(session=session)
+        items, _ = await catalog_service.list_catalog(
+            workspace_id=integration_service.workspace_id,
+            agent_addons_entitled=True,
+            q=catalog.slug,
+        )
+
+        item = next(entry for entry in items if entry.slug == catalog.slug)
+        assert item.name == "My Renamed Server"
+        assert item.description == "My own notes"
 
     async def test_platform_mcp_catalog_reports_deleted_oauth_row_as_not_connected(
         self,
@@ -1087,7 +1158,7 @@ class TestMCPIntegrationCRUD:
             )
         )
 
-        assert not integration_service._is_custom_mcp_oauth_provider(
+        assert not integration_service.is_custom_mcp_oauth_provider(
             provider.provider_id
         )
 
@@ -1103,6 +1174,84 @@ class TestMCPIntegrationCRUD:
                     client_secret=SecretStr("test-client-secret"),
                 )
             )
+
+    async def test_list_providers_excludes_discovery_owned_mcp_providers(
+        self,
+        integration_service: IntegrationService,
+        svc_role: Role,
+        session: AsyncSession,
+    ) -> None:
+        """The /providers list hides custom_mcp_* OAuth providers.
+
+        Connecting a discovery MCP catalog entry creates a custom_mcp_* OAuth
+        provider to back its flow. That provider is managed from the MCP servers
+        page and must not appear as a standalone custom OAuth integration.
+        """
+        from tracecat.integrations.router import list_providers
+
+        await integration_service.create_custom_provider(
+            params=CustomOAuthProviderCreate(
+                provider_id="custom_mcp_atlassian",
+                name="Jira / Atlassian",
+                grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+                authorization_endpoint="https://auth.example.com/authorize",
+                token_endpoint="https://auth.example.com/token",
+                client_id="mcp-client-id",
+                client_secret=SecretStr("mcp-client-secret"),
+            ),
+            allow_reserved_id=True,
+        )
+        genuine = await integration_service.create_custom_provider(
+            params=CustomOAuthProviderCreate(
+                name="My Custom OAuth",
+                grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+                authorization_endpoint="https://auth.example.com/authorize",
+                token_endpoint="https://auth.example.com/token",
+                client_id="genuine-client-id",
+                client_secret=SecretStr("genuine-client-secret"),
+            )
+        )
+
+        items = await list_providers(role=svc_role, session=session)
+        provider_ids = {item.id for item in items}
+
+        assert genuine.provider_id in provider_ids
+        assert "custom_mcp_atlassian" not in provider_ids
+        assert not any(
+            integration_service.is_custom_mcp_oauth_provider(item.id) for item in items
+        )
+
+    async def test_list_providers_keeps_user_custom_oauth_for_mcp(
+        self,
+        integration_service: IntegrationService,
+        svc_role: Role,
+        session: AsyncSession,
+    ) -> None:
+        """A user's own custom OAuth provider stays listed even when MCP-bound.
+
+        Only the discovery-minted ``custom_mcp_*`` ids are hidden. A provider the
+        user created themselves (which can never take that reserved prefix) and
+        then attached to an MCP server must remain on the integrations page.
+        """
+        from tracecat.integrations.router import list_providers
+
+        user_provider = await integration_service.create_custom_provider(
+            params=CustomOAuthProviderCreate(
+                name="My MCP OAuth App",
+                grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+                authorization_endpoint="https://auth.example.com/authorize",
+                token_endpoint="https://auth.example.com/token",
+                client_id="user-client-id",
+                client_secret=SecretStr("user-client-secret"),
+            )
+        )
+        # The user-chosen id never lands in the reserved discovery namespace.
+        assert not integration_service.is_custom_mcp_oauth_provider(
+            user_provider.provider_id
+        )
+
+        items = await list_providers(role=svc_role, session=session)
+        assert user_provider.provider_id in {item.id for item in items}
 
     async def test_mcp_provider_oauth_does_not_auto_create_without_entitlement(
         self,
@@ -1316,6 +1465,7 @@ class TestMCPIntegrationCRUD:
             mcp_integration_id=created.id,
             params=MCPIntegrationUpdate(stdio_env={"EXAMPLE_TOKEN": ""}),
         )
+        updated = _as_mcp_integration(updated)
         assert updated is not None
         assert updated.encrypted_stdio_env is not None
 
@@ -1812,6 +1962,7 @@ class TestMCPIntegrationCRUD:
         updated = await integration_service.update_mcp_integration(
             mcp_integration_id=created.id, params=update_params
         )
+        updated = _as_mcp_integration(updated)
 
         assert updated is not None
         assert updated.name == "Updated MCP"
@@ -1839,6 +1990,7 @@ class TestMCPIntegrationCRUD:
         updated = await integration_service.update_mcp_integration(
             mcp_integration_id=created.id, params=update_params
         )
+        updated = _as_mcp_integration(updated)
 
         assert updated is not None
         assert updated.name == created.name  # Unchanged
@@ -1868,6 +2020,7 @@ class TestMCPIntegrationCRUD:
                 auth_type=MCPAuthType.NONE,
             ),
         )
+        updated = _as_mcp_integration(updated)
 
         assert updated is not None
         assert updated.id == created.id
@@ -1902,6 +2055,7 @@ class TestMCPIntegrationCRUD:
                 stdio_env={"EXAMPLE_TOKEN": "secret"},
             ),
         )
+        updated = _as_mcp_integration(updated)
 
         assert updated is not None
         assert updated.id == created.id
@@ -1913,6 +2067,117 @@ class TestMCPIntegrationCRUD:
         assert updated.stdio_command == "npx"
         assert updated.stdio_args == ["@example/server"]
         assert updated.encrypted_stdio_env is not None
+
+    async def test_update_oauth2_clearing_integration_id_starts_discovery(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Editing an OAuth2 row with oauth_integration_id=null re-runs discovery.
+
+        A discovery MCP integration has no OAuth client, so it has no
+        oauth_integration_id. Re-saving it (or editing the URI) from the dialog
+        must route into discovery and surface the authorization redirect instead
+        of failing the OAuth-client validation.
+        """
+        created = MCPIntegration(
+            workspace_id=integration_service.workspace_id,
+            name="Discovery MCP",
+            slug=f"discovery-mcp-{uuid.uuid4().hex[:8]}",
+            server_type="http",
+            server_uri="https://mcp.example.com/mcp",
+            auth_type=MCPAuthType.OAUTH2,
+            oauth_integration_id=None,
+        )
+        session.add(created)
+        await session.commit()
+        assert created.oauth_integration_id is None
+
+        captured: dict[str, object] = {}
+
+        async def fake_discovery(
+            *,
+            params: MCPHttpIntegrationCreate,
+            existing_mcp_integration: MCPIntegration | None = None,
+            **_: object,
+        ) -> PlatformMCPCatalogConnectResult:
+            captured["params"] = params
+            captured["existing"] = existing_mcp_integration
+            return PlatformMCPCatalogConnectResult(
+                mcp_integration=existing_mcp_integration,
+                oauth_connect=IntegrationOAuthConnect(
+                    auth_url="https://auth.example.com/authorize?state=abc",
+                    provider_id="custom_mcp_discovery",
+                ),
+            )
+
+        monkeypatch.setattr(
+            integration_service, "connect_mcp_oauth_discovery", fake_discovery
+        )
+
+        result = await integration_service.update_mcp_integration(
+            mcp_integration_id=created.id,
+            params=MCPIntegrationUpdate(
+                server_type="http",
+                server_uri="https://mcp.example.com/v2/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=None,
+            ),
+            verify_connection=True,
+        )
+
+        assert isinstance(result, PlatformMCPCatalogConnectResult)
+        assert result.oauth_connect is not None
+        # Discovery received the merged target, including the edited server URI.
+        discovery_params = captured["params"]
+        assert isinstance(discovery_params, MCPHttpIntegrationCreate)
+        assert discovery_params.server_uri == "https://mcp.example.com/v2/mcp"
+        assert discovery_params.auth_type == MCPAuthType.OAUTH2
+        assert discovery_params.oauth_integration_id is None
+        assert captured["existing"] is not None
+
+    async def test_update_oauth2_without_clearing_id_still_requires_client(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A partial update that omits oauth_integration_id keeps the old 400.
+
+        Only an explicit null routes into discovery; a bare edit that leaves the
+        field unset must not silently start an OAuth redirect, so the original
+        validation error stands for an OAuth2 row with no client.
+        """
+        created = MCPIntegration(
+            workspace_id=integration_service.workspace_id,
+            name="No Client MCP",
+            slug=f"no-client-mcp-{uuid.uuid4().hex[:8]}",
+            server_type="http",
+            server_uri="https://mcp.example.com/mcp",
+            auth_type=MCPAuthType.OAUTH2,
+            oauth_integration_id=None,
+        )
+        session.add(created)
+        await session.commit()
+        assert created.oauth_integration_id is None
+
+        async def fail_discovery(**_: object) -> PlatformMCPCatalogConnectResult:
+            raise AssertionError("discovery must not run without an explicit null")
+
+        monkeypatch.setattr(
+            integration_service, "connect_mcp_oauth_discovery", fail_discovery
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="oauth_integration_id is required for OAuth 2.0 authentication",
+        ):
+            await integration_service.update_mcp_integration(
+                mcp_integration_id=created.id,
+                params=MCPIntegrationUpdate(description="just a description edit"),
+                verify_connection=True,
+            )
 
     async def test_delete_mcp_integration(
         self,
@@ -2453,6 +2718,7 @@ class TestMCPIntegrationAuthTypeSwapping:
         updated = await integration_service.update_mcp_integration(
             mcp_integration_id=created.id, params=update_params
         )
+        updated = _as_mcp_integration(updated)
 
         assert updated is not None
         assert updated.auth_type == MCPAuthType.OAUTH2
@@ -2481,6 +2747,7 @@ class TestMCPIntegrationAuthTypeSwapping:
         updated = await integration_service.update_mcp_integration(
             mcp_integration_id=created.id, params=update_params
         )
+        updated = _as_mcp_integration(updated)
 
         assert updated is not None
         assert updated.auth_type == MCPAuthType.CUSTOM
@@ -2506,6 +2773,7 @@ class TestMCPIntegrationAuthTypeSwapping:
         updated = await integration_service.update_mcp_integration(
             mcp_integration_id=created.id, params=update_params
         )
+        updated = _as_mcp_integration(updated)
 
         assert updated is not None
         assert updated.auth_type == MCPAuthType.NONE
@@ -2532,6 +2800,7 @@ class TestMCPIntegrationAuthTypeSwapping:
         updated = await integration_service.update_mcp_integration(
             mcp_integration_id=created.id, params=update_params
         )
+        updated = _as_mcp_integration(updated)
 
         assert updated is not None
         assert updated.auth_type == MCPAuthType.CUSTOM
@@ -2569,6 +2838,7 @@ class TestMCPIntegrationAuthTypeSwapping:
         updated = await integration_service.update_mcp_integration(
             mcp_integration_id=created.id, params=update_params
         )
+        updated = _as_mcp_integration(updated)
 
         assert updated is not None
         assert updated.oauth_integration_id == oauth_integration2.id
@@ -2596,6 +2866,7 @@ class TestMCPIntegrationAuthTypeSwapping:
         updated = await integration_service.update_mcp_integration(
             mcp_integration_id=created.id, params=update_params
         )
+        updated = _as_mcp_integration(updated)
 
         assert updated is not None
         assert updated.auth_type == MCPAuthType.OAUTH2
@@ -2621,6 +2892,7 @@ class TestMCPIntegrationAuthTypeSwapping:
         updated = await integration_service.update_mcp_integration(
             mcp_integration_id=created.id, params=update_params
         )
+        updated = _as_mcp_integration(updated)
 
         assert updated is not None
         assert updated.auth_type == MCPAuthType.OAUTH2
@@ -4574,6 +4846,7 @@ class TestMCPOAuthAuthorizationPending:
             params=MCPIntegrationUpdate(name="Pending OAuth MCP renamed"),
             verify_connection=True,
         )
+        updated = _as_mcp_integration(updated)
 
         assert updated is not None
         assert updated.name == "Pending OAuth MCP renamed"

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -417,20 +417,19 @@ class TestMCPIntegrationCRUD:
         assert unlocked.mcp_auth_type == MCPAuthType.NONE
         assert unlocked.state == "connected"
 
-    async def test_platform_mcp_catalog_uses_workspace_row_name_and_description(
+    async def test_platform_mcp_catalog_always_shows_catalog_name_and_description(
         self,
         integration_service: IntegrationService,
         session: AsyncSession,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A renamed workspace row's name/description win over catalog defaults.
+        """Catalog-bound rows display the repo-owned catalog name/description.
 
-        The catalog_slug binds the row to the entry, so the user's rename must
-        persist in the catalog listing rather than being overridden by the
-        repo-owned catalog name/description.
+        Platform catalog entries are not renameable, so the listing always shows
+        the catalog values regardless of what is stored on the workspace row.
         """
         catalog = _catalog_entry(
-            slug="renamable-mcp",
+            slug="fixed-name-mcp",
             name="Catalog Default Name",
             description="Catalog default description",
             connection_spec={
@@ -442,15 +441,17 @@ class TestMCPIntegrationCRUD:
                 "credentials": [],
                 "server_uri": "https://mcp.example.com/mcp",
             },
-            sort_key="0000:renamable-mcp",
+            sort_key="0000:fixed-name-mcp",
         )
         _install_catalog_entry(monkeypatch, catalog)
 
+        # Even if a row somehow carries a different stored name/description, the
+        # listing must not surface it for a catalog-bound entry.
         session.add(
             MCPIntegration(
                 workspace_id=integration_service.workspace_id,
-                name="My Renamed Server",
-                description="My own notes",
+                name="Stale Stored Name",
+                description="Stale stored notes",
                 slug=catalog.slug,
                 catalog_slug=catalog.slug,
                 server_type="http",
@@ -468,8 +469,56 @@ class TestMCPIntegrationCRUD:
         )
 
         item = next(entry for entry in items if entry.slug == catalog.slug)
-        assert item.name == "My Renamed Server"
-        assert item.description == "My own notes"
+        assert item.name == "Catalog Default Name"
+        assert item.description == "Catalog default description"
+
+    async def test_update_mcp_integration_ignores_rename_for_catalog_row(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Name/description edits are ignored for catalog-bound rows."""
+        catalog = _catalog_entry(
+            slug="locked-name-mcp",
+            name="Catalog Default Name",
+            description="Catalog default description",
+            connection_spec={
+                "kind": "http_none",
+                "server_type": "http",
+                "auth_type": "NONE",
+                "requires_config": False,
+                "config_fields": [],
+                "credentials": [],
+                "server_uri": "https://mcp.example.com/mcp",
+            },
+            sort_key="0000:locked-name-mcp",
+        )
+        _install_catalog_entry(monkeypatch, catalog)
+
+        mcp_integration = await integration_service.create_mcp_integration(
+            params=MCPHttpIntegrationCreate(
+                name=catalog.name,
+                description=catalog.description,
+                catalog_slug=catalog.slug,
+                server_uri="https://mcp.example.com/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        original_name = mcp_integration.name
+        original_slug = mcp_integration.slug
+
+        updated = await integration_service.update_mcp_integration(
+            mcp_integration_id=mcp_integration.id,
+            params=MCPIntegrationUpdate(
+                name="Attempted Rename",
+                description="Attempted new description",
+            ),
+        )
+        assert isinstance(updated, MCPIntegration)
+        assert updated.name == original_name
+        assert updated.slug == original_slug
+        assert updated.description == catalog.description
 
     async def test_platform_mcp_catalog_reports_deleted_oauth_row_as_not_connected(
         self,
@@ -2112,8 +2161,11 @@ class TestMCPIntegrationCRUD:
                 ),
             )
 
+        # The update path calls the undecorated impl so editors with only
+        # ``integration:update`` scope are not blocked by the create guard on
+        # the public method; patch the impl the update path actually invokes.
         monkeypatch.setattr(
-            integration_service, "connect_mcp_oauth_discovery", fake_discovery
+            integration_service, "_connect_mcp_oauth_discovery_impl", fake_discovery
         )
 
         result = await integration_service.update_mcp_integration(
@@ -2166,7 +2218,7 @@ class TestMCPIntegrationCRUD:
             raise AssertionError("discovery must not run without an explicit null")
 
         monkeypatch.setattr(
-            integration_service, "connect_mcp_oauth_discovery", fail_discovery
+            integration_service, "_connect_mcp_oauth_discovery_impl", fail_discovery
         )
 
         with pytest.raises(
@@ -2178,6 +2230,131 @@ class TestMCPIntegrationCRUD:
                 params=MCPIntegrationUpdate(description="just a description edit"),
                 verify_connection=True,
             )
+
+    @pytest.mark.parametrize(
+        ("previous_auth_type", "custom_credentials", "expect_headers_kept"),
+        [
+            # OAuth2 -> OAuth2 reconnect without editing headers: omission means
+            # "leave unchanged", so existing additional headers are preserved.
+            pytest.param(MCPAuthType.OAUTH2, None, True, id="oauth_reconnect_keeps"),
+            # CUSTOM -> OAuth2 reconnect without credentials: stale CUSTOM headers
+            # are dropped, mirroring the normal update merge.
+            pytest.param(MCPAuthType.CUSTOM, None, False, id="custom_switch_clears"),
+            # Explicitly cleared additional headers ("") always clear.
+            pytest.param(MCPAuthType.OAUTH2, "", False, id="explicit_empty_clears"),
+        ],
+    )
+    async def test_oauth_discovery_reconnect_header_merge(
+        self,
+        integration_service: IntegrationService,
+        session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+        previous_auth_type: MCPAuthType,
+        custom_credentials: str | None,
+        expect_headers_kept: bool,
+    ) -> None:
+        """Discovery reconnect mirrors the normal update header-merge semantics.
+
+        Secrets are not round-tripped to the form, so an omitted
+        ``custom_credentials`` on an OAuth2 -> OAuth2 reconnect must leave the
+        stored ``encrypted_headers`` untouched, while a CUSTOM -> OAuth2 switch
+        or an explicit empty value clears them.
+        """
+        existing_headers = b"existing-encrypted-headers"
+        created = MCPIntegration(
+            workspace_id=integration_service.workspace_id,
+            name="Reconnect Headers MCP",
+            slug=f"reconnect-headers-mcp-{uuid.uuid4().hex[:8]}",
+            server_type="http",
+            server_uri="https://mcp.example.com/mcp",
+            auth_type=previous_auth_type,
+            oauth_integration_id=None,
+            encrypted_headers=existing_headers,
+        )
+        session.add(created)
+        await session.commit()
+
+        async def fake_discover(
+            *,
+            server_uri: str,
+            allowed_endpoint_hosts: frozenset[str] = frozenset(),
+        ) -> integration_service_module.MCPOAuthDiscoveryEndpoints:
+            _ = server_uri, allowed_endpoint_hosts
+            return integration_service_module.MCPOAuthDiscoveryEndpoints(
+                authorization_endpoint="https://auth.example.com/oauth/authorize",
+                token_endpoint="https://auth.example.com/oauth/token",
+                token_methods=["none"],
+                registration_endpoint="https://mcp.example.com/oauth/register",
+                resource="https://mcp.example.com/mcp",
+            )
+
+        async def fake_register(
+            **_: object,
+        ) -> integration_service_module.MCPOAuthRegistrationResult:
+            return integration_service_module.MCPOAuthRegistrationResult(
+                client_id="dcr-client",
+                client_secret=None,
+                auth_method="none",
+            )
+
+        # Not persisted: ``_create_custom_mcp_oauth_provider`` is mocked, so an
+        # in-memory provider row is enough for the reconnect path.
+        provider_integration = OAuthIntegration(
+            workspace_id=integration_service.workspace_id,
+            provider_id="custom_mcp_reconnect",
+            grant_type=OAuthGrantType.AUTHORIZATION_CODE,
+        )
+
+        async def fake_create_provider(
+            **_: object,
+        ) -> OAuthIntegration:
+            return provider_integration
+
+        async def fake_start_authorization(
+            **_: object,
+        ) -> IntegrationOAuthConnect:
+            return IntegrationOAuthConnect(
+                auth_url="https://auth.example.com/authorize?state=abc",
+                provider_id="custom_mcp_reconnect",
+            )
+
+        monkeypatch.setattr(
+            integration_service, "_discover_mcp_oauth_endpoints", fake_discover
+        )
+        monkeypatch.setattr(
+            integration_service, "_perform_mcp_dynamic_registration", fake_register
+        )
+        monkeypatch.setattr(
+            integration_service,
+            "_create_custom_mcp_oauth_provider",
+            fake_create_provider,
+        )
+        monkeypatch.setattr(
+            integration_service,
+            "_start_custom_mcp_oauth_authorization",
+            fake_start_authorization,
+        )
+
+        await integration_service._connect_mcp_oauth_discovery_impl(
+            params=MCPHttpIntegrationCreate(
+                name="Reconnect Headers MCP",
+                server_uri="https://mcp.example.com/mcp",
+                auth_type=MCPAuthType.OAUTH2,
+                oauth_integration_id=None,
+                custom_credentials=(
+                    SecretStr(custom_credentials)
+                    if custom_credentials is not None
+                    else None
+                ),
+            ),
+            existing_mcp_integration=created,
+        )
+
+        await session.refresh(created)
+        if expect_headers_kept:
+            assert created.encrypted_headers == existing_headers
+        else:
+            assert created.encrypted_headers is None
 
     async def test_delete_mcp_integration(
         self,

--- a/tracecat/integrations/catalog/service.py
+++ b/tracecat/integrations/catalog/service.py
@@ -288,11 +288,20 @@ class PlatformMCPCatalogService(BaseService):
         connection_options = (
             (entry.connection_options or []) if agent_addons_entitled else []
         )
+        # A connected workspace row owns its name/description: the user may have
+        # renamed it after connecting, and the catalog_slug binding keeps it tied
+        # to this entry. Fall back to the catalog defaults only when no row exists.
+        name = mcp_integration.name if mcp_integration else entry.name
+        description = (
+            (mcp_integration.description or "")
+            if mcp_integration
+            else entry.description
+        )
         return PlatformMCPCatalogRead(
             id=entry.id,
             slug=entry.slug,
-            name=entry.name,
-            description=entry.description,
+            name=name,
+            description=description,
             category=entry.category,
             status=cls._catalog_status(entry.status),
             icon_url=entry.icon_url,

--- a/tracecat/integrations/catalog/service.py
+++ b/tracecat/integrations/catalog/service.py
@@ -288,20 +288,11 @@ class PlatformMCPCatalogService(BaseService):
         connection_options = (
             (entry.connection_options or []) if agent_addons_entitled else []
         )
-        # A connected workspace row owns its name/description: the user may have
-        # renamed it after connecting, and the catalog_slug binding keeps it tied
-        # to this entry. Fall back to the catalog defaults only when no row exists.
-        name = mcp_integration.name if mcp_integration else entry.name
-        description = (
-            (mcp_integration.description or "")
-            if mcp_integration
-            else entry.description
-        )
         return PlatformMCPCatalogRead(
             id=entry.id,
             slug=entry.slug,
-            name=name,
-            description=description,
+            name=entry.name,
+            description=entry.description,
             category=entry.category,
             status=cls._catalog_status(entry.status),
             icon_url=entry.icon_url,

--- a/tracecat/integrations/router.py
+++ b/tracecat/integrations/router.py
@@ -277,7 +277,7 @@ async def oauth_callback(
     await session.delete(oauth_state_db)
     await session.commit()
 
-    if svc._is_custom_mcp_oauth_provider(oauth_state_db.provider_id):
+    if svc.is_custom_mcp_oauth_provider(oauth_state_db.provider_id):
         try:
             oauth_integration = await svc.complete_mcp_oauth_discovery_callback(
                 provider_id=oauth_state_db.provider_id,
@@ -897,6 +897,11 @@ async def list_providers(
         items.append(item)
 
     for custom_provider in await svc.list_custom_providers():
+        # custom_mcp_* providers back an MCP integration's OAuth discovery flow
+        # and are managed from the MCP servers page, not as standalone OAuth
+        # integrations — keep them out of the integrations list.
+        if svc.is_custom_mcp_oauth_provider(custom_provider.provider_id):
+            continue
         integration = existing.get(
             (custom_provider.provider_id, custom_provider.grant_type)
         )
@@ -1157,8 +1162,13 @@ async def update_mcp_integration(
     session: AsyncDBSession,
     mcp_integration_id: uuid.UUID,
     params: MCPIntegrationUpdate,
-) -> MCPIntegrationRead:
-    """Update an MCP integration."""
+) -> MCPIntegrationRead | MCPCatalogConnectResponse:
+    """Update an MCP integration.
+
+    Returns an ``MCPCatalogConnectResponse`` when the edit triggers MCP OAuth
+    discovery (an OAuth2 target with ``oauth_integration_id`` explicitly
+    cleared): the caller must follow ``auth_url`` to finish authorization.
+    """
     if role.workspace_id is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1179,17 +1189,23 @@ async def update_mcp_integration(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="MCP integration not found",
             )
+        if isinstance(integration, PlatformMCPCatalogConnectResult):
+            return await _mcp_catalog_connect_response(svc, integration)
     except MCPConnectionVerificationError as exc:
         detail = f"{exc.message}: {exc.error}" if exc.error else exc.message
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=detail,
         ) from exc
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
-        ) from exc
+    except (
+        ProviderConfigurationRequiredError,
+        InsecureOAuthEndpointError,
+        ValueError,
+        httpx.HTTPError,
+    ) as exc:
+        # Plain updates surface ValueError as 400; the discovery branch can also
+        # raise provider/endpoint/HTTP errors, mapped the same way as connect.
+        _raise_mcp_connect_http_error(exc)
 
     return _mcp_integration_read(
         integration,

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -1061,6 +1061,19 @@ class IntegrationService(BaseWorkspaceService):
         catalog_spec: MCPConnectionSpec | None = None,
         existing_mcp_integration: MCPIntegration | None = None,
     ) -> PlatformMCPCatalogConnectResult:
+        return await self._connect_mcp_oauth_discovery_impl(
+            params=params,
+            catalog_spec=catalog_spec,
+            existing_mcp_integration=existing_mcp_integration,
+        )
+
+    async def _connect_mcp_oauth_discovery_impl(
+        self,
+        *,
+        params: MCPHttpIntegrationCreate,
+        catalog_spec: MCPConnectionSpec | None = None,
+        existing_mcp_integration: MCPIntegration | None = None,
+    ) -> PlatformMCPCatalogConnectResult:
         if params.server_type != "http" or params.auth_type != MCPAuthType.OAUTH2:
             raise ValueError("MCP OAuth discovery requires an HTTP OAuth MCP server")
         if params.oauth_integration_id is not None:
@@ -1125,27 +1138,45 @@ class IntegrationService(BaseWorkspaceService):
         )
         if existing_mcp_integration is not None:
             # Apply the merged HTTP OAuth2 target to the existing row. Edit-mode
-            # discovery carries the user's URI/name/timeout edits in ``params``;
-            # the connected client comes from discovery/DCR above.
-            name = params.name.strip()
-            if name != existing_mcp_integration.name:
-                existing_mcp_integration.name = name
-                existing_mcp_integration.slug = (
-                    await self._generate_mcp_integration_slug(name=name)
+            # discovery carries the user's URI/timeout edits in ``params``; the
+            # connected client comes from discovery/DCR above. Catalog-bound rows
+            # take their name/description from the repo-owned catalog entry, so
+            # those edits are ignored here.
+            if existing_mcp_integration.catalog_slug is None:
+                name = params.name.strip()
+                if name != existing_mcp_integration.name:
+                    existing_mcp_integration.name = name
+                    existing_mcp_integration.slug = (
+                        await self._generate_mcp_integration_slug(name=name)
+                    )
+                existing_mcp_integration.description = (
+                    params.description.strip() if params.description else None
                 )
-            existing_mcp_integration.description = (
-                params.description.strip() if params.description else None
-            )
             existing_mcp_integration.server_type = "http"
             existing_mcp_integration.server_uri = params.server_uri.strip()
+            previous_auth_type = existing_mcp_integration.auth_type
             existing_mcp_integration.auth_type = MCPAuthType.OAUTH2
             existing_mcp_integration.oauth_integration_id = oauth_integration.id
             existing_mcp_integration.timeout = params.timeout
             existing_mcp_integration.stdio_command = None
             existing_mcp_integration.stdio_args = None
             existing_mcp_integration.encrypted_stdio_env = None
+            existing_mcp_integration.tools = None
             if used_byo_credentials:
                 # Credentials were consumed into the generated OAuth client.
+                existing_mcp_integration.encrypted_headers = None
+            elif params.custom_credentials is not None:
+                # Non-BYO discovery: mirror the normal update merge so OAuth2
+                # "Additional headers" edits are written, and stale CUSTOM
+                # headers from the previous row are cleared when emptied.
+                custom_credentials = params.custom_credentials.get_secret_value()
+                if custom_credentials:
+                    existing_mcp_integration.encrypted_headers = self._encrypt_token(
+                        custom_credentials
+                    )
+                else:
+                    existing_mcp_integration.encrypted_headers = None
+            elif previous_auth_type == MCPAuthType.CUSTOM:
                 existing_mcp_integration.encrypted_headers = None
             self.session.add(existing_mcp_integration)
             await self.session.commit()
@@ -3539,7 +3570,7 @@ class IntegrationService(BaseWorkspaceService):
                 # field) the original validation error stands, so an accidental
                 # OAuth2 config without a client is still rejected.
                 if oauth_integration_id_was_provided:
-                    return await self.connect_mcp_oauth_discovery(
+                    return await self._connect_mcp_oauth_discovery_impl(
                         params=MCPHttpIntegrationCreate(
                             name=params.name or mcp_integration.name,
                             description=(
@@ -3599,17 +3630,21 @@ class IntegrationService(BaseWorkspaceService):
                 env=params.stdio_env,
             )
 
-        # Update fields
-        if params.name is not None:
-            if params.name.strip() != mcp_integration.name:
-                mcp_integration.name = params.name.strip()
-                mcp_integration.slug = await self._generate_mcp_integration_slug(
-                    name=params.name
+        # Update fields. Catalog-bound rows take their name/description from the
+        # repo-owned catalog entry, so those edits are ignored here; the listing
+        # always displays the catalog values regardless of what is stored.
+        catalog_bound = mcp_integration.catalog_slug is not None
+        if not catalog_bound:
+            if params.name is not None:
+                if params.name.strip() != mcp_integration.name:
+                    mcp_integration.name = params.name.strip()
+                    mcp_integration.slug = await self._generate_mcp_integration_slug(
+                        name=params.name
+                    )
+            if params.description is not None:
+                mcp_integration.description = (
+                    params.description.strip() if params.description else None
                 )
-        if params.description is not None:
-            mcp_integration.description = (
-                params.description.strip() if params.description else None
-            )
 
         if params.server_type is not None:
             mcp_integration.server_type = params.server_type

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -586,7 +586,13 @@ class IntegrationService(BaseWorkspaceService):
     # ------------------------------------------------------------------------
 
     @staticmethod
-    def _is_custom_mcp_oauth_provider(provider_id: str) -> bool:
+    def is_custom_mcp_oauth_provider(provider_id: str) -> bool:
+        """Whether a provider id is owned by the MCP OAuth discovery pipeline.
+
+        These ``custom_mcp_*`` providers are created to back an MCP integration's
+        OAuth flow and are managed from the MCP servers page; they are not
+        user-authored custom OAuth integrations.
+        """
         return provider_id.startswith(_CUSTOM_MCP_OAUTH_PROVIDER_PREFIX)
 
     @staticmethod
@@ -1118,8 +1124,29 @@ class IntegrationService(BaseWorkspaceService):
             scopes=scopes,
         )
         if existing_mcp_integration is not None:
-            existing_mcp_integration.oauth_integration_id = oauth_integration.id
+            # Apply the merged HTTP OAuth2 target to the existing row. Edit-mode
+            # discovery carries the user's URI/name/timeout edits in ``params``;
+            # the connected client comes from discovery/DCR above.
+            name = params.name.strip()
+            if name != existing_mcp_integration.name:
+                existing_mcp_integration.name = name
+                existing_mcp_integration.slug = (
+                    await self._generate_mcp_integration_slug(name=name)
+                )
+            existing_mcp_integration.description = (
+                params.description.strip() if params.description else None
+            )
+            existing_mcp_integration.server_type = "http"
+            existing_mcp_integration.server_uri = params.server_uri.strip()
             existing_mcp_integration.auth_type = MCPAuthType.OAUTH2
+            existing_mcp_integration.oauth_integration_id = oauth_integration.id
+            existing_mcp_integration.timeout = params.timeout
+            existing_mcp_integration.stdio_command = None
+            existing_mcp_integration.stdio_args = None
+            existing_mcp_integration.encrypted_stdio_env = None
+            if used_byo_credentials:
+                # Credentials were consumed into the generated OAuth client.
+                existing_mcp_integration.encrypted_headers = None
             self.session.add(existing_mcp_integration)
             await self.session.commit()
             await self.session.refresh(existing_mcp_integration)
@@ -1732,7 +1759,7 @@ class IntegrationService(BaseWorkspaceService):
             )
             return integration
 
-        if self._is_custom_mcp_oauth_provider(integration.provider_id):
+        if self.is_custom_mcp_oauth_provider(integration.provider_id):
             try:
                 return await self._refresh_custom_mcp_integration(
                     integration=integration,
@@ -2244,7 +2271,7 @@ class IntegrationService(BaseWorkspaceService):
         self, *, integration: OAuthIntegration
     ) -> bool:
         """Return whether OAuth integration is owned by MCP provider lifecycle."""
-        if self._is_custom_mcp_oauth_provider(integration.provider_id):
+        if self.is_custom_mcp_oauth_provider(integration.provider_id):
             return True
         provider_impl = await self.resolve_provider_impl(
             provider_key=ProviderKey(
@@ -2266,7 +2293,7 @@ class IntegrationService(BaseWorkspaceService):
         ]
         # Custom MCP providers own every row linked to them; provider-backed rows
         # must additionally match the provider's server URI and generated slug.
-        if not self._is_custom_mcp_oauth_provider(integration.provider_id):
+        if not self.is_custom_mcp_oauth_provider(integration.provider_id):
             provider_impl = await self.resolve_provider_impl(
                 provider_key=ProviderKey(
                     id=integration.provider_id,
@@ -2563,7 +2590,7 @@ class IntegrationService(BaseWorkspaceService):
         if (
             oauth_integration is None
             or oauth_integration.workspace_id != self.workspace_id
-            or not self._is_custom_mcp_oauth_provider(oauth_integration.provider_id)
+            or not self.is_custom_mcp_oauth_provider(oauth_integration.provider_id)
         ):
             return None
         provider_config = self.get_provider_config(integration=oauth_integration)
@@ -3436,7 +3463,7 @@ class IntegrationService(BaseWorkspaceService):
         mcp_integration_id: uuid.UUID,
         params: MCPIntegrationUpdate,
         verify_connection: bool = False,
-    ) -> MCPIntegration | None:
+    ) -> MCPIntegration | PlatformMCPCatalogConnectResult | None:
         """Update an MCP integration.
 
         With ``verify_connection``, HTTP targets are probed with the merged
@@ -3444,6 +3471,13 @@ class IntegrationService(BaseWorkspaceService):
         probe raises ``MCPConnectionVerificationError`` and leaves the stored
         configuration and verification state untouched; a successful probe
         stores the fresh tool listing alongside the update.
+
+        When the merged target is an OAuth2 HTTP server whose
+        ``oauth_integration_id`` was explicitly cleared (the discovery flow),
+        this starts MCP OAuth discovery — the same path create-mode uses — and
+        returns a ``PlatformMCPCatalogConnectResult`` carrying the authorization
+        redirect instead of persisting an OAuth2 row that has no client and can
+        never connect.
         """
         mcp_integration = await self.get_mcp_integration(
             mcp_integration_id=mcp_integration_id
@@ -3496,6 +3530,33 @@ class IntegrationService(BaseWorkspaceService):
                         "OAuth integration not found or does not belong to workspace"
                     )
             elif target_auth_type == MCPAuthType.OAUTH2:
+                # The merged target is OAuth2 with no client. When the caller
+                # explicitly cleared oauth_integration_id (the edit dialog's
+                # "MCP OAuth discovery" flow), start discovery/DCR against the
+                # server and update this row in place — mirroring create mode,
+                # which accepts OAuth2 without a client for discovery servers.
+                # Without an explicit null (a raw partial update that omits the
+                # field) the original validation error stands, so an accidental
+                # OAuth2 config without a client is still rejected.
+                if oauth_integration_id_was_provided:
+                    return await self.connect_mcp_oauth_discovery(
+                        params=MCPHttpIntegrationCreate(
+                            name=params.name or mcp_integration.name,
+                            description=(
+                                params.description
+                                if params.description is not None
+                                else mcp_integration.description
+                            ),
+                            timeout=params.timeout or mcp_integration.timeout or 30,
+                            catalog_slug=mcp_integration.catalog_slug,
+                            server_type="http",
+                            server_uri=target_server_uri,
+                            auth_type=MCPAuthType.OAUTH2,
+                            oauth_integration_id=None,
+                            custom_credentials=params.custom_credentials,
+                        ),
+                        existing_mcp_integration=mcp_integration,
+                    )
                 raise ValueError(
                     "oauth_integration_id is required for OAuth 2.0 authentication"
                 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Routes provider-backed MCP catalog entries to the MCP integration dialog and unifies OAuth discovery across create and edit. Also hides discovery-owned OAuth providers and tightens catalog UX with clearer testing and catalog-bound naming.

- **Bug Fixes**
  - Discovery entries (e.g., GitHub, Atlassian) open the MCP dialog, not the standalone OAuth dialog.
  - Test Connection is disabled for OAuth2 HTTP servers until an authorized token exists, with a clear tooltip.
  - Catalog-bound rows always use the catalog’s name/description; the dialog hides these inputs and rename edits are ignored.
  - `/providers` excludes `custom_mcp_*` discovery-owned OAuth providers.

- **New Features**
  - Editing an OAuth2 MCP integration with `oauth_integration_id: null` starts discovery and returns `MCPCatalogConnectResponse` with `auth_url`; the UI redirects and shows “Continue OAuth authorization”.
  - MCP OAuth discovery is fully backend-driven (client creation and DCR); the dialog routes pasted credentials through discovery rather than creating providers.
  - `updateMcpIntegration` now returns `MCPIntegrationRead | MCPCatalogConnectResponse`; `frontend` narrows the union and handles redirects.

<sup>Written for commit 23d20ced48875160ee0eaa3f40890c743b3ae399. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

