### PR TITLE
feat(integrations): type-validate URL credentials in MCP catalog

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -14951,6 +14951,23 @@ export const $MCPConfigField = {
       title: "Secret",
       default: false,
     },
+    placeholder: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Placeholder",
+    },
+    type: {
+      type: "string",
+      enum: ["string", "url"],
+      title: "Type",
+      default: "string",
+    },
   },
   type: "object",
   required: ["key", "label", "description", "target"],
@@ -14992,6 +15009,27 @@ export const $MCPConnectionCredential = {
         },
       ],
       title: "Default Value",
+    },
+    placeholder: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Placeholder",
+      description:
+        "Optional placeholder shown in the configure dialog to hint the expected value format (e.g. 'https://your-console.example.net').",
+    },
+    type: {
+      type: "string",
+      enum: ["string", "url"],
+      title: "Type",
+      description:
+        "Value type used for light client/server validation. 'url' requires an http(s):// scheme.",
+      default: "string",
     },
     target: {
       type: "string",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4611,9 +4611,13 @@ export type MCPConfigField = {
   target: "server_uri" | "oauth_client" | "http_header" | "stdio_env"
   required?: boolean
   secret?: boolean
+  placeholder?: string | null
+  type?: "string" | "url"
 }
 
 export type target = "server_uri" | "oauth_client" | "http_header" | "stdio_env"
+
+export type type = "string" | "url"
 
 /**
  * User-supplied value needed to materialize a catalog connection.
@@ -4625,6 +4629,14 @@ export type MCPConnectionCredential = {
   required?: boolean
   secret?: boolean
   default_value?: string | null
+  /**
+   * Optional placeholder shown in the configure dialog to hint the expected value format (e.g. 'https://your-console.example.net').
+   */
+  placeholder?: string | null
+  /**
+   * Value type used for light client/server validation. 'url' requires an http(s):// scheme.
+   */
+  type?: "string" | "url"
   target: "server_uri" | "oauth_client" | "http_header" | "stdio_env"
 }
 
