### PR TITLE
fix(storage): retry transient materialization transport errors

### DIFF
--- a/tests/unit/test_materialize_context.py
+++ b/tests/unit/test_materialize_context.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from botocore.exceptions import HTTPClientError
 from temporalio.exceptions import ApplicationError
@@ -8,6 +10,25 @@ from tracecat.dsl import action
 from tracecat.dsl.action import materialize_context
 from tracecat.dsl.schemas import ExecutionContext, TaskResult
 from tracecat.storage.object import CollectionObject, InlineObject, ObjectRef
+
+
+def test_run_sync_closes_storage_client_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    close_calls = 0
+
+    async def close_storage_client_cache() -> None:
+        nonlocal close_calls
+        close_calls += 1
+
+    monkeypatch.setattr(
+        action, "close_storage_client_cache", close_storage_client_cache
+    )
+
+    result = action.run_sync(asyncio.sleep(0, result="ok"))
+
+    assert result == "ok"
+    assert close_calls == 1
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_materialize_context.py
+++ b/tests/unit/test_materialize_context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import asyncio
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from botocore.exceptions import HTTPClientError
@@ -9,26 +9,59 @@ from temporalio.exceptions import ApplicationError
 from tracecat.dsl import action
 from tracecat.dsl.action import materialize_context
 from tracecat.dsl.schemas import ExecutionContext, TaskResult
+from tracecat.storage import blob as blob_module
+from tracecat.storage.blob import get_storage_client
 from tracecat.storage.object import CollectionObject, InlineObject, ObjectRef
 
 
-def test_run_sync_closes_storage_client_cache(
+def _close_run_sync_runner() -> None:
+    runner = getattr(action._thread_local, "runner", None)
+    if runner is not None:
+        runner.close()
+        delattr(action._thread_local, "runner")
+
+
+def test_run_sync_reuses_storage_client_until_runner_closes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    close_calls = 0
-
-    async def close_storage_client_cache() -> None:
-        nonlocal close_calls
-        close_calls += 1
-
+    _close_run_sync_runner()
+    blob_module.clear_storage_session_cache()
     monkeypatch.setattr(
-        action, "close_storage_client_cache", close_storage_client_cache
+        blob_module.config,
+        "TRACECAT__BLOB_STORAGE_ENDPOINT",
+        None,
+        raising=False,
     )
 
-    result = action.run_sync(asyncio.sleep(0, result="ok"))
+    async def use_client() -> object:
+        async with get_storage_client() as client:
+            return client
 
-    assert result == "ok"
-    assert close_calls == 1
+    try:
+        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_client = AsyncMock()
+            mock_session.client.return_value.__aenter__.return_value = mock_client
+
+            assert action.run_sync(use_client()) is mock_client
+            assert action.run_sync(use_client()) is mock_client
+
+            mock_session_cls.assert_called_once()
+            mock_session.client.assert_called_once_with(
+                "s3", config=blob_module._STORAGE_CLIENT_CONFIG
+            )
+            mock_session.client.return_value.__aenter__.assert_awaited_once()
+            mock_session.client.return_value.__aexit__.assert_not_awaited()
+
+            _close_run_sync_runner()
+
+            mock_session.client.return_value.__aexit__.assert_awaited_once_with(
+                None, None, None
+            )
+            assert len(blob_module._STORAGE_CLIENTS) == 0
+    finally:
+        _close_run_sync_runner()
+        blob_module.clear_storage_session_cache()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_materialize_context.py
+++ b/tests/unit/test_materialize_context.py
@@ -1,11 +1,33 @@
 from __future__ import annotations
 
 import pytest
+from botocore.exceptions import HTTPClientError
+from temporalio.exceptions import ApplicationError
 
 from tracecat.dsl import action
 from tracecat.dsl.action import materialize_context
 from tracecat.dsl.schemas import ExecutionContext, TaskResult
 from tracecat.storage.object import CollectionObject, InlineObject, ObjectRef
+
+
+@pytest.mark.anyio
+async def test_materialize_context_marks_storage_transport_errors_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def raise_transport_error(*_args: object, **_kwargs: object) -> object:
+        raise HTTPClientError(
+            error=RuntimeError("File descriptor 512 is used by transport")
+        )
+
+    monkeypatch.setattr(action, "retrieve_stored_object", raise_transport_error)
+
+    ctx = ExecutionContext(ACTIONS={}, TRIGGER=InlineObject(data={"trigger": 1}))
+
+    with pytest.raises(ApplicationError) as exc_info:
+        await materialize_context(ctx)
+
+    assert exc_info.value.non_retryable is False
+    assert exc_info.value.type == "StorageMaterializationError"
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_storage_blob.py
+++ b/tests/unit/test_storage_blob.py
@@ -118,8 +118,10 @@ class TestS3Operations:
             )
 
     @pytest.mark.anyio
-    async def test_get_storage_client_reuses_session_per_event_loop(self, monkeypatch):
-        """get_storage_client reuses the aioboto3 session in the same loop."""
+    async def test_get_storage_client_reuses_entered_client_per_event_loop(
+        self, monkeypatch
+    ):
+        """get_storage_client reuses the entered aiobotocore client in a loop."""
         monkeypatch.setattr(
             blob_module.config,
             "TRACECAT__BLOB_STORAGE_ENDPOINT",
@@ -138,7 +140,72 @@ class TestS3Operations:
                 assert client is mock_client
 
             mock_session_cls.assert_called_once()
-            assert mock_session.client.call_count == 2
+            mock_session.client.assert_called_once_with(
+                "s3", config=blob_module._STORAGE_CLIENT_CONFIG
+            )
+            mock_session.client.return_value.__aenter__.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_get_storage_client_concurrent_first_use_enters_client_once(
+        self, monkeypatch
+    ):
+        """Concurrent first use shares a single entered aiobotocore client."""
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_ENDPOINT",
+            None,
+            raising=False,
+        )
+
+        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_client = AsyncMock()
+
+            async def enter_client() -> AsyncMock:
+                await asyncio.sleep(0.01)
+                return mock_client
+
+            mock_session.client.return_value.__aenter__.side_effect = enter_client
+
+            async def use_client() -> None:
+                async with get_storage_client() as client:
+                    assert client is mock_client
+
+            await asyncio.gather(*(use_client() for _ in range(50)))
+
+            mock_session_cls.assert_called_once()
+            mock_session.client.assert_called_once_with(
+                "s3", config=blob_module._STORAGE_CLIENT_CONFIG
+            )
+            mock_session.client.return_value.__aenter__.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_close_storage_client_cache_closes_entered_client_context(
+        self, monkeypatch
+    ):
+        """close_storage_client_cache exits cached aiobotocore client contexts."""
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_ENDPOINT",
+            None,
+            raising=False,
+        )
+
+        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_client = AsyncMock()
+            mock_session.client.return_value.__aenter__.return_value = mock_client
+
+            async with get_storage_client() as client:
+                assert client is mock_client
+
+            mock_session.client.return_value.__aexit__.assert_not_awaited()
+
+            await blob_module.close_storage_client_cache()
+
+            mock_session.client.return_value.__aexit__.assert_awaited_once_with(
+                None, None, None
+            )
 
     def test_get_storage_client_uses_new_session_for_new_event_loop(self, monkeypatch):
         """get_storage_client does not reuse aioboto3 sessions across event loops."""

