### PR TITLE
fix(agents): scope org-wide custom-provider/catalog reads to org admins

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -1273,6 +1273,39 @@ export const $AgentCatalogListResponse = {
   description: "List catalog entries with pagination.",
 } as const
 
+export const $AgentCatalogProviderInfo = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    display_name: {
+      type: "string",
+      title: "Display Name",
+    },
+    base_url: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Base Url",
+    },
+  },
+  type: "object",
+  required: ["id", "display_name", "base_url"],
+  title: "AgentCatalogProviderInfo",
+  description: `Non-sensitive custom-provider display info embedded in workspace models.
+
+Lets workspace-scoped surfaces render provider labels and resolve a base
+URL without calling the org-wide custom-provider list endpoint (which is
+restricted to organization admins).`,
+} as const
+
 export const $AgentCatalogRead = {
   properties: {
     id: {
@@ -31315,6 +31348,110 @@ export const $WorkflowUpdate = {
   },
   type: "object",
   title: "WorkflowUpdate",
+} as const
+
+export const $WorkspaceAgentModelListResponse = {
+  properties: {
+    items: {
+      items: {
+        $ref: "#/components/schemas/WorkspaceAgentModelRead",
+      },
+      type: "array",
+      title: "Items",
+    },
+    next_cursor: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Next Cursor",
+    },
+  },
+  type: "object",
+  required: ["items"],
+  title: "WorkspaceAgentModelListResponse",
+  description:
+    "Workspace-visible models, each with embedded custom-provider info.",
+} as const
+
+export const $WorkspaceAgentModelRead = {
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      title: "Id",
+    },
+    custom_provider_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Custom Provider Id",
+    },
+    organization_id: {
+      anyOf: [
+        {
+          type: "string",
+          format: "uuid",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Organization Id",
+    },
+    model_provider: {
+      type: "string",
+      title: "Model Provider",
+    },
+    model_name: {
+      type: "string",
+      title: "Model Name",
+    },
+    model_metadata: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Model Metadata",
+    },
+    custom_provider: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/AgentCatalogProviderInfo",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+  type: "object",
+  required: [
+    "id",
+    "custom_provider_id",
+    "organization_id",
+    "model_provider",
+    "model_name",
+    "model_metadata",
+  ],
+  title: "WorkspaceAgentModelRead",
+  description:
+    "A catalog model visible to a workspace, with embedded provider info.",
 } as const
 
 export const $WorkspaceCreate = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -338,6 +338,19 @@ export type AgentCatalogListResponse = {
 }
 
 /**
+ * Non-sensitive custom-provider display info embedded in workspace models.
+ *
+ * Lets workspace-scoped surfaces render provider labels and resolve a base
+ * URL without calling the org-wide custom-provider list endpoint (which is
+ * restricted to organization admins).
+ */
+export type AgentCatalogProviderInfo = {
+  id: string
+  display_name: string
+  base_url: string | null
+}
+
+/**
  * Single catalog model entry.
  */
 export type AgentCatalogRead = {
@@ -9311,6 +9324,29 @@ export type WorkflowUpdate = {
   error_handler?: string | null
 }
 
+/**
+ * Workspace-visible models, each with embedded custom-provider info.
+ */
+export type WorkspaceAgentModelListResponse = {
+  items: Array<WorkspaceAgentModelRead>
+  next_cursor?: string | null
+}
+
+/**
+ * A catalog model visible to a workspace, with embedded provider info.
+ */
+export type WorkspaceAgentModelRead = {
+  id: string
+  custom_provider_id: string | null
+  organization_id: string | null
+  model_provider: string
+  model_name: string
+  model_metadata: {
+    [key: string]: unknown
+  } | null
+  custom_provider?: AgentCatalogProviderInfo | null
+}
+
 export type WorkspaceCreate = {
   name: string
   settings?: WorkspaceSettingsUpdate | null
@@ -10773,7 +10809,7 @@ export type GetWorkspaceModelsData = {
   workspaceId: string
 }
 
-export type GetWorkspaceModelsResponse = AgentCatalogListResponse
+export type GetWorkspaceModelsResponse = WorkspaceAgentModelListResponse
 
 export type EnableModelData = {
   requestBody: AgentModelAccessCreate
@@ -15516,7 +15552,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: AgentCatalogListResponse
+        200: WorkspaceAgentModelListResponse
         /**
          * Validation Error
          */

--- a/frontend/src/components/agents/agent-presets-builder.tsx
+++ b/frontend/src/components/agents/agent-presets-builder.tsx
@@ -51,8 +51,8 @@ import {
 } from "react-hook-form"
 import { z } from "zod"
 import type {
+  AgentCatalogProviderInfo,
   AgentCatalogRead,
-  AgentCustomProviderRead,
   AgentPresetCapability,
   AgentPresetCreate,
   AgentPresetRead,
@@ -1211,7 +1211,7 @@ function getModelSelectionKey(selection: {
 
 function buildEnabledModelOptions(
   models: AgentCatalogRead[] | undefined,
-  providers: AgentCustomProviderRead[] | undefined
+  providers: AgentCatalogProviderInfo[] | undefined
 ): EnabledModelOption[] {
   const providersById = new Map(
     (providers ?? []).map((provider) => [provider.id, provider])

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -8,16 +8,14 @@ import {
 import Cookies from "js-cookie"
 import { AlertTriangleIcon, CircleCheck } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useCallback, useRef, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 import {
   type ActionRead,
   type ActionsDeleteActionData,
   type ActionUpdate,
-  type AgentCatalogRead,
-  type AgentCustomProviderRead,
+  type AgentCatalogProviderInfo,
   type AgentGetProviderCredentialConfigResponse,
   type AgentGetProvidersStatusResponse,
-  type AgentModelAccessRead,
   type AgentSessionsListSessionsData,
   type AgentSessionsListSessionsResponse,
   type AgentSettingsRead,
@@ -137,9 +135,6 @@ import {
   integrationsListIntegrations,
   integrationsTestConnection,
   integrationsUpdateIntegration,
-  listCatalog,
-  listCustomProviders,
-  listEnabledModels,
   type MCPIntegrationCreate,
   type MCPIntegrationRead,
   type MCPIntegrationTestConnectionRequest,
@@ -342,6 +337,7 @@ import {
   type WorkflowsListWorkflowRepositoriesResponse,
   type WorkflowsMoveWorkflowToFolderData,
   type WorkflowsRemoveTagData,
+  type WorkspaceAgentModelRead,
   type WorkspaceCreate,
   type WorkspaceReadMinimal,
   type WorkspaceUpdate,
@@ -5403,71 +5399,25 @@ export function useAgentSessions(
   }
 }
 
-const AGENT_MODEL_PAGE_SIZE = 100
-
-async function fetchAllProvidersPaginated(): Promise<
-  AgentCustomProviderRead[]
-> {
-  const items: AgentCustomProviderRead[] = []
-  let cursor: string | undefined
-
-  do {
-    const response = await listCustomProviders({
-      cursor,
-      limit: AGENT_MODEL_PAGE_SIZE,
-    })
-    items.push(...response.items)
-    cursor = response.next_cursor ?? undefined
-  } while (cursor)
-
-  return items
-}
-
 async function fetchAllWorkspaceAgentModels(
   workspaceId: string
-): Promise<AgentCatalogRead[]> {
+): Promise<WorkspaceAgentModelRead[]> {
   // The workspace-models endpoint returns the full effective set (no
-  // pagination); org enablement caps the list naturally.
+  // pagination); org enablement caps the list naturally. Each entry embeds
+  // its custom-provider display info, so workspace-scoped surfaces don't need
+  // the org-wide custom-provider list (which is restricted to org admins).
   const response = await getWorkspaceModels({ workspaceId })
   return response.items
-}
-
-async function fetchAllOrgCatalogEntries(): Promise<AgentCatalogRead[]> {
-  const items: AgentCatalogRead[] = []
-  let cursor: string | undefined
-
-  do {
-    const response = await listCatalog({
-      cursor,
-      limit: AGENT_MODEL_PAGE_SIZE,
-    })
-    items.push(...response.items)
-    cursor = response.next_cursor ?? undefined
-  } while (cursor)
-
-  return items
-}
-
-async function fetchAllOrgEnabledAccessRows(): Promise<AgentModelAccessRead[]> {
-  const items: AgentModelAccessRead[] = []
-  let cursor: string | undefined
-
-  do {
-    const response = await listEnabledModels({
-      cursor,
-      limit: AGENT_MODEL_PAGE_SIZE,
-    })
-    items.push(...response.items)
-    cursor = response.next_cursor ?? undefined
-  } while (cursor)
-
-  return items
 }
 
 /**
  * Fetch the AI models that are enabled for the given workspace via
  * AgentModelAccess. Use this anywhere a workspace-scoped picker should
  * only show models the workspace is allowed to use.
+ *
+ * `providers` is derived from the custom-provider info embedded in each
+ * model, so this hook never calls the org-wide custom-provider/catalog
+ * endpoints (which are restricted to organization admins).
  */
 export function useWorkspaceAgentModels(
   workspaceId: string | null | undefined
@@ -5478,83 +5428,28 @@ export function useWorkspaceAgentModels(
     data: models,
     isLoading: modelsLoading,
     error: modelsError,
-  } = useQuery<AgentCatalogRead[], ApiError>({
+  } = useQuery<WorkspaceAgentModelRead[], ApiError>({
     queryKey: ["workspace", workspaceId, "agent-models"],
     queryFn: async () => fetchAllWorkspaceAgentModels(workspaceId as string),
     enabled,
     retry: retryHandler,
   })
 
-  const {
-    data: providers,
-    isLoading: providersLoading,
-    error: providersError,
-  } = useQuery<AgentCustomProviderRead[], ApiError>({
-    queryKey: ["organization", "agent-providers"],
-    queryFn: fetchAllProvidersPaginated,
-    enabled,
-    retry: retryHandler,
-  })
+  const providers = useMemo<AgentCatalogProviderInfo[]>(() => {
+    const byId = new Map<string, AgentCatalogProviderInfo>()
+    for (const model of models ?? []) {
+      if (model.custom_provider) {
+        byId.set(model.custom_provider.id, model.custom_provider)
+      }
+    }
+    return Array.from(byId.values())
+  }, [models])
 
   return {
     models,
     providers,
-    modelsLoading: modelsLoading || providersLoading,
-    modelsError: modelsError ?? providersError,
-  }
-}
-
-/**
- * Fetch the AI models that are enabled at the organization level (i.e.
- * AgentModelAccess rows with workspace_id === null), joined against the
- * full catalog. Use this for org-wide pickers like the default model
- * setting.
- */
-export function useOrgAgentModels() {
-  const {
-    data: catalogEntries,
-    isLoading: catalogLoading,
-    error: catalogError,
-  } = useQuery<AgentCatalogRead[], ApiError>({
-    queryKey: ["organization", "agent-catalog"],
-    queryFn: fetchAllOrgCatalogEntries,
-    retry: retryHandler,
-  })
-
-  const {
-    data: accessRows,
-    isLoading: accessLoading,
-    error: accessError,
-  } = useQuery<AgentModelAccessRead[], ApiError>({
-    queryKey: ["organization", "agent-model-access"],
-    queryFn: fetchAllOrgEnabledAccessRows,
-    retry: retryHandler,
-  })
-
-  const {
-    data: providers,
-    isLoading: providersLoading,
-    error: providersError,
-  } = useQuery<AgentCustomProviderRead[], ApiError>({
-    queryKey: ["organization", "agent-providers"],
-    queryFn: fetchAllProvidersPaginated,
-    retry: retryHandler,
-  })
-
-  const orgEnabledCatalogIds = new Set(
-    (accessRows ?? [])
-      .filter((row) => row.workspace_id === null)
-      .map((row) => row.catalog_id)
-  )
-  const models = (catalogEntries ?? []).filter((entry) =>
-    orgEnabledCatalogIds.has(entry.id)
-  )
-
-  return {
-    models,
-    providers,
-    modelsLoading: catalogLoading || accessLoading || providersLoading,
-    modelsError: catalogError ?? accessError ?? providersError,
+    modelsLoading,
+    modelsError,
   }
 }
 
@@ -5778,7 +5673,8 @@ interface ChatReadinessOptions {
 export function useChatReadiness(options?: ChatReadinessOptions) {
   const { defaultModel, defaultModelSelection, defaultModelLoading } =
     useAgentDefaultModel()
-  const { models, providers, modelsLoading } = useOrgAgentModels()
+  const workspaceId = useWorkspaceId()
+  const { models, modelsLoading } = useWorkspaceAgentModels(workspaceId)
   const modelOverride = options?.modelOverride
 
   const loading = defaultModelLoading || modelsLoading
@@ -5825,9 +5721,7 @@ export function useChatReadiness(options?: ChatReadinessOptions) {
     }
   }
 
-  const baseUrl =
-    providers?.find((provider) => provider.id === modelCfg.custom_provider_id)
-      ?.base_url ?? null
+  const baseUrl = modelCfg.custom_provider?.base_url ?? null
   const modelInfo: ModelInfo = {
     name: modelCfg.model_name,
     provider: modelCfg.model_provider,

--- a/tracecat/agent/access/service.py
+++ b/tracecat/agent/access/service.py
@@ -6,9 +6,13 @@ from uuid import UUID
 import sqlalchemy as sa
 from sqlalchemy import exists, select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import selectinload
 
 from tracecat.agent.access.schemas import AgentModelAccessRead
-from tracecat.agent.catalog.schemas import AgentCatalogRead
+from tracecat.agent.catalog.schemas import (
+    AgentCatalogRead,
+    WorkspaceAgentModelRead,
+)
 from tracecat.audit.logger import audit_log
 from tracecat.authz.controls import require_scope
 from tracecat.db.models import AgentCatalog, AgentModelAccess, Workspace
@@ -191,11 +195,17 @@ class AgentModelAccessService(BaseOrgService):
         return [AgentCatalogRead.model_validate(row) for row in rows]
 
     @require_scope("agent:read")
-    async def get_workspace_models(self, workspace_id: UUID) -> list[AgentCatalogRead]:
+    async def get_workspace_models(
+        self, workspace_id: UUID
+    ) -> list[WorkspaceAgentModelRead]:
         """Return the effective model set for a workspace.
 
         If the workspace has any explicit access rows, those fully override the
         org-level set. Otherwise the org-level set applies.
+
+        Each entry embeds non-sensitive custom-provider display info so
+        workspace-scoped callers can render provider labels and resolve base
+        URLs without the org-wide custom-provider list endpoint.
         """
         workspace_override_exists = await self.session.scalar(
             select(
@@ -226,6 +236,7 @@ class AgentModelAccessService(BaseOrgService):
                     AgentCatalog.organization_id.is_(None),
                 ),
             )
+            .options(selectinload(AgentCatalog.custom_provider))
             .order_by(
                 AgentCatalog.model_provider.asc(),
                 AgentCatalog.model_name.asc(),
@@ -233,7 +244,7 @@ class AgentModelAccessService(BaseOrgService):
         )
 
         rows = (await self.session.execute(stmt)).scalars().all()
-        return [AgentCatalogRead.model_validate(row) for row in rows]
+        return [WorkspaceAgentModelRead.model_validate(row) for row in rows]
 
     async def is_catalog_enabled(
         self,

--- a/tracecat/agent/catalog/router.py
+++ b/tracecat/agent/catalog/router.py
@@ -10,6 +10,7 @@ from tracecat.agent.catalog.schemas import (
     AgentCatalogListResponse,
     AgentCatalogRead,
     AgentCatalogUpdate,
+    WorkspaceAgentModelListResponse,
 )
 from tracecat.agent.catalog.service import AgentCatalogService
 from tracecat.auth.dependencies import OrgUserRole, WorkspaceUserPathRole
@@ -25,7 +26,7 @@ router = APIRouter()
     "/organization/agent-catalog",
     response_model=AgentCatalogListResponse,
 )
-@require_scope("agent:read")
+@require_scope("org:settings:read")
 async def list_catalog(
     role: OrgUserRole,
     session: AsyncDBSession,
@@ -56,7 +57,7 @@ async def list_catalog(
     "/organization/agent-catalog/{catalog_id}",
     response_model=AgentCatalogRead,
 )
-@require_scope("agent:read")
+@require_scope("org:settings:read")
 async def get_catalog_entry(
     catalog_id: UUID,
     role: OrgUserRole,
@@ -193,18 +194,20 @@ async def delete_catalog_entry(
 
 @router.get(
     "/workspaces/{workspace_id}/agent-models",
-    response_model=AgentCatalogListResponse,
+    response_model=WorkspaceAgentModelListResponse,
 )
 @require_scope("agent:read")
 async def get_workspace_models(
     workspace_id: UUID,
     role: WorkspaceUserPathRole,
     session: AsyncDBSession,
-) -> AgentCatalogListResponse:
+) -> WorkspaceAgentModelListResponse:
     """Get models accessible to a workspace.
 
     Returns the full effective set; the list is bounded by org enablement
-    and is expected to be small, so pagination is not used here.
+    and is expected to be small, so pagination is not used here. Each entry
+    embeds non-sensitive custom-provider display info (id, display name, base
+    URL) so workspace-scoped surfaces don't need the org-wide provider list.
     """
     if role.workspace_id != workspace_id:
         raise HTTPException(
@@ -220,4 +223,4 @@ async def get_workspace_models(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         ) from e
-    return AgentCatalogListResponse(items=models, next_cursor=None)
+    return WorkspaceAgentModelListResponse(items=models, next_cursor=None)

--- a/tracecat/agent/catalog/schemas.py
+++ b/tracecat/agent/catalog/schemas.py
@@ -26,6 +26,34 @@ class AgentCatalogListResponse(BaseModel):
     next_cursor: str | None = None
 
 
+class AgentCatalogProviderInfo(BaseModel):
+    """Non-sensitive custom-provider display info embedded in workspace models.
+
+    Lets workspace-scoped surfaces render provider labels and resolve a base
+    URL without calling the org-wide custom-provider list endpoint (which is
+    restricted to organization admins).
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    display_name: str
+    base_url: str | None
+
+
+class WorkspaceAgentModelRead(AgentCatalogRead):
+    """A catalog model visible to a workspace, with embedded provider info."""
+
+    custom_provider: AgentCatalogProviderInfo | None = None
+
+
+class WorkspaceAgentModelListResponse(BaseModel):
+    """Workspace-visible models, each with embedded custom-provider info."""
+
+    items: list[WorkspaceAgentModelRead]
+    next_cursor: str | None = None
+
+
 class CloudCatalogModelBase(BaseModel):
     """Shared, user-supplied fields for a cloud catalog entry.
 

--- a/tracecat/agent/provider/router.py
+++ b/tracecat/agent/provider/router.py
@@ -39,7 +39,7 @@ async def create_custom_provider(
     "",
     response_model=AgentCustomProviderListResponse,
 )
-@require_scope("agent:read")
+@require_scope("org:settings:read")
 async def list_custom_providers(
     role: OrgUserRole,
     session: AsyncDBSession,
@@ -66,7 +66,7 @@ async def list_custom_providers(
     "/{provider_id}",
     response_model=AgentCustomProviderRead,
 )
-@require_scope("agent:read")
+@require_scope("org:settings:read")
 async def get_custom_provider(
     provider_id: UUID,
     role: OrgUserRole,


### PR DESCRIPTION
## Summary

The organization-wide agent provider and catalog **read** endpoints require only `agent:read`, which every `organization-member` holds. As a result, any member — including a user whose only elevated role is `workspace-admin` on a single workspace — can enumerate **all** custom providers and catalog entries across the entire organization, not just the workspaces they belong to.

`AgentCustomProviderRead` exposes `display_name`, `base_url`, `passthrough`, and `api_key_header` for every provider in the org. The encrypted API key itself is never serialized, so credentials don't leak — but provider existence, names, and base URLs configured for other workspaces do.

## Fix

Gate the org-wide reads on `org:settings:read` (held by org admins/owners, not members):

- `GET /organization/agent-catalog` (list + `{id}`)
- `GET /organization/agent-custom-providers` (list + `{id}`)

Workspace-scoped surfaces no longer need those org-wide lists. The workspace endpoint `GET /workspaces/{workspace_id}/agent-models` now embeds non-sensitive custom-provider display info (`id`, `display_name`, `base_url`) on each model it returns. On the frontend, `useWorkspaceAgentModels` derives its provider list from that embedded data, and the chat-readiness path reads workspace-scoped data — so agent creation, the workflow builder, agent presets, and chat/inbox readiness continue to work for non-admin users without ever calling the org-wide endpoints.

## Notes

- The single-GET endpoints (`/{id}`) are not consumed by the frontend, so gating them is safe.
- Behavior change worth noting: chat readiness is now evaluated against the models enabled for the active workspace rather than the org-wide set. If a workspace narrows its model subset to exclude the default model, readiness correctly reports that no model is available.

## Testing

- Backend: `test_agent_catalog_service.py`, `test_agent_provider_service.py`, `test_api_actor_roles.py`, `test_api_admin_agent.py`, and `test_mcp_server.py` pass (304 tests).
- Frontend: `pnpm typecheck` passes against the regenerated client.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts org‑wide agent provider/catalog reads to org admins and moves provider display data into workspace model responses so non‑admin surfaces keep working without org‑wide calls.

- **Bug Fixes**
  - Regated `GET /organization/agent-catalog` (list + `{id}`) and `GET /organization/agent-custom-providers` (list + `{id}`) to `org:settings:read`.
  - `GET /workspaces/{workspace_id}/agent-models` returns workspace‑visible models with embedded `custom_provider` info (`id`, `display_name`, `base_url`).
  - Chat readiness now checks models enabled for the active workspace; if the workspace excludes the default model, readiness reports none available.

- **Refactors**
  - Added `AgentCatalogProviderInfo`, `WorkspaceAgentModelRead`, and `WorkspaceAgentModelListResponse`; updated `GET /workspaces/{workspace_id}/agent-models` to use the new response.
  - Frontend: `useWorkspaceAgentModels` derives providers from embedded data; removed org‑wide provider/catalog fetches; updated `GetWorkspaceModelsResponse` and `agent-presets-builder` to use `AgentCatalogProviderInfo`.
  - Service layer loads `custom_provider` via `selectinload` when building workspace model results.

<sup>Written for commit c7130189d2395ce25f2def7e1a89eb233ee6b0b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