@@ -5522,7 +5534,7 @@ export type ProviderCredentialField = {
 /**
  * Input type: 'text' or 'password'
  */
-export type type = "text" | "password"
+export type type2 = "text" | "password"
 
 /**
  * Metadata for a provider.
@@ -5801,7 +5813,7 @@ export type RegistryActionRead = {
 /**
  * The type of the action
  */
-export type type2 = "udf" | "template"
+export type type3 = "udf" | "template"
 
 /**
  * API minimal read model for a registered action.
@@ -6170,7 +6182,7 @@ export type Role = {
   [key: string]: unknown | string | boolean
 }
 
-export type type3 = "user" | "service" | "service_account"
+export type type4 = "user" | "service" | "service_account"
 
 export type service_id =
   | "tracecat-api"
@@ -7873,7 +7885,7 @@ export type Trigger = {
   }
 }
 
-export type type4 = "schedule" | "webhook"
+export type type5 = "schedule" | "webhook"
 
 /**
  * Trigger type for a workflow execution.

--- a/frontend/src/components/integrations/mcp-integration-dialog.tsx
+++ b/frontend/src/components/integrations/mcp-integration-dialog.tsx
@@ -13,7 +13,7 @@ import {
   Trash2,
 } from "lucide-react"
 import React, { useState } from "react"
-import { useFieldArray, useForm } from "react-hook-form"
+import { type Resolver, useFieldArray, useForm } from "react-hook-form"
 import {
   integrationsGetIntegration,
   mcpIntegrationsConnectPlatformMcpCatalog,
@@ -35,14 +35,15 @@ import { getMcpProviderIconId, ProviderIcon } from "@/components/icons"
 import {
   ALLOWED_COMMANDS,
   AUTH_TYPES,
+  buildMcpIntegrationFormSchema,
   catalogEntryToFormValues,
   isAllowedCommand,
   MCP_INTEGRATION_FORM_DEFAULTS,
   type MCPIntegrationFormValues,
-  mcpIntegrationFormSchema,
   missingRequiredOAuthClientCredentials,
   normalizeOAuthClientKey,
   SERVER_TYPES,
+  urlTypedStdioEnvKeys,
 } from "@/components/integrations/mcp-integration-schema"
 import {
   Accordion,
@@ -421,8 +422,17 @@ export function MCPIntegrationDialog({
     }
   }, [mcpIntegrationId, controlledOpen])
 
+  // The Zod schema needs the catalog's url-typed stdio_env keys, but those come
+  // from the connection spec (state), not the form data. Hold the active
+  // resolver in a ref and read it at validation time so we can swap it when the
+  // selected catalog option changes without re-mounting useForm.
+  const resolverRef = React.useRef(zodResolver(buildMcpIntegrationFormSchema()))
+  const resolver = React.useCallback<Resolver<MCPIntegrationFormValues>>(
+    (values, context, options) => resolverRef.current(values, context, options),
+    []
+  )
   const form = useForm<MCPIntegrationFormValues>({
-    resolver: zodResolver(mcpIntegrationFormSchema),
+    resolver,
     defaultValues: MCP_INTEGRATION_FORM_DEFAULTS,
   })
   const {
@@ -520,6 +530,21 @@ export function MCPIntegrationDialog({
     catalogEntry,
     connectionOptionId
   )
+
+  // Rebuild the resolver when the selected option's url-typed env keys change,
+  // then re-validate stdio_env so any existing error clears/updates. Keyed on a
+  // sorted string so the effect is stable across re-renders.
+  const urlEnvKeysKey = Array.from(urlTypedStdioEnvKeys(selectedCatalogSpec))
+    .sort()
+    .join(",")
+  React.useEffect(() => {
+    const urlEnvKeys = new Set(urlEnvKeysKey ? urlEnvKeysKey.split(",") : [])
+    resolverRef.current = zodResolver(buildMcpIntegrationFormSchema(urlEnvKeys))
+    if (form.formState.isSubmitted) {
+      void form.trigger("stdio_env")
+    }
+  }, [urlEnvKeysKey, form])
+
   const hasCatalogOAuthClient = hasOAuthClientConfig(selectedCatalogSpec)
   const catalogOptions = catalogEntry?.connection_options ?? []
   const connectedOAuthIntegrations =

--- a/frontend/src/components/integrations/mcp-integration-schema.ts
+++ b/frontend/src/components/integrations/mcp-integration-schema.ts
@@ -4,6 +4,7 @@ import type {
   MCPConnectionSpec,
   PlatformMCPCatalogRead,
 } from "@/client"
+import { isExpression } from "@/lib/expressions"
 
 /**
  * Form schema for the MCP integration create/edit dialog.
@@ -92,14 +93,6 @@ export function isValidStringMap(
 }
 
 /**
- * Whether a value is a Tracecat template (e.g. `${{ SECRETS.x }}`). Templated
- * values resolve at run time, so they skip format validation.
- */
-function isTemplateExpression(value: string): boolean {
-  return value.includes("${{")
-}
-
-/**
  * Whether a string is an absolute http(s):// URL with a host.
  */
 function hasHttpScheme(value: string): boolean {
@@ -164,7 +157,7 @@ export function invalidUrlEnvKeys(
       continue
     }
     const trimmed = entryValue.trim()
-    if (trimmed === "" || isTemplateExpression(trimmed)) {
+    if (trimmed === "" || isExpression(trimmed)) {
       continue
     }
     if (!hasHttpScheme(trimmed)) {

--- a/frontend/src/components/integrations/mcp-integration-schema.ts
+++ b/frontend/src/components/integrations/mcp-integration-schema.ts
@@ -92,6 +92,89 @@ export function isValidStringMap(
 }
 
 /**
+ * Whether a value is a Tracecat template (e.g. `${{ SECRETS.x }}`). Templated
+ * values resolve at run time, so they skip format validation.
+ */
+function isTemplateExpression(value: string): boolean {
+  return value.includes("${{")
+}
+
+/**
+ * Whether a string is an absolute http(s):// URL with a host.
+ */
+function hasHttpScheme(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      url.host.length > 0
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The stdio_env keys a catalog spec declares `type: "url"`. The catalog is the
+ * single source of truth for which values are URLs — there is no name-based
+ * inference.
+ */
+export function urlTypedStdioEnvKeys(
+  spec: MCPConnectionSpec | null | undefined
+): Set<string> {
+  const keys = new Set<string>()
+  for (const cred of spec?.credentials ?? []) {
+    if (cred.target === "stdio_env" && cred.type === "url") {
+      keys.add(cred.key)
+    }
+  }
+  for (const field of spec?.config_fields ?? []) {
+    if (field.target === "stdio_env" && field.type === "url") {
+      keys.add(field.key)
+    }
+  }
+  return keys
+}
+
+/**
+ * Return the `urlKeys` whose value is present but missing an http(s):// scheme.
+ * Empty and templated values are skipped. Returns [] when the JSON does not
+ * parse — shape errors are reported by {@link isValidStringMap} instead.
+ */
+export function invalidUrlEnvKeys(
+  value: string,
+  urlKeys: Set<string>
+): string[] {
+  if (urlKeys.size === 0) {
+    return []
+  }
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(value) as Record<string, unknown>
+  } catch {
+    return []
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return []
+  }
+  const invalid: string[] = []
+  for (const key of urlKeys) {
+    const entryValue = parsed[key]
+    if (typeof entryValue !== "string") {
+      continue
+    }
+    const trimmed = entryValue.trim()
+    if (trimmed === "" || isTemplateExpression(trimmed)) {
+      continue
+    }
+    if (!hasHttpScheme(trimmed)) {
+      invalid.push(key)
+    }
+  }
+  return invalid
+}
+
+/**
  * Normalize an OAuth client credential key for lenient comparisons, e.g.
  * "Client-Secret" and "client_secret" normalize to the same value.
  */
@@ -136,171 +219,211 @@ export function missingRequiredOAuthClientCredentials(
   return missing
 }
 
-export const mcpIntegrationFormSchema = z
-  .object({
-    name: z
-      .string()
-      .trim()
-      .min(3, { message: "Name must be at least 3 characters long" })
-      .max(255, { message: "Name must be 255 characters or fewer" }),
-    description: z
-      .string()
-      .trim()
-      .max(512, { message: "Description must be 512 characters or fewer" })
-      .optional()
-      .or(z.literal("")),
-    // Server type
-    server_type: z.enum(["http", "stdio"]),
-    // HTTP-type fields
-    server_uri: z.string().trim().optional().or(z.literal("")),
-    auth_type: z.enum(["OAUTH2", "CUSTOM", "NONE"]),
-    oauth_setup: z.enum([
-      "mcp_discovery",
-      "oauth_client",
-      "existing_integration",
-    ]),
-    oauth_integration_id: z.string().uuid().optional().or(z.literal("")),
-    oauth_client_credentials: z.string().trim().optional().or(z.literal("")),
-    custom_credentials: z.string().trim().optional().or(z.literal("")),
-    // Stdio-type fields
-    stdio_command: z.string().trim().optional().or(z.literal("")),
-    stdio_args: z.array(
-      z.object({
-        value: z.string(),
-      })
-    ),
-    stdio_env: z.string().trim().optional().or(z.literal("")),
-    // General fields
-    timeout: z.coerce.number().int().min(1).max(300).optional(),
-    catalog_slug: z.string().optional().or(z.literal("")),
-    connection_option_id: z.string().optional().or(z.literal("")),
-  })
-  // HTTP-type validation
-  .refine(
-    (data) => {
-      if (data.server_type === "http") {
-        if (!data.server_uri || data.server_uri.trim() === "") {
-          return false
-        }
-        try {
-          new URL(data.server_uri)
-          return true
-        } catch {
-          return false
-        }
-      }
-      return true
-    },
-    {
-      message: "Valid server URL is required for HTTP-type servers",
-      path: ["server_uri"],
-    }
-  )
-  .refine(
-    (data) => {
-      if (
-        data.server_type === "http" &&
-        data.auth_type === "OAUTH2" &&
-        data.oauth_setup === "existing_integration"
-      ) {
-        return !!data.oauth_integration_id && data.oauth_integration_id !== ""
-      }
-      return true
-    },
-    {
-      message: "OAuth integration is required for OAuth 2.0 authentication",
-      path: ["oauth_integration_id"],
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.server_type === "http" && data.auth_type === "CUSTOM") {
-        if (!data.custom_credentials || data.custom_credentials.trim() === "") {
-          return false
-        }
-        return isValidStringMap(data.custom_credentials)
-      }
-      return true
-    },
-    {
-      message:
-        "Custom credentials must be a valid JSON object with string values",
-      path: ["custom_credentials"],
-    }
-  )
-  .refine(
-    (data) => {
-      if (
-        data.server_type === "http" &&
-        data.auth_type === "OAUTH2" &&
-        data.oauth_setup === "oauth_client"
-      ) {
-        return (
-          !!data.oauth_client_credentials &&
-          data.oauth_client_credentials.trim() !== "" &&
-          isValidStringMap(data.oauth_client_credentials, { allowEmpty: true })
-        )
-      }
-      return true
-    },
-    {
-      message: "OAuth client credentials must be a valid JSON object",
-      path: ["oauth_client_credentials"],
-    }
-  )
-  .refine(
-    (data) => {
-      if (
-        data.server_type === "http" &&
-        data.auth_type === "OAUTH2" &&
-        data.custom_credentials &&
-        data.custom_credentials.trim() !== ""
-      ) {
-        return isValidStringMap(data.custom_credentials)
-      }
-      return true
-    },
-    {
-      message:
-        "Additional headers must be a valid JSON object with string values",
-      path: ["custom_credentials"],
-    }
-  )
-  // Stdio-type validation
-  .refine(
-    (data) => {
-      if (data.server_type === "stdio") {
-        if (!data.stdio_command || data.stdio_command.trim() === "") {
-          return false
-        }
-        return isAllowedCommand(data.stdio_command.trim())
-      }
-      return true
-    },
-    {
-      message: `Command must be one of: ${ALLOWED_COMMANDS.join(", ")}`,
-      path: ["stdio_command"],
-    }
-  )
-  .refine(
-    (data) => {
-      if (
-        data.server_type === "stdio" &&
-        data.stdio_env &&
-        data.stdio_env.trim() !== ""
-      ) {
-        return isValidStringMap(data.stdio_env)
-      }
-      return true
-    },
-    {
-      message:
-        "Environment variables must be a valid JSON object with string values",
-      path: ["stdio_env"],
-    }
-  )
+const mcpIntegrationFormObjectSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(3, { message: "Name must be at least 3 characters long" })
+    .max(255, { message: "Name must be 255 characters or fewer" }),
+  description: z
+    .string()
+    .trim()
+    .max(512, { message: "Description must be 512 characters or fewer" })
+    .optional()
+    .or(z.literal("")),
+  // Server type
+  server_type: z.enum(["http", "stdio"]),
+  // HTTP-type fields
+  server_uri: z.string().trim().optional().or(z.literal("")),
+  auth_type: z.enum(["OAUTH2", "CUSTOM", "NONE"]),
+  oauth_setup: z.enum([
+    "mcp_discovery",
+    "oauth_client",
+    "existing_integration",
+  ]),
+  oauth_integration_id: z.string().uuid().optional().or(z.literal("")),
+  oauth_client_credentials: z.string().trim().optional().or(z.literal("")),
+  custom_credentials: z.string().trim().optional().or(z.literal("")),
+  // Stdio-type fields
+  stdio_command: z.string().trim().optional().or(z.literal("")),
+  stdio_args: z.array(
+    z.object({
+      value: z.string(),
+    })
+  ),
+  stdio_env: z.string().trim().optional().or(z.literal("")),
+  // General fields
+  timeout: z.coerce.number().int().min(1).max(300).optional(),
+  catalog_slug: z.string().optional().or(z.literal("")),
+  connection_option_id: z.string().optional().or(z.literal("")),
+})
 
-export type MCPIntegrationFormValues = z.infer<typeof mcpIntegrationFormSchema>
+/**
+ * Build the MCP integration form schema.
+ *
+ * `urlEnvKeys` is the set of stdio_env keys the selected catalog row declares
+ * `type: "url"` (see {@link urlTypedStdioEnvKeys}). It is a parameter rather
+ * than inferred from the value because the catalog type metadata lives in the
+ * connection spec (React state), not in the form data Zod can see. Pass an
+ * empty set for BYO servers, which declare no credential types.
+ */
+export function buildMcpIntegrationFormSchema(
+  urlEnvKeys: Set<string> = new Set()
+) {
+  return (
+    mcpIntegrationFormObjectSchema
+      // HTTP-type validation
+      .refine(
+        (data) => {
+          if (data.server_type === "http") {
+            if (!data.server_uri || data.server_uri.trim() === "") {
+              return false
+            }
+            try {
+              new URL(data.server_uri)
+              return true
+            } catch {
+              return false
+            }
+          }
+          return true
+        },
+        {
+          message: "Valid server URL is required for HTTP-type servers",
+          path: ["server_uri"],
+        }
+      )
+      .refine(
+        (data) => {
+          if (
+            data.server_type === "http" &&
+            data.auth_type === "OAUTH2" &&
+            data.oauth_setup === "existing_integration"
+          ) {
+            return (
+              !!data.oauth_integration_id && data.oauth_integration_id !== ""
+            )
+          }
+          return true
+        },
+        {
+          message: "OAuth integration is required for OAuth 2.0 authentication",
+          path: ["oauth_integration_id"],
+        }
+      )
+      .refine(
+        (data) => {
+          if (data.server_type === "http" && data.auth_type === "CUSTOM") {
+            if (
+              !data.custom_credentials ||
+              data.custom_credentials.trim() === ""
+            ) {
+              return false
+            }
+            return isValidStringMap(data.custom_credentials)
+          }
+          return true
+        },
+        {
+          message:
+            "Custom credentials must be a valid JSON object with string values",
+          path: ["custom_credentials"],
+        }
+      )
+      .refine(
+        (data) => {
+          if (
+            data.server_type === "http" &&
+            data.auth_type === "OAUTH2" &&
+            data.oauth_setup === "oauth_client"
+          ) {
+            return (
+              !!data.oauth_client_credentials &&
+              data.oauth_client_credentials.trim() !== "" &&
+              isValidStringMap(data.oauth_client_credentials, {
+                allowEmpty: true,
+              })
+            )
+          }
+          return true
+        },
+        {
+          message: "OAuth client credentials must be a valid JSON object",
+          path: ["oauth_client_credentials"],
+        }
+      )
+      .refine(
+        (data) => {
+          if (
+            data.server_type === "http" &&
+            data.auth_type === "OAUTH2" &&
+            data.custom_credentials &&
+            data.custom_credentials.trim() !== ""
+          ) {
+            return isValidStringMap(data.custom_credentials)
+          }
+          return true
+        },
+        {
+          message:
+            "Additional headers must be a valid JSON object with string values",
+          path: ["custom_credentials"],
+        }
+      )
+      // Stdio-type validation
+      .refine(
+        (data) => {
+          if (data.server_type === "stdio") {
+            if (!data.stdio_command || data.stdio_command.trim() === "") {
+              return false
+            }
+            return isAllowedCommand(data.stdio_command.trim())
+          }
+          return true
+        },
+        {
+          message: `Command must be one of: ${ALLOWED_COMMANDS.join(", ")}`,
+          path: ["stdio_command"],
+        }
+      )
+      .refine(
+        (data) => {
+          if (
+            data.server_type === "stdio" &&
+            data.stdio_env &&
+            data.stdio_env.trim() !== ""
+          ) {
+            return isValidStringMap(data.stdio_env)
+          }
+          return true
+        },
+        {
+          message:
+            "Environment variables must be a valid JSON object with string values",
+          path: ["stdio_env"],
+        }
+      )
+      // URL-typed stdio env vars (declared `type: "url"` by the catalog) must
+      // carry an http(s):// scheme so they don't fail deep inside the MCP server.
+      .refine(
+        (data) =>
+          data.server_type !== "stdio" ||
+          !data.stdio_env ||
+          invalidUrlEnvKeys(data.stdio_env, urlEnvKeys).length === 0,
+        (data) => ({
+          message: `Must start with http:// or https://: ${invalidUrlEnvKeys(
+            data.stdio_env ?? "",
+            urlEnvKeys
+          ).join(", ")}`,
+          path: ["stdio_env"],
+        })
+      )
+  )
+}
+
+export type MCPIntegrationFormValues = z.infer<
+  typeof mcpIntegrationFormObjectSchema
+>
 
 export const MCP_INTEGRATION_FORM_DEFAULTS: MCPIntegrationFormValues = {
   name: "",
@@ -322,8 +445,9 @@ export const MCP_INTEGRATION_FORM_DEFAULTS: MCPIntegrationFormValues = {
 
 /**
  * Build a credentials JSON template from a catalog entry's declared
- * credentials, so the user sees the expected keys (with secret values left as
- * placeholders to fill in). Returns "" when there are no credentials.
+ * credentials, so the user sees the expected keys prefilled with each
+ * credential's default value, placeholder hint, or an empty string to fill in.
+ * Returns "" when there are no credentials.
  */
 function credentialsTemplate(
   spec: MCPConnectionSpec | null | undefined,
@@ -338,7 +462,7 @@ function credentialsTemplate(
   }
   const obj: Record<string, string> = {}
   for (const cred of creds) {
-    obj[cred.key] = cred.default_value ?? ""
+    obj[cred.key] = cred.default_value ?? cred.placeholder ?? ""
   }
   return JSON.stringify(obj, null, 2)
 }
@@ -357,17 +481,17 @@ function stdioEnvTemplate(spec: MCPConnectionSpec | null | undefined): string {
   const obj: Record<string, string> = {}
   for (const cred of spec?.credentials ?? []) {
     if (cred.target === "stdio_env" && cred.required) {
-      obj[cred.key] = ""
+      obj[cred.key] = cred.placeholder ?? ""
     }
   }
   for (const field of spec?.config_fields ?? []) {
     if (field.target === "stdio_env" && field.required) {
-      obj[field.key] = ""
+      obj[field.key] = field.placeholder ?? ""
     }
   }
   if (isStdioConnectionSpec(spec)) {
     for (const key of spec.stdio_env ?? []) {
-      obj[key] = ""
+      obj[key] ??= ""
     }
   }
   return Object.keys(obj).length > 0 ? JSON.stringify(obj, null, 2) : ""

--- a/frontend/tests/mcp-integration-schema.test.ts
+++ b/frontend/tests/mcp-integration-schema.test.ts
@@ -1,7 +1,11 @@
 import type { MCPConnectionSpec } from "@/client"
 import {
+  buildMcpIntegrationFormSchema,
   catalogEntryToFormValues,
+  invalidUrlEnvKeys,
+  MCP_INTEGRATION_FORM_DEFAULTS,
   missingRequiredOAuthClientCredentials,
+  urlTypedStdioEnvKeys,
 } from "@/components/integrations/mcp-integration-schema"
 
 function oauthSpec(
@@ -100,6 +104,138 @@ describe("missingRequiredOAuthClientCredentials", () => {
 
   it("treats unparseable JSON as having no missing credentials", () => {
     expect(missingRequiredOAuthClientCredentials(spec, "not json")).toEqual([])
+  })
+})
+
+function stdioSpec(
+  credentials: NonNullable<MCPConnectionSpec["credentials"]>
+): MCPConnectionSpec {
+  return {
+    server_type: "stdio",
+    stdio_command: "npx",
+    stdio_args: [],
+    config_fields: [],
+    credentials,
+  } as unknown as MCPConnectionSpec
+}
+
+describe("urlTypedStdioEnvKeys", () => {
+  it("collects only stdio_env credentials marked type: url", () => {
+    const spec = stdioSpec([
+      {
+        key: "VAULT_ADDR",
+        label: "Vault Server Address",
+        description: "Base URL",
+        required: true,
+        secret: false,
+        type: "url",
+        target: "stdio_env",
+      },
+      {
+        key: "VAULT_TOKEN",
+        label: "Vault Token",
+        description: "Auth token",
+        required: true,
+        secret: true,
+        target: "stdio_env",
+      },
+    ])
+    expect(urlTypedStdioEnvKeys(spec)).toEqual(new Set(["VAULT_ADDR"]))
+  })
+
+  it("ignores url-typed credentials on non-stdio_env targets", () => {
+    const spec = stdioSpec([
+      {
+        key: "SERVER_URL",
+        label: "Server URL",
+        description: "Base URL",
+        required: true,
+        secret: false,
+        type: "url",
+        target: "http_header",
+      },
+    ])
+    expect(urlTypedStdioEnvKeys(spec)).toEqual(new Set())
+  })
+
+  it("returns an empty set for a null spec", () => {
+    expect(urlTypedStdioEnvKeys(null)).toEqual(new Set())
+  })
+})
+
+describe("invalidUrlEnvKeys", () => {
+  const urlKeys = new Set(["VAULT_ADDR"])
+
+  it("flags a scheme-less value", () => {
+    const value = JSON.stringify({ VAULT_ADDR: "acme.example.net" })
+    expect(invalidUrlEnvKeys(value, urlKeys)).toEqual(["VAULT_ADDR"])
+  })
+
+  it("accepts an http(s):// value", () => {
+    const value = JSON.stringify({ VAULT_ADDR: "https://vault.example.net" })
+    expect(invalidUrlEnvKeys(value, urlKeys)).toEqual([])
+  })
+
+  it("skips empty and templated values", () => {
+    expect(
+      invalidUrlEnvKeys(JSON.stringify({ VAULT_ADDR: "" }), urlKeys)
+    ).toEqual([])
+    expect(
+      invalidUrlEnvKeys(
+        JSON.stringify({ VAULT_ADDR: "${{ SECRETS.vault.ADDR }}" }),
+        urlKeys
+      )
+    ).toEqual([])
+  })
+
+  it("ignores keys outside urlKeys", () => {
+    const value = JSON.stringify({ VAULT_TOKEN: "not-a-url" })
+    expect(invalidUrlEnvKeys(value, urlKeys)).toEqual([])
+  })
+
+  it("returns [] when there are no url keys or the JSON is unparseable", () => {
+    expect(invalidUrlEnvKeys("not json", urlKeys)).toEqual([])
+    expect(
+      invalidUrlEnvKeys(JSON.stringify({ VAULT_ADDR: "x" }), new Set())
+    ).toEqual([])
+  })
+})
+
+describe("buildMcpIntegrationFormSchema url validation", () => {
+  const baseStdio = {
+    ...MCP_INTEGRATION_FORM_DEFAULTS,
+    name: "Vault",
+    server_type: "stdio" as const,
+    stdio_command: "npx",
+  }
+  const urlEnvKeys = new Set(["VAULT_ADDR"])
+
+  it("rejects a scheme-less url-typed stdio env var", () => {
+    const result = buildMcpIntegrationFormSchema(urlEnvKeys).safeParse({
+      ...baseStdio,
+      stdio_env: JSON.stringify({ VAULT_ADDR: "acme.example.net" }),
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path[0] === "stdio_env")
+      expect(issue?.message).toContain("VAULT_ADDR")
+    }
+  })
+
+  it("accepts a well-formed url-typed stdio env var", () => {
+    const result = buildMcpIntegrationFormSchema(urlEnvKeys).safeParse({
+      ...baseStdio,
+      stdio_env: JSON.stringify({ VAULT_ADDR: "https://vault.example.net" }),
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("does not validate url shape when the spec declares no url keys", () => {
+    const result = buildMcpIntegrationFormSchema(new Set()).safeParse({
+      ...baseStdio,
+      stdio_env: JSON.stringify({ VAULT_ADDR: "acme.example.net" }),
+    })
+    expect(result.success).toBe(true)
   })
 })
 

--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -22,6 +22,7 @@
             "description": "Elasticsearch/Kibana API key sent as the Authorization header in the form 'ApiKey <base64-encoded-api-key>'. The key must include Kibana privileges feature_agentBuilder.read and feature_actions.read, or the endpoint returns 403 Forbidden.",
             "required": true,
             "secret": true,
+            "placeholder": "ApiKey <base64-encoded-api-key>",
             "target": "http_header"
           }
         ],
@@ -104,6 +105,7 @@
                 "description": "Your Panther instance URL, including the https:// scheme (e.g. https://acme.runpanther.net).",
                 "required": true,
                 "secret": false,
+                "type": "url",
                 "target": "stdio_env"
               },
               {
@@ -598,6 +600,7 @@
             "description": "Regional Falcon API base URL, e.g. https://api.crowdstrike.com (US-1), https://api.us-2.crowdstrike.com (US-2), https://api.eu-1.crowdstrike.com (EU-1), or https://api.laggar.gcw.crowdstrike.com (GovCloud). Must match the cloud your Falcon tenant runs in.",
             "required": true,
             "secret": false,
+            "type": "url",
             "target": "stdio_env"
           }
         ],
@@ -659,6 +662,8 @@
             "description": "The SentinelOne management console endpoint, e.g. https://your-console.sentinelone.net",
             "required": true,
             "secret": false,
+            "type": "url",
+            "placeholder": "https://your-console.sentinelone.net",
             "target": "stdio_env"
           }
         ],
@@ -729,6 +734,7 @@
                 "description": "Jamf Pro instance base URL, e.g. https://yourcompany.jamfcloud.com",
                 "required": true,
                 "secret": false,
+                "type": "url",
                 "target": "stdio_env"
               },
               {
@@ -753,6 +759,7 @@
                 "description": "Jamf Protect tenant URL. Optional; only needed to enable Jamf Protect tools.",
                 "required": false,
                 "secret": false,
+                "type": "url",
                 "target": "stdio_env"
               },
               {
@@ -777,6 +784,7 @@
                 "description": "Jamf Security Cloud (RADAR/RISK API) base URL. Optional; only needed for Security Cloud tools.",
                 "required": false,
                 "secret": false,
+                "type": "url",
                 "target": "stdio_env"
               },
               {
@@ -1164,6 +1172,7 @@
             "description": "Base URL of the HashiCorp Vault server, e.g. http://127.0.0.1:8200. Defaults to http://127.0.0.1:8200 if unset.",
             "required": true,
             "secret": false,
+            "type": "url",
             "target": "stdio_env"
           },
           {
@@ -1434,6 +1443,7 @@
             "description": "The Cortex (XSIAM/XDR) tenant API base URL for your tenant, e.g. https://api-<tenant>.xdr.<region>.paloaltonetworks.com. Used as CORTEX_MCP_PAPI_URL.",
             "required": true,
             "secret": false,
+            "type": "url",
             "target": "stdio_env"
           },
           {
@@ -1577,6 +1587,7 @@
             "description": "Base URL of your ServiceNow instance, e.g. https://your-instance.service-now.com",
             "required": true,
             "secret": false,
+            "type": "url",
             "target": "stdio_env"
           },
           {
@@ -1625,6 +1636,7 @@
             "description": "OAuth token endpoint, e.g. https://your-instance.service-now.com/oauth_token.do (auth_type=oauth).",
             "required": false,
             "secret": false,
+            "type": "url",
             "target": "stdio_env"
           },
           {
@@ -1734,6 +1746,7 @@
             "description": "Optional API base URL. Defaults to https://api.pagerduty.com. Set to https://api.eu.pagerduty.com for EU-region PagerDuty accounts.",
             "required": false,
             "secret": false,
+            "type": "url",
             "target": "stdio_env"
           }
         ],
@@ -2186,6 +2199,7 @@
             "description": "Base URL of your Grafana instance, e.g. http://localhost:3000 or https://myinstance.grafana.net for Grafana Cloud.",
             "required": true,
             "secret": false,
+            "type": "url",
             "target": "stdio_env"
           },
           {
@@ -2378,6 +2392,7 @@
             "description": "Base URL of the HCP Terraform / Terraform Enterprise instance. Defaults to https://app.terraform.io. Set this to your TFE host for self-managed/Enterprise deployments.",
             "required": false,
             "secret": false,
+            "type": "url",
             "target": "stdio_env"
           }
         ],

