### PR TITLE
fix: bump llm gateway token timeout

### DIFF
--- a/tracecat/agent/tokens.py
+++ b/tracecat/agent/tokens.py
@@ -361,7 +361,7 @@ def mint_llm_token(
         Signed JWT string
     """
     now = datetime.now(UTC)
-    ttl = ttl_seconds or config.TRACECAT__EXECUTOR_TOKEN_TTL_SECONDS
+    ttl = ttl_seconds or config.TRACECAT__AGENT_SANDBOX_TIMEOUT + 60
 
     payload: dict[str, Any] = {
         # Standard JWT claims


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase LLM gateway token TTL to outlive agent runs by default. `mint_llm_token` now uses `TRACECAT__AGENT_SANDBOX_TIMEOUT + 60` to prevent mid-run expiry and failed requests.

- **Bug Fixes**
  - In `tracecat/agent/tokens.py`, change default `ttl` from `TRACECAT__EXECUTOR_TOKEN_TTL_SECONDS` to `TRACECAT__AGENT_SANDBOX_TIMEOUT + 60`.

<sup>Written for commit c8b2d899fd9a2485aa21006836bda21c011f05a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

