### PR TITLE
refactor(registry): adopt ctx facade over get_context()

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/core/cases.py
@@ -8,8 +8,7 @@ from uuid import UUID
 import httpx
 from typing_extensions import Doc
 
-from tracecat_registry import config, registry, types
-from tracecat_registry.context import get_context
+from tracecat_registry import config, ctx, registry, types
 from tracecat_registry.sdk.exceptions import (
     TracecatValidationError,
 )
@@ -122,7 +121,7 @@ async def create_case(
         params["tags"] = tags
     if create_missing_tags:
         params["create_missing_tags"] = create_missing_tags
-    return await get_context().cases.create_case_simple(**params)
+    return await ctx.cases.aio.create_case_simple(**params)
 
 
 @registry.register(
@@ -214,7 +213,7 @@ async def update_case(
         client_params["create_missing_tags"] = create_missing_tags
     if append and description is not None:
         client_params["append_description"] = True
-    return await get_context().cases.update_case_simple(case_id, **client_params)
+    return await ctx.cases.aio.update_case_simple(case_id, **client_params)
 
 
 @registry.register(
@@ -246,7 +245,7 @@ async def create_comment(
         params["parent_id"] = parent_id
     if workflow_id is not None:
         params["workflow_id"] = workflow_id
-    return await get_context().cases.create_comment_simple(case_id, **params)
+    return await ctx.cases.aio.create_comment_simple(case_id, **params)
 
 
 @registry.register(
@@ -269,7 +268,7 @@ async def reply_to_comment(
         Doc("The reply content."),
     ],
 ) -> types.CaseComment:
-    return await get_context().cases.reply_to_comment(
+    return await ctx.cases.aio.reply_to_comment(
         case_id,
         parent_comment_id=parent_comment_id,
         content=content,
@@ -292,7 +291,7 @@ async def update_comment(
         Doc("The updated comment content."),
     ],
 ) -> types.CaseComment:
-    return await get_context().cases.update_comment_simple(
+    return await ctx.cases.aio.update_comment_simple(
         comment_id,
         content=content,
     )
@@ -310,7 +309,7 @@ async def get_case(
         Doc("The ID of the case to retrieve."),
     ],
 ) -> types.CaseRead:
-    return await get_context().cases.get_case(case_id)
+    return await ctx.cases.aio.get_case(case_id)
 
 
 @registry.register(
@@ -360,7 +359,7 @@ async def list_cases(
         params["order_by"] = order_by
     if sort is not None:
         params["sort"] = sort
-    response = await get_context().cases.list_cases(**params)
+    response = await ctx.cases.aio.list_cases(**params)
     if paginate:
         return response
     return response["items"]
@@ -480,7 +479,7 @@ async def search_cases(
         params["order_by"] = order_by
     if sort is not None:
         params["sort"] = sort
-    response = await get_context().cases.search_cases(**params)
+    response = await ctx.cases.aio.search_cases(**params)
     if paginate:
         return response
     return response["items"]
@@ -498,7 +497,7 @@ async def delete_case(
         Doc("The ID of the case to delete."),
     ],
 ) -> None:
-    await get_context().cases.delete_case(case_id)
+    await ctx.cases.aio.delete_case(case_id)
 
 
 @registry.register(
@@ -513,7 +512,7 @@ async def list_case_events(
         Doc("The ID of the case to get events for."),
     ],
 ) -> types.CaseEventsWithUsers:
-    return await get_context().cases.list_events(case_id)
+    return await ctx.cases.aio.list_events(case_id)
 
 
 @registry.register(
@@ -528,7 +527,7 @@ async def list_comments(
         Doc("The ID of the case to get comments for."),
     ],
 ) -> list[types.CaseCommentRead]:
-    return await get_context().cases.list_comments(case_id)
+    return await ctx.cases.aio.list_comments(case_id)
 
 
 @registry.register(
@@ -543,7 +542,7 @@ async def list_comment_threads(
         Doc("The ID of the case to get comment threads for."),
     ],
 ) -> list[types.CaseCommentThreadRead]:
-    return await get_context().cases.list_comment_threads(case_id)
+    return await ctx.cases.aio.list_comment_threads(case_id)
 
 
 @registry.register(
@@ -558,7 +557,7 @@ async def get_comment_thread(
         Doc("The ID of a comment within the thread."),
     ],
 ) -> types.CaseCommentThreadRead:
-    return await get_context().cases.get_comment_thread(comment_id)
+    return await ctx.cases.aio.get_comment_thread(comment_id)
 
 
 @registry.register(
@@ -577,7 +576,7 @@ async def assign_user(
         Doc("The ID of the user to assign to the case."),
     ],
 ) -> types.Case:
-    return await get_context().cases.assign_user_simple(
+    return await ctx.cases.aio.assign_user_simple(
         case_id,
         assignee_id=assignee_id,
     )
@@ -599,7 +598,7 @@ async def assign_user_by_email(
         Doc("The email of the user to assign to the case."),
     ],
 ) -> types.Case:
-    return await get_context().cases.assign_user_by_email(
+    return await ctx.cases.aio.assign_user_by_email(
         case_id,
         email=assignee_email,
     )
@@ -625,7 +624,7 @@ async def add_case_tag(
         Doc("If true, create the tag if it does not exist."),
     ] = False,
 ) -> types.TagRead:
-    return await get_context().cases.add_tag(
+    return await ctx.cases.aio.add_tag(
         case_id,
         tag_id=tag,
         create_if_missing=create_if_missing,
@@ -648,7 +647,7 @@ async def remove_case_tag(
         Doc("The tag identifier (ID or ref) to remove from the case."),
     ],
 ) -> None:
-    await get_context().cases.remove_tag(case_id, tag_id=tag)
+    await ctx.cases.aio.remove_tag(case_id, tag_id=tag)
 
 
 async def _upload_attachment(
@@ -666,7 +665,7 @@ async def _upload_attachment(
         ) from e
 
     content_base64 = base64.b64encode(content).decode("utf-8")
-    return await get_context().cases.create_attachment(
+    return await ctx.cases.aio.create_attachment(
         str(case_uuid),
         filename=file_name,
         content_base64=content_base64,
@@ -792,7 +791,7 @@ async def list_attachments(
             detail=f"Invalid case ID format: {case_id}"
         ) from e
 
-    return await get_context().cases.list_attachments(str(case_uuid))
+    return await ctx.cases.aio.list_attachments(str(case_uuid))
 
 
 @registry.register(
@@ -823,7 +822,7 @@ async def download_attachment(
     except ValueError as e:
         raise TracecatValidationError(detail=f"Invalid ID format: {str(e)}") from e
 
-    return await get_context().cases.download_attachment(
+    return await ctx.cases.aio.download_attachment(
         case_uuid,
         attachment_uuid,
     )
@@ -853,7 +852,7 @@ async def get_attachment(
     except ValueError as e:
         raise TracecatValidationError(detail=f"Invalid ID format: {str(e)}") from e
 
-    return await get_context().cases.get_attachment_metadata(
+    return await ctx.cases.aio.get_attachment_metadata(
         case_uuid,
         attachment_uuid,
     )
@@ -886,7 +885,7 @@ async def delete_attachment(
     except ValueError as e:
         raise TracecatValidationError(detail=f"Invalid ID format: {str(e)}") from e
 
-    await get_context().cases.delete_attachment(
+    await ctx.cases.aio.delete_attachment(
         case_uuid,
         attachment_uuid,
     )
@@ -933,7 +932,7 @@ async def get_attachment_download_url(
                 detail="Expiry cannot exceed 24 hours (86400 seconds)"
             )
 
-    return await get_context().cases.get_attachment_presigned_url(
+    return await ctx.cases.aio.get_attachment_presigned_url(
         case_uuid,
         attachment_uuid,
         expiry=expiry,
@@ -951,7 +950,7 @@ async def link_row(
     table_id: Annotated[str, Doc("Table ID")],
     row_id: Annotated[str, Doc("Row ID")],
 ) -> types.CaseTableRowRead:
-    return await get_context().cases.link_case_row(
+    return await ctx.cases.aio.link_case_row(
         case_id,
         table_id=table_id,
         row_id=row_id,
@@ -969,7 +968,7 @@ async def unlink_row(
     table_id: Annotated[str, Doc("Table ID")],
     row_id: Annotated[str, Doc("Row ID")],
 ) -> None:
-    await get_context().cases.unlink_case_row(
+    await ctx.cases.aio.unlink_case_row(
         case_id,
         table_id=table_id,
         row_id=row_id,
@@ -987,7 +986,7 @@ async def insert_row(
     table_id: Annotated[str, Doc("Table ID")],
     row: Annotated[dict[str, Any], Doc("Row values")],
 ) -> types.CaseTableRowRead:
-    return await get_context().cases.insert_case_row(
+    return await ctx.cases.aio.insert_case_row(
         case_id,
         table_id=table_id,
         row=row,

--- a/packages/tracecat-registry/tracecat_registry/core/ee/durations.py
+++ b/packages/tracecat-registry/tracecat_registry/core/ee/durations.py
@@ -9,8 +9,7 @@ from typing import Annotated
 
 from typing_extensions import Doc
 
-from tracecat_registry import registry, types
-from tracecat_registry.context import get_context
+from tracecat_registry import ctx, registry, types
 
 
 @registry.register(
@@ -41,4 +40,4 @@ async def get_case_metrics(
     if not case_ids:
         return []
 
-    return await get_context().cases.get_case_metrics(case_ids)
+    return await ctx.cases.aio.get_case_metrics(case_ids)

--- a/packages/tracecat-registry/tracecat_registry/core/ee/tasks.py
+++ b/packages/tracecat-registry/tracecat_registry/core/ee/tasks.py
@@ -9,8 +9,7 @@ from typing import Annotated, Any
 
 from typing_extensions import Doc
 
-from tracecat_registry import registry, types
-from tracecat_registry.context import get_context
+from tracecat_registry import ctx, registry, types
 
 
 @registry.register(
@@ -60,7 +59,7 @@ async def create_task(
             "workflow_id is required when default_trigger_values is provided"
         )
 
-    return await get_context().cases.create_task(
+    return await ctx.cases.aio.create_task(
         case_id=case_id,
         title=title,
         description=description,
@@ -86,7 +85,7 @@ async def get_task(
     ],
 ) -> types.CaseTaskRead:
     """Get a specific case task by ID."""
-    return await get_context().cases.get_task(task_id)
+    return await ctx.cases.aio.get_task(task_id)
 
 
 @registry.register(
@@ -103,7 +102,7 @@ async def list_tasks(
     ],
 ) -> list[types.CaseTaskRead]:
     """List all tasks for a case."""
-    return await get_context().cases.list_tasks(case_id)
+    return await ctx.cases.aio.list_tasks(case_id)
 
 
 @registry.register(
@@ -149,7 +148,7 @@ async def update_task(
 ) -> types.CaseTaskRead:
     """Update an existing case task."""
     if default_trigger_values and workflow_id is None:
-        existing_task = await get_context().cases.get_task(task_id)
+        existing_task = await ctx.cases.aio.get_task(task_id)
         effective_workflow_id = existing_task.get("workflow_id")
         if not effective_workflow_id:
             raise ValueError(
@@ -173,7 +172,7 @@ async def update_task(
     if default_trigger_values is not None:
         update_params["default_trigger_values"] = default_trigger_values
 
-    return await get_context().cases.update_task(task_id=task_id, **update_params)
+    return await ctx.cases.aio.update_task(task_id=task_id, **update_params)
 
 
 @registry.register(
@@ -190,4 +189,4 @@ async def delete_task(
     ],
 ) -> None:
     """Delete a case task."""
-    await get_context().cases.delete_task(task_id)
+    await ctx.cases.aio.delete_task(task_id)

--- a/packages/tracecat-registry/tracecat_registry/core/presets.py
+++ b/packages/tracecat-registry/tracecat_registry/core/presets.py
@@ -6,8 +6,7 @@ from typing import Annotated, Any, Literal
 
 from typing_extensions import Doc
 
-from tracecat_registry import registry
-from tracecat_registry.context import get_context
+from tracecat_registry import ctx, registry
 
 OutputTypeLiteral = Literal[
     "bool",
@@ -166,7 +165,7 @@ async def create_preset(
     if skills is not None:
         kwargs["skills"] = skills
 
-    return await get_context().agents.create_preset(**kwargs)
+    return await ctx.agents.aio.create_preset(**kwargs)
 
 
 @registry.register(
@@ -184,7 +183,7 @@ async def get_preset(
         ),
     ],
 ) -> dict[str, Any]:
-    return await get_context().agents.get_preset(slug)
+    return await ctx.agents.aio.get_preset(slug)
 
 
 @registry.register(
@@ -195,7 +194,7 @@ async def get_preset(
     required_entitlements=["agent_addons"],
 )
 async def list_presets() -> list[dict[str, Any]]:
-    return await get_context().agents.list_presets()
+    return await ctx.agents.aio.list_presets()
 
 
 @registry.register(
@@ -347,7 +346,7 @@ async def update_preset(
     if skills is not None:
         kwargs["skills"] = skills
 
-    return await get_context().agents.update_preset(slug, **kwargs)
+    return await ctx.agents.aio.update_preset(slug, **kwargs)
 
 
 @registry.register(
@@ -363,4 +362,4 @@ async def delete_preset(
         Doc("The slug identifier of the preset to delete (e.g., 'security-analyst')."),
     ],
 ) -> None:
-    await get_context().agents.delete_preset(slug)
+    await ctx.agents.aio.delete_preset(slug)

--- a/packages/tracecat-registry/tracecat_registry/core/skills.py
+++ b/packages/tracecat-registry/tracecat_registry/core/skills.py
@@ -7,8 +7,7 @@ from typing import Annotated, Any
 
 from typing_extensions import Doc
 
-from tracecat_registry import registry
-from tracecat_registry.context import get_context
+from tracecat_registry import ctx, registry
 from tracecat_registry.sdk.agents import CursorPage
 
 
@@ -26,9 +25,7 @@ async def list_skills(
     ] = None,
     reverse: Annotated[bool, Doc("Whether to reverse sort order.")] = False,
 ) -> CursorPage:
-    return await get_context().agents.list_skills(
-        limit=limit, cursor=cursor, reverse=reverse
-    )
+    return await ctx.agents.aio.list_skills(limit=limit, cursor=cursor, reverse=reverse)
 
 
 @registry.register(
@@ -42,7 +39,7 @@ async def create_skill(
     name: Annotated[str, Doc("Skill name in kebab-case (e.g., 'triage-assistant').")],
     description: Annotated[str | None, Doc("Optional skill description.")] = None,
 ) -> dict[str, Any]:
-    return await get_context().agents.create_skill(name=name, description=description)
+    return await ctx.agents.aio.create_skill(name=name, description=description)
 
 
 @registry.register(
@@ -58,7 +55,7 @@ async def get_skill(
         uuid.UUID | None, Doc("Optional canonical skill UUID.")
     ] = None,
 ) -> dict[str, Any]:
-    return await get_context().agents.get_skill(skill_id, skill_uuid=skill_uuid)
+    return await ctx.agents.aio.get_skill(skill_id, skill_uuid=skill_uuid)
 
 
 @registry.register(
@@ -79,7 +76,7 @@ async def list_skill_versions(
     ] = None,
     reverse: Annotated[bool, Doc("Whether to reverse sort order.")] = False,
 ) -> CursorPage:
-    return await get_context().agents.list_skill_versions(
+    return await ctx.agents.aio.list_skill_versions(
         skill_id=skill_id,
         skill_uuid=skill_uuid,
         limit=limit,
@@ -102,7 +99,7 @@ async def get_skill_version(
         uuid.UUID | None, Doc("Optional canonical skill UUID.")
     ] = None,
 ) -> dict[str, Any]:
-    return await get_context().agents.get_skill_version(
+    return await ctx.agents.aio.get_skill_version(
         skill_id=skill_id,
         skill_uuid=skill_uuid,
         version_id=version_id,
@@ -134,7 +131,7 @@ async def publish_skill_version(
         uuid.UUID | None, Doc("Optional canonical skill UUID.")
     ] = None,
 ) -> dict[str, Any]:
-    return await get_context().agents.publish_skill_version(
+    return await ctx.agents.aio.publish_skill_version(
         skill_id=skill_id,
         skill_uuid=skill_uuid,
         base_version_id=base_version_id,
@@ -156,7 +153,7 @@ async def restore_skill_version(
         uuid.UUID | None, Doc("Optional canonical skill UUID.")
     ] = None,
 ) -> dict[str, Any]:
-    return await get_context().agents.restore_skill_version(
+    return await ctx.agents.aio.restore_skill_version(
         skill_id=skill_id,
         skill_uuid=skill_uuid,
         version_id=version_id,
@@ -176,4 +173,4 @@ async def archive_skill(
         uuid.UUID | None, Doc("Optional canonical skill UUID.")
     ] = None,
 ) -> None:
-    await get_context().agents.archive_skill(skill_id, skill_uuid=skill_uuid)
+    await ctx.agents.aio.archive_skill(skill_id, skill_uuid=skill_uuid)

--- a/packages/tracecat-registry/tracecat_registry/core/table.py
+++ b/packages/tracecat-registry/tracecat_registry/core/table.py
@@ -3,8 +3,7 @@ from typing import Annotated, Any, Literal
 
 from typing_extensions import Doc
 
-from tracecat_registry import config, registry, types
-from tracecat_registry.context import get_context
+from tracecat_registry import config, ctx, registry, types
 from tracecat_registry.sdk.exceptions import TracecatConflictError
 
 
@@ -28,7 +27,7 @@ async def lookup(
         Doc("The value to lookup."),
     ],
 ) -> dict[str, Any] | None:
-    return await get_context().tables.lookup(table=table, column=column, value=value)
+    return await ctx.tables.aio.lookup(table=table, column=column, value=value)
 
 
 @registry.register(
@@ -51,7 +50,7 @@ async def is_in(
         Doc("The value to check for."),
     ],
 ) -> bool:
-    return await get_context().tables.exists(table=table, column=column, value=value)
+    return await ctx.tables.aio.exists(table=table, column=column, value=value)
 
 
 @registry.register(
@@ -90,7 +89,7 @@ async def lookup_many(
     }
     if limit is not None:
         params["limit"] = limit
-    return await get_context().tables.lookup_many(**params)
+    return await ctx.tables.aio.lookup_many(**params)
 
 
 @registry.register(
@@ -162,7 +161,7 @@ async def search_rows(
     if cursor is not None:
         params["cursor"] = cursor
     params["reverse"] = reverse
-    response = await get_context().tables.search_rows(**params)
+    response = await ctx.tables.aio.search_rows(**params)
     if paginate:
         return response
     if isinstance(response, dict):
@@ -190,7 +189,7 @@ async def insert_row(
         Doc("If true, update the row if it already exists (based on primary key)."),
     ] = False,
 ) -> dict[str, Any]:
-    return await get_context().tables.insert_row(
+    return await ctx.tables.aio.insert_row(
         table=table,
         row_data=row_data,
         upsert=upsert,
@@ -217,7 +216,7 @@ async def insert_rows(
         Doc("If true, update the rows if they already exist (based on primary key)."),
     ] = False,
 ) -> int:
-    return await get_context().tables.insert_rows(
+    return await ctx.tables.aio.insert_rows(
         table=table,
         rows_data=rows_data,
         upsert=upsert,
@@ -244,7 +243,7 @@ async def update_row(
         Doc("The new data for the row."),
     ],
 ) -> dict[str, Any]:
-    return await get_context().tables.update_row(
+    return await ctx.tables.aio.update_row(
         table=table,
         row_id=row_id,
         row_data=row_data,
@@ -267,7 +266,7 @@ async def delete_row(
         Doc("The ID of the row to delete."),
     ],
 ) -> None:
-    await get_context().tables.delete_row(table=table, row_id=row_id)
+    await ctx.tables.aio.delete_row(table=table, row_id=row_id)
 
 
 @registry.register(
@@ -304,7 +303,7 @@ async def create_table(
     if columns is not None:
         client_params["columns"] = columns
     try:
-        return await get_context().tables.create_table(**client_params)
+        return await ctx.tables.aio.create_table(**client_params)
     except TracecatConflictError as exc:
         raise ValueError("Table already exists") from exc
 
@@ -316,7 +315,7 @@ async def create_table(
     namespace="core.table",
 )
 async def list_tables() -> list[types.Table]:
-    return await get_context().tables.list_tables()
+    return await ctx.tables.aio.list_tables()
 
 
 @registry.register(
@@ -328,7 +327,7 @@ async def list_tables() -> list[types.Table]:
 async def get_table_metadata(
     name: Annotated[str, Doc("The name of the table to get.")],
 ) -> types.TableRead:
-    return await get_context().tables.get_table_metadata(name)
+    return await ctx.tables.aio.get_table_metadata(name)
 
 
 @registry.register(
@@ -347,7 +346,7 @@ async def update_table(
         Doc("The new table name."),
     ],
 ) -> types.TableRead:
-    return await get_context().tables.update_table(name=name, new_name=new_name)
+    return await ctx.tables.aio.update_table(name=name, new_name=new_name)
 
 
 @registry.register(
@@ -372,7 +371,7 @@ async def create_column(
         ),
     ],
 ) -> types.TableRead:
-    return await get_context().tables.create_column(table=table, column=column)
+    return await ctx.tables.aio.create_column(table=table, column=column)
 
 
 @registry.register(
@@ -398,7 +397,7 @@ async def update_column(
         ),
     ],
 ) -> types.TableRead:
-    return await get_context().tables.update_column(
+    return await ctx.tables.aio.update_column(
         table=table,
         column=column,
         update=update,
@@ -421,7 +420,7 @@ async def delete_column(
         Doc("The column name to delete."),
     ],
 ) -> types.TableRead:
-    return await get_context().tables.delete_column(table=table, column=column)
+    return await ctx.tables.aio.delete_column(table=table, column=column)
 
 
 @registry.register(
@@ -450,4 +449,4 @@ async def download(
         params["format"] = format
     if limit is not None:
         params["limit"] = limit
-    return await get_context().tables.download(**params)
+    return await ctx.tables.aio.download(**params)

--- a/packages/tracecat-registry/tracecat_registry/core/transform.py
+++ b/packages/tracecat-registry/tracecat_registry/core/transform.py
@@ -6,11 +6,10 @@ from typing_extensions import Doc
 import hashlib
 import json
 import orjson
-from tracecat_registry import ActionIsInterfaceError, registry
+from tracecat_registry import ActionIsInterfaceError, ctx, registry
 from tracecat_registry._internal.flatten import flatten_dict as _flatten_dict
 from tracecat_registry._internal.jsonpath import eval_jsonpath
 from tracecat_registry._internal.safe_lambda import build_safe_lambda
-from tracecat_registry.context import get_context
 
 
 def _compute_digests(seen: dict[tuple[Any, ...], dict[str, Any]]) -> list[str]:
@@ -148,8 +147,7 @@ async def _deduplicate_persistent(
         Items whose digests were newly created (not previously seen).
     """
     digests = _compute_digests(seen)
-    ctx = get_context()
-    created = await ctx.deduplicate.create_digests(digests, expire_seconds)
+    created = await ctx.deduplicate.aio.create_digests(digests, expire_seconds)
     return [item for item, is_new in zip(seen.values(), created) if is_new]
 
 

--- a/packages/tracecat-registry/tracecat_registry/core/workflow.py
+++ b/packages/tracecat-registry/tracecat_registry/core/workflow.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any, Literal
 
 from typing_extensions import Doc
 
-from tracecat_registry import ActionIsInterfaceError, registry
+from tracecat_registry import ActionIsInterfaceError, ctx, registry
 from tracecat_registry.context import get_context
 from tracecat_registry.sdk.workflows import (
     WorkflowExecutionError,
@@ -101,7 +101,7 @@ async def execute(
     """
     # Try to get the registry context for direct invocation
     try:
-        ctx = get_context()
+        context = get_context()
     except RuntimeError:
         # No context available - this is likely being called from DSLWorkflow
         # which should have intercepted this action before reaching the UDF.
@@ -112,14 +112,14 @@ async def execute(
     # Note: version, loop_strategy, batch_size, fail_strategy are DSLWorkflow-only params
 
     try:
-        result = await ctx.workflows.execute(
+        result = await context.workflows.execute(
             workflow_alias=workflow_alias,
             trigger_inputs=trigger_inputs,
             environment=environment,
             timeout=timeout,
             wait_strategy=wait_strategy,
             # Pass parent execution ID for correlation (stored in Temporal memo)
-            parent_workflow_execution_id=ctx.wf_exec_id,
+            parent_workflow_execution_id=context.wf_exec_id,
         )
         return result
     except WorkflowExecutionError:
@@ -156,9 +156,7 @@ async def create_workflow(
     ] = None,
 ) -> dict[str, Any]:
     """Create a new empty workflow and return ``{"id", "title"}``."""
-    return await get_context().workflows.create_workflow(
-        title=title, description=description
-    )
+    return await ctx.workflows.aio.create_workflow(title=title, description=description)
 
 
 @registry.register(
@@ -187,5 +185,4 @@ async def get_status(
     Raises:
         RuntimeError: If no context is available.
     """
-    ctx = get_context()
-    return await ctx.workflows.get_status(wf_exec_id)
+    return await ctx.workflows.aio.get_status(wf_exec_id)

--- a/packages/tracecat-registry/tracecat_registry/ctx.py
+++ b/packages/tracecat-registry/tracecat_registry/ctx.py
@@ -1,6 +1,7 @@
-"""Registry SDK facade for run_python scripts.
+"""Registry SDK facade.
 
-This module is intentionally shaped for inline scripts:
+This is the standard way to reach platform services from registry code. It is
+used both by built-in registry actions and by inline ``run_python`` scripts:
 
     from tracecat_registry import ctx
 

--- a/packages/tracecat-registry/tracecat_registry/ctx.pyi
+++ b/packages/tracecat-registry/tracecat_registry/ctx.pyi
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from tracecat_registry import types
 from tracecat_registry import types as registry_types
-from tracecat_registry.sdk.agents import AgentConfig, RankableItem
+from tracecat_registry.sdk.agents import AgentConfig, CursorPage, RankableItem
 from tracecat_registry.sdk.client import TracecatClient
 from tracecat_registry.sdk.types import CasePriority, CaseSeverity, CaseStatus, Unset
 
@@ -94,6 +94,62 @@ class _AgentsAsync:
         self,
         slug: str,
     ) -> None: ...
+    async def list_skills(
+        self,
+        *,
+        limit: int = ...,
+        cursor: str | None = ...,
+        reverse: bool = ...,
+    ) -> CursorPage: ...
+    async def create_skill(
+        self,
+        *,
+        name: str,
+        description: str | None = ...,
+    ) -> dict[str, Any]: ...
+    async def get_skill(
+        self,
+        skill_id: str,
+        *,
+        skill_uuid: str | uuid.UUID | None = ...,
+    ) -> dict[str, Any]: ...
+    async def list_skill_versions(
+        self,
+        *,
+        skill_id: str,
+        skill_uuid: str | uuid.UUID | None = ...,
+        limit: int = ...,
+        cursor: str | None = ...,
+        reverse: bool = ...,
+    ) -> CursorPage: ...
+    async def get_skill_version(
+        self,
+        *,
+        skill_id: str,
+        version_id: str | uuid.UUID,
+        skill_uuid: str | uuid.UUID | None = ...,
+    ) -> dict[str, Any]: ...
+    async def publish_skill_version(
+        self,
+        *,
+        skill_id: str,
+        files: list[dict[str, Any]],
+        skill_uuid: str | uuid.UUID | None = ...,
+        base_version_id: str | None = ...,
+    ) -> dict[str, Any]: ...
+    async def restore_skill_version(
+        self,
+        *,
+        skill_id: str,
+        version_id: str | uuid.UUID,
+        skill_uuid: str | uuid.UUID | None = ...,
+    ) -> dict[str, Any]: ...
+    async def archive_skill(
+        self,
+        skill_id: str,
+        *,
+        skill_uuid: str | uuid.UUID | None = ...,
+    ) -> None: ...
 
 class _Agents:
     @property
@@ -177,6 +233,62 @@ class _Agents:
     def delete_preset(
         self,
         slug: str,
+    ) -> None: ...
+    def list_skills(
+        self,
+        *,
+        limit: int = ...,
+        cursor: str | None = ...,
+        reverse: bool = ...,
+    ) -> CursorPage: ...
+    def create_skill(
+        self,
+        *,
+        name: str,
+        description: str | None = ...,
+    ) -> dict[str, Any]: ...
+    def get_skill(
+        self,
+        skill_id: str,
+        *,
+        skill_uuid: str | uuid.UUID | None = ...,
+    ) -> dict[str, Any]: ...
+    def list_skill_versions(
+        self,
+        *,
+        skill_id: str,
+        skill_uuid: str | uuid.UUID | None = ...,
+        limit: int = ...,
+        cursor: str | None = ...,
+        reverse: bool = ...,
+    ) -> CursorPage: ...
+    def get_skill_version(
+        self,
+        *,
+        skill_id: str,
+        version_id: str | uuid.UUID,
+        skill_uuid: str | uuid.UUID | None = ...,
+    ) -> dict[str, Any]: ...
+    def publish_skill_version(
+        self,
+        *,
+        skill_id: str,
+        files: list[dict[str, Any]],
+        skill_uuid: str | uuid.UUID | None = ...,
+        base_version_id: str | None = ...,
+    ) -> dict[str, Any]: ...
+    def restore_skill_version(
+        self,
+        *,
+        skill_id: str,
+        version_id: str | uuid.UUID,
+        skill_uuid: str | uuid.UUID | None = ...,
+    ) -> dict[str, Any]: ...
+    def archive_skill(
+        self,
+        skill_id: str,
+        *,
+        skill_uuid: str | uuid.UUID | None = ...,
     ) -> None: ...
 
 class _CasesAsync:
@@ -846,6 +958,31 @@ class _TablesAsync:
         self,
         name: str,
     ) -> types.TableRead: ...
+    async def update_table(
+        self,
+        *,
+        name: str,
+        new_name: str,
+    ) -> types.TableRead: ...
+    async def create_column(
+        self,
+        *,
+        table: str,
+        column: dict[str, Any],
+    ) -> types.TableRead: ...
+    async def update_column(
+        self,
+        *,
+        table: str,
+        column: str,
+        update: dict[str, Any],
+    ) -> types.TableRead: ...
+    async def delete_column(
+        self,
+        *,
+        table: str,
+        column: str,
+    ) -> types.TableRead: ...
     async def lookup(
         self,
         *,
@@ -930,6 +1067,31 @@ class _Tables:
     def get_table_metadata(
         self,
         name: str,
+    ) -> types.TableRead: ...
+    def update_table(
+        self,
+        *,
+        name: str,
+        new_name: str,
+    ) -> types.TableRead: ...
+    def create_column(
+        self,
+        *,
+        table: str,
+        column: dict[str, Any],
+    ) -> types.TableRead: ...
+    def update_column(
+        self,
+        *,
+        table: str,
+        column: str,
+        update: dict[str, Any],
+    ) -> types.TableRead: ...
+    def delete_column(
+        self,
+        *,
+        table: str,
+        column: str,
     ) -> types.TableRead: ...
     def lookup(
         self,
@@ -1066,6 +1228,12 @@ class _WorkflowsAsync:
         self,
         workflow_execution_id: str,
     ) -> dict[str, Any]: ...
+    async def create_workflow(
+        self,
+        *,
+        title: str | None = ...,
+        description: str | None = ...,
+    ) -> dict[str, Any]: ...
 
 class _Workflows:
     @property
@@ -1085,6 +1253,12 @@ class _Workflows:
     def get_status(
         self,
         workflow_execution_id: str,
+    ) -> dict[str, Any]: ...
+    def create_workflow(
+        self,
+        *,
+        title: str | None = ...,
+        description: str | None = ...,
     ) -> dict[str, Any]: ...
 
 agents: _Agents

--- a/packages/tracecat-registry/tracecat_registry/integrations/aws_boto3.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/aws_boto3.py
@@ -23,12 +23,12 @@ else:
 
 from tracecat_registry import (
     RegistrySecret,
+    ctx,
     secrets,
     SecretNotFoundError,
     logger,
     registry,
 )
-from tracecat_registry.context import get_context
 
 _ASSUME_ROLE_EXTERNAL_ID_SECRET_KEY = "TRACECAT_AWS_EXTERNAL_ID"
 _AWS_SERVICE_REGION_DOC = (
@@ -85,15 +85,16 @@ def _get_role_session_name() -> str:
             return session_name
 
     try:
-        ctx = get_context()
+        workspace_id = ctx.workspace_id
+        run_id = ctx.run_id
     except RuntimeError:
         return "tracecat-session"
 
     parts = ["tracecat"]
-    if ctx.workspace_id:
-        parts.extend(["ws", ctx.workspace_id.replace("-", "")[:8]])
-    if ctx.run_id:
-        parts.extend(["run", ctx.run_id.replace("-", "")[:8]])
+    if workspace_id:
+        parts.extend(["ws", workspace_id.replace("-", "")[:8]])
+    if run_id:
+        parts.extend(["run", run_id.replace("-", "")[:8]])
     return "-".join(parts)[:64]
 
 

--- a/packages/tracecat-registry/tracecat_registry/integrations/crowdstrike_falconpy.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/crowdstrike_falconpy.py
@@ -5,8 +5,7 @@ from typing import Annotated, Any
 from falconpy import APIHarnessV2
 from pydantic import Field
 
-from tracecat_registry import RegistrySecret, registry, secrets
-from tracecat_registry.context import get_context
+from tracecat_registry import RegistrySecret, ctx, registry, secrets
 
 crowdstrike_secret = RegistrySecret(
     name="crowdstrike",
@@ -60,7 +59,7 @@ async def call_command(
     # Resolve base_url: parameter takes precedence, then workspace variable
     resolved_base_url = base_url
     if not resolved_base_url:
-        resolved_base_url = await get_context().variables.get_or_default(
+        resolved_base_url = await ctx.variables.aio.get_or_default(
             "crowdstrike", "base_url", None
         )
 

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/github.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/github.py
@@ -3,8 +3,7 @@ from typing import Annotated
 from pydantic import Field
 from typing_extensions import Doc
 
-from tracecat_registry import RegistryOAuthSecret, registry, secrets
-from tracecat_registry.context import get_context
+from tracecat_registry import RegistryOAuthSecret, ctx, registry, secrets
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
@@ -61,8 +60,7 @@ async def mcp(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(github_mcp_oauth_secret.token_name)
-    ctx = get_context()
-    result = await ctx.agents.run(
+    result = await ctx.agents.aio.run(
         user_prompt=user_prompt,
         config=AgentConfig(
             model_name=resolved_model.model_name,

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/jira.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/jira.py
@@ -3,8 +3,7 @@ from typing import Annotated
 from pydantic import Field
 from typing_extensions import Doc
 
-from tracecat_registry import RegistryOAuthSecret, registry, secrets
-from tracecat_registry.context import get_context
+from tracecat_registry import RegistryOAuthSecret, ctx, registry, secrets
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
@@ -64,8 +63,7 @@ async def mcp(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(jira_mcp_oauth_secret.token_name)
-    ctx = get_context()
-    result = await ctx.agents.run(
+    result = await ctx.agents.aio.run(
         user_prompt=user_prompt,
         config=AgentConfig(
             model_name=resolved_model.model_name,

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/linear.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/linear.py
@@ -3,8 +3,7 @@ from typing import Annotated
 from pydantic import Field
 from typing_extensions import Doc
 
-from tracecat_registry import RegistryOAuthSecret, registry, secrets
-from tracecat_registry.context import get_context
+from tracecat_registry import RegistryOAuthSecret, ctx, registry, secrets
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
@@ -61,8 +60,7 @@ async def mcp(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(linear_mcp_oauth_secret.token_name)
-    ctx = get_context()
-    result = await ctx.agents.run(
+    result = await ctx.agents.aio.run(
         user_prompt=user_prompt,
         config=AgentConfig(
             model_name=resolved_model.model_name,

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/notion.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/notion.py
@@ -3,8 +3,7 @@ from typing import Annotated
 from pydantic import Field
 from typing_extensions import Doc
 
-from tracecat_registry import RegistryOAuthSecret, registry, secrets
-from tracecat_registry.context import get_context
+from tracecat_registry import RegistryOAuthSecret, ctx, registry, secrets
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
@@ -61,8 +60,7 @@ async def mcp(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(notion_mcp_oauth_secret.token_name)
-    ctx = get_context()
-    result = await ctx.agents.run(
+    result = await ctx.agents.aio.run(
         user_prompt=user_prompt,
         config=AgentConfig(
             model_name=resolved_model.model_name,

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/runreveal.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/runreveal.py
@@ -3,8 +3,7 @@ from typing import Annotated
 from pydantic import Field
 from typing_extensions import Doc
 
-from tracecat_registry import RegistryOAuthSecret, registry, secrets
-from tracecat_registry.context import get_context
+from tracecat_registry import RegistryOAuthSecret, ctx, registry, secrets
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
@@ -61,8 +60,7 @@ async def mcp(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(runreveal_mcp_oauth_secret.token_name)
-    ctx = get_context()
-    result = await ctx.agents.run(
+    result = await ctx.agents.aio.run(
         user_prompt=user_prompt,
         config=AgentConfig(
             model_name=resolved_model.model_name,

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/sentry.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/sentry.py
@@ -3,8 +3,7 @@ from typing import Annotated
 from pydantic import Field
 from typing_extensions import Doc
 
-from tracecat_registry import RegistryOAuthSecret, registry, secrets
-from tracecat_registry.context import get_context
+from tracecat_registry import RegistryOAuthSecret, ctx, registry, secrets
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
@@ -61,8 +60,7 @@ async def mcp(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(sentry_mcp_oauth_secret.token_name)
-    ctx = get_context()
-    result = await ctx.agents.run(
+    result = await ctx.agents.aio.run(
         user_prompt=user_prompt,
         config=AgentConfig(
             model_name=resolved_model.model_name,

--- a/packages/tracecat-registry/tracecat_registry/integrations/mcp/wiz.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/mcp/wiz.py
@@ -3,8 +3,7 @@ from typing import Annotated
 from pydantic import Field
 from typing_extensions import Doc
 
-from tracecat_registry import RegistryOAuthSecret, registry, secrets
-from tracecat_registry.context import get_context
+from tracecat_registry import RegistryOAuthSecret, ctx, registry, secrets
 from tracecat_registry.core.agent import PYDANTIC_AI_REGISTRY_SECRETS
 from tracecat_registry.core.ai import (
     LEGACY_MODEL_FIELD_SCHEMA_EXTRA,
@@ -61,8 +60,7 @@ async def mcp(
         model=model, model_name=model_name, model_provider=model_provider
     )
     token = secrets.get(wiz_mcp_oauth_secret.token_name)
-    ctx = get_context()
-    result = await ctx.agents.run(
+    result = await ctx.agents.aio.run(
         user_prompt=user_prompt,
         config=AgentConfig(
             model_name=resolved_model.model_name,

--- a/packages/tracecat-registry/tracecat_registry/integrations/splunk.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/splunk.py
@@ -9,8 +9,7 @@ from typing import Annotated, Any, Iterable, Literal
 import httpx
 from typing_extensions import Doc
 
-from tracecat_registry import RegistrySecret, registry, secrets
-from tracecat_registry.context import get_context
+from tracecat_registry import RegistrySecret, ctx, registry, secrets
 
 
 splunk_secret = RegistrySecret(
@@ -211,7 +210,7 @@ async def upload_csv_to_kv_collection(
     # Resolve base_url: parameter takes precedence, then workspace variable
     resolved_base_url = base_url
     if not resolved_base_url:
-        resolved_base_url = await get_context().variables.get_or_default(
+        resolved_base_url = await ctx.variables.aio.get_or_default(
             "splunk", "base_url", None
         )
     if not resolved_base_url:

--- a/packages/tracecat-registry/tracecat_registry/sdk/agents.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/agents.py
@@ -155,7 +155,7 @@ async def run_agent(
     Returns:
         AgentOutput with result, message history, usage, and session ID.
     """
-    from tracecat_registry.context import get_context
+    from tracecat_registry import ctx
 
     # Handle legacy mcp_server_url/headers
     merged_mcp_servers: list[MCPServerConfig] | None = mcp_servers
@@ -170,8 +170,7 @@ async def run_agent(
             )
         )
 
-    ctx = get_context()
-    result = await ctx.agents.run(
+    result = await ctx.agents.aio.run(
         user_prompt=user_prompt,
         config=AgentConfig(
             model_name=model_name,
@@ -234,10 +233,9 @@ async def rank_items(
     Returns:
         List of item IDs in ranked order (most to least relevant).
     """
-    from tracecat_registry.context import get_context
+    from tracecat_registry import ctx
 
-    ctx = get_context()
-    return await ctx.agents.rank_items(
+    return await ctx.agents.aio.rank_items(
         items=items,
         criteria_prompt=criteria_prompt,
         model_name=model_name,
@@ -293,10 +291,9 @@ async def rank_items_pairwise(
     Returns:
         List of item IDs in ranked order (most to least relevant).
     """
-    from tracecat_registry.context import get_context
+    from tracecat_registry import ctx
 
-    ctx = get_context()
-    return await ctx.agents.rank_items_pairwise(
+    return await ctx.agents.aio.rank_items_pairwise(
         items=items,
         criteria_prompt=criteria_prompt,
         model_name=model_name,

--- a/packages/tracecat-registry/tracecat_registry/sdk/variables.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/variables.py
@@ -40,8 +40,8 @@ class VariablesClient:
             TracecatNotFoundError: If the variable doesn't exist.
 
         Example:
-            >>> from tracecat_registry.context import get_context
-            >>> base_url = await get_context().variables.get("api_config", "base_url")
+            >>> from tracecat_registry import ctx
+            >>> base_url = await ctx.variables.aio.get("api_config", "base_url")
         """
         params: dict[str, Any] = {"key": key}
         if is_set(environment):
@@ -68,8 +68,8 @@ class VariablesClient:
             The value for the specified key, or the default if not found.
 
         Example:
-            >>> from tracecat_registry.context import get_context
-            >>> timeout = await get_context().variables.get_or_default(
+            >>> from tracecat_registry import ctx
+            >>> timeout = await ctx.variables.aio.get_or_default(
             ...     "api_config", "timeout", 30
             ... )
         """

--- a/tests/registry/test_core_cases.py
+++ b/tests/registry/test_core_cases.py
@@ -11,7 +11,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import tracecat_registry.core.cases as cases_core
 import tracecat_registry.types as registry_types
 from tracecat_registry.core.cases import (
     add_case_tag,
@@ -51,7 +50,7 @@ def mock_cases_client():
 def mock_get_context(mock_cases_client: AsyncMock):
     """Mock get_context to return a fake context with mock cases client."""
     fake_ctx = SimpleNamespace(cases=mock_cases_client)
-    with patch.object(cases_core, "get_context", return_value=fake_ctx):
+    with patch("tracecat_registry.ctx.get_context", return_value=fake_ctx):
         yield
 
 

--- a/tests/registry/test_core_table.py
+++ b/tests/registry/test_core_table.py
@@ -10,7 +10,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
-import tracecat_registry.core.table as table_core
 from tracecat_registry import config
 from tracecat_registry.core.table import (
     create_table,
@@ -38,7 +37,7 @@ def mock_tables_client():
 def mock_get_context(mock_tables_client: AsyncMock):
     """Mock get_context to return a fake context with mock tables client."""
     fake_ctx = SimpleNamespace(tables=mock_tables_client)
-    with patch.object(table_core, "get_context", return_value=fake_ctx):
+    with patch("tracecat_registry.ctx.get_context", return_value=fake_ctx):
         yield
 
 

--- a/tests/unit/test_aws_assume_role.py
+++ b/tests/unit/test_aws_assume_role.py
@@ -27,7 +27,7 @@ def test_get_sync_temporary_credentials_uses_external_id_and_default_session_nam
     )
 
     with (
-        patch.object(aws_boto3, "get_context", return_value=ctx),
+        patch("tracecat_registry.ctx.get_context", return_value=ctx),
         patch.object(
             aws_boto3.secrets,
             "get_or_default",

--- a/tests/unit/test_deduplicate.py
+++ b/tests/unit/test_deduplicate.py
@@ -102,9 +102,7 @@ class TestDeduplicateTransform:
 
         items = [{"id": 1, "v": "a"}, {"id": 2, "v": "b"}]
 
-        with patch(
-            "tracecat_registry.core.transform.get_context", return_value=mock_ctx
-        ):
+        with patch("tracecat_registry.ctx.get_context", return_value=mock_ctx):
             result = await deduplicate(items, keys=["id"], persist=True)
 
         mock_dedup_client.create_digests.assert_called_once()
@@ -116,9 +114,7 @@ class TestDeduplicateTransform:
         """persist=False does within-call dedup only, no SDK call."""
         mock_ctx = MagicMock()
 
-        with patch(
-            "tracecat_registry.core.transform.get_context", return_value=mock_ctx
-        ):
+        with patch("tracecat_registry.ctx.get_context", return_value=mock_ctx):
             result = await deduplicate(
                 [{"id": 1}, {"id": 1}, {"id": 2}],
                 keys=["id"],
@@ -140,9 +136,7 @@ class TestDeduplicateTransform:
         mock_ctx = MagicMock()
         mock_ctx.deduplicate = mock_dedup_client
 
-        with patch(
-            "tracecat_registry.core.transform.get_context", return_value=mock_ctx
-        ):
+        with patch("tracecat_registry.ctx.get_context", return_value=mock_ctx):
             result = await is_duplicate({"id": 1}, keys=["id"])
 
         assert result is True
@@ -157,9 +151,7 @@ class TestDeduplicateTransform:
         mock_ctx = MagicMock()
         mock_ctx.deduplicate = mock_dedup_client
 
-        with patch(
-            "tracecat_registry.core.transform.get_context", return_value=mock_ctx
-        ):
+        with patch("tracecat_registry.ctx.get_context", return_value=mock_ctx):
             result = await is_duplicate({"id": 99}, keys=["id"])
 
         assert result is False
@@ -169,9 +161,7 @@ class TestDeduplicateTransform:
         """Empty input returns empty list without calling SDK."""
         mock_ctx = MagicMock()
 
-        with patch(
-            "tracecat_registry.core.transform.get_context", return_value=mock_ctx
-        ):
+        with patch("tracecat_registry.ctx.get_context", return_value=mock_ctx):
             result = await deduplicate([], keys=["id"], persist=True)
 
         assert result == []


### PR DESCRIPTION
## Summary

Replaces internal `get_context()` usage with the `tracecat_registry.ctx`
facade across the registry, so there is a single, cleaner way to reach
platform services from registry code.

Because the facade is sync-first, async call sites use the `.aio` namespace:

```python
# before
from tracecat_registry.context import get_context
return await get_context().tables.lookup(...)

# after
from tracecat_registry import ctx
return await ctx.tables.aio.lookup(...)
```

## Changes

- Convert async SDK call sites in core UDFs (`cases`, `table`, `skills`,
  `presets`, `ee/tasks`, `ee/durations`, `transform`, `workflow`),
  integrations (`crowdstrike`, `splunk`, all `mcp/*`), and the SDK (`agents`)
  to `ctx.<client>.aio.<method>`.
- `aws_boto3` reads context attributes (`workspace_id`, `run_id`) through the
  facade while preserving its no-context fallback.
- Keep `get_context()` only where its eager presence check is required
  (`core.workflow.execute`) and in the facade internals (`ctx.py` /
  `context.py`).
- Complete the `ctx.pyi` stub with the methods now routed through the facade:
  table column ops (`update_table`, `create_column`, `update_column`,
  `delete_column`), agent skill ops, and `create_workflow` (both sync and
  `.aio`).
- Reword the `ctx` module docstring: it is the standard access path, not
  inline-script-only.
- Update `sdk/variables.py` docstring examples and retarget the affected test
  mocks to `tracecat_registry.ctx.get_context`.

## Verification

- `ruff check` / `ruff format --check` — clean
- `basedpyright --warnings` on the diff — 0 errors, 0 warnings
- `pytest` (test_core_cases, test_core_table, test_aws_assume_role,
  test_deduplicate, test_run_python_sdk_context) — 131 passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch registry code to the `tracecat_registry.ctx` facade instead of internal `get_context()`. This unifies access to platform services and makes async usage explicit via the `.aio` namespace.

- **Refactors**
  - Replaced async calls across core UDFs, integrations (`crowdstrike`, `splunk`, `mcp/*`), and SDK (`agents`) with `ctx.<service>.aio.<method>`.
  - Kept `get_context()` only where an eager presence check is needed (`core.workflow.execute`) and inside the facade.
  - Completed `ctx.pyi` with table column ops, agent skill APIs, and `create_workflow` (sync and async).
  - `aws_boto3` now reads `workspace_id` and `run_id` via `ctx`, with the no-context fallback preserved.
  - Updated docs and tests to reference `tracecat_registry.ctx.get_context`.

- **Migration**
  - Import `ctx` via `from tracecat_registry import ctx`.
  - Use `ctx.<service>.aio.<method>(...)` for async; `ctx.<service>.<method>(...)` for sync.
  - In tests, patch `tracecat_registry.ctx.get_context` instead of module-local `get_context`.

<sup>Written for commit 605a16239903f01bf9f1f17448d4629836bcd39e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