--- a/tests/unit/test_mcp_catalog_loader.py
+++ b/tests/unit/test_mcp_catalog_loader.py
@@ -207,6 +207,8 @@ def test_get_platform_mcp_catalog_entries_normalizes_specs_and_drops_malformed_r
                 "target": "server_uri",
                 "required": True,
                 "secret": False,
+                "placeholder": None,
+                "type": "string",
             },
             {
                 "key": "Authorization",
@@ -215,6 +217,8 @@ def test_get_platform_mcp_catalog_entries_normalizes_specs_and_drops_malformed_r
                 "target": "http_header",
                 "required": True,
                 "secret": True,
+                "placeholder": None,
+                "type": "string",
             },
         ],
         "credentials": [
@@ -225,6 +229,8 @@ def test_get_platform_mcp_catalog_entries_normalizes_specs_and_drops_malformed_r
                 "required": True,
                 "secret": False,
                 "default_value": None,
+                "placeholder": None,
+                "type": "string",
                 "target": "server_uri",
             },
             {
@@ -234,6 +240,8 @@ def test_get_platform_mcp_catalog_entries_normalizes_specs_and_drops_malformed_r
                 "required": True,
                 "secret": True,
                 "default_value": None,
+                "placeholder": None,
+                "type": "string",
                 "target": "http_header",
             },
         ],