--- a/tests/unit/test_storage_blob.py
+++ b/tests/unit/test_storage_blob.py
@@ -216,20 +216,45 @@ class TestS3Operations:
             raising=False,
         )
 
-        async def use_client() -> None:
+        async def use_client(expected_client: AsyncMock) -> None:
             async with get_storage_client() as client:
-                assert client is mock_client
+                assert client is expected_client
 
         with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
             mock_session = mock_session_cls.return_value
             mock_client = AsyncMock()
             mock_session.client.return_value.__aenter__.return_value = mock_client
 
-            asyncio.run(use_client())
-            asyncio.run(use_client())
+            asyncio.run(use_client(mock_client))
+            asyncio.run(use_client(mock_client))
 
             assert mock_session_cls.call_count == 2
             assert mock_session.client.call_count == 2
+
+    def test_get_storage_client_closes_cache_when_event_loop_closes(self, monkeypatch):
+        """Temporary asyncio.run loops close their cached aiobotocore clients."""
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_ENDPOINT",
+            None,
+            raising=False,
+        )
+
+        async def use_client(expected_client: AsyncMock) -> None:
+            async with get_storage_client() as client:
+                assert client is expected_client
+
+        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_client = AsyncMock()
+            mock_session.client.return_value.__aenter__.return_value = mock_client
+
+            asyncio.run(use_client(mock_client))
+
+            mock_session.client.return_value.__aexit__.assert_awaited_once_with(
+                None, None, None
+            )
+            assert len(blob_module._STORAGE_CLIENTS) == 0
 
     @pytest.mark.anyio
     @patch("tracecat.storage.blob.get_storage_client")

--- a/tests/unit/test_storage_blob.py
+++ b/tests/unit/test_storage_blob.py
@@ -1,5 +1,6 @@
 """Tests for the storage module."""
 
+import asyncio
 import hashlib
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -28,6 +29,12 @@ from tracecat.storage.blob import (
 
 class TestS3Operations:
     """Test S3/MinIO operations."""
+
+    @pytest.fixture(autouse=True)
+    def clear_session_cache(self):
+        blob_module.clear_storage_session_cache()
+        yield
+        blob_module.clear_storage_session_cache()
 
     @pytest.fixture
     def mock_s3_client(self):
@@ -109,6 +116,53 @@ class TestS3Operations:
             mock_session.client.assert_called_once_with(
                 "s3", config=blob_module._STORAGE_CLIENT_CONFIG
             )
+
+    @pytest.mark.anyio
+    async def test_get_storage_client_reuses_session_per_event_loop(self, monkeypatch):
+        """get_storage_client reuses the aioboto3 session in the same loop."""
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_ENDPOINT",
+            None,
+            raising=False,
+        )
+
+        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_client = AsyncMock()
+            mock_session.client.return_value.__aenter__.return_value = mock_client
+
+            async with get_storage_client() as client:
+                assert client is mock_client
+            async with get_storage_client() as client:
+                assert client is mock_client
+
+            mock_session_cls.assert_called_once()
+            assert mock_session.client.call_count == 2
+
+    def test_get_storage_client_uses_new_session_for_new_event_loop(self, monkeypatch):
+        """get_storage_client does not reuse aioboto3 sessions across event loops."""
+        monkeypatch.setattr(
+            blob_module.config,
+            "TRACECAT__BLOB_STORAGE_ENDPOINT",
+            None,
+            raising=False,
+        )
+
+        async def use_client() -> None:
+            async with get_storage_client() as client:
+                assert client is mock_client
+
+        with patch("tracecat.storage.blob.aioboto3.Session") as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_client = AsyncMock()
+            mock_session.client.return_value.__aenter__.return_value = mock_client
+
+            asyncio.run(use_client())
+            asyncio.run(use_client())
+
+            assert mock_session_cls.call_count == 2
+            assert mock_session.client.call_count == 2
 
     @pytest.mark.anyio
     @patch("tracecat.storage.blob.get_storage_client")

--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -8,9 +8,8 @@ from concurrent.futures import ThreadPoolExecutor
 from multiprocessing.connection import Connection
 
 import pytest
-from botocore.exceptions import ClientError, HTTPClientError
 
-from tracecat.storage.utils import SizedMemoryCache, cached_blob_download
+from tracecat.storage.utils import SizedMemoryCache
 
 
 def _run_shared_cache_lock_contention_probe(result_connection: Connection) -> None:
@@ -70,75 +69,6 @@ def _run_shared_cache_lock_contention_probe(result_connection: Connection) -> No
         result_connection.send(("ok", ""))
     finally:
         result_connection.close()
