### PR TITLE
fix(agents): stream replay hardening

### DIFF
--- a/alembic/versions/574d19d8c16c_add_active_stream_id_and_history_curr_.py
+++ b/alembic/versions/574d19d8c16c_add_active_stream_id_and_history_curr_.py
@@ -1,0 +1,58 @@
+"""add active_stream_id and history curr_run_id
+
+Revision ID: 574d19d8c16c
+Revises: 290137982547
+Create Date: 2026-06-22 15:16:14.572223
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "574d19d8c16c"
+down_revision: str | None = "290137982547"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Per-turn stream pivot on the session row.
+    op.add_column(
+        "agent_session",
+        sa.Column("active_stream_id", sa.UUID(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_agent_session_active_stream_id"),
+        "agent_session",
+        ["active_stream_id"],
+        unique=False,
+    )
+    # Tag history rows with the producing run so mid-turn loads can hide the
+    # active run's partial rows (Redis is the sole live-assistant source).
+    op.add_column(
+        "agent_session_history",
+        sa.Column("curr_run_id", sa.UUID(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_agent_session_history_curr_run_id"),
+        "agent_session_history",
+        ["curr_run_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_agent_session_history_curr_run_id"),
+        table_name="agent_session_history",
+    )
+    op.drop_column("agent_session_history", "curr_run_id")
+    op.drop_index(
+        op.f("ix_agent_session_active_stream_id"),
+        table_name="agent_session",
+    )
+    op.drop_column("agent_session", "active_stream_id")

--- a/alembic/versions/574d19d8c16c_add_active_stream_id_and_history_curr_.py
+++ b/alembic/versions/574d19d8c16c_add_active_stream_id_and_history_curr_.py
@@ -1,7 +1,7 @@
 """add active_stream_id and history curr_run_id
 
 Revision ID: 574d19d8c16c
-Revises: 290137982547
+Revises: 31b8cb7b312e
 Create Date: 2026-06-22 15:16:14.572223
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "574d19d8c16c"
-down_revision: str | None = "290137982547"
+down_revision: str | None = "31b8cb7b312e"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -461,7 +461,10 @@ export function useVercelChat({
     return url.toString()
   }, [chatId, workspaceId])
 
