### PR TITLE
feat(settings): configure versioned resource resolution

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4498,7 +4498,7 @@ export const $AppSettingsUpdate = {
       $ref: "#/components/schemas/VersionedResourceResolutionStrategy",
       description:
         "How versioned resource references are resolved when a feature supports both pinned and latest dependency resolution.",
-      default: "pinned",
+      default: "latest",
     },
   },
   type: "object",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4228,6 +4228,10 @@ export const $AgentSettingsRead = {
       type: "boolean",
       title: "Agent Case Chat Inject Content",
     },
+    agent_use_latest_resource_versions: {
+      type: "boolean",
+      title: "Agent Use Latest Resource Versions",
+    },
   },
   type: "object",
   required: [
@@ -4235,6 +4239,7 @@ export const $AgentSettingsRead = {
     "agent_fixed_args",
     "agent_case_chat_prompt",
     "agent_case_chat_inject_content",
+    "agent_use_latest_resource_versions",
   ],
   title: "AgentSettingsRead",
 } as const
@@ -4280,6 +4285,13 @@ export const $AgentSettingsUpdate = {
       title: "Agent Case Chat Inject Content",
       description:
         "Whether to automatically inject case content into agent prompts when a case_id is available.",
+      default: false,
+    },
+    agent_use_latest_resource_versions: {
+      type: "boolean",
+      title: "Agent Use Latest Resource Versions",
+      description:
+        "Whether agent preset execution resolves dependent skills and preset-backed subagents to their current versions instead of the versions snapshotted on the preset version.",
       default: false,
     },
   },

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4228,10 +4228,6 @@ export const $AgentSettingsRead = {
       type: "boolean",
       title: "Agent Case Chat Inject Content",
     },
-    agent_use_latest_resource_versions: {
-      type: "boolean",
-      title: "Agent Use Latest Resource Versions",
-    },
   },
   type: "object",
   required: [
@@ -4239,7 +4235,6 @@ export const $AgentSettingsRead = {
     "agent_fixed_args",
     "agent_case_chat_prompt",
     "agent_case_chat_inject_content",
-    "agent_use_latest_resource_versions",
   ],
   title: "AgentSettingsRead",
 } as const
@@ -4285,13 +4280,6 @@ export const $AgentSettingsUpdate = {
       title: "Agent Case Chat Inject Content",
       description:
         "Whether to automatically inject case content into agent prompts when a case_id is available.",
-      default: false,
-    },
-    agent_use_latest_resource_versions: {
-      type: "boolean",
-      title: "Agent Use Latest Resource Versions",
-      description:
-        "Whether agent preset execution resolves dependent skills and preset-backed subagents to their current versions instead of the versions snapshotted on the preset version.",
       default: false,
     },
   },
@@ -4447,6 +4435,9 @@ export const $AppSettingsRead = {
       type: "boolean",
       title: "App Action Form Mode Enabled",
     },
+    app_versioned_resource_resolution_strategy: {
+      $ref: "#/components/schemas/VersionedResourceResolutionStrategy",
+    },
   },
   type: "object",
   required: [
@@ -4456,6 +4447,7 @@ export const $AppSettingsRead = {
     "app_workflow_export_enabled",
     "app_create_workspace_on_register",
     "app_action_form_mode_enabled",
+    "app_versioned_resource_resolution_strategy",
   ],
   title: "AppSettingsRead",
   description: "Settings for the app.",
@@ -4501,6 +4493,12 @@ export const $AppSettingsUpdate = {
       description:
         "Whether to enable form mode for action inputs. When disabled, only YAML mode is available, preserving raw YAML formatting.",
       default: true,
+    },
+    app_versioned_resource_resolution_strategy: {
+      $ref: "#/components/schemas/VersionedResourceResolutionStrategy",
+      description:
+        "How versioned resource references are resolved when a feature supports both pinned and latest dependency resolution.",
+      default: "pinned",
     },
   },
   type: "object",
@@ -27521,6 +27519,12 @@ export const $VersionDiff = {
   ],
   title: "VersionDiff",
   description: "Result of comparing two registry versions.",
+} as const
+
+export const $VersionedResourceResolutionStrategy = {
+  type: "string",
+  enum: ["pinned", "latest"],
+  title: "VersionedResourceResolutionStrategy",
 } as const
 
 export const $VertexAICatalogCreate = {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4437,6 +4437,7 @@ export const $AppSettingsRead = {
     },
     app_versioned_resource_resolution_strategy: {
       $ref: "#/components/schemas/VersionedResourceResolutionStrategy",
+      default: "latest",
     },
   },
   type: "object",
@@ -4447,7 +4448,6 @@ export const $AppSettingsRead = {
     "app_workflow_export_enabled",
     "app_create_workspace_on_register",
     "app_action_form_mode_enabled",
-    "app_versioned_resource_resolution_strategy",
   ],
   title: "AppSettingsRead",
   description: "Settings for the app.",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1052,7 +1052,7 @@ export type AppSettingsRead = {
   app_workflow_export_enabled: boolean
   app_create_workspace_on_register: boolean
   app_action_form_mode_enabled: boolean
-  app_versioned_resource_resolution_strategy: VersionedResourceResolutionStrategy
+  app_versioned_resource_resolution_strategy?: VersionedResourceResolutionStrategy
 }
 
 /**

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -981,7 +981,6 @@ export type AgentSettingsRead = {
   agent_fixed_args: string | null
   agent_case_chat_prompt: string
   agent_case_chat_inject_content: boolean
-  agent_use_latest_resource_versions: boolean
 }
 
 export type AgentSettingsUpdate = {
@@ -1001,10 +1000,6 @@ export type AgentSettingsUpdate = {
    * Whether to automatically inject case content into agent prompts when a case_id is available.
    */
   agent_case_chat_inject_content?: boolean
-  /**
-   * Whether agent preset execution resolves dependent skills and preset-backed subagents to their current versions instead of the versions snapshotted on the preset version.
-   */
-  agent_use_latest_resource_versions?: boolean
 }
 
 /**
@@ -1057,6 +1052,7 @@ export type AppSettingsRead = {
   app_workflow_export_enabled: boolean
   app_create_workspace_on_register: boolean
   app_action_form_mode_enabled: boolean
+  app_versioned_resource_resolution_strategy: VersionedResourceResolutionStrategy
 }
 
 /**
@@ -1087,6 +1083,10 @@ export type AppSettingsUpdate = {
    * Whether to enable form mode for action inputs. When disabled, only YAML mode is available, preserving raw YAML formatting.
    */
   app_action_form_mode_enabled?: boolean
+  /**
+   * How versioned resource references are resolved when a feature supports both pinned and latest dependency resolution.
+   */
+  app_versioned_resource_resolution_strategy?: VersionedResourceResolutionStrategy
 }
 
 /**
@@ -8237,6 +8237,8 @@ export type VersionDiff = {
   actions_modified?: Array<ActionChange>
   total_changes?: number
 }
+
+export type VersionedResourceResolutionStrategy = "pinned" | "latest"
 
 /**
  * Vertex AI catalog entry.

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -981,6 +981,7 @@ export type AgentSettingsRead = {
   agent_fixed_args: string | null
   agent_case_chat_prompt: string
   agent_case_chat_inject_content: boolean
+  agent_use_latest_resource_versions: boolean
 }
 
 export type AgentSettingsUpdate = {
@@ -1000,6 +1001,10 @@ export type AgentSettingsUpdate = {
    * Whether to automatically inject case content into agent prompts when a case_id is available.
    */
   agent_case_chat_inject_content?: boolean