@@ -333,6 +341,65 @@ def test_get_platform_mcp_catalog_entries_normalizes_connection_options(
         "http",
         "stdio",
     ]
+
+
+def test_get_platform_mcp_catalog_entries_propagates_credential_type_and_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catalog ``type``/``placeholder`` reach the loaded credentials/config fields."""
+    _stub_catalog_resource(
+        monkeypatch,
+        orjson.dumps(
+            {
+                "servers": [
+                    {
+                        "slug": "typed-stdio-mcp",
+                        "name": "Typed Stdio",
+                        "description": "Has a URL-typed env credential",
+                        "category": "Endpoint",
+                        "connection_spec": {
+                            "server_type": "stdio",
+                            "auth_type": "CUSTOM",
+                            "stdio_command": "uvx",
+                            "stdio_args": ["typed-mcp"],
+                            "stdio_env": ["TOKEN", "CONSOLE_BASE_URL"],
+                            "credentials": [
+                                {
+                                    "key": "TOKEN",
+                                    "secret": True,
+                                    "target": "stdio_env",
+                                },
+                                {
+                                    "key": "CONSOLE_BASE_URL",
+                                    "secret": False,
+                                    "type": "url",
+                                    "placeholder": "https://your-console.example.net",
+                                    "target": "stdio_env",
+                                },
+                            ],
+                        },
+                    },
+                ]
+            }
+        ),
+    )
+
+    entries = loader.get_platform_mcp_catalog_entries(include_private=True)
+    spec = entries[0].connection_spec
+    assert spec is not None
+
+    creds = {cred.key: cred for cred in spec.credentials}
+    # Explicit catalog values flow through.
+    assert creds["CONSOLE_BASE_URL"].type == "url"
+    assert creds["CONSOLE_BASE_URL"].placeholder == "https://your-console.example.net"
+    # Defaults apply when the catalog omits them.
+    assert creds["TOKEN"].type == "string"
+    assert creds["TOKEN"].placeholder is None
+
+    # config_fields mirror the same data for the configure dialog.
+    fields = {field.key: field for field in spec.config_fields}
+    assert fields["CONSOLE_BASE_URL"].type == "url"
+    assert fields["CONSOLE_BASE_URL"].placeholder == "https://your-console.example.net"
 
 
 def test_get_platform_mcp_catalog_entries_merges_private_mcp_catalog(

--- a/tests/unit/test_mcp_integrations.py
+++ b/tests/unit/test_mcp_integrations.py
@@ -1319,6 +1319,177 @@ class TestMCPIntegrationCRUD:
         assert updated is not None
         assert updated.encrypted_stdio_env is not None
 
+    async def test_catalog_url_typed_stdio_env_requires_scheme(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """stdio_env values for ``type: "url"`` catalog creds need http(s)://."""
+        catalog = _catalog_entry(
+            slug="url-env-mcp",
+            name="URL Env MCP",
+            description="Stdio catalog row with a URL-typed env credential",
+            connection_spec={
+                "kind": "stdio_custom",
+                "server_type": "stdio",
+                "auth_type": "CUSTOM",
+                "requires_config": True,
+                "credentials": [
+                    {
+                        "key": "CONSOLE_BASE_URL",
+                        "label": "Console base URL",
+                        "description": "Management console endpoint",
+                        "target": "stdio_env",
+                        "required": True,
+                        "secret": False,
+                        "type": "url",
+                    }
+                ],
+                "stdio_command": None,
+                "stdio_args": [],
+                "stdio_env": [],
+                "packages": [
+                    {
+                        "manager": "uvx",
+                        "command": "uvx",
+                        "args": ["url-mcp"],
+                        "package": "url-mcp",
+                    }
+                ],
+            },
+            sort_key="0004:url-env-mcp",
+        )
+        _install_catalog_entry(monkeypatch, catalog)
+
+        # Create with a scheme-less URL is rejected.
+        with pytest.raises(ValueError, match="http://"):
+            await integration_service.create_mcp_integration(
+                params=MCPStdioIntegrationCreate(
+                    name=catalog.name,
+                    description=catalog.description,
+                    catalog_slug=catalog.slug,
+                    stdio_command="uvx",
+                    stdio_args=["url-mcp"],
+                    stdio_env={"CONSOLE_BASE_URL": "console.example.net"},
+                )
+            )
+
+        # Create with a valid https URL succeeds.
+        created = await integration_service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name=catalog.name,
+                description=catalog.description,
+                catalog_slug=catalog.slug,
+                stdio_command="uvx",
+                stdio_args=["url-mcp"],
+                stdio_env={"CONSOLE_BASE_URL": "https://console.example.net"},
+            )
+        )
+        assert created.encrypted_stdio_env is not None
+
+        # Update to a scheme-less URL is rejected against the bound catalog row.
+        with pytest.raises(ValueError, match="http://"):
+            await integration_service.update_mcp_integration(
+                mcp_integration_id=created.id,
+                params=MCPIntegrationUpdate(
+                    stdio_env={"CONSOLE_BASE_URL": "console.example.net"}
+                ),
+            )
+
+    async def test_catalog_url_typed_stdio_env_from_connection_option_on_update(
+        self,
+        integration_service: IntegrationService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Update validates URL keys declared by a non-default connection option.
+
+        Mirrors rows whose default option is remote HTTP while a local-stdio
+        option carries a ``type: "url"`` env var (e.g. Panther/Jamf). The
+        URL-typed key lives only in ``connection_options``, not the top-level
+        ``connection_spec``, so update-time validation must union both.
+        """
+        catalog = _catalog_entry(
+            slug="multi-option-url-env-mcp",
+            name="Multi Option URL Env MCP",
+            description="Remote HTTP default with a local-stdio URL env option",
+            connection_spec={
+                "kind": "http_custom",
+                "server_type": "http",
+                "auth_type": "CUSTOM",
+                "requires_config": False,
+                "config_fields": [],
+                "credentials": [],
+                "server_uri": "https://mcp.example.com/mcp",
+            },
+            connection_options=[
+                {
+                    "id": "local-stdio",
+                    "label": "Local (stdio)",
+                    "connection_spec": {
+                        "kind": "stdio_custom",
+                        "server_type": "stdio",
+                        "auth_type": "CUSTOM",
+                        "requires_config": True,
+                        "credentials": [
+                            {
+                                "key": "CONSOLE_BASE_URL",
+                                "label": "Console base URL",
+                                "description": "Management console endpoint",
+                                "target": "stdio_env",
+                                "required": True,
+                                "secret": False,
+                                "type": "url",
+                            }
+                        ],
+                        "stdio_command": None,
+                        "stdio_args": [],
+                        "stdio_env": [],
+                        "packages": [
+                            {
+                                "manager": "uvx",
+                                "command": "uvx",
+                                "args": ["url-mcp"],
+                                "package": "url-mcp",
+                            }
+                        ],
+                    },
+                }
+            ],
+            sort_key="0005:multi-option-url-env-mcp",
+        )
+        _install_catalog_entry(monkeypatch, catalog)
+
+        created = await integration_service.create_mcp_integration(
+            params=MCPStdioIntegrationCreate(
+                name=catalog.name,
+                description=catalog.description,
+                catalog_slug=catalog.slug,
+                stdio_command="uvx",
+                stdio_args=["url-mcp"],
+                stdio_env={"CONSOLE_BASE_URL": "https://console.example.net"},
+            )
+        )
+
+        # Update to a scheme-less URL is rejected even though the URL-typed key
+        # is declared only by the connection option, not connection_spec.
+        with pytest.raises(ValueError, match="http://"):
+            await integration_service.update_mcp_integration(
+                mcp_integration_id=created.id,
+                params=MCPIntegrationUpdate(
+                    stdio_env={"CONSOLE_BASE_URL": "console.example.net"}
+                ),
+            )
+
+        # A valid https URL still updates cleanly.
+        updated = await integration_service.update_mcp_integration(
+            mcp_integration_id=created.id,
+            params=MCPIntegrationUpdate(
+                stdio_env={"CONSOLE_BASE_URL": "https://console.example.org"}
+            ),
+        )
+        assert updated is not None
+        assert updated.encrypted_stdio_env is not None
+
     async def test_connect_platform_mcp_catalog_allows_missing_http_headers(
         self,
         integration_service: IntegrationService,

--- a/tests/unit/test_mcp_schemas.py
+++ b/tests/unit/test_mcp_schemas.py
@@ -1,0 +1,154 @@
+"""Schema-level validation tests for MCP integration URL credentials.
+
+URL validation is driven solely by the catalog declaring ``type: "url"`` on a
+credential — there is no env-var-name heuristic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tracecat.integrations.catalog.loader import (
+    get_platform_mcp_catalog_entry_by_slug,
+)
+from tracecat.integrations.schemas import (
+    MCPStdioIntegrationCreate,
+    validate_url_credential_values,
+)
+from tracecat.integrations.service import IntegrationService
+
+
+class TestValidateUrlCredentialValues:
+    """``validate_url_credential_values`` checks only the declared ``url_keys``."""
+
+    def test_scheme_less_url_rejected(self) -> None:
+        with pytest.raises(ValueError, match="http://"):
+            validate_url_credential_values(
+                {"PURPLEMCP_CONSOLE_BASE_URL": "usea1-015.sentinelone.net"},
+                {"PURPLEMCP_CONSOLE_BASE_URL"},
+            )
+
+    def test_valid_https_url_accepted(self) -> None:
+        # Does not raise.
+        validate_url_credential_values(
+            {"PURPLEMCP_CONSOLE_BASE_URL": "https://usea1-015.sentinelone.net"},
+            {"PURPLEMCP_CONSOLE_BASE_URL"},
+        )
+
+    def test_non_http_scheme_rejected(self) -> None:
+        with pytest.raises(ValueError, match="http://"):
+            validate_url_credential_values({"X": "ftp://host/x"}, {"X"})
+
+    def test_template_expression_skipped(self) -> None:
+        """Templated values resolve at run time, so format is not checked."""
+        validate_url_credential_values(
+            {"CONSOLE_BASE_URL": "${{ VARS.console_url }}"},
+            {"CONSOLE_BASE_URL"},
+        )
+
+    def test_empty_value_skipped(self) -> None:
+        """An unfilled placeholder must not fail validation."""
+        validate_url_credential_values({"CONSOLE_BASE_URL": ""}, {"CONSOLE_BASE_URL"})
+
+    def test_key_not_declared_url_is_ignored(self) -> None:
+        """A key not in ``url_keys`` is never validated as a URL.
+
+        This is the whole point of dropping the name heuristic: a ``*_URL`` key
+        the catalog did not mark ``type: "url"`` passes through untouched.
+        """
+        validate_url_credential_values(
+            {"SOME_OTHER_URL": "no-scheme.example.com"},
+            set(),
+        )
+
+    def test_missing_key_is_noop(self) -> None:
+        """A declared url key absent from the values is a no-op."""
+        validate_url_credential_values({"OTHER": "value"}, {"CONSOLE_BASE_URL"})
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "${{",
+            "${{ VARS.console_url",
+            "prefix${{suffix",
+        ],
+    )
+    def test_malformed_template_not_skipped(self, value: str) -> None:
+        """A bare ``${{`` with no closing ``}}`` is not a template, so the value
+        is still subject to URL validation rather than silently bypassing it."""
+        with pytest.raises(ValueError, match="http://"):
+            validate_url_credential_values(
+                {"CONSOLE_BASE_URL": value}, {"CONSOLE_BASE_URL"}
+            )
+
+    def test_template_with_surrounding_text_skipped(self) -> None:
+        """A complete template expression embedded in text still resolves at
+        run time, so it is skipped."""
+        validate_url_credential_values(
+            {"CONSOLE_BASE_URL": "https://${{ VARS.host }}/path"},
+            {"CONSOLE_BASE_URL"},
+        )
+
+    @pytest.mark.parametrize(
+        "value",
+        [123, ["https://host"], {"url": "https://host"}, None, True],
+    )
+    def test_non_string_value_rejected(self, value: object) -> None:
+        """A present, declared url key with a non-string value must be rejected
+        rather than silently skipped — otherwise invalid payloads bypass the
+        server-side URL check."""
+        with pytest.raises(ValueError, match="http://"):
+            validate_url_credential_values(
+                {"CONSOLE_BASE_URL": value},  # type: ignore[dict-item]
+                {"CONSOLE_BASE_URL"},
+            )
+
+
+class TestCatalogUrlCredentialValidation:
+    """Service collects ``type: "url"`` keys from the catalog spec to validate."""
+
+    @staticmethod
+    def _sentinelone_spec():
+        entry = get_platform_mcp_catalog_entry_by_slug(
+            "sentinelone-mcp", include_private=True
+        )
+        assert entry is not None and entry.connection_spec is not None
+        return entry.connection_spec
+
+    def test_scheme_less_url_rejected_via_catalog_type(self) -> None:
+        spec = self._sentinelone_spec()
+        params = MCPStdioIntegrationCreate(
+            name="SentinelOne Purple",
+            stdio_command="uvx",
+            stdio_env={"PURPLEMCP_CONSOLE_BASE_URL": "usea1-015.sentinelone.net"},
+            catalog_slug="sentinelone-mcp",
+        )
+        with pytest.raises(ValueError, match="http://"):
+            IntegrationService._validate_catalog_url_credentials(
+                params=params, spec=spec
+            )
+
+    def test_valid_url_accepted_via_catalog_type(self) -> None:
+        spec = self._sentinelone_spec()
+        params = MCPStdioIntegrationCreate(
+            name="SentinelOne Purple",
+            stdio_command="uvx",
+            stdio_env={
+                "PURPLEMCP_CONSOLE_BASE_URL": "https://usea1-015.sentinelone.net"
+            },
+            catalog_slug="sentinelone-mcp",
+        )
+        # Does not raise.
+        IntegrationService._validate_catalog_url_credentials(params=params, spec=spec)
+
+    def test_token_value_not_validated_as_url(self) -> None:
+        """The token credential is ``type: "string"`` and is left untouched."""
+        spec = self._sentinelone_spec()
+        params = MCPStdioIntegrationCreate(
+            name="SentinelOne Purple",
+            stdio_command="uvx",
+            stdio_env={"PURPLEMCP_CONSOLE_TOKEN": "not-a-url"},
+            catalog_slug="sentinelone-mcp",
+        )
+        # Does not raise.
+        IntegrationService._validate_catalog_url_credentials(params=params, spec=spec)

