### PR TITLE
fix(ui): avoid sidebar entitlement lock flicker

### DIFF
--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -69,6 +69,7 @@ type NavItem = {
   icon: LucideIcon
   isActive?: boolean
   isLocked?: boolean
+  isPendingEntitlement?: boolean
   onSelect?: () => void
   locked?: boolean
   visible?: boolean
@@ -159,9 +160,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         isActive: pathname?.startsWith(`${basePath}/chat`),
         visible: canAccessMissionControl,
         isLocked: entitlementsKnown && !workspaceChatEnabled,
-        onSelect: entitlementsKnown
-          ? () => setLockedFeatureDialogOpen(true)
-          : undefined,
+        isPendingEntitlement: !entitlementsKnown,
+        onSelect:
+          entitlementsKnown && !workspaceChatEnabled
+            ? () => setLockedFeatureDialogOpen(true)
+            : undefined,
       },
       {
         title: "Workflows",
@@ -184,9 +187,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         isActive: pathname?.startsWith(`${basePath}/agents`),
         visible: canViewAgents === true,
         isLocked: entitlementsKnown && !agentAddonsEnabled,
-        onSelect: entitlementsKnown
-          ? () => setLockedFeatureDialogOpen(true)
-          : undefined,
+        isPendingEntitlement: !entitlementsKnown,
+        onSelect:
+          entitlementsKnown && !agentAddonsEnabled
+            ? () => setLockedFeatureDialogOpen(true)
+            : undefined,
       },
       {
         title: "Tables",
@@ -229,9 +234,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         icon: Pyramid,
         isActive: pathname?.startsWith(`${basePath}/skills`),
         isLocked: entitlementsKnown && !agentAddonsEnabled,
-        onSelect: entitlementsKnown
-          ? () => setLockedFeatureDialogOpen(true)
-          : undefined,
+        isPendingEntitlement: !entitlementsKnown,
+        onSelect:
+          entitlementsKnown && !agentAddonsEnabled
+            ? () => setLockedFeatureDialogOpen(true)
+            : undefined,
         visible: canViewAgents === true,
       },
       {
@@ -339,6 +346,20 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                               <item.icon />
                               <span>{item.title}</span>
                               <LockedFeatureChip className="ml-auto shrink-0" />
+                            </SidebarMenuButton>
+                          ) : item.isPendingEntitlement ? (
+                            <SidebarMenuButton
+                              type="button"
+                              isActive={item.isActive}
+                              disabled
+                            >
+                              <item.icon />
+                              <span>{item.title}</span>
+                              {item.tag ? (
+                                <span className="ml-auto shrink-0 rounded-full border px-1.5 py-px text-[10px] font-medium leading-none text-muted-foreground">
+                                  {item.tag}
+                                </span>
+                              ) : null}
                             </SidebarMenuButton>
                           ) : (
                             <SidebarMenuButton asChild isActive={item.isActive}>

--- a/frontend/src/components/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/sidebar/app-sidebar.tsx
@@ -130,9 +130,14 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     canExecuteAgents === true ||
     canViewServiceAccounts === true ||
     canViewInbox === true
-  const { hasEntitlement, isLoading: entitlementsIsLoading } = useEntitlements({
+  const {
+    hasEntitlement,
+    hasEntitlementData,
+    isLoading: entitlementsIsLoading,
+  } = useEntitlements({
     enabled: shouldLoadEntitlements,
   })
+  const entitlementsKnown = !entitlementsIsLoading && hasEntitlementData
   const agentAddonsEnabled = hasEntitlement("agent_addons")
   const workspaceChatEnabled = hasEntitlement("workspace_chat")
   const serviceAccountsEnabled = hasEntitlement("service_accounts")
@@ -153,10 +158,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         tag: "Beta",
         isActive: pathname?.startsWith(`${basePath}/chat`),
         visible: canAccessMissionControl,
-        isLocked: entitlementsIsLoading || !workspaceChatEnabled,
-        onSelect: entitlementsIsLoading
-          ? undefined
-          : () => setLockedFeatureDialogOpen(true),
+        isLocked: entitlementsKnown && !workspaceChatEnabled,
+        onSelect: entitlementsKnown
+          ? () => setLockedFeatureDialogOpen(true)
+          : undefined,
       },
       {
         title: "Workflows",
@@ -178,10 +183,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         icon: MousePointerClickIcon,
         isActive: pathname?.startsWith(`${basePath}/agents`),
         visible: canViewAgents === true,
-        isLocked: entitlementsIsLoading || !agentAddonsEnabled,
-        onSelect: entitlementsIsLoading
-          ? undefined
-          : () => setLockedFeatureDialogOpen(true),
+        isLocked: entitlementsKnown && !agentAddonsEnabled,
+        onSelect: entitlementsKnown
+          ? () => setLockedFeatureDialogOpen(true)
+          : undefined,
       },
       {
         title: "Tables",
@@ -223,10 +228,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         url: `${basePath}/skills`,
         icon: Pyramid,
         isActive: pathname?.startsWith(`${basePath}/skills`),
-        isLocked: entitlementsIsLoading || !agentAddonsEnabled,
-        onSelect: entitlementsIsLoading
-          ? undefined
-          : () => setLockedFeatureDialogOpen(true),
+        isLocked: entitlementsKnown && !agentAddonsEnabled,
+        onSelect: entitlementsKnown
+          ? () => setLockedFeatureDialogOpen(true)
+          : undefined,
         visible: canViewAgents === true,
       },
       {
@@ -247,7 +252,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       canViewVariables,
       canViewSecrets,
       canViewIntegrations,
-      entitlementsIsLoading,
+      entitlementsKnown,
       agentAddonsEnabled,
       workspaceChatEnabled,
       canViewAgents,

--- a/frontend/tests/app-sidebar.test.tsx
+++ b/frontend/tests/app-sidebar.test.tsx
@@ -8,6 +8,9 @@ import { AppSidebar } from "@/components/sidebar/app-sidebar"
 
 const mockUseScopeCheck = jest.fn<boolean | undefined, [string]>()
 let mockScopes: Record<string, boolean | undefined> = {}
+let mockEntitlements: Record<string, boolean> = {}
+let mockEntitlementsIsLoading = false
+let mockHasEntitlementData = true
 
 jest.mock("next/navigation", () => ({
   useParams: () => ({}),
@@ -86,8 +89,10 @@ jest.mock("@/components/ui/sidebar", () => ({
 
 jest.mock("@/hooks/use-entitlements", () => ({
   useEntitlements: () => ({
-    hasEntitlement: () => true,
-    isLoading: false,
+    hasEntitlement: (entitlement: string) =>
+      mockEntitlements[entitlement] ?? false,
+    isLoading: mockEntitlementsIsLoading,
+    hasEntitlementData: mockHasEntitlementData,
   }),
 }))
 
@@ -103,6 +108,13 @@ describe("AppSidebar", () => {
   beforeEach(() => {
     mockUseScopeCheck.mockReset()
     mockScopes = {}
+    mockEntitlements = {
+      agent_addons: true,
+      service_accounts: true,
+      workspace_chat: true,
+    }
+    mockEntitlementsIsLoading = false
+    mockHasEntitlementData = true
     mockUseScopeCheck.mockImplementation((scope) => mockScopes[scope] ?? false)
   })
 
@@ -128,5 +140,37 @@ describe("AppSidebar", () => {
     render(<AppSidebar />)
 
     expect(screen.getByText("Chat")).toBeInTheDocument()
+  })
+
+  it("does not show entitlement locks while entitlements are loading", () => {
+    mockScopes = {
+      "agent:execute": true,
+      "agent:read": true,
+    }
+    mockEntitlements = {}
+    mockEntitlementsIsLoading = true
+    mockHasEntitlementData = false
+
+    render(<AppSidebar />)
+
+    expect(screen.getByText("Chat")).toBeInTheDocument()
+    expect(screen.queryByText("Locked")).not.toBeInTheDocument()
+  })
+
+  it("shows entitlement locks after entitlement data confirms a feature is unavailable", () => {
+    mockScopes = {
+      "agent:execute": true,
+      "agent:read": true,
+    }
+    mockEntitlements = {
+      agent_addons: true,
+      service_accounts: true,
+      workspace_chat: false,
+    }
+
+    render(<AppSidebar />)
+
+    expect(screen.getByText("Chat")).toBeInTheDocument()
+    expect(screen.getAllByText("Locked")).toHaveLength(1)
   })
 })

--- a/frontend/tests/app-sidebar.test.tsx
+++ b/frontend/tests/app-sidebar.test.tsx
@@ -68,9 +68,24 @@ jest.mock("@/components/ui/sidebar", () => ({
   SidebarMenuBadge: ({ children }: { children: ReactNode }) => (
     <span>{children}</span>
   ),
-  SidebarMenuButton: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
+  SidebarMenuButton: ({
+    asChild,
+    children,
+    disabled,
+    type,
+  }: {
+    asChild?: boolean
+    children: ReactNode
+    disabled?: boolean
+    type?: "button" | "submit" | "reset"
+  }) =>
+    asChild ? (
+      <>{children}</>
+    ) : (
+      <button type={type ?? "button"} disabled={disabled}>
+        {children}
+      </button>
+    ),
   SidebarMenuItem: ({ children }: { children: ReactNode }) => (
     <li>{children}</li>
   ),
@@ -154,6 +169,8 @@ describe("AppSidebar", () => {
     render(<AppSidebar />)
 
     expect(screen.getByText("Chat")).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: /Chat/ })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Chat/ })).toBeDisabled()
     expect(screen.queryByText("Locked")).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary

- Treat sidebar entitlement state as unknown while React Query is still resolving.
- Only render locked feature chips after entitlement data has loaded and confirms the feature is unavailable.
- Add sidebar regression coverage for loading and loaded-unavailable entitlement states.

## Root Cause

The workspace sidebar mapped entitlement loading to `isLocked`, so entitled users could briefly see locked affordances before the entitlement query completed.

## Validation

- `pnpm -C frontend exec biome check --write src/components/sidebar/app-sidebar.tsx tests/app-sidebar.test.tsx`
- `pnpm -C frontend test -- app-sidebar.test.tsx --runInBand`
- `uv run ruff check .`
- `pnpm -C frontend run typecheck`
- `git diff --check`
- `pnpm -C frontend exec biome check src/components/sidebar/app-sidebar.tsx tests/app-sidebar.test.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents sidebar entitlement lock flicker and blocks clicks while entitlements load. Pending items show as disabled until data confirms availability.

- **Bug Fixes**
  - Gate lock chips behind `entitlementsKnown` (`!isLoading && hasEntitlementData`).
  - Render pending entitlement items as disabled buttons (no link) via `isPendingEntitlement`.
  - Only attach locked item `onSelect` when entitlements are known; tests cover loading (no “Locked”, disabled) and loaded-unavailable (“Locked”).

<sup>Written for commit b76542a1a12591b3d70f95abb2056ced3362b99f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

