### PR TITLE
docs(mcp): update loop authoring guidance

### DIFF
--- a/.agents/skills/tracecat-automation-best-practices/SKILL.md
+++ b/.agents/skills/tracecat-automation-best-practices/SKILL.md
@@ -126,8 +126,11 @@ args:
   manage workflows, and action names such as `core.http_request` only inside workflow YAML.
 - Inventing `tools.*` action names. Discover actions with `list_actions`, then inspect exact
   schemas with `get_action_context`.
-- Using `for_each` or scatter/gather for normal loops, batching, filtering, joins, or table
-  writes — prefer a `core.script.run_python` loop (see [run-python](references/run-python.md)).
+- Using `for_each` for ordinary loop management, or using scatter/gather for data-heavy
+  batching, filtering, joins, or table writes. Default to scatter for workflow-level loops;
+  add gather only when downstream steps need combined results. Use `core.script.run_python`
+  for data-heavy processing (see
+  [run-python](references/run-python.md)).
 - Using `insert_rows(..., upsert=True)` without a unique index on the key column (see
   [tables](references/tables.md)).
 - Granting `core.http_request` to an agent without explicit user approval of broad network

--- a/.agents/skills/tracecat-automation-best-practices/references/run-python.md
+++ b/.agents/skills/tracecat-automation-best-practices/references/run-python.md
@@ -7,12 +7,17 @@ rather than scattering it across many nodes.
 
 ## Loops and concurrency
 
-- Prefer `core.script.run_python` loops over action-level `for_each`, even for bounded lists.
-  `for_each` can create enough scheduled work to hurt the scheduler. Use it only when the user
-  explicitly needs separate workflow action runs per item and accepts the concurrency tradeoff.
-- Prefer `core.script.run_python` loops over `core.transform.scatter` / `core.transform.gather`.
-  Scatter/gather has the same scheduler/concurrency risk; reserve it for explicit
-  workflow-stream fan-out/fan-in requirements.
+- Default to `core.transform.scatter` for workflow-level loops: scatter alerts into
+  `core.cases.create_case`, run `ai.agent` or `ai.preset_agent` per item, branch enrichment,
+  or call `core.workflow.execute`. Add `core.transform.gather` only when downstream steps need
+  combined results.
+- Use best judgment: choose `core.script.run_python` for data-heavy in-process loops such as
+  transforms, batching, joins, dedupe, sorting, grouping, chunked table writes, batch table
+  uploads, bounded async HTTP loops, and per-item error handling where separate workflow
+  streams are unnecessary.
+- Avoid action-level `for_each` by default. Use it only for known, bounded lists when the user
+  explicitly needs separate workflow action runs per item and accepts the scheduler/concurrency
+  tradeoff.
 - Use `core.loop.start` / `core.loop.end` only when each iteration depends on prior action
   output.
 - Use bounded async concurrency inside `core.script.run_python` for bulk HTTP or table

--- a/scripts/evals/tracecat_authoring/run_local.py
+++ b/scripts/evals/tracecat_authoring/run_local.py
@@ -2064,20 +2064,6 @@ def validate_prompt_table_upsert_examples(
     )
 
 
