### PR TITLE
fix(agents): hide workspace AI models tab without org-level permission

### DIFF
--- a/frontend/src/components/settings/settings-modal.tsx
+++ b/frontend/src/components/settings/settings-modal.tsx
@@ -146,6 +146,19 @@ function SettingsModalContent() {
     !scopesLoading &&
     hasGrantedScope("workspace:update", userScopes?.scopes ?? [])
 
+  // Managing a workspace's available models calls organization-level endpoints
+  // (agent:create / agent:delete), so this tab must be gated on org-level
+  // scopes — not the workspace-scoped scopes above. A workspace-admin who is
+  // only an organization member would otherwise see an editable tab whose
+  // saves the API rejects with 403.
+  const { userScopes: orgScopes, isLoading: orgScopesLoading } = useUserScopes(
+    undefined,
+    { enabled: !!workspaceId }
+  )
+  const canManageWorkspaceModels =
+    !orgScopesLoading &&
+    hasGrantedScope("agent:create", orgScopes?.scopes ?? [])
+
   useEffect(() => {
     if (
       contextWorkspaceId ||
@@ -217,13 +230,15 @@ function SettingsModalContent() {
                         activeSection={displayedSection}
                         onSelect={setActiveSection}
                       />
-                      <NavItem
-                        icon={Cpu}
-                        label="AI models"
-                        section="workspace-models"
-                        activeSection={displayedSection}
-                        onSelect={setActiveSection}
-                      />
+                      {canManageWorkspaceModels && (
+                        <NavItem
+                          icon={Cpu}
+                          label="AI models"
+                          section="workspace-models"
+                          activeSection={displayedSection}
+                          onSelect={setActiveSection}
+                        />
+                      )}
                       <NavItem
                         icon={FileIcon}
                         label="Files"


### PR DESCRIPTION
## Summary

The workspace **Settings → AI models** tab renders its editable controls (inherit toggle, model-subset picker, **Save**) to any workspace admin. However, the mutations it calls are organization-level — `POST`/`DELETE /organization/agent-model-access` require `agent:create` / `agent:delete`, which a workspace-admin who is only an organization member does not hold. The user is shown an editable form whose saves the API rejects with **403**.

This gates the tab so it only appears for users who can actually use it.

## Fix

Render the **AI models** nav item only when the current user holds `agent:create` at the **organization** level.

The important subtlety: the workspace settings nav is already gated on `workspace:update` (workspace admin), but model-access management is enforced at the org level. A workspace-admin's *workspace-context* scopes include `agent:create`, so checking those would be a false positive. We therefore query the user's **organization-level** scopes (`useUserScopes()` with no workspace argument → `GET /users/me/scopes` with no workspace context) and check `agent:create` there.

Behavior by role:
- **Organization admin/owner** — has org-level `agent:create` → tab shows, saves succeed.
- **Workspace admin who is an org member** — org-level scopes lack `agent:create` → tab hidden (previously: visible but 403 on save).
- **Workspace editor/viewer** — unchanged; they don't see the workspace settings nav at all.

There is no path to the `workspace-models` section without the nav item (the modal defaults to the Profile section and has no deep-linking), so hiding the nav item fully prevents reaching it.

## Testing

- `pnpm typecheck` passes.
- Biome lint/format clean.
- Backend unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the workspace Settings → AI models tab unless the user has org-level permission, so users without access don’t see controls that fail on save. This prevents 403 errors for workspace admins who aren’t org admins.

- **Bug Fixes**
  - Render the AI models nav item only when org-level `agent:create` is present, using `useUserScopes()` without a workspace context.

<sup>Written for commit 863ad0c46f6565610e50b1e7e8f0bcbcbca543b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

