### PR TITLE
feat(api): sync rbac assignments with memberships

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -31307,6 +31307,11 @@ export const $WorkspaceMember = {
       title: "Via Group",
       default: false,
     },
+    via_direct: {
+      type: "boolean",
+      title: "Via Direct",
+      default: false,
+    },
   },
   type: "object",
   required: ["user_id", "first_name", "last_name", "email", "role_name"],

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -31302,6 +31302,11 @@ export const $WorkspaceMember = {
       type: "string",
       title: "Role Name",
     },
+    via_group: {
+      type: "boolean",
+      title: "Via Group",
+      default: false,
+    },
   },
   type: "object",
   required: ["user_id", "first_name", "last_name", "email", "role_name"],

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -9264,6 +9264,7 @@ export type WorkspaceMember = {
   email: string
   role_name: string
   via_group?: boolean
+  via_direct?: boolean
 }
 
 export type WorkspaceMembershipCreate = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -9263,6 +9263,7 @@ export type WorkspaceMember = {
   last_name: string | null
   email: string
   role_name: string
+  via_group?: boolean
 }
 
 export type WorkspaceMembershipCreate = {

--- a/frontend/src/components/workspaces/workspace-members-table.tsx
+++ b/frontend/src/components/workspaces/workspace-members-table.tsx
@@ -21,6 +21,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -44,6 +45,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { toast } from "@/components/ui/use-toast"
 import {
   useWorkspaceMembers,
@@ -218,8 +224,21 @@ export function WorkspaceMembersTable({
                 />
               ),
               cell: ({ row }) => (
-                <div className="text-xs capitalize">
+                <div className="flex items-center gap-2 text-xs capitalize">
                   {row.getValue<string>("role_name")}
+                  {row.original.via_group && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge variant="secondary" className="font-normal">
+                          Via group
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Access granted through a group. Manage this role from
+                        the group's settings.
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
                 </div>
               ),
               enableSorting: true,
@@ -230,6 +249,9 @@ export function WorkspaceMembersTable({
               id: "actions",
               enableHiding: false,
               cell: ({ row }) => {
+                // Managed via the group, and the backend rejects these edits —
+                // disable the row actions rather than offer a guaranteed failure.
+                const viaGroup = row.original.via_group ?? false
                 return (
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
@@ -247,32 +269,78 @@ export function WorkspaceMembersTable({
                         Copy user ID
                       </DropdownMenuItem>
 
-                      {canUpdateMembers && (
-                        <DialogTrigger asChild>
-                          <DropdownMenuItem
-                            onClick={() => {
-                              setSelectedUser(row.original)
-                              setIsChangeRoleOpen(true)
-                            }}
-                          >
-                            Change role
-                          </DropdownMenuItem>
-                        </DialogTrigger>
-                      )}
+                      {canUpdateMembers &&
+                        (viaGroup ? (
+                          <Tooltip>
+                            {/*
+                             * A disabled element does not emit the pointer or
+                             * focus events Radix needs, so it cannot itself be
+                             * the tooltip trigger. Wrap the disabled item in a
+                             * focusable span and make the span the trigger so
+                             * the explanation still shows on hover/focus.
+                             */}
+                            <TooltipTrigger asChild>
+                              <span tabIndex={0}>
+                                <DropdownMenuItem
+                                  disabled
+                                  onSelect={(e) => e.preventDefault()}
+                                >
+                                  Change role
+                                </DropdownMenuItem>
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              Role is managed through the group.
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <DialogTrigger asChild>
+                            <DropdownMenuItem
+                              onClick={() => {
+                                setSelectedUser(row.original)
+                                setIsChangeRoleOpen(true)
+                              }}
+                            >
+                              Change role
+                            </DropdownMenuItem>
+                          </DialogTrigger>
+                        ))}
 
-                      {canRemoveMembers && (
-                        <AlertDialogTrigger asChild>
-                          <DropdownMenuItem
-                            className="text-rose-500 focus:text-rose-600"
-                            onClick={() => {
-                              setSelectedUser(row.original)
-                              console.debug("Selected user", row.original)
-                            }}
-                          >
-                            Remove from workspace
-                          </DropdownMenuItem>
-                        </AlertDialogTrigger>
-                      )}
+                      {canRemoveMembers &&
+                        (viaGroup ? (
+                          <Tooltip>
+                            {/*
+                             * Disabled elements swallow the events Radix needs
+                             * to open a tooltip, so the disabled item is wrapped
+                             * in a focusable span that acts as the trigger.
+                             */}
+                            <TooltipTrigger asChild>
+                              <span tabIndex={0}>
+                                <DropdownMenuItem
+                                  disabled
+                                  onSelect={(e) => e.preventDefault()}
+                                >
+                                  Remove from workspace
+                                </DropdownMenuItem>
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              Remove the user from the group to revoke access.
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <AlertDialogTrigger asChild>
+                            <DropdownMenuItem
+                              className="text-rose-500 focus:text-rose-600"
+                              onClick={() => {
+                                setSelectedUser(row.original)
+                                console.debug("Selected user", row.original)
+                              }}
+                            >
+                              Remove from workspace
+                            </DropdownMenuItem>
+                          </AlertDialogTrigger>
+                        ))}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 )

--- a/frontend/src/components/workspaces/workspace-members-table.tsx
+++ b/frontend/src/components/workspaces/workspace-members-table.tsx
@@ -249,9 +249,14 @@ export function WorkspaceMembersTable({
               id: "actions",
               enableHiding: false,
               cell: ({ row }) => {
-                // Managed via the group, and the backend rejects these edits —
-                // disable the row actions rather than offer a guaranteed failure.
+                // Removal is rejected by the backend whenever any group path
+                // exists, so gate "Remove" on via_group. "Change role" edits the
+                // direct assignment, which stays editable for a mixed-source
+                // member (both via_group and via_direct) — gate it on the
+                // absence of a direct assignment instead.
                 const viaGroup = row.original.via_group ?? false
+                const viaDirect = row.original.via_direct ?? false
+                const canEditRole = viaDirect
                 return (
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
@@ -270,7 +275,7 @@ export function WorkspaceMembersTable({
                       </DropdownMenuItem>
 
                       {canUpdateMembers &&
-                        (viaGroup ? (
+                        (!canEditRole ? (
                           <Tooltip>
                             {/*
                              * A disabled element does not emit the pointer or

--- a/packages/tracecat-ee/tracecat_ee/rbac/service.py
+++ b/packages/tracecat-ee/tracecat_ee/rbac/service.py
@@ -406,8 +406,36 @@ class RBACService(BaseOrgService):
     async def delete_group(self, group_id: UUID) -> None:
         """Delete a group."""
         group = await self.get_group(group_id)
+
+        # Capture (member, workspace) pairs the group currently materializes
+        # before the delete cascades away GroupMember/GroupRoleAssignment rows.
+        # The cascade drops the RBAC paths but not the derived Membership rows,
+        # so we must reconcile each affected user/workspace ourselves afterwards.
+        affected = (
+            await self.session.execute(
+                select(GroupMember.user_id, GroupRoleAssignment.workspace_id)
+                .join(
+                    GroupRoleAssignment,
+                    GroupRoleAssignment.group_id == GroupMember.group_id,
+                )
+                .where(
+                    GroupMember.group_id == group_id,
+                    GroupRoleAssignment.workspace_id.is_not(None),
+                )
+                .distinct()
+            )
+        ).all()
+
         await self.session.delete(group)
         await self.session.commit()
+
+        # Post-delete reconcile: drops membership for members with no remaining
+        # path to the workspace, leaves it for those who still hold one.
+        membership_svc = MembershipService(self.session)
+        for user_id, workspace_id in affected:
+            if workspace_id is None:
+                continue
+            await membership_svc.reconcile_workspace_membership(user_id, workspace_id)
 
     @require_scope("org:rbac:update")
     @audit_log(

--- a/packages/tracecat-ee/tracecat_ee/rbac/service.py
+++ b/packages/tracecat-ee/tracecat_ee/rbac/service.py
@@ -407,10 +407,9 @@ class RBACService(BaseOrgService):
         """Delete a group."""
         group = await self.get_group(group_id)
 
-        # Capture (member, workspace) pairs the group currently materializes
-        # before the delete cascades away GroupMember/GroupRoleAssignment rows.
-        # The cascade drops the RBAC paths but not the derived Membership rows,
-        # so we must reconcile each affected user/workspace ourselves afterwards.
+        # Snapshot affected (member, workspace) pairs before deleting: the
+        # cascade drops the RBAC paths but not the derived Membership rows, so we
+        # reconcile them ourselves afterwards.
         affected = (
             await self.session.execute(
                 select(GroupMember.user_id, GroupRoleAssignment.workspace_id)
@@ -634,8 +633,7 @@ class RBACService(BaseOrgService):
         await self.session.commit()
         await self.session.refresh(assignment, ["group", "role", "workspace"])
 
-        # Workspace-scoped group assignment materializes membership for every
-        # current group member (bounded cold burst on a rare admin action).
+        # A ws-scoped group assignment materializes membership for every member.
         if workspace_id is not None:
             await MembershipService(self.session).reconcile_group_members(
                 group_id, workspace_id

--- a/packages/tracecat-ee/tracecat_ee/rbac/service.py
+++ b/packages/tracecat-ee/tracecat_ee/rbac/service.py
@@ -13,6 +13,7 @@ from tracecat.audit.logger import audit_log
 from tracecat.authz.controls import require_scope, validate_scope_string
 from tracecat.authz.enums import ScopeSource
 from tracecat.authz.scopes import PRESET_ROLE_SCOPES
+from tracecat.authz.service import MembershipService
 from tracecat.db.models import (
     Group,
     GroupMember,
@@ -439,6 +440,10 @@ class RBACService(BaseOrgService):
         self.session.add(member)
         await self.session.commit()
 
+        # Group membership change affects every workspace the group grants
+        # access to. Reconcile this user against each such workspace.
+        await self._reconcile_user_for_group_workspaces(user_id, group_id)
+
     @require_scope("org:rbac:update")
     @audit_log(
         resource_type="rbac_group_member", action="delete", resource_id_attr="group_id"
@@ -461,6 +466,33 @@ class RBACService(BaseOrgService):
 
         await self.session.delete(member)
         await self.session.commit()
+
+        # User left the group: reconcile against every workspace the group
+        # grants, dropping membership where no other path remains.
+        await self._reconcile_user_for_group_workspaces(user_id, group_id)
+
+    async def _reconcile_user_for_group_workspaces(
+        self, user_id: UUID, group_id: UUID
+    ) -> None:
+        """Reconcile a user against every workspace a group holds a ws-scoped role for."""
+        workspace_ids = (
+            (
+                await self.session.execute(
+                    select(GroupRoleAssignment.workspace_id).where(
+                        GroupRoleAssignment.group_id == group_id,
+                        GroupRoleAssignment.workspace_id.is_not(None),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for workspace_id in workspace_ids:
+            if workspace_id is None:
+                continue
+            await MembershipService(self.session).reconcile_workspace_membership(
+                user_id, workspace_id
+            )
 
     async def list_group_members(
         self, group_id: UUID
@@ -573,6 +605,13 @@ class RBACService(BaseOrgService):
         self.session.add(assignment)
         await self.session.commit()
         await self.session.refresh(assignment, ["group", "role", "workspace"])
+
+        # Workspace-scoped group assignment materializes membership for every
+        # current group member (bounded cold burst on a rare admin action).
+        if workspace_id is not None:
+            await MembershipService(self.session).reconcile_group_members(
+                group_id, workspace_id
+            )
         return assignment
 
     @require_scope("org:rbac:update")
@@ -607,8 +646,17 @@ class RBACService(BaseOrgService):
     async def delete_group_role_assignment(self, assignment_id: UUID) -> None:
         """Delete a group assignment."""
         assignment = await self.get_group_role_assignment(assignment_id)
+        group_id = assignment.group_id
+        workspace_id = assignment.workspace_id
         await self.session.delete(assignment)
         await self.session.commit()
+
+        # Removing a ws-scoped group assignment may drop membership for group
+        # members who have no other path to the workspace.
+        if workspace_id is not None:
+            await MembershipService(self.session).reconcile_group_members(
+                group_id, workspace_id
+            )
 
     # =========================================================================
     # User Role Assignment Management
@@ -716,6 +764,12 @@ class RBACService(BaseOrgService):
                 "User already has an assignment for this workspace"
             ) from e
         await self.session.refresh(assignment, ["user", "role", "workspace"])
+
+        # Direct workspace-scoped assignment materializes membership.
+        if workspace_id is not None:
+            await MembershipService(self.session).reconcile_workspace_membership(
+                user_id, workspace_id
+            )
         return assignment
 
     @require_scope("org:rbac:update")
@@ -750,8 +804,17 @@ class RBACService(BaseOrgService):
     async def delete_user_assignment(self, assignment_id: UUID) -> None:
         """Delete a user role assignment."""
         assignment = await self.get_user_assignment(assignment_id)
+        user_id = assignment.user_id
+        workspace_id = assignment.workspace_id
         await self.session.delete(assignment)
         await self.session.commit()
+
+        # Removing a ws-scoped direct assignment may drop membership if no
+        # group path remains.
+        if workspace_id is not None:
+            await MembershipService(self.session).reconcile_workspace_membership(
+                user_id, workspace_id
+            )
 
     async def get_user_role_scopes(
         self,

--- a/tests/unit/test_authz_membership_service.py
+++ b/tests/unit/test_authz_membership_service.py
@@ -4,7 +4,6 @@ import uuid
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.auth.schemas import UserRole
@@ -12,6 +11,9 @@ from tracecat.auth.types import Role
 from tracecat.authz.scopes import ADMIN_SCOPES
 from tracecat.authz.service import MembershipService
 from tracecat.db.models import (
+    Group,
+    GroupMember,
+    GroupRoleAssignment,
     Membership,
     Organization,
     User,
@@ -262,14 +264,20 @@ async def test_create_membership_heals_stale_workspace_assignment(
     assert assignment_list[0].assigned_by == actor_user.id
 
 
-async def test_create_membership_duplicate_raises_integrity_error(
+async def test_create_membership_is_idempotent_when_membership_exists(
     session: AsyncSession,
     membership_service: MembershipService,
     workspace: Workspace,
     member_user: User,
     workspace_editor_role: DBRole,
 ) -> None:
-    """Creating an existing membership should raise an integrity conflict."""
+    """Re-adding an existing member is idempotent under the reconciler.
+
+    The membership dial is now derived from the workspace-scoped role path via
+    ``reconcile_workspace_membership`` (ENG-1499 / B1), which upserts with
+    ``ON CONFLICT DO NOTHING``. Calling create again writes/heals the role
+    assignment and leaves a single membership row, rather than raising.
+    """
     assert workspace_editor_role.slug == "workspace-editor"
     session.add(
         Membership(
@@ -279,8 +287,245 @@ async def test_create_membership_duplicate_raises_integrity_error(
     )
     await session.commit()
 
-    with pytest.raises(IntegrityError):
-        await membership_service.create_membership(
-            workspace_id=workspace.id,
-            params=WorkspaceMembershipCreate(user_id=member_user.id),
+    await membership_service.create_membership(
+        workspace_id=workspace.id,
+        params=WorkspaceMembershipCreate(user_id=member_user.id),
+    )
+
+    memberships = (
+        (
+            await session.execute(
+                select(Membership).where(
+                    Membership.workspace_id == workspace.id,
+                    Membership.user_id == member_user.id,
+                )
+            )
         )
+        .scalars()
+        .all()
+    )
+    assert len(memberships) == 1
+
+
+# === reconcile_workspace_membership (ENG-1499 / B1) === #
+
+
+async def _get_membership(
+    session: AsyncSession, workspace: Workspace, user: User
+) -> Membership | None:
+    return await session.scalar(
+        select(Membership).where(
+            Membership.workspace_id == workspace.id,
+            Membership.user_id == user.id,
+        )
+    )
+
+
+@pytest.fixture
+async def group(session: AsyncSession, organization: Organization) -> Group:
+    grp = Group(
+        id=uuid.uuid4(),
+        name=f"group-{uuid.uuid4().hex[:8]}",
+        organization_id=organization.id,
+    )
+    session.add(grp)
+    await session.commit()
+    await session.refresh(grp)
+    return grp
+
+
+async def test_reconcile_materializes_membership_for_direct_ws_path(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    workspace_editor_role: DBRole,
+) -> None:
+    """A direct workspace-scoped role assignment should mint a membership row."""
+    session.add(
+        UserRoleAssignment(
+            organization_id=organization.id,
+            user_id=member_user.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+        )
+    )
+    await session.commit()
+
+    await membership_service.reconcile_workspace_membership(
+        member_user.id, workspace.id
+    )
+
+    assert await _get_membership(session, workspace, member_user) is not None
+
+
+async def test_reconcile_org_wide_path_does_not_materialize(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    workspace_editor_role: DBRole,
+) -> None:
+    """Org-wide (workspace_id IS NULL) assignments must NOT create membership."""
+    session.add(
+        UserRoleAssignment(
+            organization_id=organization.id,
+            user_id=member_user.id,
+            workspace_id=None,
+            role_id=workspace_editor_role.id,
+        )
+    )
+    await session.commit()
+
+    await membership_service.reconcile_workspace_membership(
+        member_user.id, workspace.id
+    )
+
+    assert await _get_membership(session, workspace, member_user) is None
+
+
+async def test_reconcile_is_idempotent(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    workspace_editor_role: DBRole,
+) -> None:
+    """Reconciling twice yields exactly one membership row."""
+    session.add(
+        UserRoleAssignment(
+            organization_id=organization.id,
+            user_id=member_user.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+        )
+    )
+    await session.commit()
+
+    await membership_service.reconcile_workspace_membership(
+        member_user.id, workspace.id
+    )
+    await membership_service.reconcile_workspace_membership(
+        member_user.id, workspace.id
+    )
+
+    rows = (
+        (
+            await session.execute(
+                select(Membership).where(
+                    Membership.workspace_id == workspace.id,
+                    Membership.user_id == member_user.id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+
+
+async def test_reconcile_removes_membership_when_no_path_remains(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    workspace: Workspace,
+    member_user: User,
+) -> None:
+    """A membership with no backing ws-scoped path is reconciled away."""
+    session.add(Membership(user_id=member_user.id, workspace_id=workspace.id))
+    await session.commit()
+
+    await membership_service.reconcile_workspace_membership(
+        member_user.id, workspace.id
+    )
+
+    assert await _get_membership(session, workspace, member_user) is None
+
+
+async def test_reconcile_materializes_membership_for_group_ws_path(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    workspace_editor_role: DBRole,
+    group: Group,
+) -> None:
+    """Membership in a group with a ws-scoped assignment mints membership."""
+    session.add(GroupMember(group_id=group.id, user_id=member_user.id))
+    session.add(
+        GroupRoleAssignment(
+            organization_id=organization.id,
+            group_id=group.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+        )
+    )
+    await session.commit()
+
+    await membership_service.reconcile_workspace_membership(
+        member_user.id, workspace.id
+    )
+
+    assert await _get_membership(session, workspace, member_user) is not None
+
+
+async def test_reconcile_keeps_membership_when_group_path_remains(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    workspace_editor_role: DBRole,
+    group: Group,
+) -> None:
+    """Removing a direct assignment keeps membership if a group path holds it."""
+    session.add(GroupMember(group_id=group.id, user_id=member_user.id))
+    session.add(
+        GroupRoleAssignment(
+            organization_id=organization.id,
+            group_id=group.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+        )
+    )
+    session.add(Membership(user_id=member_user.id, workspace_id=workspace.id))
+    await session.commit()
+
+    # No direct assignment exists, but the group path does -> membership stays.
+    await membership_service.reconcile_workspace_membership(
+        member_user.id, workspace.id
+    )
+
+    assert await _get_membership(session, workspace, member_user) is not None
+
+
+async def test_reconcile_group_members_fans_out(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    actor_user: User,
+    workspace_editor_role: DBRole,
+    group: Group,
+) -> None:
+    """reconcile_group_members materializes membership for every group member."""
+    session.add(GroupMember(group_id=group.id, user_id=member_user.id))
+    session.add(GroupMember(group_id=group.id, user_id=actor_user.id))
+    session.add(
+        GroupRoleAssignment(
+            organization_id=organization.id,
+            group_id=group.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+        )
+    )
+    await session.commit()
+
+    await membership_service.reconcile_group_members(group.id, workspace.id)
+
+    assert await _get_membership(session, workspace, member_user) is not None
+    assert await _get_membership(session, workspace, actor_user) is not None

--- a/tests/unit/test_authz_membership_service.py
+++ b/tests/unit/test_authz_membership_service.py
@@ -21,6 +21,7 @@ from tracecat.db.models import (
     Workspace,
 )
 from tracecat.db.models import Role as DBRole
+from tracecat.exceptions import TracecatConflictError
 from tracecat.workspaces.schemas import WorkspaceMembershipCreate
 
 pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("db")]
@@ -213,6 +214,49 @@ async def test_delete_membership_removes_orphan_assignment(
     )
 
     assert assignment is None
+
+
+async def test_delete_membership_rejects_group_derived_member(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    workspace_editor_role: DBRole,
+    group: Group,
+) -> None:
+    """Removing a member whose only path is a group must conflict, not no-op.
+
+    Otherwise the delete would drop no direct assignment, the reconciler would
+    keep the membership, and the user would reappear in the workspace.
+    """
+    session.add(GroupMember(group_id=group.id, user_id=member_user.id))
+    session.add(
+        GroupRoleAssignment(
+            organization_id=organization.id,
+            group_id=group.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+        )
+    )
+    session.add(Membership(user_id=member_user.id, workspace_id=workspace.id))
+    await session.commit()
+
+    with pytest.raises(TracecatConflictError):
+        await membership_service.delete_membership(
+            workspace_id=workspace.id,
+            user_id=member_user.id,
+        )
+
+    # The group path and membership are untouched by the rejected request.
+    assert await _get_membership(session, workspace, member_user) is not None
+    group_assignment = await session.scalar(
+        select(GroupRoleAssignment).where(
+            GroupRoleAssignment.group_id == group.id,
+            GroupRoleAssignment.workspace_id == workspace.id,
+        )
+    )
+    assert group_assignment is not None
 
 
 async def test_create_membership_is_idempotent_with_existing_default_assignment(
@@ -593,3 +637,45 @@ async def test_reconcile_group_members_fans_out(
 
     assert await _get_membership(session, workspace, member_user) is not None
     assert await _get_membership(session, workspace, actor_user) is not None
+
+
+async def test_list_workspace_members_flags_group_derived_role(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    actor_user: User,
+    workspace_editor_role: DBRole,
+    group: Group,
+) -> None:
+    """Group-only members report their group role with via_group; direct ones don't."""
+    # member_user: access only via a group assignment.
+    session.add(GroupMember(group_id=group.id, user_id=member_user.id))
+    session.add(
+        GroupRoleAssignment(
+            organization_id=organization.id,
+            group_id=group.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+        )
+    )
+    session.add(Membership(user_id=member_user.id, workspace_id=workspace.id))
+    # actor_user: a direct workspace assignment.
+    session.add(
+        UserRoleAssignment(
+            organization_id=organization.id,
+            user_id=actor_user.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+        )
+    )
+    session.add(Membership(user_id=actor_user.id, workspace_id=workspace.id))
+    await session.commit()
+
+    members = await membership_service.list_workspace_members(workspace.id)
+    by_user = {m.user_id: m for m in members}
+
+    assert by_user[member_user.id].via_group is True
+    assert by_user[member_user.id].role_name == workspace_editor_role.name
+    assert by_user[actor_user.id].via_group is False

--- a/tests/unit/test_authz_membership_service.py
+++ b/tests/unit/test_authz_membership_service.py
@@ -649,7 +649,8 @@ async def test_list_workspace_members_flags_group_derived_role(
     workspace_editor_role: DBRole,
     group: Group,
 ) -> None:
-    """Group-only members report their group role with via_group; direct ones don't."""
+    """Flags reflect the access path: via_group for any group path, via_direct
+    for a direct assignment. A mixed-source member reports both."""
     # member_user: access only via a group assignment.
     session.add(GroupMember(group_id=group.id, user_id=member_user.id))
     session.add(
@@ -671,11 +672,40 @@ async def test_list_workspace_members_flags_group_derived_role(
         )
     )
     session.add(Membership(user_id=actor_user.id, workspace_id=workspace.id))
+    # mixed_user: both a direct assignment and a group path to the workspace.
+    mixed_user = User(
+        id=uuid.uuid4(),
+        email=f"mixed-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hashed",
+        role=UserRole.BASIC,
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    session.add(mixed_user)
+    await session.commit()
+    session.add(GroupMember(group_id=group.id, user_id=mixed_user.id))
+    session.add(
+        UserRoleAssignment(
+            organization_id=organization.id,
+            user_id=mixed_user.id,
+            workspace_id=workspace.id,
+            role_id=workspace_editor_role.id,
+        )
+    )
+    session.add(Membership(user_id=mixed_user.id, workspace_id=workspace.id))
     await session.commit()
 
     members = await membership_service.list_workspace_members(workspace.id)
     by_user = {m.user_id: m for m in members}
 
+    # Group-only: removable=false, role not editable.
     assert by_user[member_user.id].via_group is True
+    assert by_user[member_user.id].via_direct is False
     assert by_user[member_user.id].role_name == workspace_editor_role.name
+    # Direct-only: removable=true, role editable.
     assert by_user[actor_user.id].via_group is False
+    assert by_user[actor_user.id].via_direct is True
+    # Mixed: via_group blocks removal, but the direct role stays editable.
+    assert by_user[mixed_user.id].via_group is True
+    assert by_user[mixed_user.id].via_direct is True

--- a/tests/unit/test_authz_membership_service.py
+++ b/tests/unit/test_authz_membership_service.py
@@ -215,7 +215,7 @@ async def test_delete_membership_removes_orphan_assignment(
     assert assignment is None
 
 
-async def test_create_membership_heals_stale_workspace_assignment(
+async def test_create_membership_is_idempotent_with_existing_default_assignment(
     session: AsyncSession,
     membership_service: MembershipService,
     organization: Organization,
@@ -224,7 +224,7 @@ async def test_create_membership_heals_stale_workspace_assignment(
     actor_user: User,
     workspace_editor_role: DBRole,
 ) -> None:
-    """Create should succeed when only a stale workspace assignment exists."""
+    """Re-adding a member who already holds the default role is a no-op."""
     session.add(
         UserRoleAssignment(
             organization_id=organization.id,
@@ -262,6 +262,70 @@ async def test_create_membership_heals_stale_workspace_assignment(
     assert assignment_list[0].organization_id == organization.id
     assert assignment_list[0].role_id == workspace_editor_role.id
     assert assignment_list[0].assigned_by == actor_user.id
+
+
+async def test_create_membership_preserves_existing_custom_role(
+    session: AsyncSession,
+    membership_service: MembershipService,
+    organization: Organization,
+    workspace: Workspace,
+    member_user: User,
+    actor_user: User,
+    workspace_editor_role: DBRole,
+) -> None:
+    """Re-adding a member must not downgrade a pre-existing non-default role.
+
+    A duplicate/retried create_membership for a user who already holds a direct
+    workspace-scoped role (e.g. a custom admin role) must preserve that
+    assignment rather than overwriting it with the default workspace-editor
+    role.
+    """
+    admin_role = DBRole(
+        id=uuid.uuid4(),
+        name="Workspace Admin",
+        slug="workspace-admin",
+        description="Custom admin role",
+        organization_id=organization.id,
+    )
+    session.add(admin_role)
+    await session.flush()
+    session.add(
+        UserRoleAssignment(
+            organization_id=organization.id,
+            user_id=member_user.id,
+            workspace_id=workspace.id,
+            role_id=admin_role.id,
+            assigned_by=actor_user.id,
+        )
+    )
+    await session.commit()
+
+    await membership_service.create_membership(
+        workspace_id=workspace.id,
+        params=WorkspaceMembershipCreate(user_id=member_user.id),
+    )
+
+    assignment_list = list(
+        (
+            await session.execute(
+                select(UserRoleAssignment).where(
+                    UserRoleAssignment.workspace_id == workspace.id,
+                    UserRoleAssignment.user_id == member_user.id,
+                )
+            )
+        ).scalars()
+    )
+    membership = await session.scalar(
+        select(Membership).where(
+            Membership.workspace_id == workspace.id,
+            Membership.user_id == member_user.id,
+        )
+    )
+
+    assert membership is not None
+    assert len(assignment_list) == 1
+    # The custom admin role is preserved, not downgraded to workspace-editor.
+    assert assignment_list[0].role_id == admin_role.id
 
 
 async def test_create_membership_is_idempotent_when_membership_exists(

--- a/tests/unit/test_rbac_service.py
+++ b/tests/unit/test_rbac_service.py
@@ -16,6 +16,7 @@ from tracecat.authz.seeding import seed_system_scopes
 from tracecat.db.models import (
     Group,
     GroupMember,
+    Membership,
     Organization,
     OrganizationMembership,
     Scope,
@@ -738,3 +739,139 @@ class TestRBACServiceScopeComputation:
         # With workspace context, org-wide scopes still apply
         scopes = await service.get_group_scopes(user.id, workspace_id=workspace.id)
         assert seeded_scopes[0].name in scopes
+
+
+@pytest.mark.anyio
+class TestRBACMembershipReconcile:
+    """RBAC mutations keep the workspace membership dial in lockstep (ENG-1499)."""
+
+    async def _membership(
+        self, session: AsyncSession, workspace: Workspace, user: User
+    ) -> Membership | None:
+        return await session.scalar(
+            select(Membership).where(
+                Membership.workspace_id == workspace.id,
+                Membership.user_id == user.id,
+            )
+        )
+
+    async def test_ws_scoped_group_assignment_materializes_membership(
+        self,
+        session: AsyncSession,
+        role: Role,
+        user: User,
+        workspace: Workspace,
+        seeded_scopes: list[Scope],
+    ):
+        """Creating a ws-scoped group assignment mints membership for members."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(
+            name="WS Role", scope_ids=[seeded_scopes[0].id]
+        )
+        group = await service.create_group(name="WS Group")
+        await service.add_group_member(group.id, user.id)
+
+        assert await self._membership(session, workspace, user) is None
+
+        await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=custom_role.id,
+            workspace_id=workspace.id,
+        )
+
+        assert await self._membership(session, workspace, user) is not None
+
+    async def test_org_wide_group_assignment_does_not_materialize_membership(
+        self,
+        session: AsyncSession,
+        role: Role,
+        user: User,
+        workspace: Workspace,
+        seeded_scopes: list[Scope],
+    ):
+        """Org-wide group assignment grants scopes but not workspace membership."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(
+            name="Org Role", scope_ids=[seeded_scopes[0].id]
+        )
+        group = await service.create_group(name="Org Group")
+        await service.add_group_member(group.id, user.id)
+        await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=custom_role.id,
+            workspace_id=None,
+        )
+
+        assert await self._membership(session, workspace, user) is None
+
+    async def test_adding_member_to_assigned_group_materializes_membership(
+        self,
+        session: AsyncSession,
+        role: Role,
+        user: User,
+        workspace: Workspace,
+        seeded_scopes: list[Scope],
+    ):
+        """Adding a user to a group that already holds a ws assignment mints membership."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(
+            name="WS Role", scope_ids=[seeded_scopes[0].id]
+        )
+        group = await service.create_group(name="WS Group")
+        await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=custom_role.id,
+            workspace_id=workspace.id,
+        )
+
+        assert await self._membership(session, workspace, user) is None
+
+        await service.add_group_member(group.id, user.id)
+
+        assert await self._membership(session, workspace, user) is not None
+
+    async def test_direct_user_ws_assignment_materializes_membership(
+        self,
+        session: AsyncSession,
+        role: Role,
+        user: User,
+        workspace: Workspace,
+        seeded_scopes: list[Scope],
+    ):
+        """A direct ws-scoped user assignment mints membership."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(
+            name="WS Role", scope_ids=[seeded_scopes[0].id]
+        )
+
+        await service.create_user_assignment(
+            user_id=user.id,
+            role_id=custom_role.id,
+            workspace_id=workspace.id,
+        )
+
+        assert await self._membership(session, workspace, user) is not None
+
+    async def test_deleting_only_ws_path_removes_membership(
+        self,
+        session: AsyncSession,
+        role: Role,
+        user: User,
+        workspace: Workspace,
+        seeded_scopes: list[Scope],
+    ):
+        """Deleting the sole ws-scoped path drops membership."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(
+            name="WS Role", scope_ids=[seeded_scopes[0].id]
+        )
+        assignment = await service.create_user_assignment(
+            user_id=user.id,
+            role_id=custom_role.id,
+            workspace_id=workspace.id,
+        )
+        assert await self._membership(session, workspace, user) is not None
+
+        await service.delete_user_assignment(assignment.id)
+
+        assert await self._membership(session, workspace, user) is None

--- a/tests/unit/test_rbac_service.py
+++ b/tests/unit/test_rbac_service.py
@@ -875,3 +875,65 @@ class TestRBACMembershipReconcile:
         await service.delete_user_assignment(assignment.id)
 
         assert await self._membership(session, workspace, user) is None
+
+    async def test_deleting_group_removes_materialized_membership(
+        self,
+        session: AsyncSession,
+        role: Role,
+        user: User,
+        workspace: Workspace,
+        seeded_scopes: list[Scope],
+    ):
+        """Deleting a ws-assigned group drops membership for its members.
+
+        The cascade removes GroupMember/GroupRoleAssignment but not the derived
+        Membership rows, so delete_group must reconcile the affected members.
+        """
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(
+            name="WS Role", scope_ids=[seeded_scopes[0].id]
+        )
+        group = await service.create_group(name="WS Group")
+        await service.add_group_member(group.id, user.id)
+        await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=custom_role.id,
+            workspace_id=workspace.id,
+        )
+        assert await self._membership(session, workspace, user) is not None
+
+        await service.delete_group(group.id)
+
+        assert await self._membership(session, workspace, user) is None
+
+    async def test_deleting_group_keeps_membership_with_other_path(
+        self,
+        session: AsyncSession,
+        role: Role,
+        user: User,
+        workspace: Workspace,
+        seeded_scopes: list[Scope],
+    ):
+        """A direct path keeps membership alive when the group is deleted."""
+        service = RBACService(session, role=role)
+        custom_role = await service.create_role(
+            name="WS Role", scope_ids=[seeded_scopes[0].id]
+        )
+        group = await service.create_group(name="WS Group")
+        await service.add_group_member(group.id, user.id)
+        await service.create_group_role_assignment(
+            group_id=group.id,
+            role_id=custom_role.id,
+            workspace_id=workspace.id,
+        )
+        # Independent direct path to the same workspace.
+        await service.create_user_assignment(
+            user_id=user.id,
+            role_id=custom_role.id,
+            workspace_id=workspace.id,
+        )
+        assert await self._membership(session, workspace, user) is not None
+
+        await service.delete_group(group.id)
+
+        assert await self._membership(session, workspace, user) is not None

--- a/tracecat/authz/service.py
+++ b/tracecat/authz/service.py
@@ -7,12 +7,13 @@ from dataclasses import dataclass
 from sqlalchemy import and_, delete, exists, func, literal, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.sql import ColumnElement
 
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
 from tracecat.contexts import ctx_role
-from tracecat.db.locks import derive_lock_key_from_parts, pg_advisory_lock
+from tracecat.db.locks import derive_lock_key_from_parts, pg_advisory_xact_lock
 from tracecat.db.models import (
     GroupMember,
     GroupRoleAssignment,
@@ -41,7 +42,8 @@ class MembershipWithOrg:
 
 
 def workspace_scoped_path_exists(
-    user_id: UserID | ColumnElement[uuid.UUID], workspace_id: WorkspaceID
+    user_id: UserID | ColumnElement[uuid.UUID] | InstrumentedAttribute[uuid.UUID],
+    workspace_id: WorkspaceID,
 ) -> ColumnElement[bool]:
     """SQL EXISTS predicate: does the user hold a workspace-scoped role path to W?
 
@@ -54,7 +56,7 @@ def workspace_scoped_path_exists(
     are deliberately NOT membership-materializing, so they are excluded here.
 
     This is the single source of truth for the membership invariant. The runtime
-    reconciler and the backfill migration both use this exact predicate.
+    reconciler uses this exact predicate.
 
     ``user_id`` may be a literal or a column expression (e.g. an outer
     ``GroupMember.user_id``), so the predicate can be correlated inside a
@@ -102,26 +104,61 @@ class MembershipService(BaseService):
     async def list_workspace_members(
         self, workspace_id: WorkspaceID
     ) -> list[WorkspaceMember]:
-        """List all workspace members with their workspace roles from RBAC."""
+        """List all workspace members with their workspace roles from RBAC.
+
+        A member's displayed role comes from a direct
+        ``UserRoleAssignment`` when one exists. Members whose workspace access
+        is materialized solely through a group (e.g. a group granted Workspace
+        Admin) have no direct assignment, so the group-derived role is shown
+        instead. Without this, such members would fall back to the "Workspace
+        Editor" default and be displayed with a role they do not actually hold.
+
+        Roles are not privilege-ordered in the schema, so when a member only has
+        group-derived roles we pick one deterministically by role name.
+        """
+        # Group-derived workspace role for each user, one row per user. There is
+        # no privilege ranking on Role, so min(name) gives a stable, repeatable
+        # choice when a user inherits multiple group roles for the workspace.
+        group_role = (
+            select(
+                GroupMember.user_id.label("user_id"),
+                func.min(DBRole.name).label("role_name"),
+            )
+            .select_from(GroupMember)
+            .join(
+                GroupRoleAssignment,
+                GroupRoleAssignment.group_id == GroupMember.group_id,
+            )
+            .join(DBRole, DBRole.id == GroupRoleAssignment.role_id)
+            .where(GroupRoleAssignment.workspace_id == workspace_id)
+            .group_by(GroupMember.user_id)
+            .subquery()
+        )
+
         statement = (
             select(
                 User,
-                func.coalesce(DBRole.name, literal("Workspace Editor")).label(
-                    "role_name"
-                ),
+                # Direct assignment role wins; otherwise the group-derived role;
+                # otherwise the default editor label.
+                func.coalesce(
+                    DBRole.name,
+                    group_role.c.role_name,
+                    literal("Workspace Editor"),
+                ).label("role_name"),
             )
             .select_from(Membership)
-            .join(User, Membership.user_id == User.id)  # pyright: ignore[reportArgumentType]
+            .join(User, Membership.user_id == User.id)
             .join(Workspace, Workspace.id == Membership.workspace_id)
             .outerjoin(
                 UserRoleAssignment,
                 and_(
-                    UserRoleAssignment.user_id == User.id,  # pyright: ignore[reportArgumentType]
+                    UserRoleAssignment.user_id == User.id,
                     UserRoleAssignment.workspace_id == Membership.workspace_id,
                     UserRoleAssignment.organization_id == Workspace.organization_id,
                 ),
             )
             .outerjoin(DBRole, DBRole.id == UserRoleAssignment.role_id)
+            .outerjoin(group_role, group_role.c.user_id == User.id)
             .where(Membership.workspace_id == workspace_id)
         )
         rows = (await self.session.execute(statement)).all()
@@ -207,23 +244,28 @@ class MembershipService(BaseService):
             raise TracecatValidationError("Workspace or default role not found")
         organization_id, role_id = org_role_row
 
-        # Heal stale direct assignments left behind by prior failed remove flows.
-        await self.session.execute(
-            delete(UserRoleAssignment).where(
-                UserRoleAssignment.user_id == params.user_id,
-                UserRoleAssignment.workspace_id == workspace_id,
-            )
-        )
-
         # Write the workspace-scoped role path; the reconciler derives the
         # Membership row from it (single write path for the membership dial).
-        self.session.add(
-            UserRoleAssignment(
+        #
+        # Idempotent and non-destructive: if the user already holds a direct
+        # workspace-scoped assignment (e.g. a custom admin role, or a retry of
+        # this same call), ON CONFLICT DO NOTHING preserves it rather than
+        # downgrading them to the default workspace-editor role. The default is
+        # only materialized for users who have no existing direct assignment.
+        await self.session.execute(
+            pg_insert(UserRoleAssignment)
+            .values(
                 organization_id=organization_id,
                 user_id=params.user_id,
                 workspace_id=workspace_id,
                 role_id=role_id,
                 assigned_by=self.role.user_id if self.role else None,
+            )
+            .on_conflict_do_nothing(
+                index_elements=[
+                    UserRoleAssignment.user_id,
+                    UserRoleAssignment.workspace_id,
+                ]
             )
         )
         await self.session.commit()
@@ -260,9 +302,12 @@ class MembershipService(BaseService):
         :func:`workspace_scoped_path_exists` and upserts or deletes the
         ``Membership`` row accordingly.
 
-        Idempotent. Serialized per (user, W) with an advisory lock so concurrent
-        reconciles cannot race into a contradictory state. The unique
-        constraint (composite PK) is the only other DB backstop; no triggers, no
+        Idempotent. Serialized per (user, W) with a transaction-scoped advisory
+        lock so concurrent reconciles cannot race into a contradictory state.
+        The lock is held until this method's own commit (it must be
+        transaction-scoped: a session-level lock would be orphaned when the
+        commit returns the connection to the pool). The unique constraint
+        (composite PK) is the only other DB backstop; no triggers, no
         background job.
 
         The caller is responsible for committing any RBAC writes that motivated
@@ -271,33 +316,34 @@ class MembershipService(BaseService):
         lock_key = derive_lock_key_from_parts(
             "membership", str(user_id), str(workspace_id)
         )
-        async with pg_advisory_lock(self.session, lock_key):
-            has_path = await self.session.scalar(
-                select(workspace_scoped_path_exists(user_id, workspace_id))
-            )
-            if has_path:
-                # Upsert: presence fact, no extra columns to update.
-                await self.session.execute(
-                    pg_insert(Membership)
-                    .values(user_id=user_id, workspace_id=workspace_id)
-                    .on_conflict_do_nothing(
-                        index_elements=[Membership.user_id, Membership.workspace_id]
-                    )
+        await pg_advisory_xact_lock(self.session, lock_key)
+        has_path = await self.session.scalar(
+            select(workspace_scoped_path_exists(user_id, workspace_id))
+        )
+        if has_path:
+            # Upsert: presence fact, no extra columns to update.
+            await self.session.execute(
+                pg_insert(Membership)
+                .values(user_id=user_id, workspace_id=workspace_id)
+                .on_conflict_do_nothing(
+                    index_elements=[Membership.user_id, Membership.workspace_id]
                 )
-            else:
-                await self.session.execute(
-                    delete(Membership).where(
-                        Membership.user_id == user_id,
-                        Membership.workspace_id == workspace_id,
-                    )
-                )
-            await self.session.commit()
-            logger.debug(
-                "Reconciled workspace membership",
-                user_id=user_id,
-                workspace_id=workspace_id,
-                is_member=bool(has_path),
             )
+        else:
+            await self.session.execute(
+                delete(Membership).where(
+                    Membership.user_id == user_id,
+                    Membership.workspace_id == workspace_id,
+                )
+            )
+        # Commit releases the transaction-scoped advisory lock.
+        await self.session.commit()
+        logger.debug(
+            "Reconciled workspace membership",
+            user_id=user_id,
+            workspace_id=workspace_id,
+            is_member=bool(has_path),
+        )
 
     async def reconcile_group_members(
         self, group_id: uuid.UUID, workspace_id: WorkspaceID
@@ -325,32 +371,34 @@ class MembershipService(BaseService):
         lock_key = derive_lock_key_from_parts(
             "membership_group", str(group_id), str(workspace_id)
         )
-        async with pg_advisory_lock(self.session, lock_key):
-            # Materialize membership for members that now hold a ws-scoped path.
-            await self.session.execute(
-                pg_insert(Membership)
-                .from_select(
-                    ["user_id", "workspace_id"],
-                    select(User.id, literal(workspace_id)).where(  # pyright: ignore[reportCallIssue, reportArgumentType]
-                        User.id.in_(group_member_ids),  # pyright: ignore[reportAttributeAccessIssue]
-                        workspace_scoped_path_exists(User.id, workspace_id),  # pyright: ignore[reportArgumentType]
-                    ),
-                )
-                .on_conflict_do_nothing(
-                    index_elements=[Membership.user_id, Membership.workspace_id]
-                )
+        # Transaction-scoped: the lock is released by this method's commit, so it
+        # must not outlive the connection if that connection returns to the pool.
+        await pg_advisory_xact_lock(self.session, lock_key)
+        # Materialize membership for members that now hold a ws-scoped path.
+        await self.session.execute(
+            pg_insert(Membership)
+            .from_select(
+                ["user_id", "workspace_id"],
+                select(GroupMember.user_id, literal(workspace_id)).where(
+                    GroupMember.group_id == group_id,
+                    workspace_scoped_path_exists(GroupMember.user_id, workspace_id),
+                ),
             )
-            # Drop membership for members that no longer hold any ws-scoped path.
-            await self.session.execute(
-                delete(Membership).where(
-                    Membership.workspace_id == workspace_id,
-                    Membership.user_id.in_(group_member_ids),
-                    ~workspace_scoped_path_exists(Membership.user_id, workspace_id),  # pyright: ignore[reportArgumentType]
-                )
+            .on_conflict_do_nothing(
+                index_elements=[Membership.user_id, Membership.workspace_id]
             )
-            await self.session.commit()
-            logger.debug(
-                "Reconciled group members",
-                group_id=group_id,
-                workspace_id=workspace_id,
+        )
+        # Drop membership for members that no longer hold any ws-scoped path.
+        await self.session.execute(
+            delete(Membership).where(
+                Membership.workspace_id == workspace_id,
+                Membership.user_id.in_(group_member_ids),
+                ~workspace_scoped_path_exists(Membership.user_id, workspace_id),  # pyright: ignore[reportArgumentType]
             )
+        )
+        await self.session.commit()
+        logger.debug(
+            "Reconciled group members",
+            group_id=group_id,
+            workspace_id=workspace_id,
+        )

--- a/tracecat/authz/service.py
+++ b/tracecat/authz/service.py
@@ -141,6 +141,10 @@ class MembershipService(BaseService):
                 # user with both a direct and group path reads as via_group
                 # (removable=false) — matching what the delete would do.
                 group_scoped_path_exists(User.id, workspace_id).label("via_group"),
+                # A direct UserRoleAssignment exists. Independent of via_group: a
+                # mixed-source member is both via_group and via_direct, and the
+                # direct role stays editable (handleChangeRole edits this row).
+                UserRoleAssignment.id.is_not(None).label("via_direct"),
             )
             .select_from(Membership)
             .join(User, Membership.user_id == User.id)
@@ -157,7 +161,7 @@ class MembershipService(BaseService):
             .outerjoin(group_role, group_role.c.user_id == User.id)
             .where(Membership.workspace_id == workspace_id)
         )
-        rows = (await self.session.execute(statement)).all()
+        rows = (await self.session.execute(statement)).tuples().all()
         return [
             WorkspaceMember(
                 user_id=user.id,
@@ -166,8 +170,9 @@ class MembershipService(BaseService):
                 email=user.email,
                 role_name=role_name,
                 via_group=bool(via_group),
+                via_direct=bool(via_direct),
             )
-            for user, role_name, via_group in rows
+            for user, role_name, via_group, via_direct in rows
         ]
 
     async def get_membership(

--- a/tracecat/authz/service.py
+++ b/tracecat/authz/service.py
@@ -23,7 +23,8 @@ from tracecat.db.models import (
     Workspace,
 )
 from tracecat.db.models import Role as DBRole
-from tracecat.exceptions import TracecatValidationError
+from tracecat.db.rls import workspace_rls_context
+from tracecat.exceptions import TracecatConflictError, TracecatValidationError
 from tracecat.identifiers import OrganizationID, UserID, WorkspaceID
 from tracecat.logger import logger
 from tracecat.service import BaseService
@@ -45,28 +46,26 @@ def workspace_scoped_path_exists(
     user_id: UserID | ColumnElement[uuid.UUID] | InstrumentedAttribute[uuid.UUID],
     workspace_id: WorkspaceID,
 ) -> ColumnElement[bool]:
-    """SQL EXISTS predicate: does the user hold a workspace-scoped role path to W?
-
-    A workspace-scoped path is either:
-      - a direct ``UserRoleAssignment(user, role, workspace_id=W)``, or
-      - membership in a group that holds a ``GroupRoleAssignment(group, role,
-        workspace_id=W)``.
-
-    Org-wide assignments (``workspace_id IS NULL``) grant access via scopes but
-    are deliberately NOT membership-materializing, so they are excluded here.
-
-    This is the single source of truth for the membership invariant. The runtime
-    reconciler uses this exact predicate.
-
-    ``user_id`` may be a literal or a column expression (e.g. an outer
-    ``GroupMember.user_id``), so the predicate can be correlated inside a
-    set-based statement.
+    """
+    Source of truth for the membership invariant. Org-wide assignments
+    (``workspace_id IS NULL``) are deliberately excluded. ``user_id`` may be a
+    column expression so the predicate can correlate inside a set-based statement.
     """
     direct = exists().where(
         UserRoleAssignment.user_id == user_id,
         UserRoleAssignment.workspace_id == workspace_id,
     )
-    via_group = (
+    return or_(direct, group_scoped_path_exists(user_id, workspace_id))
+
+
+def group_scoped_path_exists(
+    user_id: UserID | ColumnElement[uuid.UUID] | InstrumentedAttribute[uuid.UUID],
+    workspace_id: WorkspaceID,
+) -> ColumnElement[bool]:
+    """Does the user reach W through a group? The group half of
+    :func:`workspace_scoped_path_exists`, shared so the two checks can't drift.
+    """
+    return (
         select(GroupMember.user_id)
         .join(
             GroupRoleAssignment,
@@ -78,7 +77,6 @@ def workspace_scoped_path_exists(
         )
         .exists()
     )
-    return or_(direct, via_group)
 
 
 class MembershipService(BaseService):
@@ -104,21 +102,16 @@ class MembershipService(BaseService):
     async def list_workspace_members(
         self, workspace_id: WorkspaceID
     ) -> list[WorkspaceMember]:
-        """List all workspace members with their workspace roles from RBAC.
+        """List workspace members with their roles.
 
-        A member's displayed role comes from a direct
-        ``UserRoleAssignment`` when one exists. Members whose workspace access
-        is materialized solely through a group (e.g. a group granted Workspace
-        Admin) have no direct assignment, so the group-derived role is shown
-        instead. Without this, such members would fall back to the "Workspace
-        Editor" default and be displayed with a role they do not actually hold.
-
-        Roles are not privilege-ordered in the schema, so when a member only has
-        group-derived roles we pick one deterministically by role name.
+        Displayed role: direct assignment if any, else group-derived, else the
+        editor default. ``via_group`` flags members reachable through a group
+        (even if they also hold a direct assignment) — the same condition under
+        which :meth:`delete_membership` refuses removal, so the UI can gate
+        per-row actions on it.
         """
-        # Group-derived workspace role for each user, one row per user. There is
-        # no privilege ranking on Role, so min(name) gives a stable, repeatable
-        # choice when a user inherits multiple group roles for the workspace.
+        # One group-derived role per user; min(name) picks deterministically
+        # when a user inherits several (Role has no privilege ranking).
         group_role = (
             select(
                 GroupMember.user_id.label("user_id"),
@@ -138,13 +131,16 @@ class MembershipService(BaseService):
         statement = (
             select(
                 User,
-                # Direct assignment role wins; otherwise the group-derived role;
-                # otherwise the default editor label.
+                # Direct role wins, else group-derived, else default editor.
                 func.coalesce(
                     DBRole.name,
                     group_role.c.role_name,
                     literal("Workspace Editor"),
                 ).label("role_name"),
+                # Same predicate as delete_membership's rejection check, so a
+                # user with both a direct and group path reads as via_group
+                # (removable=false) — matching what the delete would do.
+                group_scoped_path_exists(User.id, workspace_id).label("via_group"),
             )
             .select_from(Membership)
             .join(User, Membership.user_id == User.id)
@@ -169,8 +165,9 @@ class MembershipService(BaseService):
                 last_name=user.last_name,
                 email=user.email,
                 role_name=role_name,
+                via_group=bool(via_group),
             )
-            for user, role_name in rows
+            for user, role_name, via_group in rows
         ]
 
     async def get_membership(
@@ -244,14 +241,9 @@ class MembershipService(BaseService):
             raise TracecatValidationError("Workspace or default role not found")
         organization_id, role_id = org_role_row
 
-        # Write the workspace-scoped role path; the reconciler derives the
-        # Membership row from it (single write path for the membership dial).
-        #
-        # Idempotent and non-destructive: if the user already holds a direct
-        # workspace-scoped assignment (e.g. a custom admin role, or a retry of
-        # this same call), ON CONFLICT DO NOTHING preserves it rather than
-        # downgrading them to the default workspace-editor role. The default is
-        # only materialized for users who have no existing direct assignment.
+        # Write the role path; the reconciler derives the Membership row from it.
+        # DO NOTHING keeps any existing direct assignment (e.g. a custom admin
+        # role) instead of downgrading it to the default editor.
         await self.session.execute(
             pg_insert(UserRoleAssignment)
             .values(
@@ -275,14 +267,27 @@ class MembershipService(BaseService):
     async def delete_membership(
         self, workspace_id: WorkspaceID, user_id: UserID
     ) -> None:
-        """Delete a workspace membership.
+        """Remove the user's direct role path to the workspace, then reconcile.
+
+        Rejects with a conflict if access is group-derived: dropping direct
+        assignments would leave the group path intact and the user would
+        reappear, so they must be removed via the group instead.
 
         Note: The authorization cache is request-scoped, so changes will be
         reflected in subsequent requests automatically.
         """
-        # Remove the direct workspace-scoped role path, then reconcile. The
-        # reconciler deletes the Membership row only if no other ws-scoped path
-        # (e.g. a group assignment) still holds it.
+        # A group-derived path survives this removal, so reject before mutating.
+        has_group_path = await self.session.scalar(
+            select(group_scoped_path_exists(user_id, workspace_id))
+        )
+        if has_group_path:
+            raise TracecatConflictError(
+                "User's workspace access is granted through a group. Remove the "
+                "user from the group or change the group's role assignment."
+            )
+
+        # Remove the direct role path, then reconcile (drops Membership only if
+        # no other ws-scoped path remains).
         await self.session.execute(
             delete(UserRoleAssignment).where(
                 UserRoleAssignment.workspace_id == workspace_id,
@@ -295,49 +300,40 @@ class MembershipService(BaseService):
     async def reconcile_workspace_membership(
         self, user_id: UserID, workspace_id: WorkspaceID
     ) -> None:
-        """Drive the ``Membership`` dial in lockstep with workspace-scoped RBAC.
+        """Upsert/delete Membership(user, W) to match workspace-scoped RBAC.
 
-        Membership(user, W) must exist iff the user holds at least one
-        workspace-scoped role path to W (direct or via a group). This consults
-        :func:`workspace_scoped_path_exists` and upserts or deletes the
-        ``Membership`` row accordingly.
-
-        Idempotent. Serialized per (user, W) with a transaction-scoped advisory
-        lock so concurrent reconciles cannot race into a contradictory state.
-        The lock is held until this method's own commit (it must be
-        transaction-scoped: a session-level lock would be orphaned when the
-        commit returns the connection to the pool). The unique constraint
-        (composite PK) is the only other DB backstop; no triggers, no
-        background job.
-
-        The caller is responsible for committing any RBAC writes that motivated
-        the reconcile. This method commits its own membership change.
+        The row must exist iff the user holds at least one ws-scoped role path
+        (direct or via group). Idempotent, serialized per (user, W) by a
+        transaction-scoped advisory lock, and committed here. Runs inside a
+        temporary ws-scoped RLS context so org-scoped callers (RBAC routes) can
+        still write the row under enforce mode. The caller commits the RBAC
+        writes that motivated the reconcile.
         """
         lock_key = derive_lock_key_from_parts(
             "membership", str(user_id), str(workspace_id)
         )
-        await pg_advisory_xact_lock(self.session, lock_key)
-        has_path = await self.session.scalar(
-            select(workspace_scoped_path_exists(user_id, workspace_id))
-        )
-        if has_path:
-            # Upsert: presence fact, no extra columns to update.
-            await self.session.execute(
-                pg_insert(Membership)
-                .values(user_id=user_id, workspace_id=workspace_id)
-                .on_conflict_do_nothing(
-                    index_elements=[Membership.user_id, Membership.workspace_id]
-                )
+        async with workspace_rls_context(self.session, workspace_id):
+            await pg_advisory_xact_lock(self.session, lock_key)
+            has_path = await self.session.scalar(
+                select(workspace_scoped_path_exists(user_id, workspace_id))
             )
-        else:
-            await self.session.execute(
-                delete(Membership).where(
-                    Membership.user_id == user_id,
-                    Membership.workspace_id == workspace_id,
+            if has_path:
+                await self.session.execute(
+                    pg_insert(Membership)
+                    .values(user_id=user_id, workspace_id=workspace_id)
+                    .on_conflict_do_nothing(
+                        index_elements=[Membership.user_id, Membership.workspace_id]
+                    )
                 )
-            )
-        # Commit releases the transaction-scoped advisory lock.
-        await self.session.commit()
+            else:
+                await self.session.execute(
+                    delete(Membership).where(
+                        Membership.user_id == user_id,
+                        Membership.workspace_id == workspace_id,
+                    )
+                )
+            # Commit releases the transaction-scoped advisory lock.
+            await self.session.commit()
         logger.debug(
             "Reconciled workspace membership",
             user_id=user_id,
@@ -350,20 +346,12 @@ class MembershipService(BaseService):
     ) -> None:
         """Reconcile every member of a group against one workspace.
 
-        Used by group-level admin mutations: a single group role assignment
-        change fans out to all current group members for the affected
-        workspace.
-
-        Set-based rather than per-member: two statements (upsert + delete) under
-        a single group-level advisory lock, constant in the group size. This is
-        the fanout path that a bulk membership sync (e.g. SCIM) would hammer, so
-        it must not degrade to O(N) round trips. The group-level lock serializes
-        concurrent fanouts for the same group; per-user direct writes still
-        reconcile under their own (user, W) lock and self-heal.
+        Fans a group role-assignment change out to all current members. Set-based
+        (upsert + delete) under one group-level advisory lock, so it stays O(1)
+        round trips even under bulk syncs (SCIM). Runs in a temporary ws-scoped
+        RLS context so org-scoped RBAC routes can write the rows under enforce
+        mode.
         """
-        # Members of this group, as a subquery. The outer statements never range
-        # over ``GroupMember`` directly, so the predicate's own ``group_member``
-        # reference cannot auto-correlate to it (no alias needed).
         group_member_ids = select(GroupMember.user_id).where(
             GroupMember.group_id == group_id
         )
@@ -371,32 +359,32 @@ class MembershipService(BaseService):
         lock_key = derive_lock_key_from_parts(
             "membership_group", str(group_id), str(workspace_id)
         )
-        # Transaction-scoped: the lock is released by this method's commit, so it
-        # must not outlive the connection if that connection returns to the pool.
-        await pg_advisory_xact_lock(self.session, lock_key)
-        # Materialize membership for members that now hold a ws-scoped path.
-        await self.session.execute(
-            pg_insert(Membership)
-            .from_select(
-                ["user_id", "workspace_id"],
-                select(GroupMember.user_id, literal(workspace_id)).where(
-                    GroupMember.group_id == group_id,
-                    workspace_scoped_path_exists(GroupMember.user_id, workspace_id),
-                ),
+        async with workspace_rls_context(self.session, workspace_id):
+            # Transaction-scoped lock; released by this method's commit.
+            await pg_advisory_xact_lock(self.session, lock_key)
+            # Materialize membership for members that now hold a ws-scoped path.
+            await self.session.execute(
+                pg_insert(Membership)
+                .from_select(
+                    ["user_id", "workspace_id"],
+                    select(GroupMember.user_id, literal(workspace_id)).where(
+                        GroupMember.group_id == group_id,
+                        workspace_scoped_path_exists(GroupMember.user_id, workspace_id),
+                    ),
+                )
+                .on_conflict_do_nothing(
+                    index_elements=[Membership.user_id, Membership.workspace_id]
+                )
             )
-            .on_conflict_do_nothing(
-                index_elements=[Membership.user_id, Membership.workspace_id]
+            # Drop membership for members that no longer hold any ws-scoped path.
+            await self.session.execute(
+                delete(Membership).where(
+                    Membership.workspace_id == workspace_id,
+                    Membership.user_id.in_(group_member_ids),
+                    ~workspace_scoped_path_exists(Membership.user_id, workspace_id),
+                )
             )
-        )
-        # Drop membership for members that no longer hold any ws-scoped path.
-        await self.session.execute(
-            delete(Membership).where(
-                Membership.workspace_id == workspace_id,
-                Membership.user_id.in_(group_member_ids),
-                ~workspace_scoped_path_exists(Membership.user_id, workspace_id),  # pyright: ignore[reportArgumentType]
-            )
-        )
-        await self.session.commit()
+            await self.session.commit()
         logger.debug(
             "Reconciled group members",
             group_id=group_id,

--- a/tracecat/authz/service.py
+++ b/tracecat/authz/service.py
@@ -1,18 +1,30 @@
 from __future__ import annotations
 
+import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-from sqlalchemy import and_, delete, func, literal, select
+from sqlalchemy import and_, delete, exists, func, literal, or_, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import ColumnElement
 
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
 from tracecat.contexts import ctx_role
-from tracecat.db.models import Membership, User, UserRoleAssignment, Workspace
+from tracecat.db.locks import derive_lock_key_from_parts, pg_advisory_lock
+from tracecat.db.models import (
+    GroupMember,
+    GroupRoleAssignment,
+    Membership,
+    User,
+    UserRoleAssignment,
+    Workspace,
+)
 from tracecat.db.models import Role as DBRole
 from tracecat.exceptions import TracecatValidationError
 from tracecat.identifiers import OrganizationID, UserID, WorkspaceID
+from tracecat.logger import logger
 from tracecat.service import BaseService
 from tracecat.workspaces.schemas import (
     WorkspaceMember,
@@ -26,6 +38,45 @@ class MembershipWithOrg:
 
     membership: Membership
     org_id: OrganizationID
+
+
+def workspace_scoped_path_exists(
+    user_id: UserID | ColumnElement[uuid.UUID], workspace_id: WorkspaceID
+) -> ColumnElement[bool]:
+    """SQL EXISTS predicate: does the user hold a workspace-scoped role path to W?
+
+    A workspace-scoped path is either:
+      - a direct ``UserRoleAssignment(user, role, workspace_id=W)``, or
+      - membership in a group that holds a ``GroupRoleAssignment(group, role,
+        workspace_id=W)``.
+
+    Org-wide assignments (``workspace_id IS NULL``) grant access via scopes but
+    are deliberately NOT membership-materializing, so they are excluded here.
+
+    This is the single source of truth for the membership invariant. The runtime
+    reconciler and the backfill migration both use this exact predicate.
+
+    ``user_id`` may be a literal or a column expression (e.g. an outer
+    ``GroupMember.user_id``), so the predicate can be correlated inside a
+    set-based statement.
+    """
+    direct = exists().where(
+        UserRoleAssignment.user_id == user_id,
+        UserRoleAssignment.workspace_id == workspace_id,
+    )
+    via_group = (
+        select(GroupMember.user_id)
+        .join(
+            GroupRoleAssignment,
+            GroupRoleAssignment.group_id == GroupMember.group_id,
+        )
+        .where(
+            GroupMember.user_id == user_id,
+            GroupRoleAssignment.workspace_id == workspace_id,
+        )
+        .exists()
+    )
+    return or_(direct, via_group)
 
 
 class MembershipService(BaseService):
@@ -164,11 +215,8 @@ class MembershipService(BaseService):
             )
         )
 
-        membership = Membership(
-            user_id=params.user_id,
-            workspace_id=workspace_id,
-        )
-        self.session.add(membership)
+        # Write the workspace-scoped role path; the reconciler derives the
+        # Membership row from it (single write path for the membership dial).
         self.session.add(
             UserRoleAssignment(
                 organization_id=organization_id,
@@ -179,6 +227,7 @@ class MembershipService(BaseService):
             )
         )
         await self.session.commit()
+        await self.reconcile_workspace_membership(params.user_id, workspace_id)
 
     @require_scope("workspace:member:remove")
     async def delete_membership(
@@ -189,12 +238,9 @@ class MembershipService(BaseService):
         Note: The authorization cache is request-scoped, so changes will be
         reflected in subsequent requests automatically.
         """
-        await self.session.execute(
-            delete(Membership).where(
-                Membership.workspace_id == workspace_id,
-                Membership.user_id == user_id,
-            )
-        )
+        # Remove the direct workspace-scoped role path, then reconcile. The
+        # reconciler deletes the Membership row only if no other ws-scoped path
+        # (e.g. a group assignment) still holds it.
         await self.session.execute(
             delete(UserRoleAssignment).where(
                 UserRoleAssignment.workspace_id == workspace_id,
@@ -202,3 +248,109 @@ class MembershipService(BaseService):
             )
         )
         await self.session.commit()
+        await self.reconcile_workspace_membership(user_id, workspace_id)
+
+    async def reconcile_workspace_membership(
+        self, user_id: UserID, workspace_id: WorkspaceID
+    ) -> None:
+        """Drive the ``Membership`` dial in lockstep with workspace-scoped RBAC.
+
+        Membership(user, W) must exist iff the user holds at least one
+        workspace-scoped role path to W (direct or via a group). This consults
+        :func:`workspace_scoped_path_exists` and upserts or deletes the
+        ``Membership`` row accordingly.
+
+        Idempotent. Serialized per (user, W) with an advisory lock so concurrent
+        reconciles cannot race into a contradictory state. The unique
+        constraint (composite PK) is the only other DB backstop; no triggers, no
+        background job.
+
+        The caller is responsible for committing any RBAC writes that motivated
+        the reconcile. This method commits its own membership change.
+        """
+        lock_key = derive_lock_key_from_parts(
+            "membership", str(user_id), str(workspace_id)
+        )
+        async with pg_advisory_lock(self.session, lock_key):
+            has_path = await self.session.scalar(
+                select(workspace_scoped_path_exists(user_id, workspace_id))
+            )
+            if has_path:
+                # Upsert: presence fact, no extra columns to update.
+                await self.session.execute(
+                    pg_insert(Membership)
+                    .values(user_id=user_id, workspace_id=workspace_id)
+                    .on_conflict_do_nothing(
+                        index_elements=[Membership.user_id, Membership.workspace_id]
+                    )
+                )
+            else:
+                await self.session.execute(
+                    delete(Membership).where(
+                        Membership.user_id == user_id,
+                        Membership.workspace_id == workspace_id,
+                    )
+                )
+            await self.session.commit()
+            logger.debug(
+                "Reconciled workspace membership",
+                user_id=user_id,
+                workspace_id=workspace_id,
+                is_member=bool(has_path),
+            )
+
+    async def reconcile_group_members(
+        self, group_id: uuid.UUID, workspace_id: WorkspaceID
+    ) -> None:
+        """Reconcile every member of a group against one workspace.
+
+        Used by group-level admin mutations: a single group role assignment
+        change fans out to all current group members for the affected
+        workspace.
+
+        Set-based rather than per-member: two statements (upsert + delete) under
+        a single group-level advisory lock, constant in the group size. This is
+        the fanout path that a bulk membership sync (e.g. SCIM) would hammer, so
+        it must not degrade to O(N) round trips. The group-level lock serializes
+        concurrent fanouts for the same group; per-user direct writes still
+        reconcile under their own (user, W) lock and self-heal.
+        """
+        # Members of this group, as a subquery. The outer statements never range
+        # over ``GroupMember`` directly, so the predicate's own ``group_member``
+        # reference cannot auto-correlate to it (no alias needed).
+        group_member_ids = select(GroupMember.user_id).where(
+            GroupMember.group_id == group_id
+        )
+
+        lock_key = derive_lock_key_from_parts(
+            "membership_group", str(group_id), str(workspace_id)
+        )
+        async with pg_advisory_lock(self.session, lock_key):
+            # Materialize membership for members that now hold a ws-scoped path.
+            await self.session.execute(
+                pg_insert(Membership)
+                .from_select(
+                    ["user_id", "workspace_id"],
+                    select(User.id, literal(workspace_id)).where(  # pyright: ignore[reportCallIssue, reportArgumentType]
+                        User.id.in_(group_member_ids),  # pyright: ignore[reportAttributeAccessIssue]
+                        workspace_scoped_path_exists(User.id, workspace_id),  # pyright: ignore[reportArgumentType]
+                    ),
+                )
+                .on_conflict_do_nothing(
+                    index_elements=[Membership.user_id, Membership.workspace_id]
+                )
+            )
+            # Drop membership for members that no longer hold any ws-scoped path.
+            await self.session.execute(
+                delete(Membership).where(
+                    Membership.workspace_id == workspace_id,
+                    Membership.user_id.in_(group_member_ids),
+                    ~workspace_scoped_path_exists(Membership.user_id, workspace_id),  # pyright: ignore[reportArgumentType]
+                )
+            )
+            await self.session.commit()
+            logger.debug(
+                "Reconciled group members",
+                group_id=group_id,
+                workspace_id=workspace_id,
+            )

--- a/tracecat/db/locks.py
+++ b/tracecat/db/locks.py
@@ -39,6 +39,32 @@ async def pg_advisory_lock(session: AsyncSession, key: int) -> AsyncIterator[Non
         await session.execute(text("SELECT pg_advisory_unlock(:key)"), {"key": key})
 
 
+async def pg_advisory_xact_lock(session: AsyncSession, key: int) -> None:
+    """Acquire a transaction-scoped PostgreSQL advisory lock.
+
+    Unlike :func:`pg_advisory_lock` (a session-level lock bound to the
+    connection), this lock is released automatically when the surrounding
+    transaction commits or rolls back. Use this whenever the caller commits
+    while holding the lock: a session-level lock would be orphaned because the
+    connection can be returned to the pool at commit, leaving the unlock to run
+    on a different connection.
+
+    Must be called inside a transaction; the lock is held until that
+    transaction ends.
+
+    Args:
+        session: Database session
+        key: 64-bit integer key for the lock
+
+    Raises:
+        ValueError: If key is out of valid range for PostgreSQL advisory locks
+    """
+    if not (-(2**63) <= key < 2**63):
+        raise ValueError(f"Lock key {key} out of range for PostgreSQL advisory locks")
+
+    await session.execute(text("SELECT pg_advisory_xact_lock(:key)"), {"key": key})
+
+
 async def try_pg_advisory_lock(session: AsyncSession, key: int) -> bool:
     """Try to acquire a PostgreSQL advisory lock without blocking.
 

--- a/tracecat/db/locks.py
+++ b/tracecat/db/locks.py
@@ -42,15 +42,10 @@ async def pg_advisory_lock(session: AsyncSession, key: int) -> AsyncIterator[Non
 async def pg_advisory_xact_lock(session: AsyncSession, key: int) -> None:
     """Acquire a transaction-scoped PostgreSQL advisory lock.
 
-    Unlike :func:`pg_advisory_lock` (a session-level lock bound to the
-    connection), this lock is released automatically when the surrounding
-    transaction commits or rolls back. Use this whenever the caller commits
-    while holding the lock: a session-level lock would be orphaned because the
-    connection can be returned to the pool at commit, leaving the unlock to run
-    on a different connection.
-
-    Must be called inside a transaction; the lock is held until that
-    transaction ends.
+    Released automatically when the transaction commits or rolls back. Prefer
+    this over :func:`pg_advisory_lock` when the caller commits while holding the
+    lock — a session-level lock would be orphaned once the connection returns to
+    the pool. Must be called inside a transaction.
 
     Args:
         session: Database session

--- a/tracecat/db/rls.py
+++ b/tracecat/db/rls.py
@@ -17,6 +17,8 @@ Key features:
 from __future__ import annotations
 
 import uuid
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -99,6 +101,12 @@ def _normalize_rls_context(
 def _cache_rls_context(session: AsyncSession, context: _RLSContext) -> None:
     """Store RLS context on the sync session so event hooks can reapply it."""
     session.sync_session.info[_RLS_CONTEXT_INFO_KEY] = context
+
+
+def _get_cached_rls_context(session: AsyncSession) -> _RLSContext | None:
+    """Read the RLS context currently cached on the session, if any."""
+    cached = session.sync_session.info.get(_RLS_CONTEXT_INFO_KEY)
+    return cached if isinstance(cached, _RLSContext) else None
 
 
 _RLS_CONTEXT_SQL = text(
@@ -252,6 +260,46 @@ async def clear_rls_context(session: AsyncSession) -> None:
         user_id=None,
         bypass=False,
     )
+
+
+@asynccontextmanager
+async def workspace_rls_context(
+    session: AsyncSession,
+    workspace_id: uuid.UUID | str,
+) -> AsyncGenerator[None, None]:
+    """Temporarily scope the session's RLS context to a workspace.
+
+    Org-level operators (e.g. an org admin acting through the RBAC routes) have
+    an org context but no ``app.current_workspace_id``. That context cannot
+    write workspace-scoped tables under enforce mode, even when the operator is
+    legitimately authorized to mutate rows for a workspace in their org. This
+    overrides the workspace dimension of the cached context for the duration of
+    the block (preserving org and user), then restores the prior context on
+    exit so the caller's surrounding transaction is unaffected.
+
+    The override is re-applied on every ``after_begin`` (it is cached), so it
+    survives the intermediate commits that membership reconciliation performs.
+    """
+    previous = _get_cached_rls_context(session)
+    scoped = _normalize_rls_context(
+        org_id=previous.org_id if previous else None,
+        workspace_id=workspace_id,
+        user_id=previous.user_id if previous else None,
+        # Preserve an existing bypass (e.g. platform superuser).
+        bypass=previous.bypass if previous else False,
+    )
+    # Enter the try before caching so the finally restores the caller's context
+    # even if applying the scoped context raises mid-flight.
+    try:
+        _cache_rls_context(session, scoped)
+        await _apply_rls_context_async(session, scoped)
+        yield
+    finally:
+        if previous is not None:
+            _cache_rls_context(session, previous)
+            await _apply_rls_context_async(session, previous)
+        else:
+            await clear_rls_context(session)
 
 
 async def verify_rls_access(

--- a/tracecat/workspaces/router.py
+++ b/tracecat/workspaces/router.py
@@ -16,6 +16,7 @@ from tracecat.authz.service import MembershipService
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.exceptions import (
     TracecatAuthorizationError,
+    TracecatConflictError,
     TracecatManagementError,
     TracecatNotFoundError,
     TracecatValidationError,
@@ -312,7 +313,10 @@ async def delete_workspace_membership(
 ) -> None:
     """Delete a workspace membership."""
     service = MembershipService(session, role=role)
-    await service.delete_membership(workspace_id, user_id=user_id)
+    try:
+        await service.delete_membership(workspace_id, user_id=user_id)
+    except TracecatConflictError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
 
 
 # === Invitations === #

--- a/tracecat/workspaces/schemas.py
+++ b/tracecat/workspaces/schemas.py
@@ -117,6 +117,9 @@ class WorkspaceMember(Schema):
     last_name: str | None
     email: EmailStr
     role_name: str
+    # Access reaches the workspace through a group; the UI gates per-row
+    # remove/edit actions on this since they're managed via the group.
+    via_group: bool = False
 
 
 class WorkspaceRead(Schema):

--- a/tracecat/workspaces/schemas.py
+++ b/tracecat/workspaces/schemas.py
@@ -117,9 +117,13 @@ class WorkspaceMember(Schema):
     last_name: str | None
     email: EmailStr
     role_name: str
-    # Access reaches the workspace through a group; the UI gates per-row
-    # remove/edit actions on this since they're managed via the group.
+    # Access reaches the workspace through a group; the UI gates the per-row
+    # remove action on this since group-derived access is managed via the group.
     via_group: bool = False
+    # A direct UserRoleAssignment exists for this workspace. A member can hold
+    # both a direct and a group path; the UI gates the per-row change-role action
+    # on this (the direct assignment is editable even when via_group is true).
+    via_direct: bool = False
 
 
 class WorkspaceRead(Schema):

--- a/tracecat/workspaces/service.py
+++ b/tracecat/workspaces/service.py
@@ -16,6 +16,7 @@ from tracecat.auth.types import Role
 from tracecat.authz.controls import has_scope, require_scope
 from tracecat.authz.enums import OwnerType
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
+from tracecat.authz.service import MembershipService
 from tracecat.cases.service import CaseFieldsService
 from tracecat.db.models import (
     Invitation,
@@ -527,14 +528,9 @@ class WorkspaceService(BaseOrgService):
             # Shouldn't reach here, but handle gracefully
             raise TracecatValidationError("Invitation is no longer valid")
 
-        # Create workspace membership
-        membership = Membership(
-            user_id=user_id,
-            workspace_id=invitation.workspace_id,
-        )
-        self.session.add(membership)
-
-        # Create RBAC role assignment for the workspace
+        # Create RBAC role assignment for the workspace. Accept is just another
+        # workspace-scoped write path: we write the role, then let the
+        # reconciler materialize the Membership row as the final step.
         ws_assignment = UserRoleAssignment(
             organization_id=organization_id,
             user_id=user_id,
@@ -562,7 +558,21 @@ class WorkspaceService(BaseOrgService):
                 self.session.add(org_assignment)
 
         await self.session.commit()
-        await self.session.refresh(membership)
+
+        # Final step: reconcile the membership dial against the role we wrote.
+        await MembershipService(self.session).reconcile_workspace_membership(
+            user_id, invitation.workspace_id
+        )
+        membership = await self.session.scalar(
+            select(Membership).where(
+                Membership.user_id == user_id,
+                Membership.workspace_id == invitation.workspace_id,
+            )
+        )
+        if membership is None:
+            raise TracecatValidationError(
+                "Failed to materialize workspace membership after accepting invitation"
+            )
         return membership
 
     @require_scope("workspace:member:remove")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Syncs workspace memberships with workspace-scoped RBAC so users are auto-added/removed via direct or group role paths. Adds `via_group` and `via_direct` flags in the API/UI, keeps “Change role” editable for mixed-source members, and reconciles under workspace-scoped RLS with transaction-scoped advisory locks (ENG-1499).

- New Features
  - Added reconciliation primitives and wiring: `workspace_scoped_path_exists`, `group_scoped_path_exists`, `MembershipService.reconcile_workspace_membership`, `MembershipService.reconcile_group_members`, `pg_advisory_xact_lock`, and `workspace_rls_context`. Reconciliation runs on RBAC writes (user/group assignment create/delete, add/remove group member, group delete) and invitation acceptance, with set-based, locked fanout for groups.
  - Members API now returns `via_group` and `via_direct`, and picks role as direct > group > default. UI shows a “Via group” badge, gates Change role by `via_direct` and Remove by `via_group`, with tooltips.

- Bug Fixes
  - Allow changing role for mixed-source members (direct + group). Removing group-derived members is blocked with 409 until group access changes.
  - Re-adding a member is idempotent and preserves any existing non-default direct role; org-wide roles do not create membership.
  - Deleting groups or group assignments, and adding/removing group members, reconciles affected users under workspace RLS to avoid stale memberships.

<sup>Written for commit fb3c961f6b66e1306b0256875c3edf1195bc98a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