-def validate_prompt_loop_parallelism_guardrails(text: str) -> CheckResult:
-    required_phrases = [
-        "Prefer `core.script.run_python` loops over action-level `for_each`",
-        "Prefer `core.script.run_python` loops over `core.transform.scatter` / `core.transform.gather`",
-        "hurt the scheduler",
-    ]
-    missing = [phrase for phrase in required_phrases if phrase not in text]
-    return CheckResult(
-        "prompt_loop_parallelism_guardrails",
-        not missing,
-        f"missing={missing}",
-    )
-
-
 def validate_prompt_mcp_tool_argument_guardrails(text: str) -> CheckResult:
     required_phrases = [
         "not an MCP tool argument reference",
@@ -2125,7 +2111,6 @@ def static_prompt_checks() -> list[CheckResult]:
     checks.append(validate_prompt_result_shapes(prompt_facing_text))
     checks.append(validate_prompt_action_literals(prompt_facing_text))
     checks.append(validate_prompt_table_upsert_examples(sources))
-    checks.append(validate_prompt_loop_parallelism_guardrails(prompt_facing_text))
     checks.append(validate_prompt_mcp_tool_argument_guardrails(prompt_facing_text))
     checks.append(validate_registered_action_section(dsl_text))
     return checks

--- a/tests/unit/test_tracecat_authoring_eval.py
+++ b/tests/unit/test_tracecat_authoring_eval.py
@@ -136,14 +136,6 @@ def test_prompt_action_signature_coverage_spans_all_prompt_sources() -> None:
     assert coverage.passed, coverage.detail
 
 
-def test_prompt_facing_sources_prefer_run_python_over_workflow_fanout() -> None:
-    result = run_local.validate_prompt_loop_parallelism_guardrails(
-        run_local.combine_prompt_sources(run_local.prompt_facing_sources())
-    )
-
-    assert result.passed, result.detail
-
-
 def test_prompt_facing_sources_include_mcp_tool_argument_guardrails() -> None:
     result = run_local.validate_prompt_mcp_tool_argument_guardrails(
         run_local.combine_prompt_sources(run_local.prompt_facing_sources())

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -2967,20 +2967,25 @@ show candidate integrations first.
 `${{ condition -> true_value : false_value }}`
 - Literals: `None` (NOT `null`), `true`, `false`, strings, numbers
 - There is NO inline `for` comprehension syntax in expressions. \
-Use `core.script.run_python` for list transformations and loops.
+Use `core.script.run_python` for list transformations; see loop guidance below \
+for workflow fan-out.
 
 ## Loop and batching guidance
-- Prefer `core.script.run_python` loops over action-level `for_each`, even for \
-bounded lists. `for_each` can create enough scheduled work to hurt the scheduler.
-- Use `for_each` only when the user explicitly needs separate workflow action \
-runs per item and accepts the scheduler/concurrency tradeoff.
+- Default to `core.transform.scatter` for workflow-level loop management: \
+scatter alerts into `core.cases.create_case`, run `ai.agent` or \
+`ai.preset_agent` per item, branch enrichment, or call `core.workflow.execute`. \
+Add `core.transform.gather` only when downstream steps need combined results.
+- Use best judgment: use `core.script.run_python` for data-heavy in-process \
+work such as list transforms, batching, joins, dedupe, sorting, grouping, \
+chunked table writes, batch table uploads, and bounded async HTTP loops. \
+Run-python scripts can import Tracecat modules when needed for platform-native \
+helpers.
+- Avoid action-level `for_each` by default. Use it only for known, bounded lists \
+when the user explicitly needs separate workflow action runs per item and accepts \
+the scheduler/concurrency tradeoff. Unbounded or large `for_each` loops can hurt \
+the scheduler.
 - Use `core.loop.start` / `core.loop.end` for while-style workflow loops where \
 the next iteration depends on prior action output.
-- Prefer `core.script.run_python` loops over `core.transform.scatter` / \
-`core.transform.gather`. Scatter/gather has the same scheduler/concurrency risk \
-and should be reserved for explicit workflow-stream fan-out/fan-in requirements.
-- Use `core.script.run_python` for list transforms, batching, joins, dedupe, \
-sorting, grouping, chunked table writes, and bounded async HTTP loops.
 
 ## Key DSL fields (inside each action under `actions:`)
 - `ref` — unique slug identifier for the action
@@ -3389,30 +3394,33 @@ actions:
 ```
 
 ### Scatter/Gather (Parallel Fan-out/Fan-in)
-Prefer `core.script.run_python` loops over scatter/gather, even for bounded
-lists. Scatter/gather creates per-item scheduled work and can hurt the scheduler.
-Use it only when the user explicitly needs separate workflow execution streams
-and accepts the concurrency tradeoff.
+Default to scatter for workflow-level loops: scatter alerts into
+`core.cases.create_case`, run `ai.agent` or `ai.preset_agent` per item, branch
+enrichment, or call `core.workflow.execute`. Add gather only when a downstream
+step needs combined results. Use `core.script.run_python` for data-heavy
+in-process shaping, joins, dedupe, chunked table writes, batch table uploads, or
+bounded async HTTP loops.
 ```yaml
 actions:
-  - ref: scatter_items
+  - ref: scatter_alerts
     action: core.transform.scatter
     args:
-      collection: ${{ TRIGGER.items }}
-  - ref: process_item
-    action: core.http_request
-    depends_on: [scatter_items]
+      collection: ${{ TRIGGER.alerts }}
+  - ref: create_case
+    action: core.cases.create_case
+    depends_on: [scatter_alerts]
     args:
-      url: "https://api.example.com/process/${{ ACTIONS.scatter_items.result.id }}"
-      method: POST
+      summary: ${{ ACTIONS.scatter_alerts.result.summary || "Alert" }}
+      description: ${{ ACTIONS.scatter_alerts.result.description || "Created from alert" }}
+      payload: ${{ ACTIONS.scatter_alerts.result }}
   - ref: gather_results
     action: core.transform.gather
-    depends_on: [process_item]
+    depends_on: [create_case]
     args:
-      items: ${{ ACTIONS.process_item.result }}
+      items: ${{ ACTIONS.create_case.result }}
 ```
 **Key**: Inside a scatter stream, `ACTIONS.<scatter_ref>.result` gives each item. \
-Multiple actions can chain within the stream before the gather collects results.
+Omit gather when no downstream aggregate is needed.
 
 ### AI Action (Simple LLM Call)
 ```yaml
@@ -3446,10 +3454,11 @@ actions:
 Use top-level `model_name` and `model_provider` only when explicitly requested.
 
 ### For-each Syntax (Avoid by Default)
-Prefer `core.script.run_python` loops over `for_each`, even for bounded lists.
-`for_each` creates per-item scheduled work and can hurt the scheduler. Use it
-only when the user explicitly needs separate workflow action runs per item and
-accepts the concurrency tradeoff.
+Avoid `for_each` unless the list is known and bounded and the user explicitly
+needs separate workflow action runs per item. `for_each` creates per-item
+scheduled work and can hurt the scheduler; use `core.script.run_python` for
+ordinary in-process loops and `core.transform.scatter` / `core.transform.gather`
+for durable workflow fan-out/fan-in.
 ```yaml
 actions:
   - ref: process_items


### PR DESCRIPTION
## Summary
- Update MCP authoring guidance to default workflow loop management to scatter/gather for Temporal-backed fan-out/fan-in.
- Clarify when `core.script.run_python` is a better fit for data-heavy in-process work and table batch uploads.
- Align the Tracecat automation skill and run-python reference with the updated scatter/gather guidance.
- Remove the static eval assertion that pinned prompt wording for loop guidance.

## Validation
- `uv run pytest tests/unit/test_tracecat_authoring_eval.py`
- Commit hooks passed during `git commit --amend`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates MCP loop authoring guidance: default workflow fan-out to `core.transform.scatter`, add `core.transform.gather` only when needed, and use `core.script.run_python` for in-process, data-heavy loops. Removes the old loop guardrail check and its unit test.

- **Refactors**
  - Updated `tracecat/mcp/server.py` docs to default workflow loops to scatter (with a cases example), add gather only when downstream steps need combined results, use `core.script.run_python` for transforms/batching/joins/bounded async HTTP, clarify `core.loop.start` / `core.loop.end`, and discourage `for_each` by default.
  - Aligned `.agents/skills/tracecat-automation-best-practices/SKILL.md` and `references/run-python.md` with the new defaults and when to choose scatter/gather vs. `core.script.run_python`; advise using `for_each` only for known, bounded lists.
  - Removed the loop parallelism guardrail from `scripts/evals/tracecat_authoring/run_local.py` and its unit test in `tests/unit/test_tracecat_authoring_eval.py`.

<sup>Written for commit f77dc7796915310ff52848cdb1988a03e07fa088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

