### PR TITLE
feat(workspace): add GitHub App repository selector

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -13386,6 +13386,78 @@ export const $GitHubAppPermissions = {
   description: "Type definition for GitHub App default permissions.",
 } as const
 
+export const $GitHubAppRepository = {
+  properties: {
+    id: {
+      type: "integer",
+      title: "Id",
+    },
+    name: {
+      type: "string",
+      title: "Name",
+    },
+    full_name: {
+      type: "string",
+      title: "Full Name",
+    },
+    private: {
+      type: "boolean",
+      title: "Private",
+    },
+    default_branch: {
+      type: "string",
+      title: "Default Branch",
+    },
+    git_url: {
+      type: "string",
+      title: "Git Url",
+    },
+    html_url: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Html Url",
+    },
+    installation_id: {
+      type: "integer",
+      title: "Installation Id",
+    },
+    installation_account: {
+      type: "string",
+      title: "Installation Account",
+    },
+    installation_account_type: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Installation Account Type",
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "name",
+    "full_name",
+    "private",
+    "default_branch",
+    "git_url",
+    "installation_id",
+    "installation_account",
+  ],
+  title: "GitHubAppRepository",
+  description: "Repository granted to the configured GitHub App installation.",
+} as const
+
 export const $GitHubWebhookAttributes = {
   properties: {
     url: {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -860,6 +860,8 @@ import type {
   WorkflowsListWorkflowCommitsResponse,
   WorkflowsListWorkflowDefinitionsData,
   WorkflowsListWorkflowDefinitionsResponse,
+  WorkflowsListWorkflowRepositoriesData,
+  WorkflowsListWorkflowRepositoriesResponse,
   WorkflowsListWorkflowsData,
   WorkflowsListWorkflowsResponse,
   WorkflowsMoveWorkflowToFolderData,
@@ -3222,6 +3224,29 @@ export const workflowsPublishWorkflow = (
     },
     body: data.requestBody,
     mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * List Workflow Repositories
+ * List repositories granted to the configured GitHub App installation.
+ * @param data The data for the request.
+ * @param data.workspaceId
+ * @returns GitHubAppRepository Successful Response
+ * @throws ApiError
+ */
+export const workflowsListWorkflowRepositories = (
+  data: WorkflowsListWorkflowRepositoriesData
+): CancelablePromise<WorkflowsListWorkflowRepositoriesResponse> => {
+  return __request(OpenAPI, {
+    method: "GET",
+    url: "/workspaces/{workspace_id}/workflows/sync/repositories",
+    path: {
+      workspace_id: data.workspaceId,
+    },
     errors: {
       422: "Validation Error",
     },

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3993,6 +3993,22 @@ export type GitHubAppPermissions = {
 }
 
 /**
+ * Repository granted to the configured GitHub App installation.
+ */
+export type GitHubAppRepository = {
+  id: number
+  name: string
+  full_name: string
+  private: boolean
+  default_branch: string
+  git_url: string
+  html_url?: string | null
+  installation_id: number
+  installation_account: string
+  installation_account_type?: string | null
+}
+
+/**
  * Type definition for GitHub webhook attributes.
  */
 export type GitHubWebhookAttributes = {
@@ -10152,6 +10168,13 @@ export type WorkflowsPublishWorkflowData = {
 
 export type WorkflowsPublishWorkflowResponse = WorkflowDslPublishResult
 
+export type WorkflowsListWorkflowRepositoriesData = {
+  workspaceId: string
+}
+
+export type WorkflowsListWorkflowRepositoriesResponse =
+  Array<GitHubAppRepository>
+
 export type WorkflowsListWorkflowCommitsData = {
   /**
    * Branch name to fetch commits from
@@ -14346,6 +14369,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: WorkflowDslPublishResult
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/workflows/sync/repositories": {
+    get: {
+      req: WorkflowsListWorkflowRepositoriesData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<GitHubAppRepository>
         /**
          * Validation Error
          */

--- a/frontend/src/components/organization/workflow-pull-dialog.tsx
+++ b/frontend/src/components/organization/workflow-pull-dialog.tsx
@@ -27,6 +27,7 @@ import {
   useWorkflowSync,
 } from "@/hooks/use-workspace-sync"
 import { getRelativeTime } from "@/lib/event-history"
+import { getGitSshUrlRef } from "@/lib/git"
 
 interface WorkflowPullDialogProps {
   open: boolean
@@ -50,13 +51,17 @@ export function WorkflowPullDialog({
 
   // Use hooks for workflow sync operations
   const { pullWorkflows, pullWorkflowsIsPending } = useWorkflowSync(workspaceId)
+  const gitRepoBranch = getGitSshUrlRef(gitRepoUrl)
 
   // Fetch commits for the repository
   const {
     commits,
     commitsIsLoading: commitsLoading,
     commitsError,
-  } = useRepositoryCommits(workspaceId, { enabled: open })
+  } = useRepositoryCommits(workspaceId, {
+    branch: gitRepoBranch ?? undefined,
+    enabled: open,
+  })
 
   // Auto-select HEAD commit when commits are loaded
   useEffect(() => {

--- a/frontend/src/components/settings/workspace-sync-settings.tsx
+++ b/frontend/src/components/settings/workspace-sync-settings.tsx
@@ -83,8 +83,11 @@ export function WorkspaceSyncSettings({
   )
   const [repositoryInputMode, setRepositoryInputMode] =
     useState<RepositoryInputMode>("select")
+  const [hasSelectedRepositoryInputMode, setHasSelectedRepositoryInputMode] =
+    useState(false)
   useEffect(() => {
     if (
+      !hasSelectedRepositoryInputMode &&
       hasRepositoryOptions &&
       !repositoriesIsLoading &&
       currentGitRepoUrl &&
@@ -95,9 +98,15 @@ export function WorkspaceSyncSettings({
   }, [
     currentGitRepoUrl,
     currentGitUrlMatchesRepository,
+    hasSelectedRepositoryInputMode,
     hasRepositoryOptions,
     repositoriesIsLoading,
   ])
+  function handleRepositoryInputModeChange(mode: RepositoryInputMode) {
+    setHasSelectedRepositoryInputMode(true)
+    setRepositoryInputMode(mode)
+  }
+
   const shouldShowRepositoryModeTabs =
     hasRepositoryOptions && !repositoriesIsLoading
   const shouldShowRepositorySelect =
@@ -134,7 +143,7 @@ export function WorkspaceSyncSettings({
                       size="sm"
                       showTooltips={false}
                       value={repositoryInputMode}
-                      onValueChange={setRepositoryInputMode}
+                      onValueChange={handleRepositoryInputModeChange}
                       options={[
                         { value: "select", content: "Select" },
                         { value: "manual", content: "Manual" },

--- a/frontend/src/components/settings/workspace-sync-settings.tsx
+++ b/frontend/src/components/settings/workspace-sync-settings.tsx
@@ -2,8 +2,8 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { GitPullRequestIcon } from "lucide-react"
-import { useState } from "react"
-import { useForm } from "react-hook-form"
+import { useEffect, useState } from "react"
+import { useForm, useWatch } from "react-hook-form"
 import { z } from "zod"
 import type { GitHubAppRepository, WorkspaceRead } from "@/client"
 import { Button } from "@/components/ui/button"
@@ -25,6 +25,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { ToggleTabs } from "@/components/ui/toggle-tabs"
 import { validateGitSshUrl } from "@/lib/git"
 import { useGitHubAppRepositories, useWorkspaceSettings } from "@/lib/hooks"
 import { WorkflowPullDialog } from "../organization/workflow-pull-dialog"
@@ -38,6 +39,7 @@ export const syncSettingsSchema = z.object({
 })
 
 type SyncSettingsForm = z.infer<typeof syncSettingsSchema>
+type RepositoryInputMode = "select" | "manual"
 
 interface WorkspaceSyncSettingsProps {
   workspace: WorkspaceRead
@@ -61,6 +63,10 @@ export function WorkspaceSyncSettings({
       git_repo_url: workspace.settings?.git_repo_url || "",
     },
   })
+  const currentGitRepoUrl = useWatch({
+    control: form.control,
+    name: "git_repo_url",
+  })
 
   async function onSubmit(values: SyncSettingsForm) {
     await updateWorkspace({
@@ -72,13 +78,38 @@ export function WorkspaceSyncSettings({
 
   const persistedGitUrl = workspace.settings?.git_repo_url || undefined
   const hasRepositoryOptions = repositories.length > 0
+  const currentGitUrlMatchesRepository = repositories.some(
+    (repository) => repository.git_url === currentGitRepoUrl
+  )
+  const [repositoryInputMode, setRepositoryInputMode] =
+    useState<RepositoryInputMode>("select")
+  useEffect(() => {
+    if (
+      hasRepositoryOptions &&
+      !repositoriesIsLoading &&
+      currentGitRepoUrl &&
+      !currentGitUrlMatchesRepository
+    ) {
+      setRepositoryInputMode("manual")
+    }
+  }, [
+    currentGitRepoUrl,
+    currentGitUrlMatchesRepository,
+    hasRepositoryOptions,
+    repositoriesIsLoading,
+  ])
+  const shouldShowRepositoryModeTabs =
+    hasRepositoryOptions && !repositoriesIsLoading
   const shouldShowRepositorySelect =
-    repositoriesIsLoading || hasRepositoryOptions
+    repositoriesIsLoading ||
+    (hasRepositoryOptions && repositoryInputMode === "select")
   let repositoryDescription =
     "Git URL of the remote repository. Must use git+ssh scheme."
-  if (hasRepositoryOptions) {
+  if (hasRepositoryOptions && repositoryInputMode === "select") {
     repositoryDescription =
       "Select a repository granted to the connected GitHub App installation."
+  } else if (hasRepositoryOptions) {
+    repositoryDescription = "Enter any valid git+ssh URL manually."
   } else if (repositoriesError) {
     repositoryDescription =
       "Could not load GitHub App repositories. Enter a git+ssh URL manually."
@@ -96,7 +127,21 @@ export function WorkspaceSyncSettings({
             name="git_repo_url"
             render={({ field, fieldState }) => (
               <FormItem className="flex flex-col">
-                <FormLabel>Remote repository URL</FormLabel>
+                <div className="flex items-center justify-between gap-3">
+                  <FormLabel>Remote repository URL</FormLabel>
+                  {shouldShowRepositoryModeTabs && (
+                    <ToggleTabs<RepositoryInputMode>
+                      size="sm"
+                      showTooltips={false}
+                      value={repositoryInputMode}
+                      onValueChange={setRepositoryInputMode}
+                      options={[
+                        { value: "select", content: "Select" },
+                        { value: "manual", content: "Manual" },
+                      ]}
+                    />
+                  )}
+                </div>
                 {shouldShowRepositorySelect ? (
                   <Select
                     disabled={repositoriesIsLoading}

--- a/frontend/src/components/settings/workspace-sync-settings.tsx
+++ b/frontend/src/components/settings/workspace-sync-settings.tsx
@@ -5,7 +5,7 @@ import { GitPullRequestIcon } from "lucide-react"
 import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
-import type { WorkspaceRead } from "@/client"
+import type { GitHubAppRepository, WorkspaceRead } from "@/client"
 import { Button } from "@/components/ui/button"
 import {
   Form,
@@ -17,8 +17,16 @@ import {
   FormMessage,
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { validateGitSshUrl } from "@/lib/git"
-import { useWorkspaceSettings } from "@/lib/hooks"
+import { useGitHubAppRepositories, useWorkspaceSettings } from "@/lib/hooks"
 import { WorkflowPullDialog } from "../organization/workflow-pull-dialog"
 
 export const syncSettingsSchema = z.object({
@@ -40,6 +48,11 @@ export function WorkspaceSyncSettings({
 }: WorkspaceSyncSettingsProps) {
   const [pullDialogOpen, setPullDialogOpen] = useState(false)
   const { updateWorkspace, isUpdating } = useWorkspaceSettings(workspace.id)
+  const {
+    repositories = [],
+    repositoriesIsLoading,
+    repositoriesError,
+  } = useGitHubAppRepositories(workspace.id)
 
   const form = useForm<SyncSettingsForm>({
     resolver: zodResolver(syncSettingsSchema),
@@ -58,29 +71,79 @@ export function WorkspaceSyncSettings({
   }
 
   const persistedGitUrl = workspace.settings?.git_repo_url || undefined
+  const hasRepositoryOptions = repositories.length > 0
+  const shouldShowRepositorySelect =
+    repositoriesIsLoading || hasRepositoryOptions
+  let repositoryDescription =
+    "Git URL of the remote repository. Must use git+ssh scheme."
+  if (hasRepositoryOptions) {
+    repositoryDescription =
+      "Select a repository granted to the connected GitHub App installation."
+  } else if (repositoriesError) {
+    repositoryDescription =
+      "Could not load GitHub App repositories. Enter a git+ssh URL manually."
+  }
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-col gap-6">
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="flex flex-col gap-6"
+        >
           <FormField
             control={form.control}
             name="git_repo_url"
-            render={({ field }) => (
+            render={({ field, fieldState }) => (
               <FormItem className="flex flex-col">
                 <FormLabel>Remote repository URL</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="git+ssh://someuser@git.example.com/my-org/my-repo.git"
-                    {...field}
+                {shouldShowRepositorySelect ? (
+                  <Select
+                    disabled={repositoriesIsLoading}
+                    onValueChange={field.onChange}
                     value={field.value ?? ""}
-                  />
-                </FormControl>
-                <FormDescription>
-                  Git URL of the remote repository. Must use{" "}
-                  <span className="font-mono tracking-tighter">git+ssh</span>{" "}
-                  scheme.
-                </FormDescription>
+                  >
+                    <FormControl>
+                      <SelectTrigger aria-invalid={fieldState.invalid}>
+                        <SelectValue
+                          placeholder={
+                            repositoriesIsLoading
+                              ? "Loading repositories..."
+                              : "Select a repository"
+                          }
+                        />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectGroup>
+                        {field.value &&
+                          !repositories.some(
+                            (repository) => repository.git_url === field.value
+                          ) && (
+                            <SelectItem value={field.value}>
+                              {field.value}
+                            </SelectItem>
+                          )}
+                        {repositories.map((repository) => (
+                          <RepositorySelectItem
+                            key={`${repository.installation_id}:${repository.id}`}
+                            repository={repository}
+                          />
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <FormControl>
+                    <Input
+                      aria-invalid={fieldState.invalid}
+                      placeholder="git+ssh://git@github.com/my-org/my-repo.git"
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                )}
+                <FormDescription>{repositoryDescription}</FormDescription>
                 <FormMessage />
               </FormItem>
             )}
@@ -107,7 +170,7 @@ export function WorkspaceSyncSettings({
               variant="outline"
               size="sm"
               onClick={() => setPullDialogOpen(true)}
-              className="flex items-center space-x-2"
+              className="flex items-center gap-2"
             >
               <GitPullRequestIcon className="size-4" />
               <span>Pull workflows</span>
@@ -133,5 +196,15 @@ export function WorkspaceSyncSettings({
         }}
       />
     </div>
+  )
+}
+
+function RepositorySelectItem({
+  repository,
+}: {
+  repository: GitHubAppRepository
+}) {
+  return (
+    <SelectItem value={repository.git_url}>{repository.full_name}</SelectItem>
   )
 }

--- a/frontend/src/components/settings/workspace-sync-settings.tsx
+++ b/frontend/src/components/settings/workspace-sync-settings.tsx
@@ -69,17 +69,24 @@ export function WorkspaceSyncSettings({
   })
 
   async function onSubmit(values: SyncSettingsForm) {
+    const selectedRepository =
+      repositoryInputMode === "select"
+        ? findMatchingRepository(values.git_repo_url, repositories)
+        : undefined
+
     await updateWorkspace({
       settings: {
-        git_repo_url: values.git_repo_url,
+        git_repo_url: selectedRepository
+          ? getRepositoryGitUrl(selectedRepository)
+          : values.git_repo_url,
       },
     })
   }
 
   const persistedGitUrl = workspace.settings?.git_repo_url || undefined
   const hasRepositoryOptions = repositories.length > 0
-  const currentGitUrlMatchesRepository = repositories.some(
-    (repository) => repository.git_url === currentGitRepoUrl
+  const currentGitUrlMatchesRepository = repositories.some((repository) =>
+    matchesRepositoryGitUrl(currentGitRepoUrl, repository)
   )
   const [repositoryInputMode, setRepositoryInputMode] =
     useState<RepositoryInputMode>("select")
@@ -154,8 +161,15 @@ export function WorkspaceSyncSettings({
                 {shouldShowRepositorySelect ? (
                   <Select
                     disabled={repositoriesIsLoading}
-                    onValueChange={field.onChange}
-                    value={field.value ?? ""}
+                    onValueChange={(value) => {
+                      const repository = repositories.find(
+                        (repo) => repo.git_url === value
+                      )
+                      field.onChange(
+                        repository ? getRepositoryGitUrl(repository) : value
+                      )
+                    }}
+                    value={getRepositorySelectValue(field.value, repositories)}
                   >
                     <FormControl>
                       <SelectTrigger aria-invalid={fieldState.invalid}>
@@ -171,8 +185,8 @@ export function WorkspaceSyncSettings({
                     <SelectContent>
                       <SelectGroup>
                         {field.value &&
-                          !repositories.some(
-                            (repository) => repository.git_url === field.value
+                          !repositories.some((repository) =>
+                            matchesRepositoryGitUrl(field.value, repository)
                           ) && (
                             <SelectItem value={field.value}>
                               {field.value}
@@ -261,4 +275,38 @@ function RepositorySelectItem({
   return (
     <SelectItem value={repository.git_url}>{repository.full_name}</SelectItem>
   )
+}
+
+function getRepositoryGitUrl(repository: GitHubAppRepository) {
+  const defaultBranch = repository.default_branch.trim()
+  if (!defaultBranch || defaultBranch === "main") {
+    return repository.git_url
+  }
+  return `${repository.git_url}@${defaultBranch}`
+}
+
+function matchesRepositoryGitUrl(
+  gitUrl: string | null | undefined,
+  repository: GitHubAppRepository
+) {
+  return (
+    gitUrl === repository.git_url || gitUrl === getRepositoryGitUrl(repository)
+  )
+}
+
+function findMatchingRepository(
+  gitUrl: string | null | undefined,
+  repositories: GitHubAppRepository[]
+) {
+  return repositories.find((repository) =>
+    matchesRepositoryGitUrl(gitUrl, repository)
+  )
+}
+
+function getRepositorySelectValue(
+  gitUrl: string | null | undefined,
+  repositories: GitHubAppRepository[]
+) {
+  const repository = findMatchingRepository(gitUrl, repositories)
+  return repository?.git_url ?? gitUrl ?? ""
 }

--- a/frontend/src/components/settings/workspace-sync-settings.tsx
+++ b/frontend/src/components/settings/workspace-sync-settings.tsx
@@ -51,10 +51,11 @@ export function WorkspaceSyncSettings({
   const [pullDialogOpen, setPullDialogOpen] = useState(false)
   const { updateWorkspace, isUpdating } = useWorkspaceSettings(workspace.id)
   const {
-    repositories = [],
+    repositories: queriedRepositories = [],
     repositoriesIsLoading,
     repositoriesError,
   } = useGitHubAppRepositories(workspace.id)
+  const repositories = repositoriesError ? [] : queriedRepositories
 
   const form = useForm<SyncSettingsForm>({
     resolver: zodResolver(syncSettingsSchema),

--- a/frontend/src/components/settings/workspace-sync-settings.tsx
+++ b/frontend/src/components/settings/workspace-sync-settings.tsx
@@ -51,11 +51,10 @@ export function WorkspaceSyncSettings({
   const [pullDialogOpen, setPullDialogOpen] = useState(false)
   const { updateWorkspace, isUpdating } = useWorkspaceSettings(workspace.id)
   const {
-    repositories: queriedRepositories = [],
+    repositories = [],
     repositoriesIsLoading,
     repositoriesError,
   } = useGitHubAppRepositories(workspace.id)
-  const repositories = repositoriesError ? [] : queriedRepositories
 
   const form = useForm<SyncSettingsForm>({
     resolver: zodResolver(syncSettingsSchema),

--- a/frontend/src/lib/git.ts
+++ b/frontend/src/lib/git.ts
@@ -93,3 +93,13 @@ export function validateGitSshUrl(
       "Must be a valid Git SSH URL (e.g., git+ssh://<user>@github.com/org/repo.git)",
   })
 }
+
+/**
+ * Extract the optional ref suffix from a git+ssh URL.
+ */
+export function getGitSshUrlRef(url: string | null | undefined) {
+  if (!url) return null
+
+  const match = GIT_SSH_URL_REGEX.exec(url)
+  return match?.groups?.ref ?? null
+}

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -1,5 +1,6 @@
 import {
   type Query,
+  type QueryClient,
   useMutation,
   useQuery,
   useQueryClient,
@@ -2672,6 +2673,13 @@ export function useGitHubAppRepositories(workspaceId: string) {
   }
 }
 
+function clearGitHubAppRepositoryQueries(queryClient: QueryClient) {
+  queryClient.setQueriesData<WorkflowsListWorkflowRepositoriesResponse>(
+    { queryKey: ["github-app-repositories"] },
+    []
+  )
+}
+
 export function useGitHubAppCredentials() {
   const queryClient = useQueryClient()
 
@@ -2685,6 +2693,7 @@ export function useGitHubAppCredentials() {
       return await vcsSaveGithubAppCredentials({ requestBody: data })
     },
     onSuccess: () => {
+      clearGitHubAppRepositoryQueries(queryClient)
       // Invalidate and refetch credentials status
       queryClient.invalidateQueries({
         queryKey: ["github-app-credentials-status"],
@@ -2708,6 +2717,7 @@ export function useDeleteGitHubAppCredentials() {
       await vcsDeleteGithubAppCredentials()
     },
     onSuccess: () => {
+      clearGitHubAppRepositoryQueries(queryClient)
       queryClient.invalidateQueries({
         queryKey: ["github-app-credentials-status"],
       })

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -338,6 +338,7 @@ import {
   type WorkflowReadMinimal,
   type WorkflowsAddTagData,
   type WorkflowsCreateWorkflowData,
+  type WorkflowsListWorkflowRepositoriesResponse,
   type WorkflowsMoveWorkflowToFolderData,
   type WorkflowsRemoveTagData,
   type WorkspaceCreate,
@@ -351,6 +352,7 @@ import {
   workflowsAddTag,
   workflowsCreateWorkflow,
   workflowsDeleteWorkflow,
+  workflowsListWorkflowRepositories,
   workflowsListWorkflows,
   workflowsMoveWorkflowToFolder,
   workflowsRemoveTag,
@@ -2645,6 +2647,31 @@ export function useGitHubAppCredentialsStatus() {
   }
 }
 
+/**
+ * Fetch repositories granted to the configured GitHub App installation.
+ */
+export function useGitHubAppRepositories(workspaceId: string) {
+  const {
+    data: repositories,
+    isLoading: repositoriesIsLoading,
+    error: repositoriesError,
+    refetch: refetchRepositories,
+  } = useQuery<WorkflowsListWorkflowRepositoriesResponse>({
+    queryKey: ["github-app-repositories", workspaceId],
+    queryFn: async () =>
+      await workflowsListWorkflowRepositories({ workspaceId }),
+    enabled: Boolean(workspaceId),
+    retry: false,
+  })
+
+  return {
+    repositories,
+    repositoriesIsLoading,
+    repositoriesError,
+    refetchRepositories,
+  }
+}
+
 export function useGitHubAppCredentials() {
   const queryClient = useQueryClient()
 
@@ -2661,6 +2688,9 @@ export function useGitHubAppCredentials() {
       // Invalidate and refetch credentials status
       queryClient.invalidateQueries({
         queryKey: ["github-app-credentials-status"],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["github-app-repositories"],
       })
     },
   })
@@ -2680,6 +2710,9 @@ export function useDeleteGitHubAppCredentials() {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["github-app-credentials-status"],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["github-app-repositories"],
       })
     },
   })

--- a/frontend/tests/github-app-credentials-hooks.test.tsx
+++ b/frontend/tests/github-app-credentials-hooks.test.tsx
@@ -1,0 +1,103 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook } from "@testing-library/react"
+import type { ReactNode } from "react"
+import type { GitHubAppRepository } from "@/client"
+import {
+  vcsDeleteGithubAppCredentials,
+  vcsSaveGithubAppCredentials,
+} from "@/client"
+import {
+  useDeleteGitHubAppCredentials,
+  useGitHubAppCredentials,
+} from "@/lib/hooks"
+
+jest.mock("@/client", () => {
+  const actual = jest.requireActual("@/client")
+  return {
+    ...actual,
+    vcsDeleteGithubAppCredentials: jest.fn(),
+    vcsSaveGithubAppCredentials: jest.fn(),
+  }
+})
+
+const mockSaveGitHubAppCredentials =
+  vcsSaveGithubAppCredentials as jest.MockedFunction<
+    typeof vcsSaveGithubAppCredentials
+  >
+
+const mockDeleteGitHubAppCredentials =
+  vcsDeleteGithubAppCredentials as jest.MockedFunction<
+    typeof vcsDeleteGithubAppCredentials
+  >
+
+const cachedRepositories: GitHubAppRepository[] = [
+  {
+    id: 1,
+    name: "repo-a",
+    full_name: "test-org/repo-a",
+    private: true,
+    default_branch: "main",
+    git_url: "git+ssh://git@github.com/test-org/repo-a.git",
+    html_url: "https://github.com/test-org/repo-a",
+    installation_id: 12345678,
+    installation_account: "test-org",
+    installation_account_type: "Organization",
+  },
+]
+
+describe("GitHub App credential hooks", () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    })
+    jest.clearAllMocks()
+    mockSaveGitHubAppCredentials.mockResolvedValue({ status: "ok" })
+    mockDeleteGitHubAppCredentials.mockResolvedValue(undefined)
+  })
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+
+  it("clears cached repository options when credentials are saved", async () => {
+    queryClient.setQueryData(
+      ["github-app-repositories", "workspace-1"],
+      cachedRepositories
+    )
+
+    const { result } = renderHook(() => useGitHubAppCredentials(), { wrapper })
+
+    await result.current.saveCredentials.mutateAsync({
+      app_id: "123456",
+      private_key: "private-key",
+    })
+
+    expect(
+      queryClient.getQueryData(["github-app-repositories", "workspace-1"])
+    ).toEqual([])
+  })
+
+  it("clears cached repository options when credentials are deleted", async () => {
+    queryClient.setQueryData(
+      ["github-app-repositories", "workspace-1"],
+      cachedRepositories
+    )
+
+    const { result } = renderHook(() => useDeleteGitHubAppCredentials(), {
+      wrapper,
+    })
+
+    await result.current.deleteCredentials.mutateAsync()
+
+    expect(
+      queryClient.getQueryData(["github-app-repositories", "workspace-1"])
+    ).toEqual([])
+  })
+})

--- a/frontend/tests/workflow-pull-dialog.test.tsx
+++ b/frontend/tests/workflow-pull-dialog.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from "@testing-library/react"
+import { WorkflowPullDialog } from "@/components/organization/workflow-pull-dialog"
+import {
+  useRepositoryCommits,
+  useWorkflowSync,
+} from "@/hooks/use-workspace-sync"
+
+const mockPullWorkflows = jest.fn()
+
+jest.mock("@/hooks/use-workspace-sync", () => ({
+  useRepositoryCommits: jest.fn(),
+  useWorkflowSync: jest.fn(),
+}))
+
+jest.mock("@/components/registry/commit-selector", () => ({
+  CommitSelector: () => null,
+}))
+
+describe("WorkflowPullDialog", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(useWorkflowSync).mockReturnValue({
+      pullWorkflows: mockPullWorkflows,
+      pullWorkflowsIsPending: false,
+      pullWorkflowsError: null,
+    } as ReturnType<typeof useWorkflowSync>)
+    jest.mocked(useRepositoryCommits).mockReturnValue({
+      commits: [],
+      commitsIsLoading: false,
+      commitsError: null,
+    } as ReturnType<typeof useRepositoryCommits>)
+  })
+
+  it("loads commits from the branch encoded in the workspace git URL", () => {
+    render(
+      <WorkflowPullDialog
+        open={true}
+        onOpenChange={jest.fn()}
+        workspaceId="workspace-1"
+        gitRepoUrl="git+ssh://git@github.com/test-org/repo-b.git@trunk"
+      />
+    )
+
+    expect(useRepositoryCommits).toHaveBeenCalledWith("workspace-1", {
+      branch: "trunk",
+      enabled: true,
+    })
+  })
+})

--- a/frontend/tests/workspace-sync-settings.test.tsx
+++ b/frontend/tests/workspace-sync-settings.test.tsx
@@ -55,6 +55,18 @@ const repositories: GitHubAppRepository[] = [
     installation_account: "test-org",
     installation_account_type: "Organization",
   },
+  {
+    id: 2,
+    name: "repo-b",
+    full_name: "test-org/repo-b",
+    private: true,
+    default_branch: "trunk",
+    git_url: "git+ssh://git@github.com/test-org/repo-b.git",
+    html_url: "https://github.com/test-org/repo-b",
+    installation_id: 12345678,
+    installation_account: "test-org",
+    installation_account_type: "Organization",
+  },
 ]
 
 const workspace = {
@@ -137,6 +149,25 @@ describe("WorkspaceSyncSettings", () => {
       expect(mockUpdateWorkspace).toHaveBeenCalledWith({
         settings: {
           git_repo_url: repositories[0].git_url,
+        },
+      })
+    })
+  })
+
+  it("preserves a selected app repository's non-main default branch", async () => {
+    const user = userEvent.setup()
+    render(<WorkspaceSyncSettings workspace={setupHooks()} />)
+
+    await user.click(screen.getByRole("combobox"))
+    await user.click(
+      await screen.findByRole("option", { name: "test-org/repo-b" })
+    )
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(mockUpdateWorkspace).toHaveBeenCalledWith({
+        settings: {
+          git_repo_url: `${repositories[1].git_url}@trunk`,
         },
       })
     })

--- a/frontend/tests/workspace-sync-settings.test.tsx
+++ b/frontend/tests/workspace-sync-settings.test.tsx
@@ -19,6 +19,29 @@ jest.mock("@/components/organization/workflow-pull-dialog", () => ({
   WorkflowPullDialog: () => null,
 }))
 
+beforeAll(() => {
+  if (!HTMLElement.prototype.hasPointerCapture) {
+    Object.defineProperty(HTMLElement.prototype, "hasPointerCapture", {
+      value: () => false,
+    })
+  }
+  if (!HTMLElement.prototype.setPointerCapture) {
+    Object.defineProperty(HTMLElement.prototype, "setPointerCapture", {
+      value: () => undefined,
+    })
+  }
+  if (!HTMLElement.prototype.releasePointerCapture) {
+    Object.defineProperty(HTMLElement.prototype, "releasePointerCapture", {
+      value: () => undefined,
+    })
+  }
+  if (!HTMLElement.prototype.scrollIntoView) {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      value: () => undefined,
+    })
+  }
+})
+
 const repositories: GitHubAppRepository[] = [
   {
     id: 1,
@@ -47,8 +70,10 @@ const workspace = {
 
 function setupHooks({
   gitRepoUrl = null,
+  repositoryHook = {},
 }: {
   gitRepoUrl?: string | null
+  repositoryHook?: Partial<ReturnType<typeof useGitHubAppRepositories>>
 } = {}) {
   jest.mocked(useWorkspaceSettings).mockReturnValue({
     updateWorkspace: mockUpdateWorkspace,
@@ -61,6 +86,7 @@ function setupHooks({
     repositoriesIsLoading: false,
     repositoriesError: null,
     refetchRepositories: jest.fn(),
+    ...repositoryHook,
   } as ReturnType<typeof useGitHubAppRepositories>)
 
   return {
@@ -97,6 +123,25 @@ describe("WorkspaceSyncSettings", () => {
     })
   })
 
+  it("selects an app repository when repository options are available", async () => {
+    const user = userEvent.setup()
+    render(<WorkspaceSyncSettings workspace={setupHooks()} />)
+
+    await user.click(screen.getByRole("combobox"))
+    await user.click(
+      await screen.findByRole("option", { name: "test-org/repo-a" })
+    )
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(mockUpdateWorkspace).toHaveBeenCalledWith({
+        settings: {
+          git_repo_url: repositories[0].git_url,
+        },
+      })
+    })
+  })
+
   it("opens in manual mode for an existing custom git URL", async () => {
     const customUrl =
       "git+ssh://git@github.com/test-org/custom-repo.git@feature/custom"
@@ -114,5 +159,80 @@ describe("WorkspaceSyncSettings", () => {
       "aria-current",
       "true"
     )
+  })
+
+  it("keeps explicit select mode for an existing custom git URL", async () => {
+    const user = userEvent.setup()
+    const customUrl =
+      "git+ssh://git@github.com/test-org/custom-repo.git@feature/custom"
+    const { rerender } = render(
+      <WorkspaceSyncSettings
+        workspace={setupHooks({ gitRepoUrl: customUrl })}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Manual" })).toHaveAttribute(
+        "aria-current",
+        "true"
+      )
+    })
+
+    await user.click(screen.getByRole("button", { name: "Select" }))
+    expect(screen.getByRole("button", { name: "Select" })).toHaveAttribute(
+      "aria-current",
+      "true"
+    )
+
+    rerender(
+      <WorkspaceSyncSettings
+        workspace={setupHooks({ gitRepoUrl: customUrl })}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Select" })).toHaveAttribute(
+      "aria-current",
+      "true"
+    )
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("textbox", { name: "Remote repository URL" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("falls back to manual entry when repositories cannot load", () => {
+    render(
+      <WorkspaceSyncSettings
+        workspace={setupHooks({
+          repositoryHook: {
+            repositories: [],
+            repositoriesError: new Error("Failed to load repositories"),
+          },
+        })}
+      />
+    )
+
+    expect(screen.getByLabelText("Remote repository URL")).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Could not load GitHub App repositories. Enter a git+ssh URL manually."
+      )
+    ).toBeInTheDocument()
+  })
+
+  it("disables the repository selector while repositories are loading", () => {
+    render(
+      <WorkspaceSyncSettings
+        workspace={setupHooks({
+          repositoryHook: {
+            repositories: [],
+            repositoriesIsLoading: true,
+          },
+        })}
+      />
+    )
+
+    expect(screen.getByRole("combobox")).toBeDisabled()
+    expect(screen.getByText("Loading repositories...")).toBeInTheDocument()
   })
 })

--- a/frontend/tests/workspace-sync-settings.test.tsx
+++ b/frontend/tests/workspace-sync-settings.test.tsx
@@ -251,7 +251,7 @@ describe("WorkspaceSyncSettings", () => {
     ).toBeInTheDocument()
   })
 
-  it("ignores cached app repositories when the repository query errors", () => {
+  it("keeps cached app repositories when a repository refetch errors", () => {
     render(
       <WorkspaceSyncSettings
         workspace={setupHooks({
@@ -263,16 +263,11 @@ describe("WorkspaceSyncSettings", () => {
       />
     )
 
-    expect(screen.getByLabelText("Remote repository URL")).toBeInTheDocument()
-    expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
-    expect(
-      screen.queryByRole("button", { name: "Select" })
-    ).not.toBeInTheDocument()
-    expect(
-      screen.getByText(
-        "Could not load GitHub App repositories. Enter a git+ssh URL manually."
-      )
-    ).toBeInTheDocument()
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Select" })).toHaveAttribute(
+      "aria-current",
+      "true"
+    )
   })
 
   it("disables the repository selector while repositories are loading", () => {

--- a/frontend/tests/workspace-sync-settings.test.tsx
+++ b/frontend/tests/workspace-sync-settings.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { GitHubAppRepository, WorkspaceRead } from "@/client"
+import { WorkspaceSyncSettings } from "@/components/settings/workspace-sync-settings"
+import { useGitHubAppRepositories, useWorkspaceSettings } from "@/lib/hooks"
+
+const mockUpdateWorkspace = jest.fn()
+
+jest.mock("@/lib/hooks", () => ({
+  useGitHubAppRepositories: jest.fn(),
+  useWorkspaceSettings: jest.fn(),
+}))
+
+jest.mock("@/components/organization/workflow-pull-dialog", () => ({
+  WorkflowPullDialog: () => null,
+}))
+
+const repositories: GitHubAppRepository[] = [
+  {
+    id: 1,
+    name: "repo-a",
+    full_name: "test-org/repo-a",
+    private: true,
+    default_branch: "main",
+    git_url: "git+ssh://git@github.com/test-org/repo-a.git",
+    html_url: "https://github.com/test-org/repo-a",
+    installation_id: 12345678,
+    installation_account: "test-org",
+    installation_account_type: "Organization",
+  },
+]
+
+const workspace = {
+  id: "workspace-1",
+  name: "Workspace 1",
+  organization_id: "org-1",
+  settings: {
+    git_repo_url: null,
+    effective_allowed_attachment_extensions: [],
+    effective_allowed_attachment_mime_types: [],
+  },
+} satisfies WorkspaceRead
+
+function setupHooks({
+  gitRepoUrl = null,
+}: {
+  gitRepoUrl?: string | null
+} = {}) {
+  jest.mocked(useWorkspaceSettings).mockReturnValue({
+    updateWorkspace: mockUpdateWorkspace,
+    isUpdating: false,
+    deleteWorkspace: jest.fn(),
+    isDeleting: false,
+  } as ReturnType<typeof useWorkspaceSettings>)
+  jest.mocked(useGitHubAppRepositories).mockReturnValue({
+    repositories,
+    repositoriesIsLoading: false,
+    repositoriesError: null,
+    refetchRepositories: jest.fn(),
+  } as ReturnType<typeof useGitHubAppRepositories>)
+
+  return {
+    ...workspace,
+    settings: {
+      ...workspace.settings,
+      git_repo_url: gitRepoUrl,
+    },
+  }
+}
+
+describe("WorkspaceSyncSettings", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUpdateWorkspace.mockResolvedValue(undefined)
+  })
+
+  it("allows manual git URLs when app repositories are available", async () => {
+    const user = userEvent.setup()
+    render(<WorkspaceSyncSettings workspace={setupHooks()} />)
+
+    await user.click(screen.getByRole("button", { name: "Manual" }))
+    const customUrl =
+      "git+ssh://git@github.com/test-org/custom-repo.git@feature/review-fix"
+    await user.type(screen.getByLabelText("Remote repository URL"), customUrl)
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(mockUpdateWorkspace).toHaveBeenCalledWith({
+        settings: {
+          git_repo_url: customUrl,
+        },
+      })
+    })
+  })
+
+  it("opens in manual mode for an existing custom git URL", async () => {
+    const customUrl =
+      "git+ssh://git@github.com/test-org/custom-repo.git@feature/custom"
+
+    render(
+      <WorkspaceSyncSettings
+        workspace={setupHooks({ gitRepoUrl: customUrl })}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue(customUrl)).toBeInTheDocument()
+    })
+    expect(screen.getByRole("button", { name: "Manual" })).toHaveAttribute(
+      "aria-current",
+      "true"
+    )
+  })
+})

--- a/frontend/tests/workspace-sync-settings.test.tsx
+++ b/frontend/tests/workspace-sync-settings.test.tsx
@@ -251,6 +251,30 @@ describe("WorkspaceSyncSettings", () => {
     ).toBeInTheDocument()
   })
 
+  it("ignores cached app repositories when the repository query errors", () => {
+    render(
+      <WorkspaceSyncSettings
+        workspace={setupHooks({
+          repositoryHook: {
+            repositories,
+            repositoriesError: new Error("Failed to load repositories"),
+          },
+        })}
+      />
+    )
+
+    expect(screen.getByLabelText("Remote repository URL")).toBeInTheDocument()
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Select" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Could not load GitHub App repositories. Enter a git+ssh URL manually."
+      )
+    ).toBeInTheDocument()
+  })
+
   it("disables the repository selector while repositories are loading", () => {
     render(
       <WorkspaceSyncSettings

--- a/tests/unit/test_github_app.py
+++ b/tests/unit/test_github_app.py
@@ -143,7 +143,9 @@ class TestGitHubAppService:
         """Test retrieving GitHub App credentials."""
         with patch("tracecat.vcs.github.app.SecretsService") as mock_secrets_service:
             mock_service = Mock()
-            mock_service.get_github_app_org_secret = AsyncMock(return_value=mock_secret)
+            mock_service._get_github_app_org_secret = AsyncMock(
+                return_value=mock_secret
+            )
             mock_service.decrypt_keys = Mock(
                 return_value=[
                     SecretKeyValue(
@@ -180,7 +182,7 @@ class TestGitHubAppService:
         """Test retrieving GitHub App credentials when not found."""
         with patch("tracecat.vcs.github.app.SecretsService") as mock_secrets_service:
             mock_service = AsyncMock()
-            mock_service.get_github_app_org_secret.side_effect = TracecatNotFoundError(
+            mock_service._get_github_app_org_secret.side_effect = TracecatNotFoundError(
                 "Secret not found"
             )
             mock_secrets_service.return_value = mock_service
@@ -224,7 +226,9 @@ class TestGitHubAppService:
 
         with patch("tracecat.vcs.github.app.SecretsService") as mock_secrets_service:
             mock_service = Mock()
-            mock_service.get_github_app_org_secret = AsyncMock(return_value=mock_secret)
+            mock_service._get_github_app_org_secret = AsyncMock(
+                return_value=mock_secret
+            )
             mock_service.decrypt_keys = Mock(
                 return_value=[
                     SecretKeyValue(
@@ -264,7 +268,9 @@ class TestGitHubAppService:
         """Test getting credentials status when they exist."""
         with patch("tracecat.vcs.github.app.SecretsService") as mock_secrets_service:
             mock_service = Mock()
-            mock_service.get_github_app_org_secret = AsyncMock(return_value=mock_secret)
+            mock_service._get_github_app_org_secret = AsyncMock(
+                return_value=mock_secret
+            )
             mock_service.decrypt_keys = Mock(
                 return_value=[
                     SecretKeyValue(
@@ -564,6 +570,57 @@ class TestGitHubAppService:
             assert repositories[0].installation_id == 12345678
             assert repositories[0].installation_account == "test-org"
             assert repositories[0].installation_account_type == "Organization"
+            mock_integration.close.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_list_accessible_repositories_allows_workspace_update_scope(
+        self, github_service, github_admin_service, mock_credentials
+    ):
+        """Workspace settings users should list repos without workflow sync scope."""
+        await github_admin_service.register_app(
+            app_id=mock_credentials.app_id,
+            private_key_pem=mock_credentials.private_key,
+            webhook_secret=mock_credentials.webhook_secret,
+            client_id=mock_credentials.client_id,
+        )
+
+        workspace_settings_role = github_service.role.model_copy(
+            update={"scopes": frozenset({"workspace:update"})}
+        )
+        workspace_settings_service = GitHubAppService(
+            session=github_service.session,
+            role=workspace_settings_role,
+        )
+
+        account = Mock()
+        account.login = "test-org"
+        account.type = "Organization"
+
+        repo = Mock()
+        repo.id = 1
+        repo.name = "repo-a"
+        repo.full_name = "test-org/repo-a"
+        repo.private = True
+        repo.default_branch = "main"
+        repo.html_url = "https://github.com/test-org/repo-a"
+
+        installation = Mock()
+        installation.id = 12345678
+        installation.account = account
+        installation.get_repos.return_value = [repo]
+
+        with patch("tracecat.vcs.github.app.GithubIntegration") as mock_gh_integration:
+            mock_integration = Mock()
+            mock_integration.get_installations.return_value = [installation]
+            mock_gh_integration.return_value = mock_integration
+
+            repositories = (
+                await workspace_settings_service.list_accessible_repositories()
+            )
+
+            assert [repository.full_name for repository in repositories] == [
+                "test-org/repo-a"
+            ]
             mock_integration.close.assert_called_once()
 
     @pytest.mark.anyio

--- a/tests/unit/test_github_app.py
+++ b/tests/unit/test_github_app.py
@@ -579,6 +579,54 @@ class TestGitHubAppService:
             with pytest.raises(GitHubAppError, match="credentials not found"):
                 await github_service.list_accessible_repositories()
 
+    @pytest.mark.anyio
+    async def test_list_accessible_repositories_invalid_app_id(
+        self, github_service, mock_credentials
+    ):
+        """Invalid stored app IDs should raise a GitHub App error."""
+        bad_credentials = mock_credentials.model_copy(update={"app_id": "invalid"})
+
+        with (
+            patch.object(
+                github_service,
+                "_get_github_app_secret_state",
+                return_value=(GitHubAppSecretState.VALID, Mock(), bad_credentials),
+            ),
+            patch("tracecat.vcs.github.app.GithubIntegration") as mock_gh_integration,
+        ):
+            with pytest.raises(GitHubAppError, match="invalid credential data"):
+                await github_service.list_accessible_repositories()
+
+            mock_gh_integration.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_list_accessible_repositories_sanitizes_github_error(
+        self, github_service, mock_credentials
+    ):
+        """GitHub API errors should not expose raw upstream response data."""
+        with (
+            patch.object(
+                github_service,
+                "_get_github_app_secret_state",
+                return_value=(GitHubAppSecretState.VALID, Mock(), mock_credentials),
+            ),
+            patch("tracecat.vcs.github.app.GithubIntegration") as mock_gh_integration,
+        ):
+            mock_integration = Mock()
+            mock_integration.get_installations.side_effect = GithubException(
+                500,
+                {"message": "Server Error", "private": "upstream-details"},
+                {},
+            )
+            mock_gh_integration.return_value = mock_integration
+
+            with pytest.raises(GitHubAppError) as exc_info:
+                await github_service.list_accessible_repositories()
+
+            assert str(exc_info.value) == "GitHub API error: 500"
+            assert "upstream-details" not in str(exc_info.value)
+            mock_integration.close.assert_called_once()
+
     # ============================================================================
     # Permission Error Tests
     # ============================================================================

--- a/tests/unit/test_github_app.py
+++ b/tests/unit/test_github_app.py
@@ -510,6 +510,75 @@ class TestGitHubAppService:
             with pytest.raises(GitHubAppError, match="GitHub API error"):
                 await github_service.get_github_client_for_repo(mock_repo_url)
 
+    @pytest.mark.anyio
+    async def test_list_accessible_repositories_success(
+        self, github_service, mock_credentials
+    ):
+        """Test listing repositories granted to the GitHub App installation."""
+        account = Mock()
+        account.login = "test-org"
+        account.type = "Organization"
+
+        repo_b = Mock()
+        repo_b.id = 2
+        repo_b.name = "repo-b"
+        repo_b.full_name = "test-org/repo-b"
+        repo_b.private = True
+        repo_b.default_branch = "trunk"
+        repo_b.html_url = "https://github.com/test-org/repo-b"
+
+        repo_a = Mock()
+        repo_a.id = 1
+        repo_a.name = "repo-a"
+        repo_a.full_name = "test-org/repo-a"
+        repo_a.private = False
+        repo_a.default_branch = "main"
+        repo_a.html_url = "https://github.com/test-org/repo-a"
+
+        installation = Mock()
+        installation.id = 12345678
+        installation.account = account
+        installation.get_repos.return_value = [repo_b, repo_a]
+
+        with (
+            patch.object(
+                github_service,
+                "_get_github_app_secret_state",
+                return_value=(GitHubAppSecretState.VALID, Mock(), mock_credentials),
+            ),
+            patch("tracecat.vcs.github.app.GithubIntegration") as mock_gh_integration,
+        ):
+            mock_integration = Mock()
+            mock_integration.get_installations.return_value = [installation]
+            mock_gh_integration.return_value = mock_integration
+
+            repositories = await github_service.list_accessible_repositories()
+
+            assert [repo.full_name for repo in repositories] == [
+                "test-org/repo-a",
+                "test-org/repo-b",
+            ]
+            assert repositories[0].git_url == (
+                "git+ssh://git@github.com/test-org/repo-a.git"
+            )
+            assert repositories[0].installation_id == 12345678
+            assert repositories[0].installation_account == "test-org"
+            assert repositories[0].installation_account_type == "Organization"
+            mock_integration.close.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_list_accessible_repositories_missing_credentials(
+        self, github_service
+    ):
+        """Missing credentials should raise a GitHub App error."""
+        with patch.object(
+            github_service,
+            "_get_github_app_secret_state",
+            return_value=(GitHubAppSecretState.MISSING, None, None),
+        ):
+            with pytest.raises(GitHubAppError, match="credentials not found"):
+                await github_service.list_accessible_repositories()
+
     # ============================================================================
     # Permission Error Tests
     # ============================================================================

--- a/tests/unit/test_route_scope_guards.py
+++ b/tests/unit/test_route_scope_guards.py
@@ -356,6 +356,7 @@ async def test_organization_scope_guards(
             workflow_store_router.publish_workflow,
             ("workflow:update", "workflow:sync"),
         ),
+        (workflow_store_router.list_workflow_repositories, "workspace:update"),
         (workflow_store_router.list_workflow_commits, "workflow:sync"),
         (workflow_store_router.list_workflow_branches, "workflow:sync"),
         (workflow_store_router.pull_workflows, ("workflow:update", "workflow:sync")),

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -369,10 +369,14 @@ class SecretsService(BaseOrgService):
         """Retrieve an organization-wide secret by its name."""
         return await self._get_org_secret_by_name(secret_name, environment)
 
+    async def _get_github_app_org_secret(self) -> OrganizationSecret:
+        """Retrieve the GitHub App organization secret for workflow sync."""
+        return await self._get_org_secret_by_name("github-app-credentials")
+
     @require_scope("workflow:sync")
     async def get_github_app_org_secret(self) -> OrganizationSecret:
         """Retrieve the GitHub App organization secret for workflow sync."""
-        return await self._get_org_secret_by_name("github-app-credentials")
+        return await self._get_github_app_org_secret()
 
     @require_scope("org:secret:create")
     @audit_log(resource_type="organization_secret", action="create")

--- a/tracecat/vcs/github/app.py
+++ b/tracecat/vcs/github/app.py
@@ -585,8 +585,15 @@ class GitHubAppService(BaseOrgService):
         raw_private_key = credentials.private_key.get_secret_value()
         normalized_private_key = self._normalize_private_key(raw_private_key)
 
+        try:
+            app_id = int(credentials.app_id)
+        except ValueError as e:
+            raise GitHubAppError(
+                "Failed to retrieve GitHub App credentials: invalid credential data"
+            ) from e
+
         auth = Auth.AppAuth(
-            app_id=int(credentials.app_id),
+            app_id=app_id,
             private_key=normalized_private_key,
         )
         gh_integration = GithubIntegration(auth=auth)
@@ -625,7 +632,7 @@ class GitHubAppService(BaseOrgService):
                 status=e.status,
                 data=e.data,
             )
-            raise GitHubAppError(f"GitHub API error: {e.status} - {e.data}") from e
+            raise GitHubAppError(f"GitHub API error: {e.status}") from e
         finally:
             gh_integration.close()
 

--- a/tracecat/vcs/github/app.py
+++ b/tracecat/vcs/github/app.py
@@ -24,6 +24,7 @@ from tracecat.tiers.enums import Entitlement
 from tracecat.vcs.github.schemas import (
     GitHubAppConfig,
     GitHubAppCredentials,
+    GitHubAppRepository,
 )
 
 
@@ -551,6 +552,78 @@ class GitHubAppService(BaseOrgService):
                 status=e.status,
                 data=e.data,
                 repo=f"{repo_url.org}/{repo_url.repo}",
+            )
+            raise GitHubAppError(f"GitHub API error: {e.status} - {e.data}") from e
+        finally:
+            gh_integration.close()
+
+    @requires_entitlement(Entitlement.GIT_SYNC)
+    @require_scope("workspace:update")
+    async def list_accessible_repositories(self) -> list[GitHubAppRepository]:
+        """List repositories granted to the configured GitHub App installation.
+
+        Returns:
+            Repositories accessible through the configured GitHub App credentials.
+
+        Raises:
+            GitHubAppError: If credentials are missing, corrupted, or the GitHub API fails.
+        """
+        secret_state, _secret, credentials = await self._get_github_app_secret_state()
+        match secret_state:
+            case GitHubAppSecretState.MISSING:
+                raise GitHubAppError(
+                    "Failed to retrieve GitHub App credentials: credentials not found"
+                )
+            case GitHubAppSecretState.CORRUPTED:
+                raise GitHubAppError(
+                    "Failed to retrieve GitHub App credentials: invalid credential data"
+                )
+
+        if credentials is None:
+            raise GitHubAppError("Failed to retrieve GitHub App credentials")
+
+        raw_private_key = credentials.private_key.get_secret_value()
+        normalized_private_key = self._normalize_private_key(raw_private_key)
+
+        auth = Auth.AppAuth(
+            app_id=int(credentials.app_id),
+            private_key=normalized_private_key,
+        )
+        gh_integration = GithubIntegration(auth=auth)
+
+        def collect_repositories() -> list[GitHubAppRepository]:
+            repositories_by_id: dict[int, GitHubAppRepository] = {}
+            for installation in gh_integration.get_installations():
+                account = installation.account
+                account_login = getattr(account, "login", "unknown")
+                account_type = getattr(account, "type", None)
+
+                for repo in installation.get_repos():
+                    repositories_by_id[repo.id] = GitHubAppRepository(
+                        id=repo.id,
+                        name=repo.name,
+                        full_name=repo.full_name,
+                        private=repo.private,
+                        default_branch=repo.default_branch or "main",
+                        git_url=f"git+ssh://git@github.com/{repo.full_name}.git",
+                        html_url=repo.html_url,
+                        installation_id=installation.id,
+                        installation_account=account_login,
+                        installation_account_type=account_type,
+                    )
+
+            return sorted(
+                repositories_by_id.values(),
+                key=lambda repository: repository.full_name.lower(),
+            )
+
+        try:
+            return await asyncio.to_thread(collect_repositories)
+        except GithubException as e:
+            self.logger.error(
+                "GitHub API error listing accessible repositories",
+                status=e.status,
+                data=e.data,
             )
             raise GitHubAppError(f"GitHub API error: {e.status} - {e.data}") from e
         finally:

--- a/tracecat/vcs/github/app.py
+++ b/tracecat/vcs/github/app.py
@@ -194,7 +194,7 @@ class GitHubAppService(BaseOrgService):
         """Classify the stored GitHub App secret without failing on corruption."""
         secrets_service = SecretsService(session=self.session, role=self.role)
         try:
-            secret = await secrets_service.get_github_app_org_secret()
+            secret = await secrets_service._get_github_app_org_secret()
         except TracecatNotFoundError:
             return GitHubAppSecretState.MISSING, None, None
 

--- a/tracecat/vcs/github/schemas.py
+++ b/tracecat/vcs/github/schemas.py
@@ -17,6 +17,21 @@ class GitHubRepository(BaseModel):
     default_branch: str = "main"
 
 
+class GitHubAppRepository(BaseModel):
+    """Repository granted to the configured GitHub App installation."""
+
+    id: int
+    name: str
+    full_name: str
+    private: bool
+    default_branch: str
+    git_url: str
+    html_url: str | None = None
+    installation_id: int
+    installation_account: str
+    installation_account_type: str | None = None
+
+
 class GitHubInstallation(BaseModel):
     """GitHub App installation details."""
 

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -15,7 +15,8 @@ from tracecat.identifiers.workflow import AnyWorkflowIDPath
 from tracecat.logger import logger
 from tracecat.registry.repositories.schemas import GitBranchInfo, GitCommitInfo
 from tracecat.sync import PullOptions, PullResult
-from tracecat.vcs.github.app import GitHubAppError
+from tracecat.vcs.github.app import GitHubAppError, GitHubAppService
+from tracecat.vcs.github.schemas import GitHubAppRepository
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.store.schemas import (
     WorkflowDslPublish,
@@ -81,6 +82,33 @@ async def publish_workflow(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
+        ) from e
+
+
+@router.get("/sync/repositories", response_model=list[GitHubAppRepository])
+@require_scope("workspace:update")
+async def list_workflow_repositories(
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+) -> list[GitHubAppRepository]:
+    """List repositories granted to the configured GitHub App installation."""
+    if not role.workspace_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Workspace ID is required",
+        )
+
+    try:
+        github_service = GitHubAppService(session=session, role=role)
+        return await github_service.list_accessible_repositories()
+    except GitHubAppError as e:
+        logger.error(
+            "GitHub App error listing accessible repositories",
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unable to list repositories: {str(e)}",
         ) from e
 
 


### PR DESCRIPTION
## Summary
- Add a GitHub App repositories endpoint and typed client support
- Populate workspace sync settings with selectable repositories when available
- Invalidate repository lists when GitHub App credentials change
- Cover repository listing and route scope guard behavior with unit tests

## Testing
- Unit tests added for GitHub App repository listing and scope guards
- Not run (not requested)

## Screenshots
Repository selector populated from granted GitHub App repositories:

![Git sync repository selector](https://raw.githubusercontent.com/TracecatHQ/tracecat/0abc3d9f40876c7eef13457fd424386931119b4e/.github/pr-assets/2881/git-sync-repository-dropdown.jpg)

Manual fallback when repository listing is unavailable:

![Git sync manual fallback](https://raw.githubusercontent.com/TracecatHQ/tracecat/0abc3d9f40876c7eef13457fd424386931119b4e/.github/pr-assets/2881/git-sync-manual-fallback.jpg)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub App repository selector to workspace sync settings with a toggle to pick an authorized repo or enter a `git+ssh` URL. Preserves branch refs during pulls, aligns the listing API to `workspace:update`, hardens errors, and clears stale cached repository options when credentials change.

- **New Features**
  - Backend: `GET /workspaces/{workspace_id}/workflows/sync/repositories` lists authorized repos as `GitHubAppRepository`; requires scope `workspace:update` and `GIT_SYNC` entitlement.
  - Frontend: selector with Select/Manual tabs that auto-switches to Manual for non-listed URLs and preserves explicit mode; saves `@<default_branch>` in the URL for non-main repos; pull dialog loads commits from the branch encoded in the URL; generated client/types and `useGitHubAppRepositories`; clears and invalidates `github-app-repositories` on credential create/delete.

- **Bug Fixes**
  - Sanitize GitHub API errors and handle missing/invalid credentials without leaking upstream details.
  - Keep custom git URL visible/selectable; fall back to manual entry when repositories fail to load; ignore stale cached repository options on query errors; disable selector while loading with clearer copy.

<sup>Written for commit 9a210c892ba4faa84c614c7928003cd192e34fd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

