### PR TITLE
feat(cases): add short_id filter and get_linked_case_rows action

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/core/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/core/cases.py
@@ -314,6 +314,22 @@ async def get_case(
 
 
 @registry.register(
+    default_title="Get linked case rows",
+    display_group="Cases",
+    description="Get linked rows for a specific case by ID.",
+    namespace="core.cases",
+)
+async def get_linked_case_rows(
+    case_id: Annotated[
+        str,
+        Doc("The ID of the case to retrieve."),
+    ],
+) -> list[types.CaseTableRowRead]:
+    case = await get_context().cases.get_case(case_id, include_rows=True)
+    return case["rows"]
+
+
+@registry.register(
     default_title="List cases",
     display_group="Cases",
     description="List all cases.",
@@ -376,6 +392,10 @@ async def search_cases(
     search_term: Annotated[
         str | None,
         Doc("Text to search for in case summary and description."),
+    ] = None,
+    short_id: Annotated[
+        str | None,
+        Doc("Filter by case short_id."),
     ] = None,
     status: Annotated[
         StatusType | list[StatusType] | None,
@@ -456,6 +476,8 @@ async def search_cases(
         params["reverse"] = reverse
     if search_term is not None:
         params["search_term"] = search_term
+    if short_id is not None:
+        params["short_id"] = short_id
     if status is not None:
         params["status"] = _as_list_filter(status)
     if priority is not None:

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -220,6 +220,10 @@ async def search_cases(
         None,
         description="Text to search for in case summary, description, or short ID",
     ),
+    short_id: str | None = Query(
+        None,
+        description="Search by exact case short ID (e.g. 42 or CASE-0042)",
+    ),
     status: list[CaseStatus] | None = Query(None, description="Filter by case status"),
     priority: list[CasePriority] | None = Query(
         None, description="Filter by case priority"
@@ -301,6 +305,7 @@ async def search_cases(
         cases = await service.search_cases(
             pagination_params,
             search_term=search_term,
+            short_id=short_id,
             status=status,
             priority=priority,
             severity=severity,


### PR DESCRIPTION
## Summary

Two adjustments to how cases are queried and how linked rows are retrieved,
exposing capabilities the cases service already supports:

- **`short_id` filter** — look up cases by their exact short ID (e.g. `42` or
  `CASE-0042`). Added to the `search_cases` registry action and the internal
  `search_cases` API query parameters.
- **`get_linked_case_rows` action** — a dedicated `core.cases` registry action
  that returns the linked table rows for a case. This replaces the earlier
  approach of threading an `include_rows` flag through `get_case`,
  `list_cases`, and `search_cases`, keeping those actions focused on case data
  and giving callers a single, explicit way to fetch linked rows.

## Changes

- `packages/tracecat-registry/.../core/cases.py`
  - Add `get_linked_case_rows(case_id) -> list[CaseTableRowRead]`, which calls
    `get_case(..., include_rows=True)` and returns the `rows`.
  - Add a `short_id` filter to `search_cases`, forwarded as a request param
    when set.
- `tracecat/cases/internal_router.py`
  - Add a `short_id` query parameter to `search_cases`, passed into
    `service.search_cases(...)`.

## Notes

The underlying `CasesService` already supports `short_id` (with short-ID
normalization/validation) and `include_rows`; this change wires those through
the registry actions and the internal router so they're reachable by workflow
actions and API callers.
