### PR TITLE
feat(mcp): add Oneleet catalog server

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -2152,6 +2152,31 @@
       }
     },
     {
+      "slug": "oneleet-mcp",
+      "docs": "https://docs.oneleet.com/api-and-mcp/service-keys-and-mcp/",
+      "connection_spec": {
+        "server_type": "http",
+        "auth_type": "CUSTOM",
+        "server_uri": "https://api.oneleet.com/mcp",
+        "credentials": [
+          {
+            "key": "Authorization",
+            "label": "Oneleet service key (Authorization header)",
+            "description": "Oneleet API service key sent as the Authorization header in the form 'Bearer service_<id>_<secret>'. Create the service key in Oneleet Settings > API and grant the scopes needed by your agent.",
+            "required": true,
+            "secret": true,
+            "target": "http_header"
+          }
+        ],
+        "confidence": "high",
+        "docker_only": false,
+        "research_notes": "Oneleet documents a first-party remote MCP server at https://api.oneleet.com/mcp using Streamable HTTP transport. OAuth-based user login is not available yet, so clients authenticate with a tenant-scoped API service key. The service key is shown once at creation, uses the service_<id>_<secret> format, and is passed to MCP clients as Authorization: Bearer <your-service-key>. Service keys can be scoped to read tenant details, controls, policies, frameworks, members, integrations, evidence, monitors, pentest findings, and write evidence, integrations, or monitor reruns. No stdio, npx, uvx, pip, Docker, or OAuth option is documented for this server.",
+        "sources": [
+          "https://docs.oneleet.com/api-and-mcp/service-keys-and-mcp/"
+        ]
+      }
+    },
+    {
       "slug": "grafana-mcp",
       "docs": "https://github.com/grafana/mcp-grafana",
       "connection_spec": {

--- a/tracecat/integrations/catalog/mcp_catalog.json
+++ b/tracecat/integrations/catalog/mcp_catalog.json
@@ -303,6 +303,13 @@
       "icon": "https://www.google.com/s2/favicons?domain=drata.com&sz=128"
     },
     {
+      "slug": "oneleet-mcp",
+      "name": "Oneleet",
+      "description": "Manage compliance controls, evidence, policies, monitors, and pentest findings in Oneleet",
+      "category": "Compliance",
+      "icon": "https://www.google.com/s2/favicons?domain=oneleet.com&sz=128"
+    },
+    {
       "slug": "grafana-mcp",
       "name": "Grafana",
       "description": "Query dashboards, Prometheus, Loki, and alerts on Grafana",


### PR DESCRIPTION
## Summary
- Add Oneleet to the platform MCP catalog under Compliance.
- Add the EE connection recipe for Oneleet's hosted Streamable HTTP endpoint at `https://api.oneleet.com/mcp`.
- Configure the catalog connection to collect an `Authorization` header using a Oneleet API service key.

## Validation
- `uv run python -m json.tool tracecat/integrations/catalog/mcp_catalog.json >/dev/null`
- `uv run python -m json.tool packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json >/dev/null`
- `uv run pytest tests/unit/test_mcp_catalog_loader.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Oneleet to the MCP catalog and adds an EE connection for its hosted Streamable HTTP server. Lets users connect to Oneleet using a service key via the Authorization header.

- **New Features**
  - Public catalog: Oneleet listed under Compliance with name, description, and icon.
  - EE connection: Streamable HTTP server at https://api.oneleet.com/mcp using a custom Authorization header with a Oneleet service key in the form Bearer service_<id>_<secret>.

<sup>Written for commit dcb01d4e13d512ce0630ec5ae3e50f147872b25d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

