### PR TITLE
fix(infra): consistent local-registry wiring in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ services:
       # Local registry
       TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
       TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED:-false}
+      PYTHONPATH: ${PYTHONPATH:+${PYTHONPATH}:}/home/apiuser/.local:/app/local_registry
       # Redis
       REDIS_URL: ${REDIS_URL}
     volumes:
@@ -140,6 +141,7 @@ services:
       # Local registry
       TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
       TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED:-false}
+      PYTHONPATH: ${PYTHONPATH:+${PYTHONPATH}:}/home/apiuser/.local:/app/local_registry
       TRACECAT__EXECUTOR_CLIENT_TIMEOUT: ${TRACECAT__EXECUTOR_CLIENT_TIMEOUT:-300}
       # Sentry
       SENTRY_DSN: ${SENTRY_DSN:-}
@@ -153,6 +155,8 @@ services:
       TRACECAT__BLOB_STORAGE_BUCKET_AGENT: ${TRACECAT__BLOB_STORAGE_BUCKET_AGENT:-tracecat-agent}
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    volumes:
+      - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
     command: ["python", "-m", "tracecat.dsl.worker"]
     depends_on:
       migrations:
@@ -277,6 +281,10 @@ services:
         TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES: ${TRACECAT__RESULT_EXTERNALIZATION_THRESHOLD_BYTES}
         # Registry
         TRACECAT__UNSAFE_DISABLE_SM_MASKING: ${TRACECAT__UNSAFE_DISABLE_SM_MASKING:-false}
+        # Local registry
+        TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
+        TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED:-false}
+        PYTHONPATH: ${PYTHONPATH:+${PYTHONPATH}:}/home/apiuser/.local:/app/local_registry
         # Temporal
         TEMPORAL__CLUSTER_URL: ${TEMPORAL__CLUSTER_URL}
         TEMPORAL__CLUSTER_NAMESPACE: ${TEMPORAL__CLUSTER_NAMESPACE}
@@ -303,6 +311,8 @@ services:
         TRACECAT__BLOB_STORAGE_BUCKET_AGENT: ${TRACECAT__BLOB_STORAGE_BUCKET_AGENT:-tracecat-agent}
         MINIO_ROOT_USER: ${MINIO_ROOT_USER}
         MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      volumes:
+        - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
       command: ["python", "-m", "tracecat.agent.worker"]
       depends_on:
         migrations:
@@ -329,7 +339,11 @@ services:
       TRACECAT__SERVICE_KEY: ${TRACECAT__SERVICE_KEY} # Sensitive
       TRACECAT__LITELLM_PORT: ${TRACECAT__LITELLM_PORT:-4000}
       TRACECAT__LITELLM_BASE_URL: ${TRACECAT__LITELLM_BASE_URL:-http://litellm:4000}
-      PYTHONPATH: /app:/app/packages/tracecat-registry:/app/packages/tracecat-ee
+      TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
+      TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED:-false}
+      PYTHONPATH: /app:/app/packages/tracecat-registry:/app/packages/tracecat-ee:/home/apiuser/.local:/app/local_registry
+    volumes:
+      - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
     command: ["python", "-m", "tracecat.agent.litellm"]
     depends_on:
       migrations:
@@ -458,6 +472,10 @@ services:
       TRACECAT__SIGNING_SECRET: ${TRACECAT__SIGNING_SECRET}
       TRACECAT__FEATURE_FLAGS: ${TRACECAT__FEATURE_FLAGS}
       TRACECAT__EE_MULTI_TENANT: ${TRACECAT__EE_MULTI_TENANT:-false}
+      # Local registry
+      TRACECAT__LOCAL_REPOSITORY_PATH: ${TRACECAT__LOCAL_REPOSITORY_PATH}
+      TRACECAT__LOCAL_REPOSITORY_ENABLED: ${TRACECAT__LOCAL_REPOSITORY_ENABLED:-false}
+      PYTHONPATH: ${PYTHONPATH:+${PYTHONPATH}:}/home/apiuser/.local:/app/local_registry
       REDIS_URL: ${REDIS_URL}
       # Internal OIDC issuer (on the API server)
       USER_AUTH_SECRET: ${USER_AUTH_SECRET}