-
-
-class TestBlobStorageTransportRetries:
-    """Test narrow retries around blob storage transport failures."""
-
-    @pytest.mark.anyio
-    async def test_cached_blob_download_retries_http_client_errors(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        attempts = 0
-
-        async def fake_download_file(*, key: str, bucket: str) -> bytes:
-            nonlocal attempts
-            attempts += 1
-            assert key == "key"
-            assert bucket == "bucket"
-            if attempts < 3:
-                raise HTTPClientError(
-                    error=RuntimeError("File descriptor 512 is used by transport")
-                )
-            return b"payload"
-
-        monkeypatch.setattr(
-            "tracecat.storage.utils.STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS", 0
-        )
-        monkeypatch.setattr(
-            "tracecat.storage.utils.blob.download_file",
-            fake_download_file,
-        )
-
-        content = await cached_blob_download(
-            sha256="retry-http-client-error-sha",
-            bucket="bucket",
-            key="key",
-        )
-
-        assert content == b"payload"
-        assert attempts == 3
-
-    @pytest.mark.anyio
-    async def test_cached_blob_download_does_not_retry_service_errors(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        attempts = 0
-
-        async def fake_download_file(*, key: str, bucket: str) -> bytes:  # noqa: ARG001
-            nonlocal attempts
-            attempts += 1
-            raise ClientError(
-                error_response={"Error": {"Code": "NoSuchKey"}},
-                operation_name="GetObject",
-            )
-
-        monkeypatch.setattr(
-            "tracecat.storage.utils.STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS", 0
-        )
-        monkeypatch.setattr(
-            "tracecat.storage.utils.blob.download_file",
-            fake_download_file,
-        )
-
-        with pytest.raises(ClientError):
-            await cached_blob_download(
-                sha256="non-retry-service-error-sha",
-                bucket="bucket",
-                key="key",
-            )
-
-        assert attempts == 1
 
 
 class TestSizedMemoryCache:

--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -8,8 +8,9 @@ from concurrent.futures import ThreadPoolExecutor
 from multiprocessing.connection import Connection
 
 import pytest
+from botocore.exceptions import ClientError, HTTPClientError
 
-from tracecat.storage.utils import SizedMemoryCache
+from tracecat.storage.utils import SizedMemoryCache, cached_blob_download
 
 
 def _run_shared_cache_lock_contention_probe(result_connection: Connection) -> None:
@@ -69,6 +70,75 @@ def _run_shared_cache_lock_contention_probe(result_connection: Connection) -> No
         result_connection.send(("ok", ""))
     finally:
         result_connection.close()
+
+
+class TestBlobStorageTransportRetries:
+    """Test narrow retries around blob storage transport failures."""
+
+    @pytest.mark.anyio
+    async def test_cached_blob_download_retries_http_client_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        attempts = 0
+
+        async def fake_download_file(*, key: str, bucket: str) -> bytes:
+            nonlocal attempts
+            attempts += 1
+            assert key == "key"
+            assert bucket == "bucket"
+            if attempts < 3:
+                raise HTTPClientError(
+                    error=RuntimeError("File descriptor 512 is used by transport")
+                )
+            return b"payload"
+
+        monkeypatch.setattr(
+            "tracecat.storage.utils.STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS", 0
+        )
+        monkeypatch.setattr(
+            "tracecat.storage.utils.blob.download_file",
+            fake_download_file,
+        )
+
+        content = await cached_blob_download(
+            sha256="retry-http-client-error-sha",
+            bucket="bucket",
+            key="key",
+        )
+
+        assert content == b"payload"
+        assert attempts == 3
+
+    @pytest.mark.anyio
+    async def test_cached_blob_download_does_not_retry_service_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        attempts = 0
+
+        async def fake_download_file(*, key: str, bucket: str) -> bytes:  # noqa: ARG001
+            nonlocal attempts
+            attempts += 1
+            raise ClientError(
+                error_response={"Error": {"Code": "NoSuchKey"}},
+                operation_name="GetObject",
+            )
+
+        monkeypatch.setattr(
+            "tracecat.storage.utils.STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS", 0
+        )
+        monkeypatch.setattr(
+            "tracecat.storage.utils.blob.download_file",
+            fake_download_file,
+        )
+
+        with pytest.raises(ClientError):
+            await cached_blob_download(
+                sha256="non-retry-service-error-sha",
+                bucket="bucket",
+                key="key",
+            )
+
+        assert attempts == 1
 
 
 class TestSizedMemoryCache:

--- a/tests/unit/test_storage_cache.py
+++ b/tests/unit/test_storage_cache.py
@@ -8,8 +8,14 @@ from concurrent.futures import ThreadPoolExecutor
 from multiprocessing.connection import Connection
 
 import pytest
+from botocore.exceptions import ClientError, HTTPClientError
 
-from tracecat.storage.utils import SizedMemoryCache
+from tracecat.storage.utils import (
+    SizedMemoryCache,
+    cached_blob_download,
+    cached_select_item,
+    is_retryable_storage_transport_error,
+)
 
 
 def _run_shared_cache_lock_contention_probe(result_connection: Connection) -> None:
@@ -69,6 +75,130 @@ def _run_shared_cache_lock_contention_probe(result_connection: Connection) -> No
         result_connection.send(("ok", ""))
     finally:
         result_connection.close()
+
+
+class TestBlobStorageTransportRetries:
+    """Test narrow retries around blob storage transport failures."""
+
+    @pytest.mark.anyio
+    async def test_cached_blob_download_retries_http_client_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        attempts = 0
+
+        async def fake_download_file(*, key: str, bucket: str) -> bytes:
+            nonlocal attempts
+            attempts += 1
+            assert key == "key"
+            assert bucket == "bucket"
+            if attempts < 3:
+                raise HTTPClientError(
+                    error=RuntimeError("File descriptor 512 is used by transport")
+                )
+            return b"payload"
+
+        monkeypatch.setattr(
+            "tracecat.storage.utils.STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS", 0
+        )
+        monkeypatch.setattr(
+            "tracecat.storage.utils.blob.download_file",
+            fake_download_file,
+        )
+
+        content = await cached_blob_download(
+            sha256="retry-http-client-error-sha",
+            bucket="bucket",
+            key="key",
+        )
+
+        assert content == b"payload"
+        assert attempts == 3
+
+    @pytest.mark.anyio
+    async def test_cached_blob_download_does_not_retry_service_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        attempts = 0
+
+        async def fake_download_file(*, key: str, bucket: str) -> bytes:  # noqa: ARG001
+            nonlocal attempts
+            attempts += 1
+            raise ClientError(
+                error_response={"Error": {"Code": "NoSuchKey"}},
+                operation_name="GetObject",
+            )
+
+        monkeypatch.setattr(
+            "tracecat.storage.utils.STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS", 0
+        )
+        monkeypatch.setattr(
+            "tracecat.storage.utils.blob.download_file",
+            fake_download_file,
+        )
+
+        with pytest.raises(ClientError):
+            await cached_blob_download(
+                sha256="non-retry-service-error-sha",
+                bucket="bucket",
+                key="key",
+            )
+
+        assert attempts == 1
+
+    @pytest.mark.anyio
+    async def test_cached_select_item_retries_http_client_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        attempts = 0
+
+        async def fake_select_object_content(
+            *, key: str, bucket: str, expression: str
+        ) -> bytes:
+            nonlocal attempts
+            attempts += 1
+            assert key == "key"
+            assert bucket == "bucket"
+            assert expression == "SELECT s.items[2] FROM s3object s"
+            if attempts < 3:
+                raise HTTPClientError(error=RuntimeError("Connection reset"))
+            return b'{"_1":{"ok":true}}'
+
+        monkeypatch.setattr(
+            "tracecat.storage.utils.STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS", 0
+        )
+        monkeypatch.setattr(
+            "tracecat.storage.utils.blob.select_object_content",
+            fake_select_object_content,
+        )
+
+        item = await cached_select_item(
+            sha256="retry-select-http-client-error-sha",
+            bucket="bucket",
+            key="key",
+            local_index=2,
+        )
+
+        assert item == {"ok": True}
+        assert attempts == 3
+
+    def test_retryable_transport_detection_checks_all_wrapped_branches(self) -> None:
+        context = HTTPClientError(error=RuntimeError("Connection reset"))
+        wrapper = RuntimeError("wrapper")
+        wrapper.__cause__ = ValueError("non-retryable cause")
+        wrapper.__context__ = context
+
+        assert is_retryable_storage_transport_error(wrapper) is True
+
+    def test_retryable_transport_detection_checks_exception_groups(self) -> None:
+        group = ExceptionGroup(
+            "group",
+            [
+                ValueError("not retryable"),
+                HTTPClientError(error=RuntimeError("Connection reset")),
+            ],
+        )
+
+        assert is_retryable_storage_transport_error(group) is True
 
 
 class TestSizedMemoryCache:

--- a/tracecat/agent/executor_worker.py
+++ b/tracecat/agent/executor_worker.py
@@ -22,6 +22,7 @@ from tracecat.agent.runtime_services import (
 from tracecat.agent.worker import new_sandbox_runner
 from tracecat.dsl.client import get_temporal_client
 from tracecat.logger import logger
+from tracecat.storage.blob import close_storage_client_cache
 from tracecat.temporal.worker_lifecycle import run_worker_entrypoint
 
 if TYPE_CHECKING:
@@ -106,6 +107,7 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
                 logger.info("AgentExecutorWorker shutdown requested")
             logger.info("Temporal Worker context exited")
     finally:
+        await close_storage_client_cache()
         await _stop_runtime_services()
     if runtime_failure_reason is not None:
         raise RuntimeError(runtime_failure_reason)

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -38,6 +38,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.interceptor import SentryInterceptor
     from tracecat.dsl.plugins import TracecatPydanticAIPlugin
     from tracecat.logger import logger
+    from tracecat.storage.blob import close_storage_client_cache
     from tracecat.temporal.worker_lifecycle import run_worker_entrypoint
 
 
@@ -142,6 +143,7 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
             await shutdown_event.wait()
             logger.info("AgentWorker shutdown requested")
         logger.info("Temporal Worker context exited")
+    await close_storage_client_cache()
 
 
 if __name__ == "__main__":

--- a/tracecat/agent/worker.py
+++ b/tracecat/agent/worker.py
@@ -124,26 +124,28 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
         ],
     )
 
-    with ThreadPoolExecutor(max_workers=threadpool_max_workers) as executor:
-        workflows: list[type] = [DurableAgentWorkflow, ExecuteRegistryToolWorkflow]
+    try:
+        with ThreadPoolExecutor(max_workers=threadpool_max_workers) as executor:
+            workflows: list[type] = [DurableAgentWorkflow, ExecuteRegistryToolWorkflow]
 
-        async with Worker(
-            client,
-            task_queue=config.TRACECAT__AGENT_QUEUE,
-            activities=activities,
-            workflows=workflows,
-            workflow_runner=new_sandbox_runner(),
-            interceptors=interceptors,
-            max_concurrent_activities=max_concurrent,
-            disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
-            activity_executor=executor,
-            graceful_shutdown_timeout=timedelta(seconds=30),
-        ):
-            logger.info("AgentWorker started, ctrl+c to exit")
-            await shutdown_event.wait()
-            logger.info("AgentWorker shutdown requested")
-        logger.info("Temporal Worker context exited")
-    await close_storage_client_cache()
+            async with Worker(
+                client,
+                task_queue=config.TRACECAT__AGENT_QUEUE,
+                activities=activities,
+                workflows=workflows,
+                workflow_runner=new_sandbox_runner(),
+                interceptors=interceptors,
+                max_concurrent_activities=max_concurrent,
+                disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
+                activity_executor=executor,
+                graceful_shutdown_timeout=timedelta(seconds=30),
+            ):
+                logger.info("AgentWorker started, ctrl+c to exit")
+                await shutdown_event.wait()
+                logger.info("AgentWorker shutdown requested")
+            logger.info("Temporal Worker context exited")
+    finally:
+        await close_storage_client_cache()
 
 
 if __name__ == "__main__":

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -160,7 +160,11 @@ from tracecat.service_accounts.router import (
 )
 from tracecat.settings.router import router as org_settings_router
 from tracecat.settings.service import SettingsService, get_setting_override
-from tracecat.storage.blob import configure_bucket_lifecycle, ensure_bucket_exists
+from tracecat.storage.blob import (
+    close_storage_client_cache,
+    configure_bucket_lifecycle,
+    ensure_bucket_exists,
+)
 from tracecat.tables.internal_router import router as internal_tables_router
 from tracecat.tables.router import router as tables_router
 from tracecat.tags.router import router as tags_router
@@ -314,6 +318,8 @@ async def lifespan(app: FastAPI):
             logger.debug("Case trigger consumer task cancelled")
         except Exception as e:
             logger.warning("Case trigger consumer stopped with error", error=e)
+
+    await close_storage_client_cache()
 
 
 async def setup_org_settings(session: AsyncSession, admin_role: Role):

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -52,6 +52,7 @@ from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.integrations.mcp_validation import MCPValidationError
 from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.storage.blob import close_storage_client_cache
 from tracecat.storage.collection import (
     materialize_collection_values,
     store_collection,
@@ -248,7 +249,16 @@ def run_sync[T: Any](coro: Coroutine[Any, Any, T]) -> T:
         runner = asyncio.Runner()
         runner.__enter__()  # create & keep loop
         _thread_local.runner = runner
-    return runner.run(coro)
+    try:
+        return runner.run(coro)
+    finally:
+        try:
+            runner.run(close_storage_client_cache())
+        except Exception as e:
+            logger.warning(
+                "Failed to close thread-local storage client cache",
+                error=e,
+            )
 
 
 async def _store_collection_as_refs(prefix: str, items: list[Any]) -> CollectionObject:

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import weakref
 from collections.abc import Callable, Coroutine, Mapping
 from typing import Any, cast
 
@@ -52,7 +53,6 @@ from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.integrations.mcp_validation import MCPValidationError
 from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
-from tracecat.storage.blob import close_storage_client_cache
 from tracecat.storage.collection import (
     materialize_collection_values,
     store_collection,
@@ -72,6 +72,34 @@ from tracecat.temporal.exceptions import UserError
 from tracecat.validation.schemas import ValidationDetail
 
 _thread_local = threading.local()
+
+
+def _close_asyncio_runner(runner: asyncio.Runner) -> None:
+    try:
+        runner.close()
+    except Exception as e:
+        logger.warning(
+            "Failed to close thread-local asyncio runner",
+            error=e,
+        )
+
+
+# ThreadPoolExecutor clears thread locals when worker threads exit; closing the
+# runner there lets storage loop-close hooks drain clients without per-call churn.
+class _ThreadLocalRunner:
+    def __init__(self) -> None:
+        runner = asyncio.Runner()
+        runner.__enter__()  # create & keep loop
+        self._runner = runner
+        self._finalizer = weakref.finalize(self, _close_asyncio_runner, runner)
+        self._finalizer.atexit = False
+
+    def run[T: Any](self, coro: Coroutine[Any, Any, T]) -> T:
+        return self._runner.run(coro)
+
+    def close(self) -> None:
+        if self._finalizer.alive:
+            self._finalizer()
 
 
 async def _resolve_mcp_integrations(
@@ -246,19 +274,9 @@ def run_sync[T: Any](coro: Coroutine[Any, Any, T]) -> T:
     """Run a coroutine in the current thread."""
     runner = getattr(_thread_local, "runner", None)
     if runner is None:
-        runner = asyncio.Runner()
-        runner.__enter__()  # create & keep loop
+        runner = _ThreadLocalRunner()
         _thread_local.runner = runner
-    try:
-        return runner.run(coro)
-    finally:
-        try:
-            runner.run(close_storage_client_cache())
-        except Exception as e:
-            logger.warning(
-                "Failed to close thread-local storage client cache",
-                error=e,
-            )
+    return runner.run(coro)
 
 
 async def _store_collection_as_refs(prefix: str, items: list[Any]) -> CollectionObject:

--- a/tracecat/dsl/action.py
+++ b/tracecat/dsl/action.py
@@ -66,6 +66,7 @@ from tracecat.storage.object import (
     get_object_storage,
     retrieve_stored_object,
 )
+from tracecat.storage.utils import is_retryable_storage_transport_error
 from tracecat.temporal.exceptions import UserError
 from tracecat.validation.schemas import ValidationDetail
 
@@ -357,7 +358,18 @@ async def materialize_context(ctx: ExecutionContext) -> MaterializedExecutionCon
     try:
         materialized_results = await asyncio.gather(*coros)
     except Exception as e:
-        logger.warning("Error materializing context", error=e)
+        retryable = is_retryable_storage_transport_error(e)
+        logger.warning(
+            "Error materializing context",
+            error=e,
+            retryable=retryable,
+        )
+        if retryable:
+            raise ApplicationError(
+                "Failed to materialize context",
+                non_retryable=False,
+                type="StorageMaterializationError",
+            ) from e
         raise ApplicationError(
             "Failed to materialize context",
             non_retryable=True,

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -33,6 +33,7 @@ with workflow.unsafe.imports_passed_through():
     from tracecat.dsl.workflow import DSLWorkflow
     from tracecat.ee.interactions.service import InteractionService
     from tracecat.logger import logger
+    from tracecat.storage.blob import close_storage_client_cache
     from tracecat.storage.collection import CollectionActivities
     from tracecat.temporal.worker_lifecycle import run_worker_entrypoint
     from tracecat.tiers.activities import TierActivities
@@ -168,6 +169,7 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
             await shutdown_event.wait()
             logger.info("Worker shutdown requested")
         logger.info("Temporal Worker context exited")
+    await close_storage_client_cache()
 
 
 if __name__ == "__main__":

--- a/tracecat/dsl/worker.py
+++ b/tracecat/dsl/worker.py
@@ -147,29 +147,33 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
         os.environ.get("TEMPORAL__THREADPOOL_MAX_WORKERS", 100)
     )
 
-    with ThreadPoolExecutor(max_workers=threadpool_max_workers) as executor:
-        workflows: list[type] = [DSLWorkflow]
+    try:
+        with ThreadPoolExecutor(max_workers=threadpool_max_workers) as executor:
+            workflows: list[type] = [DSLWorkflow]
 
-        async with Worker(
-            client,
-            task_queue=os.environ.get("TEMPORAL__CLUSTER_QUEUE", "tracecat-task-queue"),
-            activities=activities,
-            workflows=workflows,
-            workflow_runner=new_sandbox_runner(),
-            interceptors=interceptors,
-            disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
-            activity_executor=executor,
-            graceful_shutdown_timeout=timedelta(seconds=30),
-        ):
-            logger.info(
-                "Worker started, ctrl+c to exit",
+            async with Worker(
+                client,
+                task_queue=os.environ.get(
+                    "TEMPORAL__CLUSTER_QUEUE", "tracecat-task-queue"
+                ),
+                activities=activities,
+                workflows=workflows,
+                workflow_runner=new_sandbox_runner(),
+                interceptors=interceptors,
                 disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
-                threadpool_max_workers=threadpool_max_workers,
-            )
-            await shutdown_event.wait()
-            logger.info("Worker shutdown requested")
-        logger.info("Temporal Worker context exited")
-    await close_storage_client_cache()
+                activity_executor=executor,
+                graceful_shutdown_timeout=timedelta(seconds=30),
+            ):
+                logger.info(
+                    "Worker started, ctrl+c to exit",
+                    disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
+                    threadpool_max_workers=threadpool_max_workers,
+                )
+                await shutdown_event.wait()
+                logger.info("Worker shutdown requested")
+            logger.info("Temporal Worker context exited")
+    finally:
+        await close_storage_client_cache()
 
 
 if __name__ == "__main__":

--- a/tracecat/executor/worker.py
+++ b/tracecat/executor/worker.py
@@ -67,6 +67,7 @@ with workflow.unsafe.imports_passed_through():
         RegistrySyncActivities,
         RegistrySyncWorkflow,
     )
+    from tracecat.storage.blob import close_storage_client_cache
     from tracecat.temporal.worker_lifecycle import run_worker_entrypoint
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
@@ -177,6 +178,7 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
     finally:
         logger.info("Shutting down executor backend")
         await shutdown_executor_backend()
+        await close_storage_client_cache()
         await action_gateway.stop()
 
 

--- a/tracecat/storage/blob.py
+++ b/tracecat/storage/blob.py
@@ -65,6 +65,9 @@ class _StorageClientEntry:
 _STORAGE_CLIENTS: weakref.WeakKeyDictionary[
     asyncio.AbstractEventLoop, _StorageClientEntry
 ] = weakref.WeakKeyDictionary()
+_STORAGE_CLIENT_CLOSE_HOOK_LOOPS: weakref.WeakSet[asyncio.AbstractEventLoop] = (
+    weakref.WeakSet()
+)
 _STORAGE_CLIENTS_LOCK = threading.RLock()
 
 
@@ -98,6 +101,7 @@ async def _get_storage_client() -> S3Client:
         if entry is None:
             entry = _StorageClientEntry()
             _STORAGE_CLIENTS[loop] = entry
+            _ensure_storage_client_loop_close_hook(loop)
 
     async with entry.lock:
         client = entry.client
@@ -125,26 +129,79 @@ def clear_storage_session_cache() -> None:
         _STORAGE_CLIENTS.clear()
 
 
-async def close_storage_client_cache() -> None:
-    """Close and clear cached aiobotocore clients owned by the current loop.
-
-    aiobotocore clients must be closed on the event loop that created them, so
-    only the current loop's entries are shut down here. Clients cached on other
-    loops are released when those loops are garbage collected (the cache is
-    keyed by a weak reference to the loop).
-    """
-    loop = asyncio.get_running_loop()
+def _pop_storage_client_entries_for_loop_shutdown(
+    loop: asyncio.AbstractEventLoop,
+) -> list[_StorageClientEntry]:
     with _STORAGE_CLIENTS_LOCK:
         entry = _STORAGE_CLIENTS.pop(loop, None)
+    return [entry] if entry is not None else []
 
-    if entry is None:
-        return
+
+def _pop_storage_client_entries_for_cache_shutdown(
+    loop: asyncio.AbstractEventLoop,
+) -> list[_StorageClientEntry]:
+    entries: list[_StorageClientEntry] = []
+    with _STORAGE_CLIENTS_LOCK:
+        if current_entry := _STORAGE_CLIENTS.pop(loop, None):
+            entries.append(current_entry)
+        for cached_loop, entry in list(_STORAGE_CLIENTS.items()):
+            if cached_loop.is_closed():
+                _STORAGE_CLIENTS.pop(cached_loop, None)
+                entries.append(entry)
+    return entries
+
+
+async def _close_storage_client_entry(entry: _StorageClientEntry) -> None:
     async with entry.lock:
         context = entry.context
         entry.context = None
         entry.client = None
         if context is not None:
             await context.__aexit__(None, None, None)
+
+
+async def _close_storage_client_entries(
+    entries: list[_StorageClientEntry],
+) -> None:
+    for entry in entries:
+        await _close_storage_client_entry(entry)
+
+
+def _ensure_storage_client_loop_close_hook(loop: asyncio.AbstractEventLoop) -> None:
+    if loop in _STORAGE_CLIENT_CLOSE_HOOK_LOOPS:
+        return
+
+    original_close = loop.close
+
+    def close_with_storage_client_cache() -> None:
+        try:
+            if not loop.is_running() and not loop.is_closed():
+                entries = _pop_storage_client_entries_for_loop_shutdown(loop)
+                if entries:
+                    loop.run_until_complete(_close_storage_client_entries(entries))
+        except Exception as e:
+            logger.warning(
+                "Failed to close storage client cache before loop shutdown",
+                error=e,
+            )
+        finally:
+            original_close()
+
+    loop.close = close_with_storage_client_cache
+    _STORAGE_CLIENT_CLOSE_HOOK_LOOPS.add(loop)
+
+
+async def close_storage_client_cache() -> None:
+    """Close and clear cached aiobotocore clients for this loop and stale loops.
+
+    Temporary event loops can be kept alive by cached aiobotocore/aiohttp state,
+    so weak-key eviction alone is not enough. Do not close clients owned by other
+    running loops, but drain entries for the current loop and loops that have
+    already been closed.
+    """
+    loop = asyncio.get_running_loop()
+    entries = _pop_storage_client_entries_for_cache_shutdown(loop)
+    await _close_storage_client_entries(entries)
 
 
 @asynccontextmanager

--- a/tracecat/storage/blob.py
+++ b/tracecat/storage/blob.py
@@ -8,7 +8,7 @@ import os
 import threading
 import weakref
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -49,73 +49,31 @@ _STORAGE_CLIENT_CONFIG = AioConfig(
 )
 
 
-@dataclass(frozen=True)
-class _StorageSessionKey:
-    endpoint: str | None
-    aws_access_key_id: str | None
-    aws_secret_access_key: str | None = field(repr=False)
+@dataclass
+class _StorageClientEntry:
+    context: AbstractAsyncContextManager[S3Client] | None = field(
+        default=None, repr=False
+    )
+    client: S3Client | None = field(default=None, repr=False)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
 
 
-# aioboto3 / aiobotocore sessions cache credential providers. Keep one session
-# per event loop and credential configuration so high-concurrency materialization
-# does not create a fresh credential HTTP client for every blob fetch.
-_STORAGE_SESSIONS: weakref.WeakKeyDictionary[
-    asyncio.AbstractEventLoop, dict[_StorageSessionKey, aioboto3.Session]
+# aiobotocore clients own the aiohttp ClientSession/TCPConnector that opens file
+# descriptors. Keep one entered client per event loop so concurrent
+# materialization reuses the HTTP connector instead of opening and closing one
+# connector per blob fetch.
+_STORAGE_CLIENTS: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, _StorageClientEntry
 ] = weakref.WeakKeyDictionary()
-_STORAGE_SESSIONS_LOCK = threading.RLock()
+_STORAGE_CLIENTS_LOCK = threading.RLock()
 
 
-def _storage_session_key() -> _StorageSessionKey:
-    endpoint = config.TRACECAT__BLOB_STORAGE_ENDPOINT
-    access_key_id = os.environ.get(
-        "AWS_ACCESS_KEY_ID", os.environ.get("MINIO_ROOT_USER")
-    )
-    secret_access_key = os.environ.get(
-        "AWS_SECRET_ACCESS_KEY",
-        os.environ.get("MINIO_ROOT_PASSWORD"),
-    )
-    return _StorageSessionKey(
-        endpoint=endpoint,
-        aws_access_key_id=access_key_id,
-        aws_secret_access_key=secret_access_key,
-    )
-
-
-def _get_storage_session() -> aioboto3.Session:
-    loop = asyncio.get_running_loop()
-    key = _storage_session_key()
-    with _STORAGE_SESSIONS_LOCK:
-        sessions = _STORAGE_SESSIONS.setdefault(loop, {})
-        session = sessions.get(key)
-        if session is None:
-            session = aioboto3.Session()
-            sessions[key] = session
-        return session
-
-
-def clear_storage_session_cache() -> None:
-    """Clear cached aioboto3 sessions.
-
-    Intended for tests and process lifecycle hooks. Production workers normally
-    keep sessions for the life of their event loop so credential providers can
-    be reused safely within that loop.
-    """
-    with _STORAGE_SESSIONS_LOCK:
-        _STORAGE_SESSIONS.clear()
-
-
-@asynccontextmanager
-async def get_storage_client() -> AsyncIterator[S3Client]:
-    """Get a configured S3 client for either AWS S3.
-
-    Yields:
-        Configured aioboto3 S3 client
-    """
-    session = _get_storage_session()
+def _create_storage_client_context() -> AbstractAsyncContextManager[S3Client]:
+    session = aioboto3.Session()
     # Configure client based on protocol
     if config.TRACECAT__BLOB_STORAGE_ENDPOINT:
         # MinIO configuration - use AWS_* or MINIO_ROOT_* credentials
-        async with session.client(
+        return session.client(
             "s3",
             endpoint_url=config.TRACECAT__BLOB_STORAGE_ENDPOINT,
             config=_STORAGE_CLIENT_CONFIG,
@@ -128,12 +86,75 @@ async def get_storage_client() -> AsyncIterator[S3Client]:
                 "AWS_SECRET_ACCESS_KEY",
                 os.environ.get("MINIO_ROOT_PASSWORD"),
             ),
-        ) as client:
-            yield client
-    else:
-        # AWS S3 configuration - use AWS credentials from environment or default credential chain
-        async with session.client("s3", config=_STORAGE_CLIENT_CONFIG) as client:
-            yield client
+        )
+    # AWS S3 configuration - use AWS credentials from environment or default credential chain
+    return session.client("s3", config=_STORAGE_CLIENT_CONFIG)
+
+
+async def _get_storage_client() -> S3Client:
+    loop = asyncio.get_running_loop()
+    with _STORAGE_CLIENTS_LOCK:
+        entry = _STORAGE_CLIENTS.get(loop)
+        if entry is None:
+            entry = _StorageClientEntry()
+            _STORAGE_CLIENTS[loop] = entry
+
+    async with entry.lock:
+        client = entry.client
+        if client is None:
+            context = _create_storage_client_context()
+            try:
+                client = await context.__aenter__()
+            except Exception:
+                entry.context = None
+                entry.client = None
+                raise
+            entry.context = context
+            entry.client = client
+        return client
+
+
+def clear_storage_session_cache() -> None:
+    """Clear cached storage clients without awaiting context shutdown.
+
+    Prefer `close_storage_client_cache()` when a cached client may have been
+    opened. This synchronous helper exists for tests that patch client creation
+    before any real HTTP connector is entered.
+    """
+    with _STORAGE_CLIENTS_LOCK:
+        _STORAGE_CLIENTS.clear()
+
+
+async def close_storage_client_cache() -> None:
+    """Close and clear cached aiobotocore clients owned by the current loop.
+
+    aiobotocore clients must be closed on the event loop that created them, so
+    only the current loop's entries are shut down here. Clients cached on other
+    loops are released when those loops are garbage collected (the cache is
+    keyed by a weak reference to the loop).
+    """
+    loop = asyncio.get_running_loop()
+    with _STORAGE_CLIENTS_LOCK:
+        entry = _STORAGE_CLIENTS.pop(loop, None)
+
+    if entry is None:
+        return
+    async with entry.lock:
+        context = entry.context
+        entry.context = None
+        entry.client = None
+        if context is not None:
+            await context.__aexit__(None, None, None)
+
+
+@asynccontextmanager
+async def get_storage_client() -> AsyncIterator[S3Client]:
+    """Get a configured S3 client for either AWS S3.
+
+    Yields:
+        Configured aioboto3 S3 client
+    """
+    yield await _get_storage_client()
 
 
 async def ensure_bucket_exists(bucket: str) -> None:

--- a/tracecat/storage/blob.py
+++ b/tracecat/storage/blob.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import os
+import threading
+import weakref
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -45,6 +49,61 @@ _STORAGE_CLIENT_CONFIG = AioConfig(
 )
 
 
+@dataclass(frozen=True)
+class _StorageSessionKey:
+    endpoint: str | None
+    aws_access_key_id: str | None
+    aws_secret_access_key: str | None = field(repr=False)
+
+
+# aioboto3 / aiobotocore sessions cache credential providers. Keep one session
+# per event loop and credential configuration so high-concurrency materialization
+# does not create a fresh credential HTTP client for every blob fetch.
+_STORAGE_SESSIONS: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, dict[_StorageSessionKey, aioboto3.Session]
+] = weakref.WeakKeyDictionary()
+_STORAGE_SESSIONS_LOCK = threading.RLock()
+
+
+def _storage_session_key() -> _StorageSessionKey:
+    endpoint = config.TRACECAT__BLOB_STORAGE_ENDPOINT
+    access_key_id = os.environ.get(
+        "AWS_ACCESS_KEY_ID", os.environ.get("MINIO_ROOT_USER")
+    )
+    secret_access_key = os.environ.get(
+        "AWS_SECRET_ACCESS_KEY",
+        os.environ.get("MINIO_ROOT_PASSWORD"),
+    )
+    return _StorageSessionKey(
+        endpoint=endpoint,
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+    )
+
+
+def _get_storage_session() -> aioboto3.Session:
+    loop = asyncio.get_running_loop()
+    key = _storage_session_key()
+    with _STORAGE_SESSIONS_LOCK:
+        sessions = _STORAGE_SESSIONS.setdefault(loop, {})
+        session = sessions.get(key)
+        if session is None:
+            session = aioboto3.Session()
+            sessions[key] = session
+        return session
+
+
+def clear_storage_session_cache() -> None:
+    """Clear cached aioboto3 sessions.
+
+    Intended for tests and process lifecycle hooks. Production workers normally
+    keep sessions for the life of their event loop so credential providers can
+    be reused safely within that loop.
+    """
+    with _STORAGE_SESSIONS_LOCK:
+        _STORAGE_SESSIONS.clear()
+
+
 @asynccontextmanager
 async def get_storage_client() -> AsyncIterator[S3Client]:
     """Get a configured S3 client for either AWS S3.
@@ -52,7 +111,7 @@ async def get_storage_client() -> AsyncIterator[S3Client]:
     Yields:
         Configured aioboto3 S3 client
     """
-    session = aioboto3.Session()
+    session = _get_storage_session()
     # Configure client based on protocol
     if config.TRACECAT__BLOB_STORAGE_ENDPOINT:
         # MinIO configuration - use AWS_* or MINIO_ROOT_* credentials

--- a/tracecat/storage/utils.py
+++ b/tracecat/storage/utils.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import math
 import threading
 import time
-from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 import orjson
@@ -24,8 +22,6 @@ if TYPE_CHECKING:
 MAX_CACHEABLE_BLOB_SIZE = 50 * 1024 * 1024  # 50 MB per item
 BLOB_CACHE_MAX_BYTES = 500 * 1024 * 1024  # 500 MB total pool
 BLOB_CACHE_TTL = 300.0  # 5 minutes
-STORAGE_TRANSPORT_RETRY_ATTEMPTS = 3
-STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS = 0.25
 
 
 def is_retryable_storage_transport_error(exc: BaseException) -> bool:
@@ -33,52 +29,15 @@ def is_retryable_storage_transport_error(exc: BaseException) -> bool:
 
     Keep this deliberately narrow: retry aiobotocore/botocore HTTP client
     transport failures, but do not retry S3 service errors, missing objects,
-    integrity failures, validation errors, or user/data errors.
+    integrity failures, validation errors, or user/data errors. Walk the
+    exception chain so a wrapped transport error is still detected.
     """
-    seen: set[int] = set()
-    stack: list[BaseException | None] = [exc]
-    while stack:
-        current = stack.pop()
-        if current is None:
-            continue
-        current_id = id(current)
-        if current_id in seen:
-            continue
-        seen.add(current_id)
-        if isinstance(current, HTTPClientError):
+    error: BaseException | None = exc
+    while error is not None:
+        if isinstance(error, HTTPClientError):
             return True
-        if isinstance(current, BaseExceptionGroup):
-            stack.extend(current.exceptions)
-        stack.append(current.__cause__)
-        stack.append(current.__context__)
+        error = error.__cause__ or error.__context__
     return False
-
-
-async def retry_storage_transport_error[T](
-    operation: str,
-    fn: Callable[[], Awaitable[T]],
-    **log_context: Any,
-) -> T:
-    """Retry a storage operation only for transient HTTP transport failures."""
-    max_attempts = max(1, STORAGE_TRANSPORT_RETRY_ATTEMPTS)
-    for attempt in range(1, max_attempts + 1):
-        try:
-            return await fn()
-        except Exception as e:
-            if attempt >= max_attempts or not is_retryable_storage_transport_error(e):
-                raise
-            delay = STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1))
-            logger.warning(
-                "Retrying blob storage transport operation",
-                operation=operation,
-                attempt=attempt,
-                max_attempts=max_attempts,
-                delay_seconds=delay,
-                error=str(e),
-                **log_context,
-            )
-            await asyncio.sleep(delay)
-    raise RuntimeError("unreachable")
 
 
 class SizedMemoryCache:
@@ -198,12 +157,7 @@ async def cached_blob_download(sha256: str, bucket: str, key: str) -> bytes:
         logger.debug("Blob cache hit", sha256=sha256[:16])
         return cached
 
-    content = await retry_storage_transport_error(
-        "blob_download",
-        lambda: blob.download_file(key=key, bucket=bucket),
-        key=key,
-        bucket=bucket,
-    )
+    content = await blob.download_file(key=key, bucket=bucket)
 
     # Skip caching large blobs to prevent memory bloat
     if len(content) <= MAX_CACHEABLE_BLOB_SIZE:
@@ -245,15 +199,10 @@ async def cached_select_item(
         return deserialize_object(cached)
 
     expression = f"SELECT s.items[{local_index}] FROM s3object s"
-    result_bytes = await retry_storage_transport_error(
-        "select_object_content",
-        lambda: blob.select_object_content(
-            key=key,
-            bucket=bucket,
-            expression=expression,
-        ),
+    result_bytes = await blob.select_object_content(
         key=key,
         bucket=bucket,
+        expression=expression,
     )
 
     # S3 Select returns {"_1": <item>} for indexed array access

--- a/tracecat/storage/utils.py
+++ b/tracecat/storage/utils.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import math
 import threading
 import time
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 import orjson
+from botocore.exceptions import HTTPClientError
 from cachetools import TTLCache
 
 from tracecat.logger import logger
@@ -21,6 +24,61 @@ if TYPE_CHECKING:
 MAX_CACHEABLE_BLOB_SIZE = 50 * 1024 * 1024  # 50 MB per item
 BLOB_CACHE_MAX_BYTES = 500 * 1024 * 1024  # 500 MB total pool
 BLOB_CACHE_TTL = 300.0  # 5 minutes
+STORAGE_TRANSPORT_RETRY_ATTEMPTS = 3
+STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS = 0.25
+
+
+def is_retryable_storage_transport_error(exc: BaseException) -> bool:
+    """Return true for transient blob-storage transport failures.
+
+    Keep this deliberately narrow: retry aiobotocore/botocore HTTP client
+    transport failures, but do not retry S3 service errors, missing objects,
+    integrity failures, validation errors, or user/data errors.
+    """
+    seen: set[int] = set()
+    stack: list[BaseException | None] = [exc]
+    while stack:
+        current = stack.pop()
+        if current is None:
+            continue
+        current_id = id(current)
+        if current_id in seen:
+            continue
+        seen.add(current_id)
+        if isinstance(current, HTTPClientError):
+            return True
+        if isinstance(current, BaseExceptionGroup):
+            stack.extend(current.exceptions)
+        stack.append(current.__cause__)
+        stack.append(current.__context__)
+    return False
+
+
+async def retry_storage_transport_error[T](
+    operation: str,
+    fn: Callable[[], Awaitable[T]],
+    **log_context: Any,
+) -> T:
+    """Retry a storage operation only for transient HTTP transport failures."""
+    max_attempts = max(1, STORAGE_TRANSPORT_RETRY_ATTEMPTS)
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await fn()
+        except Exception as e:
+            if attempt >= max_attempts or not is_retryable_storage_transport_error(e):
+                raise
+            delay = STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1))
+            logger.warning(
+                "Retrying blob storage transport operation",
+                operation=operation,
+                attempt=attempt,
+                max_attempts=max_attempts,
+                delay_seconds=delay,
+                error=str(e),
+                **log_context,
+            )
+            await asyncio.sleep(delay)
+    raise RuntimeError("unreachable")
 
 
 class SizedMemoryCache:
@@ -140,7 +198,12 @@ async def cached_blob_download(sha256: str, bucket: str, key: str) -> bytes:
         logger.debug("Blob cache hit", sha256=sha256[:16])
         return cached
 
-    content = await blob.download_file(key=key, bucket=bucket)
+    content = await retry_storage_transport_error(
+        "blob_download",
+        lambda: blob.download_file(key=key, bucket=bucket),
+        key=key,
+        bucket=bucket,
+    )
 
     # Skip caching large blobs to prevent memory bloat
     if len(content) <= MAX_CACHEABLE_BLOB_SIZE:
@@ -182,10 +245,15 @@ async def cached_select_item(
         return deserialize_object(cached)
 
     expression = f"SELECT s.items[{local_index}] FROM s3object s"
-    result_bytes = await blob.select_object_content(
+    result_bytes = await retry_storage_transport_error(
+        "select_object_content",
+        lambda: blob.select_object_content(
+            key=key,
+            bucket=bucket,
+            expression=expression,
+        ),
         key=key,
         bucket=bucket,
-        expression=expression,
     )
 
     # S3 Select returns {"_1": <item>} for indexed array access

--- a/tracecat/storage/utils.py
+++ b/tracecat/storage/utils.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import math
 import threading
 import time
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 import orjson
@@ -22,6 +24,8 @@ if TYPE_CHECKING:
 MAX_CACHEABLE_BLOB_SIZE = 50 * 1024 * 1024  # 50 MB per item
 BLOB_CACHE_MAX_BYTES = 500 * 1024 * 1024  # 500 MB total pool
 BLOB_CACHE_TTL = 300.0  # 5 minutes
+STORAGE_TRANSPORT_RETRY_ATTEMPTS = 3
+STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS = 0.25
 
 
 def is_retryable_storage_transport_error(exc: BaseException) -> bool:
@@ -32,12 +36,50 @@ def is_retryable_storage_transport_error(exc: BaseException) -> bool:
     integrity failures, validation errors, or user/data errors. Walk the
     exception chain so a wrapped transport error is still detected.
     """
-    error: BaseException | None = exc
-    while error is not None:
-        if isinstance(error, HTTPClientError):
+    seen: set[int] = set()
+    stack: list[BaseException | None] = [exc]
+    while stack:
+        current = stack.pop()
+        if current is None:
+            continue
+        current_id = id(current)
+        if current_id in seen:
+            continue
+        seen.add(current_id)
+        if isinstance(current, HTTPClientError):
             return True
-        error = error.__cause__ or error.__context__
+        if isinstance(current, BaseExceptionGroup):
+            stack.extend(current.exceptions)
+        stack.append(current.__cause__)
+        stack.append(current.__context__)
     return False
+
+
+async def retry_storage_transport_error[T](
+    operation: str,
+    fn: Callable[[], Awaitable[T]],
+    **log_context: Any,
+) -> T:
+    """Retry a storage operation only for transient HTTP transport failures."""
+    max_attempts = max(1, STORAGE_TRANSPORT_RETRY_ATTEMPTS)
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await fn()
+        except Exception as e:
+            if attempt >= max_attempts or not is_retryable_storage_transport_error(e):
+                raise
+            delay = STORAGE_TRANSPORT_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1))
+            logger.warning(
+                "Retrying blob storage transport operation",
+                operation=operation,
+                attempt=attempt,
+                max_attempts=max_attempts,
+                delay_seconds=delay,
+                error=str(e),
+                **log_context,
+            )
+            await asyncio.sleep(delay)
+    raise RuntimeError("unreachable")
 
 
 class SizedMemoryCache:
@@ -157,7 +199,12 @@ async def cached_blob_download(sha256: str, bucket: str, key: str) -> bytes:
         logger.debug("Blob cache hit", sha256=sha256[:16])
         return cached
 
-    content = await blob.download_file(key=key, bucket=bucket)
+    content = await retry_storage_transport_error(
+        "blob_download",
+        lambda: blob.download_file(key=key, bucket=bucket),
+        key=key,
+        bucket=bucket,
+    )
 
     # Skip caching large blobs to prevent memory bloat
     if len(content) <= MAX_CACHEABLE_BLOB_SIZE:
@@ -199,10 +246,15 @@ async def cached_select_item(
         return deserialize_object(cached)
 
     expression = f"SELECT s.items[{local_index}] FROM s3object s"
-    result_bytes = await blob.select_object_content(
+    result_bytes = await retry_storage_transport_error(
+        "select_object_content",
+        lambda: blob.select_object_content(
+            key=key,
+            bucket=bucket,
+            expression=expression,
+        ),
         key=key,
         bucket=bucket,
-        expression=expression,
     )
 
     # S3 Select returns {"_1": <item>} for indexed array access


### PR DESCRIPTION
## Summary

- cache `aioboto3.Session` instances per worker event loop and storage credential configuration
- add a narrow retry around blob materialization reads for transient `HTTPClientError` transport failures
- preserve retryability when materialization fails from this storage transport error class
- add regression coverage for retry behavior, non-retryable service errors, and event-loop-safe session reuse

## Why

Workflow context materialization can fail when the S3 client stack raises a transient HTTP transport error before returning object bytes. These failures should not be treated like semantic storage errors such as missing objects, integrity failures, validation failures, or S3 service errors.

This keeps the retry scope intentionally small: only botocore HTTP client transport failures from the blob materialization path are retried.

## Testing

- `uv run ruff check tracecat/storage/blob.py tracecat/storage/utils.py tracecat/dsl/action.py tests/unit/test_storage_blob.py tests/unit/test_storage_cache.py tests/unit/test_materialize_context.py`
- `uv run basedpyright tracecat/storage/blob.py tracecat/storage/utils.py tracecat/dsl/action.py tests/unit/test_storage_blob.py tests/unit/test_storage_cache.py tests/unit/test_materialize_context.py`
- `uv run pytest --confcutdir=tests/unit tests/unit/test_storage_cache.py tests/unit/test_storage_blob.py tests/unit/test_materialize_context.py -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make transient S3 HTTP transport errors retryable during context materialization and blob reads. Reuse a single entered S3 client per event loop and across sync calls, closing it on loop and service shutdown to stop file descriptor churn.

- **Bug Fixes**
  - `materialize_context` uses `is_retryable_storage_transport_error` to treat `botocore.HTTPClientError` as retryable.
  - Added narrow retries for blob downloads and S3 Select via `cached_blob_download`/`cached_select_item` using `retry_storage_transport_error`; `ClientError` is not retried, and the broad tenacity retry was removed.

- **Refactors**
  - Cache and reuse one entered `aioboto3` S3 client per event loop; added a loop-close hook and stale-loop cleanup via `close_storage_client_cache()`, plus `clear_storage_session_cache()` for tests.
  - `action.run_sync` uses a thread-local asyncio runner so the cached client persists across sync calls; clients close when the runner/thread ends and on API, agent, DSL, and executor shutdown.

<sup>Written for commit d9ced2cbd3b9da2c7ec5f2079f77a22cce38d09f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