-  // Use Vercel's useChat hook for streaming
+  // Use Vercel's useChat hook for streaming. On reconnect the server replays the
+  // whole active turn from the start (it hides the active run's DB rows mid-turn,
+  // so Redis is the sole source for the live assistant); we therefore do not send
+  // a Last-Event-ID cursor.
   const chat = aiSdk.useChat({
     id: chatId,
     resume: !!chatId && resume,

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -127,6 +127,7 @@ class EmitSessionErrorInputs(BaseModel):
     session_id: uuid.UUID
     workspace_id: uuid.UUID
     message: str
+    active_stream_id: uuid.UUID | None = None
 
 
 def _stored_user_mcp_tool_policy(
@@ -478,7 +479,9 @@ class AgentActivities:
         to the chat UI, since those happen before the loopback is wired up.
         """
         stream = await AgentStream.new(
-            session_id=args.session_id, workspace_id=args.workspace_id
+            session_id=args.session_id,
+            workspace_id=args.workspace_id,
+            stream_id=args.active_stream_id,
         )
         await stream.error(args.message)
         await stream.done()

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -57,12 +57,14 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.agent.schemas import AgentOutput, RunAgentArgs, RunUsage, ToolFilters
     from tracecat.agent.session.activities import (
         CreateSessionInput,
+        FinalizeTurnInput,
         LoadSessionInput,
         LoadSessionMessagesInput,
         LoadSessionResult,
         PendingToolResult,
         ReconcileToolResultsInput,
         create_session_activity,
+        finalize_turn_activity,
         load_session_activity,
         load_session_messages_activity,
         reconcile_tool_results_activity,
@@ -453,6 +455,9 @@ def _preserved_agents_binding(
     return None
 
 
+FINALIZE_TURN_PATCH = "durable-agent-finalize-turn-v1"
+
+
 @workflow.defn
 class DurableAgentWorkflow:
     @workflow.init
@@ -472,6 +477,7 @@ class DurableAgentWorkflow:
         self.workspace_id = args.role.workspace_id
         self.organization_id = args.role.organization_id
         self.session_id = args.agent_args.session_id
+        self.active_stream_id = args.agent_args.active_stream_id
         self.harness_type = args.harness_type or "claude_code"
         self.approvals = ApprovalManager(role=self.role)
         self.max_requests = args.agent_args.max_requests
@@ -830,6 +836,43 @@ class DurableAgentWorkflow:
             ):
                 await self._emit_session_error(e.message)
             raise
+        finally:
+            # Terminal boundary only: approval-pause awaits inside the executor
+            # loop and never reaches here. Clear the active-turn pointers so the
+            # mid-turn DB filter releases the final rows and reconnect -> 204.
+            # Patch-gated: finalize_turn_activity is a new command, so old
+            # histories recorded before this change must not replay it.
+            if workflow.patched(FINALIZE_TURN_PATCH):
+                await self._finalize_turn()
+
+    async def _finalize_turn(self) -> None:
+        """Clear active-turn pointers at terminal (compare-and-clear by run_id)."""
+        # Use the workflow-id token (same as the persisted curr_run_id), not
+        # args.agent_args.curr_run_id, which is None for DSL/workflow callers and
+        # would skip cleanup. workflow.info() is replay-safe.
+        run_id = AgentWorkflowID.from_workflow_id(
+            workflow.info().workflow_id
+        ).session_id
+        try:
+            await workflow.execute_activity(
+                finalize_turn_activity,
+                FinalizeTurnInput(
+                    role=self.role,
+                    session_id=self.session_id,
+                    run_id=run_id,
+                ),
+                start_to_close_timeout=timedelta(seconds=10),
+                # Idempotent (compare-and-clear by run_id); retry so a transient
+                # failure doesn't leave curr_run_id set and hide the final row.
+                retry_policy=RETRY_POLICIES["activity:fail_slow"],
+            )
+        except ActivityError as exc:
+            logger.warning(
+                "Failed to finalize agent turn pointers",
+                session_id=str(self.session_id),
+                run_id=str(run_id),
+                error=str(exc),
+            )
 
     async def _emit_session_error(self, message: str) -> None:
         try:
@@ -839,6 +882,10 @@ class DurableAgentWorkflow:
                     session_id=self.session_id,
                     workspace_id=self.workspace_id,
                     message=message,
+                    # Chat turns pin a per-turn stream id; the client reads the
+                    # suffixed key, so the error/done markers must land there.
+                    # None falls back to the per-session key for non-chat turns.
+                    active_stream_id=self.active_stream_id,
                 ),
                 start_to_close_timeout=timedelta(seconds=10),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
@@ -1018,6 +1065,8 @@ class DurableAgentWorkflow:
         executor_input = AgentExecutorInput(
             session_id=self.session_id,
             workspace_id=self.workspace_id,
+            active_stream_id=args.agent_args.active_stream_id,
+            curr_run_id=curr_run_id,
             user_prompt=args.agent_args.user_prompt,
             config=cfg,
             role=self.role,
@@ -1098,6 +1147,7 @@ class DurableAgentWorkflow:
                         denied_tools=denied_tools,
                         registry_lock=root_registry_lock,
                         mcp_auth_token=compiled_run.root.mcp_auth_token,
+                        active_stream_id=args.agent_args.active_stream_id,
                     )
                     logger.info(
                         "Tool execution completed",
@@ -1120,6 +1170,8 @@ class DurableAgentWorkflow:
                 executor_input = AgentExecutorInput(
                     session_id=self.session_id,
                     workspace_id=self.workspace_id,
+                    active_stream_id=args.agent_args.active_stream_id,
+                    curr_run_id=curr_run_id,
                     user_prompt=args.agent_args.user_prompt,
                     config=cfg,
                     role=self.role,
@@ -1278,6 +1330,7 @@ class DurableAgentWorkflow:
         denied_tools: list[DeniedToolCall],
         registry_lock: RegistryLock,
         mcp_auth_token: str,
+        active_stream_id: uuid.UUID | None,
     ) -> list:
         logical_time = workflow.now()
         service_role = build_tracecat_mcp_role(
@@ -1331,6 +1384,7 @@ class DurableAgentWorkflow:
                 workspace_id=self.workspace_id,
                 role=self.role,
                 pending_results=pending_results,
+                active_stream_id=active_stream_id,
             ),
             start_to_close_timeout=timedelta(seconds=300),
             retry_policy=RETRY_POLICIES["activity:fail_fast"],

--- a/tests/integration/test_agent_worker.py
+++ b/tests/integration/test_agent_worker.py
@@ -351,7 +351,7 @@ class TestAgentWorkerSingleTenant:
 
             # Verify Redis stream key format
             redis_client = await get_redis_client()
-            stream_key = StreamKey(workspace_id, session_id)
+            stream_key = StreamKey(workspace_id=workspace_id, session_id=session_id)
 
             # Read events from stream (may be empty with mocked executor)
             _ = await redis_client.xrange(stream_key)

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -76,6 +76,7 @@ from tracecat.agent.session.activities import (
     ReconcileToolResultsInput,
     ReconcileToolResultsResult,
     create_session_activity,
+    finalize_turn_activity,
     load_session_activity,
     load_session_messages_activity,
     reconcile_tool_results_activity,
@@ -964,15 +965,16 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
         async def append(self, event: Any) -> None:
             del event
 
-        async def reset_for_new_turn(self) -> None:
+        async def clear_buffer(self) -> None:
             return None
 
     async def fake_agent_stream_new(
         *,
         session_id: uuid.UUID,
         workspace_id: uuid.UUID,
+        stream_id: uuid.UUID | None = None,
     ) -> _FakeStream:
-        del session_id, workspace_id
+        del session_id, workspace_id, stream_id
         return _FakeStream()
 
     monkeypatch.setattr(
@@ -1136,12 +1138,19 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
             }
         )
 
+    # curr_run_id must match the workflow-derived run id (the workflow launches
+    # with id=AgentWorkflowID(mock_session_id), so create_session_activity sets
+    # curr_run_id=mock_session_id). This exercises _finalize_turn's compare-and-
+    # clear at terminal and the pause invariant below. (active_stream_id is the
+    # chat path's per-turn pivot; workflow-initiated sessions stay per-session
+    # and intentionally leave it null.)
     workflow_args = AgentWorkflowArgs(
         role=svc_role,
         agent_args=RunAgentArgs(
             session_id=mock_session_id,
             user_prompt="Make a test HTTP request",
             config=agent_config_with_approvals,
+            curr_run_id=mock_session_id,
         ),
         entity_type=AgentSessionEntity.WORKFLOW,
         entity_id=uuid.uuid4(),
@@ -1155,6 +1164,7 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
             load_session_activity,
             load_session_messages_activity,
             reconcile_tool_results_activity,
+            finalize_turn_activity,
             mock_build_tool_definitions,
             mock_record_approval_requests,
             mock_apply_approval_decisions,
@@ -1189,6 +1199,16 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
         )
 
         await asyncio.wait_for(approval_request_recorded.wait(), timeout=10)
+
+        # Paused at approval: the terminal `finally` has NOT run, so curr_run_id
+        # must still be set. Guards the invariant that _finalize_turn fires only
+        # at a true terminal, never on an approval pause (which awaits inside the
+        # executor loop).
+        async with AgentSessionService.with_session(role=svc_role) as svc:
+            paused_session = await svc.get_session(mock_session_id)
+            assert paused_session is not None
+            assert paused_session.curr_run_id is not None
+
         await wf_handle.execute_update(
             DurableAgentWorkflow.set_approvals,
             WorkflowApprovalSubmission(
@@ -1200,6 +1220,12 @@ async def test_agent_workflow_routes_approved_tools_to_executor_and_reconciles_h
         result = await wf_handle.result()
 
     assert result.session_id == mock_session_id
+
+    # After terminal, the finally cleared the active-turn pointers.
+    async with AgentSessionService.with_session(role=svc_role) as svc:
+        done_session = await svc.get_session(mock_session_id)
+        assert done_session is not None
+        assert done_session.curr_run_id is None
     assert agent_executor_task_queues == [
         agent_executor_queue,
         agent_executor_queue,
@@ -1919,15 +1945,16 @@ async def test_agent_workflow_does_not_retry_approved_tool_failures(
         async def append(self, event: Any) -> None:
             del event
 
-        async def reset_for_new_turn(self) -> None:
+        async def clear_buffer(self) -> None:
             return None
 
     async def fake_agent_stream_new(
         *,
         session_id: uuid.UUID,
         workspace_id: uuid.UUID,
+        stream_id: uuid.UUID | None = None,
     ) -> _FakeStream:
-        del session_id, workspace_id
+        del session_id, workspace_id, stream_id
         return _FakeStream()
 
     monkeypatch.setattr(

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -104,7 +104,7 @@ class TestSessionActivities:
         """Test that get_session_activities returns a list of activity functions."""
         activities = get_session_activities()
         assert isinstance(activities, list)
-        assert len(activities) == 4
+        assert len(activities) == 5
 
         # All returned items should have the temporal activity definition
         for activity in activities:
@@ -120,6 +120,7 @@ class TestSessionActivities:
         assert "load_session_activity" in activity_names
         assert "load_session_messages_activity" in activity_names
         assert "reconcile_tool_results_activity" in activity_names
+        assert "finalize_turn_activity" in activity_names
 
 
 class TestBuildToolDefinitionsActivity:
@@ -1156,7 +1157,9 @@ class TestLoadSessionMessagesActivity:
         assert isinstance(result, LoadSessionMessagesResult)
         assert result.messages == expected_messages
         assert result.error is None
-        mock_service.list_messages.assert_awaited_once_with(mock_session_id)
+        mock_service.list_messages.assert_awaited_once_with(
+            mock_session_id, include_active=True
+        )
 
     @pytest.mark.anyio
     @patch("tracecat.agent.session.activities.AgentSessionService.with_session")

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -103,6 +103,7 @@ async def test_initialize_stream_sink_falls_back_to_redis_on_external_lookup_err
     stream_new.assert_awaited_once_with(
         session_id=loopback_input.session_id,
         workspace_id=loopback_input.workspace_id,
+        stream_id=loopback_input.active_stream_id,
     )
 
 
@@ -153,6 +154,7 @@ async def test_emit_terminal_error_uses_redis_when_external_lookup_errors(
     stream_new.assert_awaited_once_with(
         session_id=loopback_input.session_id,
         workspace_id=loopback_input.workspace_id,
+        stream_id=loopback_input.active_stream_id,
     )
     fake_stream.error.assert_awaited_once_with("runtime exited before connect")
     fake_stream.done.assert_awaited_once()

--- a/tests/unit/test_agent_session_approval_sink.py
+++ b/tests/unit/test_agent_session_approval_sink.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import orjson
 import pytest
 from pydantic_ai.tools import ToolApproved
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tracecat.agent.approvals.enums import ApprovalStatus
@@ -279,6 +280,85 @@ async def test_replace_interrupt_with_tool_results_replaces_legacy_interrupted_r
     assert tool_result["tool_use_id"] == "call_123"
     assert tool_result["is_error"] is False
     assert orjson.loads(tool_result["content"]) == {"status": "success"}
+
+
+@pytest.mark.anyio
+async def test_replace_interrupt_with_tool_results_tags_active_run_id(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """The inserted tool_result must be tagged with the active run id so the
+    mid-turn filter hides it alongside its tool_use row. A NULL tag would leave
+    the tool_result visible while its tool_use stays hidden — a dangling result.
+    """
+    run_id = uuid.uuid4()
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Approval chat",
+        workspace_id=svc_role.workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        sdk_session_id="sdk-session",
+        curr_run_id=run_id,
+    )
+    assistant_uuid = str(uuid.uuid4())
+    session.add(agent_session)
+    # Assistant tool_use row is tagged with the active run id (durability-only).
+    session.add(
+        AgentSessionHistory(
+            session_id=agent_session.id,
+            workspace_id=svc_role.workspace_id,
+            kind=MessageKind.CHAT_MESSAGE.value,
+            curr_run_id=run_id,
+            content={
+                "uuid": assistant_uuid,
+                "sessionId": "sdk-session",
+                "type": "assistant",
+                "timestamp": "2026-03-18T00:00:00Z",
+                "cwd": "/home/agent",
+                "version": "2.0.72",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_123",
+                            "name": "core__http_request",
+                            "input": {"url": "https://example.com"},
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    await service.replace_interrupt_with_tool_results(
+        agent_session.id,
+        [
+            ToolExecutionResult(
+                tool_call_id="call_123",
+                tool_name="core.http_request",
+                result={"status": "success"},
+                is_error=False,
+            )
+        ],
+    )
+
+    # Every persisted row for this turn — the assistant tool_use and the newly
+    # inserted tool_result — must carry the active run id. The mid-turn filter
+    # (list_messages, include_active=False) keys off this tag: a NULL on the
+    # tool_result would leave it visible while its tool_use stays hidden.
+    rows = (
+        await session.execute(
+            select(AgentSessionHistory.curr_run_id, AgentSessionHistory.content)
+            .where(AgentSessionHistory.session_id == agent_session.id)
+            .order_by(AgentSessionHistory.surrogate_id)
+        )
+    ).all()
+    by_type = {content.get("type"): crid for crid, content in rows}
+    assert by_type == {"assistant": run_id, "user": run_id}
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_session_messages.py
+++ b/tests/unit/test_agent_session_messages.py
@@ -90,6 +90,7 @@ async def test_load_session_history_omits_internal_rows_and_repairs_parent_chain
         id=session_id,
         parent_session_id=None,
         sdk_session_id="sdk-session-123",
+        curr_run_id=None,
     )
     tool_result_uuid = "tool-result-uuid"
     thinking_uuid = "thinking-uuid"
@@ -191,6 +192,7 @@ async def test_list_messages_skips_misclassified_continuation_artifacts() -> Non
     agent_session = SimpleNamespace(
         id=session_id,
         parent_session_id=None,
+        curr_run_id=None,
     )
     prompt_uuid = "prompt-uuid"
     thinking_uuid = "thinking-uuid"

--- a/tests/unit/test_agent_session_router.py
+++ b/tests/unit/test_agent_session_router.py
@@ -27,12 +27,13 @@ from tracecat.agent.session.router import (
     stream_session_events,
 )
 from tracecat.agent.session.schemas import AgentSessionForkRequest
-from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.session.types import AgentSessionEntity, TurnLifecycle
 from tracecat.artifacts.schemas import CaseArtifact
 from tracecat.auth.types import Role
 from tracecat.cases.enums import CaseSeverity, CaseStatus
 from tracecat.chat.schemas import (
     ApprovalDecision,
+    ChatResponse,
     ContinueRunRequest,
     VercelChatRequest,
 )
@@ -68,6 +69,8 @@ def _agent_session_stub(**overrides: Any) -> SimpleNamespace:
         "created_at": now,
         "updated_at": now,
         "last_stream_id": None,
+        "active_stream_id": None,
+        "curr_run_id": None,
         "artifacts": [],
     }
     values.update(overrides)
@@ -409,12 +412,13 @@ async def test_send_message_continue_uses_path_session_id_for_stream_key() -> No
         session=AsyncMock(),
         is_legacy_session=AsyncMock(return_value=False),
         validate_turn_request=AsyncMock(return_value=agent_session),
+        get_session=AsyncMock(return_value=agent_session),
         run_turn=AsyncMock(return_value=None),
         build_initial_artifact=AsyncMock(return_value=None),
     )
     fake_stream = SimpleNamespace(
-        reset_for_new_turn=AsyncMock(return_value=None),
-        abort_new_turn=AsyncMock(return_value=None),
+        error=AsyncMock(return_value=None),
+        done=AsyncMock(return_value=None),
         sse=Mock(return_value=_empty_event_stream()),
     )
 
@@ -441,22 +445,25 @@ async def test_send_message_continue_uses_path_session_id_for_stream_key() -> No
 
     assert isinstance(response, StreamingResponse)
     with_session_mock.assert_called_once_with(role=role)
-    stream_new_mock.assert_awaited_once_with(session_id, workspace_id)
+    # Continuation reuses the existing per-turn stream id (None here).
+    stream_new_mock.assert_awaited_once_with(
+        session_id, workspace_id, agent_session.active_stream_id
+    )
     fake_svc.validate_turn_request.assert_awaited_once_with(
         session_id=session_id,
         request=request,
     )
-    fake_stream.reset_for_new_turn.assert_not_awaited()
     fake_stream.sse.assert_called_once()
     assert fake_stream.sse.call_args.kwargs["last_id"] == "$"
     fake_svc.run_turn.assert_awaited_once_with(
         session_id=session_id,
         request=request,
+        active_stream_id=agent_session.active_stream_id,
     )
 
 
 @pytest.mark.anyio
-async def test_send_message_new_turn_resets_stream_before_streaming() -> None:
+async def test_send_message_new_turn_uses_fresh_per_turn_stream() -> None:
     session_id = uuid.uuid4()
     workspace_id = uuid.uuid4()
     agent_session = _agent_session_stub(id=session_id, workspace_id=workspace_id)
@@ -481,13 +488,14 @@ async def test_send_message_new_turn_resets_stream_before_streaming() -> None:
         session=AsyncMock(),
         is_legacy_session=AsyncMock(return_value=False),
         validate_turn_request=AsyncMock(return_value=agent_session),
+        get_session=AsyncMock(return_value=agent_session),
         run_turn=AsyncMock(return_value=None),
         should_seed_initial_artifact=AsyncMock(return_value=False),
         build_initial_artifact=AsyncMock(return_value=None),
     )
     fake_stream = SimpleNamespace(
-        reset_for_new_turn=AsyncMock(return_value=None),
-        abort_new_turn=AsyncMock(return_value=None),
+        error=AsyncMock(return_value=None),
+        done=AsyncMock(return_value=None),
         sse=Mock(return_value=_empty_event_stream()),
     )
 
@@ -496,6 +504,98 @@ async def test_send_message_new_turn_resets_stream_before_streaming() -> None:
             "tracecat.agent.session.router.AgentSessionService.with_session",
             return_value=_AsyncContext(fake_svc),
         ) as with_session_mock,
+        patch(
+            "tracecat.agent.session.router.AgentStream.new",
+            AsyncMock(return_value=fake_stream),
+        ) as stream_new_mock,
+    ):
+        raw_send_message = cast(Any, send_message).__wrapped__
+        response = await raw_send_message(
+            session_id=session_id,
+            request=request,
+            role=role,
+            http_request=cast(
+                Any,
+                SimpleNamespace(is_disconnected=AsyncMock(return_value=False)),
+            ),
+        )
+
+    assert isinstance(response, StreamingResponse)
+    with_session_mock.assert_called_once_with(role=role)
+    fake_svc.should_seed_initial_artifact.assert_awaited_once_with(agent_session)
+    fake_svc.build_initial_artifact.assert_not_awaited()
+    fake_stream.sse.assert_called_once()
+    assert fake_stream.sse.call_args.kwargs["last_id"] == "0-0"
+    # A fresh per-turn stream id is minted and threaded into both the stream key
+    # and run_turn (same value).
+    await_args = stream_new_mock.await_args
+    assert await_args is not None
+    new_call_args = await_args.args
+    assert new_call_args[0] == session_id
+    assert new_call_args[1] == workspace_id
+    minted_stream_id = new_call_args[2]
+    assert isinstance(minted_stream_id, uuid.UUID)
+    fake_svc.run_turn.assert_awaited_once_with(
+        session_id=session_id,
+        request=request,
+        active_stream_id=minted_stream_id,
+    )
+
+
+@pytest.mark.anyio
+async def test_send_message_new_turn_bubble_id_survives_fast_finalize() -> None:
+    """On a fast turn, finalize_turn may null curr_run_id before the post-run
+    refresh. The bubble id must come from the run id run_turn returns, not the
+    re-read (now-cleared) session row, so the start frame keeps a stable id.
+    """
+    session_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    run_id = uuid.uuid4()
+    # Session row reads back with curr_run_id already cleared by finalize_turn.
+    agent_session = _agent_session_stub(
+        id=session_id, workspace_id=workspace_id, curr_run_id=None
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=workspace_id,
+        organization_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute"}),
+    )
+    request = VercelChatRequest(
+        message=UIMessage(
+            id="msg-1",
+            role="user",
+            parts=[{"type": "text", "text": "hello"}],
+        ),
+        model="gpt-4o-mini",
+        model_provider="openai",
+    )
+
+    fake_svc = SimpleNamespace(
+        session=AsyncMock(),
+        is_legacy_session=AsyncMock(return_value=False),
+        validate_turn_request=AsyncMock(return_value=agent_session),
+        get_session=AsyncMock(return_value=agent_session),
+        run_turn=AsyncMock(
+            return_value=ChatResponse(
+                stream_url="/stream", chat_id=session_id, curr_run_id=run_id
+            )
+        ),
+        should_seed_initial_artifact=AsyncMock(return_value=False),
+        build_initial_artifact=AsyncMock(return_value=None),
+    )
+    fake_stream = SimpleNamespace(
+        error=AsyncMock(return_value=None),
+        done=AsyncMock(return_value=None),
+        sse=Mock(return_value=_empty_event_stream()),
+    )
+
+    with (
+        patch(
+            "tracecat.agent.session.router.AgentSessionService.with_session",
+            return_value=_AsyncContext(fake_svc),
+        ),
         patch(
             "tracecat.agent.session.router.AgentStream.new",
             AsyncMock(return_value=fake_stream),
@@ -513,13 +613,8 @@ async def test_send_message_new_turn_resets_stream_before_streaming() -> None:
         )
 
     assert isinstance(response, StreamingResponse)
-    with_session_mock.assert_called_once_with(role=role)
-    fake_stream.reset_for_new_turn.assert_awaited_once()
-    fake_svc.should_seed_initial_artifact.assert_awaited_once_with(agent_session)
-    fake_svc.build_initial_artifact.assert_not_awaited()
-    fake_stream.abort_new_turn.assert_not_awaited()
     fake_stream.sse.assert_called_once()
-    assert fake_stream.sse.call_args.kwargs["last_id"] == "0-0"
+    assert fake_stream.sse.call_args.kwargs["message_id"] == f"{session_id}:{run_id}"
 
 
 @pytest.mark.anyio
@@ -554,15 +649,16 @@ async def test_send_message_new_turn_appends_initial_artifact() -> None:
         session=AsyncMock(),
         is_legacy_session=AsyncMock(return_value=False),
         validate_turn_request=AsyncMock(return_value=agent_session),
+        get_session=AsyncMock(return_value=agent_session),
         run_turn=AsyncMock(return_value=None),
         should_seed_initial_artifact=AsyncMock(return_value=True),
         build_initial_artifact=AsyncMock(return_value=artifact),
         apply_artifact_side_effects=AsyncMock(return_value=[artifact]),
     )
     fake_stream = SimpleNamespace(
-        reset_for_new_turn=AsyncMock(return_value=None),
+        error=AsyncMock(return_value=None),
+        done=AsyncMock(return_value=None),
         append=AsyncMock(return_value=None),
-        abort_new_turn=AsyncMock(return_value=None),
         sse=Mock(return_value=_empty_event_stream()),
     )
 
@@ -588,7 +684,6 @@ async def test_send_message_new_turn_appends_initial_artifact() -> None:
         )
 
     assert isinstance(response, StreamingResponse)
-    fake_stream.reset_for_new_turn.assert_awaited_once()
     fake_svc.should_seed_initial_artifact.assert_awaited_once_with(agent_session)
     fake_svc.build_initial_artifact.assert_awaited_once_with(agent_session)
     fake_stream.append.assert_awaited_once()
@@ -610,10 +705,11 @@ async def test_send_message_new_turn_appends_initial_artifact() -> None:
     assert len(apply_args[1]) == 1
     assert apply_args[1][0].op == "upsert"
     assert apply_args[1][0].artifact == artifact
-    fake_svc.run_turn.assert_awaited_once_with(
-        session_id=session_id,
-        request=request,
-    )
+    fake_svc.run_turn.assert_awaited_once()
+    run_turn_kwargs = fake_svc.run_turn.await_args.kwargs
+    assert run_turn_kwargs["session_id"] == session_id
+    assert run_turn_kwargs["request"] == request
+    assert isinstance(run_turn_kwargs["active_stream_id"], uuid.UUID)
 
 
 @pytest.mark.anyio
@@ -650,15 +746,16 @@ async def test_send_message_new_turn_skips_initial_artifact_after_first_prompt()
         session=AsyncMock(),
         is_legacy_session=AsyncMock(return_value=False),
         validate_turn_request=AsyncMock(return_value=agent_session),
+        get_session=AsyncMock(return_value=agent_session),
         run_turn=AsyncMock(return_value=None),
         should_seed_initial_artifact=AsyncMock(return_value=False),
         build_initial_artifact=AsyncMock(return_value=artifact),
         apply_artifact_side_effects=AsyncMock(return_value=[artifact]),
     )
     fake_stream = SimpleNamespace(
-        reset_for_new_turn=AsyncMock(return_value=None),
+        error=AsyncMock(return_value=None),
+        done=AsyncMock(return_value=None),
         append=AsyncMock(return_value=None),
-        abort_new_turn=AsyncMock(return_value=None),
         sse=Mock(return_value=_empty_event_stream()),
     )
 
@@ -684,15 +781,11 @@ async def test_send_message_new_turn_skips_initial_artifact_after_first_prompt()
         )
 
     assert isinstance(response, StreamingResponse)
-    fake_stream.reset_for_new_turn.assert_awaited_once()
     fake_svc.should_seed_initial_artifact.assert_awaited_once_with(agent_session)
     fake_svc.build_initial_artifact.assert_not_awaited()
     fake_svc.apply_artifact_side_effects.assert_not_awaited()
     fake_stream.append.assert_not_awaited()
-    fake_svc.run_turn.assert_awaited_once_with(
-        session_id=session_id,
-        request=request,
-    )
+    fake_svc.run_turn.assert_awaited_once()
 
 
 @pytest.mark.anyio
@@ -721,13 +814,15 @@ async def test_send_message_new_turn_clears_stream_when_startup_fails() -> None:
         session=AsyncMock(),
         is_legacy_session=AsyncMock(return_value=False),
         validate_turn_request=AsyncMock(return_value=agent_session),
+        get_session=AsyncMock(return_value=agent_session),
         run_turn=AsyncMock(side_effect=RuntimeError("temporal unavailable")),
         should_seed_initial_artifact=AsyncMock(return_value=False),
         build_initial_artifact=AsyncMock(return_value=None),
+        clear_active_turn=AsyncMock(return_value=None),
     )
     fake_stream = SimpleNamespace(
-        reset_for_new_turn=AsyncMock(return_value=None),
-        abort_new_turn=AsyncMock(return_value=None),
+        error=AsyncMock(return_value=None),
+        done=AsyncMock(return_value=None),
         sse=Mock(return_value=_empty_event_stream()),
     )
 
@@ -754,14 +849,18 @@ async def test_send_message_new_turn_clears_stream_when_startup_fails() -> None:
             )
 
     assert exc_info.value.status_code == 500
-    fake_stream.reset_for_new_turn.assert_awaited_once()
     fake_svc.should_seed_initial_artifact.assert_awaited_once_with(agent_session)
     fake_svc.build_initial_artifact.assert_not_awaited()
-    fake_svc.run_turn.assert_awaited_once_with(
-        session_id=session_id,
-        request=request,
-    )
-    fake_stream.abort_new_turn.assert_awaited_once()
+    fake_svc.run_turn.assert_awaited_once()
+    # Startup failure surfaces a terminal frame + clears the active-turn pointers.
+    fake_stream.error.assert_awaited_once()
+    fake_stream.done.assert_awaited_once()
+    fake_svc.clear_active_turn.assert_awaited_once()
+    clear_call = fake_svc.clear_active_turn.await_args
+    assert clear_call.args == (session_id,)
+    # Compare-and-clear: must scope the clear to the per-turn stream id minted at
+    # the HTTP layer so a concurrent newer turn's pointers are not clobbered.
+    assert isinstance(clear_call.kwargs["expected_stream_id"], uuid.UUID)
     fake_stream.sse.assert_not_called()
 
 
@@ -794,8 +893,8 @@ async def test_send_message_does_not_reset_stream_when_validation_fails() -> Non
         run_turn=AsyncMock(return_value=None),
     )
     fake_stream = SimpleNamespace(
-        reset_for_new_turn=AsyncMock(return_value=None),
-        abort_new_turn=AsyncMock(return_value=None),
+        error=AsyncMock(return_value=None),
+        done=AsyncMock(return_value=None),
         sse=Mock(return_value=_empty_event_stream()),
     )
 
@@ -823,9 +922,9 @@ async def test_send_message_does_not_reset_stream_when_validation_fails() -> Non
 
     assert exc_info.value.status_code == 404
     with_session_mock.assert_called_once_with(role=role)
-    stream_new_mock.assert_awaited_once_with(session_id, workspace_id)
-    fake_stream.reset_for_new_turn.assert_not_awaited()
-    fake_stream.abort_new_turn.assert_not_awaited()
+    # The stream is created only after validation passes, so a validation
+    # failure never mints a stream.
+    stream_new_mock.assert_not_awaited()
     fake_stream.sse.assert_not_called()
     fake_svc.run_turn.assert_not_awaited()
 
@@ -869,8 +968,8 @@ async def test_send_message_requires_entitlement_for_workspace_chat_parent() -> 
         run_turn=AsyncMock(return_value=None),
     )
     fake_stream = SimpleNamespace(
-        reset_for_new_turn=AsyncMock(return_value=None),
-        abort_new_turn=AsyncMock(return_value=None),
+        error=AsyncMock(return_value=None),
+        done=AsyncMock(return_value=None),
         sse=Mock(return_value=_empty_event_stream()),
     )
 
@@ -900,7 +999,6 @@ async def test_send_message_requires_entitlement_for_workspace_chat_parent() -> 
                 ),
             )
 
-    fake_stream.reset_for_new_turn.assert_not_awaited()
     fake_svc.run_turn.assert_not_awaited()
 
 
@@ -954,8 +1052,8 @@ def _make_stream_role(workspace_id: uuid.UUID) -> Role:
 
 
 @pytest.mark.anyio
-async def test_stream_session_events_returns_204_when_no_turn_started() -> None:
-    """last_stream_id=None with no Last-Event-ID header returns 204."""
+async def test_stream_session_events_returns_204_when_no_turn() -> None:
+    """No live run (lifecycle NONE) with no Last-Event-ID returns 204."""
     session_id = uuid.uuid4()
     workspace_id = uuid.uuid4()
     role = _make_stream_role(workspace_id)
@@ -963,10 +1061,13 @@ async def test_stream_session_events_returns_204_when_no_turn_started() -> None:
     fake_session = SimpleNamespace(
         entity_type=AgentSessionEntity.AGENT_PRESET,
         last_stream_id=None,
+        active_stream_id=None,
+        curr_run_id=None,
     )
     fake_svc = SimpleNamespace(
         session=AsyncMock(),
         get_session=AsyncMock(return_value=fake_session),
+        get_turn_lifecycle=AsyncMock(return_value=(TurnLifecycle.NONE, None)),
     )
     fake_stream = SimpleNamespace(sse=Mock(return_value=_empty_event_stream()))
 
@@ -993,20 +1094,23 @@ async def test_stream_session_events_returns_204_when_no_turn_started() -> None:
 
 
 @pytest.mark.anyio
-async def test_stream_session_events_attaches_when_turn_in_progress_no_events_yet() -> (
-    None
-):
+async def test_stream_session_events_returns_204_when_completed() -> None:
+    """A COMPLETED turn returns 204; the client refetches DB history."""
     session_id = uuid.uuid4()
     workspace_id = uuid.uuid4()
+    run_id = uuid.uuid4()
     role = _make_stream_role(workspace_id)
 
     fake_session = SimpleNamespace(
         entity_type=AgentSessionEntity.AGENT_PRESET,
-        last_stream_id="0-0",
+        last_stream_id=None,
+        active_stream_id=None,
+        curr_run_id=run_id,
     )
     fake_svc = SimpleNamespace(
         session=AsyncMock(),
         get_session=AsyncMock(return_value=fake_session),
+        get_turn_lifecycle=AsyncMock(return_value=(TurnLifecycle.COMPLETED, run_id)),
     )
     fake_stream = SimpleNamespace(sse=Mock(return_value=_empty_event_stream()))
 
@@ -1019,6 +1123,99 @@ async def test_stream_session_events_attaches_when_turn_in_progress_no_events_ye
             "tracecat.agent.session.router.AgentStream.new",
             AsyncMock(return_value=fake_stream),
         ),
+    ):
+        raw = cast(Any, stream_session_events).__wrapped__
+        response = await raw(
+            role=role,
+            request=SimpleNamespace(headers={"Last-Event-ID": "1-0"}),
+            session_id=session_id,
+        )
+
+    assert isinstance(response, Response)
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    fake_stream.sse.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_stream_session_events_emits_terminal_frame_when_failed() -> None:
+    """A FAILED/TERMINATED turn emits a finishing stream so clients don't hang."""
+    session_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    run_id = uuid.uuid4()
+    stream_id = uuid.uuid4()
+    role = _make_stream_role(workspace_id)
+
+    fake_session = SimpleNamespace(
+        entity_type=AgentSessionEntity.AGENT_PRESET,
+        last_stream_id=None,
+        active_stream_id=stream_id,
+        curr_run_id=run_id,
+    )
+    fake_svc = SimpleNamespace(
+        session=AsyncMock(),
+        get_session=AsyncMock(return_value=fake_session),
+        get_turn_lifecycle=AsyncMock(return_value=(TurnLifecycle.FAILED, run_id)),
+    )
+    fake_stream = SimpleNamespace(
+        finished_sse=Mock(return_value=_empty_event_stream()),
+        sse=Mock(return_value=_empty_event_stream()),
+    )
+
+    with (
+        patch(
+            "tracecat.agent.session.router.AgentSessionService.with_session",
+            return_value=_AsyncContext(fake_svc),
+        ),
+        patch(
+            "tracecat.agent.session.router.AgentStream.new",
+            AsyncMock(return_value=fake_stream),
+        ),
+    ):
+        raw = cast(Any, stream_session_events).__wrapped__
+        response = await raw(
+            role=role,
+            request=SimpleNamespace(headers={}),
+            session_id=session_id,
+        )
+
+    assert isinstance(response, StreamingResponse)
+    fake_stream.finished_sse.assert_called_once()
+    fake_stream.sse.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_stream_session_events_attaches_when_running_no_cursor() -> None:
+    """RUNNING with no Last-Event-ID joins the per-turn stream from 0-0."""
+    session_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    run_id = uuid.uuid4()
+    stream_id = uuid.uuid4()
+    role = _make_stream_role(workspace_id)
+
+    fake_session = SimpleNamespace(
+        entity_type=AgentSessionEntity.AGENT_PRESET,
+        last_stream_id=None,
+        active_stream_id=stream_id,
+        curr_run_id=run_id,
+    )
+    fake_svc = SimpleNamespace(
+        session=AsyncMock(),
+        get_session=AsyncMock(return_value=fake_session),
+        get_turn_lifecycle=AsyncMock(return_value=(TurnLifecycle.RUNNING, run_id)),
+    )
+    fake_stream = SimpleNamespace(
+        sse=Mock(return_value=_empty_event_stream()),
+    )
+
+    with (
+        patch(
+            "tracecat.agent.session.router.AgentSessionService.with_session",
+            return_value=_AsyncContext(fake_svc),
+        ),
+        patch(
+            "tracecat.agent.session.router.AgentStream.new",
+            AsyncMock(return_value=fake_stream),
+        ) as stream_new_mock,
     ):
         raw = cast(Any, stream_session_events).__wrapped__
         response = await raw(
@@ -1031,23 +1228,40 @@ async def test_stream_session_events_attaches_when_turn_in_progress_no_events_ye
 
     assert isinstance(response, StreamingResponse)
     fake_stream.sse.assert_called_once()
+    assert fake_stream.sse.call_args.kwargs["last_id"] == "0-0"
+    # bubble id is session:run and the stream key is the per-turn active id.
+    assert fake_stream.sse.call_args.kwargs["message_id"] == f"{session_id}:{run_id}"
+    stream_new_mock.assert_awaited_with(session_id, workspace_id, stream_id)
 
 
 @pytest.mark.anyio
-async def test_stream_session_events_attaches_when_last_event_id_present() -> None:
+async def test_stream_session_events_running_always_replays_from_start() -> None:
+    """A RUNNING reconnect ignores any Last-Event-ID and replays from 0-0.
+
+    The mid-turn DB load hides the active run's rows, so Redis is the sole source
+    for the live assistant; a partial cursor resume would drop everything before
+    the cursor. We therefore always replay the whole active turn on reconnect.
+    """
     session_id = uuid.uuid4()
     workspace_id = uuid.uuid4()
+    run_id = uuid.uuid4()
+    stream_id = uuid.uuid4()
     role = _make_stream_role(workspace_id)
 
     fake_session = SimpleNamespace(
         entity_type=AgentSessionEntity.AGENT_PRESET,
         last_stream_id=None,
+        active_stream_id=stream_id,
+        curr_run_id=run_id,
     )
     fake_svc = SimpleNamespace(
         session=AsyncMock(),
         get_session=AsyncMock(return_value=fake_session),
+        get_turn_lifecycle=AsyncMock(return_value=(TurnLifecycle.RUNNING, run_id)),
     )
-    fake_stream = SimpleNamespace(sse=Mock(return_value=_empty_event_stream()))
+    fake_stream = SimpleNamespace(
+        sse=Mock(return_value=_empty_event_stream()),
+    )
 
     with (
         patch(
@@ -1063,7 +1277,8 @@ async def test_stream_session_events_attaches_when_last_event_id_present() -> No
         response = await raw(
             role=role,
             request=SimpleNamespace(
-                headers={"Last-Event-ID": "1234-0"},
+                # Even with a fresh-looking cursor, the server replays from 0-0.
+                headers={"Last-Event-ID": "1234-0:0"},
                 is_disconnected=AsyncMock(return_value=False),
             ),
             session_id=session_id,
@@ -1071,6 +1286,8 @@ async def test_stream_session_events_attaches_when_last_event_id_present() -> No
 
     assert isinstance(response, StreamingResponse)
     fake_stream.sse.assert_called_once()
+    assert fake_stream.sse.call_args.kwargs["last_id"] == "0-0"
+    assert fake_stream.sse.call_args.kwargs["resume_from"] is None
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_session_router.py
+++ b/tests/unit/test_agent_session_router.py
@@ -447,7 +447,9 @@ async def test_send_message_continue_uses_path_session_id_for_stream_key() -> No
     with_session_mock.assert_called_once_with(role=role)
     # Continuation reuses the existing per-turn stream id (None here).
     stream_new_mock.assert_awaited_once_with(
-        session_id, workspace_id, agent_session.active_stream_id
+        session_id=session_id,
+        workspace_id=workspace_id,
+        stream_id=agent_session.active_stream_id,
     )
     fake_svc.validate_turn_request.assert_awaited_once_with(
         session_id=session_id,
@@ -530,10 +532,10 @@ async def test_send_message_new_turn_uses_fresh_per_turn_stream() -> None:
     # and run_turn (same value).
     await_args = stream_new_mock.await_args
     assert await_args is not None
-    new_call_args = await_args.args
-    assert new_call_args[0] == session_id
-    assert new_call_args[1] == workspace_id
-    minted_stream_id = new_call_args[2]
+    new_call_kwargs = await_args.kwargs
+    assert new_call_kwargs["session_id"] == session_id
+    assert new_call_kwargs["workspace_id"] == workspace_id
+    minted_stream_id = new_call_kwargs["stream_id"]
     assert isinstance(minted_stream_id, uuid.UUID)
     fake_svc.run_turn.assert_awaited_once_with(
         session_id=session_id,
@@ -1231,7 +1233,9 @@ async def test_stream_session_events_attaches_when_running_no_cursor() -> None:
     assert fake_stream.sse.call_args.kwargs["last_id"] == "0-0"
     # bubble id is session:run and the stream key is the per-turn active id.
     assert fake_stream.sse.call_args.kwargs["message_id"] == f"{session_id}:{run_id}"
-    stream_new_mock.assert_awaited_with(session_id, workspace_id, stream_id)
+    stream_new_mock.assert_awaited_with(
+        session_id=session_id, workspace_id=workspace_id, stream_id=stream_id
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_stream_connector.py
+++ b/tests/unit/test_agent_stream_connector.py
@@ -15,7 +15,34 @@ from tracecat.redis.client import RedisClient
 
 
 @pytest.mark.anyio
-async def test_abort_new_turn_clears_buffer_and_saved_cursor() -> None:
+async def test_per_turn_stream_key_includes_stream_id() -> None:
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    stream_id = uuid.uuid4()
+    client = SimpleNamespace(delete=AsyncMock(return_value=1))
+
+    per_turn = AgentStream(
+        client=cast(RedisClient, client),
+        workspace_id=workspace_id,
+        session_id=session_id,
+        stream_id=stream_id,
+    )
+    per_session = AgentStream(
+        client=cast(RedisClient, client),
+        workspace_id=workspace_id,
+        session_id=session_id,
+    )
+
+    assert per_turn._stream_key == (
+        f"agent-stream:{workspace_id}:{session_id}:{stream_id}"
+    )
+    assert per_session._stream_key == f"agent-stream:{workspace_id}:{session_id}"
+    # A new turn's key never collides with a prior turn's key.
+    assert per_turn._stream_key != per_session._stream_key
+
+
+@pytest.mark.anyio
+async def test_clear_buffer_deletes_key_without_cursor_write() -> None:
     workspace_id = uuid.uuid4()
     session_id = uuid.uuid4()
     client = SimpleNamespace(delete=AsyncMock(return_value=1))
@@ -25,12 +52,28 @@ async def test_abort_new_turn_clears_buffer_and_saved_cursor() -> None:
         session_id=session_id,
     )
 
-    stream._set_last_stream_id = AsyncMock()
-
-    await stream.abort_new_turn()
+    await stream.clear_buffer()
 
     client.delete.assert_awaited_once_with(stream._stream_key)
-    stream._set_last_stream_id.assert_awaited_once_with(None)
+
+
+@pytest.mark.anyio
+async def test_min_entry_id_returns_oldest_or_none() -> None:
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    client = SimpleNamespace(
+        xrange=AsyncMock(return_value=[("1717426372768-0", {})]),
+    )
+    stream = AgentStream(
+        client=cast(RedisClient, client),
+        workspace_id=workspace_id,
+        session_id=session_id,
+    )
+
+    assert await stream.min_entry_id() == "1717426372768-0"
+
+    client.xrange = AsyncMock(return_value=[])
+    assert await stream.min_entry_id() is None
 
 
 @pytest.mark.anyio
@@ -67,8 +110,6 @@ async def test_stream_events_yields_artifact_unified_event() -> None:
         session_id=session_id,
     )
 
-    stream._set_last_stream_id = AsyncMock()
-
     events = [
         event
         async for event in stream._stream_events(
@@ -91,7 +132,7 @@ async def test_stream_events_yields_artifact_unified_event() -> None:
 
 
 @pytest.mark.anyio
-async def test_stream_events_clears_buffer_after_terminal_marker() -> None:
+async def test_stream_events_expires_buffer_after_terminal_marker() -> None:
     workspace_id = uuid.uuid4()
     session_id = uuid.uuid4()
     raw_client = SimpleNamespace(expire=AsyncMock(return_value=None))
@@ -120,8 +161,6 @@ async def test_stream_events_clears_buffer_after_terminal_marker() -> None:
         session_id=session_id,
     )
 
-    stream._set_last_stream_id = AsyncMock()
-
     events = [
         event
         async for event in stream._stream_events(
@@ -132,7 +171,7 @@ async def test_stream_events_clears_buffer_after_terminal_marker() -> None:
 
     assert isinstance(event, StreamEnd)
 
-    stream._set_last_stream_id.assert_awaited_once_with(None)
+    # Readers never write last_stream_id; terminal only shortens the buffer TTL.
     raw_client.expire.assert_awaited_once_with(
         name=stream._stream_key,
         time=stream.COMPLETED_STREAM_TTL_SECONDS,
@@ -140,7 +179,7 @@ async def test_stream_events_clears_buffer_after_terminal_marker() -> None:
 
 
 @pytest.mark.anyio
-async def test_stream_events_preserves_cursor_when_stream_not_completed() -> None:
+async def test_stream_events_does_not_expire_when_not_completed() -> None:
     workspace_id = uuid.uuid4()
     session_id = uuid.uuid4()
     raw_client = SimpleNamespace(expire=AsyncMock(return_value=None))
@@ -170,7 +209,6 @@ async def test_stream_events_preserves_cursor_when_stream_not_completed() -> Non
     )
 
     stop_condition = AsyncMock(side_effect=[False, True])
-    stream._set_last_stream_id = AsyncMock()
 
     events = [
         event async for event in stream._stream_events(stop_condition, last_id="0-0")
@@ -178,5 +216,4 @@ async def test_stream_events_preserves_cursor_when_stream_not_completed() -> Non
 
     assert len(events) == 1
     assert isinstance(events[0], StreamDelta)
-    stream._set_last_stream_id.assert_awaited()
     raw_client.expire.assert_not_awaited()

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -15,6 +15,7 @@ from tracecat_ee.agent.activities import BuildToolDefsArgs, BuildToolDefsResult
 from tracecat_ee.agent.workflows.durable import (
     BUILD_AGENT_TOOL_DEFINITIONS_PATCH,
     EMIT_PRE_STREAM_SESSION_ERRORS_PATCH,
+    FINALIZE_TURN_PATCH,
     LOAD_TERMINAL_MESSAGE_HISTORY_PATCH,
     UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH,
     AgentWorkflowArgs,
@@ -201,7 +202,12 @@ async def test_run_skips_search_attribute_upsert_without_patch_marker() -> None:
     ):
         result = await workflow_instance.run(workflow_args)
 
-    patched_mock.assert_called_once_with(UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH)
+    # run() gates the search-attribute upsert (entry) and finalize_turn (finally)
+    # behind patch markers; legacy histories see False for both.
+    assert patched_mock.call_args_list == [
+        ((UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH,),),
+        ((FINALIZE_TURN_PATCH,),),
+    ]
     upsert_mock.assert_not_called()
     run_mock.assert_awaited_once_with(workflow_args, cfg)
     assert result == expected_output
@@ -234,7 +240,7 @@ async def test_run_skips_activity_error_emission_without_patch_marker() -> None:
     with (
         patch(
             "tracecat_ee.agent.workflows.durable.workflow.patched",
-            side_effect=[False, False],
+            side_effect=[False, False, False],
         ) as patched_mock,
         patch(
             "tracecat_ee.agent.workflows.durable.workflow.unsafe.is_replaying",
@@ -258,6 +264,7 @@ async def test_run_skips_activity_error_emission_without_patch_marker() -> None:
     assert patched_mock.call_args_list == [
         ((UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH,),),
         ((EMIT_PRE_STREAM_SESSION_ERRORS_PATCH,),),
+        ((FINALIZE_TURN_PATCH,),),
     ]
     emit_error_mock.assert_not_awaited()
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -8062,7 +8062,7 @@ async def test_get_agent_preset_returns_full_configuration(
 @pytest.mark.parametrize(
     ("last_stream_id", "expected_start_id"),
     [
-        ("1717426372766-0", "1717426372766-0"),
+        ("1717426372766-0", "0-0"),
         (None, "0-0"),
     ],
 )
@@ -8100,7 +8100,14 @@ async def test_run_agent_preset_uses_session_stream_cursor(
             created_session_request["value"] = create
             return session
 
-        async def run_turn(self, _session_id: uuid.UUID, _request: Any) -> None:
+        async def run_turn(
+            self,
+            _session_id: uuid.UUID,
+            _request: Any,
+            *,
+            active_stream_id: uuid.UUID | None = None,
+        ) -> None:
+            captured["active_stream_id"] = active_stream_id
             return None
 
     captured: dict[str, Any] = {}
@@ -8110,11 +8117,13 @@ async def test_run_agent_preset_uses_session_stream_cursor(
         workspace_id_arg: uuid.UUID,
         timeout: float,
         last_id: str,
+        stream_id: uuid.UUID | None = None,
     ) -> str:
         captured["session_id"] = session_id
         captured["workspace_id"] = workspace_id_arg
         captured["timeout"] = timeout
         captured["last_id"] = last_id
+        captured["stream_id"] = stream_id
         return "agent response"
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
@@ -8143,6 +8152,9 @@ async def test_run_agent_preset_uses_session_stream_cursor(
     assert captured["workspace_id"] == workspace_id
     assert captured["timeout"] == 120
     assert captured["last_id"] == expected_start_id
+    # Producer (run_turn) and consumer (_collect) must share the minted id.
+    assert captured["stream_id"] is not None
+    assert captured["stream_id"] == captured["active_stream_id"]
 
 
 @pytest.mark.anyio
@@ -10001,7 +10013,11 @@ async def test_collect_agent_response_returns_text(
             )
             yield StreamEnd(id="1717426372769-0")
 
-    async def _new(_session_id: uuid.UUID, _workspace_id: uuid.UUID) -> _Stream:
+    async def _new(
+        _session_id: uuid.UUID,
+        _workspace_id: uuid.UUID,
+        _stream_id: uuid.UUID | None = None,
+    ) -> _Stream:
         return _Stream()
 
     monkeypatch.setattr(mcp_server.AgentStream, "new", _new)
@@ -10046,7 +10062,11 @@ async def test_collect_agent_response_surfaces_approval_requests(
             )
             yield StreamEnd(id="1717426372769-0")
 
-    async def _new(_session_id: uuid.UUID, _workspace_id: uuid.UUID) -> _Stream:
+    async def _new(
+        _session_id: uuid.UUID,
+        _workspace_id: uuid.UUID,
+        _stream_id: uuid.UUID | None = None,
+    ) -> _Stream:
         return _Stream()
 
     monkeypatch.setattr(mcp_server.AgentStream, "new", _new)

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -10014,9 +10014,10 @@ async def test_collect_agent_response_returns_text(
             yield StreamEnd(id="1717426372769-0")
 
     async def _new(
-        _session_id: uuid.UUID,
-        _workspace_id: uuid.UUID,
-        _stream_id: uuid.UUID | None = None,
+        *,
+        session_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        stream_id: uuid.UUID | None = None,
     ) -> _Stream:
         return _Stream()
 
@@ -10063,9 +10064,10 @@ async def test_collect_agent_response_surfaces_approval_requests(
             yield StreamEnd(id="1717426372769-0")
 
     async def _new(
-        _session_id: uuid.UUID,
-        _workspace_id: uuid.UUID,
-        _stream_id: uuid.UUID | None = None,
+        *,
+        session_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        stream_id: uuid.UUID | None = None,
     ) -> _Stream:
         return _Stream()
 

--- a/tests/unit/test_vercel_sse_resume.py
+++ b/tests/unit/test_vercel_sse_resume.py
@@ -1,0 +1,159 @@
+"""SSE composite-id + resume behaviour for the Vercel adapter stream."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from tracecat.agent.adapter.vercel import sse_vercel
+from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
+from tracecat.agent.stream.events import (
+    StreamDelta,
+    StreamEnd,
+    StreamEvent,
+    parse_vercel_frame_cursor,
+)
+
+
+def _text_start(part_id: int = 0) -> UnifiedStreamEvent:
+    return UnifiedStreamEvent(type=StreamEventType.TEXT_START, part_id=part_id)
+
+
+def _text_delta(text: str, part_id: int = 0) -> UnifiedStreamEvent:
+    return UnifiedStreamEvent(
+        type=StreamEventType.TEXT_DELTA, part_id=part_id, text=text
+    )
+
+
+async def _events(*events: StreamEvent) -> AsyncIterator[StreamEvent]:
+    for event in events:
+        yield event
+
+
+def _parse_frames(raw: list[str]) -> list[tuple[str | None, str]]:
+    """Return (id, data) for each SSE frame that carries a data line."""
+    out: list[tuple[str | None, str]] = []
+    for chunk in raw:
+        sse_id: str | None = None
+        data: str | None = None
+        for line in chunk.splitlines():
+            if line.startswith("id: "):
+                sse_id = line[len("id: ") :]
+            elif line.startswith("data: "):
+                data = line[len("data: ") :]
+        if data is not None:
+            out.append((sse_id, data))
+    return out
+
+
+def test_parse_vercel_frame_cursor() -> None:
+    cursor = parse_vercel_frame_cursor("1700000000-0:3")
+    assert cursor is not None
+    assert cursor.redis_id == "1700000000-0"
+    assert cursor.frame_index == 3
+
+    assert parse_vercel_frame_cursor(None) is None
+    assert parse_vercel_frame_cursor("") is None
+    # No frame-index segment -> not a composite cursor.
+    assert parse_vercel_frame_cursor("1700000000-0") is None
+
+
+@pytest.mark.anyio
+async def test_sse_vercel_emits_composite_ids() -> None:
+    frames = [
+        chunk
+        async for chunk in sse_vercel(
+            _events(
+                StreamDelta(id="1000-0", event=_text_start()),
+                StreamDelta(id="1001-0", event=_text_delta("hello")),
+                StreamEnd(id="1002-0"),
+            ),
+            message_id="session:run",
+        )
+    ]
+    parsed = _parse_frames(frames)
+
+    # The start frame carries the stable bubble id.
+    assert any('"messageId":"session:run"' in data for _, data in parsed)
+    # Frames fanned from entry 1001-0 carry composite redis_id:frame_index ids.
+    delta_ids = [
+        sse_id for sse_id, _ in parsed if sse_id and sse_id.startswith("1001-0:")
+    ]
+    assert delta_ids, parsed
+    assert delta_ids[0] == "1001-0:0"
+
+
+@pytest.mark.anyio
+async def test_sse_vercel_omits_start_when_no_message_id() -> None:
+    frames = [
+        chunk
+        async for chunk in sse_vercel(
+            _events(StreamEnd(id="1001-0")),
+            message_id=None,
+        )
+    ]
+    # No StartEvent (messageId) frame when there is no bubble id.
+    assert not any('"type":"start"' in chunk for chunk in frames)
+    # Still terminates cleanly.
+    assert any("[DONE]" in chunk for chunk in frames)
+
+
+@pytest.mark.anyio
+async def test_sse_vercel_resume_mid_text_preserves_tail() -> None:
+    """Resuming mid-text-block renders the tail (no loss) and re-sends nothing.
+
+    The TEXT_START is in an entry before the cursor, so the fresh context never
+    re-reads it. Without the self-heal, every delta after the cursor would hit
+    "unknown part" and be silently dropped. The fix opens a repair part so the
+    tail renders, while the already-seen delta at the cursor is still dropped.
+    """
+    # Original stream: start@1000-0, "world"@1001-0, "!"@1002-0. Client's cursor
+    # is 1001-0:0 (it saw "world"). Resume re-reads from 1001-0 onward; the start
+    # at 1000-0 is NOT re-read.
+    frames = [
+        chunk
+        async for chunk in sse_vercel(
+            _events(
+                StreamDelta(id="1001-0", event=_text_delta("world")),
+                StreamDelta(id="1002-0", event=_text_delta("!")),
+                StreamEnd(id="1003-0"),
+            ),
+            message_id="session:run",
+            resume_from="1001-0:0",
+        )
+    ]
+    parsed = _parse_frames(frames)
+    deltas = [data for _, data in parsed if '"type":"text-delta"' in data]
+    # The already-seen "world" is dropped; only the tail "!" is re-emitted.
+    assert len(deltas) == 1
+    assert '"delta":"!"' in deltas[0]
+    # The repair text-start carries no id (it is not a resumable position).
+    text_starts = [(sse_id, data) for sse_id, data in parsed if '"text-start"' in data]
+    assert text_starts
+    assert all(sse_id is None for sse_id, _ in text_starts)
+
+
+@pytest.mark.anyio
+async def test_sse_vercel_resume_drops_seen_frames() -> None:
+    # Resume from frame 0 of entry 1001-0: that frame must be dropped, later
+    # entries kept.
+    frames = [
+        chunk
+        async for chunk in sse_vercel(
+            _events(
+                StreamDelta(id="1000-0", event=_text_start()),
+                StreamDelta(id="1001-0", event=_text_delta("a")),
+                StreamDelta(id="1002-0", event=_text_delta("b")),
+                StreamEnd(id="1003-0"),
+            ),
+            message_id="session:run",
+            resume_from="1001-0:0",
+        )
+    ]
+    parsed = _parse_frames(frames)
+    emitted_ids = [sse_id for sse_id, _ in parsed if sse_id]
+    # The already-seen frame 1001-0:0 is not re-emitted.
+    assert "1001-0:0" not in emitted_ids
+    # A later entry's frame is still emitted.
+    assert any(sse_id and sse_id.startswith("1002-0:") for sse_id in emitted_ids)

--- a/tests/unit/test_vercel_sse_resume.py
+++ b/tests/unit/test_vercel_sse_resume.py
@@ -7,12 +7,15 @@ from collections.abc import AsyncIterator
 import pytest
 
 from tracecat.agent.adapter.vercel import sse_vercel
-from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
+from tracecat.agent.common.stream_types import (
+    StreamEventType,
+    UnifiedStreamEvent,
+    parse_vercel_frame_cursor,
+)
 from tracecat.agent.stream.events import (
     StreamDelta,
     StreamEnd,
     StreamEvent,
-    parse_vercel_frame_cursor,
 )
 
 

--- a/tests/unit/test_vercel_stream_context.py
+++ b/tests/unit/test_vercel_stream_context.py
@@ -767,19 +767,33 @@ async def test_multiple_tools_concurrent():
 
 
 @pytest.mark.anyio
-async def test_delta_for_unknown_part_index():
-    """Test delta for unknown part index logs warning but doesn't crash."""
+async def test_delta_for_unknown_part_index_self_heals():
+    """A delta for an unopened part lazily opens one (resume self-heal).
+
+    On reconnect, a TEXT_DELTA can arrive without its TEXT_START (the start was
+    emitted before the cursor). Instead of dropping it, the adapter opens a fresh
+    text part so the tail renders. The synthesized start is flagged as a repair
+    frame so sse_vercel doesn't count it toward the composite frame index.
+    """
     ctx = VercelStreamContext(message_id="msg_test")
 
-    # Send delta without starting a part
     events = [
         UnifiedStreamEvent(type=StreamEventType.TEXT_DELTA, part_id=99, text="orphan"),
     ]
 
     frames = await collect_frames(ctx, events)
 
-    # Should handle gracefully with no frames
-    assert len(frames) == 0
+    # A start + the delta are emitted under one fresh part id (collect_frames
+    # also finalizes the open part at the end -> trailing text-end).
+    assert len(frames) == 3
+    start, delta, end = frames
+    assert isinstance(start, TextStartEventPayload)
+    assert isinstance(delta, TextDeltaEventPayload)
+    assert isinstance(end, TextEndEventPayload)
+    assert start.id == delta.id == end.id
+    assert delta.delta == "orphan"
+    # The synthesized start is marked as a repair frame for sse_vercel.
+    assert ctx.repair_frames == 1
 
 
 @pytest.mark.anyio

--- a/tracecat/agent/adapter/vercel.py
+++ b/tracecat/agent/adapter/vercel.py
@@ -60,7 +60,11 @@ from pydantic_ai.messages import (
 from pydantic_core import to_json
 
 from tracecat.agent.approvals.enums import ApprovalStatus
-from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
+from tracecat.agent.common.stream_types import (
+    StreamEventType,
+    UnifiedStreamEvent,
+    parse_vercel_frame_cursor,
+)
 from tracecat.agent.mcp.metadata import strip_proxy_tool_metadata
 from tracecat.agent.mcp.utils import normalize_mcp_tool_name
 from tracecat.agent.stream.events import (
@@ -70,7 +74,6 @@ from tracecat.agent.stream.events import (
     StreamEvent,
     StreamKeepAlive,
     StreamMessage,
-    parse_vercel_frame_cursor,
 )
 from tracecat.agent.types import UnifiedMessage
 from tracecat.artifacts.schemas import ARTIFACT_DATA_PART_TYPE

--- a/tracecat/agent/adapter/vercel.py
+++ b/tracecat/agent/adapter/vercel.py
@@ -70,6 +70,7 @@ from tracecat.agent.stream.events import (
     StreamEvent,
     StreamKeepAlive,
     StreamMessage,
+    parse_vercel_frame_cursor,
 )
 from tracecat.agent.types import UnifiedMessage
 from tracecat.artifacts.schemas import ARTIFACT_DATA_PART_TYPE
@@ -730,9 +731,14 @@ VercelSSEPayload = (
 )
 
 
-def format_sse(data: VercelSSEPayload) -> str:
-    """Formats a dictionary into a Server-Sent Event string."""
-    return f"data: {to_json(data).decode()}\n\n"
+def format_sse(data: VercelSSEPayload, sse_id: str | None = None) -> str:
+    """Formats a payload into a Server-Sent Event string.
+
+    When ``sse_id`` is given, emit an ``id:`` line so the browser records it as
+    the Last-Event-ID for reconnect.
+    """
+    prefix = f"id: {sse_id}\n" if sse_id else ""
+    return f"{prefix}data: {to_json(data).decode()}\n\n"
 
 
 @dataclasses.dataclass
@@ -754,7 +760,7 @@ class VercelStreamContext:
     consistent start/delta/end sequences required by the Vercel protocol.
     """
 
-    message_id: str
+    message_id: str | None
     # Active parts keyed by event index -> maintains per-part lifecycle state.
     part_states: dict[int, _PartState] = dataclasses.field(default_factory=dict)
     tool_finished: dict[str, bool] = dataclasses.field(default_factory=dict)
@@ -766,6 +772,11 @@ class VercelStreamContext:
     # Cache approval data for continuation reconstruction
     approval_tool_name: dict[str, str] = dataclasses.field(default_factory=dict)
     approval_input: dict[str, Any] = dataclasses.field(default_factory=dict)
+    # Count of repair frames synthesized on resume (a *_DELTA reopening a part
+    # whose start was emitted before the reconnect cursor). These frames did not
+    # exist in the original stream, so sse_vercel must emit them but neither count
+    # them toward the composite frame index nor apply the resume-drop filter.
+    repair_frames: int = 0
 
     def _create_part_state(
         self,
@@ -872,11 +883,15 @@ class VercelStreamContext:
                 if event.part_id is not None:
                     state = self.part_states.get(event.part_id)
                     if state is None:
-                        logger.warning(
-                            "Received delta for unknown part index",
-                            index=event.part_id,
-                        )
-                    elif event.text:
+                        # Resume landed mid-text-block: the TEXT_START was emitted
+                        # before the reconnect cursor, so this fresh context never
+                        # opened the part. Lazily open one so the tail renders as a
+                        # new text part in the same bubble instead of vanishing.
+                        # This start is a repair frame (not in the original stream).
+                        state = self._create_part_state(event.part_id, "text")
+                        self.repair_frames += 1
+                        yield TextStartEventPayload(id=state.part_id)
+                    if event.text:
                         yield TextDeltaEventPayload(id=state.part_id, delta=event.text)
 
             case StreamEventType.TEXT_STOP:
@@ -900,7 +915,14 @@ class VercelStreamContext:
             case StreamEventType.THINKING_DELTA:
                 if event.part_id is not None:
                     state = self.part_states.get(event.part_id)
-                    if state and event.thinking:
+                    if state is None:
+                        # Resume landed mid-thinking-block (see TEXT_DELTA above):
+                        # lazily open a reasoning part so the tail isn't dropped.
+                        # This start is a repair frame (not in the original stream).
+                        state = self._create_part_state(event.part_id, "reasoning")
+                        self.repair_frames += 1
+                        yield ReasoningStartEventPayload(id=state.part_id)
+                    if event.thinking:
                         yield ReasoningDeltaEventPayload(
                             id=state.part_id, delta=event.thinking
                         )
@@ -1771,24 +1793,72 @@ def convert_chat_messages_to_ui(
     return UIMessagesTA.validate_python(raw_messages)
 
 
-async def sse_vercel(events: AsyncIterable[StreamEvent]) -> AsyncIterable[str]:
-    """Stream Redis events as Vercel AI SDK frames without persisting adapter output."""
+async def sse_vercel(
+    events: AsyncIterable[StreamEvent],
+    *,
+    message_id: str | None,
+    resume_from: str | None = None,
+) -> AsyncIterable[str]:
+    """Stream Redis events as Vercel AI SDK frames without persisting adapter output.
 
-    message_id = f"msg_{uuid.uuid4().hex}"
+    ``message_id`` is the stable assistant-bubble id (``session_id:curr_run_id``)
+    so reconnects within a turn resume the same bubble instead of spawning a new
+    one. It is omitted for terminal reconnects where no run id can be resolved.
+
+    Each Redis entry can fan out to many Vercel frames, so frames carry a
+    composite ``id: {redis_id}:{frame_index}`` that the browser sends back as
+    ``Last-Event-ID``. On resume we re-fan the cursor entry and drop the frames
+    the client already saw (``resume_from``).
+    """
+
     context = VercelStreamContext(message_id=message_id)
+    resume_cursor = parse_vercel_frame_cursor(resume_from)
+
+    # Composite-id state: the Redis id of the entry currently fanning out and a
+    # per-entry frame counter. emit() omits id: when redis_id is None.
+    redis_id: str | None = None
+    frame_index = 0
+
+    def emit(payload: VercelSSEPayload) -> str | None:
+        nonlocal frame_index
+        # Repair frames (a part-start the handler synthesized on resume because
+        # the real start was before the cursor) did not exist in the original
+        # stream. Always emit them and do NOT consume a frame index, so the real
+        # frames keep their original indices and the drop math stays correct.
+        # They carry no id: the client never needs to resume *to* a synthesized
+        # frame, and reusing the next real frame's id would collide.
+        if context.repair_frames > 0:
+            context.repair_frames -= 1
+            return format_sse(payload)
+        sse_id = f"{redis_id}:{frame_index}" if redis_id else None
+        current_frame_index = frame_index
+        frame_index += 1
+        # Drop frames at or before the resume cursor within its entry: the client
+        # already rendered them.
+        if (
+            resume_cursor is not None
+            and redis_id == resume_cursor.redis_id
+            and current_frame_index <= resume_cursor.frame_index
+        ):
+            return None
+        return format_sse(payload, sse_id)
 
     try:
         # 1. Start of the message stream
-        yield format_sse(StartEventPayload(messageId=message_id))
+        if message_id is not None:
+            yield format_sse(StartEventPayload(messageId=message_id))
 
         # 2. Process events from Redis stream
         async for stream_event in events:
             match stream_event:
-                case StreamDelta(event=agent_event):
+                case StreamDelta(id=delta_id, event=agent_event):
+                    redis_id, frame_index = delta_id, 0
                     # Process agent stream events (PartStartEvent, PartDeltaEvent, etc.)
                     async for msg in context.handle_event(agent_event):
-                        yield format_sse(msg)
-                case StreamMessage(message=message):
+                        if frame := emit(msg):
+                            yield frame
+                case StreamMessage(id=message_redis_id, message=message):
+                    redis_id, frame_index = message_redis_id, 0
                     if approval_payload := _extract_approval_payload_from_message(
                         message
                     ):
@@ -1811,7 +1881,8 @@ async def sse_vercel(events: AsyncIterable[StreamEvent]) -> AsyncIterable[str]:
                                     ) in context.collect_current_part_end_events(
                                         index=index
                                     ):
-                                        yield format_sse(end_evt)
+                                        if frame := emit(end_evt):
+                                            yield frame
                         except Exception:
                             # Best-effort only; do not abort streaming on cache/finalize errors
                             pass
@@ -1822,7 +1893,8 @@ async def sse_vercel(events: AsyncIterable[StreamEvent]) -> AsyncIterable[str]:
                             )
                         )
                         for data_event in context.flush_data_events():
-                            yield format_sse(data_event)
+                            if frame := emit(data_event):
+                                yield frame
                     continue
                 case StreamKeepAlive():
                     yield StreamKeepAlive.sse()
@@ -1839,9 +1911,14 @@ async def sse_vercel(events: AsyncIterable[StreamEvent]) -> AsyncIterable[str]:
                     logger.debug("End-of-stream marker from Redis")
                     break
 
-        # 3. Finalize any open parts at the end of the stream
+        # 3. Finalize any open parts at the end of the stream.
+        # These post-StreamEnd frames inherit the previous entry's redis_id, so a
+        # composite-cursor resume could reopen an empty part. Safe today: /stream
+        # forces 0-0 replay (resume_from=None). Give them a sentinel id before
+        # enabling composite resume here.
         for message in context.collect_current_part_end_events():
-            yield format_sse(message)
+            if frame := emit(message):
+                yield frame
 
     except Exception as e:
         # 4. Handle errors

--- a/tracecat/agent/common/stream_types.py
+++ b/tracecat/agent/common/stream_types.py
@@ -13,6 +13,24 @@ from typing import Any, Literal
 type ArtifactEventOp = Literal["upsert", "remove"]
 
 
+@dataclass(frozen=True, slots=True)
+class VercelFrameCursor:
+    """Browser SSE cursor for a Vercel frame fanned out from one Redis entry."""
+
+    redis_id: str
+    frame_index: int
+
+
+def parse_vercel_frame_cursor(event_id: str | None) -> VercelFrameCursor | None:
+    """Parse ``<redis-id>:<frame-index>`` cursors emitted by the Vercel adapter."""
+    if not event_id:
+        return None
+    redis_id, separator, frame_index = event_id.rpartition(":")
+    if not separator or not redis_id or not frame_index.isdecimal():
+        return None
+    return VercelFrameCursor(redis_id=redis_id, frame_index=int(frame_index))
+
+
 class HarnessType(StrEnum):
     """Supported agent harnesses."""
 

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -90,6 +90,13 @@ class AgentExecutorInput(BaseModel):
 
     session_id: uuid.UUID
     workspace_id: uuid.UUID
+    # Per-turn stream id (Redis key suffix). Pinned at workflow start so the
+    # producer writes to the same per-turn key the reader joins. None for legacy
+    # executions that predate per-turn keys (falls back to the per-session key).
+    active_stream_id: uuid.UUID | None = None
+    # Workflow run id for this turn. Pinned so the producer tags persisted
+    # history rows, letting mid-turn loads hide the active run's partial rows.
+    curr_run_id: uuid.UUID | None = None
     user_prompt: str
     config: AgentConfig
     # Role for context
@@ -406,6 +413,8 @@ class SandboxedAgentExecutor:
             loopback_input = LoopbackInput(
                 session_id=self.input.session_id,
                 workspace_id=self.input.workspace_id,
+                active_stream_id=self.input.active_stream_id,
+                curr_run_id=self.input.curr_run_id,
             )
             handler = LoopbackHandler(input=loopback_input)
 

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -95,6 +95,8 @@ class LoopbackInput:
 
     session_id: uuid.UUID
     workspace_id: uuid.UUID
+    active_stream_id: uuid.UUID | None = None
+    curr_run_id: uuid.UUID | None = None
 
 
 @dataclass(kw_only=True, slots=True)
@@ -803,6 +805,7 @@ class LoopbackHandler:
         redis_stream = await AgentStream.new(
             session_id=self.input.session_id,
             workspace_id=self.input.workspace_id,
+            stream_id=self.input.active_stream_id,
         )
         return AgentStreamSink(stream=redis_stream)
 
@@ -996,6 +999,7 @@ class LoopbackHandler:
                 workspace_id=self.input.workspace_id,
                 content=_session_line_db_content(line_data),
                 kind=kind,
+                curr_run_id=self.input.curr_run_id,
             )
             session.add(history_entry)
             await session.commit()

--- a/tracecat/agent/schemas.py
+++ b/tracecat/agent/schemas.py
@@ -54,6 +54,14 @@ class RunAgentArgs(BaseModel):
     """User prompt for the agent."""
     session_id: uuid.UUID
     """Session ID for the agent execution."""
+    active_stream_id: uuid.UUID | None = None
+    """Per-turn stream id (Redis key suffix). Minted at the HTTP layer at turn
+    start and pinned here so the worker producer writes to the same per-turn key
+    the reader joins. None for legacy executions that predate per-turn keys."""
+    curr_run_id: uuid.UUID | None = None
+    """Workflow run id for this turn. Pinned here so the producer tags persisted
+    history rows with it, letting mid-turn loads hide the active run's partial
+    rows. None for legacy executions."""
     config: AgentConfig | None = None
     """Configuration for the agent. Required if preset_slug is not provided."""
     preset_slug: str | None = None

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -80,6 +80,7 @@ class ReconcileToolResultsInput(BaseModel):
     workspace_id: uuid.UUID
     role: Role
     pending_results: list[PendingToolResult]
+    active_stream_id: uuid.UUID | None = None
 
 
 class ReconcileToolResultsResult(BaseModel):
@@ -245,7 +246,7 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
                 session_id=input.session_id,
                 workspace_id=input.role.workspace_id,
             )
-            await stream.reset_for_new_turn()
+            await stream.clear_buffer()
 
         return CreateSessionResult(session_id=input.session_id, success=True)
 
@@ -333,7 +334,11 @@ async def load_session_messages_activity(
 
     try:
         async with AgentSessionService.with_session(role=input.role) as service:
-            messages = await service.list_messages(input.session_id)
+            # Terminal load: this runs before finalize_turn clears curr_run_id,
+            # so include the just-completed turn's rows in message_history.
+            messages = await service.list_messages(
+                input.session_id, include_active=True
+            )
         return LoadSessionMessagesResult(messages=messages)
 
     except Exception as e:
@@ -355,6 +360,7 @@ async def reconcile_tool_results_activity(
     stream = await AgentStream.new(
         session_id=input.session_id,
         workspace_id=input.workspace_id,
+        stream_id=input.active_stream_id,
     )
 
     for pending in input.pending_results:
@@ -435,6 +441,36 @@ async def reconcile_tool_results_activity(
     return ReconcileToolResultsResult(results=results)
 
 
+class FinalizeTurnInput(BaseModel):
+    """Input for finalize_turn_activity."""
+
+    role: Role
+    session_id: uuid.UUID
+    run_id: uuid.UUID
+
+
+@activity.defn
+async def finalize_turn_activity(input: FinalizeTurnInput) -> None:
+    """Clear active-turn pointers at terminal (compare-and-clear by run_id).
+
+    Idempotent and replay-safe: nulls curr_run_id/active_stream_id only while the
+    session still points at this run, so a stale terminal never clears a newer
+    live turn.
+    """
+    ctx_role.set(input.role)
+    try:
+        async with AgentSessionService.with_session(role=input.role) as service:
+            await service.finalize_turn(input.session_id, input.run_id)
+    except Exception as e:
+        logger.warning(
+            "Failed to finalize agent turn pointers",
+            session_id=str(input.session_id),
+            run_id=str(input.run_id),
+            error=str(e),
+        )
+        raise
+
+
 def get_session_activities() -> list:
     """Get all session-related activities for worker registration."""
     return [
@@ -442,4 +478,5 @@ def get_session_activities() -> list:
         load_session_activity,
         load_session_messages_activity,
         reconcile_tool_results_activity,
+        finalize_turn_activity,
     ]

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -25,7 +25,7 @@ from tracecat.agent.session.schemas import (
     AgentSessionUpdate,
 )
 from tracecat.agent.session.service import AgentSessionService
-from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.session.types import AgentSessionEntity, TurnLifecycle
 from tracecat.agent.stream.artifacts import artifact_stream_event
 from tracecat.agent.stream.connector import AgentStream
 from tracecat.agent.stream.events import StreamFormat
@@ -46,6 +46,16 @@ from tracecat.exceptions import EntitlementRequired, TracecatNotFoundError
 from tracecat.logger import logger
 
 router = APIRouter(prefix="/agent/sessions", tags=["agent-sessions"])
+
+
+def _bubble_id(session_id: uuid.UUID, curr_run_id: uuid.UUID | None) -> str | None:
+    """Stable assistant-bubble id for a turn, if the turn is known.
+
+    ``session_id:curr_run_id`` is stable for the whole run, so the AI SDK upserts
+    the live assistant in place across reconnects instead of spawning a duplicate
+    bubble.
+    """
+    return f"{session_id}:{curr_run_id}" if curr_run_id else None
 
 
 async def _require_workspace_chat_entitlement_for_session_tree(
@@ -438,7 +448,7 @@ async def send_message(
                 detail="Workspace access required",
             )
 
-        stream = await AgentStream.new(session_id, workspace_id)
+        message_id: str | None = None
         async with AgentSessionService.with_session(role=role) as svc:
             # Check if this is a legacy chat (read-only)
             if await svc.is_legacy_session(session_id):
@@ -459,16 +469,19 @@ async def send_message(
             )
 
             if isinstance(request, ContinueRunRequest):
-                # Continuations should follow only newly appended events. Resuming
-                # from the persisted DB cursor can replay the approval request that
-                # the active client already rendered before clicking approve/deny.
+                # Continuations resume the same workflow + per-turn stream. Reuse
+                # the existing stream id and follow only newly appended events;
+                # resuming from "0-0" would replay the approval request the active
+                # client already rendered before clicking approve/deny.
+                stream_id = agent_session.active_stream_id
+                stream = await AgentStream.new(session_id, workspace_id, stream_id)
                 start_id = "$"
             else:
-                # Each fresh execution turn gets a new Redis stream buffer so
-                # stale events from the prior turn are never replayed.
-                await stream.reset_for_new_turn()
-                # Read from the beginning of the freshly cleared stream so we still
-                # pick up events emitted before the SSE response starts consuming.
+                # Mint the per-turn stream id at the HTTP layer (turn start) so the
+                # seed artifact and the worker producer both write to the same
+                # fresh per-turn key. No reset/reuse of a prior turn's buffer.
+                stream_id = uuid.uuid4()
+                stream = await AgentStream.new(session_id, workspace_id, stream_id)
                 start_id = "0-0"
                 if await svc.should_seed_initial_artifact(agent_session) and (
                     artifact := await svc.build_initial_artifact(agent_session)
@@ -481,14 +494,23 @@ async def send_message(
 
             # Run session turn (spawns DurableAgentWorkflow)
             try:
-                await svc.run_turn(
+                turn_response = await svc.run_turn(
                     session_id=session_id,
                     request=request,
+                    active_stream_id=stream_id,
                 )
             except Exception:
                 if not isinstance(request, ContinueRunRequest):
+                    # Startup failed after we minted the stream: surface a terminal
+                    # frame so reconnecting clients don't hang, and clear pointers.
+                    # Non-continue turns always mint a fresh per-turn stream id.
+                    assert stream_id is not None
                     try:
-                        await stream.abort_new_turn()
+                        await stream.error("Failed to start agent turn")
+                        await stream.done()
+                        await svc.clear_active_turn(
+                            session_id, expected_stream_id=stream_id
+                        )
                     except Exception as rollback_exc:
                         logger.warning(
                             "Failed to clear stream state after turn startup failure",
@@ -496,6 +518,17 @@ async def send_message(
                             error=str(rollback_exc),
                         )
                 raise
+
+            # Build a bubble id stable for this turn. Prefer the run id returned by
+            # run_turn (new turns) — terminal cleanup may already have nulled the
+            # session row on a fast turn. Continuations return None and reuse the
+            # in-progress run id still pinned on the session row.
+            if turn_response is not None and turn_response.curr_run_id is not None:
+                run_id = turn_response.curr_run_id
+            else:
+                refreshed = await svc.get_session(session_id)
+                run_id = refreshed.curr_run_id if refreshed else None
+            message_id = _bubble_id(session_id, run_id)
 
         logger.info(
             "Starting Vercel streaming session",
@@ -505,7 +538,12 @@ async def send_message(
 
         # Create stream and return with Vercel format
         return StreamingResponse(
-            stream.sse(http_request.is_disconnected, last_id=start_id, format="vercel"),
+            stream.sse(
+                http_request.is_disconnected,
+                last_id=start_id,
+                format="vercel",
+                message_id=message_id,
+            ),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache, no-transform",
@@ -565,40 +603,6 @@ async def stream_session_events(
             detail="Workspace access required",
         )
 
-        # Try to get last_stream_id from session, but don't fail if session doesn't exist yet.
-        # This handles the race condition where frontend connects before session is created.
-    last_stream_id: str | None = None
-    async with AgentSessionService.with_session(role=role) as svc:
-        agent_session = await svc.get_session(session_id)
-        if agent_session is not None:
-            await _require_workspace_chat_entitlement_for_session_tree(
-                svc=svc,
-                session=svc.session,
-                role=role,
-                agent_session=agent_session,
-            )
-            last_stream_id = agent_session.last_stream_id
-        else:
-            legacy_chat = await svc.get_legacy_chat(session_id)
-            if legacy_chat is not None:
-                await require_workspace_chat_entitlement_for_entity(
-                    session=svc.session,
-                    role=role,
-                    entity_type=AgentSessionEntity(legacy_chat.entity_type),
-                )
-                last_stream_id = legacy_chat.last_stream_id
-
-    last_event_id = request.headers.get("Last-Event-ID")
-    if last_stream_id is None and not last_event_id:
-        return Response(status_code=status.HTTP_204_NO_CONTENT)
-    start_id = last_event_id or last_stream_id or "0-0"
-    logger.info(
-        "Starting session stream",
-        last_id=start_id,
-        session_id=session_id,
-    )
-
-    stream = await AgentStream.new(session_id, workspace_id)
     headers = {
         "Cache-Control": "no-cache, no-transform",
         "Connection": "keep-alive",
@@ -608,8 +612,88 @@ async def stream_session_events(
     }
     if format == "vercel":
         headers["x-vercel-ai-ui-message-stream"] = "v1"
+
+    last_event_id = request.headers.get("Last-Event-ID")
+
+    # Resolve the turn lifecycle. Temporal owns it: we describe the current run
+    # live rather than reading a cached DB status. Don't fail if the session row
+    # doesn't exist yet (the frontend may connect before it is created).
+    async with AgentSessionService.with_session(role=role) as svc:
+        agent_session = await svc.get_session(session_id)
+        if agent_session is None:
+            # Legacy chat fallback: no Temporal workflow / per-turn key. Keep the
+            # old per-session behaviour driven by the stored cursor.
+            legacy_chat = await svc.get_legacy_chat(session_id)
+            if legacy_chat is None:
+                return Response(status_code=status.HTTP_204_NO_CONTENT)
+            await require_workspace_chat_entitlement_for_entity(
+                session=svc.session,
+                role=role,
+                entity_type=AgentSessionEntity(legacy_chat.entity_type),
+            )
+            last_stream_id = legacy_chat.last_stream_id
+            if last_stream_id is None and not last_event_id:
+                return Response(status_code=status.HTTP_204_NO_CONTENT)
+            start_id = last_event_id or last_stream_id or "0-0"
+            legacy_stream = await AgentStream.new(session_id, workspace_id)
+            return StreamingResponse(
+                legacy_stream.sse(
+                    request.is_disconnected, last_id=start_id, format=format
+                ),
+                media_type="text/event-stream",
+                headers=headers,
+            )
+
+        await _require_workspace_chat_entitlement_for_session_tree(
+            svc=svc,
+            session=svc.session,
+            role=role,
+            agent_session=agent_session,
+        )
+        active_stream_id = agent_session.active_stream_id
+        lifecycle, curr_run_id = await svc.get_turn_lifecycle(agent_session)
+
+    message_id = _bubble_id(session_id, curr_run_id)
+
+    # FAILED | TERMINATED (incl. failed-to-start): the workflow will not produce a
+    # terminal frame, so emit one ourselves and let the client refetch DB history.
+    if lifecycle is TurnLifecycle.FAILED:
+        finished = await AgentStream.new(session_id, workspace_id, active_stream_id)
+        return StreamingResponse(
+            finished.finished_sse(format=format, message_id=message_id),
+            media_type="text/event-stream",
+            headers=headers,
+        )
+
+    # No live run, or the run is already COMPLETED: nothing to attach to. The
+    # canonical assistant message is in DB history; the client refetches.
+    if lifecycle is not TurnLifecycle.RUNNING:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    # RUNNING: join the per-turn Redis stream and always replay the whole active
+    # turn from the start. The mid-turn DB load hides the active run's rows, so
+    # Redis is the sole source for the live assistant; a partial (Last-Event-ID)
+    # resume would drop everything before the cursor. Full 0-0 replay keeps the
+    # bubble whole at the cost of re-streaming the in-flight turn on reconnect.
+    # (Cursor/frame-precise resume is intentionally not used here; revisit if we
+    # reconcile committed partial rows with the live stream id.)
+    stream = await AgentStream.new(session_id, workspace_id, active_stream_id)
+    start_id = "0-0"
+    resume_from: str | None = None
+
+    logger.info(
+        "Starting session stream",
+        last_id=start_id,
+        session_id=session_id,
+    )
     return StreamingResponse(
-        stream.sse(request.is_disconnected, last_id=start_id, format=format),
+        stream.sse(
+            request.is_disconnected,
+            last_id=start_id,
+            format=format,
+            message_id=message_id,
+            resume_from=resume_from,
+        ),
         media_type="text/event-stream",
         headers=headers,
     )

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -474,14 +474,22 @@ async def send_message(
                 # resuming from "0-0" would replay the approval request the active
                 # client already rendered before clicking approve/deny.
                 stream_id = agent_session.active_stream_id
-                stream = await AgentStream.new(session_id, workspace_id, stream_id)
+                stream = await AgentStream.new(
+                    session_id=session_id,
+                    workspace_id=workspace_id,
+                    stream_id=stream_id,
+                )
                 start_id = "$"
             else:
                 # Mint the per-turn stream id at the HTTP layer (turn start) so the
                 # seed artifact and the worker producer both write to the same
                 # fresh per-turn key. No reset/reuse of a prior turn's buffer.
                 stream_id = uuid.uuid4()
-                stream = await AgentStream.new(session_id, workspace_id, stream_id)
+                stream = await AgentStream.new(
+                    session_id=session_id,
+                    workspace_id=workspace_id,
+                    stream_id=stream_id,
+                )
                 start_id = "0-0"
                 if await svc.should_seed_initial_artifact(agent_session) and (
                     artifact := await svc.build_initial_artifact(agent_session)
@@ -499,14 +507,21 @@ async def send_message(
                     request=request,
                     active_stream_id=stream_id,
                 )
-            except Exception:
+            except Exception as turn_exc:
                 if not isinstance(request, ContinueRunRequest):
                     # Startup failed after we minted the stream: surface a terminal
                     # frame so reconnecting clients don't hang, and clear pointers.
                     # Non-continue turns always mint a fresh per-turn stream id.
                     assert stream_id is not None
+                    logger.warning(
+                        "Failed to start agent turn",
+                        session_id=session_id,
+                        error=str(turn_exc),
+                    )
                     try:
-                        await stream.error("Failed to start agent turn")
+                        await stream.error(
+                            f"Failed to start agent turn for session {session_id}"
+                        )
                         await stream.done()
                         await svc.clear_active_turn(
                             session_id, expected_stream_id=stream_id
@@ -635,7 +650,9 @@ async def stream_session_events(
             if last_stream_id is None and not last_event_id:
                 return Response(status_code=status.HTTP_204_NO_CONTENT)
             start_id = last_event_id or last_stream_id or "0-0"
-            legacy_stream = await AgentStream.new(session_id, workspace_id)
+            legacy_stream = await AgentStream.new(
+                session_id=session_id, workspace_id=workspace_id
+            )
             return StreamingResponse(
                 legacy_stream.sse(
                     request.is_disconnected, last_id=start_id, format=format
@@ -658,7 +675,9 @@ async def stream_session_events(
     # FAILED | TERMINATED (incl. failed-to-start): the workflow will not produce a
     # terminal frame, so emit one ourselves and let the client refetch DB history.
     if lifecycle is TurnLifecycle.FAILED:
-        finished = await AgentStream.new(session_id, workspace_id, active_stream_id)
+        finished = await AgentStream.new(
+            session_id=session_id, workspace_id=workspace_id, stream_id=active_stream_id
+        )
         return StreamingResponse(
             finished.finished_sse(format=format, message_id=message_id),
             media_type="text/event-stream",
@@ -677,7 +696,9 @@ async def stream_session_events(
     # bubble whole at the cost of re-streaming the in-flight turn on reconnect.
     # (Cursor/frame-precise resume is intentionally not used here; revisit if we
     # reconcile committed partial rows with the live stream id.)
-    stream = await AgentStream.new(session_id, workspace_id, active_stream_id)
+    stream = await AgentStream.new(
+        session_id=session_id, workspace_id=workspace_id, stream_id=active_stream_id
+    )
     start_id = "0-0"
     resume_from: str | None = None
 

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -57,7 +57,7 @@ from tracecat.agent.session.schemas import (
     AgentSessionUpdate,
 )
 from tracecat.agent.session.title_generator import generate_session_title
-from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.session.types import AgentSessionEntity, TurnLifecycle
 from tracecat.agent.subagents import (
     ResolvedAgentsConfig,
 )
@@ -771,6 +771,59 @@ class AgentSessionService(BaseWorkspaceService):
         await self.session.refresh(agent_session)
         return agent_session
 
+    async def finalize_turn(
+        self,
+        session_id: uuid.UUID,
+        run_id: uuid.UUID,
+    ) -> None:
+        """Clear the active-turn pointers at terminal (compare-and-clear).
+
+        Nulls ``curr_run_id`` and ``active_stream_id`` only while the session
+        still points at ``run_id``. The compare guards against a newer turn that
+        already overwrote these pointers: a stale terminal must not clear the
+        live turn's state. Nulling ``curr_run_id`` is what flips the mid-turn DB
+        filter off (final rows become visible) and makes reconnect resolve to
+        NONE -> 204.
+        """
+        stmt = (
+            update(AgentSession)
+            .where(
+                AgentSession.id == session_id,
+                AgentSession.workspace_id == self.workspace_id,
+                AgentSession.curr_run_id == run_id,
+            )
+            .values(curr_run_id=None, active_stream_id=None)
+        )
+        await self.session.execute(stmt)
+        await self.session.commit()
+
+    async def clear_active_turn(
+        self,
+        session_id: uuid.UUID,
+        *,
+        expected_stream_id: uuid.UUID,
+    ) -> None:
+        """Clear active-turn pointers on turn-startup failure (compare-and-clear).
+
+        The workflow never started, so we drop the pointers optimistically
+        written by ``run_turn``. Compare on ``active_stream_id`` (minted per turn
+        at the HTTP layer) so a newer turn that already overwrote these pointers
+        between our optimistic write and this cleanup is not clobbered: turns are
+        not serialized, so a concurrent turn can pin its own pointers in that
+        window. Only clear while the session still points at our stream id.
+        """
+        stmt = (
+            update(AgentSession)
+            .where(
+                AgentSession.id == session_id,
+                AgentSession.workspace_id == self.workspace_id,
+                AgentSession.active_stream_id == expected_stream_id,
+            )
+            .values(curr_run_id=None, active_stream_id=None)
+        )
+        await self.session.execute(stmt)
+        await self.session.commit()
+
     # =========================================================================
     # Session History Management (for Claude SDK session persistence)
     # =========================================================================
@@ -980,14 +1033,19 @@ class AgentSessionService(BaseWorkspaceService):
             raise TracecatNotFoundError(f"Session with ID {session_id} not found")
         return source
 
-    async def _emit_noop_continuation_done(self, *, session_id: uuid.UUID) -> None:
+    async def _emit_noop_continuation_done(
+        self,
+        *,
+        session_id: uuid.UUID,
+        active_stream_id: uuid.UUID | None,
+    ) -> None:
         """Emit an end marker so duplicate/no-op continuations don't hang SSE clients."""
         if self.workspace_id is None:
             return
         try:
             redis_client = await get_redis_client()
             await redis_client.xadd(
-                str(StreamKey(self.workspace_id, session_id)),
+                str(StreamKey(self.workspace_id, session_id, active_stream_id)),
                 {
                     tokens.DATA_KEY: orjson.dumps(
                         {tokens.END_TOKEN: tokens.END_TOKEN_VALUE},
@@ -1186,6 +1244,8 @@ class AgentSessionService(BaseWorkspaceService):
         self,
         session_id: uuid.UUID,
         request: ChatRequest | ContinueRunRequest | BasicChatRequest,
+        *,
+        active_stream_id: uuid.UUID | None = None,
     ) -> ChatResponse | None:
         """Run a session turn by spawning a DurableAgentWorkflow.
 
@@ -1194,6 +1254,10 @@ class AgentSessionService(BaseWorkspaceService):
 
         Args:
             session_id: The ID of the session.
+            active_stream_id: Per-turn stream id minted by the HTTP layer. Pinned
+                into the workflow input and onto the session row so the producer
+                and reader share the same per-turn Redis key. Defaults to a freshly
+                minted id for callers that don't manage their own stream.
             request: Either a ChatRequest (start) or ContinueRunRequest (continue).
 
         Returns:
@@ -1271,10 +1335,17 @@ class AgentSessionService(BaseWorkspaceService):
                     self.session, self.role, Entitlement.AGENT_ADDONS
                 )
             run_id = uuid.uuid4()
+            # Per-turn stream id: use the HTTP-minted id when provided, else mint
+            # one. Pinned into the workflow input so the worker producer writes to
+            # the same per-turn Redis key the reader joins (immune to the
+            # stale-turn overwrite race).
+            stream_id = active_stream_id or uuid.uuid4()
 
             args = RunAgentArgs(
                 user_prompt=user_prompt or "",
                 session_id=session_id,
+                active_stream_id=stream_id,
+                curr_run_id=run_id,
                 config=agent_config,
             )
 
@@ -1292,8 +1363,10 @@ class AgentSessionService(BaseWorkspaceService):
                 agent_preset_version_id=agent_session.agent_preset_version_id,
             )
 
-            # Update session with current run_id for approval lookups
+            # Pin run_id (approval lookups) and the per-turn stream id before
+            # launching the workflow.
             agent_session.curr_run_id = run_id
+            agent_session.active_stream_id = stream_id
             self.session.add(agent_session)
             await self.session.commit()
 
@@ -1320,9 +1393,58 @@ class AgentSessionService(BaseWorkspaceService):
                 ),
             )
 
-        # Return ChatResponse with session_id for streaming
+        # Return ChatResponse with session_id for streaming. Surface run_id so the
+        # HTTP layer builds the stable bubble id from the value we just minted
+        # rather than re-reading curr_run_id, which finalize_turn may clear before
+        # the post-run refresh on a fast turn.
         stream_url = f"/api/agent/sessions/{session_id}/stream"
-        return ChatResponse(stream_url=stream_url, chat_id=session_id)
+        return ChatResponse(
+            stream_url=stream_url, chat_id=session_id, curr_run_id=run_id
+        )
+
+    async def get_turn_lifecycle(
+        self, agent_session: AgentSession
+    ) -> tuple[TurnLifecycle, uuid.UUID | None]:
+        """Resolve the live turn lifecycle from Temporal (cold reconnect path).
+
+        Temporal owns lifecycle - we never cache it in the DB. Returns the
+        decision plus the run id used to compute it (None when there is no
+        current run). On any describe error we fall back to FAILED so a
+        reconnecting client gets a terminal frame instead of hanging.
+        """
+        from temporalio.client import WorkflowExecutionStatus
+        from temporalio.service import RPCError
+        from tracecat_ee.agent.types import AgentWorkflowID
+        from tracecat_ee.agent.workflows.durable import DurableAgentWorkflow
+
+        curr_run_id = agent_session.curr_run_id
+        if curr_run_id is None:
+            return TurnLifecycle.NONE, None
+
+        client = await get_temporal_client()
+        handle = client.get_workflow_handle_for(
+            DurableAgentWorkflow.run, AgentWorkflowID(curr_run_id)
+        )
+        try:
+            description = await handle.describe()
+        except RPCError:
+            # Workflow history already gone / never started -> treat as failed so
+            # the client receives a terminal frame and refetches DB history.
+            logger.warning(
+                "Failed to describe agent workflow for reconnect",
+                session_id=str(agent_session.id),
+                run_id=str(curr_run_id),
+            )
+            return TurnLifecycle.FAILED, curr_run_id
+
+        match description.status:
+            case WorkflowExecutionStatus.RUNNING:
+                return TurnLifecycle.RUNNING, curr_run_id
+            case WorkflowExecutionStatus.COMPLETED:
+                return TurnLifecycle.COMPLETED, curr_run_id
+            case _:
+                # FAILED | TERMINATED | CANCELED | TIMED_OUT | CONTINUED_AS_NEW
+                return TurnLifecycle.FAILED, curr_run_id
 
     async def validate_turn_request(
         self,
@@ -1397,7 +1519,10 @@ class AgentSessionService(BaseWorkspaceService):
                 run_id=str(curr_run_id),
                 source=source,
             )
-            await self._emit_noop_continuation_done(session_id=session_id)
+            await self._emit_noop_continuation_done(
+                session_id=session_id,
+                active_stream_id=agent_session.active_stream_id,
+            )
             return None
 
         # Build ApprovalMap from the request decisions
@@ -1454,7 +1579,10 @@ class AgentSessionService(BaseWorkspaceService):
                         source=source,
                         dedup_key=dedup_key,
                     )
-                    await self._emit_noop_continuation_done(session_id=session_id)
+                    await self._emit_noop_continuation_done(
+                        session_id=session_id,
+                        active_stream_id=agent_session.active_stream_id,
+                    )
                     return None
             except Exception as exc:
                 logger.warning(
@@ -1731,6 +1859,7 @@ class AgentSessionService(BaseWorkspaceService):
         session_id: uuid.UUID,
         *,
         kinds: Sequence[MessageKind] | None = None,
+        include_active: bool = False,
     ) -> list[ChatMessage]:
         """Retrieve session messages, optionally filtered by message kind.
 
@@ -1741,6 +1870,12 @@ class AgentSessionService(BaseWorkspaceService):
         Args:
             session_id: The session UUID (could be AgentSession.id or Chat.id).
             kinds: Optional list of message kinds to filter by.
+            include_active: When True, do not hide the active turn's rows. The
+                mid-turn filter exists for live UI reads (the assistant streams
+                from Redis). Terminal loads that build ``AgentOutput`` must set
+                this True: they run before ``finalize_turn`` clears
+                ``curr_run_id``, so the default filter would otherwise omit the
+                just-completed turn from the returned ``message_history``.
 
         Returns:
             List of ChatMessage objects (parent messages + current if forked).
@@ -1763,6 +1898,18 @@ class AgentSessionService(BaseWorkspaceService):
             .where(AgentSessionHistory.session_id.in_(session_ids))
             .order_by(AgentSessionHistory.surrogate_id)
         )
+        # While a turn is live (curr_run_id set), the active run's partial rows
+        # are durability-only - the live assistant streams from Redis. Hide them
+        # here so the active assistant has exactly one source (no dedupe). The
+        # gate is the cheap curr_run_id pointer; terminal nulls it (see
+        # finish/fail paths), at which point the final rows become visible.
+        if not include_active and agent_session.curr_run_id is not None:
+            all_history_stmt = all_history_stmt.where(
+                or_(
+                    AgentSessionHistory.curr_run_id.is_(None),
+                    AgentSessionHistory.curr_run_id != agent_session.curr_run_id,
+                )
+            )
         all_history_result = await self.session.execute(all_history_stmt)
         all_entries = list(all_history_result.scalars().all())
 
@@ -2010,12 +2157,19 @@ class AgentSessionService(BaseWorkspaceService):
             },
         }
 
+        # Tag the inserted tool_result with the active run id so the mid-turn
+        # filter hides it alongside its (also active-run-tagged) assistant
+        # tool_use row. A NULL tag would leave this row visible while the
+        # matching tool_use stays hidden, rendering a dangling/duplicate tool
+        # result on a mid-turn DB reload until terminal cleanup. Terminal nulls
+        # curr_run_id, at which point both rows become visible together.
         self.session.add(
             AgentSessionHistory(
                 session_id=session_id,
                 workspace_id=self.workspace_id,
                 content=entry_content,
                 kind=MessageKind.CHAT_MESSAGE.value,
+                curr_run_id=session.curr_run_id,
             )
         )
         await self.session.commit()

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -57,7 +57,11 @@ from tracecat.agent.session.schemas import (
     AgentSessionUpdate,
 )
 from tracecat.agent.session.title_generator import generate_session_title
-from tracecat.agent.session.types import AgentSessionEntity, TurnLifecycle
+from tracecat.agent.session.types import (
+    AgentSessionEntity,
+    TurnLifecycle,
+    TurnLifecycleResult,
+)
 from tracecat.agent.subagents import (
     ResolvedAgentsConfig,
 )
@@ -1045,7 +1049,11 @@ class AgentSessionService(BaseWorkspaceService):
         try:
             redis_client = await get_redis_client()
             await redis_client.xadd(
-                str(StreamKey(self.workspace_id, session_id, active_stream_id)),
+                StreamKey(
+                    workspace_id=self.workspace_id,
+                    session_id=session_id,
+                    stream_id=active_stream_id,
+                ),
                 {
                     tokens.DATA_KEY: orjson.dumps(
                         {tokens.END_TOKEN: tokens.END_TOKEN_VALUE},
@@ -1404,7 +1412,7 @@ class AgentSessionService(BaseWorkspaceService):
 
     async def get_turn_lifecycle(
         self, agent_session: AgentSession
-    ) -> tuple[TurnLifecycle, uuid.UUID | None]:
+    ) -> TurnLifecycleResult:
         """Resolve the live turn lifecycle from Temporal (cold reconnect path).
 
         Temporal owns lifecycle - we never cache it in the DB. Returns the
@@ -1419,7 +1427,7 @@ class AgentSessionService(BaseWorkspaceService):
 
         curr_run_id = agent_session.curr_run_id
         if curr_run_id is None:
-            return TurnLifecycle.NONE, None
+            return TurnLifecycleResult(TurnLifecycle.NONE, None)
 
         client = await get_temporal_client()
         handle = client.get_workflow_handle_for(
@@ -1435,16 +1443,23 @@ class AgentSessionService(BaseWorkspaceService):
                 session_id=str(agent_session.id),
                 run_id=str(curr_run_id),
             )
-            return TurnLifecycle.FAILED, curr_run_id
+            return TurnLifecycleResult(TurnLifecycle.FAILED, curr_run_id)
 
         match description.status:
-            case WorkflowExecutionStatus.RUNNING:
-                return TurnLifecycle.RUNNING, curr_run_id
+            case (
+                WorkflowExecutionStatus.RUNNING
+                | WorkflowExecutionStatus.CONTINUED_AS_NEW
+            ):
+                # CONTINUED_AS_NEW is not currently reachable - DurableAgentWorkflow
+                # loops turns internally rather than calling continue_as_new - but
+                # treat it as still-running (not failed) for consistency with how
+                # the inbox provider classifies Temporal workflow statuses.
+                return TurnLifecycleResult(TurnLifecycle.RUNNING, curr_run_id)
             case WorkflowExecutionStatus.COMPLETED:
-                return TurnLifecycle.COMPLETED, curr_run_id
+                return TurnLifecycleResult(TurnLifecycle.COMPLETED, curr_run_id)
             case _:
-                # FAILED | TERMINATED | CANCELED | TIMED_OUT | CONTINUED_AS_NEW
-                return TurnLifecycle.FAILED, curr_run_id
+                # FAILED | TERMINATED | CANCELED | TIMED_OUT
+                return TurnLifecycleResult(TurnLifecycle.FAILED, curr_run_id)
 
     async def validate_turn_request(
         self,

--- a/tracecat/agent/session/types.py
+++ b/tracecat/agent/session/types.py
@@ -3,6 +3,25 @@
 from enum import StrEnum
 
 
+class TurnLifecycle(StrEnum):
+    """In-memory reconnect decision derived live from Temporal.
+
+    Never persisted to the DB - Temporal owns turn lifecycle. Computed from
+    ``describe_workflow(curr_run_id)`` on the (cold) reconnect path.
+
+    - NONE: no current run; nothing to attach to (-> 204).
+    - RUNNING: workflow live; join the Redis stream from the client cursor.
+    - COMPLETED: turn done; canonical history is in the DB (-> 204).
+    - FAILED: workflow failed/terminated (incl. failed-to-start); emit a
+      terminal error frame + done so the client doesn't hang.
+    """
+
+    NONE = "none"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
 class AgentSessionEntity(StrEnum):
     """The type of entity associated with an agent session.
 

--- a/tracecat/agent/session/types.py
+++ b/tracecat/agent/session/types.py
@@ -1,6 +1,8 @@
 """Domain types for agent session management."""
 
+import uuid
 from enum import StrEnum
+from typing import NamedTuple
 
 
 class TurnLifecycle(StrEnum):
@@ -20,6 +22,16 @@ class TurnLifecycle(StrEnum):
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
+
+
+class TurnLifecycleResult(NamedTuple):
+    """Result of resolving a turn's live lifecycle from Temporal.
+
+    ``run_id`` is ``None`` exactly when ``lifecycle`` is ``TurnLifecycle.NONE``.
+    """
+
+    lifecycle: TurnLifecycle
+    run_id: uuid.UUID | None
 
 
 class AgentSessionEntity(StrEnum):

--- a/tracecat/agent/stream/common.py
+++ b/tracecat/agent/stream/common.py
@@ -24,7 +24,7 @@ class PersistableStreamingAgentDeps:
         session_id: uuid.UUID,
         workspace_id: uuid.UUID,
     ) -> PersistableStreamingAgentDeps:
-        stream = await AgentStream.new(session_id, workspace_id)
+        stream = await AgentStream.new(session_id=session_id, workspace_id=workspace_id)
         return cls(stream_writer=AgentStreamWriter(stream=stream))
 
     @classmethod

--- a/tracecat/agent/stream/connector.py
+++ b/tracecat/agent/stream/connector.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
+from collections.abc import (
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Mapping,
+    Sequence,
+)
 from time import monotonic
 from typing import Any
 
 import orjson
 from pydantic_core import to_jsonable_python
 
-from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.stream.events import (
     AgentStreamEventTA,
     StreamConnected,
@@ -21,6 +27,7 @@ from tracecat.agent.stream.events import (
     StreamKeepAlive,
     StreamMessage,
     UnifiedStreamEventTA,
+    parse_vercel_frame_cursor,
 )
 from tracecat.agent.types import ModelMessageTA, StreamKey
 from tracecat.chat import tokens
@@ -29,7 +36,13 @@ from tracecat.redis.client import RedisClient, get_redis_client
 
 
 class AgentStream:
-    """Stream adapter backed by Redis streams."""
+    """Stream adapter backed by Redis streams.
+
+    Each turn uses a per-turn Redis key suffixed by ``stream_id`` (the session's
+    ``active_stream_id``). Old readers harmlessly drain a dead key; a new turn
+    never collides with a prior turn's buffer. Readers are read-only and never
+    write ``last_stream_id`` - the browser owns the reconnect cursor.
+    """
 
     KEEPALIVE_INTERVAL_SECONDS = 10
     COMPLETED_STREAM_TTL_SECONDS = 5 * 60
@@ -39,16 +52,23 @@ class AgentStream:
         client: RedisClient,
         workspace_id: uuid.UUID,
         session_id: uuid.UUID,
+        stream_id: uuid.UUID | None = None,
     ):
         self.client = client
         self.workspace_id = workspace_id
         self.session_id = session_id
-        self._stream_key = StreamKey(workspace_id, session_id)
+        self.stream_id = stream_id
+        self._stream_key = StreamKey(workspace_id, session_id, stream_id)
 
     @classmethod
-    async def new(cls, session_id: uuid.UUID, workspace_id: uuid.UUID) -> AgentStream:
+    async def new(
+        cls,
+        session_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        stream_id: uuid.UUID | None = None,
+    ) -> AgentStream:
         client = await get_redis_client()
-        return cls(client, workspace_id, session_id)
+        return cls(client, workspace_id, session_id, stream_id)
 
     async def append(self, event: Any) -> None:
         """Stream a message to a Redis stream."""
@@ -67,16 +87,24 @@ class AgentStream:
         """Emit an end-of-turn marker."""
         await self.append({tokens.END_TOKEN: tokens.END_TOKEN_VALUE})
 
-    async def reset_for_new_turn(self) -> None:
-        """Delete the persisted stream buffer and reset the saved cursor."""
-        await self.client.delete(self._stream_key)
-        # Write "0-0" immediately so a reconnect during the turn has a valid cursor.
-        await self._set_last_stream_id("0-0")
+    async def clear_buffer(self) -> None:
+        """Delete the stream buffer for this key.
 
-    async def abort_new_turn(self) -> None:
-        """Clear stream state after startup fails before a turn can produce events."""
+        Used by workflow-initiated (ai.*) sessions that share a per-session key
+        and must clear any stale buffer before a new run so GET /stream replays
+        only the new run. Chat turns instead use a fresh per-turn key and never
+        reuse a prior buffer.
+        """
         await self.client.delete(self._stream_key)
-        await self._set_last_stream_id(None)
+
+    async def min_entry_id(self) -> str | None:
+        """Oldest id still in the live buffer, or None if empty/evicted.
+
+        Used for reconnect gap detection: a client cursor older than this was
+        trimmed (maxlen) or TTL-evicted, so it cannot be resumed.
+        """
+        entries = await self.client.xrange(self._stream_key, count=1)
+        return entries[0][0] if entries else None
 
     async def _expire_completed_stream(self) -> None:
         """Keep completed streams briefly for reconnects, then let Redis evict them."""
@@ -93,42 +121,85 @@ class AgentStream:
                 error=str(exc),
             )
 
-    async def _set_last_stream_id(self, last_stream_id: str | None) -> None:
-        """Update last stream ID for reconnection support."""
-
-        async with AgentSessionService.with_session() as session_svc:
-            if agent_session := await session_svc.get_session(self.session_id):
-                await session_svc.update_last_stream_id(agent_session, last_stream_id)
-
     async def _stream_events(
-        self, stop_condition: Callable[[], Awaitable[bool]], last_id: str
+        self,
+        stop_condition: Callable[[], Awaitable[bool]],
+        last_id: str,
+        *,
+        include_last_id: bool = False,
     ) -> AsyncIterator[StreamEvent]:
         """Stream events from Redis until a stop condition is met.
 
-        Continuously reads messages from the Redis stream and yields them as
-        StreamEvent objects. Handles different event types including agent events,
-        model messages, errors, and end-of-stream markers.
-
         Args:
-            stop_condition: Async callable that returns True when streaming should stop
-                          (e.g., when client disconnects).
+            stop_condition: Async callable that returns True when streaming should
+                stop (e.g., when client disconnects).
             last_id: The Redis stream ID to start reading from. Use "0-0" to read
-                    from the beginning, or a specific ID to resume from that point.
+                from the beginning, or a specific ID to resume from that point.
+            include_last_id: When resuming from a mid-entry frame cursor, also
+                re-emit the entry at ``last_id`` so the adapter can re-fan its
+                frames; the adapter then drops frames already seen by the client.
 
         Yields:
-            StreamEvent: One of StreamDelta (agent events), StreamMessage (model messages),
-                        StreamError (error events), or StreamEnd (end-of-stream marker).
+            StreamEvent: StreamDelta, StreamMessage, StreamError, or StreamEnd.
 
         Note:
-            - Periodically updates the chat's last_stream_id for reconnection support
-            - Implements exponential backoff on errors (1s sleep)
-            - Blocks for up to 1 second waiting for new messages
-            - Processes up to 100 messages per read operation
+            - Read-only: never writes last_stream_id (browser owns the cursor).
+            - Blocks for up to 1 second waiting for new messages.
+            - Processes up to 100 messages per read operation.
         """
         current_id = last_id
         last_keepalive = monotonic()
         stream_completed = False
+
+        async def parse_stream_messages(
+            messages: Sequence[tuple[str, Mapping[str, str]]],
+        ) -> AsyncIterator[StreamEvent]:
+            nonlocal current_id, stream_completed
+            for msg_id, fields in messages:
+                data = orjson.loads(fields[tokens.DATA_KEY])
+                current_id = msg_id
+                match data:
+                    case {tokens.END_TOKEN: tokens.END_TOKEN_VALUE}:
+                        stream_completed = True
+                        yield StreamEnd(id=msg_id)
+                    case {"event_kind": _}:
+                        legacy_event = AgentStreamEventTA.validate_python(data)
+                        yield StreamDelta(id=msg_id, event=legacy_event)
+                    case {"type": _}:
+                        unified_event = UnifiedStreamEventTA.validate_python(data)
+                        yield StreamDelta(id=msg_id, event=unified_event)
+                    case {"kind": "error", "error": error_message}:
+                        logger.warning(
+                            "Stream error received",
+                            error=error_message,
+                            message_id=msg_id,
+                        )
+                        yield StreamError(error=error_message)
+                    case {"kind": _}:
+                        message = ModelMessageTA.validate_python(data)
+                        yield StreamMessage(id=msg_id, message=message)
+                    case _:
+                        logger.warning(
+                            "Invalid stream message",
+                            error="Unexpected payload",
+                            message_id=msg_id,
+                        )
+
         try:
+            if include_last_id and current_id != "0-0":
+                try:
+                    entries = await self.client.xrange(
+                        self._stream_key,
+                        min_id=current_id,
+                        max_id=current_id,
+                        count=1,
+                    )
+                    async for event in parse_stream_messages(entries):
+                        yield event
+                except Exception as e:
+                    logger.error("Error reading Redis cursor entry", error=str(e))
+                    yield StreamError(error="Stream read error")
+
             while not await stop_condition():
                 try:
                     if result := await self.client.xread(
@@ -138,44 +209,8 @@ class AgentStream:
                     ):
                         last_keepalive = monotonic()
                         for _stream_name, messages in result:
-                            for msg_id, fields in messages:
-                                data = orjson.loads(fields[tokens.DATA_KEY])
-                                current_id = msg_id
-                                match data:
-                                    case {tokens.END_TOKEN: tokens.END_TOKEN_VALUE}:
-                                        stream_completed = True
-                                        yield StreamEnd(id=msg_id)
-                                    case {"event_kind": _}:
-                                        legacy_event = (
-                                            AgentStreamEventTA.validate_python(data)
-                                        )
-                                        yield StreamDelta(id=msg_id, event=legacy_event)
-                                    case {"type": _}:
-                                        unified_event = (
-                                            UnifiedStreamEventTA.validate_python(data)
-                                        )
-                                        yield StreamDelta(
-                                            id=msg_id, event=unified_event
-                                        )
-                                    case {"kind": "error", "error": error_message}:
-                                        logger.warning(
-                                            "Stream error received",
-                                            error=error_message,
-                                            message_id=msg_id,
-                                        )
-                                        yield StreamError(error=error_message)
-                                    case {"kind": _}:
-                                        message = ModelMessageTA.validate_python(data)
-                                        yield StreamMessage(id=msg_id, message=message)
-                                    case _:
-                                        logger.warning(
-                                            "Invalid stream message",
-                                            error="Unexpected payload",
-                                            message_id=msg_id,
-                                        )
-
-                        if not stream_completed:
-                            await self._set_last_stream_id(current_id)
+                            async for event in parse_stream_messages(messages):
+                                yield event
 
                     now = monotonic()
                     if now - last_keepalive >= self.KEEPALIVE_INTERVAL_SECONDS:
@@ -194,17 +229,24 @@ class AgentStream:
             yield StreamError(error="Fatal stream error")
         finally:
             logger.info("Chat stream ended", stream_key=self._stream_key)
+            # Readers never write last_stream_id; the browser owns the reconnect
+            # cursor (Last-Event-ID). We only expire the buffer after terminal.
             if stream_completed:
-                await self._set_last_stream_id(None)
                 await self._expire_completed_stream()
-            else:
-                await self._set_last_stream_id(current_id)
 
     async def stream_events(
-        self, stop_condition: Callable[[], Awaitable[bool]], last_id: str
+        self,
+        stop_condition: Callable[[], Awaitable[bool]],
+        last_id: str,
+        *,
+        include_last_id: bool = False,
     ) -> AsyncIterator[StreamEvent]:
         """Public stream-events iterator for external stream consumers."""
-        async for event in self._stream_events(stop_condition, last_id):
+        async for event in self._stream_events(
+            stop_condition,
+            last_id,
+            include_last_id=include_last_id,
+        ):
             yield event
 
     def sse(
@@ -212,14 +254,76 @@ class AgentStream:
         stop_condition: Callable[[], Awaitable[bool]],
         last_id: str,
         format: StreamFormat,
+        *,
+        message_id: str | None = None,
+        resume_from: str | None = None,
     ) -> AsyncIterable[str]:
+        cursor = parse_vercel_frame_cursor(resume_from)
+        # Strip any composite ``<redis-id>:<frame-index>`` suffix so Redis XREAD
+        # gets a plain id. No-op for plain ids / "0-0" (parse returns None).
+        last_id_cursor = parse_vercel_frame_cursor(last_id)
+        if last_id_cursor is not None:
+            last_id = last_id_cursor.redis_id
+        # Legacy callers reconnect with the composite Last-Event-ID in ``last_id``
+        # and no explicit ``resume_from``. Treat that composite as the resume
+        # cursor: re-emit the cursor entry (include_last_id) and forward it to the
+        # adapter so its dedup drops only frames the client already saw. Without
+        # this the entry's remaining frames are skipped (XREAD is exclusive).
+        if cursor is not None:
+            effective_cursor = cursor
+            effective_resume_from = resume_from
+        elif last_id_cursor is not None:
+            # ``last_id`` was reassigned to the bare redis id above; rebuild the
+            # composite to forward as the resume cursor.
+            effective_cursor = last_id_cursor
+            effective_resume_from = (
+                f"{last_id_cursor.redis_id}:{last_id_cursor.frame_index}"
+            )
+        else:
+            effective_cursor = None
+            effective_resume_from = resume_from
         match format:
             case "vercel":
                 from tracecat.agent.adapter.vercel import sse_vercel
 
-                return sse_vercel(self.stream_events(stop_condition, last_id))
+                return sse_vercel(
+                    self.stream_events(
+                        stop_condition,
+                        last_id,
+                        include_last_id=effective_cursor is not None,
+                    ),
+                    message_id=message_id,
+                    resume_from=effective_resume_from,
+                )
             case "basic":
                 return self.simple_sse(stop_condition, last_id)
+            case _:
+                raise ValueError(f"Invalid format: {format}")
+
+    def finished_sse(
+        self, format: StreamFormat, *, message_id: str | None
+    ) -> AsyncIterable[str]:
+        """Emit an immediately-finishing stream (no live content).
+
+        Used on reconnect when the cursor is stale and the turn is already
+        terminal: the client gets a clean finish and refetches DB history.
+        """
+
+        async def _empty() -> AsyncIterator[StreamEvent]:
+            return
+            yield  # pragma: no cover - establishes async generator
+
+        match format:
+            case "vercel":
+                from tracecat.agent.adapter.vercel import sse_vercel
+
+                return sse_vercel(_empty(), message_id=message_id)
+            case "basic":
+
+                async def _end() -> AsyncIterable[str]:
+                    yield StreamEnd.sse()
+
+                return _end()
             case _:
                 raise ValueError(f"Invalid format: {format}")
 

--- a/tracecat/agent/stream/connector.py
+++ b/tracecat/agent/stream/connector.py
@@ -16,6 +16,7 @@ from typing import Any
 import orjson
 from pydantic_core import to_jsonable_python
 
+from tracecat.agent.common.stream_types import parse_vercel_frame_cursor
 from tracecat.agent.stream.events import (
     AgentStreamEventTA,
     StreamConnected,
@@ -27,7 +28,6 @@ from tracecat.agent.stream.events import (
     StreamKeepAlive,
     StreamMessage,
     UnifiedStreamEventTA,
-    parse_vercel_frame_cursor,
 )
 from tracecat.agent.types import ModelMessageTA, StreamKey
 from tracecat.chat import tokens
@@ -49,6 +49,7 @@ class AgentStream:
 
     def __init__(
         self,
+        *,
         client: RedisClient,
         workspace_id: uuid.UUID,
         session_id: uuid.UUID,
@@ -58,17 +59,25 @@ class AgentStream:
         self.workspace_id = workspace_id
         self.session_id = session_id
         self.stream_id = stream_id
-        self._stream_key = StreamKey(workspace_id, session_id, stream_id)
+        self._stream_key = StreamKey(
+            workspace_id=workspace_id, session_id=session_id, stream_id=stream_id
+        )
 
     @classmethod
     async def new(
         cls,
-        session_id: uuid.UUID,
+        *,
         workspace_id: uuid.UUID,
+        session_id: uuid.UUID,
         stream_id: uuid.UUID | None = None,
     ) -> AgentStream:
         client = await get_redis_client()
-        return cls(client, workspace_id, session_id, stream_id)
+        return cls(
+            client=client,
+            workspace_id=workspace_id,
+            session_id=session_id,
+            stream_id=stream_id,
+        )
 
     async def append(self, event: Any) -> None:
         """Stream a message to a Redis stream."""

--- a/tracecat/agent/stream/events.py
+++ b/tracecat/agent/stream/events.py
@@ -13,24 +13,6 @@ UnifiedStreamEventTA: TypeAdapter[UnifiedStreamEvent] = TypeAdapter(UnifiedStrea
 AgentStreamEventTA: TypeAdapter[AgentStreamEvent] = TypeAdapter(AgentStreamEvent)
 
 
-@dataclass(frozen=True, slots=True)
-class VercelFrameCursor:
-    """Browser SSE cursor for a Vercel frame fanned out from one Redis entry."""
-
-    redis_id: str
-    frame_index: int
-
-
-def parse_vercel_frame_cursor(event_id: str | None) -> VercelFrameCursor | None:
-    """Parse ``<redis-id>:<frame-index>`` cursors emitted by the Vercel adapter."""
-    if not event_id:
-        return None
-    redis_id, separator, frame_index = event_id.rpartition(":")
-    if not separator or not redis_id or not frame_index.isdecimal():
-        return None
-    return VercelFrameCursor(redis_id=redis_id, frame_index=int(frame_index))
-
-
 @dataclass(slots=True, kw_only=True)
 class StreamDelta:
     """Container for Redis stream payloads and adapter errors."""

--- a/tracecat/agent/stream/events.py
+++ b/tracecat/agent/stream/events.py
@@ -13,6 +13,24 @@ UnifiedStreamEventTA: TypeAdapter[UnifiedStreamEvent] = TypeAdapter(UnifiedStrea
 AgentStreamEventTA: TypeAdapter[AgentStreamEvent] = TypeAdapter(AgentStreamEvent)
 
 
+@dataclass(frozen=True, slots=True)
+class VercelFrameCursor:
+    """Browser SSE cursor for a Vercel frame fanned out from one Redis entry."""
+
+    redis_id: str
+    frame_index: int
+
+
+def parse_vercel_frame_cursor(event_id: str | None) -> VercelFrameCursor | None:
+    """Parse ``<redis-id>:<frame-index>`` cursors emitted by the Vercel adapter."""
+    if not event_id:
+        return None
+    redis_id, separator, frame_index = event_id.rpartition(":")
+    if not separator or not redis_id or not frame_index.isdecimal():
+        return None
+    return VercelFrameCursor(redis_id=redis_id, frame_index=int(frame_index))
+
+
 @dataclass(slots=True, kw_only=True)
 class StreamDelta:
     """Container for Redis stream payloads and adapter errors."""

--- a/tracecat/agent/types.py
+++ b/tracecat/agent/types.py
@@ -39,10 +39,12 @@ class StreamKey(str):
         cls,
         workspace_id: uuid.UUID | str,
         session_id: uuid.UUID | str,
+        stream_id: uuid.UUID | str | None = None,
     ) -> StreamKey:
+        base = f"agent-stream:{str(workspace_id)}:{str(session_id)}"
         return super().__new__(
             cls,
-            f"agent-stream:{str(workspace_id)}:{str(session_id)}",
+            f"{base}:{str(stream_id)}" if stream_id else base,
         )
 
 

--- a/tracecat/agent/types.py
+++ b/tracecat/agent/types.py
@@ -37,14 +37,15 @@ else:
 class StreamKey(str):
     def __new__(
         cls,
-        workspace_id: uuid.UUID | str,
-        session_id: uuid.UUID | str,
-        stream_id: uuid.UUID | str | None = None,
+        *,
+        workspace_id: uuid.UUID,
+        session_id: uuid.UUID,
+        stream_id: uuid.UUID | None = None,
     ) -> StreamKey:
-        base = f"agent-stream:{str(workspace_id)}:{str(session_id)}"
+        base = f"agent-stream:{workspace_id}:{session_id}"
         return super().__new__(
             cls,
-            f"{base}:{str(stream_id)}" if stream_id else base,
+            f"{base}:{stream_id}" if stream_id else base,
         )
 
 

--- a/tracecat/chat/schemas.py
+++ b/tracecat/chat/schemas.py
@@ -76,6 +76,14 @@ class ChatResponse(BaseModel):
 
     stream_url: str = Field(..., description="URL to connect for SSE streaming")
     chat_id: uuid.UUID = Field(..., description="Unique chat identifier")
+    curr_run_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "Run id of the turn just spawned. Returned so callers can build the "
+            "stable bubble id without re-reading the session row, which terminal "
+            "cleanup (finalize_turn) may have already cleared on a fast turn."
+        ),
+    )
 
 
 class ChatCreate(BaseModel):

--- a/tracecat/chat/schemas.py
+++ b/tracecat/chat/schemas.py
@@ -79,9 +79,12 @@ class ChatResponse(BaseModel):
     curr_run_id: uuid.UUID | None = Field(
         default=None,
         description=(
-            "Run id of the turn just spawned. Returned so callers can build the "
-            "stable bubble id without re-reading the session row, which terminal "
-            "cleanup (finalize_turn) may have already cleared on a fast turn."
+            "Id of the turn just spawned, used as the Temporal workflow id (not "
+            "Temporal's own run_id). This bare UUID is wrapped as "
+            "'agent/<curr_run_id>' when passed to Temporal as the workflow id. "
+            "Returned so callers can build the stable bubble id without "
+            "re-reading the session row, which terminal cleanup (finalize_turn) "
+            "may have already cleared on a fast turn."
         ),
     )
 

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -2903,6 +2903,16 @@ class AgentSession(WorkspaceModel):
         nullable=True,
         doc="Last processed Redis stream ID - used to resume streaming from correct position",
     )
+    # Per-turn stream pivot (UUID we mint at turn start, names the Redis stream).
+    # Distinct id-space from last_stream_id (a Redis entry id, position-in-stream).
+    # Null = no live turn. Used as the per-turn Redis key suffix and to cross-check
+    # that a reconnecting client's cursor belongs to the current turn.
+    active_stream_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID,
+        nullable=True,
+        index=True,
+        doc="Per-turn stream id - Redis key suffix for the active turn's stream",
+    )
     work_dir_snapshot: Mapped[dict[str, Any] | None] = mapped_column(
         JSONB,
         nullable=True,
@@ -2975,6 +2985,12 @@ class AgentSessionHistory(WorkspaceModel):
         default="internal",
         index=True,
         doc="Message kind for filtering (chat-message, internal). Default to internal - only user/assistant messages explicitly marked visible.",
+    )
+    curr_run_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID,
+        nullable=True,
+        index=True,
+        doc="Workflow run that produced this row; used to hide active-turn rows mid-stream",
     )
 
     session: Mapped[AgentSession] = relationship(

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -9463,9 +9463,10 @@ async def _collect_agent_response(
     workspace_id: uuid.UUID,
     timeout: float,
     last_id: str,
+    stream_id: uuid.UUID | None = None,
 ) -> str | AgentAwaitingApprovalResponse:
     """Poll Redis agent stream and return text output or pending approval state."""
-    stream = await AgentStream.new(session_id, workspace_id)
+    stream = await AgentStream.new(session_id, workspace_id, stream_id)
     text_parts: list[str] = []
     approval_items: dict[str, AgentApprovalItemResponse] = {}
 
@@ -9617,21 +9618,27 @@ async def run_agent_preset(
                     agent_preset_version_id=version.id,
                 )
             )
+            # Mint the stream id in the caller so the producer (run_turn pins
+            # this id) and the consumer (below) share the same suffixed key.
+            stream_id = uuid.uuid4()
             # BasicChatRequest is handled at runtime by run_turn's match statement
             # but not included in the ChatRequest type alias
             await svc.run_turn(
-                session.id, cast(ChatRequest, BasicChatRequest(message=prompt))
+                session.id,
+                cast(ChatRequest, BasicChatRequest(message=prompt)),
+                active_stream_id=stream_id,
             )
 
         # Collect text from Redis stream
         if role.workspace_id is None:
             raise ToolError("Workspace ID is required")
-        start_id = session.last_stream_id or "0-0"
+        # The fresh per-turn key is empty before this run, so read from 0-0.
         return await _collect_agent_response(
             session.id,
             role.workspace_id,
             timeout,
-            start_id,
+            "0-0",
+            stream_id,
         )
     except ToolError:
         raise

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -130,7 +130,7 @@ from tracecat.cases.service import (
 )
 from tracecat.cases.tags.schemas import CaseTagRead
 from tracecat.cases.tags.service import CaseTagsService
-from tracecat.chat.schemas import BasicChatRequest, ChatRequest
+from tracecat.chat.schemas import BasicChatRequest
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.models import (
     Action,
@@ -9466,7 +9466,9 @@ async def _collect_agent_response(
     stream_id: uuid.UUID | None = None,
 ) -> str | AgentAwaitingApprovalResponse:
     """Poll Redis agent stream and return text output or pending approval state."""
-    stream = await AgentStream.new(session_id, workspace_id, stream_id)
+    stream = await AgentStream.new(
+        session_id=session_id, workspace_id=workspace_id, stream_id=stream_id
+    )
     text_parts: list[str] = []
     approval_items: dict[str, AgentApprovalItemResponse] = {}
 
@@ -9621,11 +9623,9 @@ async def run_agent_preset(
             # Mint the stream id in the caller so the producer (run_turn pins
             # this id) and the consumer (below) share the same suffixed key.
             stream_id = uuid.uuid4()
-            # BasicChatRequest is handled at runtime by run_turn's match statement
-            # but not included in the ChatRequest type alias
             await svc.run_turn(
                 session.id,
-                cast(ChatRequest, BasicChatRequest(message=prompt)),
+                BasicChatRequest(message=prompt),
                 active_stream_id=stream_id,
             )
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens agent stream resume/replay with per‑turn Redis keys, run tagging, composite SSE ids + cursor parsing, and turn‑aware reconnects to stop gaps and duplicate assistant bubbles.

- **New Features**
  - Per‑turn streaming: added session `active_stream_id` and history `curr_run_id`; switched to per‑turn Redis keys (key now includes `stream_id`); plumbed through executor/loopback, `mcp`, and the adapter; new `finalize_turn_activity` guarded by `FINALIZE_TURN_PATCH` compare‑and‑clears `curr_run_id`/`active_stream_id` at terminal.
  - SSE replay: `vercel` adapter emits `id: <redis-id>:<frame-index>` and parses cursors; replays from the composite cursor and self‑heals resumes by synthesizing missing `TEXT_START` or lazily opening parts on orphan deltas (repair frames don’t advance the composite index).
  - Stable UI: router uses `session_id:curr_run_id` for a stable assistant bubble; `ChatResponse` returns `curr_run_id` so the SDK can upsert across reconnects.

- **Bug Fixes**
  - Mid‑turn visibility: persisted history (incl. tool results) is tagged with `curr_run_id`, and mid‑turn loads hide the active run’s partial rows.
  - Reconnects: derive a `TurnLifecycle` to resume, 204, or emit a terminal error; the frontend stops sending Last‑Event‑ID; the server replays the active turn from Redis; `mcp` joins the per‑turn stream and starts at `0-0`; EE error frames now emit to the active per‑turn stream.
  - Key isolation: per‑turn Redis keys prevent cross‑turn cursor collisions; client cursors are parsed and cross‑checked; `mcp` mints/shares the `stream_id` for preset runs so producers/consumers join the same stream.

<sup>Written for commit 92f86c02d9fc18f3be3cfde8f67782426c08c281. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

