### PR TITLE
fix(registry): prefer configured custom repository

### DIFF
--- a/tests/unit/test_registry_repositories_router.py
+++ b/tests/unit/test_registry_repositories_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from inspect import unwrap
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -19,6 +20,58 @@ from tracecat.registry.repositories.schemas import (
 )
 
 pytestmark = pytest.mark.usefixtures("db")
+
+
+@pytest.mark.anyio
+async def test_list_registry_repositories_returns_configured_custom_origin_first(
+    session: AsyncSession,
+    test_role: Role,
+) -> None:
+    """The active custom registry setting should win over stale repository rows."""
+    list_repositories = unwrap(registry_repos_router.list_registry_repositories)
+    configured_origin = "git+ssh://current@git.example.com/acme/registry.git"
+    session.add(
+        Organization(
+            id=test_role.organization_id,
+            name="Configured registry test org",
+            slug="configured-registry-test-org",
+            is_active=True,
+        )
+    )
+    await session.flush()
+    session.add_all(
+        [
+            RegistryRepository(
+                organization_id=test_role.organization_id,
+                origin="git+ssh://old@git.example.com/acme/registry.git",
+            ),
+            RegistryRepository(
+                organization_id=test_role.organization_id,
+                origin="git+ssh://older@git.example.com/acme/registry.git",
+            ),
+            RegistryRepository(
+                organization_id=test_role.organization_id,
+                origin=configured_origin,
+            ),
+        ]
+    )
+    await session.commit()
+
+    with (
+        patch.object(
+            registry_repos_router,
+            "ensure_org_repositories",
+            new=AsyncMock(),
+        ),
+        patch.object(
+            registry_repos_router,
+            "get_setting",
+            new=AsyncMock(return_value=configured_origin),
+        ),
+    ):
+        repositories = await list_repositories(role=test_role, session=session)
+
+    assert repositories[0].origin == configured_origin
 
 
 @pytest.mark.anyio

--- a/tracecat/registry/repositories/router.py
+++ b/tracecat/registry/repositories/router.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import uuid
+from typing import cast
 
 from fastapi import APIRouter, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import case, select
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
 from tracecat import config
@@ -23,6 +24,7 @@ from tracecat.exceptions import (
 )
 from tracecat.git.utils import list_git_commits, parse_git_url
 from tracecat.logger import logger
+from tracecat.parse import safe_url
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.registry.common import ensure_org_repositories
 from tracecat.registry.constants import DEFAULT_REGISTRY_ORIGIN, REGISTRY_REPOS_PATH
@@ -46,6 +48,12 @@ from tracecat.ssh import ssh_context
 from tracecat.tiers.entitlements import Entitlement, check_entitlement
 
 router = APIRouter(prefix=REGISTRY_REPOS_PATH, tags=["registry-repositories"])
+
+
+async def _get_configured_custom_registry_origin(role: Role) -> str | None:
+    remote_url = cast(str | None, await get_setting("git_repo_url", role=role))
+    return safe_url(remote_url) if remote_url else None
+
 
 # Controls
 
@@ -189,6 +197,7 @@ async def list_registry_repositories(
     """
     # Ensure org-scoped repos exist before listing
     await ensure_org_repositories(session, role)
+    configured_origin = await _get_configured_custom_registry_origin(role)
 
     stmt = select(
         RegistryRepository.id,
@@ -197,6 +206,14 @@ async def list_registry_repositories(
         RegistryRepository.commit_sha,
         RegistryRepository.current_version_id,
     ).where(RegistryRepository.organization_id == role.organization_id)
+
+    if configured_origin:
+        stmt = stmt.order_by(
+            case((RegistryRepository.origin == configured_origin, 0), else_=1),
+            RegistryRepository.surrogate_id.asc(),
+        )
+    else:
+        stmt = stmt.order_by(RegistryRepository.surrogate_id.asc())
 
     result = await session.execute(stmt)
     rows = result.tuples().all()


### PR DESCRIPTION
## Summary
- order org registry repositories so the configured custom registry origin is returned before stale custom origins
- keep deterministic fallback ordering for repository lists
- add a regression test covering stale custom registry rows plus the active configured row

## Testing
- `uv run pytest tests/unit/test_registry_repositories_router.py -q`
- `uv run ruff check tracecat/registry/repositories/router.py tests/unit/test_registry_repositories_router.py`
- `uv run ruff format --check tracecat/registry/repositories/router.py tests/unit/test_registry_repositories_router.py`
- `uv run basedpyright tracecat/registry/repositories/router.py tests/unit/test_registry_repositories_router.py`
- `uv run ruff check .`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the configured custom registry origin is returned first when listing org repositories, with a deterministic fallback when none is configured. Adds a regression test to guard against stale rows taking precedence.

- **Bug Fixes**
  - Prefer the configured origin first in `list_registry_repositories` using a `case`-based ORDER BY.
  - Fallback to deterministic `surrogate_id` ordering when no configured origin exists.
  - Add a regression test to verify the configured origin outranks stale rows.

<sup>Written for commit 34b07ed6b588fe37c4636116db91cfd10c345e5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