--- a/tracecat/integrations/catalog/loader.py
+++ b/tracecat/integrations/catalog/loader.py
@@ -81,6 +81,8 @@ def _normalize_credentials(
             required=raw_credential.required,
             secret=raw_credential.secret,
             default_value=raw_credential.default_value,
+            placeholder=raw_credential.placeholder,
+            type=raw_credential.type,
             target=raw_credential.target,
         )
         for raw_credential in raw_spec.credentials or []

--- a/tracecat/integrations/catalog/types.py
+++ b/tracecat/integrations/catalog/types.py
@@ -13,6 +13,7 @@ from tracecat.integrations.schemas import (
     MCPConnectionOption,
     MCPConnectionSpec,
     MCPConnectionTarget,
+    MCPCredentialValueType,
     PlatformMCPCatalogStatus,
 )
 
@@ -56,6 +57,8 @@ class RawCredential(BaseModel):
     required: bool = True
     secret: bool = True
     default_value: str | None = None
+    placeholder: str | None = None
+    type: MCPCredentialValueType = "string"
     target: MCPConnectionTarget
 
 

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -355,6 +355,51 @@ class ProviderRead(BaseModel):
     redirect_uri: str | None = None
 
 
+# Credential/config-field value types the configure dialog can declare.
+# ``url`` opts a value into http(s)-scheme validation; ``string`` (the default)
+# means an opaque token with no extra format checks. A value is treated as a
+# URL only when the catalog row declares ``type: "url"`` by hand — there is no
+# name-based inference.
+MCPCredentialValueType = Literal["string", "url"]
+
+
+def _is_template_expression(value: str) -> bool:
+    """Whether a value is a Tracecat template (e.g. ``${{ SECRETS.x }}``).
+
+    Templated values resolve to their real (possibly URL) value only at run
+    time, so they must skip format validation here. A bare ``${{`` with no
+    closing ``}}`` is a malformed value, not a template, and is not skipped.
+    """
+    stripped = value.strip()
+    return stripped.startswith("${{") and stripped.endswith("}}")
+
+
+def validate_url_credential_values(values: dict[str, str], url_keys: set[str]) -> None:
+    """Require an http(s):// scheme for values whose key is declared ``type: url``.
+
+    ``url_keys`` comes from the catalog connection spec — only keys a catalog
+    row marks ``type: "url"`` are checked. Empty (not yet filled in) and
+    templated values are skipped because they are validated at run time. Keys
+    outside ``url_keys`` are left untouched.
+    """
+    for key in url_keys:
+        if key not in values:
+            continue
+        value = values.get(key)
+        if not isinstance(value, str):
+            raise ValueError(
+                f"{key!r} must be a URL starting with 'http://' or 'https://'"
+            )
+        stripped = value.strip()
+        if not stripped or _is_template_expression(stripped):
+            continue
+        parsed = urlparse(stripped)
+        if parsed.scheme.lower() not in ("http", "https") or not parsed.netloc:
+            raise ValueError(
+                f"{key!r} must be a URL starting with 'http://' or 'https://'"
+            )
+
+
 class _MCPIntegrationCreateBase(BaseModel):
     """Shared request fields for creating an MCP integration."""
 
