### PR TITLE
feat(ui): redesign commit selector dropdown

### DIFF
--- a/frontend/src/components/registry/commit-selector.tsx
+++ b/frontend/src/components/registry/commit-selector.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { ChevronDownIcon, TagIcon } from "lucide-react"
+import { Bot, ChevronDownIcon, TagIcon } from "lucide-react"
 import { useState } from "react"
 import type { GitCommitInfo } from "@/client"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -24,6 +25,27 @@ interface CommitSelectorProps {
   error: Error | null
   onSelectCommit: (commitSha: string) => void
   disabled?: boolean
+}
+
+/** Returns true when a commit author is a service/bot account, e.g. "name[bot]". */
+function isBotAuthor(author: string): boolean {
+  return author.toLowerCase().includes("[bot]")
+}
+
+/** Derives up to two uppercase initials from a commit author name. */
+function getAuthorInitials(author: string): string {
+  const cleaned = author
+    .replace(/\[bot\]/gi, "")
+    .replace(/[-_]+/g, " ")
+    .trim()
+  const parts = cleaned.split(/\s+/).filter(Boolean)
+  if (parts.length === 0) {
+    return "?"
+  }
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase()
+  }
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
 }
 
 export function CommitSelector({
@@ -100,10 +122,11 @@ export function CommitSelector({
       <DropdownMenuContent align="start" className="w-96">
         <DropdownMenuLabel>Select commit</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <div className="max-h-64 overflow-y-auto">
+        <div className="max-h-64 overflow-y-auto p-1">
           {commits?.map((commit, index) => {
             const isSelected = commit.sha === effectiveCurrentSha
             const isHead = index === 0
+            const isBot = isBotAuthor(commit.author)
             const commitDate = new Date(commit.date)
             const relativeTime = getRelativeTime(commitDate)
 
@@ -115,43 +138,64 @@ export function CommitSelector({
                   setIsOpen(false)
                 }}
                 className={cn(
-                  "flex flex-col items-start space-y-1 p-3",
-                  isSelected && "bg-accent"
+                  "relative flex cursor-pointer items-start gap-2.5 p-2.5",
+                  isSelected && "bg-primary/5"
                 )}
               >
-                <div className="flex w-full flex-col space-y-1">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center space-x-2">
-                      <span className="font-mono text-sm font-medium">
-                        {commit.sha.substring(0, 7)}
-                      </span>
-                      {isHead && (
-                        <Badge variant="secondary" className="text-xs">
-                          HEAD
-                        </Badge>
-                      )}
-                      {isSelected && !isHead && (
-                        <Badge variant="default" className="text-xs">
-                          Current
-                        </Badge>
-                      )}
-                      {isSelected && isHead && (
-                        <Badge variant="default" className="text-xs">
-                          Current • HEAD
-                        </Badge>
-                      )}
-                    </div>
-                    <span className="text-xs text-muted-foreground">
+                {isSelected && (
+                  <span
+                    aria-hidden
+                    className="absolute inset-y-1.5 left-0 w-0.5 rounded-full bg-primary"
+                  />
+                )}
+                <Avatar className="mt-0.5 size-7 flex-none">
+                  <AvatarFallback className="bg-muted text-[10px] font-medium text-muted-foreground">
+                    {isBot ? (
+                      <Bot className="size-3.5" />
+                    ) : (
+                      getAuthorInitials(commit.author)
+                    )}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-xs font-semibold">
+                      {commit.sha.substring(0, 7)}
+                    </span>
+                    {isSelected && (
+                      <Badge
+                        variant="outline"
+                        className="border-transparent bg-primary/10 text-xs font-medium text-primary"
+                      >
+                        Current
+                      </Badge>
+                    )}
+                    {isHead && (
+                      <Badge variant="secondary" className="text-xs">
+                        HEAD
+                      </Badge>
+                    )}
+                    <span
+                      className="ml-auto whitespace-nowrap text-xs text-muted-foreground"
+                      title={commitDate.toLocaleString()}
+                    >
                       {relativeTime}
                     </span>
                   </div>
+                  <p className="mt-1 line-clamp-1 text-[13px] text-foreground">
+                    {commit.message}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {commit.author || "Unknown"} •{" "}
+                    {commitDate.toLocaleDateString()}
+                  </p>
                   {commit.tags && commit.tags.length > 0 && (
-                    <div className="flex items-center space-x-1">
+                    <div className="mt-1.5 flex flex-wrap items-center gap-1">
                       {commit.tags.map((tag) => (
                         <Badge
                           key={tag}
                           variant="outline"
-                          className="text-xs flex items-center gap-1"
+                          className="flex items-center gap-1 text-xs font-normal text-muted-foreground"
                         >
                           <TagIcon className="size-2.5" />
                           {tag}
@@ -159,14 +203,6 @@ export function CommitSelector({
                       ))}
                     </div>
                   )}
-                </div>
-                <div className="w-full text-left">
-                  <p className="line-clamp-1 text-sm text-foreground">
-                    {commit.message}
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    by {commit.author} • {commitDate.toLocaleDateString()}
-                  </p>
                 </div>
               </DropdownMenuItem>
             )


### PR DESCRIPTION
## Summary

Redesigns the commit selector dropdown (`CommitSelector`) so the current/HEAD
commit no longer crowds the row.

The previous design rendered a large filled **`Current • HEAD`** badge that
wrapped to two lines, collided with the timestamp, and knocked rows out of
alignment.

## Changes

- Replace the oversized combined badge with a left **primary accent bar** plus a
  soft `Current` pill; `HEAD` stays a neutral chip.
- Add author **avatars** (initials for people, a bot glyph for `[bot]`
  accounts) to distinguish human vs automated commits at a glance.
- Selected row uses a subtle `bg-primary/5` tint instead of the heavy grey fill.
- Tags keep a consistent slot; the relative timestamp is right-aligned with the
  absolute date on hover (`title`).

Stays flat, neutral, and uses the primary color sparingly per
`frontend/CLAUDE.md` design rules. Trigger button behavior is unchanged.

## Verification

- `pnpm -C frontend exec biome check` — clean
- `pnpm -C frontend run typecheck` — clean
- pre-commit hooks (biome + frontend type check) passed

## Notes

Scoped to `frontend/src/components/registry/commit-selector.tsx`. The HTML
design spread used to compare options was kept local and is not part of this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the commit selector dropdown to reduce clutter and make Current/HEAD status and authors easier to scan. Adds avatars, a clearer selected state, and a tighter row layout without changing behavior.

- **New Features**
  - Replaced the combined "Current • HEAD" badge with a left primary accent bar on the selected row and a soft `Current` pill; `HEAD` remains a neutral chip.
  - Added author avatars (initials for people, bot icon for `[bot]` accounts).
  - Cleaner row layout: subtle `bg-primary/5` selection tint, line-clamped message, and author • date line (with `Unknown` fallback).
  - Right-aligned relative timestamp with absolute date on hover; tags use outline chips in a fixed slot.

<sup>Written for commit b2af4532dfdedbbfa0bef55731dfab18228d4f4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

