### PR TITLE
fix(engine): prepared child workflow batch dispatch deadlocks

### DIFF
--- a/tests/unit/test_dsl_workflow_concurrency.py
+++ b/tests/unit/test_dsl_workflow_concurrency.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from collections.abc import Callable
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any, cast
@@ -10,6 +11,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from temporalio.exceptions import ActivityError, ApplicationError
 
+import tracecat.dsl.workflow as dsl_workflow_module
 from tracecat import config
 from tracecat.auth.types import Role
 from tracecat.dsl.action import DSLActivities, _evaluate_loop_iterations
@@ -80,6 +82,40 @@ def _build_workflow(*, limits: EffectiveLimits | None = None) -> DSLWorkflow:
     workflow.workspace_id = workflow.role.workspace_id
     workflow.wf_exec_id = workflow.run_context.wf_exec_id
     return workflow
+
+
+def _child_dsl() -> DSLInput:
+    return DSLInput(
+        title="Child",
+        description="child workflow for unit test",
+        entrypoint=DSLEntrypoint(ref="noop", expects={}),
+        actions=[
+            ActionStatement(
+                ref="noop",
+                action="core.transform.reshape",
+                args={"value": "ok"},
+            )
+        ],
+        triggers=[],
+    )
+
+
+def _prepared_subflow_stub(
+    *,
+    get_config: Callable[[int], DSLConfig] | None = None,
+    get_trigger_input_at: Callable[[int], InlineObject] | None = None,
+) -> Any:
+    return cast(
+        Any,
+        SimpleNamespace(
+            dsl=_child_dsl(),
+            wf_id=WorkflowUUID.new("wf-00000000000000000000000000000001"),
+            registry_lock=None,
+            get_config=get_config or (lambda _idx: DSLConfig()),
+            get_trigger_input_at=get_trigger_input_at
+            or (lambda idx: InlineObject(data={"index": idx})),
+        ),
+    )
 
 
 def _activity_error_from(
@@ -603,29 +639,7 @@ def test_resolve_child_loop_batch_plan_is_independent_of_concurrency_flag(
 async def test_execute_child_workflow_batch_prepared_limits_dispatch_window() -> None:
     workflow = _build_workflow()
     task = ActionStatement(ref="run_child", action="core.workflow.execute", args={})
-    dsl = DSLInput(
-        title="Child",
-        description="child workflow for unit test",
-        entrypoint=DSLEntrypoint(ref="noop", expects={}),
-        actions=[
-            ActionStatement(
-                ref="noop",
-                action="core.transform.reshape",
-                args={"value": "ok"},
-            )
-        ],
-        triggers=[],
-    )
-    prepared = cast(
-        Any,
-        SimpleNamespace(
-            dsl=dsl,
-            wf_id="wf-00000000000000000000000000000001",
-            registry_lock=None,
-            get_config=lambda _idx: DSLConfig(),
-            get_trigger_input_at=lambda idx: InlineObject(data={"index": idx}),
-        ),
-    )
+    prepared = _prepared_subflow_stub()
 
     dispatch_in_flight = 0
     max_dispatch_in_flight = 0
@@ -688,6 +702,115 @@ async def test_execute_child_workflow_batch_prepared_limits_dispatch_window() ->
     assert max_dispatch_in_flight == 2
     assert max_child_runs_in_flight > 2
     assert [cast(InlineObject, val).data["index"] for val in result] == list(range(6))
+
+
+@pytest.mark.anyio
+async def test_child_workflow_batch_constructs_trusted_run_args() -> None:
+    workflow = _build_workflow()
+    task = ActionStatement(ref="run_child", action="core.workflow.execute", args={})
+    prepared = _prepared_subflow_stub()
+
+    captured_args: list[DSLRunArgs] = []
+
+    async def dispatch_child_mock(
+        _: ActionStatement,
+        run_args: DSLRunArgs,
+        *,
+        wait_strategy: WaitStrategy,
+        loop_index: int | None = None,
+    ) -> Any:
+        del wait_strategy
+        assert loop_index is not None
+        captured_args.append(run_args)
+        return SimpleNamespace(id=f"child-{loop_index}")
+
+    with (
+        patch.object(
+            DSLRunArgs,
+            "__init__",
+            side_effect=AssertionError("prepared child args should not revalidate"),
+        ),
+        patch.object(
+            workflow,
+            "_dispatch_child_workflow",
+            new=AsyncMock(side_effect=dispatch_child_mock),
+        ),
+    ):
+        result = await workflow._execute_child_workflow_batch_prepared(
+            task=task,
+            prepared=prepared,
+            batch_start=0,
+            batch_size=2,
+            dispatch_window=8,
+            wait_strategy=WaitStrategy.DETACH,
+            fail_strategy=FailStrategy.ISOLATED,
+            child_time_anchor=datetime.now(UTC),
+        )
+
+    assert [cast(InlineObject, val).data for val in result] == ["child-0", "child-1"]
+    assert [args.trigger_inputs for args in captured_args] == [
+        InlineObject(data={"index": 0}),
+        InlineObject(data={"index": 1}),
+    ]
+
+
+@pytest.mark.anyio
+async def test_child_workflow_batch_yields_before_next_arg_prep() -> None:
+    workflow = _build_workflow()
+    task = ActionStatement(ref="run_child", action="core.workflow.execute", args={})
+    prepared_count = dsl_workflow_module._CHILD_RUN_ARG_PREP_YIELD_EVERY + 1
+    config_indices: list[int] = []
+    sleep_checkpoints: list[tuple[float, tuple[int, ...]]] = []
+
+    def get_config(index: int) -> DSLConfig:
+        config_indices.append(index)
+        return DSLConfig()
+
+    prepared = _prepared_subflow_stub(get_config=get_config)
+
+    async def dispatch_child_mock(
+        _: ActionStatement,
+        __: DSLRunArgs,
+        *,
+        wait_strategy: WaitStrategy,
+        loop_index: int | None = None,
+    ) -> Any:
+        del wait_strategy
+        assert loop_index is not None
+        return SimpleNamespace(id=f"child-{loop_index}")
+
+    original_sleep = asyncio.sleep
+
+    async def sleep_mock(delay: float) -> None:
+        sleep_checkpoints.append((delay, tuple(config_indices)))
+        await original_sleep(0)
+
+    with (
+        patch.object(dsl_workflow_module.asyncio, "sleep", new=sleep_mock),
+        patch.object(
+            workflow,
+            "_dispatch_child_workflow",
+            new=AsyncMock(side_effect=dispatch_child_mock),
+        ),
+    ):
+        result = await workflow._execute_child_workflow_batch_prepared(
+            task=task,
+            prepared=prepared,
+            batch_start=0,
+            batch_size=prepared_count,
+            dispatch_window=prepared_count + 1,
+            wait_strategy=WaitStrategy.DETACH,
+            fail_strategy=FailStrategy.ISOLATED,
+            child_time_anchor=datetime.now(UTC),
+        )
+
+    assert len(result) == prepared_count
+    assert sleep_checkpoints == [
+        (
+            0,
+            tuple(range(dsl_workflow_module._CHILD_RUN_ARG_PREP_YIELD_EVERY)),
+        )
+    ]
 
 
 @pytest.mark.anyio

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import re
 import uuid
-from collections.abc import Awaitable, Coroutine, Iterator
+from collections.abc import Awaitable, Coroutine
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -43,7 +43,6 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.schemas import RunAgentArgs
     from tracecat.agent.session.types import AgentSessionEntity
     from tracecat.agent.types import AgentConfig
-    from tracecat.concurrency import cooperative
     from tracecat.contexts import (
         ctx_interaction,
         ctx_logical_time,
@@ -161,6 +160,9 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.workflow.schedules.schemas import GetScheduleActivityInputs
     from tracecat.workflow.schedules.service import WorkflowSchedulesService
     from tracecat.workspaces.activities import get_workspace_organization_id_activity
+
+
+_CHILD_RUN_ARG_PREP_YIELD_EVERY = 8
 
 
 def _inherit_search_attributes_with_alias(
@@ -1314,7 +1316,7 @@ class DSLWorkflow:
             )
 
             runtime_config = prepared.get_config(0)
-            sf_run_args = DSLRunArgs(
+            sf_run_args = DSLRunArgs.model_construct(
                 role=self.role,
                 dsl=prepared.dsl,
                 wf_id=prepared.wf_id,
@@ -1437,59 +1439,41 @@ class DSLWorkflow:
         retrieve its specific trigger_inputs.
         """
 
-        def iter_run_args() -> Iterator[tuple[int, DSLRunArgs]]:
-            for i in range(batch_size):
-                loop_index = batch_start + i
-                config = prepared.get_config(loop_index)
-
-                # Get trigger_inputs for this specific iteration
-                # Works with both CollectionObject and InlineObject
-                trigger_inputs = prepared.get_trigger_input_at(loop_index)
-
-                yield (
-                    loop_index,
-                    DSLRunArgs(
-                        role=self.role,
-                        dsl=prepared.dsl,
-                        wf_id=prepared.wf_id,
-                        trigger_inputs=trigger_inputs,
-                        parent_run_context=self.run_context,
-                        runtime_config=config,
-                        execution_type=self.execution_type,
-                        time_anchor=child_time_anchor,
-                        registry_lock=prepared.registry_lock,
-                    ),
-                )
-
-        dispatch_semaphore = asyncio.Semaphore(dispatch_window)
-
-        async def dispatch_child(
-            *, loop_index: int, run_args: DSLRunArgs
-        ) -> workflow.ChildWorkflowHandle[DSLWorkflow, StoredObject]:
-            async with dispatch_semaphore:
-                return await self._dispatch_child_workflow(
-                    task,
-                    run_args,
-                    loop_index=loop_index,
-                    wait_strategy=wait_strategy,
-                )
-
-        coros: list[
+        dispatch_batch: list[
             Awaitable[workflow.ChildWorkflowHandle[DSLWorkflow, StoredObject]]
         ] = []
-        async for loop_index, run_args in cooperative(
-            iter_run_args(),
-            delay=0.1,
-        ):
-            self.logger.trace(
-                "Run child workflow batch (prepared)",
-                loop_index=loop_index,
-                fail_strategy=fail_strategy,
-            )
-            coro = dispatch_child(loop_index=loop_index, run_args=run_args)
-            coros.append(coro)
+        launched_handles: list[
+            workflow.ChildWorkflowHandle[DSLWorkflow, StoredObject] | BaseException
+        ] = []
 
-        launched_handles = await asyncio.gather(*coros, return_exceptions=True)
+        for offset in range(batch_size):
+            if offset and offset % _CHILD_RUN_ARG_PREP_YIELD_EVERY == 0:
+                # Prepared subflow data has already been validated by the
+                # activity. Checkpoint before another burst of trusted model
+                # construction inside the workflow activation.
+                await asyncio.sleep(0)
+
+            loop_index = batch_start + offset
+            dispatch_batch.append(
+                self._prepare_child_workflow_dispatch(
+                    task,
+                    prepared,
+                    loop_index=loop_index,
+                    wait_strategy=wait_strategy,
+                    fail_strategy=fail_strategy,
+                    child_time_anchor=child_time_anchor,
+                )
+            )
+            if len(dispatch_batch) >= dispatch_window:
+                launched_handles.extend(
+                    await self._flush_child_workflow_dispatch_batch(dispatch_batch)
+                )
+                await asyncio.sleep(0)
+
+        if dispatch_batch:
+            launched_handles.extend(
+                await self._flush_child_workflow_dispatch_batch(dispatch_batch)
+            )
         gather_result = await self._gather_dispatched_child_results(
             launched_handles=launched_handles,
             wait_strategy=wait_strategy,
@@ -1509,6 +1493,65 @@ class DSLWorkflow:
                 case _:
                     result.append(StoredObjectValidator.validate_python(val))
         return result
+
+    def _prepare_child_workflow_dispatch(
+        self,
+        task: ActionStatement,
+        prepared: PreparedSubflowResult,
+        *,
+        loop_index: int,
+        wait_strategy: WaitStrategy,
+        fail_strategy: FailStrategy,
+        child_time_anchor: datetime,
+    ) -> Awaitable[workflow.ChildWorkflowHandle[DSLWorkflow, StoredObject]]:
+        run_args = self._build_prepared_child_run_args(
+            prepared=prepared,
+            loop_index=loop_index,
+            child_time_anchor=child_time_anchor,
+        )
+        self.logger.trace(
+            "Run child workflow batch (prepared)",
+            loop_index=loop_index,
+            fail_strategy=fail_strategy,
+        )
+        return self._dispatch_child_workflow(
+            task,
+            run_args,
+            loop_index=loop_index,
+            wait_strategy=wait_strategy,
+        )
+
+    def _build_prepared_child_run_args(
+        self,
+        *,
+        prepared: PreparedSubflowResult,
+        loop_index: int,
+        child_time_anchor: datetime,
+    ) -> DSLRunArgs:
+        return DSLRunArgs.model_construct(
+            role=self.role,
+            dsl=prepared.dsl,
+            wf_id=prepared.wf_id,
+            trigger_inputs=prepared.get_trigger_input_at(loop_index),
+            parent_run_context=self.run_context,
+            runtime_config=prepared.get_config(loop_index),
+            execution_type=self.execution_type,
+            time_anchor=child_time_anchor,
+            registry_lock=prepared.registry_lock,
+        )
+
+    async def _flush_child_workflow_dispatch_batch(
+        self,
+        dispatch_batch: list[
+            Awaitable[workflow.ChildWorkflowHandle[DSLWorkflow, StoredObject]]
+        ],
+    ) -> list[workflow.ChildWorkflowHandle[DSLWorkflow, StoredObject] | BaseException]:
+        launched_handles = await asyncio.gather(
+            *dispatch_batch,
+            return_exceptions=True,
+        )
+        dispatch_batch.clear()
+        return list(launched_handles)
 
     async def _gather_dispatched_child_results(
         self,


### PR DESCRIPTION
## Summary
- Build prepared child workflow run args with `model_construct` to avoid revalidating trusted subflow data
- Dispatch prepared child runs in bounded batches with explicit yield points to keep workflow activations responsive
- Add unit coverage for trusted arg construction and cooperative yielding behavior

## Testing
- Added unit tests covering prepared child run arg construction and batch yield checkpoints
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deadlocks when dispatching prepared child workflows in batches by batching with a bounded window, adding cooperative yield points, and constructing trusted run args without revalidation.

- **Bug Fixes**
  - Build child run args with `DSLRunArgs.model_construct` to skip revalidating trusted prepared data.
  - Replace per-iteration dispatch with explicit batch flushes honoring `dispatch_window`, yielding via `asyncio.sleep(0)` after each flush and after every `_CHILD_RUN_ARG_PREP_YIELD_EVERY` arg preps to keep activations responsive; adds unit tests for both behaviors.

<sup>Written for commit 916fd7b78b87d7e07ed63d9e6cc63888392e6a0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