@@ -476,6 +494,8 @@ services:
       TEMPORAL__PAYLOAD_ENCRYPTION_KEYRING_ARN: ${TEMPORAL__PAYLOAD_ENCRYPTION_KEYRING_ARN:-}
       TEMPORAL__PAYLOAD_ENCRYPTION_CACHE_TTL_SECONDS: ${TEMPORAL__PAYLOAD_ENCRYPTION_CACHE_TTL_SECONDS:-3600}
       TEMPORAL__PAYLOAD_ENCRYPTION_CACHE_MAX_ITEMS: ${TEMPORAL__PAYLOAD_ENCRYPTION_CACHE_MAX_ITEMS:-128}
+    volumes:
+      - ${TRACECAT__LOCAL_REPOSITORY_PATH}:/app/local_registry
     command: ["python", "-m", "tracecat.mcp"]
     depends_on:
       api:

--- a/tests/integration/test_local_registry_compose.py
+++ b/tests/integration/test_local_registry_compose.py
@@ -1,0 +1,646 @@
+"""Integration tests for local-registry hot-reload wiring in docker-compose.yml.
+
+These tests verify that the compose file's TRACECAT__LOCAL_REPOSITORY_* wiring
+is consistent across all registry-aware services, so a bind-mounted custom
+registry package is importable on every service and host edits are reflected
+live without restart.
+
+The tests mirror the real self-hosting flow documented at
+https://docs.tracecat.com/self-hosting/docker-compose:
+
+  1. Copy docker-compose.yml, Caddyfile, .env.example, env.sh into a temp dir
+  2. Run env.sh non-interactively to generate .env
+  3. Append TRACECAT__LOCAL_REPOSITORY_* settings to .env
+  4. docker compose up -d
+  5. Verify every service can import the bind-mounted package
+  6. Verify host edits are visible without restart
+
+Requirements:
+  - Docker daemon reachable
+  - Network access to pull ghcr.io/tracecathq/tracecat
+
+Run with:
+    uv run pytest tests/integration/test_local_registry_compose.py -x -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_NAME = "tracecat-lr-test"
+PUBLIC_APP_PORT = "18006"
+TIMEOUT_BRINGUP = 600
+TIMEOUT_EXEC = 120
+POLL_INTERVAL = 5
+
+REGISTRY_AWARE_SERVICES = [
+    "api",
+    "worker",
+    "executor",
+    "agent-worker",
+    "litellm",
+    "agent-executor",
+    "mcp",
+]
+
+# Services to poll for "running" state during bringup. mcp is excluded because
+# it depends on api:service_healthy, and api's startup (registry sync + tarball
+# build) can exceed the Docker healthcheck timeout. mcp's compose wiring is
+# verified via `docker compose run --rm --no-deps` in the import test instead.
+POLL_SERVICES = [s for s in REGISTRY_AWARE_SERVICES if s != "mcp"]
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+# Override root conftest autouse fixtures that require local PostgreSQL, Redis,
+# or MinIO. These compose-only tests interact with services inside Docker
+# containers only — no local infrastructure is needed.
+
+
+@pytest.fixture(autouse=True, scope="session")
+def db():
+    yield
+
+
+@pytest.fixture(autouse=True, scope="session")
+def default_org():
+    yield
+
+
+@pytest.fixture(autouse=True, scope="function")
+def clean_redis_db():
+    yield
+
+
+@pytest.fixture(autouse=True, scope="function")
+async def test_db_engine():
+    yield
+
+
+@pytest.fixture(autouse=True, scope="session")
+def workflow_bucket():
+    yield
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+    return result.returncode == 0
+
+
+requires_docker = pytest.mark.skipif(
+    not _docker_available(),
+    reason="Docker daemon not available",
+)
+
+
+@pytest.fixture(scope="module")
+def local_registry_package(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Path:
+    """Create a minimal Python package on the host for bind-mounting.
+
+    Structure:
+        <pkg_dir>/
+            pyproject.toml
+            test_actions/
+                __init__.py
+                udfs.py      # def add_numbers(a, b) -> a + b
+
+    The directory is created under /tmp (not pytest's default tmp_path, which
+    uses 0700 permissions) and chmod'd to 0755 so the container's apiuser
+    (uid 1001) can traverse and read the bind-mounted files.
+    """
+    pkg_dir = Path(tempfile.mkdtemp(prefix="lr-pkg-"))
+    (pkg_dir / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "test-actions"
+            version = "0.1.0"
+            """,
+        )
+    )
+    actions_dir = pkg_dir / "test_actions"
+    actions_dir.mkdir()
+    (actions_dir / "__init__.py").write_text("")
+    (actions_dir / "udfs.py").write_text(
+        textwrap.dedent(
+            '''\
+            """Test UDFs for local-registry compose wiring verification."""
+
+
+            def add_numbers(a: int, b: int) -> int:
+                """Add two numbers."""
+                return a + b
+            ''',
+        )
+    )
+    # Make world-readable so the container's apiuser (uid 1001) can access it
+    os.chmod(pkg_dir, 0o755)
+    os.chmod(actions_dir, 0o755)
+    for f in pkg_dir.rglob("*"):
+        if f.is_file():
+            os.chmod(f, 0o644)
+    return pkg_dir
+
+
+@pytest.fixture(scope="module")
+def workdir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Self-hosting working directory with compose files copied from the repo."""
+    wd = tmp_path_factory.mktemp("workdir")
+    for name in ("docker-compose.yml", "Caddyfile", ".env.example", "env.sh"):
+        src = REPO_ROOT / name
+        if src.exists():
+            shutil.copy2(src, wd / name)
+    return wd
+
+
+@pytest.fixture(scope="module")
+def env_file(
+    workdir: Path,
+    local_registry_package: Path,
+) -> Path:
+    """Generate .env via env.sh (non-interactive) and append local-registry settings.
+
+    Drives env.sh with stdin matching its interactive prompts:
+      1. production mode?         -> n (development)
+      2. PUBLIC_APP_URL?          -> localhost:<PUBLIC_APP_PORT>
+      3. PostgreSQL SSL mode?     -> n
+      4. superadmin email?        -> test@tracecat.com
+
+    Then appends the two TRACECAT__LOCAL_REPOSITORY_* lines that a self-hoster
+    would add to enable the local-registry feature.
+    """
+    stdin = f"n\nlocalhost:{PUBLIC_APP_PORT}\nn\ntest@tracecat.com\n"
+    result = subprocess.run(
+        ["bash", "env.sh"],
+        input=stdin,
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"env.sh failed (exit {result.returncode}):\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    env_path = workdir / ".env"
+    assert env_path.exists(), "env.sh did not create .env"
+
+    with env_path.open("a") as f:
+        f.write("\nTRACECAT__LOCAL_REPOSITORY_ENABLED=true\n")
+        f.write(f"TRACECAT__LOCAL_REPOSITORY_PATH={local_registry_package}\n")
+
+    return env_path
+
+
+def _clean_compose_env() -> dict[str, str]:
+    """Build a clean environment for Docker Compose subprocesses.
+
+    The root conftest's env_sandbox fixture calls load_dotenv() which loads the
+    repo root's .env into the test process environment. Those TRACECAT__*
+    variables take precedence over workdir/.env when Docker Compose resolves
+    variables, causing containers to connect to localhost instead of service
+    names. This strips all TRACECAT__* and related vars so Compose reads them
+    exclusively from workdir/.env.
+    """
+    env = os.environ.copy()
+    for key in list(env.keys()):
+        if (
+            key.startswith("TRACECAT__")
+            or key.startswith("TEMPORAL__")
+            or key.startswith("NEXT_")
+            or key
+            in (
+                "REDIS_URL",
+                "MINIO_ROOT_USER",
+                "MINIO_ROOT_PASSWORD",
+                "PUBLIC_APP_URL",
+                "PUBLIC_API_URL",
+                "INTERNAL_API_URL",
+                "BASE_DOMAIN",
+                "ADDRESS",
+                "NODE_ENV",
+                "OAUTH_CLIENT_ID",
+                "OAUTH_CLIENT_SECRET",
+                "OIDC_ISSUER",
+                "OIDC_CLIENT_ID",
+                "OIDC_CLIENT_SECRET",
+                "OIDC_SCOPES",
+                "USER_AUTH_SECRET",
+                "SAML_IDP_METADATA_URL",
+                "LOG_LEVEL",
+                "COMPOSE_PROJECT_NAME",
+                "COMPOSE_BAKE",
+            )
+        ):
+            del env[key]
+    return env
+
+
+@pytest.fixture(scope="module")
+def compose_stack(
+    workdir: Path,
+    env_file: Path,
+) -> tuple[Path, str]:
+    """Bring up the compose stack and yield (workdir, project_name).
+
+    Teardown runs `down --volumes --remove-orphans` in a finally block that
+    wraps the entire bringup, so containers are always cleaned up even if
+    startup fails.
+    """
+    try:
+        # Bring up infrastructure first, wait for health, run migrations
+        # manually, then start the rest with --no-deps. This avoids a race
+        # where `docker compose up -d` starts migrations before the database
+        # is fully ready (the healthcheck can pass before alembic can connect).
+        infra = ["postgres_db", "redis", "minio", "temporal", "temporal_postgres_db"]
+        subprocess.run(
+            ["docker", "compose", "-p", PROJECT_NAME, "up", "-d"] + infra,
+            cwd=workdir,
+            env=_clean_compose_env(),
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_BRINGUP,
+            check=False,
+        )
+
+        # Wait for infrastructure to be healthy
+        infra_target = set(infra)
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            ps = subprocess.run(
+                ["docker", "compose", "-p", PROJECT_NAME, "ps", "--format", "json"],
+                cwd=workdir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            if ps.returncode == 0:
+                try:
+                    svcs = [
+                        json.loads(line)
+                        for line in ps.stdout.strip().splitlines()
+                        if line
+                    ]
+                except json.JSONDecodeError:
+                    svcs = []
+                healthy = {
+                    s.get("Service")
+                    for s in svcs
+                    if s.get("State") in ("running", "healthy")
+                }
+                if infra_target.issubset(healthy):
+                    break
+            time.sleep(POLL_INTERVAL)
+
+        # Run migrations manually (avoids the up -d race condition)
+        mig_result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                "-p",
+                PROJECT_NAME,
+                "run",
+                "--rm",
+                "--no-deps",
+                "migrations",
+            ],
+            cwd=workdir,
+            env=_clean_compose_env(),
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+        if mig_result.returncode != 0:
+            pytest.fail(
+                f"Migrations failed (exit {mig_result.returncode}):\n"
+                f"stdout:\n{mig_result.stdout}\nstderr:\n{mig_result.stderr}"
+            )
+
+        # Start the rest of the stack (skip infra + migrations, use --no-deps
+        # so compose doesn't try to re-verify migration completion)
+        app_services = [
+            "api",
+            "worker",
+            "executor",
+            "agent-worker",
+            "litellm",
+            "agent-executor",
+            "mcp",
+            "ui",
+            "caddy",
+            "temporal_ui",
+        ]
+        subprocess.run(
+            ["docker", "compose", "-p", PROJECT_NAME, "up", "-d", "--no-deps"]
+            + app_services,
+            cwd=workdir,
+            env=_clean_compose_env(),
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_BRINGUP,
+            check=False,
+        )
+
+        target = set(POLL_SERVICES)
+        deadline = time.time() + TIMEOUT_BRINGUP
+        ready = False
+        while time.time() < deadline:
+            ps = subprocess.run(
+                ["docker", "compose", "-p", PROJECT_NAME, "ps", "--format", "json"],
+                cwd=workdir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            if ps.returncode == 0:
+                try:
+                    services = [
+                        json.loads(line)
+                        for line in ps.stdout.strip().splitlines()
+                        if line
+                    ]
+                except json.JSONDecodeError:
+                    services = []
+                running = {
+                    s.get("Service")
+                    for s in services
+                    if s.get("State") in ("running", "healthy")
+                }
+                if target.issubset(running):
+                    ready = True
+                    break
+            time.sleep(POLL_INTERVAL)
+
+        if not ready:
+            ps = subprocess.run(
+                ["docker", "compose", "-p", PROJECT_NAME, "ps"],
+                cwd=workdir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            pytest.fail(
+                f"Services did not become ready within {TIMEOUT_BRINGUP}s:\n{ps.stdout}"
+            )
+
+        yield workdir, PROJECT_NAME
+    finally:
+        subprocess.run(
+            [
+                "docker",
+                "compose",
+                "-p",
+                PROJECT_NAME,
+                "down",
+                "--volumes",
+                "--remove-orphans",
+            ],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+
+
+def _compose_exec(
+    workdir: Path,
+    project: str,
+    service: str,
+    command: list[str],
+    timeout: int = TIMEOUT_EXEC,
+) -> subprocess.CompletedProcess[str]:
+    """Run `docker compose exec -T <service> <command>` and return the result."""
+    return subprocess.run(
+        ["docker", "compose", "-p", project, "exec", "-T", service] + command,
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _compose_run(
+    workdir: Path,
+    project: str,
+    service: str,
+    command: list[str],
+    timeout: int = TIMEOUT_EXEC,
+) -> subprocess.CompletedProcess[str]:
+    """Run `docker compose run --rm --no-deps <service> <command>` and return the result.
+
+    Used for services that may not be running (e.g. mcp, which depends on
+    api:service_healthy). This creates a one-off container with the same
+    compose config (volumes, env, PYTHONPATH) but no dependency on other
+    services being healthy.
+    """
+    return subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-p",
+            project,
+            "run",
+            "--rm",
+            "--no-deps",
+            "-T",
+            service,
+        ]
+        + command,
+        cwd=workdir,
+        env=_clean_compose_env(),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+@requires_docker
+def test_config_render_wiring(
+    env_file: Path,
+    local_registry_package: Path,
+) -> None:
+    """Verify docker-compose.yml config renders correct local-registry wiring.
+
+    Checks that every registry-aware service has the bind mount, env vars, and
+    PYTHONPATH when the feature is enabled.
+    """
+    workdir = env_file.parent
+    compose_yml = workdir / "docker-compose.yml"
+
+    result = subprocess.run(
+        ["docker", "compose", "-f", str(compose_yml), "config"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, f"compose config failed: {result.stderr}"
+
+    config = yaml.safe_load(result.stdout)
+
+    for svc in REGISTRY_AWARE_SERVICES:
+        svc_config = config["services"][svc]
+
+        mounts = svc_config.get("volumes", [])
+        has_mount = any(
+            (isinstance(v, dict) and v.get("target") == "/app/local_registry")
+            or (isinstance(v, str) and v.endswith(":/app/local_registry"))
+            for v in mounts
+        )
+        assert has_mount, f"{svc}: /app/local_registry mount missing"
+
+        env = svc_config.get("environment", {})
+        assert "TRACECAT__LOCAL_REPOSITORY_PATH" in env, (
+            f"{svc}: TRACECAT__LOCAL_REPOSITORY_PATH env missing"
+        )
+        assert "TRACECAT__LOCAL_REPOSITORY_ENABLED" in env, (
+            f"{svc}: TRACECAT__LOCAL_REPOSITORY_ENABLED env missing"
+        )
+
+        pythonpath = env.get("PYTHONPATH", "")
+        assert "/app/local_registry" in pythonpath, (
+            f"{svc}: PYTHONPATH missing /app/local_registry (got: {pythonpath})"
+        )
+
+        if svc == "litellm":
+            assert "/app/packages/tracecat-registry" in pythonpath, (
+                f"litellm: PYTHONPATH lost package prefix (got: {pythonpath})"
+            )
+            assert "/app/packages/tracecat-ee" in pythonpath, (
+                f"litellm: PYTHONPATH lost ee prefix (got: {pythonpath})"
+            )
+
+
+@requires_docker
+def test_all_services_import_bind_mounted_package(
+    compose_stack: tuple[Path, str],
+) -> None:
+    """Every registry-aware service can import the bind-mounted package.
+
+    The 4 newly-wired services (worker, agent-worker, litellm, mcp) would fail
+    pre-fix (no mount, no PYTHONPATH, or env-without-mount contradiction).
+    """
+    workdir, project = compose_stack
+
+    import_snippet = (
+        "import sys, test_actions.udfs as m; "
+        "assert m.add_numbers(1, 2) == 3; "
+        "assert any('local_registry' in p for p in sys.path), sys.path; "
+        "print('ok')"
+    )
+
+    for svc in REGISTRY_AWARE_SERVICES:
+        # mcp depends on api:service_healthy, which may not be reached if
+        # api's startup (registry sync + tarball build) exceeds the Docker
+        # healthcheck timeout. Use `run --rm --no-deps` to test mcp's compose
+        # wiring without requiring the full dependency chain to be healthy.
+        if svc == "mcp":
+            result = _compose_run(
+                workdir, project, svc, ["python", "-c", import_snippet]
+            )
+        else:
+            result = _compose_exec(
+                workdir, project, svc, ["python", "-c", import_snippet]
+            )
+        assert result.returncode == 0, (
+            f"{svc}: import failed (exit {result.returncode})\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert "ok" in result.stdout, f"{svc}: unexpected output: {result.stdout}"
+
+
+@requires_docker
+def test_body_edit_reflects_without_restart(
+    compose_stack: tuple[Path, str],
+    local_registry_package: Path,
+) -> None:
+    """Host file edits are visible inside the executor on the next importlib.reload.
+
+    This verifies the bind mount is live (not a copied snapshot) and that
+    importlib.reload picks up host edits -- the mechanism tracecat's
+    registry/loaders.py uses in direct mode.
+    """
+    workdir, project = compose_stack
+    udfs = local_registry_package / "test_actions" / "udfs.py"
+
+    baseline = _compose_exec(
+        workdir,
+        project,
+        "executor",
+        [
+            "python",
+            "-c",
+            "import test_actions.udfs as m; "
+            "assert m.add_numbers(1, 2) == 3; "
+            "print('baseline ok')",
+        ],
+    )
+    assert baseline.returncode == 0, (
+        f"baseline import failed:\nstdout: {baseline.stdout}\nstderr: {baseline.stderr}"
+    )
+    assert "baseline ok" in baseline.stdout
+
+    udfs.write_text(
+        textwrap.dedent(
+            '''\
+            """Test UDFs for local-registry compose wiring verification."""
+
+
+            def add_numbers(a: int, b: int) -> int:
+                """Add two numbers and add 1."""
+                return a + b + 1
+            ''',
+        )
+    )
+
+    reload = _compose_exec(
+        workdir,
+        project,
+        "executor",
+        [
+            "python",
+            "-c",
+            "import importlib, test_actions.udfs as m; "
+            "importlib.reload(m); "
+            "assert m.add_numbers(1, 2) == 4, f'got {m.add_numbers(1, 2)}'; "
+            "print('reload ok')",
+        ],
+    )
+    assert reload.returncode == 0, (
+        f"reload failed:\nstdout: {reload.stdout}\nstderr: {reload.stderr}"
+    )
+    assert "reload ok" in reload.stdout


### PR DESCRIPTION
## Summary

The `TRACECAT__LOCAL_REPOSITORY_*` wiring (bind mount, env vars, `PYTHONPATH`) was inconsistent across registry-aware services in `docker-compose.yml`. This meant a bind-mounted custom registry package was not importable on `worker`, `agent-worker`, `litellm`, or `mcp`, and the env-without-mount contradiction on `worker` would cause failures on any registry import path.

## Problem

| service | env vars | mount | PYTHONPATH |
|---|---|---|---|
| api | ✅ | ✅ | ❌ |
| worker | ✅ | ❌ (contradicts env) | ❌ |
| executor | ✅ | ✅ | ✅ |
| agent-worker | ❌ | ❌ | ❌ |
| litellm | ❌ | ❌ | ❌ (different PYTHONPATH) |
| agent-executor | ✅ | ✅ | ✅ |
| mcp | ❌ | ❌ | ❌ |

The `worker` service set `TRACECAT__LOCAL_REPOSITORY_*` env vars but had no `/app/local_registry` bind mount — a direct contradiction. `agent-worker`, `mcp`, and `litellm` had none of the three.

## Fix

Added the `/app/local_registry` bind mount, `TRACECAT__LOCAL_REPOSITORY_*` env vars, and `PYTHONPATH` (`:/home/apiuser/.local:/app/local_registry`) to all 7 registry-aware services. `litellm` preserves its existing `/app:/app/packages/*` `PYTHONPATH` prefix.

The feature remains off by default (`TRACECAT__LOCAL_REPOSITORY_ENABLED` defaults to `false`), so the empty mounts are harmless until a self-hoster sets a real `TRACECAT__LOCAL_REPOSITORY_PATH` and recreates containers.

### Changes

- **`docker-compose.yml`**: +21 lines, -1 line across 5 services (`api`, `worker`, `agent-worker`, `litellm`, `mcp`)
- **`tests/integration/test_local_registry_compose.py`** (new): 3 integration tests

## Testing

Integration tests mirror the real self-hosting flow (`env.sh` + `docker compose up`):

1. **`test_config_render_wiring`** — verifies `docker compose config` renders correct mount/env/PYTHONPATH on all 7 services
2. **`test_all_services_import_bind_mounted_package`** — verifies all 7 services can `import test_actions.udfs` from the bind-mounted package at runtime (the 4 newly-wired services would fail pre-fix)
3. **`test_body_edit_reflects_without_restart`** — verifies host file edits are visible inside the executor via `importlib.reload` with no container restart

```
uv run pytest tests/integration/test_local_registry_compose.py -x -v
3 passed in 215.34s
```

## Notes

- Structural changes (add/rename/remove actions) still require a registry re-sync via `POST /api/admin/registry/sync?force=true` — this is application behavior, not governed by the compose file.
- The `TRACECAT__LOCAL_REPOSITORY_PATH` directory must be writable by the container user (uid 1001), not just readable, because the sync process runs `uv pip install --editable` which writes build artifacts into the source tree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent local‑registry wiring in `docker-compose.yml` so all registry‑aware services can import a bind‑mounted custom registry and pick up file edits without restarts. The feature stays off by default.

- **Bug Fixes**
  - Added `/app/local_registry` mount, `TRACECAT__LOCAL_REPOSITORY_PATH`, `TRACECAT__LOCAL_REPOSITORY_ENABLED`, and `PYTHONPATH` (`:/home/apiuser/.local:/app/local_registry`) to `api`, `worker`, `executor`, `agent-worker`, `litellm`, `agent-executor`, and `mcp`.
  - Fixed `worker` env-without-mount contradiction and added missing `PYTHONPATH` to `api`. Preserved `litellm`’s existing `/app:/app/packages/*` prefixes.
  - Added integration tests to verify compose config, runtime imports across all 7 services, and hot‑reload via `importlib.reload`.

- **Migration**
  - No action if you don’t use a local registry.
  - To enable: set `TRACECAT__LOCAL_REPOSITORY_ENABLED=true` and `TRACECAT__LOCAL_REPOSITORY_PATH=<host path>`, then recreate containers.
  - Ensure the path is writable by uid 1001; structural changes still require `POST /api/admin/registry/sync?force=true`.

<sup>Written for commit 4a085f404e5fa145cb085692c5b961a8e17b92c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

