### PR TITLE
feat(chat): workflow editing support and platform skill

### DIFF
--- a/packages/tracecat-ee/pyproject.toml
+++ b/packages/tracecat-ee/pyproject.toml
@@ -38,3 +38,11 @@ workspace_chat = "tracecat_ee.agent.artifacts.mount_only_provider:build_provider
 
 [tool.hatch.version]
 path = "tracecat_ee/__init__.py"
+
+[tool.hatch.build.targets.wheel]
+# Ship the package, including non-Python data files such as built-in skill
+# SKILL.md / reference markdown so importlib.resources can find them at runtime.
+packages = ["tracecat_ee"]
+artifacts = [
+    "tracecat_ee/workspace_chat/skills/**/*.md",
+]

--- a/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/__init__.py
+++ b/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/__init__.py
@@ -1,0 +1,32 @@
+"""Built-in workspace-chat copilot skills (Enterprise Edition).
+
+These skills are plain on-disk skill directories (``<name>/SKILL.md`` plus
+optional ``references/*.md``) that the agent executor stages into the copilot's
+``~/.claude/skills`` directory for every entitled workspace-chat session,
+independent of any agent preset. The claude_code runtime then discovers and
+fetches them on demand, so the guidance reaches the model regardless of model
+strength.
+
+Every built-in skill name MUST use the reserved ``tracecat-`` prefix. User and
+preset skill names are forbidden from using that prefix (enforced in
+``tracecat.agent.skill.schemas``), so a built-in skill can never collide with a
+user-authored one in the staged skills directory.
+"""
+
+from __future__ import annotations
+
+# Reserved name prefix that only platform/built-in skills may use.
+BUILTIN_SKILL_NAME_PREFIX = "tracecat-"
+
+# Canonical, always-on skills staged for every entitled workspace-chat session.
+# Each entry MUST be the name of a directory under this package that contains a
+# ``SKILL.md`` file, and MUST start with ``BUILTIN_SKILL_NAME_PREFIX``.
+BUILTIN_WORKSPACE_CHAT_SKILLS: tuple[str, ...] = (
+    "tracecat-manage-workflows",
+    "tracecat-platform-guide",
+)
+
+__all__ = [
+    "BUILTIN_SKILL_NAME_PREFIX",
+    "BUILTIN_WORKSPACE_CHAT_SKILLS",
+]

--- a/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-manage-workflows/SKILL.md
+++ b/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-manage-workflows/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: tracecat-manage-workflows
+description: REQUIRED whenever the user wants to build, create, scaffold, set up, read, inspect, view, change, modify, update, edit, add a step to, or fix a Tracecat workflow or automation. Read this SKILL.md FIRST, before calling core.workflow.create_workflow, core.workflow.get_workflow, or core.workflow.edit_workflow. It covers creating a workflow (empty or from full YAML), reading its editable draft, and editing the draft with RFC 6902 JSON Patch including the mandatory read->patch->write sequence and revision handling.
+---
+
+# Managing Tracecat workflows
+
+You manage workflows through these tools in the `core.workflow` namespace:
+
+- `core.workflow.create_workflow` — create a new workflow (empty, or with a full definition).
+- `core.workflow.get_workflow` — read a workflow's editable **draft** (its current working copy).
+- `core.workflow.edit_workflow` — apply RFC 6902 JSON Patch operations to the draft.
+- `core.workflow.get_authoring_context` — look up real action arg schemas, secrets, and examples
+  before writing an action's `args:` (see "Getting action arguments right" below).
+
+A workflow's **draft** is its current editable state — the same thing shown in the workflow
+builder. Reading and editing always operate on the draft. There is no separate save step for the
+draft itself; every successful `edit_workflow` updates the live draft.
+
+## Golden rules
+
+1. **Never guess the current shape.** Before editing, always call `get_workflow` to get the latest
+   `draft_document` and `draft_revision`. Compute your patch against that exact `draft_document`.
+2. **Always pass `base_revision`.** Use the `draft_revision` from the most recent `get_workflow` as
+   `edit_workflow`'s `base_revision`. If the draft changed since you read it, the edit is rejected
+   with a conflict — re-read and retry. Do not reuse a stale revision.
+3. **One edit at a time, sequentially.** Each successful `edit_workflow` returns a NEW
+   `draft_revision`. Use it for the next edit. Never run edits in parallel against the same draft.
+4. **Prefer small, targeted patches** over replacing the whole definition. Patch the specific
+   actions/fields you are changing.
+
+## Creating a workflow
+
+To scaffold an empty workflow (only a trigger), call `create_workflow` with a `title` (and optional
+`description`). The user can then ask you to add actions.
+
+To create a workflow that already contains actions, pass the **full definition as YAML** in
+`definition_yaml`. Put the complete workflow under a top-level `definition:` key, and **always
+include an `entrypoint`** naming the first action's `ref` (the action with no `depends_on`).
+Omitting `entrypoint` still works (it is inferred from the graph), but set it explicitly so the
+workflow starts where you intend. Example:
+
+```yaml
+definition:
+  title: Enrich and notify
+  description: Look up an indicator and post a summary to Slack
+  entrypoint:
+    ref: fetch_indicator
+    expects:
+      indicator:
+        type: str
+  actions:
+    - ref: fetch_indicator
+      action: core.http_request
+      args:
+        url: https://example.com/api/lookup
+        method: GET
+        params:
+          q: ${{ TRIGGER.indicator }}
+```
+
+`create_workflow` returns the new workflow's `id` and `title`. After creating from YAML, call
+`get_workflow` to confirm the actions landed before making further edits.
+
+## Reading a workflow
+
+`core.workflow.get_workflow(workflow_id)` returns:
+
+- `workflow_id` — the workflow's id.
+- `draft_revision` — the optimistic-concurrency token. Pass it as `base_revision` to `edit_workflow`.
+- `draft_document` — the editable draft, with these top-level sections:
+  - `metadata` — `title`, `description`, `status`, `alias`, `error_handler`.
+  - `definition` — `entrypoint`, `actions`, `config`, `returns`.
+  - `layout` — node positions in the builder (`trigger`, `viewport`, `actions`).
+  - `schedules` — workflow schedules.
+  - `case_trigger` — case-trigger configuration, if any.
+
+Always read before you edit, and read back after a non-trivial edit to confirm the result.
+
+## Editing a workflow
+
+Editing uses RFC 6902 JSON Patch. The full mechanics — patch paths, array semantics, adding and
+renaming actions, the `validate_only` preflight, and conflict handling — are in
+[editing](references/editing.md). Read it before your first edit.
+
+Quick shape:
+
+```
+edit_workflow(
+  workflow_id="wf_...",
+  base_revision="<draft_revision from get_workflow>",
+  patch_ops=[
+    {"op": "add", "path": "/definition/actions/-", "value": { ...new action... }},
+  ],
+  validate_only=false,
+)
+```
+
+Editable top-level paths are `/metadata`, `/definition`, `/layout`, `/schedules`, `/case_trigger`.
+Action paths live under `/definition/actions/...`.
+
+## Action namespaces — NOT everything is `core.`
+
+Every `action:` name starts with exactly one of these three top-level namespaces. There are
+no others. Do not prefix `core.` onto an action that is not a core action.
+
+- `core.*` — built-ins: `core.http_request`, `core.transform.reshape`, `core.script.run_python`,
+  `core.cases.create_case`, `core.table.*`, etc.
+- `ai.*` — AI actions: **`ai.agent`** (tool-calling agent), **`ai.action`** (single LLM call),
+  **`ai.preset_agent`** (saved preset, enterprise). These are `ai.agent`, NOT `core.ai.agent`.
+- `tools.*` — third-party integrations: `tools.slack.post_message`, `tools.jira.create_issue`,
+  etc. Add a `tools.*` action only when the user named that integration.
+
+For an alert-triage or any investigation/enrichment workflow, the severity/judgment step is an
+**`ai.agent`** action — do not replace it with an HTTP or Python placeholder.
+
+## Connecting actions and error branches
+
+Actions are wired together with each action's **`depends_on`** list — a list of source refs. The
+graph edges (and the trigger entrypoint) come entirely from `depends_on`; there is no separate
+edges section.
+
+Each dependency is a string `"<source_ref>"` or `"<source_ref>.<edge>"`, where `<edge>` is:
+
+- **`success`** (the default) — run after the source action **succeeds**. `"a"` and `"a.success"`
+  are equivalent.
+- **`error`** — run after the source action **fails**. This is the on-failure / error-handler
+  branch.
+
+So "add a step that runs **on error of** `reshape_1`" means: add the new action with
+`depends_on: ["reshape_1.error"]`. There is **no `on_error` field** on an action (nor `on_success`,
+`catch`, `error_handler`, etc.) — putting one in `args` or on the action will be rejected. Express
+both the normal path and the error path purely through `depends_on`:
+
+```yaml
+- ref: reshape_1
+  action: core.transform.reshape
+  args:
+    value: ${{ TRIGGER.data }}
+- ref: handle_failure        # runs only if reshape_1 fails
+  action: core.transform.reshape
+  args:
+    value: "reshape_1 failed"
+  depends_on:
+    - reshape_1.error
+```
+
+(Per-action **retries** are a different concept — that's the `retry_policy` field, not an edge.
+The workflow-wide failure handler is `/metadata/error_handler`, which names another workflow.)
+
+## When the registry rejects an action name
+
+A "does not exist" / unknown-action error from `create_workflow` or `edit_workflow` means you got
+the **name** wrong — almost always a wrong namespace prefix (e.g. `core.ai.agent` instead of
+`ai.agent`). It does **not** mean the feature is missing, disabled, gated, or needs workspace setup,
+and it is **not** a reason to ask the user to check their sidebar.
+
+1. Re-read the namespace list above and pick the correct prefix. The fix is usually that the action
+   is not a `core.` action — don't force a `core.` prefix onto an `ai.*` or `tools.*` action.
+2. If you are unsure of the exact name, call `core.workflow.get_authoring_context` with a `query`
+   (e.g. `"send slack message"`) to look up the real action name and schema before retrying.
+3. Correct the `action:` name and retry the same `create_workflow` / `edit_workflow` call. The error
+   names the offending action — fix exactly that and resubmit.
+
+Never drop a capability, downgrade to an HTTP/Python placeholder, or ask the user to debug their
+workspace because of a name error. Correct the name and keep the intended action.
+
+## Getting action arguments right
+
+Workflow actions (e.g. `core.http_request`, `core.transform.reshape`, `ai.agent`, `tools.*`
+integrations) each have a specific `args` schema. **Do not invent argument names.** When you are
+unsure of an action's exact arguments, call `core.workflow.get_authoring_context` first:
+
+- Pass `action_names` (e.g. `["core.http_request", "ai.agent"]`) for actions you already know, or a
+  `query` (e.g. `"slack post message"`) to find the right action when you don't know its name.
+- It returns each action's `parameters_json_schema` (the real arg names/types), `required_secrets`
+  (and whether they are `configured`), an example `args` payload, plus the workspace's available
+  `variable_hints` and `secret_hints` — so you can reference real `${{ SECRETS.* }}` / `${{ VARS.* }}`.
+
+Build the `args` from that schema, not from memory. Name action `ref`s by their effect
+(`fetch_indicator`, `post_to_slack`), not by implementation detail. If an action's required secrets
+are not configured, add the action anyway and tell the user which credential to set up (and where —
+see the `tracecat-platform-guide` skill) rather than dropping the step.
+
+## Workflow, not chat
+
+`create_workflow` / `get_workflow` / `edit_workflow` are how YOU manage workflows from chat. Names
+like `core.http_request` or `core.transform.reshape` are **workflow action** names that go INSIDE a
+workflow definition's `actions:` — they are not tools you call directly here.

