### PR TITLE
fix(cases): gate case trigger dispatch at runtime

### DIFF
--- a/tests/unit/test_case_trigger_consumer.py
+++ b/tests/unit/test_case_trigger_consumer.py
@@ -148,12 +148,14 @@ def _build_consumer_with_mocks(
     triggers,
     role: Role,
     dispatch: AsyncMock | None = None,
+    has_case_addons: bool = True,
 ) -> CaseTriggerConsumer:
     consumer = CaseTriggerConsumer(client=client)
     consumer._load_event = AsyncMock(return_value=event)
     consumer._load_case = AsyncMock(return_value=case)
     consumer._load_triggers = AsyncMock(return_value=triggers)
     consumer._get_service_role = AsyncMock(return_value=role)
+    consumer._has_case_addons_entitlement = AsyncMock(return_value=has_case_addons)
     if dispatch is not None:
         consumer._dispatch_workflow = dispatch
     return consumer
@@ -206,6 +208,57 @@ async def test_case_trigger_consumer_lock_prevents_ack():
     should_ack = await consumer._process_message(fields)
     assert should_ack is False
     dispatch.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_case_trigger_consumer_skips_configured_triggers_without_case_addons():
+    event_id = uuid.uuid4()
+    case_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    workflow_id = uuid.uuid4()
+
+    event = SimpleNamespace(
+        id=event_id,
+        data={},
+        created_at=None,
+        type="case_created",
+        user_id=None,
+    )
+    case = SimpleNamespace(
+        id=case_id,
+        workspace_id=workspace_id,
+        tags=[],
+    )
+    trigger = SimpleNamespace(
+        workflow_id=workflow_id,
+        tag_filters=[],
+    )
+
+    client = AsyncMock()
+    dispatch = AsyncMock(return_value=True)
+    consumer = _build_consumer_with_mocks(
+        client,
+        event=event,
+        case=case,
+        triggers=[trigger],
+        role=_build_role(workspace_id),
+        dispatch=dispatch,
+        has_case_addons=False,
+    )
+
+    fields = {
+        "event_id": str(event_id),
+        "case_id": str(case_id),
+        "workspace_id": str(workspace_id),
+        "event_type": "case_created",
+    }
+    should_ack = await consumer._process_message(fields)
+
+    assert should_ack is True
+    cast(AsyncMock, consumer._load_triggers).assert_not_awaited()
+    dispatch.assert_not_called()
+    client.exists.assert_not_called()
+    client.set_if_not_exists.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/tracecat/cases/triggers/consumer.py
+++ b/tracecat/cases/triggers/consumer.py
@@ -30,6 +30,8 @@ from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.logger import logger
 from tracecat.redis.client import RedisClient, get_redis_client
 from tracecat.registry.lock.types import RegistryLock
+from tracecat.tiers.access import is_org_entitled
+from tracecat.tiers.enums import Entitlement
 from tracecat.workflow.executions.enums import TriggerType
 from tracecat.workflow.executions.service import WorkflowExecutionsService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
@@ -177,8 +179,6 @@ class CaseTriggerConsumer:
             if case is None:
                 return True
 
-            triggers = await self._load_triggers(session, workspace_uuid, event_type)
-            case_tag_refs = {tag.ref for tag in case.tags}
             role = await self._get_service_role(session, workspace_uuid)
             explicit_workflow_id = self._parse_optional_uuid(fields.get("workflow_id"))
             explicit_comment_id = self._parse_optional_uuid(fields.get("comment_id"))
@@ -197,6 +197,19 @@ class CaseTriggerConsumer:
                 )
                 should_ack = should_ack and explicit_processed
 
+            if not await self._has_case_addons_entitlement(session, role):
+                logger.info(
+                    "Skipping configured case trigger dispatch; entitlement missing",
+                    event_id=event_id,
+                    workspace_id=workspace_id,
+                    organization_id=str(role.organization_id),
+                    entitlement=Entitlement.CASE_ADDONS.value,
+                )
+                await session.commit()
+                return should_ack
+
+            triggers = await self._load_triggers(session, workspace_uuid, event_type)
+            case_tag_refs = {tag.ref for tag in case.tags}
             for trigger in triggers:
                 if (
                     explicit_workflow_id is not None
@@ -388,6 +401,16 @@ class CaseTriggerConsumer:
         )
         self._workspace_role_cache[workspace_id] = role
         return role
+
+    async def _has_case_addons_entitlement(self, session, role: Role) -> bool:
+        organization_id = role.organization_id
+        if organization_id is None:
+            logger.warning(
+                "Skipping configured case trigger dispatch; service role has no organization",
+                workspace_id=str(role.workspace_id),
+            )
+            return False
+        return await is_org_entitled(session, organization_id, Entitlement.CASE_ADDONS)
 
     def _get_audit_role(
         self,


### PR DESCRIPTION
## Summary
- Gate configured case-trigger dispatch in the Redis consumer on the current `CASE_ADDONS` entitlement.
- Ack and skip configured trigger processing when the entitlement is missing, before loading online triggers or acquiring dispatch locks.
- Add a regression test covering the missing-entitlement skip path.

## Testing
- `uv run pytest tests/unit/test_case_trigger_consumer.py -q`
- `uv run ruff check tracecat/cases/triggers/consumer.py tests/unit/test_case_trigger_consumer.py`
- `uv run ruff format --check tracecat/cases/triggers/consumer.py tests/unit/test_case_trigger_consumer.py`
- `uv run basedpyright --warnings tracecat/cases/triggers/consumer.py tests/unit/test_case_trigger_consumer.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate configured case-trigger dispatch in the Redis consumer on the `CASE_ADDONS` entitlement. If the entitlement is missing, we ack and exit early to avoid loading triggers and acquiring dispatch locks.

- **Bug Fixes**
  - Added a runtime entitlement check using `is_org_entitled`; log and skip configured dispatch when not entitled.
  - Bypass online trigger loading and Redis lock paths; no `exists`/`set_if_not_exists` calls when gated.
  - Added regression test: `test_case_trigger_consumer_skips_configured_triggers_without_case_addons`.

<sup>Written for commit 61a09261137248d99f7ff3b4b0c02c5e21c742d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

