### PR TITLE
feat(ui): show registry locks in workflow versions

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -28723,6 +28723,8 @@ export const $WorkflowDefinitionRead = {
       },
       type: "array",
       title: "Registry Lock Entries",
+      description:
+        "Registry lock origins with server-normalized display labels.",
       readOnly: true,
     },
   },

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -19514,6 +19514,27 @@ Attributes:
         bundled tracecat_registry package is an exact match for the lock.`,
 } as const
 
+export const $RegistryLockEntryRead = {
+  properties: {
+    origin: {
+      type: "string",
+      title: "Origin",
+    },
+    version: {
+      type: "string",
+      title: "Version",
+    },
+    label: {
+      type: "string",
+      title: "Label",
+    },
+  },
+  type: "object",
+  required: ["origin", "version", "label"],
+  title: "RegistryLockEntryRead",
+  description: "Display metadata for one registry lock origin.",
+} as const
+
 export const $RegistryOAuthSecret = {
   properties: {
     type: {
@@ -28696,6 +28717,14 @@ export const $WorkflowDefinitionRead = {
       format: "date-time",
       title: "Updated At",
     },
+    registry_lock_entries: {
+      items: {
+        $ref: "#/components/schemas/RegistryLockEntryRead",
+      },
+      type: "array",
+      title: "Registry Lock Entries",
+      readOnly: true,
+    },
   },
   type: "object",
   required: [
@@ -28705,6 +28734,7 @@ export const $WorkflowDefinitionRead = {
     "version",
     "created_at",
     "updated_at",
+    "registry_lock_entries",
   ],
   title: "WorkflowDefinitionRead",
   description: "API response model for persisted workflow definitions.",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -28697,16 +28697,6 @@ export const $WorkflowDefinitionRead = {
       ],
       title: "Content",
     },
-    registry_lock: {
-      anyOf: [
-        {
-          $ref: "#/components/schemas/RegistryLock",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
     created_at: {
       type: "string",
       format: "date-time",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -28676,6 +28676,16 @@ export const $WorkflowDefinitionRead = {
       ],
       title: "Content",
     },
+    registry_lock: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/RegistryLock",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
     created_at: {
       type: "string",
       format: "date-time",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -8511,7 +8511,10 @@ export type WorkflowDefinitionRead = {
   registry_lock?: RegistryLock | null
   created_at: string
   updated_at: string
-  registry_lock_entries: Array<RegistryLockEntryRead>
+  /**
+   * Registry lock origins with server-normalized display labels.
+   */
+  readonly registry_lock_entries: Array<RegistryLockEntryRead>
 }
 
 export type WorkflowDefinitionReadMinimal = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -5944,6 +5944,15 @@ export type RegistryLock = {
 }
 
 /**
+ * Display metadata for one registry lock origin.
+ */
+export type RegistryLockEntryRead = {
+  origin: string
+  version: string
+  label: string
+}
+
+/**
  * OAuth secret for a provider.
  */
 export type RegistryOAuthSecret = {
@@ -8502,6 +8511,7 @@ export type WorkflowDefinitionRead = {
   registry_lock?: RegistryLock | null
   created_at: string
   updated_at: string
+  registry_lock_entries: Array<RegistryLockEntryRead>
 }
 
 export type WorkflowDefinitionReadMinimal = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -8499,6 +8499,7 @@ export type WorkflowDefinitionRead = {
   content?: {
     [key: string]: unknown
   } | null
+  registry_lock?: RegistryLock | null
   created_at: string
   updated_at: string
 }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -8508,7 +8508,6 @@ export type WorkflowDefinitionRead = {
   content?: {
     [key: string]: unknown
   } | null
-  registry_lock?: RegistryLock | null
   created_at: string
   updated_at: string
   /**

--- a/frontend/src/components/builder/panel/workflow-panel.tsx
+++ b/frontend/src/components/builder/panel/workflow-panel.tsx
@@ -366,9 +366,12 @@ function WorkflowVersionsHistory({
         {definitions.map((definition, index) => {
           const isCurrent = definition.version === currentVersion
           const isLatest = definition.version === latestVersion
+          const registryLockEntries = getRegistryLockEntries(definition)
+          const registryLockSummary =
+            formatRegistryLockSummary(registryLockEntries)
           return (
             <div key={definition.id}>
-              <div className="flex items-center gap-3 px-4 py-3">
+              <div className="flex items-start gap-3 px-4 py-3">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <span className="font-medium">{`v${definition.version}`}</span>
@@ -379,6 +382,37 @@ function WorkflowVersionsHistory({
                   </div>
                   <div className="mt-1 text-xs text-muted-foreground">
                     {getRelativeTime(new Date(definition.created_at))}
+                  </div>
+                  <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                    {registryLockSummary ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Badge
+                            variant="outline"
+                            className="max-w-full truncate font-mono font-normal"
+                          >
+                            {registryLockSummary}
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-sm">
+                          <div className="space-y-1">
+                            <div className="font-medium">Registry lock</div>
+                            {registryLockEntries.map(([origin, version]) => (
+                              <div
+                                key={origin}
+                                className="break-all font-mono text-xs"
+                              >
+                                {`${origin}@${version}`}
+                              </div>
+                            ))}
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">
+                        No registry lock
+                      </span>
+                    )}
                   </div>
                 </div>
                 {!isCurrent ? (
@@ -407,6 +441,27 @@ function WorkflowVersionsHistory({
       </div>
     </TooltipProvider>
   )
+}
+
+function getRegistryLockEntries(
+  definition: WorkflowDefinitionRead
+): [string, string][] {
+  const origins = definition.registry_lock?.origins
+  if (!origins) {
+    return []
+  }
+  return Object.entries(origins).sort(([a], [b]) => a.localeCompare(b))
+}
+
+function formatRegistryLockSummary(entries: [string, string][]): string | null {
+  if (entries.length === 0) {
+    return null
+  }
+  const [origin, version] = entries[0]
+  if (entries.length === 1) {
+    return `${origin}@${version}`
+  }
+  return `${origin}@${version} +${entries.length - 1}`
 }
 
 function WorkflowSettingsPanel({

--- a/frontend/src/components/builder/panel/workflow-panel.tsx
+++ b/frontend/src/components/builder/panel/workflow-panel.tsx
@@ -18,6 +18,7 @@ import { z } from "zod"
 import {
   ApiError,
   type ExpectedField_Input,
+  type RegistryLockEntryRead,
   type WorkflowDefinitionRead,
   type WorkflowRead,
   type WorkflowUpdate,
@@ -444,30 +445,14 @@ function WorkflowVersionsHistory({
   )
 }
 
-type RegistryLockEntry = {
-  origin: string
-  version: string
-  label: string
-}
-
 function getRegistryLockEntries(
   definition: WorkflowDefinitionRead
-): RegistryLockEntry[] {
-  const origins = definition.registry_lock?.origins
-  if (!origins) {
-    return []
-  }
-  return Object.entries(origins)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([origin, version]) => ({
-      origin,
-      version,
-      label: formatRegistryLockEntry(origin, version),
-    }))
+): RegistryLockEntryRead[] {
+  return definition.registry_lock_entries
 }
 
 function formatRegistryLockSummary(
-  entries: RegistryLockEntry[]
+  entries: RegistryLockEntryRead[]
 ): string | null {
   if (entries.length === 0) {
     return null
@@ -477,33 +462,6 @@ function formatRegistryLockSummary(
     return label
   }
   return `${label} +${entries.length - 1}`
-}
-
-function formatRegistryLockEntry(origin: string, version: string): string {
-  return `${formatRegistryOrigin(origin)}@${formatRegistryVersion(origin, version)}`
-}
-
-function formatRegistryOrigin(origin: string): string {
-  if (origin === "tracecat_registry") {
-    return origin
-  }
-
-  const sshUrlMatch = origin.match(
-    /^git\+ssh:\/\/git@[^/:]+[:/]([^/]+)\/(.+?)(?:\.git)?$/
-  )
-  if (sshUrlMatch) {
-    const [, org, repo] = sshUrlMatch
-    return `${org}/${repo}`
-  }
-
-  return origin
-}
-
-function formatRegistryVersion(origin: string, version: string): string {
-  if (origin === "tracecat_registry") {
-    return version
-  }
-  return version.length > 12 ? version.slice(0, 12) : version
 }
 
 function WorkflowSettingsPanel({

--- a/frontend/src/components/builder/panel/workflow-panel.tsx
+++ b/frontend/src/components/builder/panel/workflow-panel.tsx
@@ -404,9 +404,8 @@ function WorkflowVersionsHistory({
                               <div
                                 key={entry.origin}
                                 className="break-all font-mono text-xs"
-                                title={`${entry.origin}@${entry.version}`}
                               >
-                                {entry.label}
+                                {`${entry.origin}@${entry.version}`}
                               </div>
                             ))}
                           </div>

--- a/frontend/src/components/builder/panel/workflow-panel.tsx
+++ b/frontend/src/components/builder/panel/workflow-panel.tsx
@@ -391,6 +391,8 @@ function WorkflowVersionsHistory({
                           <Badge
                             variant="outline"
                             className="max-w-full overflow-hidden truncate whitespace-nowrap font-mono font-normal"
+                            tabIndex={0}
+                            aria-label={`Registry lock: ${registryLockSummary}`}
                           >
                             {registryLockSummary}
                           </Badge>

--- a/frontend/src/components/builder/panel/workflow-panel.tsx
+++ b/frontend/src/components/builder/panel/workflow-panel.tsx
@@ -389,7 +389,7 @@ function WorkflowVersionsHistory({
                         <TooltipTrigger asChild>
                           <Badge
                             variant="outline"
-                            className="max-w-full truncate font-mono font-normal"
+                            className="max-w-full overflow-hidden truncate whitespace-nowrap font-mono font-normal"
                           >
                             {registryLockSummary}
                           </Badge>
@@ -397,12 +397,13 @@ function WorkflowVersionsHistory({
                         <TooltipContent className="max-w-sm">
                           <div className="space-y-1">
                             <div className="font-medium">Registry lock</div>
-                            {registryLockEntries.map(([origin, version]) => (
+                            {registryLockEntries.map((entry) => (
                               <div
-                                key={origin}
+                                key={entry.origin}
                                 className="break-all font-mono text-xs"
+                                title={`${entry.origin}@${entry.version}`}
                               >
-                                {`${origin}@${version}`}
+                                {entry.label}
                               </div>
                             ))}
                           </div>
@@ -443,25 +444,66 @@ function WorkflowVersionsHistory({
   )
 }
 
+type RegistryLockEntry = {
+  origin: string
+  version: string
+  label: string
+}
+
 function getRegistryLockEntries(
   definition: WorkflowDefinitionRead
-): [string, string][] {
+): RegistryLockEntry[] {
   const origins = definition.registry_lock?.origins
   if (!origins) {
     return []
   }
-  return Object.entries(origins).sort(([a], [b]) => a.localeCompare(b))
+  return Object.entries(origins)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([origin, version]) => ({
+      origin,
+      version,
+      label: formatRegistryLockEntry(origin, version),
+    }))
 }
 
-function formatRegistryLockSummary(entries: [string, string][]): string | null {
+function formatRegistryLockSummary(
+  entries: RegistryLockEntry[]
+): string | null {
   if (entries.length === 0) {
     return null
   }
-  const [origin, version] = entries[0]
+  const [{ label }] = entries
   if (entries.length === 1) {
-    return `${origin}@${version}`
+    return label
   }
-  return `${origin}@${version} +${entries.length - 1}`
+  return `${label} +${entries.length - 1}`
+}
+
+function formatRegistryLockEntry(origin: string, version: string): string {
+  return `${formatRegistryOrigin(origin)}@${formatRegistryVersion(origin, version)}`
+}
+
+function formatRegistryOrigin(origin: string): string {
+  if (origin === "tracecat_registry") {
+    return origin
+  }
+
+  const sshUrlMatch = origin.match(
+    /^git\+ssh:\/\/git@[^/:]+[:/]([^/]+)\/(.+?)(?:\.git)?$/
+  )
+  if (sshUrlMatch) {
+    const [, org, repo] = sshUrlMatch
+    return `${org}/${repo}`
+  }
+
+  return origin
+}
+
+function formatRegistryVersion(origin: string, version: string): string {
+  if (origin === "tracecat_registry") {
+    return version
+  }
+  return version.length > 12 ? version.slice(0, 12) : version
 }
 
 function WorkflowSettingsPanel({

--- a/tests/unit/test_workflow_management_schemas.py
+++ b/tests/unit/test_workflow_management_schemas.py
@@ -1,4 +1,47 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from tracecat.workflow.management.schemas import (
+    WorkflowDefinitionRead,
+    format_registry_origin,
+)
 from tracecat.workflow.management.utils import build_trigger_inputs_schema
+
+
+def test_workflow_definition_read_accepts_legacy_flat_registry_lock():
+    created_at = datetime.now(UTC)
+    definition = WorkflowDefinitionRead.model_validate(
+        {
+            "id": uuid4(),
+            "workflow_id": uuid4(),
+            "workspace_id": uuid4(),
+            "version": 1,
+            "content": {},
+            "registry_lock": {
+                "tracecat_registry": "2025.12.10.123456",
+                "git+ssh://deploy@example.com/acme/actions.git": "abcdef1234567890",
+            },
+            "created_at": created_at,
+            "updated_at": created_at,
+        }
+    )
+
+    assert definition.registry_lock is not None
+    assert definition.registry_lock.origins == {
+        "tracecat_registry": "2025.12.10.123456",
+        "git+ssh://deploy@example.com/acme/actions.git": "abcdef1234567890",
+    }
+    assert definition.registry_lock.actions == {}
+    assert definition.registry_lock_entries[0].label == "acme/actions@abcdef123456"
+    assert definition.registry_lock_entries[1].label == (
+        "tracecat_registry@2025.12.10.123456"
+    )
+
+
+def test_format_registry_origin_accepts_non_git_ssh_users():
+    origin = "git+ssh://deploy@example.com/acme/actions.git"
+
+    assert format_registry_origin(origin) == "acme/actions"
 
 
 def test_build_trigger_inputs_schema_generates_json_schema():

--- a/tests/unit/test_workflow_management_schemas.py
+++ b/tests/unit/test_workflow_management_schemas.py
@@ -36,6 +36,20 @@ def test_workflow_definition_read_accepts_legacy_flat_registry_lock():
     assert definition.registry_lock_entries[1].label == (
         "tracecat_registry@2025.12.10.123456"
     )
+    serialized = definition.model_dump(mode="json")
+    assert "registry_lock" not in serialized
+    assert serialized["registry_lock_entries"] == [
+        {
+            "origin": "git+ssh://deploy@example.com/acme/actions.git",
+            "version": "abcdef1234567890",
+            "label": "acme/actions@abcdef123456",
+        },
+        {
+            "origin": "tracecat_registry",
+            "version": "2025.12.10.123456",
+            "label": "tracecat_registry@2025.12.10.123456",
+        },
+    ]
 
 
 def test_format_registry_origin_accepts_non_git_ssh_users():

--- a/tracecat/workflow/management/schemas.py
+++ b/tracecat/workflow/management/schemas.py
@@ -112,7 +112,7 @@ class WorkflowDefinitionRead(Schema):
     workspace_id: WorkspaceID
     version: int
     content: dict[str, Any] | None = None
-    registry_lock: RegistryLock | None = None
+    registry_lock: RegistryLock | None = Field(default=None, exclude=True)
     created_at: datetime
     updated_at: datetime
 

--- a/tracecat/workflow/management/schemas.py
+++ b/tracecat/workflow/management/schemas.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from typing import Any, Literal
 
 from fastapi.responses import ORJSONResponse
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 from tracecat.auth.types import Role
 from tracecat.cases.enums import CaseEventType
@@ -28,6 +28,44 @@ from tracecat.workflow.case_triggers.schemas import (
     is_case_trigger_configured,
 )
 from tracecat.workflow.schedules.schemas import ScheduleRead
+
+
+def format_registry_lock_entry(origin: str, version: str) -> str:
+    """Format a registry lock origin/version pair for API consumers."""
+    return (
+        f"{format_registry_origin(origin)}@{format_registry_version(origin, version)}"
+    )
+
+
+def format_registry_origin(origin: str) -> str:
+    """Normalize registry origins for compact display."""
+    if origin == "tracecat_registry":
+        return origin
+
+    prefix = "git+ssh://git@"
+    if not origin.startswith(prefix):
+        return origin
+
+    path_start = origin.find("/", len(prefix))
+    if path_start == -1:
+        return origin
+
+    path = origin[path_start + 1 :]
+    if path.endswith(".git"):
+        path = path[:-4]
+    parts = path.split("/")
+    if len(parts) < 2:
+        return origin
+
+    org, repo = parts[-2], parts[-1]
+    return f"{org}/{repo}"
+
+
+def format_registry_version(origin: str, version: str) -> str:
+    """Keep platform versions intact and shorten custom registry revisions."""
+    if origin == "tracecat_registry":
+        return version
+    return version[:12] if len(version) > 12 else version
 
 
 class WorkflowRead(Schema):
@@ -59,6 +97,14 @@ class WorkflowDefinitionReadMinimal(Schema):
     created_at: datetime
 
 
+class RegistryLockEntryRead(Schema):
+    """Display metadata for one registry lock origin."""
+
+    origin: str
+    version: str
+    label: str
+
+
 class WorkflowDefinitionRead(Schema):
     """API response model for persisted workflow definitions."""
 
@@ -70,6 +116,21 @@ class WorkflowDefinitionRead(Schema):
     registry_lock: RegistryLock | None = None
     created_at: datetime
     updated_at: datetime
+
+    @computed_field
+    @property
+    def registry_lock_entries(self) -> list[RegistryLockEntryRead]:
+        """Registry lock origins with server-normalized display labels."""
+        if self.registry_lock is None:
+            return []
+        return [
+            RegistryLockEntryRead(
+                origin=origin,
+                version=version,
+                label=format_registry_lock_entry(origin, version),
+            )
+            for origin, version in sorted(self.registry_lock.origins.items())
+        ]
 
 
 class WorkflowTriggerSummary(Schema):

--- a/tracecat/workflow/management/schemas.py
+++ b/tracecat/workflow/management/schemas.py
@@ -67,6 +67,7 @@ class WorkflowDefinitionRead(Schema):
     workspace_id: WorkspaceID
     version: int
     content: dict[str, Any] | None = None
+    registry_lock: RegistryLock | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/tracecat/workflow/management/schemas.py
+++ b/tracecat/workflow/management/schemas.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from datetime import datetime
 from enum import StrEnum
 from typing import Any, Literal
+from urllib.parse import urlparse
 
 from fastapi.responses import ORJSONResponse
 from pydantic import BaseModel, Field, computed_field, field_validator
@@ -42,15 +43,13 @@ def format_registry_origin(origin: str) -> str:
     if origin == "tracecat_registry":
         return origin
 
-    prefix = "git+ssh://git@"
-    if not origin.startswith(prefix):
+    parsed = urlparse(origin)
+    if parsed.scheme != "git+ssh":
         return origin
 
-    path_start = origin.find("/", len(prefix))
-    if path_start == -1:
+    path = parsed.path.lstrip("/")
+    if not path:
         return origin
-
-    path = origin[path_start + 1 :]
     if path.endswith(".git"):
         path = path[:-4]
     parts = path.split("/")
@@ -116,6 +115,23 @@ class WorkflowDefinitionRead(Schema):
     registry_lock: RegistryLock | None = None
     created_at: datetime
     updated_at: datetime
+
+    @field_validator("registry_lock", mode="before")
+    @classmethod
+    def normalize_legacy_registry_lock(cls, value: Any) -> Any:
+        """Accept flat registry locks written by the original DB migration."""
+        if value is None or isinstance(value, RegistryLock):
+            return value
+        if not isinstance(value, dict):
+            return value
+        if any(key in value for key in ("origins", "actions", "origin_fingerprints")):
+            return value
+        if not all(
+            isinstance(origin, str) and isinstance(version, str)
+            for origin, version in value.items()
+        ):
+            return value
+        return {"origins": value, "actions": {}}
 
     @computed_field
     @property


### PR DESCRIPTION
### Motivation
- Improve visibility of which registry versions a saved workflow definition uses by exposing its `RegistryLock` and surfacing a concise summary in the UI so users can quickly see pinned origins/versions per workflow version.

### Description
- Add an optional `registry_lock: RegistryLock | None` field to the `WorkflowDefinitionRead` API schema so definitions return lock data with version records (`tracecat/workflow/management/schemas.py`).
- Update generated frontend API types and schemas to include `registry_lock` on `WorkflowDefinitionRead` (`frontend/src/client/types.gen.ts` and `frontend/src/client/schemas.gen.ts`).
- Render a compact registry-lock summary badge per definition in the Versions panel and show a tooltip listing all `origin@version` entries when present (`frontend/src/components/builder/panel/workflow-panel.tsx`).
- Add small helper functions to extract, sort, and format registry-lock origin entries for consistent presentation in the UI (`getRegistryLockEntries` and `formatRegistryLockSummary`).

## Screens
<img width="588" height="584" alt="image" src="https://github.com/user-attachments/assets/ea0e83e7-aa2a-4fc3-b1e6-a31771473761" />


### Testing
- Ran frontend lint/format fix with `pnpm -C frontend exec biome check --write ...` and the check completed successfully.
- Ran Python formatting and lint checks with `uv run ruff format --check tracecat/workflow/management/schemas.py` and `uv run ruff check tracecat/workflow/management/schemas.py`, both succeeding.
- Ran TypeScript typecheck with `pnpm -C frontend run typecheck` and it completed without errors.
- Verified diffs with `git diff --check` and there were no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39699eafc48320af3ff11499416c82)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show registry lock info for workflow versions with a compact badge and tooltip so users can see pinned origins and versions at a glance. Also normalizes legacy locks and hides raw lock data in API responses for a cleaner, stable UI contract.

- **New Features**
  - API: Return computed, read-only `registry_lock_entries` on `WorkflowDefinitionRead` (always present; empty when none) with normalized `origin@version` labels.
  - Client: Generated types add `RegistryLockEntryRead` and `registry_lock_entries` on `WorkflowDefinitionRead`.
  - UI: Versions panel shows a monospaced badge with the first label and “+N”; tooltip lists all entries; displays “No registry lock” when absent.

- **Bug Fixes**
  - Accept and normalize legacy flat `registry_lock` objects from older records.
  - Do not serialize `registry_lock` in API responses; use `registry_lock_entries` instead.
  - Make the tooltip focusable and show full versions in the list (labels still shorten non-platform revisions).

<sup>Written for commit f6249839a27b247ffae03eb14f5b27d2083cbc1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