--- a/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-manage-workflows/references/editing.md
+++ b/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-manage-workflows/references/editing.md
@@ -55,7 +55,7 @@ A new action value looks like:
 {
   "ref": "post_to_slack",
   "action": "core.http_request",
-  "args": { "url": "https://hooks.slack.example/...", "method": "POST", "json": { "text": "done" } },
+  "args": { "url": "https://hooks.slack.example/...", "method": "POST", "payload": { "text": "done" } },
   "depends_on": ["fetch_indicator"]
 }
 ```

--- a/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-manage-workflows/references/editing.md
+++ b/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-manage-workflows/references/editing.md
@@ -1,0 +1,81 @@
+# Editing a workflow draft with JSON Patch
+
+`core.workflow.edit_workflow` applies RFC 6902 JSON Patch operations to the workflow draft document
+returned by `core.workflow.get_workflow`. Prefer targeted patches over replacing whole sections.
+
+## The read → patch → write loop
+
+1. Call `get_workflow(workflow_id)`. Keep its `draft_revision` and `draft_document`.
+2. Build `patch_ops` against that `draft_document`. Action indexes are positions in
+   `draft_document.definition.actions`, starting at 0.
+3. Call `edit_workflow(workflow_id, base_revision=<draft_revision>, patch_ops=[...])`.
+4. The response includes a NEW `draft_revision`. Use it for the next edit. For anything
+   non-trivial, call `get_workflow` again to confirm the result before continuing.
+
+Treat `draft_revision` as sequential state. After every successful write, use the returned
+revision. Never reuse a stale index list after another edit — re-read first.
+
+## Editable paths
+
+Top-level editable paths: `/metadata`, `/definition`, `/layout`, `/schedules`, `/case_trigger`.
+
+Common action paths (N is the 0-based index in `draft_document.definition.actions`):
+
+- `/definition/actions/-` — append a new action (RFC 6902 `-` means "end of array").
+- `/definition/actions/N` — replace an entire action.
+- `/definition/actions/N/ref` — rename an action.
+- `/definition/actions/N/args` — replace an action's args.
+- `/definition/actions/N/args/<field>` — change one argument.
+- `/definition/actions/N/depends_on` — change an action's dependency edges.
+- `/layout/actions/N/ref` — the matching layout entry's ref.
+
+Not editable: `/definition/config/scheduler` and an action's `/definition/actions/N/id`. Schedule
+`status` and `case_trigger.status` cannot be removed (set them instead of deleting).
+
+## Operation semantics
+
+- Supported ops: `add`, `remove`, `replace`, `move`, `copy`, `test`.
+- Operations apply in order. RFC 6902 array semantics: `/-` appends; indexes shift after `add`,
+  `remove`, and `move`. If you remove index 1, the old index 2 becomes index 1 for later ops in the
+  same patch — account for the shift, or order removals from highest index to lowest.
+- `add`/`replace`/`test` require a `value`. `move`/`copy` require a `from`.
+
+## Adding or renaming actions — keep edges and layout in sync
+
+When you add, remove, or rename an action, do it all in ONE patch:
+
+- Set the action `ref`.
+- Update every dependent action's `depends_on` edges that reference the old/new ref.
+- Add or update the matching `/layout/actions` entry so the node appears in the builder. New nodes
+  need a layout entry with `ref`, `x`, `y` (pick non-overlapping coordinates).
+
+A new action value looks like:
+
+```json
+{
+  "ref": "post_to_slack",
+  "action": "core.http_request",
+  "args": { "url": "https://hooks.slack.example/...", "method": "POST", "json": { "text": "done" } },
+  "depends_on": ["fetch_indicator"]
+}
+```
+
+## Validate before you commit
+
+For non-trivial edits, first call `edit_workflow(..., validate_only=true)` with your patch. If it
+reports valid, repeat the SAME patch against the SAME `base_revision` with `validate_only=false`.
+`validate_only` checks the patch (including DSL validation when the definition changed) without
+persisting.
+
+## Handling conflicts
+
+If `edit_workflow` returns a conflict (the draft changed since you read it — for example the user
+edited it in the builder), your `base_revision` is stale. Call `get_workflow` again, rebuild your
+patch against the fresh `draft_document`, and retry with the new `draft_revision`. Do not force the
+old revision.
+
+## Trigger inputs
+
+Declare `definition.entrypoint.expects` for every trigger input the workflow reads as
+`${{ TRIGGER.<name> }}`. A patch can pass validation even if a later run omits an undeclared trigger
+value, so keep `expects` complete.

--- a/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-platform-guide/SKILL.md
+++ b/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-platform-guide/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: tracecat-platform-guide
+description: REQUIRED whenever the user asks what Tracecat is, what it can do, how to do something in the product, or where to find a feature in the UI — e.g. "how do I add a secret", "where are my integrations", "what's the difference between a case and a workflow", "can Tracecat send Slack messages", "how do I schedule a workflow", "set up an OAuth integration". Read this SKILL.md FIRST when orienting a user, explaining a concept, or directing them to a page. It covers the platform mental model, what the product offers, where each feature lives in the UI, and the core concepts (secrets vs variables vs expressions). For building/editing workflows, use tracecat-manage-workflows instead.
+---
+
+# Tracecat platform guide
+
+Use this to orient users, explain what Tracecat does, and direct them to the right
+place in the UI. Stay accurate: when you don't know a detail, say so or point the user
+to the page rather than inventing steps.
+
+## What Tracecat is
+
+Tracecat is a security automation platform where AI agents and humans triage and
+investigate threats. The primitives:
+
+- **Workflows** — automations built as a graph of **actions**. Started by a **trigger**
+  (webhook, schedule, case event, manual run). Data flows through **expressions**
+  (`${{ ... }}`).
+- **Actions** — the building blocks inside a workflow: HTTP calls, transforms, Python
+  scripts, case operations, AI steps, and `tools.*` integrations (Slack, Jira, etc.).
+- **Cases** — persistent investigation records. Teams add comments, evidence/attachments,
+  tasks, and custom fields. Workflows create and enrich cases over time.
+- **Tables** — structured data rows (assets, allowlists, indicators) that workflows
+  insert into and look up across runs.
+- **Agents** — AI tool-callers. They run inside a workflow (`ai.agent`) or as saved
+  **presets** with their own instructions, tools, and MCP servers.
+- **Integrations / credentials** — how Tracecat talks to outside systems. Three models:
+  workspace **secrets**, **OAuth integrations**, and **MCP** servers.
+- **Secrets** — sensitive values (API keys, tokens), referenced as
+  `${{ SECRETS.<name>.<KEY> }}`, resolved at execution and never shown to an LLM.
+- **Variables** — non-secret config (base URLs, project IDs), referenced as
+  `${{ VARS.<name>.<key> }}`.
+
+A **case** is a record you investigate; a **workflow** is the automation that does the
+work. A **table** stores data; a **secret** stores a credential.
+
+## What we offer
+
+- Workflow automation with webhook/schedule/case triggers, branching, loops, retries.
+- Case management: cases, comments, attachments, tasks, custom fields, tags, SLAs.
+- Tables: on-demand structured storage with lookup, search, and upsert.
+- AI: single LLM calls (`ai.action`), tool-calling agents (`ai.agent`), and saved
+  preset agents (enterprise).
+- ~100+ prebuilt integrations, plus custom Python/YAML actions and MCP servers.
+- Expressions and 50+ built-in functions for data shaping.
+
+## Directing users in the UI
+
+Everything lives under a workspace at `/workspaces/<workspace_id>/...`. Direct users by
+**naming the sidebar item or page** — do not script click-by-click steps. Common pages:
+
+| Sidebar / page | Where | What's there |
+|---|---|---|
+| Chat | `/chat` | Talk to the workspace agent |
+| Workflows | `/workflows` | List, create, open the builder |
+| Cases | `/cases` | Case list and detail |
+| Tables | `/tables` | Create/browse tables and rows |
+| Variables | `/variables` | Non-secret config values |
+| Credentials | `/credentials` | API keys / secrets |
+| Integrations | `/integrations` | Connect OAuth providers |
+| MCP servers | `/mcp-servers` | Connect MCP servers |
+| Agents | `/agents` | Agent presets |
+| Runs | `/runs` | Execution history across workflows |
+| Inbox | `/inbox` | Approval queue for pending agent actions |
+| Members | `/members` | Invite users, roles |
+
+**Triggers are not separate pages.** Webhooks, schedules, and case triggers are
+configured **inside the workflow builder** (`/workflows/<id>`) in the trigger panel.
+
+## Correctness guardrails
+
+- **Secrets vs variables:** secrets are sensitive (`${{ SECRETS.<name>.<KEY> }}`);
+  variables are plain config (`${{ VARS.<name>.<key> }}`). Don't put secrets in variables.
+- **Secret safety in agents:** `ai.preset_agent` injects secrets **server-side** (the LLM
+  never sees them). `ai.action` and `ai.agent` evaluate expressions where the value **can**
+  reach the model — never tell users to put raw secrets in those prompts.
+- **Don't invent integration setup.** Per-integration setup steps (how to get a given
+  vendor's API key) are not documented here. Tell the user which credential/secret the
+  integration needs and where to add it (`/credentials` or `/integrations`), not invented
+  vendor instructions.
+- **Enterprise features** (preset agents, agent control plane, MCP access controls, skills)
+  may be gated by entitlement — if a user can't see a feature, that's likely why.
+
+## References (read on demand)
+
+- [concepts](references/concepts.md) — secrets, variables, expressions, environments.
+- [triggers-and-credentials](references/triggers-and-credentials.md) — picking a trigger;
+  the three credential models; custom actions.
+- [navigation](references/navigation.md) — full route map and sidebar.

--- a/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-platform-guide/references/concepts.md
+++ b/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-platform-guide/references/concepts.md
@@ -1,0 +1,45 @@
+# Core concepts
+
+Product-level meaning of the building blocks. (Workflow DSL syntax lives in
+`tracecat-manage-workflows`; this is about what each thing *is*.)
+
+## Secrets
+
+- Sensitive values: API keys, bot tokens, SSH keys, certs.
+- Stored under **Credentials** (`/credentials`), scoped to an **environment**
+  (`default`, `staging`, etc.).
+- Referenced as `${{ SECRETS.<name>.<KEY> }}` in action args and preset instructions.
+- Resolved at execution time. Never exposed to an LLM by the secure injection path.
+
+## Variables
+
+- Non-secret config: base URLs, project IDs, queue names, routing rules.
+- Stored under **Variables** (`/variables`), also scoped per environment.
+- Referenced as `${{ VARS.<name>.<key> }}`.
+- Use for tenant-specific defaults and shared config — anything you'd otherwise hardcode.
+
+## Environments
+
+- Both secrets and variables are scoped to a named environment, with `default` as the
+  fallback.
+- An action can override its environment to use a different set of credentials for the
+  same integration (e.g. prod vs staging API keys).
+
+## Expressions
+
+- Wrapped in `${{ ... }}`. Resolve against:
+  - `TRIGGER.<field>` — the data that started the workflow.
+  - `ACTIONS.<ref>.result` — output of an upstream action.
+  - `SECRETS.<name>.<KEY>` / `VARS.<name>.<key>` — credentials / config.
+  - `FN.<func>(...)` — built-in functions.
+- Used in action args, `run_if` conditions, and `for_each` loops.
+- Missing fields resolve to `None` rather than erroring — guard with `run_if` or ternary
+  fallbacks when a value may be absent.
+
+## Cases vs tables (don't confuse them)
+
+- A **case** is an investigation record a human works: status, severity, owner, comments,
+  attachments, tasks, custom fields.
+- A **table** is structured data storage: rows and columns, queried by lookup/search,
+  with optional unique indexes for upsert. Use tables for assets, allowlists, indicators —
+  not for investigation state.

--- a/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-platform-guide/references/navigation.md
+++ b/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-platform-guide/references/navigation.md
@@ -1,0 +1,62 @@
+# Navigation map
+
+All paths are workspace-scoped: `/workspaces/<workspace_id>/<path>`. When directing a
+user, name the **sidebar item** (and optionally the path). Don't dictate clicks.
+
+## Sidebar
+
+**Workspace:** Chat · Workflows · Cases · Agents · Tables · Variables · Credentials ·
+Integrations · MCP servers · Skills · Actions
+**Monitor:** Runs · Inbox
+**Manage:** Members · Service accounts · MCP access
+
+## Core setup
+
+| Path | What's there |
+|---|---|
+| `/credentials` | Workspace secrets / API keys |
+| `/integrations` | OAuth provider integrations |
+| `/variables` | Non-secret config variables |
+| `/tables` | Tables list |
+| `/tables/<table_id>` | Browse rows, configure columns |
+| `/cases/custom-fields`, `/cases/dropdowns`, `/cases/durations`, `/cases/tags` | Case field/tag configuration |
+| `/cases/closure-requirements` | Case closure policies |
+
+## Workflows & runs
+
+| Path | What's there |
+|---|---|
+| `/workflows` | Workflow list; create |
+| `/workflows/<id>` | Workflow builder — design actions and configure triggers (webhooks, schedules, case triggers) |
+| `/workflows/<id>/executions` | Execution history for one workflow |
+| `/workflows/<id>/executions/<exec_id>` | One run's step-by-step log |
+| `/runs` | Runs across all workflows |
+| `/workflows/tags` | Workflow tags |
+
+## Agents & MCP
+
+| Path | What's there |
+|---|---|
+| `/agents` | Agent presets list |
+| `/agents/<preset_id>` | Preset builder: instructions, tools, model, MCP |
+| `/skills` | Reusable agent skills (entitlement-gated) |
+| `/mcp-servers` | Connect/manage MCP servers |
+| `/mcp` | MCP access controls |
+
+## Cases & navigation
+
+| Path | What's there |
+|---|---|
+| `/cases` | Case list, filtering, bulk actions |
+| `/cases/<case_id>` | Case detail: timeline, comments, tasks, fields |
+| `/chat` | Workspace agent chat (entitlement-gated) |
+| `/inbox` | Approval queue for pending agent actions |
+
+## Manage
+
+| Path | What's there |
+|---|---|
+| `/members`, `/members/groups`, `/members/roles` | Users, groups, roles |
+| `/service-accounts` | Service account credentials |
+| `/actions` | Browse the org action registry (read-only) |
+| `/workspaces` | Switch workspace |

--- a/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-platform-guide/references/navigation.md
+++ b/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-platform-guide/references/navigation.md
@@ -40,6 +40,7 @@ Integrations · MCP servers · Skills · Actions
 | `/agents` | Agent presets list |
 | `/agents/<preset_id>` | Preset builder: instructions, tools, model, MCP |
 | `/skills` | Reusable agent skills (entitlement-gated) |
+| `/actions` | Browse the org action registry (read-only) |
 | `/mcp-servers` | Connect/manage MCP servers |
 | `/mcp` | MCP access controls |
 
@@ -58,5 +59,4 @@ Integrations · MCP servers · Skills · Actions
 |---|---|
 | `/members`, `/members/groups`, `/members/roles` | Users, groups, roles |
 | `/service-accounts` | Service account credentials |
-| `/actions` | Browse the org action registry (read-only) |
 | `/workspaces` | Switch workspace |

--- a/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-platform-guide/references/triggers-and-credentials.md
+++ b/packages/tracecat-ee/tracecat_ee/workspace_chat/skills/tracecat-platform-guide/references/triggers-and-credentials.md
@@ -1,0 +1,52 @@
+# Triggers, credentials, and custom actions
+
+## Picking a trigger
+
+All trigger types except where noted are configured **inside the workflow builder**
+(`/workflows/<id>`), not on a separate page.
+
+| Trigger | Fires when | Use for |
+|---|---|---|
+| **Schedule** | A cron/interval cadence | Polling, syncs, cleanup, recurring jobs |
+| **Webhook** | An external system POSTs/GETs to the workflow URL | Ingesting alerts/events; body becomes `${{ TRIGGER }}` |
+| **Case trigger** | A case event (create, update, close, comment, tag, task) | Reacting to case activity; supports a tag allowlist |
+| **Comment trigger** | A case comment/reply is posted (configured in the comment UI) | Bridging analyst chat into automation |
+| **Task trigger** | A case task is launched (configured on the task) | Running a workflow from a case task |
+| **Error workflow** | Another (published) workflow fails | Centralized failure handling; set in workflow settings |
+
+Webhooks can be secured with API keys, an IP allowlist, and allowed methods.
+
+## The three credential models
+
+Pick based on how the target system authenticates.
+
+**Prebuilt credentials (workspace secrets)** — static API keys, bot tokens, SSH keys,
+mTLS certs. Define them under **Credentials** (`/credentials`) per environment. Reference
+as `${{ SECRETS.<name>.<KEY> }}`. This is the default for most integrations.
+
+**OAuth integrations** — managed OAuth tokens, auto-refreshed. Two grant types:
+`authorization_code` (a user logs in / delegated access) and `client_credentials`
+(service-to-service). Configure under **Integrations** (`/integrations`), then complete
+the OAuth connect flow. Reference as
+`${{ SECRETS.<provider_id>_oauth.<...TOKEN> }}`. Built-in providers have stable IDs;
+custom ones use a `custom_` prefix.
+
+**MCP integrations** — Model Context Protocol servers, remote (HTTP/SSE) or stdio.
+Configure remote servers under **MCP servers** (`/mcp-servers`); agents attach them from
+the preset builder. Remote supports no-auth, custom headers, or OAuth. Stdio env vars can
+resolve `${{ SECRETS.* }}` and `${{ VARS.* }}`.
+
+## Custom extensibility
+
+- **Python UDFs** — register async functions in a custom registry package to add new
+  `tools.*` actions.
+- **YAML templates** — compose existing actions into a reusable action (small, no control
+  flow).
+- **Custom registry** — a git-backed repo of custom Python/YAML actions, synced org-wide;
+  configured in organization settings.
+
+## Authentication options (product-level)
+
+- **Basic** — email + password (dev/simple setups).
+- **OIDC** — OpenID Connect SSO.
+- **SAML 2.0** — enterprise SSO (Okta, Entra ID, Authentik, Keycloak).

--- a/packages/tracecat-registry/tracecat_registry/core/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/core/cases.py
@@ -324,7 +324,7 @@ async def get_linked_case_rows(
         Doc("The ID of the case to retrieve."),
     ],
 ) -> list[types.CaseTableRowRead]:
-    case = await get_context().cases.get_case(case_id, include_rows=True)
+    case = await ctx.cases.aio.get_case(case_id, include_rows=True)
     return case["rows"]
 
 

--- a/packages/tracecat-registry/tracecat_registry/core/workflow.py
+++ b/packages/tracecat-registry/tracecat_registry/core/workflow.py
@@ -133,10 +133,8 @@ async def execute(
 @registry.register(
     namespace="core.workflow",
     description=(
-        "Create a new empty workflow in the current workspace and return its id "
-        "and title. Use this when the user asks to create, scaffold, or start a new "
-        "workflow. The workflow starts empty (only a trigger) and can be edited in "
-        "the workflow builder afterwards."
+        "Create a new workflow, optionally pre-filled from `definition_yaml`. "
+        "Read the `tracecat-manage-workflows` skill first."
     ),
     default_title="Create workflow",
     display_group="Workflows",
@@ -146,17 +144,129 @@ async def create_workflow(
     title: Annotated[
         str | None,
         Doc(
-            "Title for the new workflow (3-100 characters). If omitted, a "
-            "timestamped title is used."
+            "Title for the new workflow (3-100 characters). For an empty create "
+            "a timestamped title is used when omitted; with `definition_yaml` "
+            "the title must come from here or a `title:` in the YAML."
         ),
     ] = None,
     description: Annotated[
         str | None,
         Doc("Optional description for the new workflow (up to 1000 characters)."),
     ] = None,
+    definition_yaml: Annotated[
+        str | None,
+        Doc(
+            "Optional full workflow definition as YAML (actions, layout, case "
+            "trigger). When provided, the workflow is created with these actions "
+            "instead of being empty. The complete workflow belongs under a "
+            "top-level `definition:` key. Schedules are not created here — add "
+            "them afterwards with `edit_workflow`."
+        ),
+    ] = None,
 ) -> dict[str, Any]:
-    """Create a new empty workflow and return ``{"id", "title"}``."""
-    return await ctx.workflows.aio.create_workflow(title=title, description=description)
+    """Create a workflow and return ``{"id", "title"}``."""
+    return await ctx.workflows.aio.create_workflow(
+        title=title, description=description, definition_yaml=definition_yaml
+    )
+
+
+@registry.register(
+    namespace="core.workflow",
+    description=(
+        "Read a workflow's editable draft (`draft_revision` + `draft_document`). "
+        "Call before `edit_workflow`. See the `tracecat-manage-workflows` skill."
+    ),
+    default_title="Get workflow",
+    display_group="Workflows",
+)
+async def get_workflow(
+    *,
+    workflow_id: Annotated[
+        str,
+        Doc("The workflow ID to read (short `wf_...` or full format)."),
+    ],
+) -> dict[str, Any]:
+    """Read a workflow's editable draft document and revision."""
+    return await ctx.workflows.aio.get_workflow(workflow_id=workflow_id)
+
+
+@registry.register(
+    namespace="core.workflow",
+    description=(
+        "Edit a workflow's draft with RFC 6902 JSON Patch ops (get_workflow → "
+        "patch → edit_workflow). Read the `tracecat-manage-workflows` skill first."
+    ),
+    default_title="Edit workflow",
+    display_group="Workflows",
+)
+async def edit_workflow(
+    *,
+    workflow_id: Annotated[
+        str,
+        Doc("The workflow ID to edit (short `wf_...` or full format)."),
+    ],
+    base_revision: Annotated[
+        str,
+        Doc(
+            "The `draft_revision` returned by `get_workflow`. The edit is "
+            "rejected with a conflict if the draft changed since then."
+        ),
+    ],
+    patch_ops: Annotated[
+        list[dict[str, Any]],
+        Doc(
+            "RFC 6902 JSON Patch operations to apply to the draft document. Each "
+            'op is an object like {"op": "add", "path": "/definition/actions/-", '
+            '"value": {...}}. Supported ops: add, remove, replace, move, copy, '
+            "test."
+        ),
+    ],
+    validate_only: Annotated[
+        bool,
+        Doc("When true, validate the patch without persisting changes."),
+    ] = False,
+) -> dict[str, Any]:
+    """Apply JSON Patch edits to a workflow draft and return the new revision."""
+    return await ctx.workflows.aio.edit_workflow(
+        workflow_id=workflow_id,
+        base_revision=base_revision,
+        patch_ops=patch_ops,
+        validate_only=validate_only,
+    )
+
+
+@registry.register(
+    namespace="core.workflow",
+    description=(
+        "Get action schemas, required secrets, and example args before writing "
+        "an action's `args:`. Resolve by `action_names` or `query`. See the "
+        "`tracecat-manage-workflows` skill."
+    ),
+    default_title="Get workflow authoring context",
+    display_group="Workflows",
+)
+async def get_authoring_context(
+    *,
+    action_names: Annotated[
+        list[str] | None,
+        Doc(
+            "Fully qualified action names to fetch context for (e.g. "
+            "`['core.http_request', 'ai.agent']`). Takes precedence over `query`."
+        ),
+    ] = None,
+    query: Annotated[
+        str | None,
+        Doc(
+            "Search string to resolve actions by name/description when "
+            "`action_names` is not provided."
+        ),
+    ] = None,
+) -> dict[str, Any]:
+    """Return action schemas, secret/variable hints, and example args."""
+    return await ctx.workflows.aio.get_authoring_context(
+        action_names=action_names,
+        query=query,
+    )
 
 
 @registry.register(

--- a/packages/tracecat-registry/tracecat_registry/ctx.pyi
+++ b/packages/tracecat-registry/tracecat_registry/ctx.pyi
@@ -1233,6 +1233,26 @@ class _WorkflowsAsync:
         *,
         title: str | None = ...,
         description: str | None = ...,
+        definition_yaml: str | None = ...,
+    ) -> dict[str, Any]: ...
+    async def get_workflow(
+        self,
+        *,
+        workflow_id: str,
+    ) -> dict[str, Any]: ...
+    async def edit_workflow(
+        self,
+        *,
+        workflow_id: str,
+        base_revision: str,
+        patch_ops: list[dict[str, Any]],
+        validate_only: bool = ...,
+    ) -> dict[str, Any]: ...
+    async def get_authoring_context(
+        self,
+        *,
+        action_names: list[str] | None = ...,
+        query: str | None = ...,
     ) -> dict[str, Any]: ...
 
 class _Workflows:
@@ -1259,6 +1279,26 @@ class _Workflows:
         *,
         title: str | None = ...,
         description: str | None = ...,
+        definition_yaml: str | None = ...,
+    ) -> dict[str, Any]: ...
+    def get_workflow(
+        self,
+        *,
+        workflow_id: str,
+    ) -> dict[str, Any]: ...
+    def edit_workflow(
+        self,
+        *,
+        workflow_id: str,
+        base_revision: str,
+        patch_ops: list[dict[str, Any]],
+        validate_only: bool = ...,
+    ) -> dict[str, Any]: ...
+    def get_authoring_context(
+        self,
+        *,
+        action_names: list[str] | None = ...,
+        query: str | None = ...,
     ) -> dict[str, Any]: ...
 
 agents: _Agents

--- a/packages/tracecat-registry/tracecat_registry/sdk/workflows.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/workflows.py
@@ -56,13 +56,21 @@ class WorkflowsClient:
         *,
         title: str | None = None,
         description: str | None = None,
+        definition_yaml: str | None = None,
     ) -> dict[str, Any]:
-        """Create a new empty workflow in the current workspace.
+        """Create a new workflow in the current workspace.
 
         Args:
-            title: Workflow title (3-100 characters). If omitted, the API assigns
-                a timestamped title.
+            title: Workflow title (3-100 characters). For an empty create
+                (no ``definition_yaml``), the API assigns a timestamped title
+                when omitted. With ``definition_yaml``, the title must come from
+                this arg or a ``title:`` in the YAML, else the create is rejected.
             description: Optional workflow description.
+            definition_yaml: Optional full workflow definition as YAML. When
+                provided, the workflow is created with these actions (and any
+                layout/case trigger) instead of being empty. Schedules are not
+                created from this YAML; add them afterwards via
+                :meth:`edit_workflow`.
 
         Returns:
             dict containing:
@@ -70,7 +78,7 @@ class WorkflowsClient:
                 - title: The workflow title.
 
         Raises:
-            TracecatValidationError: If the title is invalid.
+            TracecatValidationError: If the title or definition is invalid.
             TracecatAPIError: For other API errors.
         """
         data: dict[str, Any] = {}
@@ -78,7 +86,97 @@ class WorkflowsClient:
             data["title"] = title
         if description is not None:
             data["description"] = description
+        if definition_yaml is not None:
+            data["definition_yaml"] = definition_yaml
         return await self._client.post("/workflows", json=data)
+
+    async def get_workflow(self, *, workflow_id: str) -> dict[str, Any]:
+        """Read a workflow's editable draft document and revision.
+
+        Args:
+            workflow_id: Workflow UUID (short ``wf_...`` or full format).
+
+        Returns:
+            dict with ``workflow_id``, ``draft_revision``, and ``draft_document``
+            (the editable metadata/definition/layout/schedules/case_trigger).
+            Pass ``draft_revision`` as ``base_revision`` to :meth:`edit_workflow`.
+
+        Raises:
+            TracecatNotFoundError: If the workflow does not exist.
+            TracecatAPIError: For other API errors.
+        """
+        return await self._client.get(f"/workflows/{workflow_id}/edit-document")
+
+    async def edit_workflow(
+        self,
+        *,
+        workflow_id: str,
+        base_revision: str,
+        patch_ops: list[dict[str, Any]],
+        validate_only: bool = False,
+    ) -> dict[str, Any]:
+        """Edit a workflow draft using RFC 6902 JSON Patch operations.
+
+        Fetch the current document and revision with :meth:`get_workflow`,
+        compute the patch ops against ``draft_document``, then call this with the
+        returned ``draft_revision`` as ``base_revision``.
+
+        Args:
+            workflow_id: Workflow UUID (short ``wf_...`` or full format).
+            base_revision: The ``draft_revision`` the patch is computed against.
+            patch_ops: RFC 6902 JSON Patch operations restricted to the editable
+                sections (metadata, definition, layout, schedules, case_trigger).
+            validate_only: When True, validate the patch without persisting.
+
+        Returns:
+            dict with ``message``, ``workflow_id``, and the new ``draft_revision``.
+
+        Raises:
+            TracecatConflictError: If ``base_revision`` no longer matches the
+                current draft (concurrent edit). Re-fetch and retry.
+            TracecatValidationError: If the patch is invalid.
+            TracecatAPIError: For other API errors.
+        """
+        return await self._client.patch(
+            f"/workflows/{workflow_id}/edit-document",
+            json={
+                "base_revision": base_revision,
+                "patch_ops": patch_ops,
+                "validate_only": validate_only,
+            },
+        )
+
+    async def get_authoring_context(
+        self,
+        *,
+        action_names: list[str] | None = None,
+        query: str | None = None,
+    ) -> dict[str, Any]:
+        """Fetch authoring context (schemas, secrets, examples) for actions.
+
+        Resolve actions either by explicit ``action_names`` or, when none are
+        given, by ``query`` search. With neither, only the workspace
+        variable/secret hints are returned.
+
+        Args:
+            action_names: Fully qualified action names (e.g.
+                ``["core.http_request"]``) to fetch context for.
+            query: Search string to resolve actions by name/description when
+                ``action_names`` is omitted.
+
+        Returns:
+            dict with ``actions`` (each a schema/secrets/examples context),
+            ``variable_hints``, and ``secret_hints``.
+
+        Raises:
+            TracecatAPIError: For API errors.
+        """
+        data: dict[str, Any] = {}
+        if action_names is not None:
+            data["action_names"] = action_names
+        if query is not None:
+            data["query"] = query
+        return await self._client.post("/workflows/authoring-context", json=data)
 
     async def execute(
         self,

--- a/tests/registry/test_internal_workflow_router.py
+++ b/tests/registry/test_internal_workflow_router.py
@@ -6,15 +6,24 @@ These tests verify the request/response schemas for the internal workflow API.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any, cast
 
 import pytest
+from fastapi import HTTPException
+from starlette.status import HTTP_400_BAD_REQUEST, HTTP_409_CONFLICT
 
 from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.mcp.schemas import JsonPatchOperation
 from tracecat.workflow.executions.internal_router import (
+    InternalWorkflowCreateRequest,
+    InternalWorkflowEditRequest,
     InternalWorkflowExecuteRequest,
     InternalWorkflowExecuteResponse,
     InternalWorkflowStatusResponse,
+    _build_import_data_from_definition_yaml,
+    _raise_workflow_edit_http_error,
 )
+from tracecat.workflow.management.draft import WorkflowEditError
 
 # Mark all tests to use the db fixture (required by conftest autouse)
 pytestmark = pytest.mark.usefixtures("db")
@@ -177,3 +186,212 @@ class TestInternalWorkflowStatusResponse:
         )
         assert data["status"] == "COMPLETED"
         assert data["result"] == {"output": "success"}
+
+
+class TestInternalWorkflowCreateRequest:
+    """Tests for the create request, including the optional definition_yaml."""
+
+    def test_create_defaults(self):
+        req = InternalWorkflowCreateRequest()
+        assert req.title is None
+        assert req.description is None
+        assert req.definition_yaml is None
+
+    def test_create_with_definition_yaml(self):
+        req = InternalWorkflowCreateRequest(definition_yaml="definition:\n  title: T\n")
+        assert req.definition_yaml == "definition:\n  title: T\n"
+
+    def test_invalid_dsl_raises_raw_tracecat_error_not_pydantic(self):
+        """DSLInput validators raise raw TracecatDSLError, not ValidationError.
+
+        Why the create handler must catch TracecatValidationError (else 500).
+        """
+        from pydantic import ValidationError as PydanticValidationError
+
+        from tracecat.exceptions import TracecatDSLError
+        from tracecat.workflow.management.schemas import ExternalWorkflowDefinition
+
+        import_data = {
+            "definition": {
+                "title": "T",
+                "description": "D",
+                "entrypoint": {"ref": None},
+                "actions": [
+                    {"ref": "dup", "action": "core.transform.reshape", "args": {}},
+                    {"ref": "dup", "action": "core.transform.reshape", "args": {}},
+                ],
+            }
+        }
+        with pytest.raises(TracecatDSLError) as exc:
+            ExternalWorkflowDefinition.model_validate(import_data)
+        assert not isinstance(exc.value, PydanticValidationError)
+
+
+class TestInternalWorkflowEditRequest:
+    """Tests for the edit-document request schema."""
+
+    def test_edit_request_defaults_validate_only_false(self):
+        req = InternalWorkflowEditRequest(
+            base_revision="rev1",
+            patch_ops=[JsonPatchOperation(op="add", path="/metadata/title", value="X")],
+        )
+        assert req.base_revision == "rev1"
+        assert req.validate_only is False
+        assert req.patch_ops[0].op == "add"
+
+
+class TestBuildImportDataFromDefinitionYaml:
+    """Tests for the copilot YAML -> import-data normalization."""
+
+    def test_wraps_bare_definition(self):
+        # A bare workflow (no top-level `definition:` key) is enveloped.
+        data = _build_import_data_from_definition_yaml(
+            definition_yaml=(
+                "title: T\n"
+                "entrypoint:\n"
+                "  ref: start\n"
+                "actions:\n"
+                "  - ref: start\n"
+                "    action: core.transform.reshape\n"
+                "    args:\n"
+                "      value: hi\n"
+            ),
+            title=None,
+            description=None,
+        )
+        assert "definition" in data
+        assert data["definition"]["title"] == "T"
+
+    def test_injects_missing_entrypoint(self):
+        # Missing entrypoint is defaulted so DSLInput validation passes.
+        data = _build_import_data_from_definition_yaml(
+            definition_yaml=(
+                "definition:\n"
+                "  title: T\n"
+                "  actions:\n"
+                "    - ref: start\n"
+                "      action: core.transform.reshape\n"
+                "      args:\n"
+                "        value: hi\n"
+            ),
+            title=None,
+            description=None,
+        )
+        assert data["definition"]["entrypoint"] == {"ref": None}
+
+    def test_rejects_invalid_yaml(self):
+        with pytest.raises(HTTPException) as exc:
+            _build_import_data_from_definition_yaml(
+                definition_yaml="::: not yaml :::\n: x",
+                title=None,
+                description=None,
+            )
+        assert exc.value.status_code == HTTP_400_BAD_REQUEST
+
+    def test_defaults_title_and_autogenerates_layout(self):
+        yaml_text = (
+            "definition:\n"
+            "  entrypoint:\n"
+            "    ref: start\n"
+            "  actions:\n"
+            "    - ref: start\n"
+            "      action: core.transform.reshape\n"
+            "      args:\n"
+            "        value: hello\n"
+        )
+        data = _build_import_data_from_definition_yaml(
+            definition_yaml=yaml_text,
+            title="My Workflow",
+            description="desc",
+        )
+        assert data["definition"]["title"] == "My Workflow"
+        assert data["definition"]["description"] == "desc"
+        # Layout was auto-generated because none was supplied.
+        assert "layout" in data
+
+
+class TestRaiseWorkflowEditHttpError:
+    """Tests mapping the engine error onto HTTP responses."""
+
+    def test_conflict_maps_to_409(self):
+        err = WorkflowEditError(
+            "Draft revision mismatch", conflict=True, current_revision="rev9"
+        )
+        with pytest.raises(HTTPException) as exc:
+            _raise_workflow_edit_http_error(err)
+        assert exc.value.status_code == HTTP_409_CONFLICT
+        detail = cast(dict[str, Any], exc.value.detail)
+        assert detail["current_revision"] == "rev9"
+
+    def test_validation_error_maps_to_400_with_details(self):
+        err = WorkflowEditError(
+            "1 validation error(s)",
+            code="validation_error",
+            details={"type": "validation_error", "errors": []},
+        )
+        with pytest.raises(HTTPException) as exc:
+            _raise_workflow_edit_http_error(err)
+        assert exc.value.status_code == HTTP_400_BAD_REQUEST
+        assert exc.value.detail == {"type": "validation_error", "errors": []}
+
+    def test_plain_error_maps_to_400_message(self):
+        err = WorkflowEditError("Patch path '/x' is not editable via edit_workflow")
+        with pytest.raises(HTTPException) as exc:
+            _raise_workflow_edit_http_error(err)
+        assert exc.value.status_code == HTTP_400_BAD_REQUEST
+        assert "not editable" in exc.value.detail
+
+
+class TestInvalidPatchApplicationRaisesToolError:
+    """Bad patch application raises ToolError, not WorkflowEditError.
+
+    Why the route needs a dedicated ``except ToolError`` (else these 500).
+    """
+
+    def test_replace_missing_path_raises_tool_error(self):
+        from fastmcp.exceptions import ToolError
+
+        from tracecat.mcp.json_patch import apply_json_patch_operations
+        from tracecat.mcp.schemas import JsonPatchOperation
+
+        with pytest.raises(ToolError) as exc:
+            apply_json_patch_operations(
+                document={"metadata": {"title": "T"}},
+                patch_ops=[
+                    JsonPatchOperation(op="replace", path="/metadata/nope", value=1)
+                ],
+            )
+        assert not isinstance(exc.value, WorkflowEditError)
+
+    def test_array_index_out_of_range_raises_tool_error(self):
+        from fastmcp.exceptions import ToolError
+
+        from tracecat.mcp.json_patch import apply_json_patch_operations
+        from tracecat.mcp.schemas import JsonPatchOperation
+
+        with pytest.raises(ToolError):
+            apply_json_patch_operations(
+                document={"items": []},
+                patch_ops=[JsonPatchOperation(op="replace", path="/items/5", value=1)],
+            )
+
+
+class TestWorkflowAuthoringContextRequest:
+    """Tests for the authoring-context request schema."""
+
+    def test_defaults_to_none(self):
+        from tracecat.mcp.schemas import WorkflowAuthoringContextRequest
+
+        req = WorkflowAuthoringContextRequest()
+        assert req.action_names is None
+        assert req.query is None
+
+    def test_accepts_action_names_and_query(self):
+        from tracecat.mcp.schemas import WorkflowAuthoringContextRequest
+
+        req = WorkflowAuthoringContextRequest(
+            action_names=["core.http_request", "ai.agent"],
+            query="reshape",
+        )
+        assert req.action_names == ["core.http_request", "ai.agent"]
+        assert req.query == "reshape"

--- a/tests/registry/test_internal_workflow_router.py
+++ b/tests/registry/test_internal_workflow_router.py
@@ -247,7 +247,7 @@ class TestBuildImportDataFromDefinitionYaml:
         # A bare workflow (no top-level `definition:` key) is enveloped.
         data = _build_import_data_from_definition_yaml(
             definition_yaml=(
-                "title: T\n"
+                "title: Bare WF\n"
                 "entrypoint:\n"
                 "  ref: start\n"
                 "actions:\n"
@@ -260,14 +260,14 @@ class TestBuildImportDataFromDefinitionYaml:
             description=None,
         )
         assert "definition" in data
-        assert data["definition"]["title"] == "T"
+        assert data["definition"]["title"] == "Bare WF"
 
     def test_injects_missing_entrypoint(self):
         # Missing entrypoint is defaulted so DSLInput validation passes.
         data = _build_import_data_from_definition_yaml(
             definition_yaml=(
                 "definition:\n"
-                "  title: T\n"
+                "  title: Inferred entrypoint\n"
                 "  actions:\n"
                 "    - ref: start\n"
                 "      action: core.transform.reshape\n"
@@ -315,7 +315,7 @@ class TestBuildImportDataFromDefinitionYaml:
         # the create call doesn't 400 on a missing field.
         yaml_text = (
             "definition:\n"
-            "  title: T\n"
+            "  title: No description\n"
             "  entrypoint:\n"
             "    ref: start\n"
             "  actions:\n"
@@ -333,13 +333,58 @@ class TestBuildImportDataFromDefinitionYaml:
 
     def test_does_not_override_existing_description(self):
         # A description already present in the YAML is preserved over the caller's.
-        yaml_text = "definition:\n  title: T\n  description: from_yaml\n"
+        yaml_text = "definition:\n  title: Keep description\n  description: from_yaml\n"
         data = _build_import_data_from_definition_yaml(
             definition_yaml=yaml_text,
             title=None,
             description="from_caller",
         )
         assert data["definition"]["description"] == "from_yaml"
+
+    @pytest.mark.parametrize("depends_on", ["1", "[1]", "[true]"])
+    def test_rejects_non_string_depends_on(self, depends_on: str):
+        # A scalar or non-string-list depends_on would make auto_generate_layout
+        # raise a raw TypeError/AttributeError that escapes the 400-mapping in
+        # create_workflow (-> 500). Reject the correctable input here as a 400.
+        yaml_text = (
+            "definition:\n"
+            "  title: T\n"
+            "  entrypoint:\n"
+            "    ref: start\n"
+            "  actions:\n"
+            "    - ref: start\n"
+            "      action: core.transform.reshape\n"
+            f"      depends_on: {depends_on}\n"
+            "      args:\n"
+            "        value: hi\n"
+        )
+        with pytest.raises(HTTPException) as exc:
+            _build_import_data_from_definition_yaml(
+                definition_yaml=yaml_text, title=None, description=None
+            )
+        assert exc.value.status_code == HTTP_400_BAD_REQUEST
+
+    def test_rejects_too_short_title(self):
+        # A 1-2 char title imports via DSLInput but later breaks the edit
+        # endpoints (WorkflowEditMetadata requires min_length=3). Reject it now.
+        with pytest.raises(HTTPException) as exc:
+            _build_import_data_from_definition_yaml(
+                definition_yaml="definition:\n  title: T\n",
+                title=None,
+                description=None,
+            )
+        assert exc.value.status_code == HTTP_400_BAD_REQUEST
+
+    def test_rejects_oversized_description(self):
+        # A >1000 char description imports but breaks the edit endpoints
+        # (WorkflowEditMetadata requires max_length=1000). Reject it now.
+        with pytest.raises(HTTPException) as exc:
+            _build_import_data_from_definition_yaml(
+                definition_yaml="definition:\n  title: Valid Title\n",
+                title=None,
+                description="x" * 1001,
+            )
+        assert exc.value.status_code == HTTP_400_BAD_REQUEST
 
 
 class TestRaiseWorkflowEditHttpError:

--- a/tests/registry/test_internal_workflow_router.py
+++ b/tests/registry/test_internal_workflow_router.py
@@ -309,6 +309,38 @@ class TestBuildImportDataFromDefinitionYaml:
         # Layout was auto-generated because none was supplied.
         assert "layout" in data
 
+    def test_defaults_missing_description_to_empty_string(self):
+        # When neither the YAML nor the caller supplies a description, default
+        # it to "" so the required DSLInput.description field is satisfied and
+        # the create call doesn't 400 on a missing field.
+        yaml_text = (
+            "definition:\n"
+            "  title: T\n"
+            "  entrypoint:\n"
+            "    ref: start\n"
+            "  actions:\n"
+            "    - ref: start\n"
+            "      action: core.transform.reshape\n"
+            "      args:\n"
+            "        value: hello\n"
+        )
+        data = _build_import_data_from_definition_yaml(
+            definition_yaml=yaml_text,
+            title=None,
+            description=None,
+        )
+        assert data["definition"]["description"] == ""
+
+    def test_does_not_override_existing_description(self):
+        # A description already present in the YAML is preserved over the caller's.
+        yaml_text = "definition:\n  title: T\n  description: from_yaml\n"
+        data = _build_import_data_from_definition_yaml(
+            definition_yaml=yaml_text,
+            title=None,
+            description="from_caller",
+        )
+        assert data["definition"]["description"] == "from_yaml"
+
 
 class TestRaiseWorkflowEditHttpError:
     """Tests mapping the engine error onto HTTP responses."""

--- a/tests/registry/test_workflow_sdk.py
+++ b/tests/registry/test_workflow_sdk.py
@@ -23,6 +23,7 @@ def mock_tracecat_client() -> MagicMock:
     client = MagicMock()
     client.get = AsyncMock()
     client.post = AsyncMock()
+    client.patch = AsyncMock()
     return client
 
 
@@ -171,6 +172,138 @@ class TestWorkflowsClientGetStatus:
         assert result["status"] == "RUNNING"
         mock_tracecat_client.get.assert_called_once_with(
             "/workflows/executions/wf-00000000000000000000000000000123/exec-456"
+        )
+
+
+class TestWorkflowsClientCreate:
+    """Tests for WorkflowsClient.create_workflow()."""
+
+    @pytest.mark.anyio
+    async def test_create_empty_omits_definition(
+        self, workflows_client: WorkflowsClient, mock_tracecat_client: MagicMock
+    ):
+        """Create without definition_yaml posts only title/description."""
+        mock_tracecat_client.post.return_value = {"id": "wf_abc", "title": "T"}
+
+        await workflows_client.create_workflow(title="T", description="D")
+
+        mock_tracecat_client.post.assert_called_once_with(
+            "/workflows",
+            json={"title": "T", "description": "D"},
+        )
+
+    @pytest.mark.anyio
+    async def test_create_with_definition_yaml(
+        self, workflows_client: WorkflowsClient, mock_tracecat_client: MagicMock
+    ):
+        """Create with definition_yaml forwards it in the body."""
+        mock_tracecat_client.post.return_value = {"id": "wf_abc", "title": "T"}
+
+        await workflows_client.create_workflow(
+            title="T", definition_yaml="definition:\n  title: T\n"
+        )
+
+        mock_tracecat_client.post.assert_called_once_with(
+            "/workflows",
+            json={"title": "T", "definition_yaml": "definition:\n  title: T\n"},
+        )
+
+
+class TestWorkflowsClientGetWorkflow:
+    """Tests for WorkflowsClient.get_workflow()."""
+
+    @pytest.mark.anyio
+    async def test_get_workflow_hits_edit_document(
+        self, workflows_client: WorkflowsClient, mock_tracecat_client: MagicMock
+    ):
+        """get_workflow reads the draft edit-document endpoint."""
+        mock_tracecat_client.get.return_value = {
+            "workflow_id": "wf_abc",
+            "draft_revision": "rev1",
+            "draft_document": {},
+        }
+
+        result = await workflows_client.get_workflow(workflow_id="wf_abc")
+
+        assert result["draft_revision"] == "rev1"
+        mock_tracecat_client.get.assert_called_once_with(
+            "/workflows/wf_abc/edit-document"
+        )
+
+
+class TestWorkflowsClientEditWorkflow:
+    """Tests for WorkflowsClient.edit_workflow()."""
+
+    @pytest.mark.anyio
+    async def test_edit_workflow_patches_edit_document(
+        self, workflows_client: WorkflowsClient, mock_tracecat_client: MagicMock
+    ):
+        """edit_workflow PATCHes the edit-document endpoint with the patch body."""
+        mock_tracecat_client.patch.return_value = {
+            "message": "ok",
+            "workflow_id": "wf_abc",
+            "draft_revision": "rev2",
+        }
+        patch_ops = [{"op": "add", "path": "/definition/actions/-", "value": {}}]
+
+        result = await workflows_client.edit_workflow(
+            workflow_id="wf_abc",
+            base_revision="rev1",
+            patch_ops=patch_ops,
+            validate_only=True,
+        )
+
+        assert result["draft_revision"] == "rev2"
+        mock_tracecat_client.patch.assert_called_once_with(
+            "/workflows/wf_abc/edit-document",
+            json={
+                "base_revision": "rev1",
+                "patch_ops": patch_ops,
+                "validate_only": True,
+            },
+        )
+
+
+class TestWorkflowsClientGetAuthoringContext:
+    """Tests for WorkflowsClient.get_authoring_context()."""
+
+    @pytest.mark.anyio
+    async def test_get_authoring_context_by_names(
+        self, workflows_client: WorkflowsClient, mock_tracecat_client: MagicMock
+    ):
+        """By-name lookup POSTs only action_names to the authoring-context route."""
+        mock_tracecat_client.post.return_value = {
+            "actions": [],
+            "variable_hints": [],
+            "secret_hints": [],
+        }
+
+        result = await workflows_client.get_authoring_context(
+            action_names=["core.http_request", "ai.agent"]
+        )
+
+        assert result == {"actions": [], "variable_hints": [], "secret_hints": []}
+        mock_tracecat_client.post.assert_called_once_with(
+            "/workflows/authoring-context",
+            json={"action_names": ["core.http_request", "ai.agent"]},
+        )
+
+    @pytest.mark.anyio
+    async def test_get_authoring_context_by_query(
+        self, workflows_client: WorkflowsClient, mock_tracecat_client: MagicMock
+    ):
+        """By-query lookup POSTs only the query to the authoring-context route."""
+        mock_tracecat_client.post.return_value = {
+            "actions": [],
+            "variable_hints": [],
+            "secret_hints": [],
+        }
+
+        await workflows_client.get_authoring_context(query="reshape")
+
+        mock_tracecat_client.post.assert_called_once_with(
+            "/workflows/authoring-context",
+            json={"query": "reshape"},
         )
 
 

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -653,6 +653,67 @@ def test_agent_preset_list_tool_result_above_limit_emits_no_side_effects() -> No
     assert effects == []
 
 
+def test_create_workflow_tool_result_emits_upsert_side_effect() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.workflow.create_workflow",
+            tool_input={"title": "Triage workflow"},
+            tool_output={
+                "id": "wf-1234",
+                "title": "Triage workflow",
+            },
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert len(effects) == 1
+    assert effects[0].op == "upsert"
+    payload = artifact_data_payload(effects[0].op, effects[0].artifact)
+    assert payload["artifact"]["type"] == "workflow"
+    assert payload["artifact"]["id"] == "wf-1234"
+    assert payload["artifact"]["title"] == "Triage workflow"
+
+
+def test_get_workflow_tool_result_resolves_nested_draft_title() -> None:
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.workflow.get_workflow",
+            tool_input=None,
+            tool_output={
+                "id": "wf-1234",
+                "draft_document": {"metadata": {"title": "Triage workflow"}},
+            },
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert len(effects) == 1
+    payload = artifact_data_payload(effects[0].op, effects[0].artifact)
+    assert payload["artifact"]["title"] == "Triage workflow"
+
+
+def test_edit_workflow_titleless_result_emits_no_side_effect() -> None:
+    """edit_workflow returns no title, so it must not upsert and clobber the
+    workflow artifact title (set by create/get) with the workflow id."""
+    effects = list(
+        artifact_side_effects_for_tool_result(
+            tool_name="core.workflow.edit_workflow",
+            tool_input={"workflow_id": "wf-1234"},
+            tool_output={
+                "message": "Workflow wf-1234 updated successfully",
+                "workflow_id": "wf-1234",
+                "draft_revision": "rev-1",
+            },
+            is_error=False,
+            tool_call_id="toolu_123",
+        )
+    )
+
+    assert effects == []
+
+
 def test_table_tool_result_mapping_content_emits_upsert_side_effect() -> None:
     effects = list(
         artifact_side_effects_for_tool_result(

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -23,7 +23,6 @@ from tracecat.artifacts.schemas import (
     artifact_data_payload,
 )
 from tracecat.cases.enums import CaseSeverity, CaseStatus
-from tracecat.chat.tools import WORKSPACE_CHAT_DEFAULT_TOOLS
 
 
 def test_artifact_data_payload_serializes_camel_case_fields() -> None:
@@ -298,15 +297,9 @@ def test_artifact_bindings_list_canonical_tool_names() -> None:
         "core.workflow.execute": "upsert",
         "core.workflow.get_status": "upsert",
         "core.workflow.create_workflow": "upsert",
+        "core.workflow.get_workflow": "upsert",
+        "core.workflow.edit_workflow": "upsert",
     }
-
-
-def test_workspace_chat_domain_tools_have_artifact_bindings() -> None:
-    bound_tool_names = {
-        tool_name for binding in ARTIFACT_BINDINGS for tool_name in binding.tool_names
-    }
-
-    assert set(WORKSPACE_CHAT_DEFAULT_TOOLS).issubset(bound_tool_names)
 
 
 def test_case_delete_tool_result_emits_remove_side_effect() -> None:

--- a/tests/unit/test_authoring_context.py
+++ b/tests/unit/test_authoring_context.py
@@ -1,0 +1,148 @@
+"""Unit tests for the shared workflow authoring-context module.
+
+These cover the pure, infra-free pieces (schema/example/requirement shaping)
+used by the MCP ``get_workflow_authoring_context`` tool, the
+``/internal/workflows/authoring-context`` endpoint, and the
+``core.workflow.get_authoring_context`` registry action. The DB- and
+registry-backed builders (``build_action_contexts`` etc.) are exercised through
+the MCP integration path.
+"""
+
+from __future__ import annotations
+
+from tracecat.agent.authoring_context import (
+    ActionRequirementPayload,
+    _build_example_from_schema,
+    _evaluate_configuration,
+    _optional_secret_names,
+)
+
+
+class TestBuildExampleFromSchema:
+    """``_build_example_from_schema`` derives a payload from required props."""
+
+    def test_only_required_props_typed_by_json_type(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "url": {"type": "string"},
+                "count": {"type": "integer"},
+                "ratio": {"type": "number"},
+                "enabled": {"type": "boolean"},
+                "items": {"type": "array"},
+                "body": {"type": "object"},
+                "anything": {},
+                "optional": {"type": "string"},
+            },
+            "required": [
+                "url",
+                "count",
+                "ratio",
+                "enabled",
+                "items",
+                "body",
+                "anything",
+            ],
+        }
+
+        example = _build_example_from_schema(schema)
+
+        assert example == {
+            "url": "example",
+            "count": 1,
+            "ratio": 1.0,
+            "enabled": True,
+            "items": [],
+            "body": {},
+            "anything": "value",
+        }
+        # Non-required props are never included.
+        assert "optional" not in example
+
+    def test_no_required_yields_empty_example(self):
+        assert (
+            _build_example_from_schema({"properties": {"x": {"type": "string"}}}) == {}
+        )
+
+
+class TestOptionalSecretNames:
+    """``_optional_secret_names`` lists only optional *secret* requirements."""
+
+    def test_filters_to_optional_secrets(self):
+        requirements: list[ActionRequirementPayload] = [
+            {
+                "type": "secret",
+                "name": "required_api",
+                "required_keys": ["KEY"],
+                "optional_keys": [],
+                "optional": False,
+            },
+            {
+                "type": "secret",
+                "name": "ca_cert",
+                "required_keys": [],
+                "optional_keys": ["CERT"],
+                "optional": True,
+            },
+            {
+                "type": "oauth",
+                "name": "github_oauth",
+                "provider_id": "github",
+                "grant_type": "authorization_code",
+                "optional": True,
+            },
+        ]
+
+        assert _optional_secret_names(requirements) == ["ca_cert"]
+
+
+class TestEvaluateConfiguration:
+    """``_evaluate_configuration`` reports readiness against the inventories."""
+
+    def test_missing_secret_key_is_reported(self):
+        requirements: list[ActionRequirementPayload] = [
+            {
+                "type": "secret",
+                "name": "api",
+                "required_keys": ["TOKEN"],
+                "optional_keys": [],
+                "optional": False,
+            }
+        ]
+
+        configured, missing = _evaluate_configuration(requirements, {"api": set()})
+
+        assert configured is False
+        assert missing == ["missing key: api.TOKEN"]
+
+    def test_optional_secret_never_blocks(self):
+        requirements: list[ActionRequirementPayload] = [
+            {
+                "type": "secret",
+                "name": "ca_cert",
+                "required_keys": ["CERT"],
+                "optional_keys": [],
+                "optional": True,
+            }
+        ]
+
+        configured, missing = _evaluate_configuration(requirements, {})
+
+        assert configured is True
+        assert missing == []
+
+    def test_all_required_keys_present_is_configured(self):
+        requirements: list[ActionRequirementPayload] = [
+            {
+                "type": "secret",
+                "name": "api",
+                "required_keys": ["TOKEN"],
+                "optional_keys": [],
+                "optional": False,
+            }
+        ]
+
+        configured, missing = _evaluate_configuration(requirements, {"api": {"TOKEN"}})
+
+        assert configured is True
+        assert missing == []

--- a/tests/unit/test_authoring_context.py
+++ b/tests/unit/test_authoring_context.py
@@ -12,14 +12,14 @@ from __future__ import annotations
 
 from tracecat.agent.authoring_context import (
     ActionRequirementPayload,
-    _build_example_from_schema,
-    _evaluate_configuration,
-    _optional_secret_names,
+    build_example_from_schema,
+    evaluate_configuration,
+    optional_secret_names,
 )
 
 
 class TestBuildExampleFromSchema:
-    """``_build_example_from_schema`` derives a payload from required props."""
+    """``build_example_from_schema`` derives a payload from required props."""
 
     def test_only_required_props_typed_by_json_type(self):
         schema = {
@@ -45,7 +45,7 @@ class TestBuildExampleFromSchema:
             ],
         }
 
-        example = _build_example_from_schema(schema)
+        example = build_example_from_schema(schema)
 
         assert example == {
             "url": "example",
@@ -61,12 +61,12 @@ class TestBuildExampleFromSchema:
 
     def test_no_required_yields_empty_example(self):
         assert (
-            _build_example_from_schema({"properties": {"x": {"type": "string"}}}) == {}
+            build_example_from_schema({"properties": {"x": {"type": "string"}}}) == {}
         )
 
 
 class TestOptionalSecretNames:
-    """``_optional_secret_names`` lists only optional *secret* requirements."""
+    """``optional_secret_names`` lists only optional *secret* requirements."""
 
     def test_filters_to_optional_secrets(self):
         requirements: list[ActionRequirementPayload] = [
@@ -93,11 +93,11 @@ class TestOptionalSecretNames:
             },
         ]
 
-        assert _optional_secret_names(requirements) == ["ca_cert"]
+        assert optional_secret_names(requirements) == ["ca_cert"]
 
 
 class TestEvaluateConfiguration:
-    """``_evaluate_configuration`` reports readiness against the inventories."""
+    """``evaluate_configuration`` reports readiness against the inventories."""
 
     def test_missing_secret_key_is_reported(self):
         requirements: list[ActionRequirementPayload] = [
@@ -110,7 +110,7 @@ class TestEvaluateConfiguration:
             }
         ]
 
-        configured, missing = _evaluate_configuration(requirements, {"api": set()})
+        configured, missing = evaluate_configuration(requirements, {"api": set()})
 
         assert configured is False
         assert missing == ["missing key: api.TOKEN"]
@@ -126,7 +126,7 @@ class TestEvaluateConfiguration:
             }
         ]
 
-        configured, missing = _evaluate_configuration(requirements, {})
+        configured, missing = evaluate_configuration(requirements, {})
 
         assert configured is True
         assert missing == []
@@ -142,7 +142,7 @@ class TestEvaluateConfiguration:
             }
         ]
 
-        configured, missing = _evaluate_configuration(requirements, {"api": {"TOKEN"}})
+        configured, missing = evaluate_configuration(requirements, {"api": {"TOKEN"}})
 
         assert configured is True
         assert missing == []

--- a/tests/unit/test_builtin_skills.py
+++ b/tests/unit/test_builtin_skills.py
@@ -1,0 +1,173 @@
+"""Tests for always-on built-in (EE) workspace-chat skills.
+
+Covers the reserved skill-name namespace, the ``builtin_skills`` config field
+threading across the Temporal payload boundary, and the executor staging that
+copies packaged skill directories into the per-run skills directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tracecat.agent.executor.activity import SandboxedAgentExecutor
+from tracecat.agent.skill.schemas import (
+    RESERVED_SKILL_NAME_PREFIX,
+    SkillCreate,
+)
+
+
+class TestReservedSkillNamespace:
+    """User/preset skill names may not use the reserved platform prefix."""
+
+    def test_reserved_prefix_rejected(self):
+        with pytest.raises(ValueError, match="reserved prefix"):
+            SkillCreate(name=f"{RESERVED_SKILL_NAME_PREFIX}manage-workflows")
+
+    def test_non_reserved_name_allowed(self):
+        skill = SkillCreate(name="my-custom-skill")
+        assert skill.name == "my-custom-skill"
+
+    def test_reserved_prefix_matches_ee_constant(self):
+        # Keep the core validator prefix in sync with the EE package constant.
+        from tracecat_ee.workspace_chat.skills import BUILTIN_SKILL_NAME_PREFIX
+
+        assert RESERVED_SKILL_NAME_PREFIX == BUILTIN_SKILL_NAME_PREFIX
+
+
+class TestBuiltinSkillsConstant:
+    """The EE built-in skill catalog is well-formed and present on disk."""
+
+    def test_all_builtin_skills_use_reserved_prefix(self):
+        from tracecat_ee.workspace_chat.skills import (
+            BUILTIN_SKILL_NAME_PREFIX,
+            BUILTIN_WORKSPACE_CHAT_SKILLS,
+        )
+
+        assert BUILTIN_WORKSPACE_CHAT_SKILLS
+        for name in BUILTIN_WORKSPACE_CHAT_SKILLS:
+            assert name.startswith(BUILTIN_SKILL_NAME_PREFIX)
+
+    def test_each_builtin_skill_has_skill_md(self):
+        from importlib.resources import files
+
+        from tracecat_ee.workspace_chat.skills import BUILTIN_WORKSPACE_CHAT_SKILLS
+
+        root = files("tracecat_ee.workspace_chat.skills")
+        for name in BUILTIN_WORKSPACE_CHAT_SKILLS:
+            assert (root / name / "SKILL.md").is_file()
+
+
+class TestBuiltinSkillsPayloadThreading:
+    """``builtin_skills`` survives the AgentConfig <-> payload round-trip."""
+
+    def test_round_trip_preserves_builtin_skills(self):
+        from tracecat.agent.types import AgentConfig
+        from tracecat.agent.workflow_config import (
+            agent_config_from_payload,
+            agent_config_to_payload,
+        )
+
+        config = AgentConfig(
+            model_name="claude",
+            model_provider="anthropic",
+            builtin_skills=["tracecat-manage-workflows"],
+        )
+        restored = agent_config_from_payload(agent_config_to_payload(config))
+        assert restored.builtin_skills == ["tracecat-manage-workflows"]
+
+    def test_round_trip_defaults_to_none(self):
+        from tracecat.agent.types import AgentConfig
+        from tracecat.agent.workflow_config import (
+            agent_config_from_payload,
+            agent_config_to_payload,
+        )
+
+        config = AgentConfig(model_name="claude", model_provider="anthropic")
+        restored = agent_config_from_payload(agent_config_to_payload(config))
+        assert restored.builtin_skills is None
+
+
+def _executor_with_builtin_skills(names: list[str] | None) -> Any:
+    """Build a minimal stand-in exposing only what _stage_builtin_skills needs."""
+    fake = SimpleNamespace(
+        input=SimpleNamespace(config=SimpleNamespace(builtin_skills=names))
+    )
+    # Bind the unbound coroutine method to the fake instance.
+    fake.stage = SandboxedAgentExecutor._stage_builtin_skills.__get__(fake)
+    return fake
+
+
+class TestResolveBuiltinWorkspaceChatSkills:
+    """The config-build gate returns built-in skills only when entitled."""
+
+    @pytest.mark.anyio
+    async def test_returns_skills_when_entitled(self, monkeypatch):
+        from tracecat.agent.session import service as session_service
+        from tracecat.agent.session.service import AgentSessionService
+
+        async def _entitled(session, role):  # noqa: ANN001
+            return True
+
+        # Patch the name bound in `service` (imported by value), not in `policy`.
+        monkeypatch.setattr(session_service, "is_workspace_chat_entitled", _entitled)
+
+        from tracecat_ee.workspace_chat.skills import BUILTIN_WORKSPACE_CHAT_SKILLS
+
+        svc = SimpleNamespace(session=object(), role=object())
+        resolve = AgentSessionService._resolve_builtin_workspace_chat_skills.__get__(
+            svc
+        )
+        result = await resolve()
+        assert result == list(BUILTIN_WORKSPACE_CHAT_SKILLS)
+        assert "tracecat-manage-workflows" in result
+
+    @pytest.mark.anyio
+    async def test_returns_none_when_not_entitled(self, monkeypatch):
+        from tracecat.agent.session import service as session_service
+        from tracecat.agent.session.service import AgentSessionService
+
+        async def _not_entitled(session, role):  # noqa: ANN001
+            return False
+
+        monkeypatch.setattr(
+            session_service, "is_workspace_chat_entitled", _not_entitled
+        )
+
+        svc = SimpleNamespace(session=object(), role=object())
+        resolve = AgentSessionService._resolve_builtin_workspace_chat_skills.__get__(
+            svc
+        )
+        assert await resolve() is None
+
+
+class TestStageBuiltinSkills:
+    """The executor copies packaged built-in skills into the run skills dir."""
+
+    @pytest.mark.anyio
+    async def test_noop_when_no_builtin_skills(self, tmp_path: Path):
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        await _executor_with_builtin_skills(None).stage(skills_dir)
+        assert list(skills_dir.iterdir()) == []
+
+    @pytest.mark.anyio
+    async def test_stages_real_builtin_skill(self, tmp_path: Path):
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        await _executor_with_builtin_skills(["tracecat-manage-workflows"]).stage(
+            skills_dir
+        )
+        assert (skills_dir / "tracecat-manage-workflows" / "SKILL.md").is_file()
+
+    @pytest.mark.anyio
+    async def test_skips_unknown_or_unprefixed_names(self, tmp_path: Path):
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        await _executor_with_builtin_skills(
+            ["not-prefixed", "tracecat-does-not-exist"]
+        ).stage(skills_dir)
+        assert list(skills_dir.iterdir()) == []

--- a/tests/unit/test_chat_tools.py
+++ b/tests/unit/test_chat_tools.py
@@ -33,6 +33,9 @@ def test_workspace_chat_default_tools_include_authoring_actions() -> None:
         "core.cases.get_case",
         "core.cases.search_cases",
         "core.workflow.create_workflow",
+        "core.workflow.get_workflow",
+        "core.workflow.edit_workflow",
+        "core.workflow.get_authoring_context",
     ]
 
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -25,6 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat_registry import RegistryOAuthSecret, RegistrySecret
 
 import tracecat.mcp.auth as mcp_auth
+from tracecat.agent import authoring_context
 from tracecat.agent.common.stream_types import (
     StreamEventType,
     ToolCallContent,
@@ -2324,25 +2325,19 @@ async def test_replace_workflow_schedules_creates_schedules_with_payload_status(
     None
 ):
     workflow_id = uuid.uuid4()
-    existing_schedule_id = uuid.uuid4()
-    created_params: list[Any] = []
-    deleted_ids: list[uuid.UUID] = []
+    replace_calls: list[tuple[Any, list[Any], bool]] = []
 
     class _FakeWorkflowSchedulesService:
-        async def list_schedules(self, workflow_id: uuid.UUID) -> list[Any]:
-            _ = workflow_id
-            return [SimpleNamespace(id=existing_schedule_id)]
-
-        async def delete_schedule(
-            self, schedule_id: uuid.UUID, commit: bool = True
+        # The edit-document path delegates to the workflow:update-scoped
+        # replace_schedules surface (not the per-schedule create/delete scopes),
+        # so the fake mirrors that single entry point.
+        async def replace_schedules(
+            self,
+            workflow_id: uuid.UUID,
+            schedules: list[Any],
+            commit: bool = True,
         ) -> None:
-            _ = commit
-            deleted_ids.append(schedule_id)
-
-        async def create_schedule(self, params: Any, commit: bool = True) -> Any:
-            _ = commit
-            created_params.append(params)
-            return SimpleNamespace(id=uuid.uuid4())
+            replace_calls.append((workflow_id, list(schedules), commit))
 
     await draft.replace_workflow_schedules(
         service=cast(Any, _FakeWorkflowSchedulesService()),
@@ -2363,7 +2358,10 @@ async def test_replace_workflow_schedules_creates_schedules_with_payload_status(
         ],
     )
 
-    assert deleted_ids == [existing_schedule_id]
+    assert len(replace_calls) == 1
+    called_workflow_id, created_params, commit = replace_calls[0]
+    assert called_workflow_id == workflow_id
+    assert commit is False
     assert [params.status for params in created_params] == ["offline", "online"]
 
 
@@ -2881,7 +2879,7 @@ async def test_publish_workflow_builtin_registry_not_ready_returns_validation_fa
 
 
 def test_evaluate_configuration_reports_missing_workspace_secret_keys():
-    requirements: list[mcp_server.ActionRequirementPayload] = [
+    requirements: list[authoring_context.ActionRequirementPayload] = [
         {
             "type": "secret",
             "name": "slack",
@@ -2891,7 +2889,7 @@ def test_evaluate_configuration_reports_missing_workspace_secret_keys():
         }
     ]
     workspace_inventory = {"slack": set()}
-    configured, missing = mcp_server._evaluate_configuration(
+    configured, missing = authoring_context.evaluate_configuration(
         requirements,
         workspace_inventory,
     )
@@ -2901,7 +2899,7 @@ def test_evaluate_configuration_reports_missing_workspace_secret_keys():
 
 
 def test_secrets_to_requirements_represents_oauth_as_oauth():
-    requirements = mcp_server._secrets_to_requirements(
+    requirements = authoring_context.secrets_to_requirements(
         [RegistryOAuthSecret(provider_id="github", grant_type="authorization_code")]
     )
 
@@ -2917,14 +2915,14 @@ def test_secrets_to_requirements_represents_oauth_as_oauth():
 
 
 def test_evaluate_configuration_oauth_configured_when_integration_exists():
-    requirements = mcp_server._secrets_to_requirements(
+    requirements = authoring_context.secrets_to_requirements(
         [RegistryOAuthSecret(provider_id="github", grant_type="authorization_code")]
     )
     oauth_inventory = {
         ProviderKey(id="github", grant_type=OAuthGrantType.AUTHORIZATION_CODE)
     }
 
-    configured, missing = mcp_server._evaluate_configuration(
+    configured, missing = authoring_context.evaluate_configuration(
         requirements,
         {},
         oauth_inventory,
@@ -2935,11 +2933,11 @@ def test_evaluate_configuration_oauth_configured_when_integration_exists():
 
 
 def test_evaluate_configuration_reports_missing_oauth_integration():
-    requirements = mcp_server._secrets_to_requirements(
+    requirements = authoring_context.secrets_to_requirements(
         [RegistryOAuthSecret(provider_id="github", grant_type="authorization_code")]
     )
 
-    configured, missing = mcp_server._evaluate_configuration(
+    configured, missing = authoring_context.evaluate_configuration(
         requirements,
         {},
         set(),
@@ -2950,7 +2948,7 @@ def test_evaluate_configuration_reports_missing_oauth_integration():
 
 
 def test_evaluate_configuration_skips_optional_oauth_integration():
-    requirements = mcp_server._secrets_to_requirements(
+    requirements = authoring_context.secrets_to_requirements(
         [
             RegistryOAuthSecret(
                 provider_id="github",
@@ -2960,7 +2958,7 @@ def test_evaluate_configuration_skips_optional_oauth_integration():
         ]
     )
 
-    configured, missing = mcp_server._evaluate_configuration(
+    configured, missing = authoring_context.evaluate_configuration(
         requirements,
         {},
         set(),
@@ -2973,7 +2971,7 @@ def test_evaluate_configuration_skips_optional_oauth_integration():
 def test_evaluate_configuration_skips_optional_secret_with_keys():
     # Regression: a wholly-optional secret that declares keys (e.g. the mtls /
     # ca_cert secrets inherited from core.http_request) must not block readiness.
-    requirements: list[mcp_server.ActionRequirementPayload] = [
+    requirements: list[authoring_context.ActionRequirementPayload] = [
         {
             "type": "secret",
             "name": "mtls",
@@ -2983,7 +2981,7 @@ def test_evaluate_configuration_skips_optional_secret_with_keys():
         }
     ]
 
-    configured, missing = mcp_server._evaluate_configuration(requirements, {})
+    configured, missing = authoring_context.evaluate_configuration(requirements, {})
 
     assert configured is True
     assert missing == []
@@ -2992,7 +2990,7 @@ def test_evaluate_configuration_skips_optional_secret_with_keys():
 def test_evaluate_configuration_required_present_with_optional_absent():
     # An action that wraps core.http_request: required urlscan secret present,
     # optional mtls/ca_cert absent -> configured, nothing missing.
-    requirements: list[mcp_server.ActionRequirementPayload] = [
+    requirements: list[authoring_context.ActionRequirementPayload] = [
         {
             "type": "secret",
             "name": "urlscan",
@@ -3010,7 +3008,7 @@ def test_evaluate_configuration_required_present_with_optional_absent():
     ]
     workspace_inventory = {"urlscan": {"URLSCAN_API_KEY"}}
 
-    configured, missing = mcp_server._evaluate_configuration(
+    configured, missing = authoring_context.evaluate_configuration(
         requirements, workspace_inventory
     )
 
@@ -3021,7 +3019,7 @@ def test_evaluate_configuration_required_present_with_optional_absent():
 def test_evaluate_configuration_reports_required_but_not_optional():
     # Required secret absent, optional secret absent -> unconfigured, and only the
     # required secret is reported as missing.
-    requirements: list[mcp_server.ActionRequirementPayload] = [
+    requirements: list[authoring_context.ActionRequirementPayload] = [
         {
             "type": "secret",
             "name": "urlscan",
@@ -3038,7 +3036,7 @@ def test_evaluate_configuration_reports_required_but_not_optional():
         },
     ]
 
-    configured, missing = mcp_server._evaluate_configuration(requirements, {})
+    configured, missing = authoring_context.evaluate_configuration(requirements, {})
 
     assert configured is False
     assert missing == ["missing secret: urlscan"]
@@ -3074,7 +3072,9 @@ async def test_load_oauth_inventory_includes_only_connected(monkeypatch):
         lambda role: _AsyncContext(_IntegrationService()),
     )
 
-    inventory = await mcp_server._load_oauth_inventory(cast(Any, SimpleNamespace()))
+    inventory = await authoring_context.load_oauth_inventory(
+        cast(Any, SimpleNamespace())
+    )
 
     assert inventory == {
         ProviderKey(id="github", grant_type=OAuthGrantType.AUTHORIZATION_CODE)
@@ -3160,10 +3160,10 @@ async def test_get_action_context_includes_configuration(monkeypatch):
 
     monkeypatch.setattr(
         mcp_server,
-        "_load_secret_inventory",
+        "load_secret_inventory",
         _secret_inventory,
     )
-    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _oauth_inventory)
+    monkeypatch.setattr(mcp_server, "load_oauth_inventory", _oauth_inventory)
     monkeypatch.setattr(
         "tracecat.registry.actions.service.RegistryActionsService.with_session",
         lambda role: _AsyncContext(registry_service),
@@ -3224,8 +3224,8 @@ async def test_get_action_context_oauth_configured_when_integration_exists(monke
         return {ProviderKey(id="github", grant_type=OAuthGrantType.AUTHORIZATION_CODE)}
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
-    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _oauth_inventory)
+    monkeypatch.setattr(mcp_server, "load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "load_oauth_inventory", _oauth_inventory)
     monkeypatch.setattr(
         "tracecat.registry.actions.service.RegistryActionsService.with_session",
         lambda role: _AsyncContext(_github_oauth_registry_service()),
@@ -3265,8 +3265,8 @@ async def test_get_action_context_reports_missing_oauth_integration(monkeypatch)
         return set()
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
-    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _oauth_inventory)
+    monkeypatch.setattr(mcp_server, "load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "load_oauth_inventory", _oauth_inventory)
     monkeypatch.setattr(
         "tracecat.registry.actions.service.RegistryActionsService.with_session",
         lambda role: _AsyncContext(_github_oauth_registry_service()),
@@ -3289,7 +3289,7 @@ async def test_get_action_context_reports_missing_oauth_integration(monkeypatch)
 @pytest.mark.anyio
 async def test_list_secrets_metadata_returns_keys_not_values(monkeypatch):
     async def _resolve(_workspace_id):
-        return uuid.uuid4(), SimpleNamespace()
+        return uuid.uuid4(), SimpleNamespace(scopes=frozenset({"secret:read"}))
 
     workspace_secret = SimpleNamespace(
         id=uuid.uuid4(),
@@ -6399,8 +6399,8 @@ async def test_action_catalog_resource(monkeypatch):
             return []
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
-    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _empty_oauth_inventory)
+    monkeypatch.setattr(mcp_server, "load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "load_oauth_inventory", _empty_oauth_inventory)
     monkeypatch.setattr(
         "tracecat.registry.actions.service.RegistryActionsService.with_session",
         lambda role: _AsyncContext(_RegistryService()),
@@ -6463,8 +6463,8 @@ async def test_list_actions_browse_without_query(monkeypatch):
             return []
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
-    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _empty_oauth_inventory)
+    monkeypatch.setattr(mcp_server, "load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "load_oauth_inventory", _empty_oauth_inventory)
     monkeypatch.setattr(
         "tracecat.registry.actions.service.RegistryActionsService.with_session",
         lambda role: _AsyncContext(_RegistryService()),
@@ -6530,8 +6530,8 @@ async def test_list_actions_surfaces_optional_secrets(monkeypatch):
             ]
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
-    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _empty_oauth_inventory)
+    monkeypatch.setattr(mcp_server, "load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "load_oauth_inventory", _empty_oauth_inventory)
     monkeypatch.setattr(
         "tracecat.registry.actions.service.RegistryActionsService.with_session",
         lambda role: _AsyncContext(_RegistryService()),
@@ -6587,8 +6587,8 @@ async def test_list_actions_browse_with_namespace(monkeypatch):
             return []
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
-    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _empty_oauth_inventory)
+    monkeypatch.setattr(mcp_server, "load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "load_oauth_inventory", _empty_oauth_inventory)
     monkeypatch.setattr(
         "tracecat.registry.actions.service.RegistryActionsService.with_session",
         lambda role: _AsyncContext(_RegistryService()),
@@ -6642,8 +6642,8 @@ async def test_list_actions_paginates_and_rejects_mismatched_cursor(monkeypatch)
             return []
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
-    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _empty_oauth_inventory)
+    monkeypatch.setattr(mcp_server, "load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "load_oauth_inventory", _empty_oauth_inventory)
     monkeypatch.setattr(
         "tracecat.registry.actions.service.RegistryActionsService.with_session",
         lambda role: _AsyncContext(_RegistryService()),
@@ -8236,7 +8236,10 @@ async def test_get_workflow_authoring_context_truncates_embedded_collections(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workspace_id = uuid.uuid4()
-    role = SimpleNamespace(workspace_id=workspace_id)
+    role = SimpleNamespace(
+        workspace_id=workspace_id,
+        scopes=frozenset({"secret:read", "variable:read"}),
+    )
 
     async def _resolve(_workspace_id: str) -> tuple[uuid.UUID, SimpleNamespace]:
         return workspace_id, role
@@ -8289,8 +8292,8 @@ async def test_get_workflow_authoring_context_truncates_embedded_collections(
         return _Tool()
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
-    monkeypatch.setattr(mcp_server, "_load_oauth_inventory", _empty_oauth_inventory)
+    monkeypatch.setattr(mcp_server, "load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "load_oauth_inventory", _empty_oauth_inventory)
     monkeypatch.setattr(mcp_server, "_MCP_EMBEDDED_COLLECTION_LIMIT", 1)
     monkeypatch.setattr(mcp_server, "create_tool_from_registry", _create_tool)
     monkeypatch.setattr(
@@ -8298,9 +8301,12 @@ async def test_get_workflow_authoring_context_truncates_embedded_collections(
         lambda role: _AsyncContext(_RegistryService()),
     )
     monkeypatch.setattr(
-        mcp_server.VariablesService,
-        "with_session",
+        "tracecat.agent.authoring_context.VariablesService.with_session",
         lambda role: _AsyncContext(_VariablesService()),
+    )
+    monkeypatch.setattr(
+        "tracecat.agent.authoring_context.load_secret_inventory",
+        _secret_inventory,
     )
 
     payload = _payload(
@@ -8371,7 +8377,7 @@ async def test_get_agent_preset_authoring_context_includes_output_type_guidance(
             ]
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(mcp_server, "_load_secret_inventory", _secret_inventory)
+    monkeypatch.setattr(mcp_server, "load_secret_inventory", _secret_inventory)
     monkeypatch.setattr(
         mcp_server, "_build_integrations_inventory", _integrations_inventory
     )
@@ -10130,3 +10136,22 @@ def test_validate_patch_payload_rejects_invented_on_error_field() -> None:
     # The message steers the model to the real error-edge syntax.
     assert "depends_on" in error.message
     assert ".error" in error.message
+
+
+def test_validate_patch_payload_wraps_nested_tracecat_validation_error() -> None:
+    """A nested ActionStatement validator raising a raw TracecatValidationError
+    (e.g. interaction + for_each) must surface as a structured WorkflowEditError,
+    not escape as a raw exception that the edit endpoint reports as a 500.
+    """
+    payload = _minimal_edit_document_payload()
+    payload["definition"]["actions"][0]["for_each"] = "${{ for var.x in [1, 2] }}"
+    payload["definition"]["actions"][0]["interaction"] = {"type": "response"}
+
+    with pytest.raises(draft.WorkflowEditError) as exc_info:
+        draft.validate_workflow_patch_payload(payload)
+
+    error = exc_info.value
+    assert error.code == "validation_error"
+    assert error.details is not None
+    assert error.details["type"] == "validation_error"
+    assert "interaction" in error.message.lower()

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -70,6 +70,8 @@ try:
 finally:
     mcp_auth.create_mcp_auth = _original_create_mcp_auth
 
+from tracecat.workflow.management import draft  # noqa: E402
+
 
 def _tool(fn: Any) -> Callable[..., Coroutine[Any, Any, Any]]:
     """Cast a FastMCP-decorated tool back to a callable for test invocation.
@@ -515,14 +517,14 @@ def test_extract_layout_positions_full():
             {"ref": "step2", "x": 300, "y": 400},
         ],
     }
-    trigger, viewport, actions = mcp_server._extract_layout_positions(layout_data)
+    trigger, viewport, actions = draft.extract_layout_positions(layout_data)
     assert trigger == (10, 20)
     assert viewport == (30, 40, 1.5)
     assert actions == {"step1": (100, 200), "step2": (300, 400)}
 
 
 def test_extract_layout_positions_none():
-    trigger, viewport, actions = mcp_server._extract_layout_positions(None)
+    trigger, viewport, actions = draft.extract_layout_positions(None)
     assert trigger is None
     assert viewport is None
     assert actions is None
@@ -533,7 +535,7 @@ def test_extract_layout_positions_partial():
         "trigger": {"x": 5},
         "actions": [{"ref": "a", "y": 99}],
     }
-    trigger, viewport, actions = mcp_server._extract_layout_positions(layout_data)
+    trigger, viewport, actions = draft.extract_layout_positions(layout_data)
     assert trigger == (5, 0.0)
     assert viewport is None
     assert actions == {"a": (0.0, 99)}
@@ -544,7 +546,7 @@ def test_extract_layout_positions_nested_position_shape():
         "trigger": {"position": {"x": 10, "y": 20}},
         "actions": [{"ref": "a", "position": {"x": 30, "y": 40}}],
     }
-    trigger, viewport, actions = mcp_server._extract_layout_positions(layout_data)
+    trigger, viewport, actions = draft.extract_layout_positions(layout_data)
     assert trigger == (10, 20)
     assert viewport is None
     assert actions == {"a": (30, 40)}
@@ -557,9 +559,7 @@ def test_auto_generate_layout_round_trips_through_extract():
         {"ref": "step2", "depends_on": ["step1"]},
     ]
     layout_data = layout_module.auto_generate_layout(actions)
-    trigger, viewport, action_positions = mcp_server._extract_layout_positions(
-        layout_data
-    )
+    trigger, viewport, action_positions = draft.extract_layout_positions(layout_data)
     assert trigger == (0, 0)
     assert viewport is None
     assert action_positions is not None
@@ -731,7 +731,7 @@ async def test_apply_workflow_yaml_update_validates_definition(monkeypatch):
     monkeypatch.setattr(mcp_server, "validate_dsl", _validate_dsl)
     monkeypatch.setattr(
         mcp_server,
-        "_replace_workflow_definition_from_dsl",
+        "replace_workflow_definition_from_dsl",
         _replace_workflow_definition_from_dsl,
     )
 
@@ -810,8 +810,8 @@ async def test_get_workflow_returns_metadata_only(monkeypatch):
 def test_build_workflow_edit_document_normalizes_null_schedule_timeout() -> None:
     workflow = _workflow_stub(schedules=[_schedule_stub(timeout=None)])
 
-    document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
 
     assert document.schedules is not None
@@ -850,11 +850,11 @@ def test_build_workflow_edit_document_sorts_schedules_by_canonical_content() -> 
         ]
     )
 
-    document_one = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow_one)
+    document_one = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow_one)
     )
-    document_two = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow_two)
+    document_two = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow_two)
     )
 
     assert [schedule.cron for schedule in document_one.schedules] == [
@@ -877,8 +877,8 @@ def test_build_workflow_edit_document_omits_invalid_online_case_trigger() -> Non
         )
     )
 
-    document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
 
     assert document.case_trigger is None
@@ -890,11 +890,11 @@ def test_compute_workflow_edit_revision_normalizes_layout_position_aliases() -> 
         trigger_position_y=20.0,
         actions=[_action_stub(position_x=30.0, position_y=40.0)],
     )
-    document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
     alias_payload = json.loads(
-        json.dumps(mcp_server._workflow_edit_document_payload(document))
+        json.dumps(draft.workflow_edit_document_payload(document))
     )
     alias_payload["layout"]["trigger"] = {"position": {"x": 10.0, "y": 20.0}}
     alias_payload["layout"]["actions"][0] = {
@@ -908,16 +908,16 @@ def test_compute_workflow_edit_revision_normalizes_layout_position_aliases() -> 
     assert alias_document.layout.trigger.y == 20.0
     assert alias_document.layout.trigger.position is None
     assert alias_document.layout.actions[0].position is None
-    assert mcp_server._compute_workflow_edit_revision(
+    assert draft.compute_workflow_edit_revision(
         alias_document
-    ) == mcp_server._compute_workflow_edit_revision(document)
+    ) == draft.compute_workflow_edit_revision(document)
 
 
 def test_workflow_edit_document_rejects_null_layout_actions() -> None:
     workflow = _workflow_stub(actions=[_action_stub()])
-    payload = mcp_server._workflow_edit_document_payload(
-        mcp_server._build_workflow_edit_document(
-            cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    payload = draft.workflow_edit_document_payload(
+        draft.build_workflow_edit_document(
+            cast(draft._WorkflowEditDocumentSource, workflow)
         )
     )
     payload["layout"]["actions"] = None
@@ -939,9 +939,9 @@ async def test_replace_workflow_definition_from_dsl_uses_existing_workflow() -> 
         returns=None,
         actions=[],
     )
-    updated_payload = mcp_server._workflow_edit_document_payload(
-        mcp_server._build_workflow_edit_document(
-            cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    updated_payload = draft.workflow_edit_document_payload(
+        draft.build_workflow_edit_document(
+            cast(draft._WorkflowEditDocumentSource, workflow)
         )
     )
     updated_payload["metadata"]["title"] = "Updated workflow"
@@ -956,7 +956,7 @@ async def test_replace_workflow_definition_from_dsl_uses_existing_workflow() -> 
         }
     ]
     updated_document = mcp_server.WorkflowEditDocument.model_validate(updated_payload)
-    dsl = mcp_server._workflow_edit_document_to_dsl(updated_document)
+    dsl = draft.workflow_edit_document_to_dsl(updated_document)
 
     captured: dict[str, Any] = {}
 
@@ -987,7 +987,7 @@ async def test_replace_workflow_definition_from_dsl_uses_existing_workflow() -> 
         workspace_id=uuid.uuid4(),
         create_actions_from_dsl=_create_actions_from_dsl,
     )
-    await mcp_server._replace_workflow_definition_from_dsl(
+    await draft.replace_workflow_definition_from_dsl(
         service=cast(Any, service),
         workflow=cast(Any, workflow),
         dsl=dsl,
@@ -1056,9 +1056,9 @@ async def test_edit_workflow_updates_metadata(monkeypatch):
         lambda role: _AsyncContext(workflow_service),
     )
 
-    base_revision = mcp_server._compute_workflow_edit_revision(
-        mcp_server._build_workflow_edit_document(
-            cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    base_revision = draft.compute_workflow_edit_revision(
+        draft.build_workflow_edit_document(
+            cast(draft._WorkflowEditDocumentSource, workflow)
         )
     )
     payload = _payload(
@@ -1119,9 +1119,9 @@ async def test_edit_workflow_refreshes_related_state_before_response_revision(
         lambda role: _AsyncContext(workflow_service),
     )
 
-    base_revision = mcp_server._compute_workflow_edit_revision(
-        mcp_server._build_workflow_edit_document(
-            cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    base_revision = draft.compute_workflow_edit_revision(
+        draft.build_workflow_edit_document(
+            cast(draft._WorkflowEditDocumentSource, workflow)
         )
     )
     payload = _payload(
@@ -1190,9 +1190,9 @@ async def test_edit_workflow_validate_only_does_not_persist(monkeypatch):
         lambda role: _AsyncContext(_WorkflowService()),
     )
 
-    base_revision = mcp_server._compute_workflow_edit_revision(
-        mcp_server._build_workflow_edit_document(
-            cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    base_revision = draft.compute_workflow_edit_revision(
+        draft.build_workflow_edit_document(
+            cast(draft._WorkflowEditDocumentSource, workflow)
         )
     )
     payload = _payload(
@@ -1239,9 +1239,9 @@ async def test_edit_workflow_validate_only_rejects_invalid_schedule(monkeypatch)
         lambda role: _AsyncContext(_WorkflowService()),
     )
 
-    base_revision = mcp_server._compute_workflow_edit_revision(
-        mcp_server._build_workflow_edit_document(
-            cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    base_revision = draft.compute_workflow_edit_revision(
+        draft.build_workflow_edit_document(
+            cast(draft._WorkflowEditDocumentSource, workflow)
         )
     )
 
@@ -1296,17 +1296,17 @@ async def test_edit_workflow_validate_only_runs_full_definition_validation(monke
             return workflow
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(mcp_server, "validate_dsl", _validate_dsl)
+    monkeypatch.setattr(draft, "validate_dsl", _validate_dsl)
     monkeypatch.setattr(
         mcp_server.WorkflowsManagementService,
         "with_session",
         lambda role: _AsyncContext(_WorkflowService()),
     )
 
-    draft_document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    draft_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
-    base_revision = mcp_server._compute_workflow_edit_revision(draft_document)
+    base_revision = draft.compute_workflow_edit_revision(draft_document)
 
     with pytest.raises(ToolError) as exc_info:
         await _tool(mcp_server.edit_workflow)(
@@ -1386,9 +1386,9 @@ async def test_edit_workflow_updates_metadata_with_disconnected_layout_actions(
         lambda role: _AsyncContext(_WorkflowService()),
     )
 
-    base_revision = mcp_server._compute_workflow_edit_revision(
-        mcp_server._build_workflow_edit_document(
-            cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    base_revision = draft.compute_workflow_edit_revision(
+        draft.build_workflow_edit_document(
+            cast(draft._WorkflowEditDocumentSource, workflow)
         )
     )
     payload = _payload(
@@ -1433,10 +1433,10 @@ async def test_persist_workflow_edit_document_ignores_stale_layout_refs_after_de
         trigger_position_y=2.0,
         actions=[orphan_action, connected_action],
     )
-    original_document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    original_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
-    updated_payload = mcp_server._workflow_edit_document_payload(original_document)
+    updated_payload = draft.workflow_edit_document_payload(original_document)
     updated_payload["definition"]["returns"] = {"status": "ok"}
     updated_payload["layout"]["trigger"]["x"] = 99.0
     updated_document = mcp_server.WorkflowEditDocument.model_validate(updated_payload)
@@ -1455,13 +1455,13 @@ async def test_persist_workflow_edit_document_ignores_stale_layout_refs_after_de
         kwargs["workflow"].actions = [connected_action]
 
     monkeypatch.setattr(
-        mcp_server,
-        "_replace_workflow_definition_from_dsl",
+        draft,
+        "replace_workflow_definition_from_dsl",
         _replace_definition_from_dsl,
     )
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
-    await mcp_server._persist_workflow_edit_document(
+    await draft.persist_workflow_edit_document(
         role=SimpleNamespace(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
@@ -1505,10 +1505,10 @@ async def test_persist_workflow_edit_document_skips_reorder_only_changes(
             _schedule_stub(cron="0 * * * *", timeout=0.0),
         ],
     )
-    original_document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    original_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
-    updated_payload = mcp_server._workflow_edit_document_payload(original_document)
+    updated_payload = draft.workflow_edit_document_payload(original_document)
     updated_payload["definition"]["actions"] = list(
         reversed(updated_payload["definition"]["actions"])
     )
@@ -1535,13 +1535,13 @@ async def test_persist_workflow_edit_document_skips_reorder_only_changes(
         raise AssertionError(f"unexpected definition replacement: {kwargs!r}")
 
     monkeypatch.setattr(
-        mcp_server,
-        "_replace_workflow_definition_from_dsl",
+        draft,
+        "replace_workflow_definition_from_dsl",
         _replace_definition_from_dsl,
     )
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
-    await mcp_server._persist_workflow_edit_document(
+    await draft.persist_workflow_edit_document(
         role=SimpleNamespace(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
@@ -1599,10 +1599,10 @@ async def test_edit_workflow_validate_only_canonicalizes_draft_revision(monkeypa
         lambda role: _AsyncContext(_WorkflowService()),
     )
 
-    draft_document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    draft_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
-    base_revision = mcp_server._compute_workflow_edit_revision(draft_document)
+    base_revision = draft.compute_workflow_edit_revision(draft_document)
     reversed_definition_actions = list(
         reversed(draft_document.definition.model_dump(mode="json")["actions"])
     )
@@ -1687,18 +1687,18 @@ async def test_edit_workflow_validate_only_revision_drops_removed_action_layout(
             return workflow
 
     monkeypatch.setattr(mcp_server, "_resolve_workspace_role", _resolve)
-    monkeypatch.setattr(mcp_server, "validate_dsl", _validate_dsl)
+    monkeypatch.setattr(draft, "validate_dsl", _validate_dsl)
     monkeypatch.setattr(
         mcp_server.WorkflowsManagementService,
         "with_session",
         lambda role: _AsyncContext(_WorkflowService()),
     )
 
-    draft_document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    draft_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
-    base_revision = mcp_server._compute_workflow_edit_revision(draft_document)
-    updated_payload = mcp_server._workflow_edit_document_payload(draft_document)
+    base_revision = draft.compute_workflow_edit_revision(draft_document)
+    updated_payload = draft.workflow_edit_document_payload(draft_document)
     updated_payload["definition"]["actions"] = [
         action
         for action in updated_payload["definition"]["actions"]
@@ -1710,7 +1710,7 @@ async def test_edit_workflow_validate_only_revision_drops_removed_action_layout(
         for action_layout in expected_payload["layout"]["actions"]
         if action_layout["ref"] == "step_a"
     ]
-    expected_revision = mcp_server._compute_workflow_edit_revision(
+    expected_revision = draft.compute_workflow_edit_revision(
         mcp_server.WorkflowEditDocument.model_validate(expected_payload)
     )
 
@@ -1733,7 +1733,7 @@ async def test_edit_workflow_validate_only_revision_drops_removed_action_layout(
     assert payload["valid"] is True
     assert payload["validate_only"] is True
     assert payload["draft_revision"] == expected_revision
-    assert payload["draft_revision"] != mcp_server._compute_workflow_edit_revision(
+    assert payload["draft_revision"] != draft.compute_workflow_edit_revision(
         mcp_server.WorkflowEditDocument.model_validate(updated_payload)
     )
 
@@ -1763,10 +1763,10 @@ async def test_edit_workflow_validate_only_revision_drops_inert_case_trigger(
         lambda role: _AsyncContext(_WorkflowService()),
     )
 
-    draft_document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    draft_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
-    base_revision = mcp_server._compute_workflow_edit_revision(draft_document)
+    base_revision = draft.compute_workflow_edit_revision(draft_document)
 
     payload = _payload(
         await _tool(mcp_server.edit_workflow)(
@@ -1860,8 +1860,8 @@ async def test_edit_workflow_rejects_stale_revision(monkeypatch):
     ],
 )
 def test_parse_workflow_edit_request_rejects_forbidden_paths(path, value):
-    with pytest.raises(ToolError, match="not editable via edit_workflow"):
-        mcp_server._parse_workflow_edit_request(
+    with pytest.raises(draft.WorkflowEditError, match="not editable via edit_workflow"):
+        draft.parse_workflow_edit_request(
             base_revision="revision",
             patch_ops=[{"op": "add", "path": path, "value": value}],
             validate_only=False,
@@ -1892,10 +1892,10 @@ def test_parse_workflow_edit_request_rejects_removing_schedule_status(
     expected_path,
 ):
     with pytest.raises(
-        ToolError,
+        draft.WorkflowEditError,
         match=re.escape(f"Patch path '{expected_path}' cannot be removed"),
     ):
-        mcp_server._parse_workflow_edit_request(
+        draft.parse_workflow_edit_request(
             base_revision="revision",
             patch_ops=patch_ops,
             validate_only=False,
@@ -1926,10 +1926,10 @@ def test_parse_workflow_edit_request_rejects_removing_case_trigger_status(
     expected_path,
 ):
     with pytest.raises(
-        ToolError,
+        draft.WorkflowEditError,
         match=re.escape(f"Patch path '{expected_path}' cannot be removed"),
     ):
-        mcp_server._parse_workflow_edit_request(
+        draft.parse_workflow_edit_request(
             base_revision="revision",
             patch_ops=patch_ops,
             validate_only=False,
@@ -1966,11 +1966,11 @@ async def test_edit_workflow_rejects_schedule_parent_replace_that_omits_status(
         lambda role: _AsyncContext(_WorkflowService()),
     )
 
-    draft_document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    draft_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
-    base_revision = mcp_server._compute_workflow_edit_revision(draft_document)
-    schedule_payload = mcp_server._workflow_edit_document_payload(draft_document)[
+    base_revision = draft.compute_workflow_edit_revision(draft_document)
+    schedule_payload = draft.workflow_edit_document_payload(draft_document)[
         "schedules"
     ][0]
     del schedule_payload["status"]
@@ -2024,11 +2024,11 @@ async def test_edit_workflow_rejects_case_trigger_parent_replace_that_omits_stat
         lambda role: _AsyncContext(_WorkflowService()),
     )
 
-    draft_document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    draft_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
-    base_revision = mcp_server._compute_workflow_edit_revision(draft_document)
-    case_trigger_payload = mcp_server._workflow_edit_document_payload(draft_document)[
+    base_revision = draft.compute_workflow_edit_revision(draft_document)
+    case_trigger_payload = draft.workflow_edit_document_payload(draft_document)[
         "case_trigger"
     ]
     del case_trigger_payload["status"]
@@ -2095,9 +2095,9 @@ async def test_edit_workflow_rejects_unknown_nested_fields(monkeypatch):
         lambda role: _AsyncContext(_WorkflowService()),
     )
 
-    base_revision = mcp_server._compute_workflow_edit_revision(
-        mcp_server._build_workflow_edit_document(
-            cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    base_revision = draft.compute_workflow_edit_revision(
+        draft.build_workflow_edit_document(
+            cast(draft._WorkflowEditDocumentSource, workflow)
         )
     )
 
@@ -2171,9 +2171,9 @@ async def test_edit_workflow_rejects_excluded_nested_fields_in_parent_replace(
         lambda role: _AsyncContext(_WorkflowService()),
     )
 
-    base_revision = mcp_server._compute_workflow_edit_revision(
-        mcp_server._build_workflow_edit_document(
-            cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    base_revision = draft.compute_workflow_edit_revision(
+        draft.build_workflow_edit_document(
+            cast(draft._WorkflowEditDocumentSource, workflow)
         )
     )
 
@@ -2197,10 +2197,10 @@ async def test_persist_workflow_edit_document_applies_metadata_with_definition_c
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = _workflow_stub(status="offline", alias=None)
-    original_document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    original_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
-    updated_payload = mcp_server._workflow_edit_document_payload(original_document)
+    updated_payload = draft.workflow_edit_document_payload(original_document)
     updated_payload["metadata"]["status"] = "online"
     updated_payload["metadata"]["alias"] = "new-alias"
     updated_payload["definition"]["actions"] = [
@@ -2236,13 +2236,13 @@ async def test_persist_workflow_edit_document_applies_metadata_with_definition_c
         captured.update(kwargs)
 
     monkeypatch.setattr(
-        mcp_server,
-        "_replace_workflow_definition_from_dsl",
+        draft,
+        "replace_workflow_definition_from_dsl",
         _replace_definition_from_dsl,
     )
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
-    await mcp_server._persist_workflow_edit_document(
+    await draft.persist_workflow_edit_document(
         role=SimpleNamespace(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
@@ -2260,10 +2260,10 @@ async def test_persist_workflow_edit_document_preserves_offline_schedule_status_
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = _workflow_stub()
-    original_document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    original_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
-    updated_payload = mcp_server._workflow_edit_document_payload(original_document)
+    updated_payload = draft.workflow_edit_document_payload(original_document)
     updated_payload["schedules"] = [
         {
             "cron": "0 * * * *",
@@ -2299,15 +2299,15 @@ async def test_persist_workflow_edit_document_preserves_offline_schedule_status_
         async def update_schedule(self, schedule_id: uuid.UUID, params: Any) -> None:
             updated_schedules.append((schedule_id, params))
 
-    monkeypatch.setattr(mcp_server, "_replace_workflow_schedules", _replace_schedules)
+    monkeypatch.setattr(draft, "replace_workflow_schedules", _replace_schedules)
     monkeypatch.setattr(
-        mcp_server,
+        draft,
         "WorkflowSchedulesService",
         _FakeWorkflowSchedulesService,
     )
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
-    await mcp_server._persist_workflow_edit_document(
+    await draft.persist_workflow_edit_document(
         role=SimpleNamespace(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
@@ -2344,17 +2344,17 @@ async def test_replace_workflow_schedules_creates_schedules_with_payload_status(
             created_params.append(params)
             return SimpleNamespace(id=uuid.uuid4())
 
-    await mcp_server._replace_workflow_schedules(
+    await draft.replace_workflow_schedules(
         service=cast(Any, _FakeWorkflowSchedulesService()),
         workflow_id=cast(Any, workflow_id),
         schedules=[
-            mcp_server.WorkflowSchedule(
+            draft.WorkflowSchedule(
                 cron="0 * * * *",
                 status="offline",
                 inputs={},
                 timeout=0,
             ),
-            mcp_server.WorkflowSchedule(
+            draft.WorkflowSchedule(
                 cron="30 * * * *",
                 status="online",
                 inputs={},
@@ -2421,7 +2421,7 @@ async def test_apply_workflow_yaml_update_replaces_schedules_without_stale_state
         update_params=mcp_server.WorkflowUpdate(),
         yaml_payload=mcp_server.WorkflowYamlPayload(
             schedules=[
-                mcp_server.WorkflowSchedule(
+                draft.WorkflowSchedule(
                     every=timedelta(hours=2),
                     status="offline",
                     inputs={},
@@ -2466,10 +2466,10 @@ async def test_persist_workflow_edit_document_resets_removed_layout_fields() -> 
         viewport_zoom=1.5,
         actions=[action],
     )
-    original_document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    original_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
-    updated_payload = mcp_server._workflow_edit_document_payload(original_document)
+    updated_payload = draft.workflow_edit_document_payload(original_document)
     del updated_payload["layout"]["trigger"]["x"]
     del updated_payload["layout"]["viewport"]["x"]
     del updated_payload["layout"]["actions"][0]["x"]
@@ -2486,7 +2486,7 @@ async def test_persist_workflow_edit_document_resets_removed_layout_fields() -> 
             return None
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
-    await mcp_server._persist_workflow_edit_document(
+    await draft.persist_workflow_edit_document(
         role=SimpleNamespace(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
@@ -2536,10 +2536,10 @@ async def test_persist_workflow_edit_document_resets_removed_layout_actions() ->
         position_y=70.0,
     )
     workflow = _workflow_stub(actions=[action_a, action_b])
-    original_document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    original_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
-    updated_payload = mcp_server._workflow_edit_document_payload(original_document)
+    updated_payload = draft.workflow_edit_document_payload(original_document)
     updated_payload["layout"]["actions"] = [updated_payload["layout"]["actions"][1]]
     updated_document = mcp_server.WorkflowEditDocument.model_validate(updated_payload)
 
@@ -2554,7 +2554,7 @@ async def test_persist_workflow_edit_document_resets_removed_layout_actions() ->
             return None
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
-    await mcp_server._persist_workflow_edit_document(
+    await draft.persist_workflow_edit_document(
         role=SimpleNamespace(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
@@ -2593,10 +2593,10 @@ async def test_persist_workflow_edit_document_resets_removed_layout_object() -> 
         viewport_zoom=1.5,
         actions=[action],
     )
-    original_document = mcp_server._build_workflow_edit_document(
-        cast(mcp_server._WorkflowEditDocumentSource, workflow)
+    original_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, workflow)
     )
-    updated_payload = mcp_server._workflow_edit_document_payload(original_document)
+    updated_payload = draft.workflow_edit_document_payload(original_document)
     del updated_payload["layout"]
     updated_document = mcp_server.WorkflowEditDocument.model_validate(updated_payload)
 
@@ -2611,7 +2611,7 @@ async def test_persist_workflow_edit_document_resets_removed_layout_object() -> 
             return None
 
     service = SimpleNamespace(session=_FakeSession(), workspace_id=uuid.uuid4())
-    await mcp_server._persist_workflow_edit_document(
+    await draft.persist_workflow_edit_document(
         role=SimpleNamespace(),
         service=cast(Any, service),
         workflow=cast(Any, workflow),
@@ -10068,3 +10068,65 @@ async def test_collect_agent_response_surfaces_approval_requests(
             "args": {"url": "https://example.com"},
         }
     ]
+
+
+def _minimal_edit_document_payload() -> dict[str, Any]:
+    """A minimal valid WorkflowEditDocument payload: trigger -> a -> b."""
+    return {
+        "metadata": {"title": "Test workflow", "description": "", "status": "offline"},
+        "definition": {
+            "entrypoint": {"ref": "a", "expects": {}},
+            "actions": [
+                {"ref": "a", "action": "core.transform.reshape", "args": {"value": 1}},
+                {"ref": "b", "action": "core.transform.reshape", "args": {"value": 2}},
+            ],
+        },
+    }
+
+
+def test_validate_patch_payload_accepts_error_edge_dependency() -> None:
+    """`depends_on: ['<ref>.error']` is the supported on-failure branch syntax."""
+    payload = _minimal_edit_document_payload()
+    # Run a new action only when action `a` fails.
+    payload["definition"]["actions"].append(
+        {
+            "ref": "a_error_handler",
+            "action": "core.transform.reshape",
+            "args": {"value": "handled"},
+            "depends_on": ["a.error"],
+        }
+    )
+
+    document = draft.validate_workflow_patch_payload(payload)
+
+    handler = next(
+        action
+        for action in document.definition.actions
+        if action.ref == "a_error_handler"
+    )
+    assert handler.depends_on == ["a.error"]
+
+
+def test_validate_patch_payload_rejects_invented_on_error_field() -> None:
+    """An invented `on_error` action field yields a structured 400-able error.
+
+    Regression: this previously escaped as a raw pydantic ValidationError and
+    surfaced to the agent as an opaque 500. It must now be a WorkflowEditError
+    that names the offending field and points at the real error-edge syntax.
+    """
+    payload = _minimal_edit_document_payload()
+    payload["definition"]["actions"][0]["on_error"] = "a_error_handler"
+
+    with pytest.raises(draft.WorkflowEditError) as exc_info:
+        draft.validate_workflow_patch_payload(payload)
+
+    error = exc_info.value
+    assert error.code == "validation_error"
+    assert error.details is not None
+    assert error.details["type"] == "validation_error"
+    # The structured errors pinpoint the offending field.
+    locs = {tuple(item["loc"]) for item in error.details["errors"]}
+    assert ("definition", "actions", 0, "on_error") in locs
+    # The message steers the model to the real error-edge syntax.
+    assert "depends_on" in error.message
+    assert ".error" in error.message

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -159,6 +159,7 @@ def _workflow_stub(**overrides: Any) -> SimpleNamespace:
         "actions": [],
         "schedules": [],
         "case_trigger": None,
+        "graph_version": 1,
         "trigger_position_x": 0.0,
         "trigger_position_y": 0.0,
         "viewport_x": 0.0,
@@ -2279,6 +2280,9 @@ async def test_persist_workflow_edit_document_preserves_offline_schedule_status_
         def add(self, obj: Any) -> None:
             _ = obj
 
+        def expire(self, obj: Any, attrs: list[str] | None = None) -> None:
+            _ = obj, attrs
+
         async def refresh(self, obj: Any, attrs: list[str] | None = None) -> None:
             _ = obj, attrs
 
@@ -2437,6 +2441,122 @@ async def test_apply_workflow_yaml_update_replaces_schedules_without_stale_state
     persisted = result.scalars().all()
     assert [s.every for s in persisted] == [timedelta(hours=2)]
     assert old_schedule_id not in {s.id for s in persisted}
+
+
+@pytest.mark.anyio
+async def test_apply_workflow_yaml_update_bumps_graph_version_on_definition(
+    session: AsyncSession, svc_role: Role, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression test: rewriting the action graph via the YAML update path must
+    bump graph_version so a builder holding a stale base_version gets a 409 from
+    the graph API instead of silently applying ops against the old graph.
+    """
+
+    async def _validate_dsl(*_args: Any, **_kwargs: Any) -> set[Any]:
+        return set()
+
+    monkeypatch.setattr(mcp_server, "validate_dsl", _validate_dsl)
+
+    workflow = Workflow(
+        title="Graph version workflow",
+        description="Graph version regression test",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+    )
+    session.add(workflow)
+    await session.commit()
+    assert workflow.graph_version == 1
+
+    service = mcp_server.WorkflowsManagementService(session, role=svc_role)
+    workflow_id = mcp_server.WorkflowUUID.new(workflow.id)
+    loaded = await service.get_workflow(workflow_id, for_update=True)
+    assert loaded is not None
+
+    definition_yaml = (
+        "definition:\n"
+        "  title: Graph version workflow\n"
+        "  description: Graph version regression test\n"
+        "  entrypoint:\n"
+        "    ref: start\n"
+        "  actions:\n"
+        "    - ref: start\n"
+        "      action: core.transform.reshape\n"
+        "      args:\n"
+        "        value: hello\n"
+        "  config:\n"
+        "    scheduler: static\n"
+    )
+    yaml_payload = mcp_server._parse_workflow_yaml_payload(definition_yaml)
+
+    await mcp_server._apply_workflow_yaml_update(
+        role=svc_role,
+        service=service,
+        workflow=loaded,
+        workflow_id=workflow_id,
+        update_params=mcp_server.WorkflowUpdate(),
+        yaml_payload=yaml_payload,
+        definition_yaml=definition_yaml,
+        update_mode="replace",
+    )
+    await session.commit()
+
+    refreshed = (
+        await session.execute(select(Workflow).where(Workflow.id == workflow.id))
+    ).scalar_one()
+    assert refreshed.graph_version == 2
+
+
+@pytest.mark.anyio
+async def test_persist_workflow_edit_document_bumps_graph_version_on_definition(
+    session: AsyncSession, svc_role: Role
+) -> None:
+    """Regression test: rewriting the action graph through the edit-document path
+    must bump graph_version so concurrent builder graph ops with a stale
+    base_version are rejected with a 409 instead of applied against the old graph.
+    """
+    workflow = Workflow(
+        title="Edit doc workflow",
+        description="Edit-document graph version regression test",
+        status="offline",
+        workspace_id=svc_role.workspace_id,
+    )
+    session.add(workflow)
+    await session.commit()
+    assert workflow.graph_version == 1
+
+    service = mcp_server.WorkflowsManagementService(session, role=svc_role)
+    workflow_id = mcp_server.WorkflowUUID.new(workflow.id)
+    loaded = await service.get_workflow(workflow_id, for_update=True)
+    assert loaded is not None
+
+    original_document = draft.build_workflow_edit_document(
+        cast(draft._WorkflowEditDocumentSource, loaded)
+    )
+    updated_payload = draft.workflow_edit_document_payload(original_document)
+    updated_payload["definition"]["actions"] = [
+        {
+            "ref": "step_a",
+            "action": "core.transform.reshape",
+            "args": {"value": "hello"},
+            "depends_on": [],
+            "description": "",
+        }
+    ]
+    updated_payload["layout"]["actions"] = [{"ref": "step_a", "x": 0.0, "y": 0.0}]
+    updated_document = mcp_server.WorkflowEditDocument.model_validate(updated_payload)
+
+    await draft.persist_workflow_edit_document(
+        role=svc_role,
+        service=service,
+        workflow=loaded,
+        original_document=original_document,
+        updated_document=updated_document,
+    )
+
+    refreshed = (
+        await session.execute(select(Workflow).where(Workflow.id == workflow.id))
+    ).scalar_one()
+    assert refreshed.graph_version == 2
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_workflow_schedules_service.py
+++ b/tests/unit/test_workflow_schedules_service.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import EDITOR_SCOPES
 from tracecat.db.models import Schedule, Workflow
+from tracecat.exceptions import ScopeDeniedError
 from tracecat.identifiers import WorkspaceID
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.workflow.schedules import bridge
@@ -118,3 +122,65 @@ async def test_delete_schedule_deletes_existing_schedule(
     result = await session.execute(select(Schedule).where(Schedule.id == schedule.id))
     assert result.scalar_one_or_none() is None
     assert deleted_temporal_schedule_ids == [schedule.id]
+
+
+def _editor_role(svc_role) -> Role:
+    """A workspace-editor role: workflow:update + schedule:create, no schedule:delete."""
+    return svc_role.model_copy(update={"scopes": EDITOR_SCOPES})
+
+
+@pytest.mark.anyio
+async def test_replace_schedules_allowed_for_workflow_editor(
+    session: AsyncSession, svc_role, monkeypatch
+):
+    """Editing schedules through the workflow-edit surface is gated by
+    workflow:update, so an editor without the admin-only schedule:delete scope
+    can replace schedules (regression for the edit_workflow RBAC failure)."""
+    workflow, schedule = await _create_workflow_with_schedule(
+        session, svc_role.workspace_id
+    )
+
+    async def _delete_schedule(schedule_id):
+        return None
+
+    async def _create_schedule(*, schedule_id, **kwargs):
+        return SimpleNamespace(id=str(schedule_id))
+
+    monkeypatch.setattr(bridge, "delete_schedule", _delete_schedule)
+    monkeypatch.setattr(bridge, "create_schedule", _create_schedule)
+
+    editor_role = _editor_role(svc_role)
+    assert "schedule:delete" not in (editor_role.scopes or frozenset())
+    service = WorkflowSchedulesService(session, role=editor_role)
+
+    await service.replace_schedules(
+        WorkflowUUID.new(workflow.id),
+        [
+            ScheduleCreate(
+                workflow_id=WorkflowUUID.new(workflow.id),
+                every=timedelta(hours=2),
+                inputs={},
+                status="offline",
+                timeout=0,
+            )
+        ],
+    )
+
+    remaining = await service.list_schedules(workflow_id=WorkflowUUID.new(workflow.id))
+    assert len(remaining) == 1
+    # The pre-existing schedule was deleted and the new one created.
+    assert remaining[0].id != schedule.id
+    assert remaining[0].every == timedelta(hours=2)
+
+
+@pytest.mark.anyio
+async def test_delete_schedule_still_requires_admin_scope(
+    session: AsyncSession, svc_role
+):
+    """The standalone delete_schedule surface keeps its schedule:delete gate;
+    the workflow-edit replacement path must not have weakened it."""
+    _, schedule = await _create_workflow_with_schedule(session, svc_role.workspace_id)
+    service = WorkflowSchedulesService(session, role=_editor_role(svc_role))
+
+    with pytest.raises(ScopeDeniedError):
+        await service.delete_schedule(schedule.id)

--- a/tracecat/agent/authoring_context.py
+++ b/tracecat/agent/authoring_context.py
@@ -18,6 +18,7 @@ from tracecat_registry import RegistryOAuthSecret, RegistrySecret
 
 from tracecat.agent.tools import create_tool_from_registry
 from tracecat.auth.types import Role
+from tracecat.authz.controls import has_scope
 from tracecat.integrations.enums import IntegrationStatus, OAuthGrantType
 from tracecat.integrations.schemas import ProviderKey
 from tracecat.integrations.service import IntegrationService
@@ -86,7 +87,7 @@ class WorkflowAuthoringContextResponse(BaseModel):
     notes: list[str] = Field(default_factory=list)
 
 
-def _build_example_from_schema(schema: dict[str, Any]) -> dict[str, Any]:
+def build_example_from_schema(schema: dict[str, Any]) -> dict[str, Any]:
     """Build a compact example payload from JSON schema properties."""
     example: dict[str, Any] = {}
     properties = schema.get("properties", {})
@@ -111,7 +112,7 @@ def _build_example_from_schema(schema: dict[str, Any]) -> dict[str, Any]:
     return example
 
 
-def _secrets_to_requirements(
+def secrets_to_requirements(
     secrets: Sequence[RegistrySecret | RegistryOAuthSecret],
 ) -> list[ActionRequirementPayload]:
     """Convert registry secret objects to public requirement metadata.
@@ -145,7 +146,7 @@ def _secrets_to_requirements(
     return requirements
 
 
-def _optional_secret_names(
+def optional_secret_names(
     requirements: Sequence[ActionRequirementPayload],
 ) -> list[str]:
     """Names of optional secret requirements (e.g. mtls/ca_cert).
@@ -160,7 +161,7 @@ def _optional_secret_names(
     ]
 
 
-async def _load_secret_inventory(role: Role) -> dict[str, set[str]]:
+async def load_secret_inventory(role: Role) -> dict[str, set[str]]:
     """Load workspace secret key inventory for the default environment."""
     async with SecretsService.with_session(role=role) as svc:
         workspace_inventory: dict[str, set[str]] = {}
@@ -173,7 +174,7 @@ async def _load_secret_inventory(role: Role) -> dict[str, set[str]]:
         return workspace_inventory
 
 
-async def _load_oauth_inventory(role: Role) -> set[ProviderKey]:
+async def load_oauth_inventory(role: Role) -> set[ProviderKey]:
     """Load connected workspace OAuth integrations keyed by provider.
 
     Only integrations that have completed authentication (``CONNECTED`` status,
@@ -193,7 +194,7 @@ async def _load_oauth_inventory(role: Role) -> set[ProviderKey]:
     }
 
 
-def _evaluate_configuration(
+def evaluate_configuration(
     requirements: Sequence[ActionRequirementPayload],
     workspace_inventory: dict[str, set[str]],
     oauth_inventory: set[ProviderKey] | None = None,
@@ -249,8 +250,8 @@ async def build_action_contexts(
     """
     resolved_names = list(action_names) if action_names else []
 
-    workspace_inventory = await _load_secret_inventory(role)
-    oauth_inventory = await _load_oauth_inventory(role)
+    workspace_inventory = await load_secret_inventory(role)
+    oauth_inventory = await load_oauth_inventory(role)
     action_contexts: list[ActionContextResponse] = []
     async with RegistryActionsService.with_session(role=role) as registry_svc:
         if not resolved_names and query:
@@ -261,12 +262,12 @@ async def build_action_contexts(
             if indexed is None:
                 continue
             tool = await create_tool_from_registry(action_name, indexed)
-            requirements = _secrets_to_requirements(
+            requirements = secrets_to_requirements(
                 registry_svc.aggregate_secrets_from_manifest(
                     indexed.manifest, action_name
                 )
             )
-            configured, missing = _evaluate_configuration(
+            configured, missing = evaluate_configuration(
                 requirements, workspace_inventory, oauth_inventory
             )
             action_contexts.append(
@@ -277,15 +278,21 @@ async def build_action_contexts(
                     required_secrets=requirements,
                     configured=configured,
                     missing_requirements=missing,
-                    optional_secrets=_optional_secret_names(requirements),
-                    examples=[_build_example_from_schema(tool.parameters_json_schema)],
+                    optional_secrets=optional_secret_names(requirements),
+                    examples=[build_example_from_schema(tool.parameters_json_schema)],
                 )
             )
     return action_contexts
 
 
 async def build_variable_hints(*, role: Role) -> list[dict[str, Any]]:
-    """List workspace variables in the default environment as hints."""
+    """List workspace variables in the default environment as hints.
+
+    Returns ``[]`` when the caller lacks ``variable:read`` so the full set of
+    variable names+keys is not enumerated to an unauthorized author.
+    """
+    if not has_scope(role.scopes or frozenset(), "variable:read"):
+        return []
     async with VariablesService.with_session(role=role) as var_svc:
         variables = await var_svc.list_variables(
             environment=DEFAULT_SECRETS_ENVIRONMENT
@@ -301,8 +308,14 @@ async def build_variable_hints(*, role: Role) -> list[dict[str, Any]]:
 
 
 async def build_secret_hints(*, role: Role) -> list[dict[str, Any]]:
-    """List workspace secrets in the default environment as hints."""
-    workspace_inventory = await _load_secret_inventory(role)
+    """List workspace secrets in the default environment as hints.
+
+    Returns ``[]`` when the caller lacks ``secret:read`` so the full set of
+    secret names+keys is not enumerated to an unauthorized author.
+    """
+    if not has_scope(role.scopes or frozenset(), "secret:read"):
+        return []
+    workspace_inventory = await load_secret_inventory(role)
     return [
         {
             "name": secret_name,

--- a/tracecat/agent/authoring_context.py
+++ b/tracecat/agent/authoring_context.py
@@ -1,0 +1,313 @@
+"""Shared workflow authoring context logic.
+
+Holds the reusable action authoring-context builder, its helpers, and the
+Pydantic response schemas. Extracted from ``tracecat.mcp.server`` so non-MCP
+API endpoints (e.g. the internal workflows router that backs the
+``core.workflow.get_authoring_context`` registry action) can reuse the same
+logic without importing the FastMCP runtime. ``tracecat.mcp.server`` re-imports
+these symbols, so behavior stays identical across both surfaces.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Literal, TypedDict, cast
+
+from pydantic import BaseModel, Field
+from tracecat_registry import RegistryOAuthSecret, RegistrySecret
+
+from tracecat.agent.tools import create_tool_from_registry
+from tracecat.auth.types import Role
+from tracecat.integrations.enums import IntegrationStatus, OAuthGrantType
+from tracecat.integrations.schemas import ProviderKey
+from tracecat.integrations.service import IntegrationService
+from tracecat.registry.actions.service import RegistryActionsService
+from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
+from tracecat.secrets.service import SecretsService
+from tracecat.variables.service import VariablesService
+
+
+class ActionSecretRequirementPayload(TypedDict):
+    """Workspace secret requirement needed by an action."""
+
+    type: Literal["secret"]
+    name: str
+    required_keys: list[str]
+    optional_keys: list[str]
+    optional: bool
+
+
+class ActionOAuthRequirementPayload(TypedDict):
+    """OAuth integration requirement needed by an action.
+
+    OAuth requirements are backed by workspace integrations (configured under
+    /integrations), not by workspace secrets. ``name`` is the synthetic secret
+    name (e.g. ``github_oauth``) used in ``${{ SECRETS.<name>.<token> }}``
+    expressions at runtime, but readiness is evaluated against the workspace's
+    configured OAuth integrations keyed by ``(provider_id, grant_type)``.
+    """
+
+    type: Literal["oauth"]
+    name: str
+    provider_id: str
+    grant_type: str
+    optional: bool
+
+
+ActionRequirementPayload = (
+    ActionSecretRequirementPayload | ActionOAuthRequirementPayload
+)
+
+
+class ActionDiscoveryResponse(BaseModel):
+    """Action discovery item response."""
+
+    action_name: str
+    description: str | None = None
+    configured: bool
+    missing_requirements: list[str] = Field(default_factory=list)
+    optional_secrets: list[str] = Field(default_factory=list)
+
+
+class ActionContextResponse(ActionDiscoveryResponse):
+    """Full action authoring context response."""
+
+    parameters_json_schema: dict[str, Any]
+    required_secrets: list[ActionRequirementPayload] = Field(default_factory=list)
+    examples: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class WorkflowAuthoringContextResponse(BaseModel):
+    """Workflow authoring context response."""
+
+    actions: list[ActionContextResponse] = Field(default_factory=list)
+    variable_hints: list[dict[str, Any]] = Field(default_factory=list)
+    secret_hints: list[dict[str, Any]] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+def _build_example_from_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Build a compact example payload from JSON schema properties."""
+    example: dict[str, Any] = {}
+    properties = schema.get("properties", {})
+    required = schema.get("required", [])
+    for key in required:
+        prop = properties.get(key, {})
+        prop_type = prop.get("type")
+        if prop_type == "string":
+            example[key] = "example"
+        elif prop_type == "integer":
+            example[key] = 1
+        elif prop_type == "number":
+            example[key] = 1.0
+        elif prop_type == "boolean":
+            example[key] = True
+        elif prop_type == "array":
+            example[key] = []
+        elif prop_type == "object":
+            example[key] = {}
+        else:
+            example[key] = "value"
+    return example
+
+
+def _secrets_to_requirements(
+    secrets: Sequence[RegistrySecret | RegistryOAuthSecret],
+) -> list[ActionRequirementPayload]:
+    """Convert registry secret objects to public requirement metadata.
+
+    OAuth requirements are represented as OAuth requirements (provider_id +
+    grant_type), not as workspace secret/key pairs, so readiness can be checked
+    against the workspace's configured OAuth integrations.
+    """
+    requirements: list[ActionRequirementPayload] = []
+    for secret in secrets:
+        if isinstance(secret, RegistrySecret):
+            requirements.append(
+                {
+                    "type": "secret",
+                    "name": secret.name,
+                    "required_keys": list(secret.keys or []),
+                    "optional_keys": list(secret.optional_keys or []),
+                    "optional": secret.optional,
+                }
+            )
+        elif isinstance(secret, RegistryOAuthSecret):
+            requirements.append(
+                {
+                    "type": "oauth",
+                    "name": secret.name,
+                    "provider_id": secret.provider_id,
+                    "grant_type": secret.grant_type,
+                    "optional": secret.optional,
+                }
+            )
+    return requirements
+
+
+def _optional_secret_names(
+    requirements: Sequence[ActionRequirementPayload],
+) -> list[str]:
+    """Names of optional secret requirements (e.g. mtls/ca_cert).
+
+    These are credentials an action *may* use but does not require to run, so
+    their absence never makes an action unconfigured.
+    """
+    return [
+        req["name"]
+        for req in requirements
+        if req["type"] == "secret" and req.get("optional", False)
+    ]
+
+
+async def _load_secret_inventory(role: Role) -> dict[str, set[str]]:
+    """Load workspace secret key inventory for the default environment."""
+    async with SecretsService.with_session(role=role) as svc:
+        workspace_inventory: dict[str, set[str]] = {}
+        workspace_secrets = await svc.list_secrets()
+        for secret in workspace_secrets:
+            if secret.environment != DEFAULT_SECRETS_ENVIRONMENT:
+                continue
+            keys = {kv.key for kv in svc.decrypt_keys(secret.encrypted_keys)}
+            workspace_inventory[secret.name] = keys
+        return workspace_inventory
+
+
+async def _load_oauth_inventory(role: Role) -> set[ProviderKey]:
+    """Load connected workspace OAuth integrations keyed by provider.
+
+    Only integrations that have completed authentication (``CONNECTED`` status,
+    i.e. an access token is stored) can have
+    ``${{ SECRETS.<provider>_oauth.*_TOKEN }}`` injected at runtime. A
+    configured-but-not-connected provider (client credentials saved but the
+    OAuth flow not completed) yields no token at runtime, so it must not count
+    as configured for action readiness. Keys are workspace-level
+    ``(provider_id, grant_type)`` pairs, not per-user rows.
+    """
+    async with IntegrationService.with_session(role=role) as svc:
+        integrations = await svc.list_integrations()
+    return {
+        ProviderKey(id=integration.provider_id, grant_type=integration.grant_type)
+        for integration in integrations
+        if integration.status == IntegrationStatus.CONNECTED
+    }
+
+
+def _evaluate_configuration(
+    requirements: Sequence[ActionRequirementPayload],
+    workspace_inventory: dict[str, set[str]],
+    oauth_inventory: set[ProviderKey] | None = None,
+) -> tuple[bool, list[str]]:
+    """Evaluate whether required secrets and OAuth integrations are configured."""
+    oauth_inventory = oauth_inventory or set()
+    missing: list[str] = []
+    for req in requirements:
+        if req.get("type") == "oauth":
+            oauth_req = cast(ActionOAuthRequirementPayload, req)
+            if oauth_req.get("optional", False):
+                continue
+            provider_key = ProviderKey(
+                id=oauth_req["provider_id"],
+                grant_type=OAuthGrantType(oauth_req["grant_type"]),
+            )
+            if provider_key not in oauth_inventory:
+                missing.append(
+                    "missing oauth integration: "
+                    f"{provider_key.id} ({provider_key.grant_type.value})"
+                )
+            continue
+
+        secret_req = cast(ActionSecretRequirementPayload, req)
+        if secret_req.get("optional", False):
+            # A wholly-optional secret never blocks readiness, even when it
+            # declares keys (e.g. the mtls/ca_cert secrets inherited from
+            # core.http_request). At runtime these are absent-by-default, so an
+            # action that only "needs" optional secrets is still usable.
+            continue
+        secret_name = secret_req["name"]
+        required_keys = set(secret_req["required_keys"])
+        available_keys = workspace_inventory.get(secret_name)
+        if available_keys is None:
+            missing.append(f"missing secret: {secret_name}")
+            continue
+        for key in sorted(required_keys):
+            if key not in available_keys:
+                missing.append(f"missing key: {secret_name}.{key}")
+    return len(missing) == 0, missing
+
+
+async def build_action_contexts(
+    *,
+    role: Role,
+    action_names: list[str] | None = None,
+    query: str | None = None,
+) -> list[ActionContextResponse]:
+    """Build full authoring context (schema + secrets + example) for actions.
+
+    Resolve actions by explicit name list, or by search ``query`` when no names
+    are given. Unknown action names are skipped.
+    """
+    resolved_names = list(action_names) if action_names else []
+
+    workspace_inventory = await _load_secret_inventory(role)
+    oauth_inventory = await _load_oauth_inventory(role)
+    action_contexts: list[ActionContextResponse] = []
+    async with RegistryActionsService.with_session(role=role) as registry_svc:
+        if not resolved_names and query:
+            entries = await registry_svc.search_actions_from_index(query, limit=20)
+            resolved_names = [f"{entry.namespace}.{entry.name}" for entry, _ in entries]
+        for action_name in resolved_names:
+            indexed = await registry_svc.get_action_from_index(action_name)
+            if indexed is None:
+                continue
+            tool = await create_tool_from_registry(action_name, indexed)
+            requirements = _secrets_to_requirements(
+                registry_svc.aggregate_secrets_from_manifest(
+                    indexed.manifest, action_name
+                )
+            )
+            configured, missing = _evaluate_configuration(
+                requirements, workspace_inventory, oauth_inventory
+            )
+            action_contexts.append(
+                ActionContextResponse(
+                    action_name=action_name,
+                    description=tool.description,
+                    parameters_json_schema=tool.parameters_json_schema,
+                    required_secrets=requirements,
+                    configured=configured,
+                    missing_requirements=missing,
+                    optional_secrets=_optional_secret_names(requirements),
+                    examples=[_build_example_from_schema(tool.parameters_json_schema)],
+                )
+            )
+    return action_contexts
+
+
+async def build_variable_hints(*, role: Role) -> list[dict[str, Any]]:
+    """List workspace variables in the default environment as hints."""
+    async with VariablesService.with_session(role=role) as var_svc:
+        variables = await var_svc.list_variables(
+            environment=DEFAULT_SECRETS_ENVIRONMENT
+        )
+        return [
+            {
+                "name": var.name,
+                "keys": sorted(var.values.keys()),
+                "environment": var.environment,
+            }
+            for var in variables
+        ]
+
+
+async def build_secret_hints(*, role: Role) -> list[dict[str, Any]]:
+    """List workspace secrets in the default environment as hints."""
+    workspace_inventory = await _load_secret_inventory(role)
+    return [
+        {
+            "name": secret_name,
+            "keys": sorted(keys),
+            "environment": DEFAULT_SECRETS_ENVIRONMENT,
+        }
+        for secret_name, keys in workspace_inventory.items()
+    ]

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -8,6 +8,7 @@ import tempfile
 import uuid
 from collections import Counter
 from dataclasses import dataclass, field
+from importlib.resources import as_file, files
 from pathlib import Path
 from time import perf_counter
 from typing import Any, cast
@@ -17,6 +18,7 @@ from temporalio import activity
 from tracecat_ee.workspace_chat.policy import (
     is_workspace_chat_entitled,
 )
+from tracecat_ee.workspace_chat.skills import BUILTIN_SKILL_NAME_PREFIX
 
 from tracecat import config as app_config
 from tracecat.agent.artifacts.working_set import ArtifactWorkingSetInput
@@ -646,6 +648,7 @@ class SandboxedAgentExecutor:
             skills_dir = job_dir / "home" / ".claude" / "skills"
             skills_dir.mkdir(parents=True, exist_ok=True)
             await self._stage_resolved_skills(skills_dir)
+            await self._stage_builtin_skills(skills_dir)
 
             # Note: The MCP socket directory is mounted directly into NSJail at /mcp-sockets
             # so we don't need to symlink it here
@@ -719,6 +722,43 @@ class SandboxedAgentExecutor:
                     shutil.copytree,
                     cached_dir,
                     skills_dir / resolved_skill.skill_name,
+                    dirs_exist_ok=True,
+                )
+
+    async def _stage_builtin_skills(self, skills_dir: Path) -> None:
+        """Stage always-on built-in (EE) platform skills into the run home dir.
+
+        Built-in skills are plain on-disk directories packaged inside
+        ``tracecat_ee``. They are identified by name only (resolved from the
+        config, which set them when the org is workspace-chat entitled), so this
+        method maps each reserved-prefix name to its packaged directory and
+        copies it into the staged skills directory. Built-in skills own the
+        ``tracecat-`` namespace, so they never collide with preset
+        ``resolved_skills`` staged just before this.
+        """
+        config = cast(Any, self.input.config)
+        names = config.builtin_skills or []
+        if not names:
+            return
+
+        skills_root = files("tracecat_ee.workspace_chat.skills")
+        for name in dict.fromkeys(names):
+            if (
+                not name.startswith(BUILTIN_SKILL_NAME_PREFIX)
+                or "/" in name
+                or name in {".", ".."}
+            ):
+                logger.warning("Skipping invalid built-in skill name", skill=name)
+                continue
+            source = skills_root / name
+            if not (source / "SKILL.md").is_file():
+                logger.warning("Built-in skill missing SKILL.md; skipping", skill=name)
+                continue
+            with as_file(source) as source_path:
+                await asyncio.to_thread(
+                    shutil.copytree,
+                    source_path,
+                    skills_dir / name,
                     dirs_exist_ok=True,
                 )
 

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -31,6 +31,10 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import SQLAlchemyError
 from temporalio.common import TypedSearchAttributes
+from tracecat_ee.workspace_chat.policy import is_workspace_chat_entitled
+from tracecat_ee.workspace_chat.skills import (
+    BUILTIN_WORKSPACE_CHAT_SKILLS,
+)
 from tracecat_registry._internal.exceptions import SecretNotFoundError
 
 import tracecat.agent.adapter.vercel
@@ -152,6 +156,19 @@ class AgentSessionService(BaseWorkspaceService):
             tools,
             agent_addons_enabled=await self.has_entitlement(Entitlement.AGENT_ADDONS),
         )
+
+    async def _resolve_builtin_workspace_chat_skills(self) -> list[str] | None:
+        """Always-on platform skills staged for entitled workspace-chat sessions.
+
+        Returns the reserved-prefix skill names to stage into the copilot's
+        skills directory, or ``None`` when the org is not entitled to Workspace
+        Chat or the Enterprise package is unavailable. Names only — the executor
+        resolves each to a packaged skill directory at stage time.
+        """
+
+        if not await is_workspace_chat_entitled(self.session, self.role):
+            return None
+        return list(BUILTIN_WORKSPACE_CHAT_SKILLS)
 
     async def _resolve_workspace_chat_actions(
         self,
@@ -1599,6 +1616,9 @@ class AgentSessionService(BaseWorkspaceService):
         elif session_entity is AgentSessionEntity.WORKSPACE_CHAT:
             # Copilot uses org-level credentials, not workspace credentials
             entity_instructions = await self._entity_to_prompt(agent_session)
+            # Always-on platform skills (e.g. workflow management) staged for
+            # every entitled workspace-chat session, with or without a preset.
+            builtin_skills = await self._resolve_builtin_workspace_chat_skills()
             if agent_session.agent_preset_id:
                 async with agent_svc.with_preset_config(
                     preset_id=agent_session.agent_preset_id,
@@ -1609,7 +1629,11 @@ class AgentSessionService(BaseWorkspaceService):
                         if preset_config.instructions
                         else entity_instructions
                     )
-                    config = replace(preset_config, instructions=combined_instructions)
+                    config = replace(
+                        preset_config,
+                        instructions=combined_instructions,
+                        builtin_skills=builtin_skills,
+                    )
                     yield config
             else:
                 # Copilot without preset uses org-level credentials (default).
@@ -1627,6 +1651,7 @@ class AgentSessionService(BaseWorkspaceService):
                         catalog_id=model_config.catalog_id,
                         actions=actions,
                         mcp_servers=mcp_servers,
+                        builtin_skills=builtin_skills,
                     )
         elif session_entity in (
             AgentSessionEntity.WORKFLOW,

--- a/tracecat/agent/skill/schemas.py
+++ b/tracecat/agent/skill/schemas.py
@@ -18,12 +18,23 @@ from pydantic import (
 from tracecat.core.schemas import Schema
 from tracecat.identifiers import WorkspaceID
 
+# Reserved name prefix for built-in/platform skills. User- and preset-authored
+# skills may not use it, so platform skills (staged into the same on-disk skills
+# directory) can never collide with a user skill of the same name. Kept in sync
+# with ``tracecat_ee.workspace_chat.skills.BUILTIN_SKILL_NAME_PREFIX``.
+RESERVED_SKILL_NAME_PREFIX = "tracecat-"
+
 
 def _validate_skill_name(value: str) -> str:
     if value.startswith("-") or value.endswith("-"):
         raise ValueError("Skill name must not start or end with a hyphen")
     if "--" in value:
         raise ValueError("Skill name must not contain consecutive hyphens")
+    if value.startswith(RESERVED_SKILL_NAME_PREFIX):
+        raise ValueError(
+            f"Skill name must not start with the reserved prefix "
+            f"{RESERVED_SKILL_NAME_PREFIX!r}"
+        )
     return value
 
 

--- a/tracecat/agent/types.py
+++ b/tracecat/agent/types.py
@@ -143,6 +143,11 @@ class AgentConfig:
     enable_thinking: bool = True
     enable_internet_access: bool = False
     resolved_skills: list[ResolvedSkillRef] | None = None
+    builtin_skills: list[str] | None = None
+    """Names of built-in platform skills to stage into the agent's skills
+    directory, independent of preset-bound ``resolved_skills``. Names only (not
+    host paths) so the value is Temporal-replay-safe; the executor resolves each
+    name to a packaged skill directory at stage time."""
 
 
 # --- Tool Types (Harness-Agnostic) ---

--- a/tracecat/agent/workflow_config.py
+++ b/tracecat/agent/workflow_config.py
@@ -137,6 +137,7 @@ def agent_config_to_payload(config: AgentConfig) -> AgentConfigPayload:
             if config.resolved_skills
             else None
         ),
+        builtin_skills=config.builtin_skills,
     )
 
 
@@ -168,4 +169,5 @@ def agent_config_from_payload(payload: AgentConfigPayload) -> AgentConfig:
             if payload.resolved_skills
             else None
         ),
+        builtin_skills=payload.builtin_skills,
     )

--- a/tracecat/agent/workflow_schemas.py
+++ b/tracecat/agent/workflow_schemas.py
@@ -124,3 +124,4 @@ class AgentConfigPayload(BaseModel):
     enable_thinking: bool = Field(default=True)
     enable_internet_access: bool = Field(default=False)
     resolved_skills: list[ResolvedSkillRefPayload] | None = Field(default=None)
+    builtin_skills: list[str] | None = Field(default=None)

--- a/tracecat/artifacts/bindings.py
+++ b/tracecat/artifacts/bindings.py
@@ -711,10 +711,18 @@ def _workflow_artifact_from_output(
     if result is None:
         return None
 
+    # ``edit_workflow`` returns no title (only message/workflow_id/draft_revision),
+    # so skip the upsert when no real title resolves. An empty side effect leaves
+    # the existing artifact untouched, preventing a title-less edit response from
+    # clobbering the title set by create_workflow/get_workflow with the workflow id.
+    title = result.resolved_title
+    if not title:
+        return None
+
     payload: WorkflowArtifactPayload = {
         "type": "workflow",
         "id": result.id,
-        "title": result.resolved_title or result.id,
+        "title": title,
         "color": _DEFAULT_WORKFLOW_ARTIFACT_COLOR,
     }
     if result.is_published is not None:

--- a/tracecat/artifacts/bindings.py
+++ b/tracecat/artifacts/bindings.py
@@ -132,6 +132,14 @@ class _AgentPresetToolResult(_ArtifactProjectionModel):
     )
 
 
+class _WorkflowEditDocumentMetadata(_ArtifactProjectionModel):
+    title: str | None = None
+
+
+class _WorkflowEditDocument(_ArtifactProjectionModel):
+    metadata: _WorkflowEditDocumentMetadata | None = None
+
+
 class _WorkflowToolResult(_ArtifactProjectionModel):
     id: str = Field(
         validation_alias=AliasChoices("id", "workflow_id", "workflowId", "wf_id")
@@ -142,6 +150,17 @@ class _WorkflowToolResult(_ArtifactProjectionModel):
     is_published: bool | None = Field(
         default=None, validation_alias=AliasChoices("is_published", "isPublished")
     )
+    # ``get_workflow``/``edit_workflow`` carry the title nested under the
+    # editable draft document instead of at the top level.
+    draft_document: _WorkflowEditDocument | None = None
+
+    @property
+    def resolved_title(self) -> str | None:
+        if self.title:
+            return self.title
+        if self.draft_document and self.draft_document.metadata:
+            return self.draft_document.metadata.title
+        return None
 
 
 class _WorkflowRunToolResult(_ArtifactProjectionModel):
@@ -358,7 +377,11 @@ ARTIFACT_BINDINGS: tuple[ArtifactBinding, ...] = (
         build=_build_workflow_run_artifact,
     ),
     ArtifactBinding(
-        tool_names=("core.workflow.create_workflow",),
+        tool_names=(
+            "core.workflow.create_workflow",
+            "core.workflow.get_workflow",
+            "core.workflow.edit_workflow",
+        ),
         op="upsert",
         build=_build_workflow_artifact,
     ),
@@ -691,7 +714,7 @@ def _workflow_artifact_from_output(
     payload: WorkflowArtifactPayload = {
         "type": "workflow",
         "id": result.id,
-        "title": result.title or result.id,
+        "title": result.resolved_title or result.id,
         "color": _DEFAULT_WORKFLOW_ARTIFACT_COLOR,
     }
     if result.is_published is not None:

--- a/tracecat/authz/controls.py
+++ b/tracecat/authz/controls.py
@@ -168,6 +168,75 @@ class HasRole(Protocol):
     role: Role
 
 
+def require_scopes_for_role(
+    role: Role | None,
+    *scopes: str,
+    require_all: bool = True,
+) -> None:
+    """Imperatively assert that ``role`` holds the required scope(s).
+
+    This is the imperative counterpart to the ``require_scope`` decorator: use
+    it when the role is only available at call time (e.g. an MCP tool that
+    resolves a workspace role) and the scope must be enforced before invoking a
+    shared service method that is intentionally left unscoped.
+
+    Platform superusers (``"*"`` scope) bypass all checks, matching the
+    decorator's behavior.
+
+    Args:
+        role: The role to check. ``None`` is treated as having no scopes.
+        *scopes: The scope(s) required for access.
+        require_all: If True (default), all scopes must be present. If False,
+            any one of the scopes is sufficient.
+
+    Raises:
+        ScopeDeniedError: If the role doesn't have the required scope(s).
+    """
+    required = set(scopes)
+    if not required:
+        return
+
+    if role is None:
+        raise ScopeDeniedError(
+            required_scopes=list(required), missing_scopes=list(required)
+        )
+
+    user_scopes = role.scopes
+    if user_scopes is None:
+        raise ScopeDeniedError(
+            required_scopes=list(required), missing_scopes=list(required)
+        )
+
+    # Platform superuser has "*" scope - bypass all checks
+    if "*" in user_scopes:
+        return
+
+    if require_all:
+        missing = get_missing_scopes(user_scopes, required)
+        if missing:
+            logger.warning(
+                "Scope check failed - missing required scopes",
+                required_scopes=list(required),
+                missing_scopes=list(missing),
+            )
+            raise ScopeDeniedError(
+                required_scopes=list(required),
+                missing_scopes=list(missing),
+            )
+    else:
+        if not has_any_scope(user_scopes, required):
+            logger.warning(
+                "Scope check failed - none of required scopes present",
+                required_scopes=list(required),
+            )
+            raise ScopeDeniedError(
+                required_scopes=list(required),
+                missing_scopes=list(required),
+            )
+
+    logger.debug("Scope check passed", required_scopes=list(required))
+
+
 # =============================================================================
 # Scope-based Authorization Decorator
 # =============================================================================
@@ -266,45 +335,7 @@ def require_scope(*scopes: str, require_all: bool = True) -> Callable[[T], T]:
             return
 
         role = method_role or ctx_role.get()
-        if role is None:
-            raise ScopeDeniedError(
-                required_scopes=list(required), missing_scopes=list(required)
-            )
-
-        user_scopes = role.scopes
-        if user_scopes is None:
-            raise ScopeDeniedError(
-                required_scopes=list(required), missing_scopes=list(required)
-            )
-
-        # Platform superuser has "*" scope - bypass all checks
-        if "*" in user_scopes:
-            return
-
-        if require_all:
-            missing = get_missing_scopes(user_scopes, required)
-            if missing:
-                logger.warning(
-                    "Scope check failed - missing required scopes",
-                    required_scopes=list(required),
-                    missing_scopes=list(missing),
-                )
-                raise ScopeDeniedError(
-                    required_scopes=list(required),
-                    missing_scopes=list(missing),
-                )
-        else:
-            if not has_any_scope(user_scopes, required):
-                logger.warning(
-                    "Scope check failed - none of required scopes present",
-                    required_scopes=list(required),
-                )
-                raise ScopeDeniedError(
-                    required_scopes=list(required),
-                    missing_scopes=list(required),
-                )
-
-        logger.debug("Scope check passed", required_scopes=list(required))
+        require_scopes_for_role(role, *required, require_all=require_all)
 
     def decorator(fn: T) -> T:
         if asyncio.iscoroutinefunction(fn):

--- a/tracecat/chat/tools.py
+++ b/tracecat/chat/tools.py
@@ -33,6 +33,9 @@ WORKSPACE_CHAT_BASE_DEFAULT_TOOLS = [
     "core.cases.get_case",
     "core.cases.search_cases",
     "core.workflow.create_workflow",
+    "core.workflow.get_workflow",
+    "core.workflow.edit_workflow",
+    "core.workflow.get_authoring_context",
 ]
 
 WORKSPACE_CHAT_DEFAULT_TOOLS = [

--- a/tracecat/executor/worker.py
+++ b/tracecat/executor/worker.py
@@ -90,6 +90,12 @@ def new_sandbox_runner() -> SandboxedWorkflowRunner:
     )
     del invalid_module_member_children["datetime"]
 
+    # Add beartype to passthrough modules to avoid circular import issues
+    # with its custom import hooks conflicting with Temporal's sandbox.
+    passthrough_modules = SandboxRestrictions.passthrough_modules_default | {
+        "beartype",
+    }
+
     return SandboxedWorkflowRunner(
         restrictions=dataclasses.replace(
             SandboxRestrictions.default,
@@ -97,6 +103,7 @@ def new_sandbox_runner() -> SandboxedWorkflowRunner:
                 SandboxRestrictions.invalid_module_members_default,
                 children=invalid_module_member_children,
             ),
+            passthrough_modules=passthrough_modules,
         )
     )
 

--- a/tracecat/mcp/schemas.py
+++ b/tracecat/mcp/schemas.py
@@ -309,6 +309,18 @@ class WorkflowEditResponse(BaseModel):
     validate_only: bool = False
 
 
+class WorkflowAuthoringContextRequest(BaseModel):
+    """Request body for authoring-context lookup.
+
+    Resolve actions either by explicit ``action_names`` or, when none are
+    given, by ``query`` search. Both may be omitted to fetch only the workspace
+    variable/secret hints.
+    """
+
+    action_names: list[str] | None = None
+    query: str | None = None
+
+
 class ActionSecretRequirement(BaseModel):
     name: str
     required_keys: list[str] = Field(default_factory=list)

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -13,7 +13,7 @@ import hashlib
 import json
 import uuid
 from collections import defaultdict, deque
-from collections.abc import Collection, Iterator, Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from io import StringIO
 from pathlib import PurePosixPath
@@ -22,7 +22,6 @@ from typing import (
     Any,
     Literal,
     NamedTuple,
-    Protocol,
     TypedDict,
     cast,
     get_args,
@@ -46,9 +45,8 @@ from pydantic import (
 )
 from redis.asyncio import Redis as AsyncRedis
 from slugify import slugify
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
-from sqlalchemy.ext.asyncio import AsyncSession
 from temporalio.client import WorkflowExecutionStatus
 from tracecat_registry import RegistryOAuthSecret, RegistrySecret
 
@@ -133,19 +131,15 @@ from tracecat.cases.tags.service import CaseTagsService
 from tracecat.chat.schemas import BasicChatRequest, ChatRequest
 from tracecat.db.engine import get_async_session_context_manager
 from tracecat.db.models import (
-    Action,
     Table,
     Workflow,
     WorkflowDefinition,
 )
 from tracecat.dsl.common import (
-    DSLEntrypoint,
     DSLInput,
-    build_action_statements_from_actions,
     get_execution_type_from_search_attr,
     get_trigger_type_from_search_attr,
 )
-from tracecat.dsl.schemas import DSLConfig
 from tracecat.dsl.validation import (
     format_input_schema_validation_error,
     normalize_trigger_inputs,
@@ -184,7 +178,7 @@ from tracecat.mcp.config import (
     TRACECAT_MCP__RATE_LIMIT_BURST,
     TRACECAT_MCP__RATE_LIMIT_RPS,
 )
-from tracecat.mcp.json_patch import apply_json_patch_operations, validate_patch_paths
+from tracecat.mcp.json_patch import apply_json_patch_operations
 from tracecat.mcp.middleware import (
     MCPInputSizeLimitMiddleware,
     MCPTimeoutMiddleware,
@@ -197,13 +191,9 @@ from tracecat.mcp.schemas import (
     MCPTruncationInfo,
     MCPTruncationSummary,
     ValidationResponse,
-    WorkflowEditDefinition,
     WorkflowEditDocument,
-    WorkflowEditMetadata,
-    WorkflowEditRequest,
     WorkflowEditResponse,
     WorkflowLayout,
-    WorkflowSchedule,
     WorkflowYamlPayload,
 )
 from tracecat.pagination import CursorPaginatedResponse, CursorPaginationParams
@@ -251,11 +241,26 @@ from tracecat.workflow.case_triggers.schemas import (
     CaseTriggerConfig,
     CaseTriggerRead,
     CaseTriggerUpdate,
-    is_case_trigger_configured,
 )
 from tracecat.workflow.case_triggers.service import CaseTriggersService
 from tracecat.workflow.executions.service import WorkflowExecutionsService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
+from tracecat.workflow.management.draft import (
+    WorkflowEditError,
+    apply_layout_to_workflow,
+    build_workflow_edit_document,
+    compute_workflow_edit_revision,
+    extract_layout_positions,
+    normalize_workflow_edit_document_for_persisted_revision,
+    parse_workflow_edit_request,
+    persist_workflow_edit_document,
+    replace_workflow_definition_from_dsl,
+    replace_workflow_schedules,
+    validate_workflow_edit_document,
+    validate_workflow_patch_payload,
+    workflow_edit_document_changed_sections,
+    workflow_edit_document_payload,
+)
 from tracecat.workflow.management.folders.service import WorkflowFolderService
 from tracecat.workflow.management.layout import (
     WorkflowActionLayoutInput,
@@ -264,7 +269,6 @@ from tracecat.workflow.management.layout import (
 from tracecat.workflow.management.management import WorkflowsManagementService
 from tracecat.workflow.management.schemas import WorkflowCreate, WorkflowUpdate
 from tracecat.workflow.schedules.schemas import (
-    ScheduleCreate,
     ScheduleRead,
 )
 from tracecat.workflow.schedules.service import WorkflowSchedulesService
@@ -779,24 +783,6 @@ async def _resolve_agent_preset_model(
 _WORKFLOW_YAML_TOP_LEVEL_KEYS = frozenset(
     {"definition", "layout", "schedules", "case_trigger"}
 )
-
-
-def _schedule_create_from_payload(
-    *,
-    workflow_id: WorkflowUUID,
-    schedule: WorkflowSchedule,
-) -> ScheduleCreate:
-    return ScheduleCreate(
-        workflow_id=workflow_id,
-        inputs=schedule.inputs,
-        cron=schedule.cron,
-        every=schedule.every,
-        offset=schedule.offset,
-        start_at=schedule.start_at,
-        end_at=schedule.end_at,
-        status=schedule.status,
-        timeout=schedule.timeout,
-    )
 
 
 class MCPMessageResponse(BaseModel):
@@ -1575,589 +1561,16 @@ def _compute_sha256(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
-_WORKFLOW_EDITABLE_TOP_LEVEL_PATHS = frozenset(
-    {"metadata", "definition", "layout", "schedules", "case_trigger"}
-)
-_WORKFLOW_NONEDITABLE_PATH_PATTERNS: tuple[tuple[str, ...], ...] = (
-    ("definition", "config", "scheduler"),
-    ("definition", "actions", "*", "id"),
-)
-_WORKFLOW_NONREMOVABLE_PATH_PATTERNS: tuple[tuple[str, ...], ...] = (
-    ("schedules", "*", "status"),
-    ("case_trigger", "status"),
-)
+def _workflow_edit_error_to_tool_error(error: WorkflowEditError) -> ToolError:
+    """Map a transport-neutral edit error onto the historical ToolError payload.
 
-
-class _WorkflowEditDocumentSource(Protocol):
-    title: str
-    description: str | None
-    status: str
-    alias: str | None
-    error_handler: str | None
-    entrypoint: str | None
-    expects: dict[str, Any] | None
-    config: dict[str, Any] | None
-    returns: Any | None
-    trigger_position_x: float | None
-    trigger_position_y: float | None
-    viewport_x: float | None
-    viewport_y: float | None
-    viewport_zoom: float | None
-    actions: list[Action] | None
-    schedules: Sequence[Any] | None
-    case_trigger: Any | None
-
-
-def _workflow_schedule_sort_key(schedule: Any) -> str:
-    """Return a stable sort key for workflow schedules."""
-    payload = ScheduleRead.model_validate(schedule, from_attributes=True).model_dump(
-        mode="json",
-        exclude={
-            "id",
-            "workspace_id",
-            "workflow_id",
-            "created_at",
-            "updated_at",
-        },
-    )
-    if payload["timeout"] is None:
-        payload["timeout"] = 0
-    return json.dumps(payload, sort_keys=True)
-
-
-def _build_workflow_edit_document(
-    workflow: Workflow | _WorkflowEditDocumentSource,
-) -> WorkflowEditDocument:
-    """Build the canonical JSON document used by edit_workflow."""
-    actions = sorted(
-        workflow.actions or [],
-        key=lambda action: action.ref,
-    )
-    action_statements = build_action_statements_from_actions(actions) if actions else []
-
-    schedules = []
-    for schedule in sorted(
-        workflow.schedules or [],
-        key=_workflow_schedule_sort_key,
-    ):
-        schedule_payload = ScheduleRead.model_validate(
-            schedule, from_attributes=True
-        ).model_dump(
-            mode="json",
-            exclude={
-                "id",
-                "workspace_id",
-                "workflow_id",
-                "created_at",
-                "updated_at",
-            },
-        )
-        if schedule_payload["timeout"] is None:
-            schedule_payload["timeout"] = 0
-        schedules.append(schedule_payload)
-
-    case_trigger_payload: dict[str, Any] | None = None
-    if case_trigger := workflow.case_trigger:
-        case_trigger_read = CaseTriggerRead.model_validate(
-            case_trigger, from_attributes=True
-        )
-        if is_case_trigger_configured(
-            status=case_trigger_read.status,
-            event_types=case_trigger_read.event_types,
-            tag_filters=case_trigger_read.tag_filters,
-        ):
-            candidate_payload = case_trigger_read.model_dump(
-                mode="json", exclude={"id", "workflow_id"}
-            )
-            try:
-                case_trigger_payload = CaseTriggerConfig.model_validate(
-                    candidate_payload
-                ).model_dump(mode="json")
-            except ValidationError:
-                case_trigger_payload = None
-
-    return WorkflowEditDocument.model_validate(
-        {
-            "metadata": WorkflowEditMetadata(
-                title=workflow.title,
-                description=workflow.description or "",
-                status=cast(Literal["online", "offline"], workflow.status),
-                alias=workflow.alias,
-                error_handler=workflow.error_handler,
-            ).model_dump(mode="json"),
-            "definition": WorkflowEditDefinition(
-                entrypoint=DSLEntrypoint(
-                    ref=workflow.entrypoint,
-                    expects=workflow.expects,
-                ),
-                actions=action_statements,
-                config=DSLConfig.model_validate(workflow.config or {}),
-                returns=workflow.returns,
-            ).model_dump(mode="json", exclude_none=False),
-            "layout": {
-                "trigger": {
-                    "x": (
-                        workflow.trigger_position_x
-                        if workflow.trigger_position_x is not None
-                        else 0.0
-                    ),
-                    "y": (
-                        workflow.trigger_position_y
-                        if workflow.trigger_position_y is not None
-                        else 0.0
-                    ),
-                },
-                "viewport": {
-                    "x": workflow.viewport_x
-                    if workflow.viewport_x is not None
-                    else 0.0,
-                    "y": workflow.viewport_y
-                    if workflow.viewport_y is not None
-                    else 0.0,
-                    "zoom": (
-                        workflow.viewport_zoom
-                        if workflow.viewport_zoom is not None
-                        else 1.0
-                    ),
-                },
-                "actions": [
-                    {"ref": action.ref, "x": action.position_x, "y": action.position_y}
-                    for action in actions
-                ],
-            },
-            "schedules": schedules,
-            "case_trigger": case_trigger_payload,
-        }
-    )
-
-
-def _workflow_edit_document_payload(
-    document: WorkflowEditDocument,
-) -> dict[str, Any]:
-    """Serialize the canonical workflow edit document for patching and hashing."""
-    return document.model_dump(mode="json", exclude_none=False)
-
-
-def _workflow_schedule_payload_sort_key(schedule: dict[str, Any]) -> str:
-    """Return a stable sort key for already-serialized workflow schedules."""
-    payload = dict(schedule)
-    if payload["timeout"] is None:
-        payload["timeout"] = 0
-    return json.dumps(payload, sort_keys=True)
-
-
-def _canonicalize_workflow_edit_document(
-    document: WorkflowEditDocument,
-) -> WorkflowEditDocument:
-    """Normalize document ordering before hashing or comparison."""
-    payload = _workflow_edit_document_payload(document)
-    payload["definition"]["actions"] = sorted(
-        payload["definition"]["actions"],
-        key=lambda action: cast(str, action["ref"]),
-    )
-    payload["layout"]["actions"] = sorted(
-        payload["layout"]["actions"],
-        key=lambda action: cast(str, action["ref"]),
-    )
-    payload["schedules"] = sorted(
-        payload["schedules"],
-        key=_workflow_schedule_payload_sort_key,
-    )
-    return WorkflowEditDocument.model_validate(payload)
-
-
-def _normalize_workflow_edit_document_for_persisted_revision(
-    document: WorkflowEditDocument,
-) -> WorkflowEditDocument:
-    """Normalize transient edit state that persistence drops on refresh."""
-    payload = _workflow_edit_document_payload(document)
-    action_refs = {action.ref for action in document.definition.actions}
-    payload["layout"]["actions"] = [
-        action_layout
-        for action_layout in payload["layout"]["actions"]
-        if action_layout["ref"] in action_refs
-    ]
-    if payload["case_trigger"] is not None:
-        case_trigger = CaseTriggerConfig.model_validate(payload["case_trigger"])
-        if not case_trigger.is_configured():
-            payload["case_trigger"] = None
-    return WorkflowEditDocument.model_validate(payload)
-
-
-def _workflow_edit_document_changed_sections(
-    original_document: WorkflowEditDocument,
-    updated_document: WorkflowEditDocument,
-) -> set[str]:
-    original_payload = _workflow_edit_document_payload(
-        _canonicalize_workflow_edit_document(original_document)
-    )
-    updated_payload = _workflow_edit_document_payload(
-        _canonicalize_workflow_edit_document(updated_document)
-    )
-    return {
-        key for key in updated_payload if updated_payload[key] != original_payload[key]
-    }
-
-
-def _compute_workflow_edit_revision(document: WorkflowEditDocument) -> str:
-    """Compute a stable draft revision for the editable workflow document."""
-    payload = _workflow_edit_document_payload(
-        _canonicalize_workflow_edit_document(document)
-    )
-    serialized = orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
-    return hashlib.sha256(serialized).hexdigest()
-
-
-def _decode_patch_path(path: str) -> tuple[str, ...]:
-    """Decode a JSON pointer path into unescaped tokens."""
-    return tuple(
-        token.replace("~1", "/").replace("~0", "~") for token in path.split("/")[1:]
-    )
-
-
-def _encode_patch_path(tokens: tuple[str, ...]) -> str:
-    """Encode path tokens into a JSON pointer."""
-    return "/" + "/".join(
-        token.replace("~", "~0").replace("/", "~1") for token in tokens
-    )
-
-
-def _patch_path_matches_pattern(path: str, pattern: tuple[str, ...]) -> bool:
-    """Check whether a decoded patch path matches a non-editable pattern."""
-    tokens = _decode_patch_path(path)
-    if len(tokens) < len(pattern):
-        return False
-    return all(
-        expected in {"*", actual}
-        for actual, expected in zip(tokens, pattern, strict=False)
-    )
-
-
-def _iter_noneditable_payload_paths(
-    payload: Any,
-    pattern: tuple[str, ...],
-    *,
-    prefix: tuple[str, ...] = (),
-) -> Iterator[tuple[str, ...]]:
-    """Yield matching non-editable JSON pointer token paths present in a payload."""
-    if not pattern:
-        yield prefix
-        return
-
-    token, *rest = pattern
-    if isinstance(payload, dict):
-        if token == "*":
-            for key, value in payload.items():
-                yield from _iter_noneditable_payload_paths(
-                    value,
-                    tuple(rest),
-                    prefix=prefix + (str(key),),
-                )
-        elif token in payload:
-            yield from _iter_noneditable_payload_paths(
-                payload[token],
-                tuple(rest),
-                prefix=prefix + (token,),
-            )
-    elif isinstance(payload, list):
-        if token == "*":
-            for index, value in enumerate(payload):
-                yield from _iter_noneditable_payload_paths(
-                    value,
-                    tuple(rest),
-                    prefix=prefix + (str(index),),
-                )
-        elif token.isdigit():
-            index = int(token)
-            if 0 <= index < len(payload):
-                yield from _iter_noneditable_payload_paths(
-                    payload[index],
-                    tuple(rest),
-                    prefix=prefix + (token,),
-                )
-
-
-def _iter_missing_payload_paths(
-    payload: Any,
-    pattern: tuple[str, ...],
-    *,
-    prefix: tuple[str, ...] = (),
-) -> Iterator[tuple[str, ...]]:
-    """Yield non-removable JSON pointer token paths missing from a payload."""
-    if not pattern:
-        return
-
-    token, *rest = pattern
-    if isinstance(payload, dict):
-        if token == "*":
-            for key, value in payload.items():
-                yield from _iter_missing_payload_paths(
-                    value,
-                    tuple(rest),
-                    prefix=prefix + (str(key),),
-                )
-        elif token in payload:
-            yield from _iter_missing_payload_paths(
-                payload[token],
-                tuple(rest),
-                prefix=prefix + (token,),
-            )
-        elif not rest:
-            yield prefix + (token,)
-    elif isinstance(payload, list):
-        if token == "*":
-            for index, value in enumerate(payload):
-                yield from _iter_missing_payload_paths(
-                    value,
-                    tuple(rest),
-                    prefix=prefix + (str(index),),
-                )
-        elif token.isdigit():
-            index = int(token)
-            if 0 <= index < len(payload):
-                yield from _iter_missing_payload_paths(
-                    payload[index],
-                    tuple(rest),
-                    prefix=prefix + (token,),
-                )
-
-
-def _validate_workflow_patch_payload(payload: dict[str, Any]) -> None:
-    """Reject patched payloads that still contain non-editable nested fields."""
-    for pattern in _WORKFLOW_NONEDITABLE_PATH_PATTERNS:
-        if found_path := next(_iter_noneditable_payload_paths(payload, pattern), None):
-            raise ToolError(
-                f"Patch path '{_encode_patch_path(found_path)}' is not editable via edit_workflow"
-            )
-    for pattern in _WORKFLOW_NONREMOVABLE_PATH_PATTERNS:
-        if missing_path := next(_iter_missing_payload_paths(payload, pattern), None):
-            raise ToolError(
-                f"Patch path '{_encode_patch_path(missing_path)}' cannot be removed via edit_workflow"
-            )
-
-
-def _validate_workflow_patch_paths(patch_ops: list[JsonPatchOperation]) -> None:
-    """Reject JSON Patch paths outside the editable workflow document."""
-    validate_patch_paths(
-        patch_ops,
-        allowed_top_level_paths=_WORKFLOW_EDITABLE_TOP_LEVEL_PATHS,
-    )
-    for patch_op in patch_ops:
-        for path in (patch_op.path, patch_op.from_):
-            if path is None:
-                continue
-            if any(
-                _patch_path_matches_pattern(path, pattern)
-                for pattern in _WORKFLOW_NONEDITABLE_PATH_PATTERNS
-            ):
-                raise ToolError(
-                    f"Patch path '{path}' is not editable via edit_workflow"
-                )
-        removed_paths: tuple[str | None, ...] = (
-            (patch_op.path,)
-            if patch_op.op == "remove"
-            else (patch_op.from_,)
-            if patch_op.op == "move"
-            else ()
-        )
-        for path in removed_paths:
-            if path is None:
-                continue
-            if any(
-                _patch_path_matches_pattern(path, pattern)
-                for pattern in _WORKFLOW_NONREMOVABLE_PATH_PATTERNS
-            ):
-                raise ToolError(
-                    f"Patch path '{path}' cannot be removed via edit_workflow"
-                )
-
-
-def _workflow_edit_document_to_dsl(document: WorkflowEditDocument) -> DSLInput:
-    """Convert the editable workflow document into a DSLInput."""
-    return DSLInput(
-        title=document.metadata.title,
-        description=document.metadata.description,
-        entrypoint=document.definition.entrypoint,
-        actions=document.definition.actions,
-        config=document.definition.config,
-        returns=document.definition.returns,
-        error_handler=document.metadata.error_handler,
-    )
-
-
-async def _validate_workflow_edit_document(
-    document: WorkflowEditDocument,
-    *,
-    workflow_id: WorkflowUUID,
-    existing_layout_action_refs: set[str] | None = None,
-    validate_definition: bool = False,
-    session: AsyncSession | None = None,
-    role: Role | None = None,
-) -> None:
-    """Validate editable workflow document semantics before persistence."""
-    action_refs = {action.ref for action in document.definition.actions}
-    allowed_layout_action_refs = action_refs | (existing_layout_action_refs or set())
-    for action_layout in document.layout.actions:
-        if action_layout.ref not in allowed_layout_action_refs:
-            raise ToolError(
-                f"Unknown action ref {action_layout.ref!r} in layout.actions"
-            )
-    if document.definition.actions:
-        try:
-            dsl = _workflow_edit_document_to_dsl(document)
-        except (TracecatValidationError, ValidationError, ValueError) as exc:
-            raise ToolError(f"Invalid workflow definition: {exc}") from exc
-        if validate_definition:
-            if session is None or role is None:
-                raise RuntimeError("session and role are required for DSL validation")
-            validation_results = await validate_dsl(
-                session=session,
-                dsl=dsl,
-                role=role,
-            )
-            _raise_dsl_validation_tool_error(validation_results)
-    for schedule in document.schedules:
-        try:
-            _schedule_create_from_payload(
-                workflow_id=workflow_id,
-                schedule=schedule,
-            )
-        except ValidationError as exc:
-            raise ToolError(f"Invalid workflow schedule: {exc}") from exc
-
-
-def _parse_workflow_edit_request(
-    *,
-    base_revision: str,
-    patch_ops: list[dict[str, Any]] | list[JsonPatchOperation],
-    validate_only: bool,
-) -> WorkflowEditRequest:
-    """Parse and validate the edit_workflow request payload."""
-    request = WorkflowEditRequest.model_validate(
-        {
-            "base_revision": base_revision,
-            "patch_ops": patch_ops,
-            "validate_only": validate_only,
-        }
-    )
-    _validate_workflow_patch_paths(request.patch_ops)
-    return request
-
-
-async def _persist_workflow_edit_document(
-    *,
-    role: Any,
-    service: WorkflowsManagementService,
-    workflow: Workflow,
-    original_document: WorkflowEditDocument,
-    updated_document: WorkflowEditDocument,
-) -> None:
-    """Persist changes from the editable workflow document back to the draft."""
-    changed_sections = _workflow_edit_document_changed_sections(
-        original_document,
-        updated_document,
-    )
-    if not changed_sections:
-        return
-
-    workflow_id = WorkflowUUID.new(workflow.id)
-    layout_payload = updated_document.layout.model_dump(mode="json", exclude_none=False)
-    _, _, action_positions = _extract_layout_positions(layout_payload)
-
-    if "definition" in changed_sections:
-        if updated_document.definition.actions:
-            await _replace_workflow_definition_from_dsl(
-                service=service,
-                workflow=workflow,
-                dsl=_workflow_edit_document_to_dsl(updated_document),
-                action_positions=action_positions,
-            )
-        else:
-            workflow.title = updated_document.metadata.title
-            workflow.description = updated_document.metadata.description
-            workflow.status = updated_document.metadata.status
-            workflow.alias = updated_document.metadata.alias
-            workflow.error_handler = updated_document.metadata.error_handler
-            workflow.entrypoint = updated_document.definition.entrypoint.ref
-            entrypoint_data = updated_document.definition.entrypoint.model_dump(
-                exclude_none=True
-            )
-            workflow.expects = entrypoint_data.get("expects") or {}
-            workflow.returns = updated_document.definition.returns
-            workflow.config = updated_document.definition.config.model_dump(mode="json")
-            service.session.add(workflow)
-            await service.session.execute(
-                delete(Action).where(
-                    Action.workspace_id == service.workspace_id,
-                    Action.workflow_id == workflow.id,
-                )
-            )
-            await service.session.flush()
-            await service.session.refresh(workflow, ["actions"])
-    if "metadata" in changed_sections:
-        metadata = updated_document.metadata
-        update_params = WorkflowUpdate(
-            title=metadata.title,
-            description=metadata.description,
-            status=metadata.status,
-            alias=metadata.alias,
-            error_handler=metadata.error_handler,
-        )
-        for key, value in update_params.model_dump(exclude_unset=True).items():
-            setattr(workflow, key, value)
-        service.session.add(workflow)
-
-    if "layout" in changed_sections:
-        await service.session.refresh(workflow, ["actions"])
-        allowed_missing_layout_action_refs = {
-            layout_action.ref
-            for layout_action in original_document.layout.actions
-            if layout_action.ref
-            not in {action.ref for action in updated_document.definition.actions}
-        }
-        _apply_layout_to_workflow(
-            workflow=workflow,
-            layout=WorkflowLayout.model_validate(layout_payload),
-            clear_missing=True,
-            allowed_missing_action_refs=allowed_missing_layout_action_refs,
-        )
-        service.session.add(workflow)
-        for action in workflow.actions:
-            service.session.add(action)
-
-    if "schedules" in changed_sections:
-        schedule_service = WorkflowSchedulesService(service.session, role=role)
-        await _replace_workflow_schedules(
-            service=schedule_service,
-            workflow_id=workflow_id,
-            schedules=updated_document.schedules,
-        )
-
-    if "case_trigger" in changed_sections:
-        case_trigger_service = CaseTriggersService(service.session, role=role)
-        if updated_document.case_trigger is None:
-            await case_trigger_service.upsert_case_trigger(
-                workflow_id,
-                CaseTriggerConfig(status="offline", event_types=[], tag_filters=[]),
-                create_missing_tags=True,
-                commit=False,
-            )
-        else:
-            await case_trigger_service.upsert_case_trigger(
-                workflow_id,
-                updated_document.case_trigger,
-                create_missing_tags=True,
-                commit=False,
-            )
-
-    await service.session.commit()
-    await service.session.refresh(workflow)
-    if any(section in changed_sections for section in {"definition", "layout"}):
-        await service.session.refresh(workflow, ["actions"])
-    if "schedules" in changed_sections:
-        await service.session.refresh(workflow, ["schedules"])
-    if "case_trigger" in changed_sections:
-        await service.session.refresh(workflow, ["case_trigger"])
+    Preserves the exact ToolError content the edit/import/update tools produced
+    before the edit-document engine was extracted: structured validation errors
+    are JSON-encoded, everything else uses the plain message.
+    """
+    if error.code == "validation_error" and error.details is not None:
+        return ToolError(json.dumps(error.details, default=str))
+    return ToolError(error.message)
 
 
 def _normalize_workflow_file_relative_path(relative_path: str) -> str:
@@ -2484,168 +1897,6 @@ def _ensure_inline_workflow_yaml_size(definition_yaml: str) -> None:
         )
 
 
-async def _replace_workflow_definition_from_dsl(
-    service: WorkflowsManagementService,
-    workflow: Workflow,
-    dsl: DSLInput,
-    action_positions: dict[str, tuple[float, float]] | None = None,
-) -> None:
-    """Replace draft workflow definition from DSL (actions + metadata)."""
-    workflow.title = dsl.title
-    workflow.description = dsl.description
-    workflow.entrypoint = dsl.entrypoint.ref
-    entrypoint_data = dsl.entrypoint.model_dump()
-    workflow.expects = entrypoint_data.get("expects") or {}
-    workflow.returns = dsl.returns
-    workflow.config = dsl.config.model_dump(mode="json")
-    workflow.error_handler = dsl.error_handler
-    service.session.add(workflow)
-
-    await service.session.execute(
-        delete(Action).where(
-            Action.workspace_id == service.workspace_id,
-            Action.workflow_id == workflow.id,
-        )
-    )
-    await service.create_actions_from_dsl(dsl, workflow.id, action_positions)
-    await service.session.flush()
-    await service.session.refresh(workflow, ["actions"])
-
-
-def _extract_layout_positions(
-    layout_data: WorkflowLayout | Mapping[str, object] | None,
-) -> tuple[
-    tuple[float, float] | None,
-    tuple[float, float, float] | None,
-    dict[str, tuple[float, float]] | None,
-]:
-    """Extract layout data into position tuples for workflow/action creation.
-
-    Returns (trigger_position, viewport, action_positions).
-    """
-    if not layout_data:
-        return None, None, None
-    layout = (
-        layout_data
-        if isinstance(layout_data, WorkflowLayout)
-        else WorkflowLayout.model_validate(layout_data)
-    )
-    trigger_position: tuple[float, float] | None = None
-    if layout.trigger is not None:
-        trigger_position = (
-            layout.trigger.x if layout.trigger.x is not None else 0.0,
-            layout.trigger.y if layout.trigger.y is not None else 0.0,
-        )
-    viewport: tuple[float, float, float] | None = None
-    if layout.viewport is not None:
-        viewport = (
-            layout.viewport.x if layout.viewport.x is not None else 0.0,
-            layout.viewport.y if layout.viewport.y is not None else 0.0,
-            layout.viewport.zoom if layout.viewport.zoom is not None else 1.0,
-        )
-    action_positions: dict[str, tuple[float, float]] | None = None
-    if layout.actions:
-        action_positions = {
-            ap.ref: (
-                ap.x if ap.x is not None else 0.0,
-                ap.y if ap.y is not None else 0.0,
-            )
-            for ap in layout.actions
-        }
-    return trigger_position, viewport, action_positions
-
-
-def _apply_layout_to_workflow(
-    *,
-    workflow: Workflow,
-    layout: WorkflowLayout,
-    clear_missing: bool = False,
-    allowed_missing_action_refs: set[str] | None = None,
-) -> None:
-    """Apply optional trigger/action/viewport layout updates to a workflow."""
-    if layout.trigger is not None:
-        if clear_missing or layout.trigger.x is not None:
-            workflow.trigger_position_x = (
-                layout.trigger.x if layout.trigger.x is not None else 0.0
-            )
-        if clear_missing or layout.trigger.y is not None:
-            workflow.trigger_position_y = (
-                layout.trigger.y if layout.trigger.y is not None else 0.0
-            )
-    elif clear_missing:
-        workflow.trigger_position_x = 0.0
-        workflow.trigger_position_y = 0.0
-
-    if layout.viewport is not None:
-        if clear_missing or layout.viewport.x is not None:
-            workflow.viewport_x = (
-                layout.viewport.x if layout.viewport.x is not None else 0.0
-            )
-        if clear_missing or layout.viewport.y is not None:
-            workflow.viewport_y = (
-                layout.viewport.y if layout.viewport.y is not None else 0.0
-            )
-        if clear_missing or layout.viewport.zoom is not None:
-            workflow.viewport_zoom = (
-                layout.viewport.zoom if layout.viewport.zoom is not None else 1.0
-            )
-    elif clear_missing:
-        workflow.viewport_x = 0.0
-        workflow.viewport_y = 0.0
-        workflow.viewport_zoom = 1.0
-
-    action_by_ref = {action.ref: action for action in workflow.actions}
-    seen_action_refs: set[str] = set()
-    for action_position in layout.actions:
-        action = action_by_ref.get(action_position.ref)
-        if action is None:
-            if (
-                allowed_missing_action_refs is not None
-                and action_position.ref in allowed_missing_action_refs
-            ):
-                continue
-            raise ToolError(
-                f"Unknown action ref {action_position.ref!r} in layout.actions"
-            )
-        seen_action_refs.add(action_position.ref)
-        if clear_missing or action_position.x is not None:
-            action.position_x = (
-                action_position.x if action_position.x is not None else 0.0
-            )
-        if clear_missing or action_position.y is not None:
-            action.position_y = (
-                action_position.y if action_position.y is not None else 0.0
-            )
-
-    if clear_missing:
-        missing_action_refs = set(action_by_ref) - seen_action_refs
-        for action_ref in missing_action_refs:
-            action = action_by_ref[action_ref]
-            action.position_x = 0.0
-            action.position_y = 0.0
-
-
-async def _replace_workflow_schedules(
-    *,
-    service: WorkflowSchedulesService,
-    workflow_id: WorkflowUUID,
-    schedules: Sequence[WorkflowSchedule],
-) -> None:
-    """Replace all schedules for a workflow from YAML payload."""
-    existing = await service.list_schedules(workflow_id=workflow_id)
-    for schedule in existing:
-        await service.delete_schedule(schedule.id, commit=False)
-
-    for schedule in schedules:
-        await service.create_schedule(
-            _schedule_create_from_payload(
-                workflow_id=workflow_id,
-                schedule=schedule,
-            ),
-            commit=False,
-        )
-
-
 async def _apply_case_trigger_payload(
     *,
     service: CaseTriggersService,
@@ -2727,9 +1978,7 @@ async def _create_workflow_from_import_data(
 ) -> Workflow:
     """Create a workflow from normalized import data."""
     layout_data = import_data.get("layout")
-    trigger_position, viewport, action_positions = _extract_layout_positions(
-        layout_data
-    )
+    trigger_position, viewport, action_positions = extract_layout_positions(layout_data)
     try:
         async with WorkflowsManagementService.with_session(role=role) as svc:
             return await svc.create_workflow_from_external_definition(
@@ -2771,7 +2020,7 @@ async def _apply_workflow_yaml_update(
 
     update_action_positions: dict[str, tuple[float, float]] | None = None
     if yaml_payload is not None and yaml_payload.layout is not None:
-        _, _, update_action_positions = _extract_layout_positions(yaml_payload.layout)
+        _, _, update_action_positions = extract_layout_positions(yaml_payload.layout)
 
     if yaml_payload is not None and yaml_payload.definition is not None:
         validation_results = await validate_dsl(
@@ -2780,7 +2029,7 @@ async def _apply_workflow_yaml_update(
             role=role,
         )
         _raise_dsl_validation_tool_error(validation_results)
-        await _replace_workflow_definition_from_dsl(
+        await replace_workflow_definition_from_dsl(
             service=service,
             workflow=workflow,
             dsl=yaml_payload.definition,
@@ -2790,13 +2039,13 @@ async def _apply_workflow_yaml_update(
 
     if yaml_payload is not None and yaml_payload.layout is not None:
         await service.session.refresh(workflow, ["actions"])
-        _apply_layout_to_workflow(workflow=workflow, layout=yaml_payload.layout)
+        apply_layout_to_workflow(workflow=workflow, layout=yaml_payload.layout)
         for action in workflow.actions:
             service.session.add(action)
 
     if yaml_payload is not None and yaml_payload.schedules is not None:
         schedule_service = WorkflowSchedulesService(service.session, role=role)
-        await _replace_workflow_schedules(
+        await replace_workflow_schedules(
             service=schedule_service,
             workflow_id=workflow_id,
             schedules=yaml_payload.schedules,
@@ -4116,6 +3365,8 @@ async def create_workflow(
             description=workflow.description,
             status=workflow.status,
         )
+    except WorkflowEditError as e:
+        raise _workflow_edit_error_to_tool_error(e) from e
     except ToolError:
         raise
     except ValueError as e:
@@ -4149,7 +3400,7 @@ async def get_workflow(
             workflow = await svc.get_workflow(workflow_id)
             if not workflow:
                 raise ToolError(f"Workflow {workflow_id} not found")
-            draft_document = _build_workflow_edit_document(workflow)
+            draft_document = build_workflow_edit_document(workflow)
             payload = WorkflowMetadataResponse(
                 id=WorkflowUUID.new(workflow.id),
                 title=workflow.title,
@@ -4158,7 +3409,7 @@ async def get_workflow(
                 version=workflow.version,
                 alias=workflow.alias,
                 entrypoint=workflow.entrypoint,
-                draft_revision=_compute_workflow_edit_revision(draft_document),
+                draft_revision=compute_workflow_edit_revision(draft_document),
                 draft_document=draft_document,
             )
             if include_definition_yaml:
@@ -4173,6 +3424,8 @@ async def get_workflow(
                     update=inline.model_dump(exclude_none=True)
                 )
             return payload
+    except WorkflowEditError as e:
+        raise _workflow_edit_error_to_tool_error(e) from e
     except ToolError:
         raise
     except ValueError as e:
@@ -4195,7 +3448,7 @@ async def edit_workflow(
     try:
         _, role = await _resolve_workspace_role(workspace_id)
         wf_id = WorkflowUUID.new(workflow_id)
-        request = _parse_workflow_edit_request(
+        request = parse_workflow_edit_request(
             base_revision=base_revision,
             patch_ops=patch_ops,
             validate_only=validate_only,
@@ -4206,8 +3459,8 @@ async def edit_workflow(
             if workflow is None:
                 raise ToolError(f"Workflow {workflow_id} not found")
 
-            draft_document = _build_workflow_edit_document(workflow)
-            current_revision = _compute_workflow_edit_revision(draft_document)
+            draft_document = build_workflow_edit_document(workflow)
+            current_revision = compute_workflow_edit_revision(draft_document)
             if request.base_revision != current_revision:
                 raise ToolError(
                     {
@@ -4219,17 +3472,15 @@ async def edit_workflow(
                 )
 
             patched_payload = apply_json_patch_operations(
-                document=_workflow_edit_document_payload(draft_document),
+                document=workflow_edit_document_payload(draft_document),
                 patch_ops=request.patch_ops,
             )
-            _validate_workflow_patch_payload(patched_payload)
-
-            updated_document = WorkflowEditDocument.model_validate(patched_payload)
-            changed_sections = _workflow_edit_document_changed_sections(
+            updated_document = validate_workflow_patch_payload(patched_payload)
+            changed_sections = workflow_edit_document_changed_sections(
                 draft_document,
                 updated_document,
             )
-            await _validate_workflow_edit_document(
+            await validate_workflow_edit_document(
                 updated_document,
                 workflow_id=wf_id,
                 existing_layout_action_refs={
@@ -4246,14 +3497,14 @@ async def edit_workflow(
                     workflow_id=str(workflow.id),
                     valid=True,
                     validate_only=True,
-                    draft_revision=_compute_workflow_edit_revision(
-                        _normalize_workflow_edit_document_for_persisted_revision(
+                    draft_revision=compute_workflow_edit_revision(
+                        normalize_workflow_edit_document_for_persisted_revision(
                             updated_document
                         )
                     ),
                 )
 
-            await _persist_workflow_edit_document(
+            await persist_workflow_edit_document(
                 role=role,
                 service=svc,
                 workflow=workflow,
@@ -4264,12 +3515,14 @@ async def edit_workflow(
                 workflow,
                 ["actions", "schedules", "case_trigger"],
             )
-            refreshed_document = _build_workflow_edit_document(workflow)
+            refreshed_document = build_workflow_edit_document(workflow)
             return WorkflowEditResponse(
                 message=f"Workflow {workflow_id} updated successfully",
                 workflow_id=str(workflow.id),
-                draft_revision=_compute_workflow_edit_revision(refreshed_document),
+                draft_revision=compute_workflow_edit_revision(refreshed_document),
             )
+    except WorkflowEditError as e:
+        raise _workflow_edit_error_to_tool_error(e) from e
     except ToolError:
         raise
     except ValueError as e:
@@ -4356,6 +3609,8 @@ async def update_workflow(
                 message=f"Workflow {workflow_id} updated successfully",
                 mode=mode,
             )
+    except WorkflowEditError as e:
+        raise _workflow_edit_error_to_tool_error(e) from e
     except ToolError:
         raise
     except ValueError as e:

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -1869,6 +1869,12 @@ async def _apply_workflow_yaml_update(
             role=role,
         )
         _raise_dsl_validation_tool_error(validation_results)
+        # The action graph is being rewritten. Bump graph_version so a builder
+        # holding a stale base_version gets a 409 from the graph API instead of
+        # silently applying graph operations against the old action graph. The
+        # workflow row is held under FOR UPDATE for the lifetime of this session,
+        # so this increment cannot race a concurrent graph mutation.
+        workflow.graph_version += 1
         await replace_workflow_definition_from_dsl(
             service=service,
             workflow=workflow,

--- a/tracecat/mcp/server.py
+++ b/tracecat/mcp/server.py
@@ -48,10 +48,24 @@ from slugify import slugify
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 from temporalio.client import WorkflowExecutionStatus
-from tracecat_registry import RegistryOAuthSecret, RegistrySecret
 
 from tracecat import config
 from tracecat.agent.access.service import AgentModelAccessService
+from tracecat.agent.authoring_context import (
+    ActionContextResponse,
+    ActionDiscoveryResponse,
+    build_example_from_schema,
+    build_secret_hints,
+    build_variable_hints,
+    evaluate_configuration,
+    load_oauth_inventory,
+    load_secret_inventory,
+    optional_secret_names,
+    secrets_to_requirements,
+)
+from tracecat.agent.authoring_context import (
+    WorkflowAuthoringContextResponse as SharedWorkflowAuthoringContextResponse,
+)
 from tracecat.agent.common.stream_types import StreamEventType, UnifiedStreamEvent
 from tracecat.agent.folders.service import AgentFolderService
 from tracecat.agent.preset.schemas import (
@@ -80,6 +94,7 @@ from tracecat.agent.types import OutputType
 from tracecat.auth.schemas import UserRead
 from tracecat.auth.types import Role
 from tracecat.auth.users import search_users
+from tracecat.authz.controls import require_scopes_for_role
 from tracecat.cases.dropdowns.schemas import (
     CaseDropdownDefinitionCreate,
     CaseDropdownDefinitionRead,
@@ -162,7 +177,6 @@ from tracecat.identifiers.workflow import (
 )
 from tracecat.integrations.enums import IntegrationStatus, OAuthGrantType
 from tracecat.integrations.providers import all_providers
-from tracecat.integrations.schemas import ProviderKey
 from tracecat.integrations.service import IntegrationService
 from tracecat.logger import logger
 from tracecat.mcp.auth import (
@@ -452,161 +466,6 @@ def _normalize_folder_path_arg(path: str, *, allow_root: bool = True) -> str:
     return f"/{'/'.join(parts)}/"
 
 
-def _build_example_from_schema(schema: dict[str, Any]) -> dict[str, Any]:
-    """Build a compact example payload from JSON schema properties."""
-    example: dict[str, Any] = {}
-    properties = schema.get("properties", {})
-    required = schema.get("required", [])
-    for key in required:
-        prop = properties.get(key, {})
-        prop_type = prop.get("type")
-        if prop_type == "string":
-            example[key] = "example"
-        elif prop_type == "integer":
-            example[key] = 1
-        elif prop_type == "number":
-            example[key] = 1.0
-        elif prop_type == "boolean":
-            example[key] = True
-        elif prop_type == "array":
-            example[key] = []
-        elif prop_type == "object":
-            example[key] = {}
-        else:
-            example[key] = "value"
-    return example
-
-
-def _secrets_to_requirements(
-    secrets: Sequence[RegistrySecret | RegistryOAuthSecret],
-) -> list[ActionRequirementPayload]:
-    """Convert registry secret objects to public requirement metadata.
-
-    OAuth requirements are represented as OAuth requirements (provider_id +
-    grant_type), not as workspace secret/key pairs, so readiness can be checked
-    against the workspace's configured OAuth integrations.
-    """
-    requirements: list[ActionRequirementPayload] = []
-    for secret in secrets:
-        if isinstance(secret, RegistrySecret):
-            requirements.append(
-                {
-                    "type": "secret",
-                    "name": secret.name,
-                    "required_keys": list(secret.keys or []),
-                    "optional_keys": list(secret.optional_keys or []),
-                    "optional": secret.optional,
-                }
-            )
-        elif isinstance(secret, RegistryOAuthSecret):
-            requirements.append(
-                {
-                    "type": "oauth",
-                    "name": secret.name,
-                    "provider_id": secret.provider_id,
-                    "grant_type": secret.grant_type,
-                    "optional": secret.optional,
-                }
-            )
-    return requirements
-
-
-def _optional_secret_names(
-    requirements: Sequence[ActionRequirementPayload],
-) -> list[str]:
-    """Names of optional secret requirements (e.g. mtls/ca_cert).
-
-    These are credentials an action *may* use but does not require to run, so
-    their absence never makes an action unconfigured.
-    """
-    return [
-        req["name"]
-        for req in requirements
-        if req["type"] == "secret" and req.get("optional", False)
-    ]
-
-
-async def _load_secret_inventory(
-    role: Role,
-) -> dict[str, set[str]]:
-    """Load workspace secret key inventory for the default environment."""
-
-    async with SecretsService.with_session(role=role) as svc:
-        workspace_inventory: dict[str, set[str]] = {}
-
-        workspace_secrets = await svc.list_secrets()
-        for secret in workspace_secrets:
-            if secret.environment != DEFAULT_SECRETS_ENVIRONMENT:
-                continue
-            keys = {kv.key for kv in svc.decrypt_keys(secret.encrypted_keys)}
-            workspace_inventory[secret.name] = keys
-
-        return workspace_inventory
-
-
-async def _load_oauth_inventory(role: Role) -> set[ProviderKey]:
-    """Load connected workspace OAuth integrations keyed by provider.
-
-    Only integrations that have completed authentication (``CONNECTED`` status,
-    i.e. an access token is stored) can have
-    ``${{ SECRETS.<provider>_oauth.*_TOKEN }}`` injected at runtime. A
-    configured-but-not-connected provider (client credentials saved but the
-    OAuth flow not completed) yields no token at runtime, so it must not count
-    as configured for action readiness. Keys are workspace-level
-    ``(provider_id, grant_type)`` pairs, not per-user rows.
-    """
-    async with IntegrationService.with_session(role=role) as svc:
-        integrations = await svc.list_integrations()
-    return {
-        ProviderKey(id=integration.provider_id, grant_type=integration.grant_type)
-        for integration in integrations
-        if integration.status == IntegrationStatus.CONNECTED
-    }
-
-
-def _evaluate_configuration(
-    requirements: Sequence[ActionRequirementPayload],
-    workspace_inventory: dict[str, set[str]],
-    oauth_inventory: set[ProviderKey] | None = None,
-) -> tuple[bool, list[str]]:
-    """Evaluate whether required secrets and OAuth integrations are configured."""
-    oauth_inventory = oauth_inventory or set()
-    missing: list[str] = []
-    for req in requirements:
-        if req.get("type") == "oauth":
-            oauth_req = cast(ActionOAuthRequirementPayload, req)
-            if oauth_req.get("optional", False):
-                continue
-            provider_key = ProviderKey(
-                id=oauth_req["provider_id"],
-                grant_type=OAuthGrantType(oauth_req["grant_type"]),
-            )
-            if provider_key not in oauth_inventory:
-                missing.append(
-                    "missing oauth integration: "
-                    f"{provider_key.id} ({provider_key.grant_type.value})"
-                )
-            continue
-
-        secret_req = cast(ActionSecretRequirementPayload, req)
-        if secret_req.get("optional", False):
-            # A wholly-optional secret never blocks readiness, even when it
-            # declares keys (e.g. the mtls/ca_cert secrets inherited from
-            # core.http_request). At runtime these are absent-by-default, so an
-            # action that only "needs" optional secrets is still usable.
-            continue
-        secret_name = secret_req["name"]
-        required_keys = set(secret_req["required_keys"])
-        available_keys = workspace_inventory.get(secret_name)
-        if available_keys is None:
-            missing.append(f"missing secret: {secret_name}")
-            continue
-        for key in sorted(required_keys):
-            if key not in available_keys:
-                missing.append(f"missing key: {secret_name}.{key}")
-    return len(missing) == 0, missing
-
-
 def _get_supported_output_type_literals() -> list[str]:
     """Return the supported primitive output_type literal values."""
     output_type_value = getattr(OutputType, "__value__", OutputType)
@@ -836,38 +695,6 @@ class MCPValidationErrorPayload(TypedDict, total=False):
     input_schema: dict[str, object]
 
 
-class ActionSecretRequirementPayload(TypedDict):
-    """Workspace secret requirement needed by an action."""
-
-    type: Literal["secret"]
-    name: str
-    required_keys: list[str]
-    optional_keys: list[str]
-    optional: bool
-
-
-class ActionOAuthRequirementPayload(TypedDict):
-    """OAuth integration requirement needed by an action.
-
-    OAuth requirements are backed by workspace integrations (configured under
-    /integrations), not by workspace secrets. ``name`` is the synthetic secret
-    name (e.g. ``github_oauth``) used in ``${{ SECRETS.<name>.<token> }}``
-    expressions at runtime, but readiness is evaluated against the workspace's
-    configured OAuth integrations keyed by ``(provider_id, grant_type)``.
-    """
-
-    type: Literal["oauth"]
-    name: str
-    provider_id: str
-    grant_type: str
-    optional: bool
-
-
-ActionRequirementPayload = (
-    ActionSecretRequirementPayload | ActionOAuthRequirementPayload
-)
-
-
 class WorkflowSummaryResponse(BaseModel):
     """Compact workflow metadata returned by create/get/list tools."""
 
@@ -1077,37 +904,19 @@ class WorkflowPublishResponse(BaseModel):
     errors: list[MCPValidationErrorPayload] = Field(default_factory=list)
 
 
-class ActionDiscoveryResponse(BaseModel):
-    """Action discovery item response."""
-
-    action_name: str
-    description: str | None = None
-    configured: bool
-    missing_requirements: list[str] = Field(default_factory=list)
-    optional_secrets: list[str] = Field(default_factory=list)
-
-
-class ActionContextResponse(ActionDiscoveryResponse):
-    """Full action authoring context response."""
-
-    parameters_json_schema: dict[str, Any]
-    required_secrets: list[ActionRequirementPayload] = Field(default_factory=list)
-    examples: list[dict[str, Any]] = Field(default_factory=list)
-
-
 class ActionNamesPayload(BaseModel):
     """Selected workflow action names for authoring context."""
 
     action_names: list[str] = Field(default_factory=list)
 
 
-class WorkflowAuthoringContextResponse(BaseModel):
-    """Workflow authoring context response."""
+class WorkflowAuthoringContextResponse(SharedWorkflowAuthoringContextResponse):
+    """MCP workflow authoring context response.
 
-    actions: list[ActionContextResponse] = Field(default_factory=list)
-    variable_hints: list[dict[str, Any]] = Field(default_factory=list)
-    secret_hints: list[dict[str, Any]] = Field(default_factory=list)
-    notes: list[str] = Field(default_factory=list)
+    Extends the shared response (action schemas + variable/secret hints) with the
+    MCP-only ``truncation`` summary for embedded collections.
+    """
+
     truncation: MCPTruncationSummary | None = None
 
 
@@ -1939,6 +1748,37 @@ async def _apply_case_trigger_payload(
         )
 
 
+def _validate_actions_for_layout(
+    actions: Any,
+) -> Sequence[WorkflowActionLayoutInput]:
+    """Validate the raw ``definition.actions`` shape before auto-layout.
+
+    ``auto_generate_layout`` assumes each action is a mapping with a ``ref``
+    key, so a malformed shape (e.g. a mapping instead of a list, or a list of
+    scalars) would otherwise surface as a raw ``TypeError``/``KeyError``. Guard
+    those correctable authoring mistakes and raise a clear ``ToolError`` so they
+    become validation-style errors rather than generic failures.
+    """
+    if not isinstance(actions, list):
+        raise ToolError(
+            "Workflow definition.actions must be a list of action objects "
+            "(each with a 'ref')"
+        )
+    for action in actions:
+        if not isinstance(action, Mapping):
+            raise ToolError(
+                "Workflow definition.actions must be a list of action objects "
+                "(each with a 'ref')"
+            )
+        ref = action.get("ref")
+        if not isinstance(ref, str) or not ref:
+            raise ToolError(
+                "Each action in definition.actions must include a non-empty "
+                "string 'ref'"
+            )
+    return cast(Sequence[WorkflowActionLayoutInput], actions)
+
+
 def _build_import_data_from_workflow_yaml(
     *,
     definition_yaml: str,
@@ -1965,7 +1805,7 @@ def _build_import_data_from_workflow_yaml(
         actions = definition.get("actions", [])
         if actions:
             normalized["layout"] = auto_generate_layout(
-                cast(Sequence[WorkflowActionLayoutInput], actions)
+                _validate_actions_for_layout(actions)
             )
     return normalized
 
@@ -2014,7 +1854,7 @@ async def _apply_workflow_yaml_update(
         actions_raw = defn_raw.get("actions", [])
         if actions_raw:
             auto_layout = auto_generate_layout(
-                cast(Sequence[WorkflowActionLayoutInput], actions_raw)
+                _validate_actions_for_layout(actions_raw)
             )
             yaml_payload.layout = WorkflowLayout.model_validate(auto_layout)
 
@@ -2864,8 +2704,8 @@ async def _build_action_catalog(workspace_id: uuid.UUID) -> ActionCatalogRespons
     """Build the action catalog for a workspace."""
 
     ws_id, role = await _resolve_workspace_role(workspace_id)
-    workspace_inventory = await _load_secret_inventory(role)
-    oauth_inventory = await _load_oauth_inventory(role)
+    workspace_inventory = await load_secret_inventory(role)
+    oauth_inventory = await load_oauth_inventory(role)
 
     async with RegistryActionsService.with_session(role=role) as svc:
         entries = await svc.list_actions_from_index()
@@ -2905,8 +2745,8 @@ async def _build_action_catalog(workspace_id: uuid.UUID) -> ActionCatalogRespons
                     indexed.manifest, action_info.name
                 )
                 if secrets:
-                    requirements = _secrets_to_requirements(secrets)
-                    configured, missing = _evaluate_configuration(
+                    requirements = secrets_to_requirements(secrets)
+                    configured, missing = evaluate_configuration(
                         requirements, workspace_inventory, oauth_inventory
                     )
                     if not configured:
@@ -4082,8 +3922,8 @@ async def list_actions(
     try:
         _, role = await _resolve_workspace_role(workspace_id)
         limit = _normalize_limit(limit, default=50, max_limit=200)
-        workspace_inventory = await _load_secret_inventory(role)
-        oauth_inventory = await _load_oauth_inventory(role)
+        workspace_inventory = await load_secret_inventory(role)
+        oauth_inventory = await load_oauth_inventory(role)
         async with RegistryActionsService.with_session(role=role) as svc:
             if query:
                 entries = await svc.search_actions_from_index(query, limit=None)
@@ -4100,8 +3940,8 @@ async def list_actions(
                 secrets = svc.aggregate_secrets_from_manifest(
                     indexed.manifest, action_name
                 )
-                requirements = _secrets_to_requirements(secrets)
-                configured, missing = _evaluate_configuration(
+                requirements = secrets_to_requirements(secrets)
+                configured, missing = evaluate_configuration(
                     requirements, workspace_inventory, oauth_inventory
                 )
                 items.append(
@@ -4110,7 +3950,7 @@ async def list_actions(
                         description=entry.description,
                         configured=configured,
                         missing_requirements=missing,
-                        optional_secrets=_optional_secret_names(requirements),
+                        optional_secrets=optional_secret_names(requirements),
                     )
                 )
             page = _paginate_items(
@@ -4276,16 +4116,16 @@ async def get_action_context(
 
     try:
         _, role = await _resolve_workspace_role(workspace_id)
-        workspace_inventory = await _load_secret_inventory(role)
-        oauth_inventory = await _load_oauth_inventory(role)
+        workspace_inventory = await load_secret_inventory(role)
+        oauth_inventory = await load_oauth_inventory(role)
         async with RegistryActionsService.with_session(role=role) as svc:
             indexed = await svc.get_action_from_index(action_name)
             if indexed is None:
                 raise ToolError(f"Action {action_name} not found")
             tool = await create_tool_from_registry(action_name, indexed)
             secrets = svc.aggregate_secrets_from_manifest(indexed.manifest, action_name)
-            requirements = _secrets_to_requirements(secrets)
-            configured, missing = _evaluate_configuration(
+            requirements = secrets_to_requirements(secrets)
+            configured, missing = evaluate_configuration(
                 requirements, workspace_inventory, oauth_inventory
             )
             schema = tool.parameters_json_schema
@@ -4296,8 +4136,8 @@ async def get_action_context(
                 required_secrets=requirements,
                 configured=configured,
                 missing_requirements=missing,
-                optional_secrets=_optional_secret_names(requirements),
-                examples=[_build_example_from_schema(schema)],
+                optional_secrets=optional_secret_names(requirements),
+                examples=[build_example_from_schema(schema)],
             )
     except ToolError:
         raise
@@ -4340,8 +4180,8 @@ async def get_workflow_authoring_context(
         _, role = await _resolve_workspace_role(workspace_id)
         action_names = list(actions.action_names) if actions is not None else []
 
-        workspace_inventory = await _load_secret_inventory(role)
-        oauth_inventory = await _load_oauth_inventory(role)
+        workspace_inventory = await load_secret_inventory(role)
+        oauth_inventory = await load_oauth_inventory(role)
         action_contexts: list[ActionContextResponse] = []
         async with RegistryActionsService.with_session(role=role) as registry_svc:
             if not action_names and query:
@@ -4354,12 +4194,12 @@ async def get_workflow_authoring_context(
                 if indexed is None:
                     continue
                 tool = await create_tool_from_registry(action_name, indexed)
-                requirements = _secrets_to_requirements(
+                requirements = secrets_to_requirements(
                     registry_svc.aggregate_secrets_from_manifest(
                         indexed.manifest, action_name
                     )
                 )
-                configured, missing = _evaluate_configuration(
+                configured, missing = evaluate_configuration(
                     requirements, workspace_inventory, oauth_inventory
                 )
                 action_contexts.append(
@@ -4370,35 +4210,15 @@ async def get_workflow_authoring_context(
                         required_secrets=requirements,
                         configured=configured,
                         missing_requirements=missing,
-                        optional_secrets=_optional_secret_names(requirements),
+                        optional_secrets=optional_secret_names(requirements),
                         examples=[
-                            _build_example_from_schema(tool.parameters_json_schema)
+                            build_example_from_schema(tool.parameters_json_schema)
                         ],
                     )
                 )
 
-        async with VariablesService.with_session(role=role) as var_svc:
-            variables = await var_svc.list_variables(
-                environment=DEFAULT_SECRETS_ENVIRONMENT
-            )
-            variable_hints = [
-                {
-                    "name": var.name,
-                    "keys": sorted(var.values.keys()),
-                    "environment": var.environment,
-                }
-                for var in variables
-            ]
-
-        secret_hints: list[dict[str, Any]] = []
-        for secret_name, keys in workspace_inventory.items():
-            secret_hints.append(
-                {
-                    "name": secret_name,
-                    "keys": sorted(keys),
-                    "environment": DEFAULT_SECRETS_ENVIRONMENT,
-                }
-            )
+        variable_hints = await build_variable_hints(role=role)
+        secret_hints = await build_secret_hints(role=role)
 
         truncated_sections, truncation = _truncate_named_sections(
             {
@@ -7720,6 +7540,7 @@ async def list_variables(
 
     try:
         _, role = await _resolve_workspace_role(workspace_id)
+        require_scopes_for_role(role, "variable:read")
         async with VariablesService.with_session(role=role) as svc:
             variables = await svc.list_variables(environment=environment)
             page = _paginate_items(
@@ -7743,6 +7564,9 @@ async def list_variables(
                 filters={"environment": environment},
             )
             return page
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -7760,6 +7584,7 @@ async def get_variable(
 
     try:
         _, role = await _resolve_workspace_role(workspace_id)
+        require_scopes_for_role(role, "variable:read")
         async with VariablesService.with_session(role=role) as svc:
             variable = await svc.get_variable_by_name(
                 variable_name, environment=environment
@@ -7772,6 +7597,9 @@ async def get_variable(
                 keys=sorted(variable.values.keys()),
                 values=variable.values,
             )
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -7790,6 +7618,7 @@ async def list_secrets_metadata(
 
     try:
         _, role = await _resolve_workspace_role(workspace_id)
+        require_scopes_for_role(role, "secret:read")
         result: list[SecretMetadataResponse] = []
         async with SecretsService.with_session(role=role) as svc:
             workspace_secrets = await svc.list_secrets()
@@ -7821,6 +7650,9 @@ async def list_secrets_metadata(
             return page
     except ToolError:
         raise
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -7855,6 +7687,9 @@ async def get_secret_metadata(
             )
     except ToolError:
         raise
+    except ScopeDeniedError as e:
+        required = ", ".join(e.required_scopes)
+        raise ToolError(f"Missing required scope: {required}") from e
     except ValueError as e:
         raise ToolError(str(e)) from e
     except Exception as e:
@@ -7875,7 +7710,7 @@ async def _build_agent_preset_authoring_context(
     async with VariablesService.with_session(role=role) as svc:
         variables = await svc.list_variables(environment=DEFAULT_SECRETS_ENVIRONMENT)
 
-    workspace_inventory = await _load_secret_inventory(role)
+    workspace_inventory = await load_secret_inventory(role)
     models_by_provider: dict[str, list[str]] = defaultdict(list)
     for model_name, model in sorted(models.items(), key=lambda item: item[0]):
         provider = cast(str, model.model_dump(mode="json")["provider"])

--- a/tracecat/workflow/executions/internal_router.py
+++ b/tracecat/workflow/executions/internal_router.py
@@ -3,31 +3,71 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
+import yaml
 from fastapi import APIRouter, HTTPException
+from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from starlette.status import (
     HTTP_200_OK,
     HTTP_201_CREATED,
     HTTP_400_BAD_REQUEST,
     HTTP_404_NOT_FOUND,
+    HTTP_409_CONFLICT,
     HTTP_500_INTERNAL_SERVER_ERROR,
 )
 from temporalio.client import WorkflowExecutionStatus, WorkflowFailureError
 from temporalio.service import RPCError
 
+from tracecat.agent.authoring_context import (
+    WorkflowAuthoringContextResponse,
+    build_action_contexts,
+    build_secret_hints,
+    build_variable_hints,
+)
 from tracecat.auth.dependencies import ExecutorWorkspaceRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
 from tracecat.dsl.common import DSLInput
+from tracecat.exceptions import (
+    BuiltinRegistryHasNoSelectionError,
+    TracecatValidationError,
+)
 from tracecat.identifiers import WorkflowExecutionID, WorkflowID
-from tracecat.identifiers.workflow import AnyWorkflowID, WorkflowUUID
+from tracecat.identifiers.workflow import (
+    AnyWorkflowID,
+    AnyWorkflowIDPath,
+    WorkflowUUID,
+)
 from tracecat.logger import logger
+from tracecat.mcp.json_patch import apply_json_patch_operations
+from tracecat.mcp.schemas import (
+    JsonPatchOperation,
+    WorkflowAuthoringContextRequest,
+    WorkflowEditDocument,
+    WorkflowEditResponse,
+)
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.workflow.executions.enums import TriggerType
 from tracecat.workflow.executions.service import WorkflowExecutionsService
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
+from tracecat.workflow.management.draft import (
+    WorkflowEditError,
+    build_workflow_edit_document,
+    compute_workflow_edit_revision,
+    normalize_workflow_edit_document_for_persisted_revision,
+    parse_workflow_edit_request,
+    persist_workflow_edit_document,
+    validate_workflow_edit_document,
+    validate_workflow_patch_payload,
+    workflow_edit_document_changed_sections,
+    workflow_edit_document_payload,
+)
+from tracecat.workflow.management.layout import (
+    WorkflowActionLayoutInput,
+    auto_generate_layout,
+)
 from tracecat.workflow.management.management import WorkflowsManagementService
 from tracecat.workflow.management.schemas import WorkflowCreate
 
@@ -114,6 +154,13 @@ class InternalWorkflowCreateRequest(BaseModel):
     description: str | None = Field(
         default=None, description="Optional workflow description"
     )
+    definition_yaml: str | None = Field(
+        default=None,
+        description=(
+            "Optional full workflow definition as YAML. When provided, the "
+            "workflow is created with these actions instead of being empty."
+        ),
+    )
 
 
 class InternalWorkflowCreateResponse(BaseModel):
@@ -129,6 +176,80 @@ class InternalWorkflowCreateResponse(BaseModel):
         return WorkflowUUID.new(v)
 
 
+# Top-level keys that mark an already-enveloped workflow YAML payload.
+_WORKFLOW_YAML_TOP_LEVEL_KEYS = frozenset(
+    {"definition", "layout", "schedules", "case_trigger"}
+)
+
+
+def _build_import_data_from_definition_yaml(
+    *,
+    definition_yaml: str,
+    title: str | None,
+    description: str | None,
+) -> dict[str, Any]:
+    """Parse copilot-supplied workflow YAML into external import data.
+
+    Forgiving normalization so weaker models can one-shot a workflow:
+
+    - Accept either an enveloped payload (top-level ``definition``/``layout``/
+      ``schedules``/``case_trigger``) or a bare workflow definition, wrapping the
+      latter under ``definition`` (mirrors the MCP create path). A top-level
+      ``schedules`` key is tolerated for envelope detection but dropped on import
+      (no schedules field); add schedules afterwards via edit-document.
+    - Default ``title``/``description`` from the request when omitted.
+    - Inject a default ``entrypoint`` when missing. ``DSLInput`` requires the
+      key, but infers the actual entrypoint ref from actions with no
+      ``depends_on``; supplying ``{"ref": None}`` lets a model that forgets the
+      entrypoint still produce a valid workflow.
+    - Auto-generate a top-down layout when none is supplied.
+    """
+    try:
+        raw = yaml.safe_load(definition_yaml)
+    except yaml.YAMLError as exc:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=f"Invalid YAML: {exc}",
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail="Workflow definition YAML must decode to a mapping",
+        )
+    payload = cast(dict[str, Any], raw)
+
+    # Envelope a bare definition (no top-level definition/layout/... keys).
+    if "definition" in payload or _WORKFLOW_YAML_TOP_LEVEL_KEYS.intersection(
+        payload.keys()
+    ):
+        import_data = payload
+    else:
+        import_data = cast(dict[str, Any], {"definition": payload})
+
+    definition = import_data.get("definition")
+    if not isinstance(definition, dict):
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail="Workflow definition must be a mapping",
+        )
+    if "title" not in definition and title is not None:
+        definition["title"] = title
+    if "description" not in definition and description:
+        definition["description"] = description
+    # DSLInput requires the entrypoint key; let it infer the ref from the graph.
+    if "entrypoint" not in definition:
+        definition["entrypoint"] = {"ref": None}
+
+    if not import_data.get("layout"):
+        actions = definition.get("actions", [])
+        if actions:
+            import_data["layout"] = auto_generate_layout(
+                cast(list[WorkflowActionLayoutInput], actions)
+            )
+    return import_data
+
+
 @router.post("", status_code=HTTP_201_CREATED)
 @require_scope("workflow:create")
 async def create_workflow(
@@ -137,19 +258,254 @@ async def create_workflow(
     session: AsyncDBSession,
     params: InternalWorkflowCreateRequest,
 ) -> InternalWorkflowCreateResponse:
-    """Create a new empty workflow in the current workspace."""
+    """Create a workflow in the current workspace.
+
+    Empty by default; when ``definition_yaml`` is provided, the workflow is
+    created with the supplied actions, layout, and case trigger. Schedules are
+    not created here; add them afterwards via the edit-document endpoint.
+    """
     service = WorkflowsManagementService(session, role)
     try:
-        workflow = await service.create_workflow(
-            WorkflowCreate(title=params.title, description=params.description)
-        )
-    except (ValueError, ValidationError) as e:
+        if params.definition_yaml is not None:
+            import_data = _build_import_data_from_definition_yaml(
+                definition_yaml=params.definition_yaml,
+                title=params.title,
+                description=params.description,
+            )
+            workflow = await service.create_workflow_from_external_definition(
+                import_data
+            )
+        else:
+            workflow = await service.create_workflow(
+                WorkflowCreate(title=params.title, description=params.description)
+            )
+    except HTTPException:
+        raise
+    except (
+        BuiltinRegistryHasNoSelectionError,
+        TracecatValidationError,
+        ValueError,
+        ValidationError,
+    ) as e:
+        # Recoverable client errors -> 400, matching the import router.
+        # TracecatValidationError covers raw TracecatDSLError from DSLInput
+        # validators (not wrapped as a Pydantic ValidationError).
         raise HTTPException(
             status_code=HTTP_400_BAD_REQUEST,
             detail=str(e),
         ) from e
     return InternalWorkflowCreateResponse(
         id=WorkflowUUID.new(workflow.id), title=workflow.title
+    )
+
+
+class InternalWorkflowEditDocumentResponse(BaseModel):
+    """Editable draft document plus its optimistic-concurrency revision."""
+
+    workflow_id: str = Field(..., description="Workflow ID (short wf_... format)")
+    draft_revision: str = Field(
+        ..., description="Revision token to pass back as base_revision when editing"
+    )
+    draft_document: WorkflowEditDocument = Field(
+        ..., description="Editable workflow draft (metadata/definition/layout/...)"
+    )
+
+
+class InternalWorkflowEditRequest(BaseModel):
+    """Request to edit a workflow draft via RFC 6902 JSON Patch."""
+
+    base_revision: str = Field(
+        ..., description="draft_revision returned by GET /{workflow_id}/edit-document"
+    )
+    patch_ops: list[JsonPatchOperation] = Field(
+        ..., description="RFC 6902 JSON Patch operations to apply to the draft"
+    )
+    validate_only: bool = Field(
+        default=False, description="Validate the patch without persisting changes"
+    )
+
+
+def _raise_workflow_edit_http_error(error: WorkflowEditError) -> None:
+    """Map a transport-neutral edit error onto an HTTP error.
+
+    Revision conflicts become 409 (carrying ``current_revision`` so the caller
+    can refetch and retry); everything else becomes 400 with the same message
+    or structured ``details`` payload the engine produced.
+    """
+    if error.conflict:
+        raise HTTPException(
+            status_code=HTTP_409_CONFLICT,
+            detail={
+                "type": "conflict",
+                "status": "conflict",
+                "message": error.message,
+                "current_revision": error.current_revision,
+            },
+        )
+    raise HTTPException(
+        status_code=HTTP_400_BAD_REQUEST,
+        detail=error.details if error.details is not None else error.message,
+    )
+
+
+@router.get("/{workflow_id}/edit-document", status_code=HTTP_200_OK)
+@require_scope("workflow:read")
+async def get_workflow_edit_document(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    workflow_id: AnyWorkflowIDPath,
+) -> InternalWorkflowEditDocumentResponse:
+    """Return a workflow's editable draft document and its revision token."""
+    wf_id = workflow_id  # AnyWorkflowIDPath validates the id -> 422 not 500
+    service = WorkflowsManagementService(session, role)
+    workflow = await service.get_workflow(wf_id)
+    if workflow is None:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"Workflow {wf_id} not found",
+        )
+    try:
+        draft_document = build_workflow_edit_document(workflow)
+        draft_revision = compute_workflow_edit_revision(draft_document)
+    except WorkflowEditError as e:
+        _raise_workflow_edit_http_error(e)
+        raise  # unreachable; satisfies type checker
+    return InternalWorkflowEditDocumentResponse(
+        workflow_id=str(workflow.id),
+        draft_revision=draft_revision,
+        draft_document=draft_document,
+    )
+
+
+@router.patch("/{workflow_id}/edit-document", status_code=HTTP_200_OK)
+@require_scope("workflow:update")
+async def edit_workflow_document(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    workflow_id: AnyWorkflowIDPath,
+    params: InternalWorkflowEditRequest,
+) -> WorkflowEditResponse:
+    """Apply RFC 6902 JSON Patch operations to a workflow draft.
+
+    Mirrors the MCP ``edit_workflow`` tool, reusing the shared edit-document
+    engine so behavior matches exactly. A stale ``base_revision`` yields 409.
+    """
+    wf_id = workflow_id  # AnyWorkflowIDPath validates the id -> 422 not 500
+    service = WorkflowsManagementService(session, role)
+    try:
+        request = parse_workflow_edit_request(
+            base_revision=params.base_revision,
+            patch_ops=params.patch_ops,
+            validate_only=params.validate_only,
+        )
+
+        workflow = await service.get_workflow(wf_id, for_update=True)
+        if workflow is None:
+            raise HTTPException(
+                status_code=HTTP_404_NOT_FOUND,
+                detail=f"Workflow {wf_id} not found",
+            )
+
+        draft_document = build_workflow_edit_document(workflow)
+        current_revision = compute_workflow_edit_revision(draft_document)
+        if request.base_revision != current_revision:
+            raise WorkflowEditError(
+                "Draft revision mismatch",
+                conflict=True,
+                current_revision=current_revision,
+            )
+
+        patched_payload = apply_json_patch_operations(
+            document=workflow_edit_document_payload(draft_document),
+            patch_ops=request.patch_ops,
+        )
+        updated_document = validate_workflow_patch_payload(patched_payload)
+        changed_sections = workflow_edit_document_changed_sections(
+            draft_document,
+            updated_document,
+        )
+        await validate_workflow_edit_document(
+            updated_document,
+            workflow_id=wf_id,
+            existing_layout_action_refs={
+                action_layout.ref for action_layout in draft_document.layout.actions
+            },
+            validate_definition="definition" in changed_sections,
+            session=service.session,
+            role=role,
+        )
+
+        if request.validate_only:
+            return WorkflowEditResponse(
+                message=f"Workflow {wf_id} patch is valid",
+                workflow_id=str(workflow.id),
+                valid=True,
+                validate_only=True,
+                draft_revision=compute_workflow_edit_revision(
+                    normalize_workflow_edit_document_for_persisted_revision(
+                        updated_document
+                    )
+                ),
+            )
+
+        await persist_workflow_edit_document(
+            role=role,
+            service=service,
+            workflow=workflow,
+            original_document=draft_document,
+            updated_document=updated_document,
+        )
+        await service.session.refresh(
+            workflow,
+            ["actions", "schedules", "case_trigger"],
+        )
+        refreshed_document = build_workflow_edit_document(workflow)
+        return WorkflowEditResponse(
+            message=f"Workflow {wf_id} updated successfully",
+            workflow_id=str(workflow.id),
+            draft_revision=compute_workflow_edit_revision(refreshed_document),
+        )
+    except WorkflowEditError as e:
+        _raise_workflow_edit_http_error(e)
+        raise  # unreachable; satisfies type checker
+    except ToolError as e:
+        # apply_json_patch_operations raises ToolError on bad patch application
+        # (bad path/index, failed `test`). Mirror the MCP tool: 400 not 500.
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+
+@router.post("/authoring-context", status_code=HTTP_200_OK)
+@require_scope("workflow:read")
+async def get_authoring_context(
+    *,
+    role: ExecutorWorkspaceRole,
+    session: AsyncDBSession,
+    params: WorkflowAuthoringContextRequest,
+) -> WorkflowAuthoringContextResponse:
+    """Return authoring context (action schemas, secrets, examples) for actions.
+
+    Surfaced to the chat agent via the ``core.workflow.get_authoring_context``
+    registry action so it can write workflow ``args:`` blocks against real action
+    schemas instead of guessing. Resolves actions by explicit ``action_names`` or
+    by ``query`` search; with neither, returns only the workspace
+    variable/secret hints.
+    """
+    actions = await build_action_contexts(
+        role=role,
+        action_names=params.action_names,
+        query=params.query,
+    )
+    variable_hints = await build_variable_hints(role=role)
+    secret_hints = await build_secret_hints(role=role)
+    return WorkflowAuthoringContextResponse(
+        actions=actions,
+        variable_hints=variable_hints,
+        secret_hints=secret_hints,
     )
 
 

--- a/tracecat/workflow/executions/internal_router.py
+++ b/tracecat/workflow/executions/internal_router.py
@@ -237,6 +237,14 @@ def _build_import_data_from_definition_yaml(
         definition["title"] = title
     if "description" not in definition:
         definition["description"] = description or ""
+    # Enforce the same title/description constraints the draft edit endpoints
+    # apply (WorkflowEditMetadata), so an imported workflow can't later 500 them.
+    try:
+        WorkflowCreate(
+            title=definition.get("title"), description=definition.get("description")
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     # DSLInput requires the entrypoint key; let it infer the ref from the graph.
     if "entrypoint" not in definition:
         definition["entrypoint"] = {"ref": None}
@@ -250,14 +258,18 @@ def _build_import_data_from_definition_yaml(
             # 400-mapping except block in create_workflow and surfaces as a 500.
             # Guard the correctable authoring mistake here as a 400.
             if not isinstance(actions, list) or not all(
-                isinstance(action, dict) and isinstance(action.get("ref"), str)
+                isinstance(action, dict)
+                and isinstance(action.get("ref"), str)
+                and isinstance(action.get("depends_on") or [], list)
+                and all(isinstance(d, str) for d in action.get("depends_on") or [])
                 for action in actions
             ):
                 raise HTTPException(
                     status_code=HTTP_400_BAD_REQUEST,
                     detail=(
                         "Workflow definition.actions must be a list of action "
-                        "objects, each with a string 'ref'"
+                        "objects, each with a string 'ref' and an optional "
+                        "'depends_on' list of strings"
                     ),
                 )
             import_data["layout"] = auto_generate_layout(

--- a/tracecat/workflow/executions/internal_router.py
+++ b/tracecat/workflow/executions/internal_router.py
@@ -235,8 +235,8 @@ def _build_import_data_from_definition_yaml(
         )
     if "title" not in definition and title is not None:
         definition["title"] = title
-    if "description" not in definition and description:
-        definition["description"] = description
+    if "description" not in definition:
+        definition["description"] = description or ""
     # DSLInput requires the entrypoint key; let it infer the ref from the graph.
     if "entrypoint" not in definition:
         definition["entrypoint"] = {"ref": None}
@@ -244,6 +244,22 @@ def _build_import_data_from_definition_yaml(
     if not import_data.get("layout"):
         actions = definition.get("actions", [])
         if actions:
+            # auto_generate_layout indexes each action as a mapping (a["ref"]),
+            # so a malformed shape (a mapping instead of a list, or a list of
+            # scalars) would raise a raw TypeError/KeyError that escapes the
+            # 400-mapping except block in create_workflow and surfaces as a 500.
+            # Guard the correctable authoring mistake here as a 400.
+            if not isinstance(actions, list) or not all(
+                isinstance(action, dict) and isinstance(action.get("ref"), str)
+                for action in actions
+            ):
+                raise HTTPException(
+                    status_code=HTTP_400_BAD_REQUEST,
+                    detail=(
+                        "Workflow definition.actions must be a list of action "
+                        "objects, each with a string 'ref'"
+                    ),
+                )
             import_data["layout"] = auto_generate_layout(
                 cast(list[WorkflowActionLayoutInput], actions)
             )

--- a/tracecat/workflow/management/draft.py
+++ b/tracecat/workflow/management/draft.py
@@ -539,6 +539,21 @@ def validate_workflow_patch_payload(payload: dict[str, Any]) -> WorkflowEditDocu
                 "errors": ValidationDetailListTA.dump_python(details, mode="json"),
             },
         ) from exc
+    except TracecatValidationError as exc:
+        # Nested ActionStatement validators (e.g. interaction + for_each) raise
+        # a raw TracecatValidationError, not a Pydantic ValidationError, so it
+        # bypasses the branch above. Surface it as a structured WorkflowEditError
+        # too so the caller gets a 400/tool error to correct, never a 500.
+        message = str(exc) or "The patched workflow document is invalid."
+        raise WorkflowEditError(
+            message,
+            code="validation_error",
+            details={
+                "type": "validation_error",
+                "status": "error",
+                "message": message,
+            },
+        ) from exc
 
 
 def validate_workflow_patch_paths(patch_ops: list[JsonPatchOperation]) -> None:
@@ -979,16 +994,21 @@ async def replace_workflow_schedules(
     workflow_id: WorkflowUUID,
     schedules: Sequence[WorkflowSchedule],
 ) -> None:
-    """Replace all schedules for a workflow from YAML payload."""
-    existing = await service.list_schedules(workflow_id=workflow_id)
-    for schedule in existing:
-        await service.delete_schedule(schedule.id, commit=False)
+    """Replace all schedules for a workflow from YAML payload.
 
-    for schedule in schedules:
-        await service.create_schedule(
+    Delegates to the ``workflow:update``-scoped ``replace_schedules`` surface so
+    editing schedules through the edit-workflow document path is gated by the
+    workflow-edit permission rather than the standalone, admin-only
+    ``schedule:delete`` scope.
+    """
+    await service.replace_schedules(
+        workflow_id,
+        [
             schedule_create_from_payload(
                 workflow_id=workflow_id,
                 schedule=schedule,
-            ),
-            commit=False,
-        )
+            )
+            for schedule in schedules
+        ],
+        commit=False,
+    )

--- a/tracecat/workflow/management/draft.py
+++ b/tracecat/workflow/management/draft.py
@@ -1,0 +1,994 @@
+"""Shared workflow draft edit-document engine (RFC 6902 JSON Patch).
+
+This module is the transport-neutral engine for building, canonicalizing,
+hashing, validating, and persisting the editable workflow "edit document" used
+by ``edit_workflow``. It is shared by the MCP server (``tracecat.mcp.server``)
+and internal FastAPI routers so neither has to import the other.
+
+Transport neutrality: every recoverable error is raised as
+:class:`WorkflowEditError`. Callers are responsible for mapping it onto their
+transport's error type (``fastmcp.exceptions.ToolError`` for the MCP server,
+``fastapi.HTTPException`` for routers), preserving the original message and any
+structured ``code``/``details`` payload.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Collection, Iterator, Mapping, Sequence
+from typing import Any, Literal, Protocol, cast
+
+import orjson
+from fastmcp.exceptions import ToolError
+from pydantic import ValidationError
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
+from tracecat.db.models import Action, Workflow
+from tracecat.dsl.common import (
+    DSLEntrypoint,
+    DSLInput,
+    build_action_statements_from_actions,
+)
+from tracecat.dsl.schemas import DSLConfig
+from tracecat.exceptions import TracecatValidationError
+from tracecat.identifiers.workflow import WorkflowUUID
+from tracecat.mcp.json_patch import validate_patch_paths
+from tracecat.mcp.schemas import (
+    JsonPatchOperation,
+    WorkflowEditDefinition,
+    WorkflowEditDocument,
+    WorkflowEditMetadata,
+    WorkflowEditRequest,
+    WorkflowLayout,
+    WorkflowSchedule,
+)
+from tracecat.validation.schemas import (
+    ValidationDetail,
+    ValidationDetailListTA,
+    ValidationResult,
+)
+from tracecat.validation.service import validate_dsl
+from tracecat.workflow.case_triggers.schemas import (
+    CaseTriggerConfig,
+    CaseTriggerRead,
+    is_case_trigger_configured,
+)
+from tracecat.workflow.case_triggers.service import CaseTriggersService
+from tracecat.workflow.management.management import WorkflowsManagementService
+from tracecat.workflow.management.schemas import WorkflowUpdate
+from tracecat.workflow.schedules.schemas import ScheduleCreate, ScheduleRead
+from tracecat.workflow.schedules.service import WorkflowSchedulesService
+
+
+class WorkflowEditError(Exception):
+    """Transport-neutral error for the workflow edit-document engine.
+
+    Callers map this onto their transport error type while preserving the
+    message and structured payload. ``code``/``details`` reconstruct the
+    JSON payloads that the MCP server previously embedded directly in
+    ``ToolError`` (``{"type": "validation_error", ...}`` and
+    ``{"type": "conflict", ...}``).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        details: dict[str, Any] | None = None,
+        conflict: bool = False,
+        current_revision: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.details = details
+        self.conflict = conflict
+        self.current_revision = current_revision
+
+
+_WORKFLOW_EDITABLE_TOP_LEVEL_PATHS = frozenset(
+    {"metadata", "definition", "layout", "schedules", "case_trigger"}
+)
+# First path segments that only ever live under ``/definition``. Models
+# (especially weaker ones) routinely drop the ``/definition`` prefix and write
+# ``/actions/0/...`` instead of ``/definition/actions/0/...``. Because these
+# segments are unambiguous, we transparently rewrite them to the canonical path
+# before validation so a near-miss patch still applies.
+_WORKFLOW_DEFINITION_CHILD_SEGMENTS = frozenset(
+    {"actions", "entrypoint", "config", "returns"}
+)
+_WORKFLOW_NONEDITABLE_PATH_PATTERNS: tuple[tuple[str, ...], ...] = (
+    ("definition", "config", "scheduler"),
+    ("definition", "actions", "*", "id"),
+)
+_WORKFLOW_NONREMOVABLE_PATH_PATTERNS: tuple[tuple[str, ...], ...] = (
+    ("schedules", "*", "status"),
+    ("case_trigger", "status"),
+)
+
+
+class _WorkflowEditDocumentSource(Protocol):
+    title: str
+    description: str | None
+    status: str
+    alias: str | None
+    error_handler: str | None
+    entrypoint: str | None
+    expects: dict[str, Any] | None
+    config: dict[str, Any] | None
+    returns: Any | None
+    trigger_position_x: float | None
+    trigger_position_y: float | None
+    viewport_x: float | None
+    viewport_y: float | None
+    viewport_zoom: float | None
+    actions: list[Action] | None
+    schedules: Sequence[Any] | None
+    case_trigger: Any | None
+
+
+# NOTE: `_validation_result_payload` is replicated here (rather than imported
+# from `tracecat.mcp.server`) because that helper is a private of the MCP
+# server and is reused by several non-edit MCP tools; importing a private from
+# `tracecat.mcp` would couple this transport-neutral module back to the MCP
+# transport. The body mirrors `tracecat.mcp.server._validation_result_payload`.
+def _validation_result_payload(vr: ValidationResult) -> dict[str, object]:
+    """Serialize a validation result for user-facing error output."""
+    payload = cast(
+        dict[str, object], vr.root.model_dump(mode="json", exclude_none=True)
+    )
+    if "msg" in payload and "message" not in payload:
+        payload["message"] = payload["msg"]
+    raw_detail = payload.get("detail")
+    if isinstance(raw_detail, list):
+        payload["details"] = [
+            (
+                {
+                    "type": detail.get("type", ""),
+                    "msg": detail.get("msg", str(detail)),
+                    "loc": list(detail.get("loc", ()) or ()),
+                }
+                if isinstance(detail, dict)
+                else {
+                    "type": getattr(detail, "type", ""),
+                    "msg": getattr(detail, "msg", str(detail)),
+                    "loc": list(getattr(detail, "loc", ()) or ()),
+                }
+            )
+            for detail in raw_detail
+        ]
+    return payload
+
+
+# NOTE: `schedule_create_from_payload` is a public copy moved out of
+# `tracecat.mcp.server` (where it was `_schedule_create_from_payload`). It was
+# only used by the edit-document path, so it lives here and the MCP server
+# imports it.
+def schedule_create_from_payload(
+    *,
+    workflow_id: WorkflowUUID,
+    schedule: WorkflowSchedule,
+) -> ScheduleCreate:
+    return ScheduleCreate(
+        workflow_id=workflow_id,
+        inputs=schedule.inputs,
+        cron=schedule.cron,
+        every=schedule.every,
+        offset=schedule.offset,
+        start_at=schedule.start_at,
+        end_at=schedule.end_at,
+        status=schedule.status,
+        timeout=schedule.timeout,
+    )
+
+
+def _workflow_schedule_sort_key(schedule: Any) -> str:
+    """Return a stable sort key for workflow schedules."""
+    payload = ScheduleRead.model_validate(schedule, from_attributes=True).model_dump(
+        mode="json",
+        exclude={
+            "id",
+            "workspace_id",
+            "workflow_id",
+            "created_at",
+            "updated_at",
+        },
+    )
+    if payload["timeout"] is None:
+        payload["timeout"] = 0
+    return json.dumps(payload, sort_keys=True)
+
+
+def build_workflow_edit_document(
+    workflow: Workflow | _WorkflowEditDocumentSource,
+) -> WorkflowEditDocument:
+    """Build the canonical JSON document used by edit_workflow."""
+    actions = sorted(
+        workflow.actions or [],
+        key=lambda action: action.ref,
+    )
+    action_statements = build_action_statements_from_actions(actions) if actions else []
+
+    schedules = []
+    for schedule in sorted(
+        workflow.schedules or [],
+        key=_workflow_schedule_sort_key,
+    ):
+        schedule_payload = ScheduleRead.model_validate(
+            schedule, from_attributes=True
+        ).model_dump(
+            mode="json",
+            exclude={
+                "id",
+                "workspace_id",
+                "workflow_id",
+                "created_at",
+                "updated_at",
+            },
+        )
+        if schedule_payload["timeout"] is None:
+            schedule_payload["timeout"] = 0
+        schedules.append(schedule_payload)
+
+    case_trigger_payload: dict[str, Any] | None = None
+    if case_trigger := workflow.case_trigger:
+        case_trigger_read = CaseTriggerRead.model_validate(
+            case_trigger, from_attributes=True
+        )
+        if is_case_trigger_configured(
+            status=case_trigger_read.status,
+            event_types=case_trigger_read.event_types,
+            tag_filters=case_trigger_read.tag_filters,
+        ):
+            candidate_payload = case_trigger_read.model_dump(
+                mode="json", exclude={"id", "workflow_id"}
+            )
+            try:
+                case_trigger_payload = CaseTriggerConfig.model_validate(
+                    candidate_payload
+                ).model_dump(mode="json")
+            except ValidationError:
+                case_trigger_payload = None
+
+    return WorkflowEditDocument.model_validate(
+        {
+            "metadata": WorkflowEditMetadata(
+                title=workflow.title,
+                description=workflow.description or "",
+                status=cast(Literal["online", "offline"], workflow.status),
+                alias=workflow.alias,
+                error_handler=workflow.error_handler,
+            ).model_dump(mode="json"),
+            "definition": WorkflowEditDefinition(
+                entrypoint=DSLEntrypoint(
+                    ref=workflow.entrypoint,
+                    expects=workflow.expects,
+                ),
+                actions=action_statements,
+                config=DSLConfig.model_validate(workflow.config or {}),
+                returns=workflow.returns,
+            ).model_dump(mode="json", exclude_none=False),
+            "layout": {
+                "trigger": {
+                    "x": (
+                        workflow.trigger_position_x
+                        if workflow.trigger_position_x is not None
+                        else 0.0
+                    ),
+                    "y": (
+                        workflow.trigger_position_y
+                        if workflow.trigger_position_y is not None
+                        else 0.0
+                    ),
+                },
+                "viewport": {
+                    "x": workflow.viewport_x
+                    if workflow.viewport_x is not None
+                    else 0.0,
+                    "y": workflow.viewport_y
+                    if workflow.viewport_y is not None
+                    else 0.0,
+                    "zoom": (
+                        workflow.viewport_zoom
+                        if workflow.viewport_zoom is not None
+                        else 1.0
+                    ),
+                },
+                "actions": [
+                    {"ref": action.ref, "x": action.position_x, "y": action.position_y}
+                    for action in actions
+                ],
+            },
+            "schedules": schedules,
+            "case_trigger": case_trigger_payload,
+        }
+    )
+
+
+def workflow_edit_document_payload(
+    document: WorkflowEditDocument,
+) -> dict[str, Any]:
+    """Serialize the canonical workflow edit document for patching and hashing."""
+    return document.model_dump(mode="json", exclude_none=False)
+
+
+def _workflow_schedule_payload_sort_key(schedule: dict[str, Any]) -> str:
+    """Return a stable sort key for already-serialized workflow schedules."""
+    payload = dict(schedule)
+    if payload["timeout"] is None:
+        payload["timeout"] = 0
+    return json.dumps(payload, sort_keys=True)
+
+
+def canonicalize_workflow_edit_document(
+    document: WorkflowEditDocument,
+) -> WorkflowEditDocument:
+    """Normalize document ordering before hashing or comparison."""
+    payload = workflow_edit_document_payload(document)
+    payload["definition"]["actions"] = sorted(
+        payload["definition"]["actions"],
+        key=lambda action: cast(str, action["ref"]),
+    )
+    payload["layout"]["actions"] = sorted(
+        payload["layout"]["actions"],
+        key=lambda action: cast(str, action["ref"]),
+    )
+    payload["schedules"] = sorted(
+        payload["schedules"],
+        key=_workflow_schedule_payload_sort_key,
+    )
+    return WorkflowEditDocument.model_validate(payload)
+
+
+def normalize_workflow_edit_document_for_persisted_revision(
+    document: WorkflowEditDocument,
+) -> WorkflowEditDocument:
+    """Normalize transient edit state that persistence drops on refresh."""
+    payload = workflow_edit_document_payload(document)
+    action_refs = {action.ref for action in document.definition.actions}
+    payload["layout"]["actions"] = [
+        action_layout
+        for action_layout in payload["layout"]["actions"]
+        if action_layout["ref"] in action_refs
+    ]
+    if payload["case_trigger"] is not None:
+        case_trigger = CaseTriggerConfig.model_validate(payload["case_trigger"])
+        if not case_trigger.is_configured():
+            payload["case_trigger"] = None
+    return WorkflowEditDocument.model_validate(payload)
+
+
+def workflow_edit_document_changed_sections(
+    original_document: WorkflowEditDocument,
+    updated_document: WorkflowEditDocument,
+) -> set[str]:
+    original_payload = workflow_edit_document_payload(
+        canonicalize_workflow_edit_document(original_document)
+    )
+    updated_payload = workflow_edit_document_payload(
+        canonicalize_workflow_edit_document(updated_document)
+    )
+    return {
+        key for key in updated_payload if updated_payload[key] != original_payload[key]
+    }
+
+
+def compute_workflow_edit_revision(document: WorkflowEditDocument) -> str:
+    """Compute a stable draft revision for the editable workflow document."""
+    payload = workflow_edit_document_payload(
+        canonicalize_workflow_edit_document(document)
+    )
+    serialized = orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def _decode_patch_path(path: str) -> tuple[str, ...]:
+    """Decode a JSON pointer path into unescaped tokens."""
+    return tuple(
+        token.replace("~1", "/").replace("~0", "~") for token in path.split("/")[1:]
+    )
+
+
+def _encode_patch_path(tokens: tuple[str, ...]) -> str:
+    """Encode path tokens into a JSON pointer."""
+    return "/" + "/".join(
+        token.replace("~", "~0").replace("/", "~1") for token in tokens
+    )
+
+
+def _patch_path_matches_pattern(path: str, pattern: tuple[str, ...]) -> bool:
+    """Check whether a decoded patch path matches a non-editable pattern."""
+    tokens = _decode_patch_path(path)
+    if len(tokens) < len(pattern):
+        return False
+    return all(
+        expected in {"*", actual}
+        for actual, expected in zip(tokens, pattern, strict=False)
+    )
+
+
+def _iter_noneditable_payload_paths(
+    payload: Any,
+    pattern: tuple[str, ...],
+    *,
+    prefix: tuple[str, ...] = (),
+) -> Iterator[tuple[str, ...]]:
+    """Yield matching non-editable JSON pointer token paths present in a payload."""
+    if not pattern:
+        yield prefix
+        return
+
+    token, *rest = pattern
+    if isinstance(payload, dict):
+        if token == "*":
+            for key, value in payload.items():
+                yield from _iter_noneditable_payload_paths(
+                    value,
+                    tuple(rest),
+                    prefix=prefix + (str(key),),
+                )
+        elif token in payload:
+            yield from _iter_noneditable_payload_paths(
+                payload[token],
+                tuple(rest),
+                prefix=prefix + (token,),
+            )
+    elif isinstance(payload, list):
+        if token == "*":
+            for index, value in enumerate(payload):
+                yield from _iter_noneditable_payload_paths(
+                    value,
+                    tuple(rest),
+                    prefix=prefix + (str(index),),
+                )
+        elif token.isdigit():
+            index = int(token)
+            if 0 <= index < len(payload):
+                yield from _iter_noneditable_payload_paths(
+                    payload[index],
+                    tuple(rest),
+                    prefix=prefix + (token,),
+                )
+
+
+def _iter_missing_payload_paths(
+    payload: Any,
+    pattern: tuple[str, ...],
+    *,
+    prefix: tuple[str, ...] = (),
+) -> Iterator[tuple[str, ...]]:
+    """Yield non-removable JSON pointer token paths missing from a payload."""
+    if not pattern:
+        return
+
+    token, *rest = pattern
+    if isinstance(payload, dict):
+        if token == "*":
+            for key, value in payload.items():
+                yield from _iter_missing_payload_paths(
+                    value,
+                    tuple(rest),
+                    prefix=prefix + (str(key),),
+                )
+        elif token in payload:
+            yield from _iter_missing_payload_paths(
+                payload[token],
+                tuple(rest),
+                prefix=prefix + (token,),
+            )
+        elif not rest:
+            yield prefix + (token,)
+    elif isinstance(payload, list):
+        if token == "*":
+            for index, value in enumerate(payload):
+                yield from _iter_missing_payload_paths(
+                    value,
+                    tuple(rest),
+                    prefix=prefix + (str(index),),
+                )
+        elif token.isdigit():
+            index = int(token)
+            if 0 <= index < len(payload):
+                yield from _iter_missing_payload_paths(
+                    payload[index],
+                    tuple(rest),
+                    prefix=prefix + (token,),
+                )
+
+
+def validate_workflow_patch_payload(payload: dict[str, Any]) -> WorkflowEditDocument:
+    """Validate a patched payload and return the parsed edit document.
+
+    Rejects payloads that still contain non-editable nested fields, then parses
+    the payload into a :class:`WorkflowEditDocument`. A schema failure (e.g. an
+    unknown field such as ``on_error`` that a model invented) is surfaced as a
+    structured :class:`WorkflowEditError` so callers return a 400/tool error the
+    agent can read and correct — never an opaque 500.
+    """
+    for pattern in _WORKFLOW_NONEDITABLE_PATH_PATTERNS:
+        if found_path := next(_iter_noneditable_payload_paths(payload, pattern), None):
+            raise WorkflowEditError(
+                f"Patch path '{_encode_patch_path(found_path)}' is not editable via edit_workflow"
+            )
+    for pattern in _WORKFLOW_NONREMOVABLE_PATH_PATTERNS:
+        if missing_path := next(_iter_missing_payload_paths(payload, pattern), None):
+            raise WorkflowEditError(
+                f"Patch path '{_encode_patch_path(missing_path)}' cannot be removed via edit_workflow"
+            )
+    try:
+        return WorkflowEditDocument.model_validate(payload)
+    except ValidationError as exc:
+        details = ValidationDetail.list_from_pydantic(exc)
+        message = (
+            "The patched workflow document is invalid. Fix the reported "
+            "field(s) and retry. Note: an action has no `on_error` field — to "
+            "run a step when another step fails, add a dependency on the source "
+            "ref's error path, e.g. `depends_on: ['<source_ref>.error']`."
+        )
+        raise WorkflowEditError(
+            message,
+            code="validation_error",
+            details={
+                "type": "validation_error",
+                "status": "error",
+                "message": message,
+                "errors": ValidationDetailListTA.dump_python(details, mode="json"),
+            },
+        ) from exc
+
+
+def validate_workflow_patch_paths(patch_ops: list[JsonPatchOperation]) -> None:
+    """Reject JSON Patch paths outside the editable workflow document."""
+    try:
+        validate_patch_paths(
+            patch_ops,
+            allowed_top_level_paths=_WORKFLOW_EDITABLE_TOP_LEVEL_PATHS,
+        )
+    except ToolError as exc:
+        # Keep the engine transport-neutral: the json_patch helper raises the
+        # MCP ToolError, which we normalize to WorkflowEditError here.
+        raise WorkflowEditError(str(exc)) from exc
+    for patch_op in patch_ops:
+        for path in (patch_op.path, patch_op.from_):
+            if path is None:
+                continue
+            if any(
+                _patch_path_matches_pattern(path, pattern)
+                for pattern in _WORKFLOW_NONEDITABLE_PATH_PATTERNS
+            ):
+                raise WorkflowEditError(
+                    f"Patch path '{path}' is not editable via edit_workflow"
+                )
+        removed_paths: tuple[str | None, ...] = (
+            (patch_op.path,)
+            if patch_op.op == "remove"
+            else (patch_op.from_,)
+            if patch_op.op == "move"
+            else ()
+        )
+        for path in removed_paths:
+            if path is None:
+                continue
+            if any(
+                _patch_path_matches_pattern(path, pattern)
+                for pattern in _WORKFLOW_NONREMOVABLE_PATH_PATTERNS
+            ):
+                raise WorkflowEditError(
+                    f"Patch path '{path}' cannot be removed via edit_workflow"
+                )
+
+
+def workflow_edit_document_to_dsl(document: WorkflowEditDocument) -> DSLInput:
+    """Convert the editable workflow document into a DSLInput."""
+    return DSLInput(
+        title=document.metadata.title,
+        description=document.metadata.description,
+        entrypoint=document.definition.entrypoint,
+        actions=document.definition.actions,
+        config=document.definition.config,
+        returns=document.definition.returns,
+        error_handler=document.metadata.error_handler,
+    )
+
+
+def _raise_dsl_validation_edit_error(
+    validation_results: Collection[ValidationResult],
+) -> None:
+    """Raise a transport-neutral validation error mirroring the MCP payload.
+
+    The ``details`` payload reproduces the dict that
+    ``tracecat.mcp.server._raise_dsl_validation_tool_error`` previously
+    JSON-encoded into a ``ToolError``.
+    """
+    if validation_results:
+        raise WorkflowEditError(
+            f"{len(validation_results)} validation error(s)",
+            code="validation_error",
+            details={
+                "type": "validation_error",
+                "message": f"{len(validation_results)} validation error(s)",
+                "status": "error",
+                "errors": [
+                    _validation_result_payload(result) for result in validation_results
+                ],
+            },
+        )
+
+
+async def validate_workflow_edit_document(
+    document: WorkflowEditDocument,
+    *,
+    workflow_id: WorkflowUUID,
+    existing_layout_action_refs: set[str] | None = None,
+    validate_definition: bool = False,
+    session: AsyncSession | None = None,
+    role: Role | None = None,
+) -> None:
+    """Validate editable workflow document semantics before persistence."""
+    action_refs = {action.ref for action in document.definition.actions}
+    allowed_layout_action_refs = action_refs | (existing_layout_action_refs or set())
+    for action_layout in document.layout.actions:
+        if action_layout.ref not in allowed_layout_action_refs:
+            raise WorkflowEditError(
+                f"Unknown action ref {action_layout.ref!r} in layout.actions"
+            )
+    if document.definition.actions:
+        try:
+            dsl = workflow_edit_document_to_dsl(document)
+        except (TracecatValidationError, ValidationError, ValueError) as exc:
+            raise WorkflowEditError(f"Invalid workflow definition: {exc}") from exc
+        if validate_definition:
+            if session is None or role is None:
+                raise RuntimeError("session and role are required for DSL validation")
+            validation_results = await validate_dsl(
+                session=session,
+                dsl=dsl,
+                role=role,
+            )
+            _raise_dsl_validation_edit_error(validation_results)
+    for schedule in document.schedules:
+        try:
+            schedule_create_from_payload(
+                workflow_id=workflow_id,
+                schedule=schedule,
+            )
+        except ValidationError as exc:
+            raise WorkflowEditError(f"Invalid workflow schedule: {exc}") from exc
+
+
+def _normalize_patch_pointer(path: str | None) -> str | None:
+    """Rewrite a near-miss JSON pointer to its canonical editable path.
+
+    Adds the missing ``/definition`` prefix when the first segment is a
+    definition-only key (``actions``/``entrypoint``/``config``/``returns``).
+    Leaves already-correct and unrelated paths untouched.
+    """
+    if path is None or not path.startswith("/"):
+        return path
+    first, sep, rest = path[1:].partition("/")
+    if first in _WORKFLOW_DEFINITION_CHILD_SEGMENTS:
+        return f"/definition/{first}{sep}{rest}" if sep else f"/definition/{first}"
+    return path
+
+
+def _normalize_patch_op_paths(
+    patch_ops: list[JsonPatchOperation],
+) -> list[JsonPatchOperation]:
+    """Return patch ops with near-miss ``path``/``from`` pointers canonicalized."""
+    normalized: list[JsonPatchOperation] = []
+    for op in patch_ops:
+        new_path = _normalize_patch_pointer(op.path)
+        new_from = _normalize_patch_pointer(op.from_)
+        if new_path == op.path and new_from == op.from_:
+            normalized.append(op)
+        else:
+            normalized.append(
+                op.model_copy(update={"path": new_path, "from_": new_from})
+            )
+    return normalized
+
+
+def parse_workflow_edit_request(
+    *,
+    base_revision: str,
+    patch_ops: list[dict[str, Any]] | list[JsonPatchOperation],
+    validate_only: bool,
+) -> WorkflowEditRequest:
+    """Parse and validate the edit_workflow request payload.
+
+    Near-miss patch paths (e.g. ``/actions/0/...`` missing the ``/definition``
+    prefix) are transparently canonicalized before validation so a model that
+    drops the prefix still succeeds.
+    """
+    request = WorkflowEditRequest.model_validate(
+        {
+            "base_revision": base_revision,
+            "patch_ops": patch_ops,
+            "validate_only": validate_only,
+        }
+    )
+    request.patch_ops = _normalize_patch_op_paths(request.patch_ops)
+    validate_workflow_patch_paths(request.patch_ops)
+    return request
+
+
+async def persist_workflow_edit_document(
+    *,
+    role: Any,
+    service: WorkflowsManagementService,
+    workflow: Workflow,
+    original_document: WorkflowEditDocument,
+    updated_document: WorkflowEditDocument,
+) -> None:
+    """Persist changes from the editable workflow document back to the draft."""
+    changed_sections = workflow_edit_document_changed_sections(
+        original_document,
+        updated_document,
+    )
+    if not changed_sections:
+        return
+
+    workflow_id = WorkflowUUID.new(workflow.id)
+    layout_payload = updated_document.layout.model_dump(mode="json", exclude_none=False)
+    _, _, action_positions = extract_layout_positions(layout_payload)
+
+    if "definition" in changed_sections:
+        if updated_document.definition.actions:
+            await replace_workflow_definition_from_dsl(
+                service=service,
+                workflow=workflow,
+                dsl=workflow_edit_document_to_dsl(updated_document),
+                action_positions=action_positions,
+            )
+        else:
+            workflow.title = updated_document.metadata.title
+            workflow.description = updated_document.metadata.description
+            workflow.status = updated_document.metadata.status
+            workflow.alias = updated_document.metadata.alias
+            workflow.error_handler = updated_document.metadata.error_handler
+            workflow.entrypoint = updated_document.definition.entrypoint.ref
+            entrypoint_data = updated_document.definition.entrypoint.model_dump(
+                exclude_none=True
+            )
+            workflow.expects = entrypoint_data.get("expects") or {}
+            workflow.returns = updated_document.definition.returns
+            workflow.config = updated_document.definition.config.model_dump(mode="json")
+            service.session.add(workflow)
+            await service.session.execute(
+                delete(Action).where(
+                    Action.workspace_id == service.workspace_id,
+                    Action.workflow_id == workflow.id,
+                )
+            )
+            await service.session.flush()
+            await service.session.refresh(workflow, ["actions"])
+    if "metadata" in changed_sections:
+        metadata = updated_document.metadata
+        update_params = WorkflowUpdate(
+            title=metadata.title,
+            description=metadata.description,
+            status=metadata.status,
+            alias=metadata.alias,
+            error_handler=metadata.error_handler,
+        )
+        for key, value in update_params.model_dump(exclude_unset=True).items():
+            setattr(workflow, key, value)
+        service.session.add(workflow)
+
+    if "layout" in changed_sections:
+        await service.session.refresh(workflow, ["actions"])
+        allowed_missing_layout_action_refs = {
+            layout_action.ref
+            for layout_action in original_document.layout.actions
+            if layout_action.ref
+            not in {action.ref for action in updated_document.definition.actions}
+        }
+        apply_layout_to_workflow(
+            workflow=workflow,
+            layout=WorkflowLayout.model_validate(layout_payload),
+            clear_missing=True,
+            allowed_missing_action_refs=allowed_missing_layout_action_refs,
+        )
+        service.session.add(workflow)
+        for action in workflow.actions:
+            service.session.add(action)
+
+    if "schedules" in changed_sections:
+        schedule_service = WorkflowSchedulesService(service.session, role=role)
+        await replace_workflow_schedules(
+            service=schedule_service,
+            workflow_id=workflow_id,
+            schedules=updated_document.schedules,
+        )
+
+    if "case_trigger" in changed_sections:
+        case_trigger_service = CaseTriggersService(service.session, role=role)
+        if updated_document.case_trigger is None:
+            await case_trigger_service.upsert_case_trigger(
+                workflow_id,
+                CaseTriggerConfig(status="offline", event_types=[], tag_filters=[]),
+                create_missing_tags=True,
+                commit=False,
+            )
+        else:
+            await case_trigger_service.upsert_case_trigger(
+                workflow_id,
+                updated_document.case_trigger,
+                create_missing_tags=True,
+                commit=False,
+            )
+
+    await service.session.commit()
+    await service.session.refresh(workflow)
+    if any(section in changed_sections for section in {"definition", "layout"}):
+        await service.session.refresh(workflow, ["actions"])
+    if "schedules" in changed_sections:
+        await service.session.refresh(workflow, ["schedules"])
+    if "case_trigger" in changed_sections:
+        await service.session.refresh(workflow, ["case_trigger"])
+
+
+async def replace_workflow_definition_from_dsl(
+    service: WorkflowsManagementService,
+    workflow: Workflow,
+    dsl: DSLInput,
+    action_positions: dict[str, tuple[float, float]] | None = None,
+) -> None:
+    """Replace draft workflow definition from DSL (actions + metadata)."""
+    workflow.title = dsl.title
+    workflow.description = dsl.description
+    workflow.entrypoint = dsl.entrypoint.ref
+    entrypoint_data = dsl.entrypoint.model_dump()
+    workflow.expects = entrypoint_data.get("expects") or {}
+    workflow.returns = dsl.returns
+    workflow.config = dsl.config.model_dump(mode="json")
+    workflow.error_handler = dsl.error_handler
+    service.session.add(workflow)
+
+    await service.session.execute(
+        delete(Action).where(
+            Action.workspace_id == service.workspace_id,
+            Action.workflow_id == workflow.id,
+        )
+    )
+    await service.create_actions_from_dsl(dsl, workflow.id, action_positions)
+    await service.session.flush()
+    await service.session.refresh(workflow, ["actions"])
+
+
+def extract_layout_positions(
+    layout_data: WorkflowLayout | Mapping[str, object] | None,
+) -> tuple[
+    tuple[float, float] | None,
+    tuple[float, float, float] | None,
+    dict[str, tuple[float, float]] | None,
+]:
+    """Extract layout data into position tuples for workflow/action creation.
+
+    Returns (trigger_position, viewport, action_positions).
+    """
+    if not layout_data:
+        return None, None, None
+    layout = (
+        layout_data
+        if isinstance(layout_data, WorkflowLayout)
+        else WorkflowLayout.model_validate(layout_data)
+    )
+    trigger_position: tuple[float, float] | None = None
+    if layout.trigger is not None:
+        trigger_position = (
+            layout.trigger.x if layout.trigger.x is not None else 0.0,
+            layout.trigger.y if layout.trigger.y is not None else 0.0,
+        )
+    viewport: tuple[float, float, float] | None = None
+    if layout.viewport is not None:
+        viewport = (
+            layout.viewport.x if layout.viewport.x is not None else 0.0,
+            layout.viewport.y if layout.viewport.y is not None else 0.0,
+            layout.viewport.zoom if layout.viewport.zoom is not None else 1.0,
+        )
+    action_positions: dict[str, tuple[float, float]] | None = None
+    if layout.actions:
+        action_positions = {
+            ap.ref: (
+                ap.x if ap.x is not None else 0.0,
+                ap.y if ap.y is not None else 0.0,
+            )
+            for ap in layout.actions
+        }
+    return trigger_position, viewport, action_positions
+
+
+def apply_layout_to_workflow(
+    *,
+    workflow: Workflow,
+    layout: WorkflowLayout,
+    clear_missing: bool = False,
+    allowed_missing_action_refs: set[str] | None = None,
+) -> None:
+    """Apply optional trigger/action/viewport layout updates to a workflow."""
+    if layout.trigger is not None:
+        if clear_missing or layout.trigger.x is not None:
+            workflow.trigger_position_x = (
+                layout.trigger.x if layout.trigger.x is not None else 0.0
+            )
+        if clear_missing or layout.trigger.y is not None:
+            workflow.trigger_position_y = (
+                layout.trigger.y if layout.trigger.y is not None else 0.0
+            )
+    elif clear_missing:
+        workflow.trigger_position_x = 0.0
+        workflow.trigger_position_y = 0.0
+
+    if layout.viewport is not None:
+        if clear_missing or layout.viewport.x is not None:
+            workflow.viewport_x = (
+                layout.viewport.x if layout.viewport.x is not None else 0.0
+            )
+        if clear_missing or layout.viewport.y is not None:
+            workflow.viewport_y = (
+                layout.viewport.y if layout.viewport.y is not None else 0.0
+            )
+        if clear_missing or layout.viewport.zoom is not None:
+            workflow.viewport_zoom = (
+                layout.viewport.zoom if layout.viewport.zoom is not None else 1.0
+            )
+    elif clear_missing:
+        workflow.viewport_x = 0.0
+        workflow.viewport_y = 0.0
+        workflow.viewport_zoom = 1.0
+
+    action_by_ref = {action.ref: action for action in workflow.actions}
+    seen_action_refs: set[str] = set()
+    for action_position in layout.actions:
+        action = action_by_ref.get(action_position.ref)
+        if action is None:
+            if (
+                allowed_missing_action_refs is not None
+                and action_position.ref in allowed_missing_action_refs
+            ):
+                continue
+            raise WorkflowEditError(
+                f"Unknown action ref {action_position.ref!r} in layout.actions"
+            )
+        seen_action_refs.add(action_position.ref)
+        if clear_missing or action_position.x is not None:
+            action.position_x = (
+                action_position.x if action_position.x is not None else 0.0
+            )
+        if clear_missing or action_position.y is not None:
+            action.position_y = (
+                action_position.y if action_position.y is not None else 0.0
+            )
+
+    if clear_missing:
+        missing_action_refs = set(action_by_ref) - seen_action_refs
+        for action_ref in missing_action_refs:
+            action = action_by_ref[action_ref]
+            action.position_x = 0.0
+            action.position_y = 0.0
+
+
+async def replace_workflow_schedules(
+    *,
+    service: WorkflowSchedulesService,
+    workflow_id: WorkflowUUID,
+    schedules: Sequence[WorkflowSchedule],
+) -> None:
+    """Replace all schedules for a workflow from YAML payload."""
+    existing = await service.list_schedules(workflow_id=workflow_id)
+    for schedule in existing:
+        await service.delete_schedule(schedule.id, commit=False)
+
+    for schedule in schedules:
+        await service.create_schedule(
+            schedule_create_from_payload(
+                workflow_id=workflow_id,
+                schedule=schedule,
+            ),
+            commit=False,
+        )

--- a/tracecat/workflow/management/draft.py
+++ b/tracecat/workflow/management/draft.py
@@ -752,6 +752,12 @@ async def persist_workflow_edit_document(
     _, _, action_positions = extract_layout_positions(layout_payload)
 
     if "definition" in changed_sections:
+        # The action graph is being rewritten. Bump graph_version so a builder
+        # holding a stale base_version gets a 409 from the graph API instead of
+        # silently applying graph operations against the old action graph. The
+        # workflow row is held under FOR UPDATE for the lifetime of this session,
+        # so this increment cannot race a concurrent graph mutation.
+        workflow.graph_version += 1
         if updated_document.definition.actions:
             await replace_workflow_definition_from_dsl(
                 service=service,
@@ -819,6 +825,11 @@ async def persist_workflow_edit_document(
             workflow_id=workflow_id,
             schedules=updated_document.schedules,
         )
+        # The deleted Schedule rows are already flushed, but the eagerly-loaded
+        # workflow.schedules collection still references them; expire it so the
+        # final commit/refresh and any save-update cascade do not touch deleted
+        # instances.
+        service.session.expire(workflow, ["schedules"])
 
     if "case_trigger" in changed_sections:
         case_trigger_service = CaseTriggersService(service.session, role=role)

--- a/tracecat/workflow/schedules/service.py
+++ b/tracecat/workflow/schedules/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Sequence
 
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
@@ -87,6 +88,16 @@ class WorkflowSchedulesService(BaseWorkspaceService):
         TracecatServiceError
             If there is an error creating the schedule.
 
+        """
+        return await self._create_schedule_impl(params, commit=commit)
+
+    async def _create_schedule_impl(
+        self, params: ScheduleCreate, commit: bool = True
+    ) -> Schedule:
+        """Create a schedule without enforcing the standalone schedule scope.
+
+        Scope enforcement is the caller's responsibility (see ``create_schedule``
+        and ``replace_schedules``).
         """
         await self._lock_workflow(params.workflow_id)
         schedule = Schedule(
@@ -281,6 +292,16 @@ class WorkflowSchedulesService(BaseWorkspaceService):
             If an error occurs while deleting the schedule from Temporal.
 
         """
+        await self._delete_schedule_impl(schedule_id, commit=commit)
+
+    async def _delete_schedule_impl(
+        self, schedule_id: AnyScheduleID, commit: bool = True
+    ) -> None:
+        """Delete a schedule without enforcing the standalone schedule scope.
+
+        Scope enforcement is the caller's responsibility (see ``delete_schedule``
+        and ``replace_schedules``).
+        """
         schedule = await self._get_schedule_with_workflow_lock(schedule_id)
         await self.session.delete(schedule)
         logger.info("Deleted schedule", schedule_id=schedule_id)
@@ -301,6 +322,34 @@ class WorkflowSchedulesService(BaseWorkspaceService):
                 )
 
         add_after_commit_callback(self.session, _delete_schedule)
+
+        if commit:
+            await self.session.commit()
+        else:
+            await self.session.flush()
+
+    @require_scope("workflow:update")
+    async def replace_schedules(
+        self,
+        workflow_id: WorkflowID,
+        schedules: Sequence[ScheduleCreate],
+        commit: bool = True,
+    ) -> None:
+        """Replace all schedules for a workflow as part of a workflow edit.
+
+        This is the internal surface used by the edit-workflow document path. It
+        is gated by ``workflow:update`` (the workflow-edit permission) rather
+        than the standalone ``schedule:create``/``schedule:delete`` scopes, so a
+        user who is allowed to edit workflows can change their schedules without
+        also holding the admin-only ``schedule:delete`` scope. The delete and
+        create work happens against the unscoped helpers and is committed as a
+        single transaction with the rest of the edit.
+        """
+        existing = await self.list_schedules(workflow_id=workflow_id)
+        for schedule in existing:
+            await self._delete_schedule_impl(schedule.id, commit=False)
+        for params in schedules:
+            await self._create_schedule_impl(params, commit=False)
 
         if commit:
             await self.session.commit()

--- a/tracecat/workspaces/prompts.py
+++ b/tracecat/workspaces/prompts.py
@@ -23,9 +23,22 @@ class WorkspaceCopilotPrompts(BaseModel):
 
             You have access to various tools to help users manage their workspace:
             - Case management: List, view, update, and manage security cases
-            - Workflow operations: Query and understand automation workflows
+            - Workflow operations: Create, read, and edit automation workflows
             - Lookup tables: Access and query data tables
             - General workspace queries and operations
+
+            <workflows>
+            Whenever the user asks you to build, create, scaffold, read, inspect,
+            change, or edit a workflow, you MUST first read the
+            `tracecat-manage-workflows` skill (open its SKILL.md with the Read
+            tool) and follow it. It documents the exact `core.workflow.*` tools
+            (`create_workflow`, `get_workflow`, `edit_workflow`) and the required
+            read -> patch -> write sequence. Do NOT call `core.workflow.edit_workflow`
+            or `core.workflow.create_workflow` with a definition before consulting
+            that skill. Before editing, always `get_workflow` first and pass its
+            `draft_revision` as `base_revision`; prefer `validate_only: true` to
+            check a patch before applying it.
+            </workflows>
 
             Always be helpful, accurate, concise, and ask for clarification when needed.
         """)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds end-to-end workflow editing to Workspace Chat via RFC 6902 JSON Patch with a shared draft engine and an authoring context. Also ships always-on platform skills in `tracecat-ee`, tightens scope/error handling, bumps `graph_version`, and expires schedules on draft edits.

- **New Features**
  - Workflow editing: `core.workflow.get_workflow` (read draft) and `core.workflow.edit_workflow` (JSON Patch with `base_revision`, 409 checks) powered by a shared engine in `tracecat/workflow/management/draft.py`, reused by MCP and the internal router with consistent error mapping. Edits bump `graph_version` and expire schedules.
  - Workflow creation: `core.workflow.create_workflow` accepts optional `definition_yaml`; when provided, title is required via arg or YAML. SDK and internal router updated with an import helper.
  - Authoring context: shared builder in `tracecat/agent/authoring_context.py` with action schemas, required secret/variable hints, and a readiness summary; available via `core.workflow.get_authoring_context` and an internal endpoint. Default chat tools now include `create_workflow`, `get_workflow`, `edit_workflow`, and `get_authoring_context`. System prompt tells the model to read `tracecat-manage-workflows` before edits.
  - Built‑in skills (EE): `tracecat-manage-workflows` and `tracecat-platform-guide` packaged into `tracecat-ee` wheels (Markdown shipped) and auto‑staged by the executor for entitled Workspace Chat sessions. User/preset skills cannot use the reserved `tracecat-` prefix.
  - Hardening: editor-scope checks via `require_scopes_for_role`; artifact bindings resolve workflow title from the draft document; sandbox allows `beartype` import hooks; MCP/internal endpoints reuse shared modules; chat tools list/prompt updated.

- **Migration**
  - Skill names: user/preset skills cannot start with the reserved `tracecat-` prefix.
  - SDK: adopt optional `definition_yaml` in `create_workflow`, and the read → patch → write flow with `get_workflow`/`edit_workflow`.
  - EE skills: ensure `tracecat-ee` is installed and the org is entitled to Workspace Chat to get auto‑staged platform skills.

<sup>Written for commit 2c8dec4cff270e554aa111db31e783c9c9f9efe0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