+  /**
+   * Whether agent preset execution resolves dependent skills and preset-backed subagents to their current versions instead of the versions snapshotted on the preset version.
+   */
+  agent_use_latest_resource_versions?: boolean
 }
 
 /**

--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -105,7 +105,6 @@ import { getApiErrorDetail, retryHandler } from "@/lib/errors"
 import {
   useAgentDefaultModel,
   useModelProvidersStatus,
-  useOrgAgentSettings,
   useProviderCredentialConfigs,
 } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
@@ -1917,13 +1916,6 @@ export function OrgSettingsAgentForm() {
     updateDefaultModel,
     isUpdating,
   } = useAgentDefaultModel()
-  const {
-    agentSettings,
-    agentSettingsIsLoading,
-    agentSettingsError,
-    updateAgentSettings,
-    updateAgentSettingsIsPending,
-  } = useOrgAgentSettings()
 
   const {
     data: customProviders,
@@ -2171,14 +2163,12 @@ export function OrgSettingsAgentForm() {
     !customProviders &&
     !catalogEntries &&
     !enabledAccessRows &&
-    !agentSettings &&
     (providerConfigsLoading ||
       providersStatusLoading ||
       customProvidersLoading ||
       catalogEntriesLoading ||
       enabledAccessRowsLoading ||
-      defaultModelLoading ||
-      agentSettingsIsLoading)
+      defaultModelLoading)
 
   function invalidateOrganizationAgentQueries() {
     void queryClient.invalidateQueries({
@@ -2329,14 +2319,6 @@ export function OrgSettingsAgentForm() {
         variant: "destructive",
       })
     }
-  }
-
-  function handleLatestResourceVersionsChange(enabled: boolean) {
-    void updateAgentSettings({
-      requestBody: {
-        agent_use_latest_resource_versions: enabled,
-      },
-    }).catch(() => undefined)
   }
 
   async function handleModelToggle(model: ModelCatalogEntry) {
@@ -2527,8 +2509,7 @@ export function OrgSettingsAgentForm() {
     customProvidersError ??
     catalogEntriesError ??
     enabledAccessRowsError ??
-    defaultModelError ??
-    agentSettingsError
+    defaultModelError
   const providerSectionLoading =
     providerConfigsLoading ||
     providersStatusLoading ||
@@ -2649,41 +2630,6 @@ export function OrgSettingsAgentForm() {
         {isSelectionUpdating ? (
           <p className="text-xs text-muted-foreground">Saving changes…</p>
         ) : null}
-      </section>
-
-      <section className="space-y-4">
-        <div className="space-y-1">
-          <h3 className="text-lg font-semibold tracking-tight">
-            Resource versions
-          </h3>
-          <p className="text-sm text-muted-foreground">
-            Choose how agent presets resolve dependent skills and preset-backed
-            subagents during execution.
-          </p>
-        </div>
-
-        {agentSettingsIsLoading && !agentSettings ? (
-          <CenteredSpinner />
-        ) : (
-          <div className="flex items-start justify-between gap-4 rounded-lg border p-4">
-            <div className="space-y-1">
-              <p className="text-sm font-medium">Use latest preset resources</p>
-              <p className="text-sm text-muted-foreground">
-                Resolve skills and preset-backed subagents to their current
-                published versions instead of the versions saved on the preset
-                version.
-              </p>
-            </div>
-            <Switch
-              aria-label="Use latest preset resources"
-              checked={
-                agentSettings?.agent_use_latest_resource_versions ?? false
-              }
-              disabled={agentSettingsIsLoading || updateAgentSettingsIsPending}
-              onCheckedChange={handleLatestResourceVersionsChange}
-            />
-          </div>
-        )}
       </section>
 
       <section className="space-y-4">

--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -105,6 +105,7 @@ import { getApiErrorDetail, retryHandler } from "@/lib/errors"
 import {
   useAgentDefaultModel,
   useModelProvidersStatus,
+  useOrgAgentSettings,
   useProviderCredentialConfigs,
 } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
@@ -1916,6 +1917,13 @@ export function OrgSettingsAgentForm() {
     updateDefaultModel,
     isUpdating,
   } = useAgentDefaultModel()
+  const {
+    agentSettings,
+    agentSettingsIsLoading,
+    agentSettingsError,
+    updateAgentSettings,
+    updateAgentSettingsIsPending,
+  } = useOrgAgentSettings()
 
   const {
     data: customProviders,
@@ -2163,12 +2171,14 @@ export function OrgSettingsAgentForm() {
     !customProviders &&
     !catalogEntries &&
     !enabledAccessRows &&
+    !agentSettings &&
     (providerConfigsLoading ||
       providersStatusLoading ||
       customProvidersLoading ||
       catalogEntriesLoading ||
       enabledAccessRowsLoading ||
-      defaultModelLoading)
+      defaultModelLoading ||
+      agentSettingsIsLoading)
 
   function invalidateOrganizationAgentQueries() {
     void queryClient.invalidateQueries({
@@ -2319,6 +2329,14 @@ export function OrgSettingsAgentForm() {
         variant: "destructive",
       })
     }
+  }
+
+  function handleLatestResourceVersionsChange(enabled: boolean) {
+    void updateAgentSettings({
+      requestBody: {
+        agent_use_latest_resource_versions: enabled,
+      },
+    }).catch(() => undefined)
   }
 
   async function handleModelToggle(model: ModelCatalogEntry) {
@@ -2509,7 +2527,8 @@ export function OrgSettingsAgentForm() {
     customProvidersError ??
     catalogEntriesError ??
     enabledAccessRowsError ??
-    defaultModelError
+    defaultModelError ??
+    agentSettingsError
   const providerSectionLoading =
     providerConfigsLoading ||
     providersStatusLoading ||
@@ -2537,8 +2556,7 @@ export function OrgSettingsAgentForm() {
         <AlertNotification
           level="error"
           message={
-            getApiErrorDetail(pageError) ??
-            "Unable to load model provider settings."
+            getApiErrorDetail(pageError) ?? "Unable to load agent settings."
           }
         />
       ) : null}
@@ -2631,6 +2649,41 @@ export function OrgSettingsAgentForm() {
         {isSelectionUpdating ? (
           <p className="text-xs text-muted-foreground">Saving changes…</p>
         ) : null}
+      </section>
+
+      <section className="space-y-4">
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold tracking-tight">
+            Resource versions
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            Choose how agent presets resolve dependent skills and preset-backed
+            subagents during execution.
+          </p>
+        </div>
+
+        {agentSettingsIsLoading && !agentSettings ? (
+          <CenteredSpinner />
+        ) : (
+          <div className="flex items-start justify-between gap-4 rounded-lg border p-4">
+            <div className="space-y-1">
+              <p className="text-sm font-medium">Use latest preset resources</p>
+              <p className="text-sm text-muted-foreground">
+                Resolve skills and preset-backed subagents to their current
+                published versions instead of the versions saved on the preset
+                version.
+              </p>
+            </div>
+            <Switch
+              aria-label="Use latest preset resources"
+              checked={
+                agentSettings?.agent_use_latest_resource_versions ?? false
+              }
+              disabled={agentSettingsIsLoading || updateAgentSettingsIsPending}
+              onCheckedChange={handleLatestResourceVersionsChange}
+            />
+          </div>
+        )}
       </section>
 
       <section className="space-y-4">

--- a/frontend/src/components/organization/org-settings-app.tsx
+++ b/frontend/src/components/organization/org-settings-app.tsx
@@ -54,7 +54,7 @@ export function OrgSettingsAppForm() {
       app_action_form_mode_enabled:
         appSettings?.app_action_form_mode_enabled ?? true,
       app_versioned_resource_resolution_strategy:
-        appSettings?.app_versioned_resource_resolution_strategy ?? "pinned",
+        appSettings?.app_versioned_resource_resolution_strategy ?? "latest",
     },
   })
 

--- a/frontend/src/components/organization/org-settings-app.tsx
+++ b/frontend/src/components/organization/org-settings-app.tsx
@@ -25,6 +25,7 @@ const appFormSchema = z.object({
   app_workflow_export_enabled: z.boolean(),
   app_create_workspace_on_register: z.boolean(),
   app_action_form_mode_enabled: z.boolean(),
+  app_versioned_resource_resolution_strategy: z.enum(["pinned", "latest"]),
 })
 
 type AppFormValues = z.infer<typeof appFormSchema>
@@ -52,6 +53,8 @@ export function OrgSettingsAppForm() {
         appSettings?.app_create_workspace_on_register ?? false,
       app_action_form_mode_enabled:
         appSettings?.app_action_form_mode_enabled ?? true,
+      app_versioned_resource_resolution_strategy:
+        appSettings?.app_versioned_resource_resolution_strategy ?? "pinned",
     },
   })
 
@@ -66,6 +69,8 @@ export function OrgSettingsAppForm() {
           app_create_workspace_on_register:
             data.app_create_workspace_on_register,
           app_action_form_mode_enabled: data.app_action_form_mode_enabled,
+          app_versioned_resource_resolution_strategy:
+            data.app_versioned_resource_resolution_strategy,
         },
       })
     } catch {
@@ -213,6 +218,31 @@ export function OrgSettingsAppForm() {
                 <Switch
                   checked={field.value}
                   onCheckedChange={field.onChange}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="app_versioned_resource_resolution_strategy"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <FormLabel>Use latest versioned resources</FormLabel>
+                <FormDescription>
+                  Resolve supported versioned resource dependencies to their
+                  current versions instead of the versions saved on the parent
+                  resource.
+                </FormDescription>
+              </div>
+              <FormControl>
+                <Switch
+                  checked={field.value === "latest"}
+                  onCheckedChange={(checked) =>
+                    field.onChange(checked ? "latest" : "pinned")
+                  }
                 />
               </FormControl>
             </FormItem>

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -59,6 +59,7 @@ with workflow.unsafe.imports_passed_through():
         CreateSessionInput,
         LoadSessionInput,
         LoadSessionMessagesInput,
+        LoadSessionResult,
         PendingToolResult,
         ReconcileToolResultsInput,
         create_session_activity,
@@ -67,7 +68,11 @@ with workflow.unsafe.imports_passed_through():
         reconcile_tool_results_activity,
     )
     from tracecat.agent.session.types import AgentSessionEntity
-    from tracecat.agent.subagents import has_manual_tool_approvals
+    from tracecat.agent.subagents import (
+        AgentSubagentsConfig,
+        ResolvedAgentsConfig,
+        has_manual_tool_approvals,
+    )
     from tracecat.agent.tokens import (
         InternalToolContext,
         LLMRouteClaim,
@@ -425,6 +430,27 @@ UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH = (
 # marker have aged out, then use workflow.deprecate_patch(...) before removing
 # the marker entirely in a later cleanup.
 LOAD_TERMINAL_MESSAGE_HISTORY_PATCH = "durable-agent-load-terminal-message-history-v1"
+PRESERVE_RESUMED_AGENT_BINDINGS_PATCH = (
+    "durable-agent-preserve-resumed-agent-bindings-v1"
+)
+
+
+def _agents_config_from_binding(
+    binding: ResolvedAgentsConfig,
+) -> AgentSubagentsConfig:
+    return AgentSubagentsConfig.model_validate(binding.model_dump(mode="json"))
+
+
+def _preserved_agents_binding(
+    load_result: LoadSessionResult,
+) -> ResolvedAgentsConfig | None:
+    if not load_result.found:
+        return None
+    if load_result.agents_binding is not None:
+        return load_result.agents_binding
+    if load_result.has_resume_state:
+        return ResolvedAgentsConfig()
+    return None
 
 
 @workflow.defn
@@ -578,18 +604,23 @@ class DurableAgentWorkflow:
         self,
         args: AgentWorkflowArgs,
         cfg: AgentConfig,
+        *,
+        agents: AgentSubagentsConfig | None = None,
+        follow_latest_versions: bool | None = None,
     ) -> ResolvedAgentsRuntimeConfig:
-        if not cfg.agents.enabled:
+        agents_config = agents if agents is not None else cfg.agents
+        if not agents_config.enabled:
             return ResolvedAgentsRuntimeConfig()
-        if not cfg.agents.subagents:
+        if not agents_config.subagents:
             return ResolvedAgentsRuntimeConfig(enabled=True)
         return await workflow.execute_activity(
             resolve_agents_config_activity,
             ResolveAgentsConfigActivityInput(
                 role=self.role,
-                agents=cfg.agents,
+                agents=agents_config,
                 parent_preset_id=args.agent_preset_id,
                 parent_slug=args.agent_args.preset_slug,
+                follow_latest_versions=follow_latest_versions,
             ),
             start_to_close_timeout=timedelta(seconds=30),
             retry_policy=RETRY_POLICIES["activity:fail_fast"],
@@ -873,7 +904,28 @@ class DurableAgentWorkflow:
         curr_run_id = AgentWorkflowID.from_workflow_id(
             workflow.info().workflow_id
         ).session_id
-        agents_result = await self._resolve_agents_config(args, cfg)
+        load_result: LoadSessionResult | None = None
+        if workflow.patched(PRESERVE_RESUMED_AGENT_BINDINGS_PATCH):
+            # Load session topology before resolving agents. A resumed session's
+            # stored binding is the stable runtime contract, even if the preset
+            # now follows a newer child version.
+            load_result = await workflow.execute_activity(
+                load_session_activity,
+                LoadSessionInput(role=self.role, session_id=self.session_id),
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
+            if preserved_binding := _preserved_agents_binding(load_result):
+                agents_result = await self._resolve_agents_config(
+                    args,
+                    cfg,
+                    agents=_agents_config_from_binding(preserved_binding),
+                    follow_latest_versions=False,
+                )
+            else:
+                agents_result = await self._resolve_agents_config(args, cfg)
+        else:
+            agents_result = await self._resolve_agents_config(args, cfg)
 
         # Create or get the AgentSession - idempotent, safe to call on resume
         # Persist the active workflow token as curr_run_id for approval lookups.
@@ -929,14 +981,16 @@ class DurableAgentWorkflow:
             registry_lock_origins=list(root_registry_lock.origins.keys()),
         )
 
-        # Load existing session metadata for resume. sdk_session_data is legacy
-        # replay compatibility only; new activity executions leave it unset.
-        load_result = await workflow.execute_activity(
-            load_session_activity,
-            LoadSessionInput(role=self.role, session_id=self.session_id),
-            start_to_close_timeout=timedelta(seconds=30),
-            retry_policy=RETRY_POLICIES["activity:fail_fast"],
-        )
+        if load_result is None:
+            # Legacy command order for histories without the binding-preservation
+            # patch marker. sdk_session_data is replay compatibility only; new
+            # activity executions leave it unset.
+            load_result = await workflow.execute_activity(
+                load_session_activity,
+                LoadSessionInput(role=self.role, session_id=self.session_id),
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
 
         if load_result.found and load_result.sdk_session_id:
             logger.info(

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -60,6 +60,11 @@ from tracecat.agent.executor.activity import (
     AgentExecutorResult,
     ToolExecutionResult,
 )
+from tracecat.agent.preset.activities import ResolveAgentsConfigActivityInput
+from tracecat.agent.preset.resolver import (
+    ResolvedAgentsRuntimeConfig,
+    ResolvedSubagentConfig,
+)
 from tracecat.agent.schemas import RunAgentArgs
 from tracecat.agent.session.activities import (
     CreateSessionInput,
@@ -77,8 +82,14 @@ from tracecat.agent.session.activities import (
 )
 from tracecat.agent.session.service import AgentSessionService
 from tracecat.agent.session.types import AgentSessionEntity
+from tracecat.agent.subagents import (
+    AgentSubagentsConfig,
+    ResolvedAgentsConfig,
+    ResolvedAttachedSubagentRef,
+)
 from tracecat.agent.tokens import UserMCPServerClaim
 from tracecat.agent.types import AgentConfig
+from tracecat.agent.workflow_config import agent_config_to_payload
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import SERVICE_PRINCIPAL_SCOPES
 from tracecat.chat.schemas import ChatMessage
@@ -502,6 +513,7 @@ async def test_agent_workflow_streams_tool_definition_error(
 
     activities = [
         create_mock_create_session_activity(),
+        create_mock_load_session_activity(),
         mock_build_tool_definitions,
         mock_emit_session_error,
     ]
@@ -672,6 +684,143 @@ async def test_agent_workflow_simple_execution(
         assert result.message_history == session_messages
 
     assert [input.session_id for input in message_load_inputs] == [mock_session_id]
+
+
+@pytest.mark.anyio
+@pytest.mark.integration
+async def test_agent_workflow_preserves_stored_subagent_binding_on_resume(
+    svc_role: Role,
+    temporal_client: Client,
+    agent_worker_factory,
+    mock_session_id: uuid.UUID,
+) -> None:
+    queue = f"test-agent-queue-{mock_session_id}"
+    child_preset_id = uuid.uuid4()
+    stored_version_id = uuid.uuid4()
+    latest_version_id = uuid.uuid4()
+    stored_ref = ResolvedAttachedSubagentRef(
+        preset="analyst",
+        preset_version=1,
+        preset_id=child_preset_id,
+        preset_version_id=stored_version_id,
+    )
+    latest_ref = ResolvedAttachedSubagentRef(
+        preset="analyst",
+        preset_version=2,
+        preset_id=child_preset_id,
+        preset_version_id=latest_version_id,
+    )
+    stored_binding = ResolvedAgentsConfig(enabled=True, subagents=[stored_ref])
+    latest_agents_config = AgentSubagentsConfig(enabled=True, subagents=[latest_ref])
+    resolve_inputs: list[ResolveAgentsConfigActivityInput] = []
+    create_inputs: list[CreateSessionInput] = []
+    agent_inputs: list[AgentExecutorInput] = []
+
+    @activity.defn(name="load_session_activity")
+    async def mock_load_session_activity(
+        input: LoadSessionInput,
+    ) -> LoadSessionResult:
+        assert input.session_id == mock_session_id
+        return LoadSessionResult(
+            found=True,
+            sdk_session_id="sdk-session",
+            agents_binding=stored_binding,
+            has_resume_state=True,
+        )
+
+    @activity.defn(name="resolve_agents_config_activity")
+    async def mock_resolve_agents_config_activity(
+        input: ResolveAgentsConfigActivityInput,
+    ) -> ResolvedAgentsRuntimeConfig:
+        resolve_inputs.append(input)
+        assert input.follow_latest_versions is False
+        assert len(input.agents.subagents) == 1
+        resolved_ref = input.agents.subagents[0]
+        assert isinstance(resolved_ref, ResolvedAttachedSubagentRef)
+        assert resolved_ref.preset_version_id == stored_version_id
+
+        return ResolvedAgentsRuntimeConfig(
+            enabled=True,
+            subagents=[
+                ResolvedSubagentConfig(
+                    binding=stored_ref,
+                    description="Stored analyst",
+                    prompt="Complete the delegated analysis.",
+                    config=agent_config_to_payload(
+                        AgentConfig(
+                            model_name="claude-3-5-sonnet-20241022",
+                            model_provider="anthropic",
+                            actions=[],
+                        )
+                    ),
+                )
+            ],
+        )
+
+    @activity.defn(name="create_session_activity")
+    async def mock_create_session_activity(
+        input: CreateSessionInput,
+    ) -> CreateSessionResult:
+        create_inputs.append(input)
+        assert input.agents_binding == stored_binding
+        return CreateSessionResult(session_id=input.session_id, success=True)
+
+    @activity.defn(name="run_agent_activity")
+    async def mock_run_agent_activity(
+        input: AgentExecutorInput,
+    ) -> AgentExecutorResult:
+        agent_inputs.append(input)
+        return AgentExecutorResult(success=True, output={"status": "ok"})
+
+    workflow_args = AgentWorkflowArgs(
+        role=svc_role,
+        agent_args=RunAgentArgs(
+            session_id=mock_session_id,
+            user_prompt="Continue the existing session",
+            config=AgentConfig(
+                model_name="claude-3-5-sonnet-20241022",
+                model_provider="anthropic",
+                actions=[],
+                agents=latest_agents_config,
+            ),
+        ),
+        entity_type=AgentSessionEntity.WORKFLOW,
+        entity_id=uuid.uuid4(),
+    )
+
+    activities = [
+        mock_load_session_activity,
+        mock_resolve_agents_config_activity,
+        mock_create_session_activity,
+        create_mock_load_session_messages_activity(),
+        create_mock_build_tool_definitions_activity(),
+        mock_run_agent_activity,
+        create_mock_execute_action_activity(),
+        create_mock_reconcile_tool_results_activity(),
+        *ApprovalManager.get_activities(),
+    ]
+
+    async with agent_worker_factory(
+        temporal_client, task_queue=queue, custom_activities=activities
+    ):
+        result = await temporal_client.execute_workflow(
+            DurableAgentWorkflow.run,
+            workflow_args,
+            id=AgentWorkflowID(mock_session_id),
+            task_queue=queue,
+            retry_policy=RETRY_POLICIES["workflow:fail_fast"],
+            execution_timeout=timedelta(seconds=30),
+        )
+
+    assert result.session_id == mock_session_id
+    assert result.output == {"status": "ok"}
+    assert len(resolve_inputs) == 1
+    assert resolve_inputs[0].agents.subagents == [stored_ref]
+    assert len(create_inputs) == 1
+    assert create_inputs[0].agents_binding == stored_binding
+    assert len(agent_inputs) == 1
+    assert agent_inputs[0].sdk_session_id == "sdk-session"
+    assert [subagent.alias for subagent in agent_inputs[0].subagents] == ["analyst"]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -1033,6 +1033,7 @@ class TestLoadSessionActivity:
         )
 
         mock_agent_session = MagicMock()
+        mock_agent_session.agents_binding = None
         mock_agent_session.sdk_session_id = None
         mock_agent_session.parent_session_id = None
 
@@ -1051,6 +1052,8 @@ class TestLoadSessionActivity:
         assert result.sdk_session_id is None
         assert result.sdk_session_data is None
         assert result.is_fork is False
+        assert result.agents_binding is None
+        assert result.has_resume_state is False
 
     @pytest.mark.anyio
     @patch("tracecat.agent.session.activities.AgentSessionService.with_session")
@@ -1064,6 +1067,10 @@ class TestLoadSessionActivity:
         )
 
         mock_agent_session = MagicMock()
+        agents_binding = ResolvedAgentsConfig.model_validate(
+            {"enabled": True, "subagents": []}
+        )
+        mock_agent_session.agents_binding = agents_binding.model_dump(mode="json")
         mock_agent_session.sdk_session_id = "sdk-session-123"
         mock_agent_session.parent_session_id = None
 
@@ -1082,6 +1089,8 @@ class TestLoadSessionActivity:
         assert result.sdk_session_id == "sdk-session-123"
         assert result.sdk_session_data is None
         assert result.is_fork is False
+        assert result.agents_binding == agents_binding
+        assert result.has_resume_state is True
 
     @pytest.mark.anyio
     @patch("tracecat.agent.session.activities.AgentSessionService.with_session")
@@ -1096,6 +1105,7 @@ class TestLoadSessionActivity:
         )
 
         mock_agent_session = MagicMock()
+        mock_agent_session.agents_binding = None
         mock_agent_session.sdk_session_id = None
         mock_agent_session.parent_session_id = parent_session_id
         mock_parent_session = MagicMock()
@@ -1117,6 +1127,8 @@ class TestLoadSessionActivity:
         assert result.sdk_session_id == "parent-sdk-session"
         assert result.sdk_session_data is None
         assert result.is_fork is True
+        assert result.agents_binding is None
+        assert result.has_resume_state is True
 
 
 class TestLoadSessionMessagesActivity:

--- a/tests/unit/test_agent_preset_activities.py
+++ b/tests/unit/test_agent_preset_activities.py
@@ -229,6 +229,69 @@ async def test_resolve_agents_config_resolves_pinned_ref_by_version_id(
 
 
 @pytest.mark.anyio
+async def test_resolve_agents_config_explicitly_disables_latest_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    preset_id = uuid.uuid4()
+    preset_version_id = uuid.uuid4()
+    version = SimpleNamespace(
+        id=preset_version_id,
+        preset_id=preset_id,
+        version=4,
+        agents={"enabled": False},
+        tool_approvals={},
+    )
+    service = SimpleNamespace(
+        resolve_agent_preset_version=AsyncMock(return_value=version),
+        get_preset=AsyncMock(return_value=SimpleNamespace(description="Child preset")),
+        resolve_agent_preset_config=AsyncMock(
+            return_value=AgentConfig(
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                retries=3,
+            )
+        ),
+        use_latest_resource_versions=AsyncMock(return_value=True),
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+    )
+
+    monkeypatch.setattr(
+        "tracecat.agent.preset.activities.AgentPresetService.with_session",
+        lambda **_: _AsyncContext(service),
+    )
+
+    result = await resolve_agents_config_activity(
+        ResolveAgentsConfigActivityInput(
+            role=role,
+            agents=AgentSubagentsConfig(
+                enabled=True,
+                subagents=[
+                    ResolvedAttachedSubagentRef(
+                        preset="old-analyst-slug",
+                        preset_version=2,
+                        name="analyst",
+                        preset_id=preset_id,
+                        preset_version_id=preset_version_id,
+                    )
+                ],
+            ),
+            follow_latest_versions=False,
+        )
+    )
+
+    service.use_latest_resource_versions.assert_not_awaited()
+    service.resolve_agent_preset_version.assert_awaited_once_with(
+        preset_version_id=preset_version_id,
+    )
+    assert result.subagents[0].binding.preset_version_id == preset_version_id
+
+
+@pytest.mark.anyio
 async def test_resolve_agents_config_rejects_subagent_with_tool_approvals(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_agent_preset_activities.py
+++ b/tests/unit/test_agent_preset_activities.py
@@ -186,6 +186,7 @@ async def test_resolve_agents_config_resolves_pinned_ref_by_version_id(
                 retries=3,
             )
         ),
+        use_latest_resource_versions=AsyncMock(return_value=False),
     )
     role = Role(
         type="service",
@@ -222,6 +223,7 @@ async def test_resolve_agents_config_resolves_pinned_ref_by_version_id(
     service.resolve_agent_preset_version.assert_awaited_once_with(
         preset_version_id=preset_version_id,
     )
+    service.use_latest_resource_versions.assert_awaited_once()
     assert result.subagents[0].binding.preset_version_id == preset_version_id
     assert result.subagents[0].binding.preset_version == 4
 
@@ -239,6 +241,7 @@ async def test_resolve_agents_config_rejects_subagent_with_tool_approvals(
     )
     service = SimpleNamespace(
         resolve_agent_preset_version=AsyncMock(return_value=version),
+        use_latest_resource_versions=AsyncMock(return_value=False),
     )
     role = Role(
         type="service",
@@ -285,7 +288,9 @@ async def test_resolve_agents_config_rejects_invalid_fallback_alias(
 
     monkeypatch.setattr(
         "tracecat.agent.preset.activities.AgentPresetService.with_session",
-        lambda **_: _AsyncContext(SimpleNamespace()),
+        lambda **_: _AsyncContext(
+            SimpleNamespace(use_latest_resource_versions=AsyncMock(return_value=False))
+        ),
     )
 
     with pytest.raises(

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -51,7 +51,10 @@ from tracecat.registry.versions.schemas import (
     RegistryVersionManifest,
     RegistryVersionManifestAction,
 )
-from tracecat.settings.schemas import AgentSettingsUpdate
+from tracecat.settings.schemas import (
+    AppSettingsUpdate,
+    VersionedResourceResolutionStrategy,
+)
 from tracecat.settings.service import SettingsService
 from tracecat.storage.blob import ensure_bucket_exists
 
@@ -1036,8 +1039,12 @@ class TestAgentPresetService:
         """Latest-resource mode resolves skills by current version at execution time."""
 
         settings_service = SettingsService(session=session, role=svc_admin_role)
-        await settings_service.update_agent_settings(
-            AgentSettingsUpdate(agent_use_latest_resource_versions=True)
+        await settings_service.update_app_settings(
+            AppSettingsUpdate(
+                app_versioned_resource_resolution_strategy=(
+                    VersionedResourceResolutionStrategy.LATEST
+                )
+            )
         )
         skill_service = SkillService(session=session, role=svc_role)
         created_skill = await skill_service.create_skill(
@@ -2534,8 +2541,12 @@ class TestAgentPresetService:
         """Latest-resource mode resolves preset-backed subagents by current version."""
 
         settings_service = SettingsService(session=session, role=svc_admin_role)
-        await settings_service.update_agent_settings(
-            AgentSettingsUpdate(agent_use_latest_resource_versions=True)
+        await settings_service.update_app_settings(
+            AppSettingsUpdate(
+                app_versioned_resource_resolution_strategy=(
+                    VersionedResourceResolutionStrategy.LATEST
+                )
+            )
         )
         child = await agent_preset_service.create_preset(
             agent_preset_create_params.model_copy(

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -1340,10 +1340,19 @@ class TestAgentPresetService:
         configure_minio_for_skills,
         session: AsyncSession,
         svc_role: Role,
+        svc_admin_role: Role,
         agent_preset_service: AgentPresetService,
     ) -> None:
         """Preset version creation rejects duplicate resolved skill names."""
 
+        settings_service = SettingsService(session=session, role=svc_admin_role)
+        await settings_service.update_app_settings(
+            AppSettingsUpdate(
+                app_versioned_resource_resolution_strategy=(
+                    VersionedResourceResolutionStrategy.PINNED
+                )
+            )
+        )
         skill_service = SkillService(session=session, role=svc_role)
         skill_a = await skill_service.create_skill(SkillCreate(name="shared-name"))
         skill_a_shared = await skill_service.publish_skill(skill_a.id)
@@ -1419,10 +1428,19 @@ class TestAgentPresetService:
         configure_minio_for_skills,
         session: AsyncSession,
         svc_role: Role,
+        svc_admin_role: Role,
         agent_preset_service: AgentPresetService,
     ) -> None:
         """Preset resolution fails before runtime if a snapshot contains duplicates."""
 
+        settings_service = SettingsService(session=session, role=svc_admin_role)
+        await settings_service.update_app_settings(
+            AppSettingsUpdate(
+                app_versioned_resource_resolution_strategy=(
+                    VersionedResourceResolutionStrategy.PINNED
+                )
+            )
+        )
         skill_service = SkillService(session=session, role=svc_role)
         skill_a = await skill_service.create_skill(SkillCreate(name="shared-name"))
         skill_a_shared = await skill_service.publish_skill(skill_a.id)

--- a/tests/unit/test_agent_preset_service.py
+++ b/tests/unit/test_agent_preset_service.py
@@ -51,6 +51,8 @@ from tracecat.registry.versions.schemas import (
     RegistryVersionManifest,
     RegistryVersionManifestAction,
 )
+from tracecat.settings.schemas import AgentSettingsUpdate
+from tracecat.settings.service import SettingsService
 from tracecat.storage.blob import ensure_bucket_exists
 
 pytestmark = pytest.mark.usefixtures("db")
@@ -1022,6 +1024,71 @@ class TestAgentPresetService:
         assert len(version_read.skills) == 1
         assert version_read.skills[0].skill_version_id == skill_version.id
         assert version_read.skills[0].skill_version == 1
+
+    async def test_resolve_config_uses_latest_skill_versions_when_setting_enabled(
+        self,
+        configure_minio_for_skills,
+        session: AsyncSession,
+        svc_role: Role,
+        svc_admin_role: Role,
+        agent_preset_service: AgentPresetService,
+    ) -> None:
+        """Latest-resource mode resolves skills by current version at execution time."""
+
+        settings_service = SettingsService(session=session, role=svc_admin_role)
+        await settings_service.update_agent_settings(
+            AgentSettingsUpdate(agent_use_latest_resource_versions=True)
+        )
+        skill_service = SkillService(session=session, role=svc_role)
+        created_skill = await skill_service.create_skill(
+            SkillCreate(name="latest-skill-v1")
+        )
+        skill_version_one = await skill_service.publish_skill(created_skill.id)
+
+        created_preset = await agent_preset_service.create_preset(
+            AgentPresetCreate(
+                name="Latest skill preset",
+                description="Preset that follows skill current versions",
+                instructions="Use the selected skill",
+                model_name="gpt-4o-mini",
+                model_provider="openai",
+                skills=[
+                    AgentPresetSkillBindingBase(
+                        skill_id=created_skill.id,
+                        skill_version_id=skill_version_one.id,
+                    )
+                ],
+            )
+        )
+
+        draft = await skill_service.get_draft(created_skill.id)
+        assert draft is not None
+        await skill_service.patch_draft(
+            skill_id=created_skill.id,
+            params=SkillDraftPatch(
+                base_revision=draft.draft_revision,
+                operations=[
+                    SkillDraftUpsertTextFileOp(
+                        path="SKILL.md",
+                        content=(
+                            "---\nname: latest-skill-v2\n---\n\n# latest-skill-v2\n"
+                        ),
+                        content_type="text/markdown; charset=utf-8",
+                    )
+                ],
+            ),
+        )
+        skill_version_two = await skill_service.publish_skill(created_skill.id)
+
+        config = await agent_preset_service.resolve_agent_preset_config(
+            preset_id=created_preset.id
+        )
+
+        assert config.resolved_skills is not None
+        assert len(config.resolved_skills) == 1
+        resolved_skill = config.resolved_skills[0]
+        assert resolved_skill.skill_version_id == skill_version_two.id
+        assert resolved_skill.skill_name == "latest-skill-v2"
 
     async def test_list_versions_returns_metadata_without_skill_lookups(
         self,
@@ -2455,6 +2522,68 @@ class TestAgentPresetService:
         assert agents.enabled is True
         assert isinstance(agents.subagents[0], ResolvedAttachedSubagentRef)
         assert agents.subagents[0].preset_id == child.id
+
+    async def test_resolve_config_uses_latest_subagent_version_when_setting_enabled(
+        self,
+        session: AsyncSession,
+        svc_role: Role,
+        svc_admin_role: Role,
+        agent_preset_service: AgentPresetService,
+        agent_preset_create_params: AgentPresetCreate,
+    ) -> None:
+        """Latest-resource mode resolves preset-backed subagents by current version."""
+
+        settings_service = SettingsService(session=session, role=svc_admin_role)
+        await settings_service.update_agent_settings(
+            AgentSettingsUpdate(agent_use_latest_resource_versions=True)
+        )
+        child = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={
+                    "name": "Latest Child",
+                    "slug": "latest-child",
+                    "instructions": "Child v1",
+                }
+            )
+        )
+        child_version_one = await agent_preset_service.get_current_version_for_preset(
+            child
+        )
+        parent = await agent_preset_service.create_preset(
+            agent_preset_create_params.model_copy(
+                update={
+                    "name": "Latest Parent",
+                    "slug": "latest-parent",
+                    "agents": AgentSubagentsConfig.model_validate(
+                        {
+                            "enabled": True,
+                            "subagents": [{"preset": child.slug}],
+                        }
+                    ),
+                }
+            )
+        )
+
+        await agent_preset_service.update_preset(
+            child,
+            AgentPresetUpdate(instructions="Child v2"),
+        )
+        child_version_two = await agent_preset_service.get_current_version_for_preset(
+            child
+        )
+
+        config = await agent_preset_service.resolve_agent_preset_config(
+            preset_id=parent.id
+        )
+
+        assert child_version_two.id != child_version_one.id
+        assert config.agents.enabled is True
+        assert len(config.agents.subagents) == 1
+        resolved_subagent = config.agents.subagents[0]
+        assert isinstance(resolved_subagent, ResolvedAttachedSubagentRef)
+        assert resolved_subagent.preset_id == child.id
+        assert resolved_subagent.preset_version_id == child_version_two.id
+        assert resolved_subagent.preset_version == child_version_two.version
 
     async def test_update_parent_rejects_subagent_with_tool_approvals(
         self,

--- a/tests/unit/test_organization_settings.py
+++ b/tests/unit/test_organization_settings.py
@@ -17,14 +17,21 @@ from tracecat.settings.router import (
     check_saml_domain_prerequisites,
 )
 from tracecat.settings.schemas import (
+    AppSettingsUpdate,
     AuditSettingsUpdate,
     GitSettingsUpdate,
     SAMLSettingsUpdate,
     SettingCreate,
     SettingUpdate,
     ValueType,
+    VersionedResourceResolutionStrategy,
 )
-from tracecat.settings.service import SettingsService, get_setting, get_setting_override
+from tracecat.settings.service import (
+    SettingsService,
+    get_setting,
+    get_setting_override,
+    get_versioned_resource_resolution_strategy,
+)
 
 pytestmark = pytest.mark.usefixtures("db")
 
@@ -500,6 +507,34 @@ async def test_get_setting_shorthand(
         assert nonexistent_no_default is None
     finally:
         ctx_role.reset(token)  # type: ignore
+
+
+@pytest.mark.anyio
+async def test_get_versioned_resource_resolution_strategy(
+    settings_service_with_defaults: SettingsService,
+    svc_admin_role: Role,
+) -> None:
+    service = settings_service_with_defaults
+
+    strategy = await get_versioned_resource_resolution_strategy(
+        role=svc_admin_role,
+        session=service.session,
+    )
+    assert strategy is VersionedResourceResolutionStrategy.PINNED
+
+    await service.update_app_settings(
+        AppSettingsUpdate(
+            app_versioned_resource_resolution_strategy=(
+                VersionedResourceResolutionStrategy.LATEST
+            )
+        )
+    )
+
+    strategy = await get_versioned_resource_resolution_strategy(
+        role=svc_admin_role,
+        session=service.session,
+    )
+    assert strategy is VersionedResourceResolutionStrategy.LATEST
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_organization_settings.py
+++ b/tests/unit/test_organization_settings.py
@@ -17,6 +17,7 @@ from tracecat.settings.router import (
     check_saml_domain_prerequisites,
 )
 from tracecat.settings.schemas import (
+    AppSettingsRead,
     AppSettingsUpdate,
     AuditSettingsUpdate,
     GitSettingsUpdate,
@@ -507,6 +508,22 @@ async def test_get_setting_shorthand(
         assert nonexistent_no_default is None
     finally:
         ctx_role.reset(token)  # type: ignore
+
+
+def test_app_settings_read_defaults_versioned_resource_strategy() -> None:
+    settings = AppSettingsRead(
+        app_registry_validation_enabled=False,
+        app_executions_query_limit=100,
+        app_interactions_enabled=False,
+        app_workflow_export_enabled=True,
+        app_create_workspace_on_register=False,
+        app_action_form_mode_enabled=True,
+    )
+
+    assert (
+        settings.app_versioned_resource_resolution_strategy
+        is VersionedResourceResolutionStrategy.LATEST
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_organization_settings.py
+++ b/tests/unit/test_organization_settings.py
@@ -520,12 +520,12 @@ async def test_get_versioned_resource_resolution_strategy(
         role=svc_admin_role,
         session=service.session,
     )
-    assert strategy is VersionedResourceResolutionStrategy.PINNED
+    assert strategy is VersionedResourceResolutionStrategy.LATEST
 
     await service.update_app_settings(
         AppSettingsUpdate(
             app_versioned_resource_resolution_strategy=(
-                VersionedResourceResolutionStrategy.LATEST
+                VersionedResourceResolutionStrategy.PINNED
             )
         )
     )
@@ -534,7 +534,7 @@ async def test_get_versioned_resource_resolution_strategy(
         role=svc_admin_role,
         session=service.session,
     )
-    assert strategy is VersionedResourceResolutionStrategy.LATEST
+    assert strategy is VersionedResourceResolutionStrategy.PINNED
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -39,15 +39,19 @@ class TestTokenBucket:
         assert bucket.tokens == 20.0
 
     @pytest.mark.anyio
-    async def test_refill(self):
+    async def test_refill(self, monkeypatch: pytest.MonkeyPatch):
         """Test that tokens are refilled based on elapsed time."""
+        current_time = 1_000.0
+        monkeypatch.setattr(
+            "tracecat.middleware.rate_limit.time.time", lambda: current_time
+        )
         bucket = TokenBucket(rate=10.0, capacity=20.0)
         # Consume some tokens
         await bucket.consume(tokens=15.0)
         assert bucket.tokens == 5.0
 
         # Manually set the last refill time to simulate elapsed time
-        bucket.last_refill = time.time() - 1.0  # 1 second ago
+        current_time += 1.0
 
         # Consume again, which should trigger a refill
         result = await bucket.consume(tokens=1.0)

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -93,12 +93,14 @@ async def resolve_agents_config_activity(
     args: ResolveAgentsConfigActivityInput,
 ) -> ResolvedAgentsRuntimeConfig:
     async with AgentPresetService.with_session(role=args.role) as service:
+        follow_latest_versions = await service.use_latest_resource_versions()
         resolved = await resolve_agents_config(
             service,
             agents=args.agents,
             parent_preset_id=args.parent_preset_id,
             parent_slug=args.parent_slug,
             include_runtime_config=True,
+            follow_latest_versions=follow_latest_versions,
         )
         return resolved.to_runtime_config()
 

--- a/tracecat/agent/preset/activities.py
+++ b/tracecat/agent/preset/activities.py
@@ -57,6 +57,7 @@ class ResolveAgentsConfigActivityInput(BaseModel):
     agents: AgentSubagentsConfig = Field(default_factory=AgentSubagentsConfig)
     parent_preset_id: uuid.UUID | None = None
     parent_slug: str | None = None
+    follow_latest_versions: bool | None = None
 
 
 @activity.defn
@@ -93,7 +94,9 @@ async def resolve_agents_config_activity(
     args: ResolveAgentsConfigActivityInput,
 ) -> ResolvedAgentsRuntimeConfig:
     async with AgentPresetService.with_session(role=args.role) as service:
-        follow_latest_versions = await service.use_latest_resource_versions()
+        follow_latest_versions = args.follow_latest_versions
+        if follow_latest_versions is None:
+            follow_latest_versions = await service.use_latest_resource_versions()
         resolved = await resolve_agents_config(
             service,
             agents=args.agents,

--- a/tracecat/agent/preset/resolver.py
+++ b/tracecat/agent/preset/resolver.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 
 from tracecat.agent.subagents import (
     AgentSubagentsConfig,
+    AttachedSubagentRef,
     ResolvedAgentsConfig,
     ResolvedAttachedSubagentRef,
     has_manual_tool_approvals,
@@ -145,25 +146,39 @@ async def resolve_agents_config(
             )
         aliases.add(alias)
 
-        preset_id = getattr(ref, "preset_id", None)
-        preset_version_id = getattr(ref, "preset_version_id", None)
-        if follow_latest_versions and preset_id is not None:
-            version = await service.resolve_agent_preset_version(
-                preset_id=preset_id,
-            )
-        elif follow_latest_versions:
-            version = await service.resolve_agent_preset_version(
-                slug=ref.preset,
-            )
-        elif preset_version_id is not None:
-            version = await service.resolve_agent_preset_version(
-                preset_version_id=preset_version_id,
-            )
-        else:
-            version = await service.resolve_agent_preset_version(
-                slug=ref.preset,
-                preset_version=ref.preset_version,
-            )
+        # Resolved refs carry immutable preset/version UUIDs; unresolved refs
+        # only carry a slug + optional version int. Matching narrows the union
+        # so we read the right identifiers without runtime getattr() lookups.
+        # Order matters: ResolvedAttachedSubagentRef subclasses
+        # AttachedSubagentRef, so the resolved case must come first or resolved
+        # refs would silently fall into the base-class branch.
+        match ref:
+            case ResolvedAttachedSubagentRef(
+                preset_id=preset_id, preset_version_id=preset_version_id
+            ):
+                # Persisted ref has stable UUIDs to resolve against.
+                if follow_latest_versions:
+                    # Pinned identity, but the caller wants the newest version.
+                    version = await service.resolve_agent_preset_version(
+                        preset_id=preset_id,
+                    )
+                else:
+                    # Resolve the exact persisted version.
+                    version = await service.resolve_agent_preset_version(
+                        preset_version_id=preset_version_id,
+                    )
+            case AttachedSubagentRef(preset=preset_slug, preset_version=preset_version):
+                # Unresolved ref has no persisted UUID; resolve by slug.
+                preset_version_id = None
+                if follow_latest_versions:
+                    version = await service.resolve_agent_preset_version(
+                        slug=preset_slug
+                    )
+                else:
+                    version = await service.resolve_agent_preset_version(
+                        slug=preset_slug,
+                        preset_version=preset_version,
+                    )
         references_parent_id = (
             parent_preset_id is not None and version.preset_id == parent_preset_id
         )

--- a/tracecat/agent/preset/resolver.py
+++ b/tracecat/agent/preset/resolver.py
@@ -123,6 +123,7 @@ async def resolve_agents_config(
     parent_preset_id: uuid.UUID | None = None,
     parent_slug: str | None = None,
     include_runtime_config: bool = False,
+    follow_latest_versions: bool = False,
 ) -> ResolvedAgentsConfigResult:
     """Resolve and validate preset-backed subagent refs."""
 
@@ -144,8 +145,17 @@ async def resolve_agents_config(
             )
         aliases.add(alias)
 
+        preset_id = getattr(ref, "preset_id", None)
         preset_version_id = getattr(ref, "preset_version_id", None)
-        if preset_version_id is not None:
+        if follow_latest_versions and preset_id is not None:
+            version = await service.resolve_agent_preset_version(
+                preset_id=preset_id,
+            )
+        elif follow_latest_versions:
+            version = await service.resolve_agent_preset_version(
+                slug=ref.preset,
+            )
+        elif preset_version_id is not None:
             version = await service.resolve_agent_preset_version(
                 preset_version_id=preset_version_id,
             )

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -72,16 +72,14 @@ from tracecat.pagination import (
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.secrets import secrets_manager
 from tracecat.service import BaseWorkspaceService, requires_entitlement
-from tracecat.settings.service import get_setting
+from tracecat.settings.schemas import VersionedResourceResolutionStrategy
+from tracecat.settings.service import get_versioned_resource_resolution_strategy
 from tracecat.tiers.enums import Entitlement
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from tracecat.auth.types import Role
-
-
-AGENT_USE_LATEST_RESOURCE_VERSIONS_SETTING = "agent_use_latest_resource_versions"
 
 
 class AgentPresetService(BaseWorkspaceService):
@@ -112,14 +110,11 @@ class AgentPresetService(BaseWorkspaceService):
     async def use_latest_resource_versions(self) -> bool:
         """Return whether preset dependencies should resolve to current versions."""
 
-        return bool(
-            await get_setting(
-                AGENT_USE_LATEST_RESOURCE_VERSIONS_SETTING,
-                role=self.role,
-                session=self.session,
-                default=False,
-            )
+        strategy = await get_versioned_resource_resolution_strategy(
+            role=self.role,
+            session=self.session,
         )
+        return strategy is VersionedResourceResolutionStrategy.LATEST
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def list_presets(self) -> Sequence[AgentPreset]:

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -1629,8 +1629,10 @@ class AgentPresetService(BaseWorkspaceService):
                 include_runtime_config=False,
                 follow_latest_versions=True,
             )
-            agents = AgentSubagentsConfig.model_validate(
-                resolved_agents.to_agents_binding().model_dump(mode="json")
+            binding = resolved_agents.to_agents_binding()
+            agents = AgentSubagentsConfig(
+                enabled=binding.enabled,
+                subagents=list(binding.subagents),
             )
         return AgentConfig(
             model_name=version.model_name,

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -49,6 +49,7 @@ from tracecat.db.models import (
     AgentPresetSkill,
     AgentPresetVersion,
     AgentPresetVersionSkill,
+    Skill,
     SkillVersion,
 )
 from tracecat.dsl.common import create_default_execution_context
@@ -71,12 +72,16 @@ from tracecat.pagination import (
 from tracecat.registry.actions.service import RegistryActionsService
 from tracecat.secrets import secrets_manager
 from tracecat.service import BaseWorkspaceService, requires_entitlement
+from tracecat.settings.service import get_setting
 from tracecat.tiers.enums import Entitlement
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from tracecat.auth.types import Role
+
+
+AGENT_USE_LATEST_RESOURCE_VERSIONS_SETTING = "agent_use_latest_resource_versions"
 
 
 class AgentPresetService(BaseWorkspaceService):
@@ -103,6 +108,18 @@ class AgentPresetService(BaseWorkspaceService):
     def __init__(self, session: AsyncSession, role: Role | None = None):
         super().__init__(session, role=role)
         self.skills = SkillService(session, role=self.role)
+
+    async def use_latest_resource_versions(self) -> bool:
+        """Return whether preset dependencies should resolve to current versions."""
+
+        return bool(
+            await get_setting(
+                AGENT_USE_LATEST_RESOURCE_VERSIONS_SETTING,
+                role=self.role,
+                session=self.session,
+                default=False,
+            )
+        )
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def list_presets(self) -> Sequence[AgentPreset]:
@@ -1578,6 +1595,7 @@ class AgentPresetService(BaseWorkspaceService):
     async def _version_to_agent_config(
         self, version: AgentPresetVersion
     ) -> AgentConfig:
+        use_latest_resource_versions = await self.use_latest_resource_versions()
         # Resolve refs only — no headers / stdio env. The resulting
         # AgentConfig is safe to cross Temporal boundaries. Trusted callers
         # (build_tool_definitions, trusted MCP server) re-resolve secrets
@@ -1585,7 +1603,8 @@ class AgentPresetService(BaseWorkspaceService):
         mcp_servers = await self.resolve_mcp_integration_refs(version.mcp_integrations)
         model_settings: dict[str, Any] = {}
         resolved_skills = await self.skills.get_resolved_skill_refs_for_preset_version(
-            version.id
+            version.id,
+            use_latest_versions=use_latest_resource_versions,
         )
         duplicate_skill_names = sorted(
             name
@@ -1606,6 +1625,18 @@ class AgentPresetService(BaseWorkspaceService):
         # Only disable parallel tool calls if tools will be present
         if version.actions or mcp_servers:
             model_settings["parallel_tool_calls"] = False
+        agents = AgentSubagentsConfig.model_validate(version.agents)
+        if use_latest_resource_versions:
+            resolved_agents = await resolve_agents_config(
+                self,
+                agents=agents,
+                parent_preset_id=version.preset_id,
+                include_runtime_config=False,
+                follow_latest_versions=True,
+            )
+            agents = AgentSubagentsConfig.model_validate(
+                resolved_agents.to_agents_binding().model_dump(mode="json")
+            )
         return AgentConfig(
             model_name=version.model_name,
             model_provider=version.model_provider,
@@ -1617,7 +1648,7 @@ class AgentPresetService(BaseWorkspaceService):
             namespaces=version.namespaces,
             tool_approvals=version.tool_approvals,
             mcp_servers=mcp_servers,
-            agents=AgentSubagentsConfig.model_validate(version.agents),
+            agents=agents,
             retries=version.retries,
             model_settings=model_settings,
             enable_thinking=version.enable_thinking,
@@ -1631,19 +1662,50 @@ class AgentPresetService(BaseWorkspaceService):
         """Create and flush a new immutable version from the preset head."""
         if not preset_locked:
             await self._lock_preset_for_versioning(preset.id)
-        duplicate_name_stmt = (
-            select(
-                SkillVersion.name,
-                func.count(AgentPresetSkill.id).label("binding_count"),
+        if await self.use_latest_resource_versions():
+            duplicate_name_stmt = (
+                select(
+                    SkillVersion.name,
+                    func.count(AgentPresetSkill.id).label("binding_count"),
+                )
+                .join(
+                    Skill,
+                    sa.and_(
+                        AgentPresetSkill.workspace_id == Skill.workspace_id,
+                        AgentPresetSkill.skill_id == Skill.id,
+                    ),
+                )
+                .join(
+                    SkillVersion,
+                    sa.and_(
+                        SkillVersion.workspace_id == Skill.workspace_id,
+                        SkillVersion.skill_id == Skill.id,
+                        SkillVersion.id == Skill.current_version_id,
+                    ),
+                )
+                .where(
+                    AgentPresetSkill.workspace_id == self.workspace_id,
+                    AgentPresetSkill.preset_id == preset.id,
+                )
+                .group_by(SkillVersion.name)
+                .having(func.count(AgentPresetSkill.id) > 1)
             )
-            .join(SkillVersion, AgentPresetSkill.skill_version_id == SkillVersion.id)
-            .where(
-                AgentPresetSkill.workspace_id == self.workspace_id,
-                AgentPresetSkill.preset_id == preset.id,
+        else:
+            duplicate_name_stmt = (
+                select(
+                    SkillVersion.name,
+                    func.count(AgentPresetSkill.id).label("binding_count"),
+                )
+                .join(
+                    SkillVersion, AgentPresetSkill.skill_version_id == SkillVersion.id
+                )
+                .where(
+                    AgentPresetSkill.workspace_id == self.workspace_id,
+                    AgentPresetSkill.preset_id == preset.id,
+                )
+                .group_by(SkillVersion.name)
+                .having(func.count(AgentPresetSkill.id) > 1)
             )
-            .group_by(SkillVersion.name)
-            .having(func.count(AgentPresetSkill.id) > 1)
-        )
         duplicate_names = sorted(
             name
             for name, _count in (await self.session.execute(duplicate_name_stmt))

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -104,6 +104,8 @@ class LoadSessionResult(BaseModel):
     # SDK JSONL across Temporal boundaries.
     sdk_session_data: str | None = Field(default=None, deprecated=True)
     is_fork: bool = False  # If True, runtime should use fork_session=True with SDK
+    agents_binding: ResolvedAgentsConfig | None = None
+    has_resume_state: bool = False
     error: str | None = None
 
 
@@ -275,6 +277,15 @@ async def load_session_activity(input: LoadSessionInput) -> LoadSessionResult:
 
             is_fork = False
             sdk_session_id = agent_session.sdk_session_id
+            agents_binding = (
+                ResolvedAgentsConfig.model_validate(agent_session.agents_binding)
+                if agent_session.agents_binding is not None
+                else None
+            )
+            has_resume_state = (
+                agent_session.sdk_session_id is not None
+                or agent_session.parent_session_id is not None
+            )
 
             # For forked sessions, only fork on the first turn (when child has
             # no sdk_session_id yet). Subsequent turns resume the child's own
@@ -292,7 +303,11 @@ async def load_session_activity(input: LoadSessionInput) -> LoadSessionResult:
                         session_id=input.session_id,
                         parent_session_id=agent_session.parent_session_id,
                     )
-                    return LoadSessionResult(found=True)
+                    return LoadSessionResult(
+                        found=True,
+                        agents_binding=agents_binding,
+                        has_resume_state=has_resume_state,
+                    )
                 is_fork = True
                 sdk_session_id = parent_session.sdk_session_id
 
@@ -300,6 +315,8 @@ async def load_session_activity(input: LoadSessionInput) -> LoadSessionResult:
                 found=True,
                 sdk_session_id=sdk_session_id,
                 is_fork=is_fork,
+                agents_binding=agents_binding,
+                has_resume_state=has_resume_state,
             )
 
     except Exception as e:

--- a/tracecat/agent/skill/service.py
+++ b/tracecat/agent/skill/service.py
@@ -2204,9 +2204,17 @@ class SkillService(BaseWorkspaceService):
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def get_resolved_skill_refs_for_preset_version(
-        self, preset_version_id: uuid.UUID
+        self,
+        preset_version_id: uuid.UUID,
+        *,
+        use_latest_versions: bool = False,
     ) -> list[ResolvedSkillRef]:
-        """Return exact skill refs for an immutable preset version."""
+        """Return skill refs for an immutable preset version."""
+
+        if use_latest_versions:
+            return await self._get_latest_skill_refs_for_preset_version(
+                preset_version_id
+            )
 
         stmt = (
             select(
@@ -2236,6 +2244,79 @@ class SkillService(BaseWorkspaceService):
             for skill_id, skill_name, skill_version_id, manifest_sha256 in rows
             if skill_name is not None
         ]
+
+    async def _get_latest_skill_refs_for_preset_version(
+        self, preset_version_id: uuid.UUID
+    ) -> list[ResolvedSkillRef]:
+        """Return current skill versions for a preset version's skill IDs."""
+
+        stmt = (
+            select(
+                AgentPresetVersionSkill.skill_id,
+                Skill.name,
+                Skill.current_version_id,
+                SkillVersion.name,
+                SkillVersion.manifest_sha256,
+            )
+            .join(
+                Skill,
+                sa.and_(
+                    AgentPresetVersionSkill.workspace_id == Skill.workspace_id,
+                    AgentPresetVersionSkill.skill_id == Skill.id,
+                ),
+            )
+            .outerjoin(
+                SkillVersion,
+                sa.and_(
+                    SkillVersion.workspace_id == Skill.workspace_id,
+                    SkillVersion.skill_id == Skill.id,
+                    SkillVersion.id == Skill.current_version_id,
+                ),
+            )
+            .where(
+                AgentPresetVersionSkill.workspace_id == self.workspace_id,
+                AgentPresetVersionSkill.preset_version_id == preset_version_id,
+            )
+            .order_by(
+                SkillVersion.name.asc().nulls_last(),
+                Skill.name.asc(),
+                AgentPresetVersionSkill.skill_id.asc(),
+            )
+        )
+        rows = (await self.session.execute(stmt)).tuples().all()
+        resolved: list[ResolvedSkillRef] = []
+        missing_current: list[str] = []
+        for (
+            skill_id,
+            skill_name,
+            current_version_id,
+            current_version_name,
+            manifest_sha256,
+        ) in rows:
+            if current_version_id is None:
+                missing_current.append(f"{skill_name} ({skill_id})")
+                continue
+            if current_version_name is None:
+                self._raise_missing_version_name(skill_version_id=current_version_id)
+            resolved.append(
+                ResolvedSkillRef(
+                    skill_id=skill_id,
+                    skill_name=current_version_name,
+                    skill_version_id=current_version_id,
+                    manifest_sha256=manifest_sha256,
+                )
+            )
+
+        if missing_current:
+            raise TracecatValidationError(
+                "Some skills have no current published version",
+                detail={
+                    "code": "skill_not_published",
+                    "skills": sorted(missing_current),
+                    "preset_version_id": str(preset_version_id),
+                },
+            )
+        return resolved
 
     @requires_entitlement(Entitlement.AGENT_ADDONS)
     async def get_resolved_skill_ref(

--- a/tracecat/agent/tokens.py
+++ b/tracecat/agent/tokens.py
@@ -361,7 +361,7 @@ def mint_llm_token(
         Signed JWT string
     """
     now = datetime.now(UTC)
-    ttl = ttl_seconds or config.TRACECAT__EXECUTOR_TOKEN_TTL_SECONDS
+    ttl = ttl_seconds or config.TRACECAT__AGENT_SANDBOX_TIMEOUT + 60
 
     payload: dict[str, Any] = {
         # Standard JWT claims

--- a/tracecat/settings/schemas.py
+++ b/tracecat/settings/schemas.py
@@ -174,6 +174,7 @@ class AgentSettingsRead(BaseSettingsGroup):
     agent_fixed_args: str | None
     agent_case_chat_prompt: str
     agent_case_chat_inject_content: bool
+    agent_use_latest_resource_versions: bool
 
 
 class AgentSettingsUpdate(BaseSettingsGroup):
@@ -194,6 +195,14 @@ class AgentSettingsUpdate(BaseSettingsGroup):
     agent_case_chat_inject_content: bool = Field(
         default=False,
         description="Whether to automatically inject case content into agent prompts when a case_id is available.",
+    )
+    agent_use_latest_resource_versions: bool = Field(
+        default=False,
+        description=(
+            "Whether agent preset execution resolves dependent skills and "
+            "preset-backed subagents to their current versions instead of the "
+            "versions snapshotted on the preset version."
+        ),
     )
 
 

--- a/tracecat/settings/schemas.py
+++ b/tracecat/settings/schemas.py
@@ -79,6 +79,11 @@ class SAMLSettingsUpdate(BaseSettingsGroup):
     saml_idp_metadata_url: str | None = Field(default=None)
 
 
+class VersionedResourceResolutionStrategy(StrEnum):
+    PINNED = "pinned"
+    LATEST = "latest"
+
+
 class AppSettingsRead(BaseSettingsGroup):
     """Settings for the app."""
 
@@ -88,6 +93,7 @@ class AppSettingsRead(BaseSettingsGroup):
     app_workflow_export_enabled: bool
     app_create_workspace_on_register: bool
     app_action_form_mode_enabled: bool
+    app_versioned_resource_resolution_strategy: VersionedResourceResolutionStrategy
 
 
 class AppSettingsUpdate(BaseSettingsGroup):
@@ -115,6 +121,15 @@ class AppSettingsUpdate(BaseSettingsGroup):
     app_action_form_mode_enabled: bool = Field(
         default=True,
         description="Whether to enable form mode for action inputs. When disabled, only YAML mode is available, preserving raw YAML formatting.",
+    )
+    app_versioned_resource_resolution_strategy: VersionedResourceResolutionStrategy = (
+        Field(
+            default=VersionedResourceResolutionStrategy.PINNED,
+            description=(
+                "How versioned resource references are resolved when a feature "
+                "supports both pinned and latest dependency resolution."
+            ),
+        )
     )
 
 
@@ -174,7 +189,6 @@ class AgentSettingsRead(BaseSettingsGroup):
     agent_fixed_args: str | None
     agent_case_chat_prompt: str
     agent_case_chat_inject_content: bool
-    agent_use_latest_resource_versions: bool
 
 
 class AgentSettingsUpdate(BaseSettingsGroup):
@@ -195,14 +209,6 @@ class AgentSettingsUpdate(BaseSettingsGroup):
     agent_case_chat_inject_content: bool = Field(
         default=False,
         description="Whether to automatically inject case content into agent prompts when a case_id is available.",
-    )
-    agent_use_latest_resource_versions: bool = Field(
-        default=False,
-        description=(
-            "Whether agent preset execution resolves dependent skills and "
-            "preset-backed subagents to their current versions instead of the "
-            "versions snapshotted on the preset version."
-        ),
     )
 
 

--- a/tracecat/settings/schemas.py
+++ b/tracecat/settings/schemas.py
@@ -93,7 +93,9 @@ class AppSettingsRead(BaseSettingsGroup):
     app_workflow_export_enabled: bool
     app_create_workspace_on_register: bool
     app_action_form_mode_enabled: bool
-    app_versioned_resource_resolution_strategy: VersionedResourceResolutionStrategy
+    app_versioned_resource_resolution_strategy: VersionedResourceResolutionStrategy = (
+        VersionedResourceResolutionStrategy.LATEST
+    )
 
 
 class AppSettingsUpdate(BaseSettingsGroup):

--- a/tracecat/settings/schemas.py
+++ b/tracecat/settings/schemas.py
@@ -124,7 +124,7 @@ class AppSettingsUpdate(BaseSettingsGroup):
     )
     app_versioned_resource_resolution_strategy: VersionedResourceResolutionStrategy = (
         Field(
-            default=VersionedResourceResolutionStrategy.PINNED,
+            default=VersionedResourceResolutionStrategy.LATEST,
             description=(
                 "How versioned resource references are resolved when a feature "
                 "supports both pinned and latest dependency resolution."

--- a/tracecat/settings/service.py
+++ b/tracecat/settings/service.py
@@ -396,7 +396,7 @@ async def get_versioned_resource_resolution_strategy(
         VERSIONED_RESOURCE_RESOLUTION_STRATEGY_SETTING,
         role=role,
         session=session,
-        default=VersionedResourceResolutionStrategy.PINNED,
+        default=VersionedResourceResolutionStrategy.LATEST,
     )
     return VersionedResourceResolutionStrategy(value)
 

--- a/tracecat/settings/service.py
+++ b/tracecat/settings/service.py
@@ -34,6 +34,11 @@ from tracecat.settings.schemas import (
     SAMLSettingsUpdate,
     SettingCreate,
     SettingUpdate,
+    VersionedResourceResolutionStrategy,
+)
+
+VERSIONED_RESOURCE_RESOLUTION_STRATEGY_SETTING = (
+    "app_versioned_resource_resolution_strategy"
 )
 
 
@@ -378,6 +383,22 @@ async def get_setting(
         logger.debug("Setting not found, using default value", key=key)
         return default
     return no_default_val
+
+
+async def get_versioned_resource_resolution_strategy(
+    *,
+    role: Role | None = None,
+    session: AsyncSession | None = None,
+) -> VersionedResourceResolutionStrategy:
+    """Return the org's versioned resource dependency resolution strategy."""
+
+    value = await get_setting(
+        VERSIONED_RESOURCE_RESOLUTION_STRATEGY_SETTING,
+        role=role,
+        session=session,
+        default=VersionedResourceResolutionStrategy.PINNED,
+    )
+    return VersionedResourceResolutionStrategy(value)
 
 
 async def get_setting_cached(


### PR DESCRIPTION
## Summary

- Replace the agent-only latest dependency toggle with a generic app-level `app_versioned_resource_resolution_strategy` setting (`latest` by default, `pinned` opt-out).
- Add a shared settings resolver for versioned resource dependency strategy so future versioned-resource consumers can opt into the same policy without duplicating a raw setting key.
- Keep agent preset execution as the first consumer: skills and preset-backed subagents follow current versions by default, and use saved versions only when the generic strategy is set to `pinned`.
- Move the organization UI control from Agent settings to Application settings and regenerate the frontend client.

## QA

- Verified in the local Tracecat cluster at `https://main.tracecat.localhost/organization/settings/app`.
- Confirmed the Application settings UI shows the generic “Use latest versioned resources” control.
- Toggled it on, saved, reloaded, and confirmed the switch stayed on from the persisted settings response.
- Restored the local QA cluster setting to pinned after verification.
- Browser console errors: none.
- API logs showed authenticated `PATCH /settings/app` 204 responses and reload `GET /settings/app` 200 responses.
- Follow-up default change verified with focused unit tests, generated client default, and commit hooks.

## Tests

- `just gen-client-ci`
- `TRACECAT__DB_ENCRYPTION_KEY=<test Fernet key> uv run pytest tests/unit/test_organization_settings.py::test_init_default_settings tests/unit/test_organization_settings.py::test_get_versioned_resource_resolution_strategy tests/unit/test_agent_preset_service.py::TestAgentPresetService::test_resolve_config_uses_latest_skill_versions_when_setting_enabled tests/unit/test_agent_preset_service.py::TestAgentPresetService::test_resolve_config_uses_latest_subagent_version_when_setting_enabled`
- `uv run ruff check .`
- `uv run ruff format --check tracecat/settings/schemas.py tracecat/settings/service.py tests/unit/test_organization_settings.py`
- `uv run basedpyright tracecat/settings/schemas.py tracecat/settings/service.py tests/unit/test_organization_settings.py`
- `pnpm -C frontend check`
- `pnpm -C frontend run typecheck`
- Commit hooks: passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an app-level setting to choose how versioned dependencies resolve for agent presets: pinned or latest (default: latest). Resumed sessions now keep their stored subagent bindings so runs don’t drift when newer versions ship.

- **New Features**
  - Added `app_versioned_resource_resolution_strategy` (`pinned` | `latest`) and server helper `get_versioned_resource_resolution_strategy`.
  - Presets follow this policy for skills and preset-backed subagents via `AgentPresetService.use_latest_resource_versions()`, `SkillService.get_resolved_skill_refs_for_preset_version(use_latest_versions=...)`, and `resolve_agents_config(follow_latest_versions=...)`, including in `_version_to_agent_config` and `resolve_agents_config_activity`.
  - Frontend: new toggle under App settings (“Use latest versioned resources”); regenerated `schemas.gen.ts` and `types.gen.ts`.

- **Bug Fixes**
  - Default `AppSettingsRead` and the server getter to `latest` when unset.
  - Preserve resumed session subagent bindings: load session before resolution and resolve with `follow_latest_versions=false` when a stored binding exists.
  - Increased LLM gateway token TTL to match the agent sandbox timeout.

<sup>Written for commit 5c6fce62560b60f65e216956128c00de66386e23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

