### PR TITLE
fix: render agent folder breadcrumbs

### DIFF
--- a/frontend/src/components/nav/controls-header.tsx
+++ b/frontend/src/components/nav/controls-header.tsx
@@ -461,6 +461,61 @@ function normalizeAgentActionPath(rawPath: string | null): string {
     : withLeadingSlash
 }
 
+function AgentFoldersBreadcrumb({
+  workspaceId,
+  path,
+}: {
+  workspaceId: string
+  path: string | null
+}) {
+  const normalizedPath = normalizeAgentActionPath(path)
+  const segments = normalizedPath.split("/").filter(Boolean)
+  const baseHref = `/workspaces/${workspaceId}/agents`
+  const getFolderHref = (folderPath: string) => {
+    if (folderPath === "/") {
+      return `${baseHref}?view=folders&path=%2F`
+    }
+    return `${baseHref}?view=folders&path=${encodeURIComponent(folderPath)}`
+  }
+
+  return (
+    <Breadcrumb>
+      <BreadcrumbList className="relative z-10 flex items-center gap-2 text-sm flex-nowrap overflow-hidden whitespace-nowrap min-w-0 bg-transparent pr-1">
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild className="font-semibold hover:no-underline">
+            <Link href={baseHref}>Agents</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        {segments.map((segment, index) => {
+          const folderPath = `/${segments.slice(0, index + 1).join("/")}`
+          const isLast = index === segments.length - 1
+          return (
+            <Fragment key={folderPath}>
+              <BreadcrumbSeparator className="shrink-0">
+                <span className="text-muted-foreground">/</span>
+              </BreadcrumbSeparator>
+              <BreadcrumbItem>
+                {isLast ? (
+                  <BreadcrumbPage className="font-semibold">
+                    {segment}
+                  </BreadcrumbPage>
+                ) : (
+                  <BreadcrumbLink
+                    asChild
+                    className="font-semibold hover:no-underline"
+                  >
+                    <Link href={getFolderHref(folderPath)}>{segment}</Link>
+                  </BreadcrumbLink>
+                )}
+              </BreadcrumbItem>
+            </Fragment>
+          )
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}
+
 function AgentsActions() {
   const pathname = usePathname()
   const workspaceId = useWorkspaceId()
@@ -1926,8 +1981,16 @@ function getPageConfig(
       }
     }
 
+    const agentsView = searchParams?.get("view") === "list" ? "list" : "folders"
     return {
-      title: "Agents",
+      title: (
+        <AgentFoldersBreadcrumb
+          workspaceId={workspaceId}
+          path={
+            agentsView === "folders" ? (searchParams?.get("path") ?? "/") : "/"
+          }
+        />
+      ),
       actions: <AgentsActions />,
     }
   }


### PR DESCRIPTION
## Summary
- Render the Agents folder breadcrumb in the shared workspace header for the Agents catalog route.
- Preserve the existing `view=folders&path=...` URL model so parent folder crumbs navigate back to the right folder.

## Motivation
The Agents catalog only rendered a static `Agents` title, even when the folder view had a nested `path` query param. Users could enter nested folders but had no breadcrumb links to return to parent folders from the header.

## Validation
- `pnpm -C frontend exec biome check src/components/nav/controls-header.tsx`
- `pnpm -C frontend exec tsc --noEmit --pretty false --incremental false`
- `uv run ruff check .`
- `just cluster up -d`
- Browser QA against the local Tracecat UI: verified `Agents / qa-breadcrumbs / nested`, clicked the parent crumb, and confirmed it navigates to the parent folder view.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render folder breadcrumbs in the Agents catalog header that reflect the current nested path. Preserves the existing `view=folders&path=...` URLs so each parent crumb navigates back correctly; falls back to a simple title in `view=list`.

<sup>Written for commit 150e365a0a946e2a40e70d5d7926304185a23e85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