@@ -579,6 +624,20 @@ class MCPConnectionCredential(BaseModel):
     required: bool = True
     secret: bool = True
     default_value: str | None = None
+    placeholder: str | None = Field(
+        default=None,
+        description=(
+            "Optional placeholder shown in the configure dialog to hint the "
+            "expected value format (e.g. 'https://your-console.example.net')."
+        ),
+    )
+    type: MCPCredentialValueType = Field(
+        default="string",
+        description=(
+            "Value type used for light client/server validation. 'url' requires "
+            "an http(s):// scheme."
+        ),
+    )
     target: MCPConnectionTarget
 
 
@@ -600,6 +659,8 @@ class MCPConfigField(BaseModel):
     target: MCPConnectionTarget
     required: bool = True
     secret: bool = False
+    placeholder: str | None = None
+    type: MCPCredentialValueType = "string"
 
 
 class _MCPConnectionSpecBase(BaseModel):
@@ -620,6 +681,8 @@ class _MCPConnectionSpecBase(BaseModel):
                 target=credential.target,
                 required=credential.required,
                 secret=credential.secret,
+                placeholder=credential.placeholder,
+                type=credential.type,
             )
             for credential in self.credentials
         ]

--- a/tracecat/integrations/schemas.py
+++ b/tracecat/integrations/schemas.py
@@ -22,6 +22,7 @@ from pydantic import (
     field_validator,
 )
 
+from tracecat.expressions.patterns import STANDALONE_TEMPLATE
 from tracecat.identifiers import UserID, WorkspaceID
 from tracecat.integrations.enums import IntegrationStatus, MCPAuthType, OAuthGrantType
 from tracecat.integrations.types import MCPServerType
@@ -363,17 +364,6 @@ class ProviderRead(BaseModel):
 MCPCredentialValueType = Literal["string", "url"]
 
 
-def _is_template_expression(value: str) -> bool:
-    """Whether a value is a Tracecat template (e.g. ``${{ SECRETS.x }}``).
-
-    Templated values resolve to their real (possibly URL) value only at run
-    time, so they must skip format validation here. A bare ``${{`` with no
-    closing ``}}`` is a malformed value, not a template, and is not skipped.
-    """
-    stripped = value.strip()
-    return stripped.startswith("${{") and stripped.endswith("}}")
-
-
 def validate_url_credential_values(values: dict[str, str], url_keys: set[str]) -> None:
     """Require an http(s):// scheme for values whose key is declared ``type: url``.
 
@@ -391,7 +381,9 @@ def validate_url_credential_values(values: dict[str, str], url_keys: set[str]) -
                 f"{key!r} must be a URL starting with 'http://' or 'https://'"
             )
         stripped = value.strip()
-        if not stripped or _is_template_expression(stripped):
+        # Empty (not yet filled in) and templated values resolve to their real
+        # value only at run time, so skip format validation here.
+        if not stripped or STANDALONE_TEMPLATE.match(stripped):
             continue
         parsed = urlparse(stripped)
         if parsed.scheme.lower() not in ("http", "https") or not parsed.netloc:

--- a/tracecat/integrations/service.py
+++ b/tracecat/integrations/service.py
@@ -4,7 +4,7 @@ import asyncio
 import re
 import secrets
 import uuid
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
@@ -80,6 +80,7 @@ from tracecat.integrations.schemas import (
     ProviderKey,
     ProviderMetadata,
     ProviderScopes,
+    validate_url_credential_values,
 )
 from tracecat.integrations.types import (
     DCRResponse,
@@ -2402,24 +2403,26 @@ class IntegrationService(BaseWorkspaceService):
             raise ValueError("Platform MCP catalog row not found")
         if catalog_entry.status != "available":
             raise ValueError(f"{catalog_entry.name} is not available to connect")
-        if not self._params_match_catalog_connection_specs(
+        matched_spec = self._match_catalog_connection_spec(
             params=params, catalog_entry=catalog_entry
-        ):
+        )
+        if matched_spec is None:
             raise ValueError(
                 f"Requested server and auth configuration does not match any "
                 f"connection option for {catalog_entry.name}"
             )
+        self._validate_catalog_url_credentials(params=params, spec=matched_spec)
 
         await self.require_entitlement(Entitlement.AGENT_ADDONS)
         return catalog_entry
 
     @staticmethod
-    def _params_match_catalog_connection_specs(
+    def _match_catalog_connection_spec(
         *,
         params: MCPIntegrationCreate,
         catalog_entry: PlatformMCPCatalogEntry,
-    ) -> bool:
-        """Whether create params match one of a catalog row's connect recipes.
+    ) -> MCPConnectionSpec | None:
+        """Return the catalog connect recipe the create params bind to, if any.
 
         Guards against binding an arbitrary payload to a platform catalog row
         (e.g. an auth-less row spoofing an OAuth-only connector as connected).
@@ -2437,8 +2440,71 @@ class IntegrationService(BaseWorkspaceService):
             if spec.server_type != params.server_type:
                 continue
             if params.server_type == "stdio" or spec.auth_type == params.auth_type:
-                return True
-        return False
+                return spec
+        return None
+
+    @staticmethod
+    def _validate_catalog_url_credentials(
+        *, params: MCPIntegrationCreate, spec: MCPConnectionSpec
+    ) -> None:
+        """Enforce http(s):// on stdio_env values the catalog marks ``type: url``.
+
+        The catalog row is the single source of truth for which values are
+        URLs; only credentials it declares ``type: "url"`` are checked.
+        """
+        if not isinstance(params, MCPStdioIntegrationCreate) or not params.stdio_env:
+            return
+        IntegrationService._validate_stdio_env_url_keys(
+            spec=spec, stdio_env=params.stdio_env
+        )
+
+    @staticmethod
+    def _stdio_env_url_keys(specs: Iterable[MCPConnectionSpec]) -> set[str]:
+        """Collect stdio_env keys any of ``specs`` declares ``type: url``."""
+        return {
+            cred.key
+            for spec in specs
+            for cred in spec.credentials
+            if cred.type == "url" and cred.target == "stdio_env"
+        }
+
+    @staticmethod
+    def _validate_stdio_env_url_keys(
+        *, spec: MCPConnectionSpec, stdio_env: dict[str, str]
+    ) -> None:
+        """Validate stdio_env values for keys the catalog marks ``type: url``."""
+        url_keys = IntegrationService._stdio_env_url_keys([spec])
+        if url_keys:
+            validate_url_credential_values(stdio_env, url_keys)
+
+    def _validate_stdio_env_against_catalog(
+        self, *, catalog_slug: str | None, stdio_env: dict[str, str]
+    ) -> None:
+        """Validate stdio_env URLs against the bound catalog row, if any.
+
+        BYO rows (no ``catalog_slug``) declare no credential types, so there is
+        nothing to validate. URL-typed keys are unioned across every spec the
+        row offers (``connection_spec`` plus each ``connection_options`` spec):
+        the update payload carries no server/auth discriminator to pin a single
+        option, and a key the row marks ``type: url`` in any option must stay a
+        URL on update.
+        """
+        if not catalog_slug:
+            return
+        catalog_entry = get_platform_mcp_catalog_entry_by_slug(
+            catalog_slug, include_private=True
+        )
+        if catalog_entry is None:
+            return
+        specs: list[MCPConnectionSpec] = []
+        if catalog_entry.connection_spec is not None:
+            specs.append(catalog_entry.connection_spec)
+        specs.extend(
+            option.connection_spec for option in catalog_entry.connection_options or []
+        )
+        url_keys = self._stdio_env_url_keys(specs)
+        if url_keys:
+            validate_url_credential_values(stdio_env, url_keys)
 
     @require_scope("integration:create")
     async def create_mcp_integration(
@@ -3537,6 +3603,11 @@ class IntegrationService(BaseWorkspaceService):
                 ),
                 env=params.stdio_env,
             )
+            if params.stdio_env is not None:
+                self._validate_stdio_env_against_catalog(
+                    catalog_slug=mcp_integration.catalog_slug,
+                    stdio_env=params.stdio_env,
+                )
 
         # Update fields
         if params.name is not None:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds URL typing to MCP catalog credentials and enforces http(s):// for those fields across the UI and API to prevent misconfiguration. BYO entries are unaffected.

- **New Features**
  - Catalog schema: add `type` (`"string" | "url"`, default `"string"`) and `placeholder` to `MCPConnectionCredential` and `MCPConfigField`.
  - Private catalog: mark base URL fields as `type: "url"` and add helpful placeholders.
  - Frontend: dynamic form schema via `buildMcpIntegrationFormSchema`; resolver swaps when the selected option changes; validates only catalog-declared URL `stdio_env` keys; skips templated values using the shared expression helper; JSON templates prefill defaults/placeholders.
  - Backend: propagate `type`/`placeholder`; introduce `MCPCredentialValueType` and `validate_url_credential_values` (uses shared template regex); on create, bind to the matched catalog spec and enforce URL-typed `stdio_env`; on update, union URL keys across `connection_spec` and all `connection_options` and enforce.
  - Tests: cover loader propagation, schema helpers and form validation, and service enforcement on create/update (including option-only URL keys).

<sup>Written for commit 3bbb277af6a1675efcd8c0028a6bfdfd5d2dd2ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

