### PR TITLE
fix(agents): batch agent approvals

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4770,17 +4770,12 @@ export const $ApprovalRead = {
     decision: {
       anyOf: [
         {
-          type: "boolean",
-        },
-        {
-          additionalProperties: true,
-          type: "object",
+          $ref: "#/components/schemas/PersistedApprovalDecision",
         },
         {
           type: "null",
         },
       ],
-      title: "Decision",
     },
     approved_by: {
       anyOf: [
@@ -6137,6 +6132,24 @@ export const $Body_workflows_create_workflow = {
   },
   type: "object",
   title: "Body_workflows-create_workflow",
+} as const
+
+export const $BooleanApprovalDecision = {
+  properties: {
+    value: {
+      type: "boolean",
+      title: "Value",
+    },
+    metadata: {
+      additionalProperties: true,
+      type: "object",
+      title: "Metadata",
+    },
+  },
+  type: "object",
+  required: ["value", "metadata"],
+  title: "BooleanApprovalDecision",
+  description: "Persisted boolean decision enriched with submission metadata.",
 } as const
 
 export const $CachePoint = {
@@ -18480,6 +18493,23 @@ export const $PayloadChangedEventRead = {
   description: "Event for when a case payload is changed.",
 } as const
 
+export const $PersistedApprovalDecision = {
+  anyOf: [
+    {
+      type: "boolean",
+    },
+    {
+      $ref: "#/components/schemas/ToolApprovedDecision",
+    },
+    {
+      $ref: "#/components/schemas/ToolDeniedDecision",
+    },
+    {
+      $ref: "#/components/schemas/BooleanApprovalDecision",
+    },
+  ],
+} as const
+
 export const $PlatformAuditSettingsRead = {
   properties: {
     audit_webhook_url: {
@@ -26629,6 +26659,31 @@ export const $ToolApproved = {
   title: "ToolApproved",
 } as const
 
+export const $ToolApprovedDecision = {
+  properties: {
+    kind: {
+      type: "string",
+      const: "tool-approved",
+      title: "Kind",
+    },
+    override_args: {
+      additionalProperties: true,
+      type: "object",
+      title: "Override Args",
+    },
+    metadata: {
+      additionalProperties: true,
+      type: "object",
+      title: "Metadata",
+    },
+  },
+  type: "object",
+  required: ["kind"],
+  title: "ToolApprovedDecision",
+  description:
+    "Persisted decision for a tool approved with argument overrides.",
+} as const
+
 export const $ToolDenied = {
   properties: {
     message: {
@@ -26645,6 +26700,29 @@ export const $ToolDenied = {
   },
   type: "object",
   title: "ToolDenied",
+} as const
+
+export const $ToolDeniedDecision = {
+  properties: {
+    kind: {
+      type: "string",
+      const: "tool-denied",
+      title: "Kind",
+    },
+    message: {
+      type: "string",
+      title: "Message",
+    },
+    metadata: {
+      additionalProperties: true,
+      type: "object",
+      title: "Metadata",
+    },
+  },
+  type: "object",
+  required: ["kind"],
+  title: "ToolDeniedDecision",
+  description: "Persisted decision for a denied tool call.",
 } as const
 
 export const $ToolResultBlock = {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -4700,28 +4700,7 @@ export const $ApprovalInteraction = {
 
 export const $ApprovalMap = {
   additionalProperties: {
-    anyOf: [
-      {
-        type: "boolean",
-      },
-      {
-        oneOf: [
-          {
-            $ref: "#/components/schemas/ToolApproved",
-          },
-          {
-            $ref: "#/components/schemas/ToolDenied",
-          },
-        ],
-        discriminator: {
-          propertyName: "kind",
-          mapping: {
-            "tool-approved": "#/components/schemas/ToolApproved",
-            "tool-denied": "#/components/schemas/ToolDenied",
-          },
-        },
-      },
-    ],
+    $ref: "#/components/schemas/ApprovalResult",
   },
   type: "object",
 } as const
@@ -4811,6 +4790,31 @@ export const $ApprovalRead = {
   required: ["id", "tool_call_id", "tool_name", "status", "created_at"],
   title: "ApprovalRead",
   description: "Response schema for approval data in chat timeline.",
+} as const
+
+export const $ApprovalResult = {
+  anyOf: [
+    {
+      type: "boolean",
+    },
+    {
+      oneOf: [
+        {
+          $ref: "#/components/schemas/ToolApproved",
+        },
+        {
+          $ref: "#/components/schemas/ToolDenied",
+        },
+      ],
+      discriminator: {
+        propertyName: "kind",
+        mapping: {
+          "tool-approved": "#/components/schemas/ToolApproved",
+          "tool-denied": "#/components/schemas/ToolDenied",
+        },
+      },
+    },
+  ],
 } as const
 
 export const $ApprovalStatus = {

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1156,7 +1156,7 @@ export type ApprovalInteraction = {
 }
 
 export type ApprovalMap = {
-  [key: string]: boolean | ToolApproved | ToolDenied
+  [key: string]: ApprovalResult
 }
 
 /**
@@ -1176,6 +1176,8 @@ export type ApprovalRead = {
   approved_at?: string | null
   created_at: string
 }
+
+export type ApprovalResult = boolean | ToolApproved | ToolDenied
 
 /**
  * Possible states for a deferred tool approval.

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -1171,12 +1171,7 @@ export type ApprovalRead = {
   } | null
   status: ApprovalStatus
   reason?: string | null
-  decision?:
-    | boolean
-    | {
-        [key: string]: unknown
-      }
-    | null
+  decision?: PersistedApprovalDecision | null
   approved_by?: string | null
   approved_at?: string | null
   created_at: string
@@ -1571,6 +1566,16 @@ export type Body_workflows_create_workflow = {
    */
   use_workflow_id?: boolean
   file?: (Blob | File) | null
+}
+
+/**
+ * Persisted boolean decision enriched with submission metadata.
+ */
+export type BooleanApprovalDecision = {
+  value: boolean
+  metadata: {
+    [key: string]: unknown
+  }
 }
 
 export type CachePoint = {
@@ -5572,6 +5577,12 @@ export type PayloadChangedEventRead = {
   created_at: string
 }
 
+export type PersistedApprovalDecision =
+  | boolean
+  | ToolApprovedDecision
+  | ToolDeniedDecision
+  | BooleanApprovalDecision
+
 /**
  * Platform audit settings response.
  */
@@ -8060,9 +8071,33 @@ export type ToolApproved = {
   kind?: "tool-approved"
 }
 
+/**
+ * Persisted decision for a tool approved with argument overrides.
+ */
+export type ToolApprovedDecision = {
+  kind: "tool-approved"
+  override_args?: {
+    [key: string]: unknown
+  }
+  metadata?: {
+    [key: string]: unknown
+  }
+}
+
 export type ToolDenied = {
   message?: string
   kind?: "tool-denied"
+}
+
+/**
+ * Persisted decision for a denied tool call.
+ */
+export type ToolDeniedDecision = {
+  kind: "tool-denied"
+  message?: string
+  metadata?: {
+    [key: string]: unknown
+  }
 }
 
 export type ToolResultBlock = {

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -2063,6 +2063,49 @@ type DecisionState = {
   overrideArgs?: string
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function submittedDecisionFromApproval(
+  approval: ApprovalCard
+): DecisionState | undefined {
+  if (approval.status === "approved") {
+    if (
+      isRecord(approval.decision) &&
+      approval.decision.kind === "tool-approved" &&
+      "override_args" in approval.decision
+    ) {
+      return {
+        action: "override",
+        overrideArgs: formatArgs(approval.decision.override_args),
+      }
+    }
+    return { action: "approve" }
+  }
+
+  if (approval.status === "rejected") {
+    const reason =
+      approval.reason ??
+      (isRecord(approval.decision) &&
+      typeof approval.decision.message === "string"
+        ? approval.decision.message
+        : undefined)
+    return { action: "deny", reason }
+  }
+
+  return undefined
+}
+
+function approvalStateKey(approval: ApprovalCard): string {
+  return JSON.stringify({
+    id: approval.tool_call_id,
+    status: approval.status ?? "pending",
+    decision: approval.decision ?? null,
+    reason: approval.reason ?? null,
+  })
+}
+
 function ApprovalRequestPart({
   approvals,
   onSubmit,
@@ -2077,13 +2120,20 @@ function ApprovalRequestPart({
   const [submitting, setSubmitting] = useState(false)
 
   const approvalsKey = useMemo(
-    () => approvals.map((a) => a.tool_call_id).join(":"),
+    () => approvals.map(approvalStateKey).join(":"),
     [approvals]
   )
 
   useEffect(() => {
+    const nextSubmittedDecisions: Record<string, DecisionState> = {}
+    for (const approval of approvals) {
+      const submittedDecision = submittedDecisionFromApproval(approval)
+      if (submittedDecision) {
+        nextSubmittedDecisions[approval.tool_call_id] = submittedDecision
+      }
+    }
     setDecisions({})
-    setSubmittedDecisions({})
+    setSubmittedDecisions(nextSubmittedDecisions)
   }, [approvalsKey])
 
   const hasSelectedPendingDecision =

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -118,6 +118,8 @@ import {
   getSessionLastError,
   isApprovalCardArray,
   isInterruptArtifactError,
+  isToolApprovedDecision,
+  isToolDeniedDecision,
   type ModelInfo,
   toUIMessage,
   transformMessages,
@@ -2063,18 +2065,13 @@ type DecisionState = {
   overrideArgs?: string
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null
-}
-
 function submittedDecisionFromApproval(
   approval: ApprovalCard
 ): DecisionState | undefined {
   if (approval.status === "approved") {
     if (
-      isRecord(approval.decision) &&
-      approval.decision.kind === "tool-approved" &&
-      "override_args" in approval.decision
+      isToolApprovedDecision(approval.decision) &&
+      approval.decision.override_args !== undefined
     ) {
       return {
         action: "override",
@@ -2087,7 +2084,7 @@ function submittedDecisionFromApproval(
   if (approval.status === "rejected") {
     const reason =
       approval.reason ??
-      (isRecord(approval.decision) &&
+      (isToolDeniedDecision(approval.decision) &&
       typeof approval.decision.message === "string"
         ? approval.decision.message
         : undefined)

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -2071,6 +2071,9 @@ function ApprovalRequestPart({
   onSubmit?: (decisions: ApprovalDecision[]) => Promise<void>
 }) {
   const [decisions, setDecisions] = useState<Record<string, DecisionState>>({})
+  const [submittedDecisions, setSubmittedDecisions] = useState<
+    Record<string, DecisionState>
+  >({})
   const [submitting, setSubmitting] = useState(false)
 
   const approvalsKey = useMemo(
@@ -2080,11 +2083,23 @@ function ApprovalRequestPart({
 
   useEffect(() => {
     setDecisions({})
+    setSubmittedDecisions({})
   }, [approvalsKey])
 
-  const readyToSubmit =
+  const hasSelectedPendingDecision =
     approvals.length > 0 &&
-    approvals.every((approval) => decisions[approval.tool_call_id]?.action)
+    approvals.some((approval) => {
+      if (submittedDecisions[approval.tool_call_id]) {
+        return false
+      }
+      return Boolean(decisions[approval.tool_call_id]?.action)
+    })
+
+  const allApprovalsSubmitted =
+    approvals.length > 0 &&
+    approvals.every((approval) =>
+      Boolean(submittedDecisions[approval.tool_call_id])
+    )
 
   const setDecision = useCallback(
     (toolCallId: string, update: Partial<DecisionState>) => {
@@ -2100,26 +2115,28 @@ function ApprovalRequestPart({
   )
 
   const handleSubmit = useCallback(async () => {
-    if (!onSubmit || !readyToSubmit) {
+    if (!onSubmit || !hasSelectedPendingDecision) {
       toast({
         title: "Pending decisions",
-        description: "Choose an action for each tool before continuing.",
+        description:
+          "Choose an action for at least one tool before continuing.",
       })
       return
     }
 
     const payload: ApprovalDecision[] = []
+    const acceptedDecisions: Record<string, DecisionState> = {}
     for (const approval of approvals) {
+      if (submittedDecisions[approval.tool_call_id]) {
+        continue
+      }
       const decision = decisions[approval.tool_call_id]
       if (!decision?.action) {
-        toast({
-          title: "Missing decision",
-          description: `Select an action for ${approval.tool_name}.`,
-        })
-        return
+        continue
       }
       if (decision.action === "approve") {
         payload.push({ tool_call_id: approval.tool_call_id, action: "approve" })
+        acceptedDecisions[approval.tool_call_id] = decision
       } else if (decision.action === "override") {
         try {
           const parsed = decision.overrideArgs
@@ -2130,6 +2147,7 @@ function ApprovalRequestPart({
             action: "override",
             override_args: parsed,
           })
+          acceptedDecisions[approval.tool_call_id] = decision
         } catch {
           toast({
             variant: "destructive",
@@ -2144,19 +2162,36 @@ function ApprovalRequestPart({
           action: "deny",
           reason: decision.reason ?? "",
         })
+        acceptedDecisions[approval.tool_call_id] = decision
       }
     }
 
     try {
       setSubmitting(true)
       await onSubmit(payload)
-      setDecisions({})
+      setSubmittedDecisions((prev) => ({
+        ...prev,
+        ...acceptedDecisions,
+      }))
+      setDecisions((prev) => {
+        const next = { ...prev }
+        for (const toolCallId of Object.keys(acceptedDecisions)) {
+          delete next[toolCallId]
+        }
+        return next
+      })
     } catch (error) {
       console.error(error)
     } finally {
       setSubmitting(false)
     }
-  }, [approvals, decisions, onSubmit, readyToSubmit])
+  }, [
+    approvals,
+    decisions,
+    hasSelectedPendingDecision,
+    onSubmit,
+    submittedDecisions,
+  ])
 
   const disabled = !onSubmit
 
@@ -2170,19 +2205,31 @@ function ApprovalRequestPart({
         {approvals.map((approval, index) => {
           const actionId = approval.tool_name.replaceAll("__", ".")
           const decision = decisions[approval.tool_call_id]
+          const submittedDecision = submittedDecisions[approval.tool_call_id]
+          const visibleDecision = submittedDecision ?? decision
+          const isSubmitted = Boolean(submittedDecision)
           const initialOverrideArgs = formatArgs(approval.args)
           const isLastApproval = index === approvals.length - 1
           return (
             <div
               key={approval.tool_call_id}
-              className="space-y-3 rounded-md border border-border/60 bg-background p-3"
+              data-testid={`approval-card-${approval.tool_call_id}`}
+              className={cn(
+                "space-y-3 rounded-md border border-border/60 bg-background p-3 transition-colors",
+                isSubmitted && "bg-muted/10",
+                !isSubmitted &&
+                  visibleDecision?.action !== undefined &&
+                  "border-foreground/20"
+              )}
             >
               <div className="flex flex-wrap items-center justify-between gap-3">
-                <div>
-                  <div className="flex items-center gap-2.5">
+                <div className="min-w-0 flex-1">
+                  <div className="flex min-w-0 flex-wrap items-center gap-2.5">
                     {getIcon(actionId, TOOL_ICON_PROPS)}
-                    <p className="font-medium text-sm">{actionId}</p>
-                    {getStatusBadge("approval-requested")}
+                    <p className="min-w-0 truncate font-medium text-sm">
+                      {actionId}
+                    </p>
+                    {isSubmitted ? null : getStatusBadge("approval-requested")}
                   </div>
                 </div>
                 <JsonViewWithControls
@@ -2196,7 +2243,7 @@ function ApprovalRequestPart({
                     type="button"
                     size="sm"
                     variant="outline"
-                    disabled={disabled || submitting}
+                    disabled={disabled || submitting || isSubmitted}
                     onClick={() =>
                       setDecision(approval.tool_call_id, {
                         action: "approve",
@@ -2205,8 +2252,8 @@ function ApprovalRequestPart({
                       })
                     }
                     className={cn(
-                      decision?.action === "approve" &&
-                        "border-success bg-background text-success hover:bg-success/10 hover:text-success"
+                      visibleDecision?.action === "approve" &&
+                        "border-success/55 text-success hover:border-success/65 hover:bg-background hover:text-success disabled:opacity-100"
                     )}
                   >
                     <CheckIcon className="mr-1 size-3" />
@@ -2216,7 +2263,7 @@ function ApprovalRequestPart({
                     type="button"
                     size="sm"
                     variant="outline"
-                    disabled={disabled || submitting}
+                    disabled={disabled || submitting || isSubmitted}
                     onClick={() =>
                       setDecision(approval.tool_call_id, {
                         action: "override",
@@ -2226,8 +2273,8 @@ function ApprovalRequestPart({
                       })
                     }
                     className={cn(
-                      decision?.action === "override" &&
-                        "border-success bg-background text-success hover:bg-success/10 hover:text-success"
+                      visibleDecision?.action === "override" &&
+                        "border-success/55 text-success hover:border-success/65 hover:bg-background hover:text-success disabled:opacity-100"
                     )}
                   >
                     <PencilIcon className="mr-1 size-3" />
@@ -2237,7 +2284,7 @@ function ApprovalRequestPart({
                     type="button"
                     size="sm"
                     variant="outline"
-                    disabled={disabled || submitting}
+                    disabled={disabled || submitting || isSubmitted}
                     onClick={() =>
                       setDecision(approval.tool_call_id, {
                         action: "deny",
@@ -2245,8 +2292,8 @@ function ApprovalRequestPart({
                       })
                     }
                     className={cn(
-                      decision?.action === "deny" &&
-                        "border-destructive bg-background text-destructive hover:bg-destructive/10 hover:text-destructive"
+                      visibleDecision?.action === "deny" &&
+                        "border-destructive/55 text-destructive hover:border-destructive/65 hover:bg-background hover:text-destructive disabled:opacity-100"
                     )}
                   >
                     <XIcon className="mr-1 size-3" />
@@ -2254,19 +2301,24 @@ function ApprovalRequestPart({
                   </Button>
                 </div>
               </div>
-              {decision?.action === "override" && (
+              {visibleDecision?.action === "override" && (
                 <div
                   data-testid={`approval-override-editor-${approval.tool_call_id}`}
                 >
                   <CodeEditor
-                    value={decision.overrideArgs ?? initialOverrideArgs}
+                    value={visibleDecision.overrideArgs ?? initialOverrideArgs}
                     language="json"
-                    onChange={(value) =>
+                    readOnly={disabled || submitting || isSubmitted}
+                    onChange={(value) => {
+                      if (isSubmitted) {
+                        return
+                      }
                       setDecision(approval.tool_call_id, {
-                        ...decision,
+                        ...(decision ?? {}),
+                        action: "override",
                         overrideArgs: value,
                       })
-                    }
+                    }}
                     className={cn(
                       "text-xs",
                       "[&_.cm-editor]:!border [&_.cm-editor]:!border-input [&_.cm-editor]:!bg-background [&_.cm-editor]:rounded-md",
@@ -2275,35 +2327,48 @@ function ApprovalRequestPart({
                   />
                 </div>
               )}
-              {decision?.action === "deny" && (
+              {visibleDecision?.action === "deny" && (
                 <Textarea
                   className="text-xs"
                   rows={3}
-                  value={decision.reason ?? ""}
+                  value={visibleDecision.reason ?? ""}
                   onChange={(event) =>
                     setDecision(approval.tool_call_id, {
-                      ...decision,
+                      ...(decision ?? {}),
+                      action: "deny",
                       reason: event.target.value,
                     })
                   }
                   placeholder="Share a short reason"
-                  disabled={disabled || submitting}
+                  disabled={disabled || submitting || isSubmitted}
                 />
               )}
               {isLastApproval && (
                 <div className="flex flex-wrap justify-end gap-2 pt-1">
                   <Button
                     type="button"
+                    variant={allApprovalsSubmitted ? "outline" : "default"}
                     onClick={handleSubmit}
-                    disabled={disabled || submitting || !readyToSubmit}
-                    className="h-6 gap-1 px-2 text-xs"
+                    disabled={
+                      disabled ||
+                      submitting ||
+                      allApprovalsSubmitted ||
+                      !hasSelectedPendingDecision
+                    }
+                    className={cn(
+                      "h-6 gap-1 px-2 text-xs",
+                      allApprovalsSubmitted &&
+                        "border-border bg-muted text-muted-foreground disabled:opacity-100"
+                    )}
                   >
                     {submitting ? (
                       <Loader2 className="size-3 animate-spin" />
                     ) : (
                       <CheckIcon className="size-3" />
                     )}
-                    {submitting ? "Submitting..." : "Submit"}
+                    {submitting && "Submitting..."}
+                    {!submitting && allApprovalsSubmitted && "Submitted"}
+                    {!submitting && !allApprovalsSubmitted && "Submit"}
                   </Button>
                 </div>
               )}

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -484,9 +484,9 @@ export function transformMessages(messages: ai.UIMessage[]): ai.UIMessage[] {
         const trace = getTrace(toolCallId)
         recordDedupe(trace, posKey, hasOutput)
 
-        if (state === "input-available") {
+        if (state === "input-streaming" || state === "input-available") {
           // OPEN STATE
-          // If we encounter an input-available part, we open a tool call state.
+          // If we encounter an input part, we open a tool call state.
           // A fresh open supersedes any prior open/approval bookkeeping.
           trace.openPos = posKey
           trace.approvalPos = undefined

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -4,6 +4,7 @@ import type {
   AgentSessionEntity,
   AgentSessionRead,
   AgentSessionReadVercel,
+  ApprovalStatus,
   ChatReadMinimal,
   ChatReadVercel,
   UIMessage,
@@ -14,6 +15,9 @@ export type ApprovalCard = {
   tool_call_id: string
   tool_name: string
   args?: unknown
+  status?: ApprovalStatus
+  decision?: boolean | Record<string, unknown> | null
+  reason?: string | null
 }
 
 type ServerToolPart = Extract<UIMessage["parts"][number], { state: string }>
@@ -484,7 +488,10 @@ export function transformMessages(messages: ai.UIMessage[]): ai.UIMessage[] {
         const trace = getTrace(toolCallId)
         recordDedupe(trace, posKey, hasOutput)
 
-        if (state === "input-streaming" || state === "input-available") {
+        if (
+          !trace.hasOutput &&
+          (state === "input-streaming" || state === "input-available")
+        ) {
           // OPEN STATE
           // If we encounter an input part, we open a tool call state.
           // A fresh open supersedes any prior open/approval bookkeeping.

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -4,6 +4,7 @@ import type {
   AgentSessionEntity,
   AgentSessionRead,
   AgentSessionReadVercel,
+  ApprovalRead,
   ApprovalStatus,
   ChatReadMinimal,
   ChatReadVercel,
@@ -16,9 +17,19 @@ export type ApprovalCard = {
   tool_name: string
   args?: unknown
   status?: ApprovalStatus
-  decision?: boolean | Record<string, unknown> | null
+  decision?: ApprovalRead["decision"]
   reason?: string | null
 }
+
+type PersistedApprovalDecision = NonNullable<ApprovalRead["decision"]>
+type ToolApprovedDecision = Extract<
+  PersistedApprovalDecision,
+  { kind: "tool-approved" }
+>
+type ToolDeniedDecision = Extract<
+  PersistedApprovalDecision,
+  { kind: "tool-denied" }
+>
 
 type ServerToolPart = Extract<UIMessage["parts"][number], { state: string }>
 type LegacyToolState =
@@ -394,6 +405,30 @@ export function isApprovalCardArray(data: unknown): data is ApprovalCard[] {
         item.tool_name.length > 0
       )
     })
+  )
+}
+
+/** Whether a persisted approval decision contains tool argument overrides. */
+export function isToolApprovedDecision(
+  decision: unknown
+): decision is ToolApprovedDecision {
+  return (
+    typeof decision === "object" &&
+    decision !== null &&
+    "kind" in decision &&
+    decision.kind === "tool-approved"
+  )
+}
+
+/** Whether a persisted approval decision denies a tool call. */
+export function isToolDeniedDecision(
+  decision: unknown
+): decision is ToolDeniedDecision {
+  return (
+    typeof decision === "object" &&
+    decision !== null &&
+    "kind" in decision &&
+    decision.kind === "tool-denied"
   )
 }
 

--- a/frontend/tests/chat-session-pane.test.tsx
+++ b/frontend/tests/chat-session-pane.test.tsx
@@ -1,5 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react"
 import type { UIMessage } from "ai"
 import { StrictMode } from "react"
 import type { AgentSessionReadVercel, MCPIntegrationRead } from "@/client"
@@ -772,6 +778,109 @@ describe("ChatSessionPane", () => {
         ],
       })
     )
+  })
+
+  it("submits selected approval decisions without requiring the full batch", async () => {
+    const sendMessage = jest.fn().mockResolvedValue(undefined)
+
+    mockUseVercelChat.mockReturnValue({
+      sendMessage,
+      setMessages: jest.fn(),
+      regenerate: jest.fn(),
+      messages: [
+        {
+          id: "msg-approval",
+          role: "assistant",
+          parts: [
+            {
+              type: "data-approval-request",
+              data: [
+                {
+                  tool_call_id: "tc-1",
+                  tool_name: "core__http_request",
+                  args: { url: "https://example.com" },
+                },
+                {
+                  tool_call_id: "tc-2",
+                  tool_name: "core__http_request",
+                  args: { url: "https://example.org" },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      status: "ready",
+      lastError: null,
+      clearError: jest.fn(),
+      // biome-ignore lint/suspicious/noExplicitAny: mock return type needs flexibility for testing
+    } as any)
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <ChatSessionPane
+            chat={createChatFixture()}
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+          />
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+
+    const firstCard = screen.getByTestId("approval-card-tc-1")
+    const secondCard = screen.getByTestId("approval-card-tc-2")
+    const approvalSubmit = screen
+      .getAllByRole("button", { name: "Submit" })
+      .find((button) => button.textContent?.trim() === "Submit")
+    if (!approvalSubmit) {
+      throw new Error("Approval submit button not found")
+    }
+
+    expect(approvalSubmit).toBeDisabled()
+
+    fireEvent.click(within(firstCard).getByRole("button", { name: "Approve" }))
+    expect(approvalSubmit).toBeEnabled()
+
+    fireEvent.click(approvalSubmit)
+
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledTimes(1)
+    })
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parts: [
+          expect.objectContaining({
+            data: expect.objectContaining({
+              decisions: [
+                expect.objectContaining({
+                  tool_call_id: "tc-1",
+                  action: "approve",
+                }),
+              ],
+            }),
+          }),
+        ],
+      })
+    )
+
+    expect(
+      within(firstCard).queryByLabelText("Decision: Approved")
+    ).not.toBeInTheDocument()
+    expect(firstCard).toHaveClass("bg-muted/10")
+    expect(firstCard).not.toHaveClass("opacity-75")
+    const submittedApproveButton = within(firstCard).getByRole("button", {
+      name: "Approve",
+    })
+    expect(submittedApproveButton).toBeDisabled()
+    expect(submittedApproveButton).toHaveClass("border-success/55")
+    expect(submittedApproveButton).toHaveClass("text-success")
+    expect(submittedApproveButton).toHaveClass("disabled:opacity-100")
+    expect(
+      within(secondCard).queryByLabelText("Decision: Approved")
+    ).not.toBeInTheDocument()
   })
 
   it("supports @ mention tools in draft mode and passes selected tools before first send", async () => {

--- a/frontend/tests/chat-session-pane.test.tsx
+++ b/frontend/tests/chat-session-pane.test.tsx
@@ -883,6 +883,79 @@ describe("ChatSessionPane", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("mounts previously submitted approval cards as disabled", () => {
+    mockUseVercelChat.mockReturnValue({
+      sendMessage: jest.fn(),
+      setMessages: jest.fn(),
+      regenerate: jest.fn(),
+      messages: [
+        {
+          id: "msg-approval",
+          role: "assistant",
+          parts: [
+            {
+              type: "data-approval-request",
+              data: [
+                {
+                  tool_call_id: "tc-1",
+                  tool_name: "core__http_request",
+                  args: { url: "https://example.com" },
+                  status: "approved",
+                  decision: true,
+                },
+                {
+                  tool_call_id: "tc-2",
+                  tool_name: "core__http_request",
+                  args: { url: "https://example.org" },
+                  status: "pending",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      status: "ready",
+      lastError: null,
+      clearError: jest.fn(),
+      // biome-ignore lint/suspicious/noExplicitAny: mock return type needs flexibility for testing
+    } as any)
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <ChatSessionPane
+            chat={createChatFixture()}
+            workspaceId="workspace-1"
+            entityType="case"
+            entityId="case-1"
+            modelInfo={{ name: "gpt-4o-mini", provider: "openai" }}
+          />
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+
+    const firstCard = screen.getByTestId("approval-card-tc-1")
+    const secondCard = screen.getByTestId("approval-card-tc-2")
+    const approvalSubmit = screen
+      .getAllByRole("button", { name: "Submit" })
+      .find((button) => button.textContent?.trim() === "Submit")
+    if (!approvalSubmit) {
+      throw new Error("Approval submit button not found")
+    }
+
+    expect(firstCard).toHaveClass("bg-muted/10")
+    expect(
+      within(firstCard).getByRole("button", { name: "Approve" })
+    ).toBeDisabled()
+    expect(
+      within(firstCard).getByRole("button", { name: "Approve" })
+    ).toHaveClass("border-success/55")
+    expect(
+      within(secondCard).getByRole("button", { name: "Approve" })
+    ).toBeEnabled()
+    expect(approvalSubmit).toBeDisabled()
+  })
+
   it("supports @ mention tools in draft mode and passes selected tools before first send", async () => {
     const onBeforeSend = jest.fn().mockResolvedValue("chat-2")
     const action = {

--- a/frontend/tests/chat-transform.test.ts
+++ b/frontend/tests/chat-transform.test.ts
@@ -85,4 +85,139 @@ describe("transformMessages", () => {
 
     expect(transformed).toEqual([messages[1]])
   })
+
+  it("deduplicates replayed pending approval parts by tool call id", () => {
+    const messages = [
+      {
+        id: "msg-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-core__http_request",
+            toolCallId: "toolu_01http",
+            state: "input-available",
+            input: { url: "https://google.com" },
+          },
+          {
+            type: "data-approval-request",
+            data: [
+              {
+                tool_call_id: "toolu_01http",
+                tool_name: "core.http_request",
+                args: { url: "https://google.com" },
+              },
+            ],
+          },
+          {
+            type: "tool-core__http_request",
+            toolCallId: "toolu_01http",
+            state: "input-available",
+            input: { url: "https://google.com" },
+          },
+          {
+            type: "data-approval-request",
+            data: [
+              {
+                tool_call_id: "toolu_01http",
+                tool_name: "core.http_request",
+                args: { url: "https://google.com" },
+              },
+            ],
+          },
+        ],
+      },
+    ] as ai.UIMessage[]
+
+    const transformed = transformMessages(messages)
+
+    expect(transformed).toHaveLength(1)
+    expect(transformed[0]?.parts).toEqual([
+      {
+        type: "tool-core__http_request",
+        toolCallId: "toolu_01http",
+        state: "input-available",
+        input: { url: "https://google.com" },
+      },
+      {
+        type: "data-approval-request",
+        data: [
+          {
+            tool_call_id: "toolu_01http",
+            tool_name: "core.http_request",
+            args: { url: "https://google.com" },
+          },
+        ],
+      },
+    ])
+  })
+
+  it("deduplicates replayed terminal tool parts by tool call id", () => {
+    const messages = [
+      {
+        id: "msg-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-core__http_request",
+            toolCallId: "toolu_01http",
+            state: "input-available",
+            input: { url: "https://google.com" },
+          },
+          {
+            type: "data-approval-request",
+            data: [
+              {
+                tool_call_id: "toolu_01http",
+                tool_name: "core.http_request",
+                args: { url: "https://google.com" },
+              },
+            ],
+          },
+          {
+            type: "tool-core__http_request",
+            toolCallId: "toolu_01http",
+            state: "output-available",
+            input: { url: "https://google.com" },
+            output: { status_code: 200, replay: 1 },
+          },
+          {
+            type: "tool-core__http_request",
+            toolCallId: "toolu_01http",
+            state: "input-available",
+            input: { url: "https://google.com" },
+          },
+          {
+            type: "data-approval-request",
+            data: [
+              {
+                tool_call_id: "toolu_01http",
+                tool_name: "core.http_request",
+                args: { url: "https://google.com" },
+              },
+            ],
+          },
+          {
+            type: "tool-core__http_request",
+            toolCallId: "toolu_01http",
+            state: "output-error",
+            input: { url: "https://google.com" },
+            errorText: "Connection failed",
+          },
+        ],
+      },
+    ] as ai.UIMessage[]
+
+    const transformed = transformMessages(messages)
+
+    expect(transformed).toHaveLength(1)
+    expect(transformed[0]?.parts).toEqual([
+      {
+        type: "tool-core__http_request",
+        toolCallId: "toolu_01http",
+        state: "output-error",
+        input: { url: "https://google.com" },
+        errorText: "Connection failed",
+      },
+    ])
+  })
 })

--- a/frontend/tests/chat-transform.test.ts
+++ b/frontend/tests/chat-transform.test.ts
@@ -220,4 +220,44 @@ describe("transformMessages", () => {
       },
     ])
   })
+
+  it.each(["input-streaming", "input-available"] as const)(
+    "keeps terminal input when a replayed %s part arrives afterward",
+    (state) => {
+      const messages = [
+        {
+          id: "msg-1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-core__http_request",
+              toolCallId: "toolu_01http",
+              state: "output-available",
+              input: { url: "https://example.com", timeout: 30 },
+              output: { status_code: 200 },
+            },
+            {
+              type: "tool-core__http_request",
+              toolCallId: "toolu_01http",
+              state,
+              input: { url: "https://exam" },
+            },
+          ],
+        },
+      ] as ai.UIMessage[]
+
+      const transformed = transformMessages(messages)
+
+      expect(transformed).toHaveLength(1)
+      expect(transformed[0]?.parts).toEqual([
+        {
+          type: "tool-core__http_request",
+          toolCallId: "toolu_01http",
+          state: "output-available",
+          input: { url: "https://example.com", timeout: 30 },
+          output: { status_code: 200 },
+        },
+      ])
+    }
+  )
 })

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -121,6 +121,8 @@ class ApprovalDecisionPayload(BaseModel):
 class ApplyApprovalResultsActivityInputs(BaseModel):
     role: Role
     session_id: uuid.UUID
+    # Unique by tool_call_id: handle_decisions builds these from a dict, and the
+    # persistence upsert cannot carry one conflict key twice.
     decisions: list[ApprovalDecisionPayload]
 
 

--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/router.py
@@ -13,7 +13,7 @@ from tracecat.auth.dependencies import WorkspaceUserRouteRole
 from tracecat.authz.controls import require_scope
 from tracecat.chat.schemas import ApprovalDecision, ContinueRunRequest
 from tracecat.db.engine import get_async_session
-from tracecat.exceptions import TracecatNotFoundError
+from tracecat.exceptions import TracecatConflictError, TracecatNotFoundError
 from tracecat.logger import logger
 from tracecat_ee.agent.approvals.service import ApprovalMap, ApprovalService
 
@@ -129,6 +129,17 @@ async def submit_approvals(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(exc),
+        ) from exc
+    except TracecatConflictError as exc:
+        # Contradicts a decision already recorded: the caller holds stale state.
+        logger.warning(
+            "Conflicting approval decision submitted",
+            session_id=session_id,
+            error=str(exc),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail or str(exc),
         ) from exc
     except ValueError as exc:
         logger.warning(

--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/service.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/service.py
@@ -648,23 +648,34 @@ class ApprovalManager:
             return
 
         async with ApprovalService.with_session(role=input.role) as service:
-            for decision in input.decisions:
-                # Get or create approval record
-                approval = await service.get_approval_by_session_and_tool(
-                    session_id=input.session_id,
-                    tool_call_id=decision.tool_call_id,
+            tool_call_ids = [decision.tool_call_id for decision in input.decisions]
+            stmt = (
+                select(Approval)
+                .where(
+                    Approval.workspace_id == service.workspace_id,
+                    Approval.session_id == input.session_id,
+                    Approval.tool_call_id.in_(tool_call_ids),
                 )
+                .with_for_update()
+            )
+            result = await service.session.execute(stmt)
+            approvals_by_tool_id = {
+                approval.tool_call_id: approval for approval in result.scalars().all()
+            }
 
+            for decision in input.decisions:
+                approval = approvals_by_tool_id.get(decision.tool_call_id)
                 if approval is None:
-                    # Create placeholder record if it doesn't exist
-                    approval = await service.create_approval(
-                        ApprovalCreate(
-                            session_id=input.session_id,
-                            tool_call_id=decision.tool_call_id,
-                            tool_name="unknown",
-                            tool_call_args=None,
-                        )
+                    approval = Approval(
+                        workspace_id=service.workspace_id,
+                        session_id=input.session_id,
+                        tool_call_id=decision.tool_call_id,
+                        tool_name="unknown",
+                        tool_call_args=None,
+                        status=ApprovalStatus.PENDING,
                     )
+                    service.session.add(approval)
+                    approvals_by_tool_id[decision.tool_call_id] = approval
 
                 # Determine status and calculate approved_at timestamp
                 status = (
@@ -699,15 +710,11 @@ class ApprovalManager:
                 if resolved_decision is not None:
                     update_data["decision"] = resolved_decision
 
-                # Update the approval with decision
-                await service.update_approval(
-                    approval,
-                    ApprovalUpdate(**update_data),
-                )
-
-                # Manually set approved_at since it's not part of ApprovalUpdate
+                for key, value in update_data.items():
+                    setattr(approval, key, value)
                 approval.approved_at = approved_at
-                await service.session.commit()
+
+            await service.session.commit()
 
     @staticmethod
     @activity.defn

--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/service.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/service.py
@@ -17,7 +17,8 @@ from pydantic_ai.tools import (
     ToolApproved,
     ToolDenied,
 )
-from sqlalchemy import select
+from sqlalchemy import func, null, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from temporalio import activity, workflow
 from temporalio.client import WorkflowExecution, WorkflowExecutionStatus, WorkflowHandle
 
@@ -418,7 +419,8 @@ class ApprovalService(BaseWorkspaceService):
         await self.session.commit()
 
 
-type ApprovalMap = dict[str, bool | DeferredToolApprovalResult]
+type ApprovalResult = bool | DeferredToolApprovalResult
+type ApprovalMap = dict[str, ApprovalResult]
 
 
 class ApprovalManagerStatus(StrEnum):
@@ -648,51 +650,16 @@ class ApprovalManager:
             return
 
         async with ApprovalService.with_session(role=input.role) as service:
-            tool_call_ids = [decision.tool_call_id for decision in input.decisions]
-            stmt = (
-                select(Approval)
-                .where(
-                    Approval.workspace_id == service.workspace_id,
-                    Approval.session_id == input.session_id,
-                    Approval.tool_call_id.in_(tool_call_ids),
-                )
-                .with_for_update()
-            )
-            result = await service.session.execute(stmt)
-            approvals_by_tool_id = {
-                approval.tool_call_id: approval for approval in result.scalars().all()
-            }
-
+            now = datetime.now(tz=UTC)
+            # Untyped: these are SQLAlchemy insert values keyed by column name,
+            # where each value may be a Python scalar or a SQL element (null()).
+            rows: list[dict[str, Any]] = []
             for decision in input.decisions:
-                approval = approvals_by_tool_id.get(decision.tool_call_id)
-                if approval is None:
-                    approval = Approval(
-                        workspace_id=service.workspace_id,
-                        session_id=input.session_id,
-                        tool_call_id=decision.tool_call_id,
-                        tool_name="unknown",
-                        tool_call_args=None,
-                        status=ApprovalStatus.PENDING,
-                    )
-                    service.session.add(approval)
-                    approvals_by_tool_id[decision.tool_call_id] = approval
-
-                # Determine status and calculate approved_at timestamp
                 status = (
                     ApprovalStatus.APPROVED
                     if decision.approved
                     else ApprovalStatus.REJECTED
                 )
-                approved_at = (
-                    datetime.now(tz=UTC) if status != ApprovalStatus.PENDING else None
-                )
-
-                # Build update payload - only include decision if it was explicitly set
-                update_data: dict[str, Any] = {
-                    "status": status,
-                    "reason": decision.reason,
-                    "approved_by": decision.approved_by,
-                }
                 resolved_decision = decision.decision
                 if decision.decision_metadata:
                     if isinstance(resolved_decision, dict):
@@ -707,13 +674,41 @@ class ApprovalManager:
                         }
                     elif resolved_decision is None:
                         resolved_decision = {"metadata": decision.decision_metadata}
-                if resolved_decision is not None:
-                    update_data["decision"] = resolved_decision
+                rows.append(
+                    {
+                        "workspace_id": service.workspace_id,
+                        "session_id": input.session_id,
+                        "tool_call_id": decision.tool_call_id,
+                        "tool_name": "unknown",
+                        "tool_call_args": None,
+                        "status": status,
+                        "reason": decision.reason,
+                        "approved_by": decision.approved_by,
+                        "approved_at": now,
+                        # SQL NULL (not Python None) so COALESCE preserves a stored
+                        # decision instead of overwriting it with JSON null.
+                        "decision": resolved_decision
+                        if resolved_decision is not None
+                        else null(),
+                    }
+                )
 
-                for key, value in update_data.items():
-                    setattr(approval, key, value)
-                approval.approved_at = approved_at
-
+            stmt = pg_insert(Approval).values(rows)
+            stmt = stmt.on_conflict_do_update(
+                constraint="uq_approval_workspace_session_tool",
+                set_={
+                    "status": stmt.excluded.status,
+                    "reason": stmt.excluded.reason,
+                    "approved_by": stmt.excluded.approved_by,
+                    "approved_at": stmt.excluded.approved_at,
+                    "decision": func.coalesce(
+                        stmt.excluded.decision, Approval.decision
+                    ),
+                    # onupdate does not fire for ON CONFLICT DO UPDATE.
+                    "updated_at": func.now(),
+                },
+            )
+            await service.session.execute(stmt)
             await service.session.commit()
 
     @staticmethod

--- a/packages/tracecat-ee/tracecat_ee/agent/approvals/service.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/approvals/service.py
@@ -433,6 +433,7 @@ class ApprovalManager:
     def __init__(self, role: Role) -> None:
         self._approvals: ApprovalMap = {}
         self._decision_metadata_by_tool_call_id: dict[str, dict[str, Any]] = {}
+        self._approved_by_by_tool_call_id: dict[str, uuid.UUID] = {}
         self._status: ApprovalManagerStatus = ApprovalManagerStatus.IDLE
         self.role = role
         agent_ctx = AgentContext.get()
@@ -440,7 +441,6 @@ class ApprovalManager:
             raise RuntimeError("Agent context is not set")
         self.session_id = agent_ctx.session_id
         self._expected_tool_calls: dict[str, ToolCallPart] = {}
-        self._approved_by: uuid.UUID | None = None
 
     @classmethod
     def get_activities(cls) -> list[Callable[..., Any]]:
@@ -460,10 +460,30 @@ class ApprovalManager:
         approved_by: uuid.UUID | None = None,
         decision_metadata: dict[str, dict[str, Any]] | None = None,
     ) -> None:
-        self._approvals = approvals
-        self._status = ApprovalManagerStatus.READY
-        self._approved_by = approved_by
-        self._decision_metadata_by_tool_call_id = decision_metadata or {}
+        """Record approval decisions, accepting partial submissions.
+
+        Parallel tool calls surface as individual approval cards that are
+        decided one by one, so decisions are merged across submissions. The
+        manager only becomes READY (resuming the run) once every expected
+        tool call has a decision.
+        """
+        self._approvals.update(approvals)
+        if approved_by is not None:
+            for tool_call_id in approvals:
+                self._approved_by_by_tool_call_id[tool_call_id] = approved_by
+        if decision_metadata:
+            self._decision_metadata_by_tool_call_id.update(decision_metadata)
+
+        expected_ids = set(self._expected_tool_calls.keys())
+        if expected_ids.issubset(self._approvals.keys()):
+            self._status = ApprovalManagerStatus.READY
+        else:
+            self._status = ApprovalManagerStatus.PENDING
+            logger.info(
+                "Partial approval decisions recorded",
+                decided=sorted(self._approvals.keys()),
+                awaiting=sorted(expected_ids - set(self._approvals.keys())),
+            )
 
     async def wait(self) -> None:
         await workflow.wait_condition(lambda: self.is_ready())
@@ -480,7 +500,7 @@ class ApprovalManager:
         self._expected_tool_calls = {
             approval.tool_call_id: approval for approval in approvals
         }
-        self._approved_by = None
+        self._approved_by_by_tool_call_id.clear()
 
         # Preserve per-tool proxy metadata on approval rows for display and
         # decision reconciliation.
@@ -516,7 +536,13 @@ class ApprovalManager:
         return self._approvals.get(tool_call_id)
 
     def validate_responses(self, approvals: ApprovalMap) -> None:
-        """Validate that approval responses cover all expected tool calls."""
+        """Validate approval responses against the expected tool calls.
+
+        Partial submissions are valid: parallel tool calls are decided one
+        card at a time, and ``set`` accumulates decisions until every expected
+        tool call is covered. Responses for unknown tool calls or with missing
+        decisions are rejected.
+        """
         if not self._expected_tool_calls:
             raise ValueError("No pending approvals to validate")
         if not approvals:
@@ -524,24 +550,6 @@ class ApprovalManager:
 
         expected_ids = set(self._expected_tool_calls.keys())
         provided_ids = set(approvals.keys())
-
-        missing = expected_ids - provided_ids
-        if missing:
-            expected_tools = [
-                f"{self._expected_tool_calls[tid].tool_name} ({tid})"
-                for tid in sorted(missing)
-            ]
-            logger.warning(
-                "Missing approval responses",
-                missing_count=len(missing),
-                expected_tools=expected_tools,
-                expected_ids=sorted(expected_ids),
-                provided_ids=sorted(provided_ids),
-            )
-            raise ValueError(
-                f"Missing approval responses for {len(missing)} tool call(s). "
-                f"Expected approvals for: {', '.join(expected_tools)}"
-            )
 
         unexpected = provided_ids - expected_ids
         if unexpected:
@@ -557,7 +565,7 @@ class ApprovalManager:
                 f"Expected only: {', '.join(sorted(expected_ids))}"
             )
 
-        for tool_call_id in expected_ids:
+        for tool_call_id in provided_ids:
             if approvals[tool_call_id] is None:
                 tool_name = self._expected_tool_calls[tool_call_id].tool_name
                 logger.warning(
@@ -608,7 +616,7 @@ class ApprovalManager:
                     decision_metadata=self._decision_metadata_by_tool_call_id.get(
                         tool_call_id
                     ),
-                    approved_by=self._approved_by,
+                    approved_by=self._approved_by_by_tool_call_id.get(tool_call_id),
                 )
             )
         if decisions:
@@ -621,7 +629,7 @@ class ApprovalManager:
                 ),
                 start_to_close_timeout=timedelta(seconds=30),
             )
-        self._approved_by = None
+        self._approved_by_by_tool_call_id.clear()
         self._decision_metadata_by_tool_call_id.clear()
 
     @staticmethod

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -1061,7 +1061,8 @@ class DurableAgentWorkflow:
             )
 
     @workflow.update
-    def set_approvals(self, submission: WorkflowApprovalSubmission) -> None:
+    def set_approvals(self, submission: WorkflowApprovalSubmission) -> bool:
+        submission = WorkflowApprovalSubmission.model_validate(submission)
         logger.info(
             "Setting approvals",
             approvals=submission.approvals,
@@ -1081,6 +1082,7 @@ class DurableAgentWorkflow:
         # a definitively rejected continuation attempt.
         if submission.new_stream_id is not None:
             self.active_stream_id = submission.new_stream_id
+        return self.approvals.is_ready()
 
     @set_approvals.validator
     def validate_set_approvals(self, submission: WorkflowApprovalSubmission) -> None:

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -2641,12 +2641,13 @@ async def test_agent_workflow_approval_with_override_args(
                 )
                 assert approval is not None
                 assert approval.status == ApprovalStatus.APPROVED
-                assert isinstance(approval.decision, dict)
-                assert approval.decision["kind"] == "tool-approved"
-                assert "override_args" in approval.decision
+                decision = approval.decision
+                assert isinstance(decision, dict)
+                assert "kind" in decision
+                assert decision["kind"] == "tool-approved"
+                assert "override_args" in decision
                 assert (
-                    approval.decision["override_args"]["url"]
-                    == "https://modified.example.com"
+                    decision["override_args"]["url"] == "https://modified.example.com"
                 )
     except Exception:
         if wf_handle:
@@ -2774,8 +2775,12 @@ async def test_agent_workflow_mixed_approvals_and_rejections(
                     a for a in updated_approvals if a.status == ApprovalStatus.REJECTED
                 ]
                 assert len(rejected) == 1
-                assert isinstance(rejected[0].decision, dict)
-                assert rejected[0].decision["message"] == "Too risky"
+                decision = rejected[0].decision
+                assert isinstance(decision, dict)
+                assert "kind" in decision
+                assert decision["kind"] == "tool-denied"
+                assert "message" in decision
+                assert decision["message"] == "Too risky"
     except Exception:
         if wf_handle:
             try:

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -16,6 +16,7 @@ from tracecat.agent.common.protocol import RuntimeEventEnvelope
 from tracecat.agent.common.socket_io import MessageType, build_message
 from tracecat.agent.common.stream_types import (
     StreamEventType,
+    ToolCallContent,
     UnifiedStreamEvent,
 )
 from tracecat.agent.executor.loopback import (
@@ -650,3 +651,66 @@ async def test_send_done_preserves_existing_error_state() -> None:
     assert handler._result.error == "runtime failed"
     stream.error.assert_not_awaited()
     stream.done.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_parallel_approval_requests_accumulate_across_events() -> None:
+    """N parallel gated tool calls arrive as N approval events; keep them all."""
+    handler = _make_handler()
+    handler._stream_sink = _FakeStream()
+
+    first = UnifiedStreamEvent.approval_request_event(
+        [ToolCallContent(id="call-1", name="core.http_request", input={"n": 1})]
+    )
+    second = UnifiedStreamEvent.approval_request_event(
+        [ToolCallContent(id="call-2", name="core.http_request", input={"n": 2})]
+    )
+
+    await handler._handle_stream_event(first)
+    await handler._handle_stream_event(second)
+
+    result = handler.build_result()
+    assert result.approval_requested is True
+    assert [item.id for item in result.approval_items] == ["call-1", "call-2"]
+    assert handler._pending_approval_tool_call_ids == {"call-1", "call-2"}
+
+
+@pytest.mark.anyio
+async def test_accumulated_approval_request_copies_input() -> None:
+    handler = _make_handler()
+    handler._stream_sink = _FakeStream()
+    original_input = {"n": 1, "nested": {"flag": True}}
+
+    event = UnifiedStreamEvent.approval_request_event(
+        [
+            ToolCallContent(
+                id="call-1",
+                name="core.http_request",
+                input=original_input,
+            )
+        ]
+    )
+
+    await handler._handle_stream_event(event)
+
+    original_input["n"] = 2
+    original_input["nested"]["flag"] = False
+
+    result = handler.build_result()
+    assert result.approval_items[0].input == {"n": 1, "nested": {"flag": True}}
+
+
+@pytest.mark.anyio
+async def test_duplicate_approval_request_events_are_deduped() -> None:
+    handler = _make_handler()
+    handler._stream_sink = _FakeStream()
+
+    event = UnifiedStreamEvent.approval_request_event(
+        [ToolCallContent(id="call-1", name="core.http_request", input={"n": 1})]
+    )
+
+    await handler._handle_stream_event(event)
+    await handler._handle_stream_event(event)
+
+    result = handler.build_result()
+    assert [item.id for item in result.approval_items] == ["call-1"]

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -17,12 +17,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import orjson
 import pytest
 from claude_agent_sdk.types import (
+    AssistantMessage,
     HookContext,
     PreToolUseHookInput,
     ResultMessage,
     StopHookInput,
     StreamEvent,
     SyncHookJSONOutput,
+    ToolUseBlock,
 )
 
 import tracecat.agent.runtime.claude_code.runtime as runtime_module
@@ -2492,6 +2494,172 @@ class TestClaudeAgentRuntimePreToolUseHook:
         assert hook_output.get("permissionDecision") == "allow"
         assert mock_socket_writer.send_stream_event.await_args is None
         runtime.client.interrupt.assert_not_awaited()
+
+
+def _approval_events(mock_socket_writer: MagicMock) -> list[UnifiedStreamEvent]:
+    return [
+        call.args[0]
+        for call in mock_socket_writer.send_stream_event.await_args_list
+        if call.args[0].type == StreamEventType.APPROVAL_REQUEST
+    ]
+
+
+class TestClaudeAgentRuntimeParallelApprovals:
+    """Parallel tool calls must each surface an approval request.
+
+    The CLI delivers parallel tool calls as N single-block assistant messages
+    (sharing one API message id) before executing anything, then serializes
+    execution — so the first gated PreToolUse hook's interrupt prevents the
+    sibling hooks from ever firing. Approvals are therefore registered from
+    the assistant message stream, and the hook only denies and interrupts.
+    """
+
+    def _make_runtime(
+        self, mock_socket_writer: MagicMock
+    ) -> tuple[ClaudeAgentRuntime, AsyncMock]:
+        runtime = ClaudeAgentRuntime(
+            mock_socket_writer, transport_factory=lambda _: MagicMock()
+        )
+        runtime.tool_approvals = {"core.http_request": True}
+        client = MagicMock()
+        interrupt = AsyncMock()
+        client.interrupt = interrupt
+        runtime.client = client
+        return runtime, interrupt
+
+    @staticmethod
+    def _tool_use_message(
+        tool_use_id: str,
+        url: str,
+        *,
+        parent_tool_use_id: str | None = None,
+    ) -> AssistantMessage:
+        """One tool_use block per assistant message, mirroring the CLI shape."""
+        return AssistantMessage(
+            content=[
+                ToolUseBlock(
+                    id=tool_use_id,
+                    name="mcp__tracecat-registry__core__http_request",
+                    input={"url": url},
+                )
+            ],
+            model="claude-sonnet-4-5",
+            parent_tool_use_id=parent_tool_use_id,
+            message_id="msg-batch-1",
+        )
+
+    @pytest.mark.anyio
+    async def test_registers_every_gated_call_from_split_assistant_messages(
+        self,
+        mock_socket_writer: MagicMock,
+    ) -> None:
+        runtime, interrupt = self._make_runtime(mock_socket_writer)
+
+        await runtime._register_assistant_tool_approvals(
+            self._tool_use_message("call-1", "https://example.com")
+        )
+        await runtime._register_assistant_tool_approvals(
+            self._tool_use_message("call-2", "https://example.org")
+        )
+
+        events = _approval_events(mock_socket_writer)
+        assert [item.id for event in events for item in event.approval_items or []] == [
+            "call-1",
+            "call-2",
+        ]
+        assert runtime._pending_approval_tool_ids == {"call-1", "call-2"}
+        # Registration must not interrupt: the remaining sibling messages and
+        # the hook-driven interrupt still need the turn alive.
+        interrupt.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_hook_denies_registered_calls_and_interrupts_once(
+        self,
+        mock_socket_writer: MagicMock,
+    ) -> None:
+        runtime, interrupt = self._make_runtime(mock_socket_writer)
+        await runtime._register_assistant_tool_approvals(
+            self._tool_use_message("call-1", "https://example.com")
+        )
+        await runtime._register_assistant_tool_approvals(
+            self._tool_use_message("call-2", "https://example.org")
+        )
+
+        for tool_use_id in ("call-1", "call-2"):
+            result = await runtime._pre_tool_use_hook(
+                input_data=make_hook_input(
+                    tool_name="mcp__tracecat-registry__core__http_request",
+                    tool_input={"url": "https://example.com"},
+                    tool_use_id=tool_use_id,
+                ),
+                tool_use_id=tool_use_id,
+                context=make_hook_context(),
+            )
+            hook_output = get_hook_output(result)
+            assert hook_output.get("permissionDecision") == "deny"
+
+        # No duplicate approval events from the hook, and a single interrupt.
+        assert len(_approval_events(mock_socket_writer)) == 2
+        interrupt.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_subagent_assistant_messages_are_skipped(
+        self,
+        mock_socket_writer: MagicMock,
+    ) -> None:
+        runtime, _interrupt = self._make_runtime(mock_socket_writer)
+
+        await runtime._register_assistant_tool_approvals(
+            self._tool_use_message(
+                "call-sub",
+                "https://example.com",
+                parent_tool_use_id="call-task",
+            )
+        )
+
+        assert _approval_events(mock_socket_writer) == []
+        assert runtime._pending_approval_tool_ids == set()
+
+    @pytest.mark.anyio
+    async def test_auto_approved_tools_are_not_registered(
+        self,
+        mock_socket_writer: MagicMock,
+    ) -> None:
+        runtime, _interrupt = self._make_runtime(mock_socket_writer)
+        runtime.tool_approvals = {"core.http_request": False}
+
+        await runtime._register_assistant_tool_approvals(
+            self._tool_use_message("call-1", "https://example.com")
+        )
+
+        assert _approval_events(mock_socket_writer) == []
+        assert runtime._pending_approval_tool_ids == set()
+
+    @pytest.mark.anyio
+    async def test_hook_fallback_emits_for_unregistered_call(
+        self,
+        mock_socket_writer: MagicMock,
+    ) -> None:
+        """Calls the message path can't see (e.g. subagent) still get events."""
+        runtime, interrupt = self._make_runtime(mock_socket_writer)
+
+        result = await runtime._pre_tool_use_hook(
+            input_data=make_hook_input(
+                tool_name="mcp__tracecat-registry__core__http_request",
+                tool_input={"url": "https://example.com"},
+                tool_use_id="call-unseen",
+            ),
+            tool_use_id="call-unseen",
+            context=make_hook_context(),
+        )
+
+        hook_output = get_hook_output(result)
+        assert hook_output.get("permissionDecision") == "deny"
+        events = _approval_events(mock_socket_writer)
+        assert [item.id for event in events for item in event.approval_items or []] == [
+            "call-unseen"
+        ]
+        interrupt.assert_awaited_once()
 
 
 class TestClaudeAgentRuntimeStopHook:

--- a/tests/unit/test_agent_session_approval_sink.py
+++ b/tests/unit/test_agent_session_approval_sink.py
@@ -579,6 +579,239 @@ async def test_replace_interrupt_with_tool_results_tags_active_run_id(
 
 
 @pytest.mark.anyio
+async def test_replace_interrupt_with_tool_results_spans_split_assistant_rows(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """Parallel tool calls span multiple single-block assistant rows.
+
+    Claude Code writes one assistant JSONL row per tool_use block (sharing the
+    API message id), so reconciliation must union the pending tool call IDs
+    across rows and anchor the combined tool_result entry after the last one.
+    """
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Approval chat",
+        workspace_id=svc_role.workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        sdk_session_id="sdk-session",
+    )
+    session.add(agent_session)
+
+    first_assistant_uuid = str(uuid.uuid4())
+    second_assistant_uuid = str(uuid.uuid4())
+    for row_uuid, tool_call_id, url in (
+        (first_assistant_uuid, "call_1", "https://example.com"),
+        (second_assistant_uuid, "call_2", "https://example.org"),
+    ):
+        session.add(
+            AgentSessionHistory(
+                session_id=agent_session.id,
+                workspace_id=svc_role.workspace_id,
+                kind=MessageKind.CHAT_MESSAGE.value,
+                content={
+                    "uuid": row_uuid,
+                    "sessionId": "sdk-session",
+                    "type": "assistant",
+                    "timestamp": "2026-03-18T00:00:00Z",
+                    "message": {
+                        "id": "msg_batch",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": tool_call_id,
+                                "name": "core__http_request",
+                                "input": {"url": url},
+                            }
+                        ],
+                    },
+                },
+            )
+        )
+    # SDK interrupt placeholders for both pending calls.
+    for tool_call_id in ("call_1", "call_2"):
+        session.add(
+            AgentSessionHistory(
+                session_id=agent_session.id,
+                workspace_id=svc_role.workspace_id,
+                kind=MessageKind.CHAT_MESSAGE.value,
+                content={
+                    "uuid": str(uuid.uuid4()),
+                    "parentUuid": second_assistant_uuid,
+                    "sessionId": "sdk-session",
+                    "type": "user",
+                    "timestamp": "2026-03-18T00:00:01Z",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": tool_call_id,
+                                "content": "interrupted",
+                                "is_error": True,
+                            }
+                        ],
+                    },
+                },
+            )
+        )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    await service.replace_interrupt_with_tool_results(
+        agent_session.id,
+        [
+            ToolExecutionResult(
+                tool_call_id="call_1",
+                tool_name="core.http_request",
+                result={"status": "success"},
+                is_error=False,
+            ),
+            ToolExecutionResult(
+                tool_call_id="call_2",
+                tool_name="core.http_request",
+                result={"status": "success"},
+                is_error=False,
+            ),
+        ],
+    )
+
+    history = await service.get_session_history(agent_session.id)
+    tool_result_entries = [
+        entry
+        for entry in history
+        if entry.content.get("type") == "user"
+        and any(
+            isinstance(block, dict) and block.get("type") == "tool_result"
+            for block in entry.content.get("message", {}).get("content", [])
+        )
+    ]
+
+    # The interrupt placeholders are replaced by ONE user row answering both
+    # tool calls together, anchored after the last assistant row.
+    assert len(tool_result_entries) == 1
+    [entry] = tool_result_entries
+    assert entry.content.get("parentUuid") == second_assistant_uuid
+    blocks = entry.content["message"]["content"]
+    assert {block["tool_use_id"] for block in blocks} == {"call_1", "call_2"}
+    assert all(block["is_error"] is False for block in blocks)
+
+
+@pytest.mark.anyio
+async def test_replace_interrupt_with_tool_results_spans_split_rows_without_message_id(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """When SDK rows omit message.id, contiguous assistant rows are one batch."""
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Approval chat",
+        workspace_id=svc_role.workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        sdk_session_id="sdk-session",
+    )
+    session.add(agent_session)
+
+    first_assistant_uuid = str(uuid.uuid4())
+    second_assistant_uuid = str(uuid.uuid4())
+    for row_uuid, tool_call_id, url in (
+        (first_assistant_uuid, "call_1", "https://example.com"),
+        (second_assistant_uuid, "call_2", "https://example.org"),
+    ):
+        session.add(
+            AgentSessionHistory(
+                session_id=agent_session.id,
+                workspace_id=svc_role.workspace_id,
+                kind=MessageKind.CHAT_MESSAGE.value,
+                content={
+                    "uuid": row_uuid,
+                    "sessionId": "sdk-session",
+                    "type": "assistant",
+                    "timestamp": "2026-03-18T00:00:00Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": tool_call_id,
+                                "name": "core__http_request",
+                                "input": {"url": url},
+                            }
+                        ],
+                    },
+                },
+            )
+        )
+    for tool_call_id in ("call_1", "call_2"):
+        session.add(
+            AgentSessionHistory(
+                session_id=agent_session.id,
+                workspace_id=svc_role.workspace_id,
+                kind=MessageKind.CHAT_MESSAGE.value,
+                content={
+                    "uuid": str(uuid.uuid4()),
+                    "parentUuid": second_assistant_uuid,
+                    "sessionId": "sdk-session",
+                    "type": "user",
+                    "timestamp": "2026-03-18T00:00:01Z",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": tool_call_id,
+                                "content": "interrupted",
+                                "is_error": True,
+                            }
+                        ],
+                    },
+                },
+            )
+        )
+    await session.commit()
+
+    service = AgentSessionService(session=session, role=svc_role)
+    await service.replace_interrupt_with_tool_results(
+        agent_session.id,
+        [
+            ToolExecutionResult(
+                tool_call_id="call_1",
+                tool_name="core.http_request",
+                result={"status": "success"},
+                is_error=False,
+            ),
+            ToolExecutionResult(
+                tool_call_id="call_2",
+                tool_name="core.http_request",
+                result={"status": "success"},
+                is_error=False,
+            ),
+        ],
+    )
+
+    history = await service.get_session_history(agent_session.id)
+    tool_result_entries = [
+        entry
+        for entry in history
+        if entry.content.get("type") == "user"
+        and any(
+            isinstance(block, dict) and block.get("type") == "tool_result"
+            for block in entry.content.get("message", {}).get("content", [])
+        )
+    ]
+
+    assert len(tool_result_entries) == 1
+    [entry] = tool_result_entries
+    assert entry.content.get("parentUuid") == second_assistant_uuid
+    blocks = entry.content["message"]["content"]
+    assert {block["tool_use_id"] for block in blocks} == {"call_1", "call_2"}
+    assert all(block["is_error"] is False for block in blocks)
+
+
+@pytest.mark.anyio
 async def test_replace_interrupt_with_tool_results_does_not_duplicate_existing_result(
     session: AsyncSession,
     svc_role: Role,
@@ -1028,13 +1261,14 @@ async def test_run_turn_continue_with_inbox_source_for_non_external_session(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
+    curr_run_id = uuid.uuid4()
     agent_session = AgentSession(
         id=uuid.uuid4(),
         title="Preset chat",
         workspace_id=svc_role.workspace_id,
         entity_type=AgentSessionEntity.AGENT_PRESET.value,
         entity_id=uuid.uuid4(),
-        curr_run_id=uuid.uuid4(),
+        curr_run_id=curr_run_id,
     )
     session.add(agent_session)
     session.add(
@@ -1062,9 +1296,7 @@ async def test_run_turn_continue_with_inbox_source_for_non_external_session(
     )
 
     execute_update = AsyncMock(return_value=None)
-    fake_redis = SimpleNamespace(
-        xadd=AsyncMock(return_value="1-0"),
-    )
+    fake_redis = _ApprovalContinuationRedis()
     with _mock_approval_continuation_dependencies(fake_redis, execute_update):
         result = await service.run_turn(agent_session.id, continuation)
 
@@ -1072,7 +1304,58 @@ async def test_run_turn_continue_with_inbox_source_for_non_external_session(
     assert result is not None
     assert result.active_stream_id is not None
     execute_update.assert_awaited_once()
-    fake_redis.xadd.assert_awaited_once()
+    assert len(fake_redis.streams) == 1
+
+
+@pytest.mark.anyio
+async def test_run_turn_continue_partial_approval_reports_not_resumed(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    curr_run_id = uuid.uuid4()
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Preset chat",
+        workspace_id=svc_role.workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        curr_run_id=curr_run_id,
+    )
+    session.add(agent_session)
+    for tool_call_id in ("tool_call_123", "tool_call_456"):
+        session.add(
+            Approval(
+                workspace_id=svc_role.workspace_id,
+                session_id=agent_session.id,
+                tool_call_id=tool_call_id,
+                tool_name="core.http_request",
+                tool_call_args={"url": "https://example.com"},
+                status=ApprovalStatus.PENDING,
+            )
+        )
+    await session.commit()
+    await session.refresh(agent_session)
+
+    service = AgentSessionService(session=session, role=svc_role)
+    continuation = ContinueRunRequest(
+        decisions=[
+            ApprovalDecision(
+                tool_call_id="tool_call_123",
+                action="approve",
+            )
+        ],
+        source="inbox",
+    )
+
+    execute_update = AsyncMock(return_value=False)
+    fake_redis = _ApprovalContinuationRedis()
+    with _mock_approval_continuation_dependencies(fake_redis, execute_update):
+        result = await service.run_turn(agent_session.id, continuation)
+
+    assert result is not None
+    assert result.curr_run_id == curr_run_id
+    assert result.active_stream_id is not None
+    execute_update.assert_awaited_once()
 
 
 @pytest.mark.anyio
@@ -1080,13 +1363,14 @@ async def test_run_turn_continue_override_maps_to_tool_approved(
     session: AsyncSession,
     svc_role: Role,
 ) -> None:
+    curr_run_id = uuid.uuid4()
     agent_session = AgentSession(
         id=uuid.uuid4(),
         title="Preset chat",
         workspace_id=svc_role.workspace_id,
         entity_type=AgentSessionEntity.AGENT_PRESET.value,
         entity_id=uuid.uuid4(),
-        curr_run_id=uuid.uuid4(),
+        curr_run_id=curr_run_id,
     )
     session.add(agent_session)
     session.add(

--- a/tests/unit/test_agent_session_approval_sink.py
+++ b/tests/unit/test_agent_session_approval_sink.py
@@ -36,12 +36,27 @@ class _ApprovalContinuationRedis:
 
     def __init__(self) -> None:
         self.streams: dict[str, list[tuple[str, dict[str, str]]]] = {}
+        self.values: dict[str, str] = {}
         self.fail_next_xadd = False
 
     async def delete(self, key: str) -> int:
-        removed = int(key in self.streams)
+        removed = int(key in self.streams or key in self.values)
         self.streams.pop(key, None)
+        self.values.pop(key, None)
         return removed
+
+    async def set_if_not_exists(
+        self,
+        key: str,
+        value: str,
+        *,
+        expire_seconds: int,
+    ) -> bool:
+        _ = expire_seconds
+        if key in self.values:
+            return False
+        self.values[key] = value
+        return True
 
     async def xadd(
         self,
@@ -100,6 +115,10 @@ def _mock_approval_continuation_dependencies(
         ),
         patch(
             "tracecat.agent.stream.connector.get_redis_client",
+            AsyncMock(return_value=redis_client),
+        ),
+        patch(
+            "tracecat.agent.session.service.get_redis_client",
             AsyncMock(return_value=redis_client),
         ),
     ):
@@ -1269,6 +1288,7 @@ async def test_run_turn_continue_with_inbox_source_for_non_external_session(
         entity_type=AgentSessionEntity.AGENT_PRESET.value,
         entity_id=uuid.uuid4(),
         curr_run_id=curr_run_id,
+        active_stream_id=uuid.uuid4(),
     )
     session.add(agent_session)
     session.add(
@@ -1357,6 +1377,118 @@ async def test_run_turn_continue_partial_approval_reports_not_resumed(
     assert result.active_stream_id is not None
     execute_update.assert_awaited_once()
 
+    approved = await session.scalar(
+        select(Approval).where(
+            Approval.session_id == agent_session.id,
+            Approval.tool_call_id == "tool_call_123",
+        )
+    )
+    assert approved is not None
+    assert approved.status is ApprovalStatus.APPROVED
+    assert approved.decision == {"value": True, "metadata": {"source": "inbox"}}
+
+    pending = await session.scalar(
+        select(Approval).where(
+            Approval.session_id == agent_session.id,
+            Approval.tool_call_id == "tool_call_456",
+        )
+    )
+    assert pending is not None
+    assert pending.status is ApprovalStatus.PENDING
+
+    stream_key = (
+        f"agent-stream:{svc_role.workspace_id}:{agent_session.id}:"
+        f"{result.active_stream_id}"
+    )
+    stream_payloads = [
+        orjson.loads(fields[tokens.DATA_KEY])
+        for _, fields in fake_redis.streams[stream_key]
+    ]
+    assert stream_payloads[-1] == {
+        tokens.END_TOKEN: tokens.END_TOKEN_VALUE,
+        "terminal": False,
+        "reason": "approval_pending",
+    }
+
+
+@pytest.mark.anyio
+async def test_run_turn_continue_old_worker_none_defaults_to_resumed(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    curr_run_id = uuid.uuid4()
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Preset chat",
+        workspace_id=svc_role.workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        curr_run_id=curr_run_id,
+        active_stream_id=uuid.uuid4(),
+    )
+    session.add(agent_session)
+    session.add(
+        Approval(
+            workspace_id=svc_role.workspace_id,
+            session_id=agent_session.id,
+            tool_call_id="tool_call_123",
+            tool_name="core.http_request",
+            tool_call_args={"url": "https://example.com"},
+            status=ApprovalStatus.PENDING,
+        )
+    )
+    await session.commit()
+    await session.refresh(agent_session)
+
+    service = AgentSessionService(session=session, role=svc_role)
+    continuation = ContinueRunRequest(
+        decisions=[
+            ApprovalDecision(
+                tool_call_id="tool_call_123",
+                action="approve",
+            )
+        ],
+        source="inbox",
+    )
+
+    execute_update = AsyncMock(return_value=None)
+    fake_redis = _ApprovalContinuationRedis()
+    with _mock_approval_continuation_dependencies(fake_redis, execute_update):
+        result = await service.run_turn(agent_session.id, continuation)
+
+    assert result is not None
+    assert result.curr_run_id == curr_run_id
+    assert result.active_stream_id is not None
+    execute_update.assert_awaited_once()
+
+
+def test_approval_submission_key_is_stable_for_tool_call_set() -> None:
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    run_id = uuid.uuid4()
+
+    first_key = AgentSessionService._approval_submission_key(
+        workspace_id=workspace_id,
+        session_id=session_id,
+        run_id=run_id,
+        tool_call_ids=("tool_call_123", "tool_call_456"),
+    )
+    reordered_key = AgentSessionService._approval_submission_key(
+        workspace_id=workspace_id,
+        session_id=session_id,
+        run_id=run_id,
+        tool_call_ids=("tool_call_456", "tool_call_123"),
+    )
+    different_key = AgentSessionService._approval_submission_key(
+        workspace_id=workspace_id,
+        session_id=session_id,
+        run_id=run_id,
+        tool_call_ids=("tool_call_123",),
+    )
+
+    assert first_key == reordered_key
+    assert first_key != different_key
+
 
 @pytest.mark.anyio
 async def test_run_turn_continue_override_maps_to_tool_approved(
@@ -1399,9 +1531,7 @@ async def test_run_turn_continue_override_maps_to_tool_approved(
     )
 
     execute_update = AsyncMock(return_value=None)
-    fake_redis = SimpleNamespace(
-        xadd=AsyncMock(return_value="1-0"),
-    )
+    fake_redis = _ApprovalContinuationRedis()
     with _mock_approval_continuation_dependencies(fake_redis, execute_update):
         result = await service.run_turn(agent_session.id, continuation)
 
@@ -1419,7 +1549,7 @@ async def test_run_turn_continue_override_maps_to_tool_approved(
     assert result is not None
     assert result.active_stream_id is not None
     assert submission.new_stream_id == result.active_stream_id
-    fake_redis.xadd.assert_awaited_once()
+    assert len(fake_redis.streams) == 1
     await session.refresh(agent_session)
     assert agent_session.active_stream_id == result.active_stream_id
 

--- a/tests/unit/test_agent_session_approval_sink.py
+++ b/tests/unit/test_agent_session_approval_sink.py
@@ -27,6 +27,7 @@ from tracecat.chat import tokens
 from tracecat.chat.enums import MessageKind
 from tracecat.chat.schemas import ApprovalDecision, BasicChatRequest, ContinueRunRequest
 from tracecat.db.models import AgentSession, AgentSessionHistory, Approval
+from tracecat.exceptions import TracecatConflictError
 
 pytestmark = pytest.mark.usefixtures("db")
 
@@ -1411,6 +1412,249 @@ async def test_run_turn_continue_partial_approval_reports_not_resumed(
     }
 
 
+async def _partial_batch_session(
+    session: AsyncSession,
+    svc_role: Role,
+) -> tuple[AgentSession, AgentSessionService]:
+    """Seed a session whose parallel batch has one decided and one pending call."""
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Preset chat",
+        workspace_id=svc_role.workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        curr_run_id=uuid.uuid4(),
+    )
+    session.add(agent_session)
+    for tool_call_id in ("tool_call_123", "tool_call_456"):
+        session.add(
+            Approval(
+                workspace_id=svc_role.workspace_id,
+                session_id=agent_session.id,
+                tool_call_id=tool_call_id,
+                tool_name="core.http_request",
+                tool_call_args={"url": "https://example.com"},
+                status=ApprovalStatus.PENDING,
+            )
+        )
+    await session.commit()
+    await session.refresh(agent_session)
+
+    service = AgentSessionService(session=session, role=svc_role)
+    first = ContinueRunRequest(
+        decisions=[ApprovalDecision(tool_call_id="tool_call_123", action="approve")],
+        source="inbox",
+    )
+    with _mock_approval_continuation_dependencies(
+        _ApprovalContinuationRedis(), AsyncMock(return_value=False)
+    ):
+        await service.run_turn(agent_session.id, first)
+
+    return agent_session, service
+
+
+@pytest.mark.anyio
+async def test_run_turn_continue_matching_resubmission_is_noop(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """A replayed decision for an already-decided call must not 400."""
+    agent_session, service = await _partial_batch_session(session, svc_role)
+
+    execute_update = AsyncMock(return_value=False)
+    with _mock_approval_continuation_dependencies(
+        _ApprovalContinuationRedis(), execute_update
+    ):
+        result = await service.run_turn(
+            agent_session.id,
+            ContinueRunRequest(
+                decisions=[
+                    ApprovalDecision(tool_call_id="tool_call_123", action="approve")
+                ],
+                source="inbox",
+            ),
+        )
+
+    assert result is None
+    execute_update.assert_not_awaited()
+
+    pending = await session.scalar(
+        select(Approval).where(
+            Approval.session_id == agent_session.id,
+            Approval.tool_call_id == "tool_call_456",
+        )
+    )
+    assert pending is not None
+    assert pending.status is ApprovalStatus.PENDING
+
+
+@pytest.mark.anyio
+async def test_run_turn_continue_deny_replay_across_surfaces_is_noop(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """Each surface supplies its own deny reason; the outcome still matches."""
+    agent_session = await _seed_approval_session(
+        session,
+        svc_role,
+        approvals=[
+            Approval(
+                tool_call_id="tool_call_123",
+                tool_name="core.http_request",
+                tool_call_args={"url": "https://example.com"},
+                status=ApprovalStatus.REJECTED,
+                decision={
+                    "kind": "tool-denied",
+                    "message": "Tool denied by user",
+                    "metadata": {"source": "inbox"},
+                },
+            ),
+            Approval(
+                tool_call_id="tool_call_456",
+                tool_name="core.http_request",
+                tool_call_args={"url": "https://example.com"},
+                status=ApprovalStatus.PENDING,
+            ),
+        ],
+    )
+
+    service = AgentSessionService(session=session, role=svc_role)
+    execute_update = AsyncMock(return_value=True)
+    with _mock_approval_continuation_dependencies(
+        _ApprovalContinuationRedis(), execute_update
+    ):
+        result = await service.run_turn(
+            agent_session.id,
+            ContinueRunRequest(
+                decisions=[
+                    # Slack's default reason differs from the recorded inbox one.
+                    ApprovalDecision(
+                        tool_call_id="tool_call_123",
+                        action="deny",
+                        reason="The tool call was denied.",
+                    ),
+                    ApprovalDecision(tool_call_id="tool_call_456", action="approve"),
+                ],
+                source="slack",
+            ),
+        )
+
+    assert result is not None
+    execute_update.assert_awaited_once()
+    submitted = execute_update.await_args
+    assert submitted is not None
+    assert set(submitted.args[1].approvals) == {"tool_call_456"}
+
+
+@pytest.mark.anyio
+async def test_run_turn_continue_conflicting_resubmission_raises(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """A stale card contradicting a recorded decision must not read as accepted."""
+    agent_session, service = await _partial_batch_session(session, svc_role)
+
+    execute_update = AsyncMock(return_value=False)
+    with _mock_approval_continuation_dependencies(
+        _ApprovalContinuationRedis(), execute_update
+    ):
+        with pytest.raises(TracecatConflictError):
+            await service.run_turn(
+                agent_session.id,
+                ContinueRunRequest(
+                    decisions=[
+                        ApprovalDecision(tool_call_id="tool_call_123", action="deny")
+                    ],
+                    source="slack",
+                ),
+            )
+
+    execute_update.assert_not_awaited()
+    approved = await session.scalar(
+        select(Approval).where(
+            Approval.session_id == agent_session.id,
+            Approval.tool_call_id == "tool_call_123",
+        )
+    )
+    assert approved is not None
+    assert approved.status is ApprovalStatus.APPROVED
+
+
+@pytest.mark.anyio
+async def test_run_turn_continue_mixed_resubmission_forwards_pending_only(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """Resending a decided call alongside a pending one forwards only the latter."""
+    agent_session, service = await _partial_batch_session(session, svc_role)
+
+    execute_update = AsyncMock(return_value=True)
+    with _mock_approval_continuation_dependencies(
+        _ApprovalContinuationRedis(), execute_update
+    ):
+        result = await service.run_turn(
+            agent_session.id,
+            ContinueRunRequest(
+                decisions=[
+                    ApprovalDecision(tool_call_id="tool_call_123", action="approve"),
+                    ApprovalDecision(tool_call_id="tool_call_456", action="approve"),
+                ],
+                source="inbox",
+            ),
+        )
+
+    assert result is not None
+    execute_update.assert_awaited_once()
+    assert execute_update.await_args is not None
+    submitted = execute_update.await_args.args[1]
+    assert set(submitted.approvals) == {"tool_call_456"}
+
+
+@pytest.mark.anyio
+async def test_run_turn_continue_conflicting_after_batch_settled_raises(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """Once nothing is pending, a contradicting replay still must not report success."""
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Preset chat",
+        workspace_id=svc_role.workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        curr_run_id=uuid.uuid4(),
+    )
+    session.add(agent_session)
+    session.add(
+        Approval(
+            workspace_id=svc_role.workspace_id,
+            session_id=agent_session.id,
+            tool_call_id="tool_call_123",
+            tool_name="core.http_request",
+            tool_call_args={"url": "https://example.com"},
+            status=ApprovalStatus.APPROVED,
+            decision={"value": True, "metadata": {"source": "inbox"}},
+        )
+    )
+    await session.commit()
+    await session.refresh(agent_session)
+
+    service = AgentSessionService(session=session, role=svc_role)
+    with _mock_approval_continuation_dependencies(
+        _ApprovalContinuationRedis(), AsyncMock(return_value=False)
+    ):
+        with pytest.raises(TracecatConflictError):
+            await service.run_turn(
+                agent_session.id,
+                ContinueRunRequest(
+                    decisions=[
+                        ApprovalDecision(tool_call_id="tool_call_123", action="deny")
+                    ],
+                    source="slack",
+                ),
+            )
+
+
 @pytest.mark.anyio
 async def test_run_turn_continue_old_worker_none_defaults_to_resumed(
     session: AsyncSession,
@@ -1824,10 +2068,20 @@ async def test_run_turn_rejects_invalid_approval_ids_before_stream_rotation(
 
 
 @pytest.mark.anyio
-async def test_run_turn_continue_without_pending_approvals_is_noop(
+@pytest.mark.parametrize(
+    "seed_decided,expectation",
+    [
+        pytest.param(False, pytest.raises(ValueError), id="unknown-tool-call-rejected"),
+        pytest.param(True, contextlib.nullcontext(), id="settled-replay-is-noop"),
+    ],
+)
+async def test_run_turn_continue_without_pending_approvals(
     session: AsyncSession,
     svc_role: Role,
+    seed_decided: bool,
+    expectation: contextlib.AbstractContextManager[object],
 ) -> None:
+    """With nothing pending, only a matching settled replay is a no-op."""
     rotated_stream_id = uuid.uuid4()
     agent_session = AgentSession(
         id=uuid.uuid4(),
@@ -1839,6 +2093,18 @@ async def test_run_turn_continue_without_pending_approvals_is_noop(
         active_stream_id=rotated_stream_id,
     )
     session.add(agent_session)
+    if seed_decided:
+        session.add(
+            Approval(
+                workspace_id=svc_role.workspace_id,
+                session_id=agent_session.id,
+                tool_call_id="tool_call_123",
+                tool_name="core.http_request",
+                tool_call_args={"url": "https://example.com"},
+                status=ApprovalStatus.APPROVED,
+                decision={"value": True, "metadata": {"source": "inbox"}},
+            )
+        )
     await session.commit()
     await session.refresh(agent_session)
 
@@ -1860,9 +2126,9 @@ async def test_run_turn_continue_without_pending_approvals_is_noop(
         "tracecat.agent.session.service.get_temporal_client",
         AsyncMock(return_value=fake_client),
     ):
-        result = await service.run_turn(agent_session.id, continuation)
+        with expectation:
+            assert await service.run_turn(agent_session.id, continuation) is None
 
-    assert result is None
     get_workflow_handle_for.assert_not_called()
     fake_handle.execute_update.assert_not_awaited()
 
@@ -2002,3 +2268,191 @@ async def test_run_turn_merges_basic_chat_request_instructions(
         == "Base preset instructions\n\nSlack actor context for this turn:\n- Slack email: jordan@example.com"
     )
     assert workflow_args.agent_args.user_prompt == "summarize this thread"
+
+
+async def _seed_approval_session(
+    session: AsyncSession,
+    svc_role: Role,
+    *,
+    approvals: list[Approval],
+) -> AgentSession:
+    """Seed a session plus caller-supplied approval rows."""
+    workspace_id = svc_role.workspace_id
+    assert workspace_id is not None
+    agent_session = AgentSession(
+        id=uuid.uuid4(),
+        title="Preset chat",
+        workspace_id=workspace_id,
+        entity_type=AgentSessionEntity.AGENT_PRESET.value,
+        entity_id=uuid.uuid4(),
+        curr_run_id=uuid.uuid4(),
+    )
+    session.add(agent_session)
+    await session.flush()
+    for approval in approvals:
+        approval.workspace_id = workspace_id
+        approval.session_id = agent_session.id
+        session.add(approval)
+    await session.commit()
+    return agent_session
+
+
+@pytest.mark.anyio
+async def test_apply_decisions_skips_already_terminal_row(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """A deny submitted against an APPROVED row must not overwrite it."""
+    agent_session = await _seed_approval_session(
+        session,
+        svc_role,
+        approvals=[
+            Approval(
+                tool_call_id="tool_call_123",
+                tool_name="core.http_request",
+                tool_call_args={"url": "https://example.com"},
+                status=ApprovalStatus.APPROVED,
+                decision={"value": True},
+            )
+        ],
+    )
+
+    service = AgentSessionService(session=session, role=svc_role)
+    await service._apply_submitted_approval_decisions(
+        session_id=agent_session.id,
+        approval_map={"tool_call_123": False},
+        decision_metadata={},
+    )
+
+    row = (
+        await session.execute(
+            select(Approval.status, Approval.decision).where(
+                Approval.session_id == agent_session.id,
+                Approval.tool_call_id == "tool_call_123",
+            )
+        )
+    ).one()
+    assert row.status is ApprovalStatus.APPROVED
+    assert row.decision == {"value": True}
+
+
+@pytest.mark.anyio
+async def test_apply_decisions_warns_on_missing_row(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """Tool call IDs with no persisted row warn once, batched, instead of raising."""
+    agent_session = await _seed_approval_session(session, svc_role, approvals=[])
+
+    service = AgentSessionService(session=session, role=svc_role)
+    with patch("tracecat.agent.session.service.logger") as mock_logger:
+        await service._apply_submitted_approval_decisions(
+            session_id=agent_session.id,
+            approval_map={"tool_call_missing": True, "tool_call_absent": False},
+            decision_metadata={},
+        )
+
+    mock_logger.warning.assert_called_once()
+    assert mock_logger.warning.call_args.kwargs["tool_call_ids"] == [
+        "tool_call_absent",
+        "tool_call_missing",
+    ]
+
+
+@pytest.mark.anyio
+async def test_apply_decisions_nulls_approved_by_for_unknown_user(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """A role user_id with no user row must not raise an FK violation."""
+    agent_session = await _seed_approval_session(
+        session,
+        svc_role,
+        approvals=[
+            Approval(
+                tool_call_id="tool_call_123",
+                tool_name="core.http_request",
+                tool_call_args={"url": "https://example.com"},
+                status=ApprovalStatus.PENDING,
+            )
+        ],
+    )
+
+    ghost_role = svc_role.model_copy(update={"user_id": uuid.uuid4()})
+    service = AgentSessionService(session=session, role=ghost_role)
+    await service._apply_submitted_approval_decisions(
+        session_id=agent_session.id,
+        approval_map={"tool_call_123": True},
+        decision_metadata={},
+    )
+
+    row = (
+        await session.execute(
+            select(Approval.status, Approval.approved_by).where(
+                Approval.session_id == agent_session.id,
+                Approval.tool_call_id == "tool_call_123",
+            )
+        )
+    ).one()
+    assert row.status is ApprovalStatus.APPROVED
+    assert row.approved_by is None
+
+
+@pytest.mark.anyio
+async def test_apply_decisions_visible_to_later_read_in_same_session(
+    session: AsyncSession,
+    svc_role: Role,
+) -> None:
+    """Rows already in the identity map must not read back stale after apply.
+
+    ``_emit_approval_idle_segment`` re-selects these rows in the same session
+    right after the decisions land, so a Core UPDATE must not leave the ORM
+    holding the pre-update PENDING state.
+    """
+    agent_session = await _seed_approval_session(
+        session,
+        svc_role,
+        approvals=[
+            Approval(
+                tool_call_id="tool_call_123",
+                tool_name="core.http_request",
+                tool_call_args={"url": "https://example.com"},
+                status=ApprovalStatus.PENDING,
+            )
+        ],
+    )
+
+    service = AgentSessionService(session=session, role=svc_role)
+    preloaded = await session.scalar(
+        select(Approval).where(
+            Approval.session_id == agent_session.id,
+            Approval.tool_call_id == "tool_call_123",
+        )
+    )
+    assert preloaded is not None
+    assert preloaded.status is ApprovalStatus.PENDING
+
+    await service._apply_submitted_approval_decisions(
+        session_id=agent_session.id,
+        approval_map={"tool_call_123": True},
+        decision_metadata={"tool_call_123": {"source": "inbox"}},
+    )
+
+    items = await service._approval_stream_items(
+        session_id=agent_session.id,
+        tool_call_ids=["tool_call_123"],
+    )
+    assert [item.status for item in items] == ["approved"]
+
+    reread = await session.scalar(
+        select(Approval).where(
+            Approval.session_id == agent_session.id,
+            Approval.tool_call_id == "tool_call_123",
+        )
+    )
+    assert reread is not None
+    assert reread.status is ApprovalStatus.APPROVED
+    assert reread.decision == {"value": True, "metadata": {"source": "inbox"}}
+    # `updated_at` cannot be asserted to advance here: the test fixture runs one
+    # outer transaction, and `func.now()` is transaction-start time.
+    assert reread.approved_at is not None

--- a/tests/unit/test_agent_session_router.py
+++ b/tests/unit/test_agent_session_router.py
@@ -395,7 +395,12 @@ async def test_remove_session_artifact_removes_and_returns_artifacts() -> None:
 async def test_send_message_continue_uses_path_session_id_for_stream_key() -> None:
     session_id = uuid.uuid4()
     workspace_id = uuid.uuid4()
-    agent_session = _agent_session_stub(id=session_id, workspace_id=workspace_id)
+    agent_session = _agent_session_stub(
+        id=session_id,
+        workspace_id=workspace_id,
+        active_stream_id=uuid.uuid4(),
+        curr_run_id=uuid.uuid4(),
+    )
     role = Role(
         type="service",
         service_id="tracecat-api",

--- a/tests/unit/test_agent_session_router.py
+++ b/tests/unit/test_agent_session_router.py
@@ -41,7 +41,11 @@ from tracecat.chat.schemas import (
     ContinueRunRequest,
     VercelChatRequest,
 )
-from tracecat.exceptions import EntitlementRequired, TracecatNotFoundError
+from tracecat.exceptions import (
+    EntitlementRequired,
+    TracecatConflictError,
+    TracecatNotFoundError,
+)
 
 
 async def _empty_event_stream() -> AsyncIterator[None]:
@@ -980,6 +984,60 @@ async def test_send_message_new_turn_clears_stream_when_startup_fails() -> None:
     # the HTTP layer so a concurrent newer turn's pointers are not clobbered.
     assert isinstance(clear_call.kwargs["expected_stream_id"], uuid.UUID)
     fake_stream.sse.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_send_message_maps_conflicting_decision_to_409() -> None:
+    """A decision contradicting a recorded one is a conflict, not a 500."""
+    session_id = uuid.uuid4()
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute"}),
+    )
+    request = ContinueRunRequest(
+        decisions=[ApprovalDecision(tool_call_id="tool_call_123", action="deny")],
+        source="slack",
+    )
+
+    fake_svc = SimpleNamespace(
+        session=Mock(),
+        is_legacy_session=AsyncMock(return_value=False),
+        validate_turn_request=AsyncMock(return_value=SimpleNamespace(curr_run_id=None)),
+        run_turn=AsyncMock(
+            side_effect=TracecatConflictError(
+                "Approval decision conflicts with a decision already recorded"
+                " for tool call tool_call_123"
+            )
+        ),
+    )
+
+    with (
+        patch(
+            "tracecat.agent.session.router.AgentSessionService.with_session",
+            return_value=_AsyncContext(fake_svc),
+        ),
+        patch(
+            "tracecat.agent.session.router._require_workspace_chat_entitlement_for_session_tree",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        raw_send_message = cast(Any, send_message).__wrapped__
+        with pytest.raises(HTTPException) as exc_info:
+            await raw_send_message(
+                session_id=session_id,
+                request=request,
+                role=role,
+                http_request=cast(
+                    Any,
+                    SimpleNamespace(is_disconnected=AsyncMock(return_value=False)),
+                ),
+            )
+
+    assert exc_info.value.status_code == 409
+    assert "already recorded" in str(exc_info.value.detail)
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_stream_connector.py
+++ b/tests/unit/test_agent_stream_connector.py
@@ -267,6 +267,113 @@ async def test_stream_events_expires_buffer_after_terminal_marker() -> None:
 
 
 @pytest.mark.anyio
+async def test_stream_events_yields_nonterminal_idle_boundary_without_expiring() -> (
+    None
+):
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    raw_client = SimpleNamespace(expire=AsyncMock(return_value=None))
+    client = SimpleNamespace(
+        xread=AsyncMock(
+            return_value=[
+                (
+                    f"agent-stream:{workspace_id}:{session_id}",
+                    [
+                        (
+                            "1717426372769-0",
+                            {
+                                tokens.DATA_KEY: (
+                                    b'{"[TURN_END]":1,'
+                                    b'"terminal":false,'
+                                    b'"reason":"approval_pending"}'
+                                ),
+                            },
+                        )
+                    ],
+                )
+            ]
+        ),
+        xrange=AsyncMock(return_value=[]),
+        delete=AsyncMock(return_value=1),
+        _get_client=AsyncMock(return_value=raw_client),
+    )
+    stream = AgentStream(
+        client=cast(RedisClient, client),
+        workspace_id=workspace_id,
+        session_id=session_id,
+    )
+
+    events = [
+        event
+        async for event in stream._stream_events(
+            AsyncMock(side_effect=[False, True]), last_id="0-0"
+        )
+    ]
+
+    assert len(events) == 1
+    assert isinstance(events[0], StreamEnd)
+    raw_client.expire.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_stream_events_skips_stale_nonterminal_idle_boundary() -> None:
+    workspace_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    raw_client = SimpleNamespace(expire=AsyncMock(return_value=None))
+    client = SimpleNamespace(
+        xread=AsyncMock(
+            return_value=[
+                (
+                    f"agent-stream:{workspace_id}:{session_id}",
+                    [
+                        (
+                            "1717426372769-0",
+                            {
+                                tokens.DATA_KEY: (
+                                    b'{"[TURN_END]":1,'
+                                    b'"terminal":false,'
+                                    b'"reason":"approval_pending"}'
+                                ),
+                            },
+                        ),
+                        (
+                            "1717426372770-0",
+                            {
+                                tokens.DATA_KEY: b'{"type":"text_delta","text":"next"}',
+                            },
+                        ),
+                    ],
+                )
+            ]
+        ),
+        xrange=AsyncMock(return_value=[("1717426372770-0", {})]),
+        delete=AsyncMock(return_value=1),
+        _get_client=AsyncMock(return_value=raw_client),
+    )
+    stream = AgentStream(
+        client=cast(RedisClient, client),
+        workspace_id=workspace_id,
+        session_id=session_id,
+    )
+
+    events = [
+        event
+        async for event in stream._stream_events(
+            AsyncMock(side_effect=[False, True]), last_id="0-0"
+        )
+    ]
+
+    assert len(events) == 1
+    assert isinstance(events[0], StreamDelta)
+    client.xrange.assert_awaited_once_with(
+        stream._stream_key,
+        min_id="(1717426372769-0",
+        count=1,
+    )
+    raw_client.expire.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_stream_events_does_not_expire_when_not_completed() -> None:
     workspace_id = uuid.uuid4()
     session_id = uuid.uuid4()

--- a/tests/unit/test_approvals_manager.py
+++ b/tests/unit/test_approvals_manager.py
@@ -140,12 +140,12 @@ class TestApprovalManager:
         # Should not raise
         approval_manager.validate_responses(approvals)
 
-    async def test_validate_responses_missing_approvals(
+    async def test_validate_responses_accepts_partial_approvals(
         self,
         approval_manager: ApprovalManager,
         sample_tool_calls: list[ToolCallPart],
     ) -> None:
-        """Test validation fails when approval responses are missing."""
+        """Partial submissions are valid: approvals are decided one by one."""
         approval_manager._expected_tool_calls = {
             tc.tool_call_id: tc for tc in sample_tool_calls
         }
@@ -153,11 +153,11 @@ class TestApprovalManager:
         # Provide only partial approvals
         approvals: ApprovalMap = {
             "call_123": True,
-            # Missing call_456
+            # call_456 will be decided in a later submission
         }
 
-        with pytest.raises(ValueError, match="Missing approval responses"):
-            approval_manager.validate_responses(approvals)
+        # Should not raise
+        approval_manager.validate_responses(approvals)
 
     async def test_validate_responses_unexpected_approvals(
         self,
@@ -244,7 +244,52 @@ class TestApprovalManager:
 
         assert approval_manager._approvals == approvals
         assert approval_manager.is_ready()
-        assert approval_manager._approved_by == approved_by
+        assert approval_manager._approved_by_by_tool_call_id == {
+            "call_123": approved_by,
+            "call_456": approved_by,
+        }
+
+    async def test_set_accumulates_partial_decisions(
+        self,
+        approval_manager: ApprovalManager,
+        sample_tool_calls: list[ToolCallPart],
+    ) -> None:
+        """Parallel approvals decided one by one only resume when complete."""
+        approval_manager._expected_tool_calls = {
+            tc.tool_call_id: tc for tc in sample_tool_calls
+        }
+        first_approver = uuid.uuid4()
+        second_approver = uuid.uuid4()
+
+        approval_manager.set({"call_123": True}, approved_by=first_approver)
+
+        assert not approval_manager.is_ready()
+        assert approval_manager._approvals == {"call_123": True}
+
+        approval_manager.set({"call_456": False}, approved_by=second_approver)
+
+        assert approval_manager.is_ready()
+        assert approval_manager._approvals == {"call_123": True, "call_456": False}
+        assert approval_manager._approved_by_by_tool_call_id == {
+            "call_123": first_approver,
+            "call_456": second_approver,
+        }
+
+    async def test_set_resubmission_overwrites_decision(
+        self,
+        approval_manager: ApprovalManager,
+        sample_tool_calls: list[ToolCallPart],
+    ) -> None:
+        """Re-deciding the same tool call is idempotent (last write wins)."""
+        approval_manager._expected_tool_calls = {
+            tc.tool_call_id: tc for tc in sample_tool_calls
+        }
+
+        approval_manager.set({"call_123": True})
+        approval_manager.set({"call_123": False})
+
+        assert not approval_manager.is_ready()
+        assert approval_manager._approvals == {"call_123": False}
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_approvals_manager.py
+++ b/tests/unit/test_approvals_manager.py
@@ -1,13 +1,15 @@
 """Tests for ApprovalManager and Temporal activities."""
 
+import asyncio
 import uuid
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pydantic_ai.messages import ToolCallPart
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from tracecat_ee.agent.activities import (
     ApplyApprovalResultsActivityInputs,
@@ -25,7 +27,8 @@ from tracecat_ee.agent.context import AgentContext
 
 from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.auth.types import Role
-from tracecat.db.models import AgentSession, User
+from tracecat.db.engine import get_async_session_context_manager
+from tracecat.db.models import AgentSession, Approval, User
 
 pytestmark = pytest.mark.usefixtures("db")
 
@@ -290,6 +293,40 @@ class TestApprovalManager:
 
         assert not approval_manager.is_ready()
         assert approval_manager._approvals == {"call_123": False}
+
+    async def test_handle_decisions_emits_unique_tool_call_ids(
+        self,
+        approval_manager: ApprovalManager,
+        sample_tool_calls: list[ToolCallPart],
+    ) -> None:
+        """The persistence upsert cannot carry one conflict key twice.
+
+        Resubmitting a decision is the only way a duplicate could plausibly
+        reach the activity, so drive that and assert the payload collapses it.
+        """
+        approval_manager._expected_tool_calls = {
+            tc.tool_call_id: tc for tc in sample_tool_calls
+        }
+        approval_manager.set({"call_123": True})
+        approval_manager.set({"call_123": False})
+        approval_manager.set({"call_456": True})
+
+        execute_activity = AsyncMock(return_value=None)
+        with patch(
+            "tracecat_ee.agent.approvals.service.workflow.execute_activity",
+            execute_activity,
+        ):
+            await approval_manager.handle_decisions()
+
+        execute_activity.assert_awaited_once()
+        assert execute_activity.await_args is not None
+        payload = execute_activity.await_args.kwargs["arg"]
+        submitted = [decision.tool_call_id for decision in payload.decisions]
+        assert sorted(submitted) == ["call_123", "call_456"]
+        assert len(submitted) == len(set(submitted))
+        # Last write wins, so the resubmitted deny is what persists.
+        decided = {d.tool_call_id: d.approved for d in payload.decisions}
+        assert decided == {"call_123": False, "call_456": True}
 
 
 @pytest.mark.anyio
@@ -701,3 +738,248 @@ class TestApplyApprovalDecisionMetadata:
                     "actor": {"user_id": "U123", "display_name": "jordan"},
                 },
             }
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("patched_approval_service")
+class TestApplyApprovalDecisionsUpsert:
+    """Pins the ON CONFLICT DO UPDATE persistence contract."""
+
+    async def test_apply_approval_none_decision_preserves_stored_decision(
+        self,
+        session: AsyncSession,
+        svc_role: Role,
+        mock_agent_session: AgentSession,
+    ) -> None:
+        """decision=None must not overwrite a stored decision with JSON null."""
+        service = ApprovalService(session=session, role=svc_role)
+        await service.create_approval(
+            ApprovalCreate(
+                session_id=mock_agent_session.id,
+                tool_call_id="call_preserve",
+                tool_name="tool_1",
+                tool_call_args={},
+            )
+        )
+
+        stored = {"kind": "tool-approved", "override_args": {"a": 1}}
+        await ApprovalManager.apply_approval_decisions(
+            ApplyApprovalResultsActivityInputs(
+                role=svc_role,
+                session_id=mock_agent_session.id,
+                decisions=[
+                    ApprovalDecisionPayload(
+                        tool_call_id="call_preserve",
+                        approved=True,
+                        decision=stored,
+                    )
+                ],
+            )
+        )
+
+        await ApprovalManager.apply_approval_decisions(
+            ApplyApprovalResultsActivityInputs(
+                role=svc_role,
+                session_id=mock_agent_session.id,
+                decisions=[
+                    ApprovalDecisionPayload(
+                        tool_call_id="call_preserve",
+                        approved=False,
+                        reason="cancelled",
+                        decision=None,
+                    )
+                ],
+            )
+        )
+
+        approval = await service.get_approval_by_session_and_tool(
+            session_id=mock_agent_session.id,
+            tool_call_id="call_preserve",
+        )
+        assert approval is not None
+        await session.refresh(approval)
+        # Status/reason advance, but the stored decision survives.
+        assert approval.status == ApprovalStatus.REJECTED
+        assert approval.reason == "cancelled"
+        assert approval.decision == stored
+
+    async def test_apply_approval_last_writer_wins(
+        self,
+        session: AsyncSession,
+        svc_role: Role,
+        mock_agent_session: AgentSession,
+    ) -> None:
+        """Approve then deny for the same tool call results in deny."""
+        service = ApprovalService(session=session, role=svc_role)
+
+        for approved, decision, reason in (
+            (True, True, "ok"),
+            (False, False, "revoked"),
+        ):
+            await ApprovalManager.apply_approval_decisions(
+                ApplyApprovalResultsActivityInputs(
+                    role=svc_role,
+                    session_id=mock_agent_session.id,
+                    decisions=[
+                        ApprovalDecisionPayload(
+                            tool_call_id="call_lww",
+                            approved=approved,
+                            reason=reason,
+                            decision=decision,
+                        )
+                    ],
+                )
+            )
+
+        approval = await service.get_approval_by_session_and_tool(
+            session_id=mock_agent_session.id,
+            tool_call_id="call_lww",
+        )
+        assert approval is not None
+        await session.refresh(approval)
+        assert approval.status == ApprovalStatus.REJECTED
+        assert approval.reason == "revoked"
+        assert approval.decision is False
+
+    async def test_apply_approval_sets_updated_at_on_conflict(
+        self,
+        session: AsyncSession,
+        svc_role: Role,
+        mock_agent_session: AgentSession,
+    ) -> None:
+        """The conflict path must set updated_at explicitly.
+
+        onupdate does not fire for ON CONFLICT DO UPDATE. This asserts the
+        column is written, not that it advances: func.now() is transaction-start
+        time and this fixture runs the whole test in one transaction, so no
+        unit test here can observe it move. In production each activity call
+        commits its own transaction, so retries do stamp a new value.
+        """
+        service = ApprovalService(session=session, role=svc_role)
+        approval = await service.create_approval(
+            ApprovalCreate(
+                session_id=mock_agent_session.id,
+                tool_call_id="call_touch",
+                tool_name="tool_1",
+                tool_call_args={},
+            )
+        )
+
+        await ApprovalManager.apply_approval_decisions(
+            ApplyApprovalResultsActivityInputs(
+                role=svc_role,
+                session_id=mock_agent_session.id,
+                decisions=[
+                    ApprovalDecisionPayload(
+                        tool_call_id="call_touch",
+                        approved=True,
+                        decision=True,
+                    )
+                ],
+            )
+        )
+
+        await session.refresh(approval)
+        assert approval.updated_at is not None
+        assert approval.status == ApprovalStatus.APPROVED
+
+
+@pytest.mark.anyio
+class TestApplyApprovalDecisionsConcurrency:
+    async def test_concurrent_apply_for_missing_approval(
+        self,
+        svc_role: Role,
+    ) -> None:
+        """Two concurrent applies for a MISSING row must both succeed with one row.
+
+        Uses real independent sessions (no patched_approval_service) so each
+        call runs in its own transaction, which is what SELECT FOR UPDATE could
+        not guard: it cannot lock a row that does not exist.
+
+        A barrier holds both calls open until each has issued its read, so the
+        interleaving is deterministic. Without it asyncio.gather may serialize
+        the two transactions and the race never occurs.
+        """
+        session_id = uuid.uuid4()
+        tool_call_id = "call_concurrent"
+        both_started = asyncio.Barrier(2)
+
+        # Commit the agent session globally so independent connections satisfy the FK.
+        async with get_async_session_context_manager() as setup:
+            setup.add(
+                AgentSession(
+                    id=session_id,
+                    title="Concurrency Test Session",
+                    workspace_id=svc_role.workspace_id,
+                    entity_type="workflow",
+                    entity_id=uuid.uuid4(),
+                )
+            )
+            await setup.commit()
+
+        def make_input(approved: bool, reason: str):
+            return ApplyApprovalResultsActivityInputs(
+                role=svc_role,
+                session_id=session_id,
+                decisions=[
+                    ApprovalDecisionPayload(
+                        tool_call_id=tool_call_id,
+                        approved=approved,
+                        reason=reason,
+                        decision=approved,
+                    )
+                ],
+            )
+
+        real_execute = AsyncSession.execute
+
+        async def barriered_execute(self, statement, *args, **kwargs):
+            """Sync both transactions after their first statement, before commit."""
+            result = await real_execute(self, statement, *args, **kwargs)
+            if not getattr(self, "_hit_barrier", False):
+                self._hit_barrier = True
+                await both_started.wait()
+            return result
+
+        try:
+            with patch.object(AsyncSession, "execute", barriered_execute):
+                results = await asyncio.gather(
+                    ApprovalManager.apply_approval_decisions(
+                        make_input(True, "attempt_a")
+                    ),
+                    ApprovalManager.apply_approval_decisions(
+                        make_input(False, "attempt_b")
+                    ),
+                    return_exceptions=True,
+                )
+            errors = [r for r in results if isinstance(r, BaseException)]
+            assert not errors, f"concurrent applies raised: {errors}"
+
+            async with get_async_session_context_manager() as verify:
+                rows = (
+                    (
+                        await verify.execute(
+                            select(Approval).where(
+                                Approval.workspace_id == svc_role.workspace_id,
+                                Approval.session_id == session_id,
+                                Approval.tool_call_id == tool_call_id,
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                assert len(rows) == 1
+                assert rows[0].tool_name == "unknown"
+        finally:
+            async with get_async_session_context_manager() as cleanup:
+                await cleanup.execute(
+                    delete(Approval).where(
+                        Approval.workspace_id == svc_role.workspace_id,
+                        Approval.session_id == session_id,
+                    )
+                )
+                await cleanup.execute(
+                    delete(AgentSession).where(AgentSession.id == session_id)
+                )
+                await cleanup.commit()

--- a/tests/unit/test_chat_schemas.py
+++ b/tests/unit/test_chat_schemas.py
@@ -1,0 +1,54 @@
+"""Tests for chat API schemas."""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from tracecat.agent.approvals.enums import ApprovalStatus
+from tracecat.chat.schemas import ApprovalRead
+
+
+def approval_read_data(decision: object) -> dict[str, object]:
+    """Build validation input for an approval timeline record."""
+    return {
+        "id": uuid.uuid4(),
+        "tool_call_id": "tool-call-1",
+        "tool_name": "core.example.action",
+        "status": ApprovalStatus.APPROVED,
+        "decision": decision,
+        "created_at": datetime.now(UTC),
+    }
+
+
+@pytest.mark.parametrize(
+    "decision",
+    [
+        True,
+        False,
+        {"kind": "tool-approved"},
+        {
+            "kind": "tool-approved",
+            "override_args": {"limit": 10},
+            "metadata": {"source": "inbox"},
+        },
+        {
+            "kind": "tool-denied",
+            "message": "Not approved",
+            "metadata": {"source": "inbox"},
+        },
+        {"value": True, "metadata": {"source": "inbox"}},
+    ],
+)
+def test_approval_read_accepts_persisted_decision_shapes(decision: object) -> None:
+    approval = ApprovalRead.model_validate(approval_read_data(decision))
+
+    assert approval.decision == decision
+
+
+def test_approval_read_rejects_unstructured_decision() -> None:
+    with pytest.raises(ValidationError):
+        ApprovalRead.model_validate(
+            approval_read_data({"unexpected": "decision shape"})
+        )

--- a/tests/unit/test_vercel_adapter.py
+++ b/tests/unit/test_vercel_adapter.py
@@ -18,13 +18,17 @@ from tracecat.chat.enums import MessageKind
 from tracecat.chat.schemas import ApprovalRead, ChatMessage
 
 
-def _approval_message(status: ApprovalStatus) -> ChatMessage:
+def _approval_message(
+    status: ApprovalStatus,
+    *,
+    tool_call_id: str = "toolu_123",
+) -> ChatMessage:
     return ChatMessage(
         id=str(uuid4()),
         kind=MessageKind.APPROVAL_REQUEST,
         approval=ApprovalRead(
             id=uuid4(),
-            tool_call_id="toolu_123",
+            tool_call_id=tool_call_id,
             tool_name="core.cases.list_cases",
             tool_call_args={"limit": 100},
             status=status,
@@ -45,6 +49,19 @@ def test_convert_chat_messages_to_ui_skips_resolved_approval_request() -> None:
     messages = convert_chat_messages_to_ui([_approval_message(ApprovalStatus.APPROVED)])
 
     assert messages == []
+
+
+def test_convert_chat_messages_to_ui_keeps_resolved_card_while_batch_pending() -> None:
+    approved = _approval_message(ApprovalStatus.APPROVED, tool_call_id="toolu_a")
+    pending = _approval_message(ApprovalStatus.PENDING, tool_call_id="toolu_b")
+
+    messages = convert_chat_messages_to_ui([approved, pending])
+    approval_parts = [cast(DataUIPart, message.parts[0]) for message in messages]
+
+    assert [part["data"][0]["status"] for part in approval_parts] == [
+        "approved",
+        "pending",
+    ]
 
 
 def test_convert_chat_messages_to_ui_emits_cancelled_marker() -> None:

--- a/tracecat/agent/adapter/vercel.py
+++ b/tracecat/agent/adapter/vercel.py
@@ -62,6 +62,7 @@ from pydantic_core import to_json
 from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.common.stream_types import (
     StreamEventType,
+    ToolCallContent,
     UnifiedStreamEvent,
     parse_vercel_frame_cursor,
 )
@@ -94,6 +95,22 @@ if TYPE_CHECKING:
     from tracecat.chat.schemas import ChatMessage
 # Using a type alias for ProviderMetadata since its structure is not defined.
 ProviderMetadata = dict[str, dict[str, Any]]
+
+
+def _approval_item_to_data_part(item: ToolCallContent) -> dict[str, Any]:
+    """Convert a stream approval item into the UI approval-card payload."""
+    data: dict[str, Any] = {
+        "tool_call_id": item.id,
+        "tool_name": item.name,
+        "args": strip_proxy_tool_metadata(item.input),
+    }
+    if item.status is not None:
+        data["status"] = item.status
+    if item.decision is not None:
+        data["decision"] = item.decision
+    if item.reason is not None:
+        data["reason"] = item.reason
+    return data
 
 
 def _extract_structured_error(output: Any) -> str | None:
@@ -1121,11 +1138,7 @@ class VercelStreamContext:
                     yield DataEventPayload(
                         type=APPROVAL_DATA_PART_TYPE,
                         data=[
-                            {
-                                "tool_call_id": item.id,
-                                "tool_name": item.name,
-                                "args": strip_proxy_tool_metadata(item.input),
-                            }
+                            _approval_item_to_data_part(item)
                             for item in event.approval_items
                         ],
                     )
@@ -1592,6 +1605,12 @@ def convert_chat_messages_to_ui(
     """
     mutable_messages: list[MutableMessage] = []
     tool_entries: dict[str, MutableToolPart] = {}
+    has_pending_approval = any(
+        message.kind == MessageKind.APPROVAL_REQUEST
+        and message.approval is not None
+        and message.approval.status == ApprovalStatus.PENDING
+        for message in messages
+    )
 
     for chat_message in messages:
         # Handle compaction status badges from DB (kind=COMPACTION)
@@ -1630,7 +1649,10 @@ def convert_chat_messages_to_ui(
         # These are inserted by list_messages() when loading session history
         if chat_message.kind == MessageKind.APPROVAL_REQUEST and chat_message.approval:
             approval = chat_message.approval
-            if approval.status != ApprovalStatus.PENDING:
+            # Keep decided cards visible while their batch is still waiting.
+            # Once no approvals are pending, the completed tool state makes the
+            # approval card redundant.
+            if approval.status != ApprovalStatus.PENDING and not has_pending_approval:
                 continue
             # Create an assistant message with the approval data part
             # Normalize tool name for display
@@ -1639,6 +1661,9 @@ def convert_chat_messages_to_ui(
                 "tool_call_id": approval.tool_call_id,
                 "tool_name": tool_name,
                 "args": approval.tool_call_args or {},
+                "status": approval.status.value,
+                "decision": approval.decision,
+                "reason": approval.reason,
             }
             mutable_message = MutableMessage(
                 id=chat_message.id,

--- a/tracecat/agent/approvals/types.py
+++ b/tracecat/agent/approvals/types.py
@@ -1,0 +1,32 @@
+"""Types for persisted agent approval decisions."""
+
+from typing import Any, Literal, NotRequired, TypedDict
+
+
+class ToolApprovedDecision(TypedDict):
+    """Persisted decision for a tool approved with argument overrides."""
+
+    kind: Literal["tool-approved"]
+    override_args: NotRequired[dict[str, Any]]
+    metadata: NotRequired[dict[str, Any]]
+
+
+class ToolDeniedDecision(TypedDict):
+    """Persisted decision for a denied tool call."""
+
+    kind: Literal["tool-denied"]
+    message: NotRequired[str]
+    metadata: NotRequired[dict[str, Any]]
+
+
+class BooleanApprovalDecision(TypedDict):
+    """Persisted boolean decision enriched with submission metadata."""
+
+    value: bool
+    metadata: dict[str, Any]
+
+
+type PersistedApprovalDecision = (
+    bool | ToolApprovedDecision | ToolDeniedDecision | BooleanApprovalDecision
+)
+"""Decision payload stored for a completed approval."""

--- a/tracecat/agent/common/stream_types.py
+++ b/tracecat/agent/common/stream_types.py
@@ -10,6 +10,8 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, Literal
 
+from tracecat.agent.approvals.types import PersistedApprovalDecision
+
 type ArtifactEventOp = Literal["upsert", "remove"]
 type ApprovalStreamStatus = Literal["pending", "approved", "rejected"]
 
@@ -93,7 +95,7 @@ class ToolCallContent:
     """Trusted runtime metadata about the tool call scope."""
     status: ApprovalStreamStatus | None = None
     """Current approval status, when replaying persisted approval state."""
-    decision: bool | dict[str, Any] | None = None
+    decision: PersistedApprovalDecision | None = None
     """Persisted decision payload, when one exists."""
     reason: str | None = None
     """Persisted rejection reason, when one exists."""

--- a/tracecat/agent/common/stream_types.py
+++ b/tracecat/agent/common/stream_types.py
@@ -11,6 +11,7 @@ from enum import StrEnum
 from typing import Any, Literal
 
 type ArtifactEventOp = Literal["upsert", "remove"]
+type ApprovalStreamStatus = Literal["pending", "approved", "rejected"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -90,6 +91,12 @@ class ToolCallContent:
     """Arguments for the tool call."""
     metadata: dict[str, Any] | None = None
     """Trusted runtime metadata about the tool call scope."""
+    status: ApprovalStreamStatus | None = None
+    """Current approval status, when replaying persisted approval state."""
+    decision: bool | dict[str, Any] | None = None
+    """Persisted decision payload, when one exists."""
+    reason: str | None = None
+    """Persisted rejection reason, when one exists."""
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ToolCallContent:
@@ -100,6 +107,9 @@ class ToolCallContent:
             name=data["name"],
             input=data.get("input", {}),
             metadata=data.get("metadata"),
+            status=data.get("status"),
+            decision=data.get("decision"),
+            reason=data.get("reason"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -112,6 +122,12 @@ class ToolCallContent:
         }
         if self.metadata is not None:
             result["metadata"] = self.metadata
+        if self.status is not None:
+            result["status"] = self.status
+        if self.decision is not None:
+            result["decision"] = self.decision
+        if self.reason is not None:
+            result["reason"] = self.reason
         return result
 
 

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -15,6 +15,7 @@ The loopback is used by the agent executor activity which handles:
 from __future__ import annotations
 
 import asyncio
+import copy
 import uuid
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -663,10 +664,22 @@ class LoopbackHandler:
                 items=event.approval_items,
             )
             self._result.approval_requested = True
-            self._result.approval_items = [
-                ToolCallContent(id=item.id, name=item.name, input=item.input)
-                for item in (event.approval_items or [])
-            ]
+            # The runtime emits one APPROVAL_REQUEST event per gated tool call,
+            # so parallel tool calls arrive as N separate events. Accumulate
+            # across events (dedup by tool call ID) rather than overwriting,
+            # which kept only the last event's items.
+            existing_ids = {item.id for item in self._result.approval_items}
+            for item in event.approval_items or []:
+                if item.id in existing_ids:
+                    continue
+                existing_ids.add(item.id)
+                self._result.approval_items.append(
+                    ToolCallContent(
+                        id=item.id,
+                        name=item.name,
+                        input=copy.deepcopy(item.input),
+                    )
+                )
             self._pending_approval_tool_call_ids.update(
                 item.id for item in (event.approval_items or [])
             )

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -566,19 +566,16 @@ class ClaudeAgentRuntime:
                 return alias
         return None
 
-    def _tool_name_requires_approval(self, tool_name: str) -> bool:
-        """Whether a tool call requires manual approval, judged by name alone.
-
-        Mirrors the PreToolUse hook's approval rule for root-level tool calls:
-        preset-backed subagent servers are exempt, everything else consults
-        ``tool_approvals`` by normalized action name.
-        """
+    def _tool_call_requires_approval(
+        self,
+        input_data: HookInput,
+        tool_name: str,
+    ) -> bool:
+        """Whether a tool call requires manual approval."""
+        if self._explicit_subagent_alias_for_tool(input_data, tool_name) is not None:
+            return False
         if self.tool_approvals is None:
             return False
-        for alias in self._explicit_subagent_aliases:
-            server_name = self._subagent_registry_server_name(alias)
-            if tool_name.startswith((f"mcp__{server_name}__", f"mcp.{server_name}.")):
-                return False
         return self.tool_approvals.get(normalize_mcp_tool_name(tool_name)) is True
 
     @staticmethod
@@ -1053,7 +1050,16 @@ class ClaudeAgentRuntime:
         for block in message.content:
             if not isinstance(block, ToolUseBlock):
                 continue
-            if not self._tool_name_requires_approval(block.name):
+            if not self._tool_call_requires_approval(
+                cast(
+                    HookInput,
+                    {
+                        "tool_name": block.name,
+                        "tool_input": block.input or {},
+                    },
+                ),
+                block.name,
+            ):
                 continue
             await self._emit_approval_request(
                 normalize_mcp_tool_name(block.name),
@@ -1165,12 +1171,7 @@ class ClaudeAgentRuntime:
 
         # Preset-backed subagents cannot require manual approvals in v1.
         # Dynamic/general-purpose subagents still inherit root approvals.
-        requires_approval = self._explicit_subagent_alias_for_tool(
-            input_data, tool_name
-        ) is None and (
-            self.tool_approvals is not None
-            and self.tool_approvals.get(action_name) is True
-        )
+        requires_approval = self._tool_call_requires_approval(input_data, tool_name)
 
         if requires_approval:
             # Requires approval - stream request and interrupt

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -33,6 +33,7 @@ from claude_agent_sdk import (
 )
 from claude_agent_sdk.types import (
     AgentDefinition,
+    AssistantMessage,
     HookContext,
     HookInput,
     McpHttpServerConfig,
@@ -44,6 +45,7 @@ from claude_agent_sdk.types import (
     SyncHookJSONOutput,
     SystemMessage,
     ToolResultBlock,
+    ToolUseBlock,
     UserMessage,
 )
 
@@ -564,6 +566,21 @@ class ClaudeAgentRuntime:
                 return alias
         return None
 
+    def _tool_name_requires_approval(self, tool_name: str) -> bool:
+        """Whether a tool call requires manual approval, judged by name alone.
+
+        Mirrors the PreToolUse hook's approval rule for root-level tool calls:
+        preset-backed subagent servers are exempt, everything else consults
+        ``tool_approvals`` by normalized action name.
+        """
+        if self.tool_approvals is None:
+            return False
+        for alias in self._explicit_subagent_aliases:
+            server_name = self._subagent_registry_server_name(alias)
+            if tool_name.startswith((f"mcp__{server_name}__", f"mcp.{server_name}.")):
+                return False
+        return self.tool_approvals.get(normalize_mcp_tool_name(tool_name)) is True
+
     @staticmethod
     def _agent_tool_target(tool_input: dict[str, Any]) -> str | None:
         for key in ("subagent_type", "agent_type", "type", "name"):
@@ -969,7 +986,27 @@ class ClaudeAgentRuntime:
 
         Streams APPROVAL_REQUEST event via socket and interrupts the client.
         The orchestrator handles persistence and coordination.
+
+        Root-level tool calls are normally registered ahead of time from the
+        assistant message stream (``_register_assistant_tool_approvals``), in
+        which case this only needs to interrupt. Unregistered calls (e.g.
+        subagent-originated ones) still get their event emitted here.
         """
+        await self._emit_approval_request(tool_name, tool_input, tool_use_id)
+
+        logger.info("Approval request streamed, interrupting", tool_name=tool_name)
+
+        await self._interrupt_once()
+
+    async def _emit_approval_request(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        tool_use_id: str,
+    ) -> None:
+        """Stream an APPROVAL_REQUEST event for a tool call, at most once."""
+        if tool_use_id in self._pending_approval_tool_ids:
+            return
         self._pending_approval_tool_ids.add(tool_use_id)
 
         approval_event = UnifiedStreamEvent.approval_request_event(
@@ -983,11 +1020,51 @@ class ClaudeAgentRuntime:
         )
         await self._event_writer.send_stream_event(approval_event)
 
-        logger.info("Approval request streamed, interrupting", tool_name=tool_name)
+    async def _interrupt_once(self) -> None:
+        """Abort the current turn, at most once per run.
 
-        if self.client is not None:
-            self._was_interrupted = True
-            await self.client.interrupt()
+        ``interrupt()`` is turn-global: the first call aborts the whole turn,
+        so repeat calls are pointless and may race CLI teardown.
+        """
+        if self.client is None or self._was_interrupted:
+            return
+        self._was_interrupted = True
+        await self.client.interrupt()
+
+    async def _register_assistant_tool_approvals(
+        self, message: AssistantMessage
+    ) -> None:
+        """Emit approval requests for gated tool calls in an assistant message.
+
+        Parallel tool calls arrive as N single-block assistant messages
+        (sharing one API message id), all of which stream past *before* the CLI
+        executes anything. The PreToolUse hook cannot capture the siblings: the
+        CLI serializes tool execution, so the interrupt triggered by the first
+        gated hook aborts the turn and the remaining hooks never fire —
+        dropping their approval requests entirely. Emitting each gated call
+        here, at message-stream time, guarantees every parallel approval is
+        streamed before the interrupt lands. The hook then only denies
+        execution and interrupts.
+        """
+        if message.parent_tool_use_id is not None:
+            # Subagent tool calls are handled by the hook fallback.
+            return
+
+        for block in message.content:
+            if not isinstance(block, ToolUseBlock):
+                continue
+            if not self._tool_name_requires_approval(block.name):
+                continue
+            await self._emit_approval_request(
+                normalize_mcp_tool_name(block.name),
+                block.input,
+                block.id,
+            )
+            logger.info(
+                "Registered approval request from assistant message",
+                tool_name=block.name,
+                tool_use_id=block.id,
+            )
 
     async def interrupt(self, *, reason: str) -> None:
         """Gracefully stop the in-flight turn via the Claude SDK client.
@@ -1719,7 +1796,9 @@ class ClaudeAgentRuntime:
                             # AssistantMessage, UserMessage, etc.
                             await self._emit_new_session_lines()
 
-                            if isinstance(message, UserMessage):
+                            if isinstance(message, AssistantMessage):
+                                await self._register_assistant_tool_approvals(message)
+                            elif isinstance(message, UserMessage):
                                 await self._emit_user_tool_results(message)
                 finally:
                     stderr_task.cancel()

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -53,17 +53,25 @@ from tracecat.logger import logger
 
 router = APIRouter(prefix="/agent/sessions", tags=["agent-sessions"])
 
-# SSE headers for Vercel AI SDK streaming responses from POST /messages.
-_VERCEL_SSE_HEADERS = {
+SSE_HEADERS = {
     "Cache-Control": "no-cache, no-transform",
     "Transfer-Encoding": "chunked",
-    "Content-Encoding": "none",
     "Connection": "keep-alive",
     "Keep-Alive": "timeout=120",
     "Pragma": "no-cache",
-    "X-Accel-Buffering": "no",  # Disable nginx buffering
+    "X-Accel-Buffering": "no",
+}
+VERCEL_SSE_HEADERS = {
+    **SSE_HEADERS,
     "x-vercel-ai-ui-message-stream": "v1",
 }
+
+
+def _sse_headers(format: StreamFormat) -> dict[str, str]:
+    """Return SSE headers for the requested stream format."""
+    if format == "vercel":
+        return dict(VERCEL_SSE_HEADERS)
+    return dict(SSE_HEADERS)
 
 
 def _bubble_id(session_id: uuid.UUID, curr_run_id: uuid.UUID | None) -> str | None:
@@ -518,7 +526,7 @@ async def send_message(
                             format="vercel", message_id=message_id
                         ),
                         media_type="text/event-stream",
-                        headers=_VERCEL_SSE_HEADERS,
+                        headers=_sse_headers("vercel"),
                     )
 
                 stream = await AgentStream.new(
@@ -593,7 +601,7 @@ async def send_message(
                 message_id=message_id,
             ),
             media_type="text/event-stream",
-            headers=_VERCEL_SSE_HEADERS,
+            headers=_sse_headers("vercel"),
         )
     except TracecatNotFoundError as e:
         raise HTTPException(
@@ -642,15 +650,7 @@ async def stream_session_events(
             detail="Workspace access required",
         )
 
-    headers = {
-        "Cache-Control": "no-cache, no-transform",
-        "Connection": "keep-alive",
-        "Keep-Alive": "timeout=120",
-        "Pragma": "no-cache",
-        "X-Accel-Buffering": "no",  # Disable nginx buffering
-    }
-    if format == "vercel":
-        headers["x-vercel-ai-ui-message-stream"] = "v1"
+    headers = _sse_headers(format)
 
     last_event_id = request.headers.get("Last-Event-ID")
 

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -608,6 +608,13 @@ async def send_message(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         ) from e
+    except TracecatConflictError as e:
+        # A decision contradicting one already recorded: the client is acting on
+        # stale state and should refresh, not retry.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=e.detail or str(e),
+        ) from e
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -11,7 +11,7 @@ from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from functools import partial
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 
 import orjson
 from pydantic_ai.messages import (
@@ -20,6 +20,8 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.tools import ToolApproved, ToolDenied
 from sqlalchemy import (
+    TIMESTAMP,
+    String,
     and_,
     case,
     column,
@@ -29,8 +31,9 @@ from sqlalchemy import (
     or_,
     select,
     update,
+    values,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.exc import SQLAlchemyError
 from temporalio.client import (
     WorkflowUpdateRPCTimeoutOrCancelledError,
@@ -115,6 +118,7 @@ from tracecat.chat.tools import (
     get_default_tools,
 )
 from tracecat.db.models import (
+    APPROVAL_STATUS_ENUM,
     AgentSession,
     AgentSessionHistory,
     Approval,
@@ -145,7 +149,7 @@ from tracecat.workflow.executions.enums import (
 from tracecat.workspaces.prompts import WorkspaceCopilotPrompts
 
 if TYPE_CHECKING:
-    from tracecat_ee.agent.approvals.service import ApprovalMap
+    from tracecat_ee.agent.approvals.service import ApprovalMap, ApprovalResult
 
     from tracecat.agent.executor.activity import ToolExecutionResult
 
@@ -208,12 +212,22 @@ class SessionHistoryData:
     is_fork: bool = False  # If True, SDK should use fork_session=True
 
 
+class _ApprovalDecisionFields(NamedTuple):
+    """Approval row fields derived from a deferred approval result."""
+
+    status: ApprovalStatus
+    reason: str | None
+    decision: PersistedApprovalDecision
+    approved_by: uuid.UUID | None
+    approved_at: datetime
+
+
 def _approval_decision_fields(
-    result: Any,
+    result: ApprovalResult,
     *,
     approved_by: uuid.UUID | None,
-    decision_metadata: dict[str, Any] | None,
-) -> dict[str, Any]:
+    decision_metadata: ApprovalDecisionMetadata | None,
+) -> _ApprovalDecisionFields:
     """Map a deferred approval result into Approval row update fields."""
     status: ApprovalStatus
     reason: str | None = None
@@ -250,13 +264,42 @@ def _approval_decision_fields(
         case _:
             raise ValueError(f"Unsupported approval result: {type(result)}")
 
-    return {
-        "status": status,
-        "reason": reason,
-        "decision": decision,
-        "approved_by": approved_by,
-        "approved_at": datetime.now(tz=UTC),
-    }
+    return _ApprovalDecisionFields(
+        status=status,
+        reason=reason,
+        decision=decision,
+        approved_by=approved_by,
+        approved_at=datetime.now(tz=UTC),
+    )
+
+
+def _decision_matches_persisted(
+    result: ApprovalResult, persisted: PersistedApprovalDecision | None
+) -> bool:
+    """Return whether a resubmitted decision matches what was already stored.
+
+    Compares outcome and override args but not metadata, so the same decision
+    replayed from a different surface (Slack <-> inbox) is still a match.
+    """
+    if persisted is None:
+        return False
+
+    fields = _approval_decision_fields(result, approved_by=None, decision_metadata=None)
+    submitted = fields.decision
+    # A bare bool is the legacy shape; {"value": ...} is the same decision
+    # enriched with submission metadata, so the two must compare equal.
+    if isinstance(submitted, bool):
+        if isinstance(persisted, bool):
+            return submitted == persisted
+        return submitted == persisted.get("value")
+    if isinstance(persisted, bool):
+        return False
+    # Compare the outcome only. Metadata and the deny message are excluded:
+    # each surface supplies its own default reason, so including them would
+    # reject a replay of the same decision from a different surface.
+    return all(
+        submitted.get(key) == persisted.get(key) for key in ("kind", "override_args")
+    )
 
 
 @dataclass(frozen=True)
@@ -278,12 +321,31 @@ class ApprovalContinuationAttempt:
     previous_stream_id: uuid.UUID | None
 
 
+type ApprovalDecisionMetadata = dict[str, Any]
+"""Submission metadata persisted alongside a decision.
+
+Always carries ``source``; client-supplied keys are merged over it, so the
+value type stays open. ``_decision_matches_persisted`` ignores this entirely
+so the same decision replayed from another surface is not a conflict.
+"""
+
+
 @dataclass(frozen=True)
 class _ValidatedContinuation:
     """Approvals resolved from a validated continuation request."""
 
     approval_map: ApprovalMap
-    decision_metadata: dict[str, dict[str, Any]]
+    decision_metadata: dict[str, ApprovalDecisionMetadata]
+
+
+class _DecisionRow(NamedTuple):
+    """One row of the VALUES clause; field order must match the columns."""
+
+    tool_call_id: str
+    status: ApprovalStatus
+    reason: str | None
+    decision: PersistedApprovalDecision
+    approved_at: datetime
 
 
 class AgentSessionService(BaseWorkspaceService):
@@ -1254,49 +1316,96 @@ class AgentSessionService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         return set(result.scalars().all())
 
+    async def _settled_approval_decisions(
+        self, session_id: uuid.UUID
+    ) -> dict[str, PersistedApprovalDecision | None]:
+        """Return already-decided approvals so retries can be reconciled."""
+        stmt = select(Approval.tool_call_id, Approval.decision).where(
+            Approval.workspace_id == self.workspace_id,
+            Approval.session_id == session_id,
+            Approval.status != ApprovalStatus.PENDING,
+        )
+        result = await self.session.execute(stmt)
+        return {row.tool_call_id: row.decision for row in result}
+
     async def _apply_submitted_approval_decisions(
         self,
         *,
         session_id: uuid.UUID,
-        approval_map: Mapping[str, Any],
-        decision_metadata: Mapping[str, dict[str, Any]],
+        approval_map: Mapping[str, ApprovalResult],
+        decision_metadata: Mapping[str, ApprovalDecisionMetadata],
     ) -> None:
         """Persist accepted approval decisions before the full set resumes."""
         if not approval_map:
             return
 
-        tool_call_ids = list(approval_map)
-        stmt = (
-            select(Approval)
-            .where(
-                Approval.workspace_id == self.workspace_id,
-                Approval.session_id == session_id,
-                Approval.tool_call_id.in_(tool_call_ids),
-                Approval.status == ApprovalStatus.PENDING,
-            )
-            .with_for_update()
-        )
-        result = await self.session.execute(stmt)
-        approvals_by_tool_id = {
-            approval.tool_call_id: approval for approval in result.scalars().all()
-        }
         approved_by = await self._existing_user_id(self.role.user_id)
-
+        rows: list[_DecisionRow] = []
         for tool_call_id, approval_result in approval_map.items():
-            approval = approvals_by_tool_id.get(tool_call_id)
-            if approval is None:
-                logger.warning(
-                    "Accepted approval decision has no persisted approval row",
-                    session_id=str(session_id),
-                    tool_call_id=tool_call_id,
-                )
-                continue
-            for field, value in _approval_decision_fields(
+            fields = _approval_decision_fields(
                 approval_result,
                 approved_by=approved_by,
                 decision_metadata=decision_metadata.get(tool_call_id),
-            ).items():
-                setattr(approval, field, value)
+            )
+            rows.append(
+                _DecisionRow(
+                    tool_call_id=tool_call_id,
+                    status=fields.status,
+                    reason=fields.reason,
+                    decision=fields.decision,
+                    approved_at=fields.approved_at,
+                )
+            )
+
+        # Column types mirror the Approval model so values bind directly.
+        decisions = (
+            values(
+                column("tool_call_id", String),
+                column("status", APPROVAL_STATUS_ENUM),
+                column("reason", String),
+                column("decision", JSONB),
+                column("approved_at", TIMESTAMP(timezone=True)),
+                name="decisions",
+            )
+            .data(rows)
+            .alias()
+        )
+
+        stmt = (
+            update(Approval)
+            .where(
+                Approval.workspace_id == self.workspace_id,
+                Approval.session_id == session_id,
+                Approval.status == ApprovalStatus.PENDING,
+                Approval.tool_call_id == decisions.c.tool_call_id,
+            )
+            .values(
+                status=decisions.c.status,
+                reason=decisions.c.reason,
+                decision=decisions.c.decision,
+                approved_by=literal(approved_by, UUID),
+                approved_at=decisions.c.approved_at,
+                # Core-level bulk UPDATE does not fire the mapper `onupdate`.
+                updated_at=func.now(),
+            )
+            .returning(Approval.tool_call_id)
+            # "fetch" expires the updated rows in the identity map so
+            # `_emit_approval_idle_segment` re-reads them fresh. It reuses the
+            # RETURNING above, so this costs no extra query. "evaluate" cannot
+            # replay a criteria that joins a SQL-only VALUES clause.
+            .execution_options(synchronize_session="fetch")
+        )
+        result = await self.session.execute(stmt)
+        updated = set(result.scalars().all())
+
+        # Validation admits only pending IDs, so a miss here means the row was
+        # decided by a concurrent submitter in between, or is missing entirely.
+        if skipped := set(approval_map) - updated:
+            logger.warning(
+                "Accepted approval decisions were missing or no longer pending",
+                session_id=str(session_id),
+                tool_call_ids=sorted(skipped),
+            )
 
         await self.session.commit()
 
@@ -2012,12 +2121,18 @@ class AgentSessionService(BaseWorkspaceService):
         *,
         request: ContinueRunRequest,
         pending_tool_call_ids: set[str],
+        settled_decisions: Mapping[str, PersistedApprovalDecision | None],
     ) -> _ValidatedContinuation:
-        """Validate decisions against the pending set and build the ApprovalMap.
+        """Validate decisions against pending and already-settled approvals.
+
+        Partial batches make resubmission normal: a decision that matches what
+        is already persisted is dropped as a no-op, so only still-pending
+        decisions reach the workflow.
 
         Raises:
-            ValueError: On duplicate submitted IDs or any mismatch with the
-                pending tool-call-id set.
+            ValueError: On duplicate submitted IDs, or IDs that are neither
+                pending nor already decided.
+            TracecatConflictError: If a decision contradicts a settled one.
         """
 
         source = request.source
@@ -2027,27 +2142,30 @@ class AgentSessionService(BaseWorkspaceService):
         submitted_tool_call_id_set = set(submitted_tool_call_ids)
         if len(submitted_tool_call_ids) != len(submitted_tool_call_id_set):
             raise ValueError("Approval decisions contain duplicate tool call IDs")
-        if not submitted_tool_call_id_set or not submitted_tool_call_id_set.issubset(
-            pending_tool_call_ids
-        ):
+        unexpected = sorted(
+            submitted_tool_call_id_set
+            - pending_tool_call_ids
+            - settled_decisions.keys()
+        )
+        if not submitted_tool_call_id_set or unexpected:
             missing = sorted(pending_tool_call_ids - submitted_tool_call_id_set)
-            unexpected = sorted(submitted_tool_call_id_set - pending_tool_call_ids)
             raise ValueError(
                 "Approval decisions do not match pending tool calls"
                 f" (missing={missing}, unexpected={unexpected})"
             )
 
         approval_map: ApprovalMap = {}
-        decision_metadata: dict[str, dict[str, Any]] = {}
+        decision_metadata: dict[str, ApprovalDecisionMetadata] = {}
         for decision in request.decisions:
+            approval_result: ApprovalResult
             if decision.action == "approve":
-                approval_map[decision.tool_call_id] = True
+                approval_result = True
             elif decision.action == "override":
-                approval_map[decision.tool_call_id] = ToolApproved(
+                approval_result = ToolApproved(
                     override_args=decision.override_args or {}
                 )
             elif decision.action == "deny":
-                approval_map[decision.tool_call_id] = ToolDenied(
+                approval_result = ToolDenied(
                     message=decision.reason or "Tool denied by user"
                 )
             else:
@@ -2056,10 +2174,24 @@ class AgentSessionService(BaseWorkspaceService):
                     action=decision.action,
                     tool_call_id=decision.tool_call_id,
                 )
-                approval_map[decision.tool_call_id] = ToolDenied(
+                approval_result = ToolDenied(
                     message=decision.reason or "Tool denied by user"
                 )
-            merged_metadata: dict[str, Any] = {"source": source}
+
+            if decision.tool_call_id not in pending_tool_call_ids:
+                # Already settled: identical resubmissions are dropped, but a
+                # contradicting one must not read as accepted.
+                if not _decision_matches_persisted(
+                    approval_result, settled_decisions[decision.tool_call_id]
+                ):
+                    raise TracecatConflictError(
+                        "Approval decision conflicts with a decision already"
+                        f" recorded for tool call {decision.tool_call_id}"
+                    )
+                continue
+
+            approval_map[decision.tool_call_id] = approval_result
+            merged_metadata: ApprovalDecisionMetadata = {"source": source}
             if decision.metadata:
                 merged_metadata.update(decision.metadata)
                 merged_metadata["source"] = source
@@ -2144,22 +2276,25 @@ class AgentSessionService(BaseWorkspaceService):
 
         source: Literal["inbox", "slack"] = request.source
 
-        # Idempotency path: if approvals are already resolved, accept duplicate
-        # submissions as a no-op (cross-surface races Slack <-> inbox).
+        # Idempotency path: resubmissions are normal for partial batches, so
+        # reconcile against settled decisions instead of only pending ones.
+        # A matching replay is a no-op; a contradicting one raises.
         pending_tool_call_ids = await self._pending_approval_tool_call_ids(session_id)
-        if not pending_tool_call_ids:
+        settled_decisions = await self._settled_approval_decisions(session_id)
+
+        validated = self._validate_continuation_decisions(
+            request=request,
+            pending_tool_call_ids=pending_tool_call_ids,
+            settled_decisions=settled_decisions,
+        )
+        if not validated.approval_map:
             logger.info(
-                "Ignoring approval continuation without pending approvals",
+                "Ignoring approval continuation with no undecided approvals",
                 session_id=str(session_id),
                 run_id=str(curr_run_id),
                 source=source,
             )
             return None
-
-        validated = self._validate_continuation_decisions(
-            request=request,
-            pending_tool_call_ids=pending_tool_call_ids,
-        )
 
         # Resolve the workflow handle first. These operations do not mutate
         # continuation state, so failures here should not suppress a later retry.

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -1845,7 +1845,9 @@ class AgentSessionService(BaseWorkspaceService):
         submitted_tool_call_id_set = set(submitted_tool_call_ids)
         if len(submitted_tool_call_ids) != len(submitted_tool_call_id_set):
             raise ValueError("Approval decisions contain duplicate tool call IDs")
-        if submitted_tool_call_id_set != pending_tool_call_ids:
+        if not submitted_tool_call_id_set or not submitted_tool_call_id_set.issubset(
+            pending_tool_call_ids
+        ):
             missing = sorted(pending_tool_call_ids - submitted_tool_call_id_set)
             unexpected = sorted(submitted_tool_call_id_set - pending_tool_call_ids)
             raise ValueError(
@@ -1894,7 +1896,7 @@ class AgentSessionService(BaseWorkspaceService):
         attempt: ApprovalContinuationAttempt,
         validated: _ValidatedContinuation,
         handle: Any,
-    ) -> None:
+    ) -> bool:
         """Submit the Temporal update, preserving the attempt on ambiguous failure.
 
         Ambiguous transport failures leave the attempt intact so a retry reuses
@@ -1906,7 +1908,7 @@ class AgentSessionService(BaseWorkspaceService):
         )
 
         try:
-            await handle.execute_update(
+            resumed = await handle.execute_update(
                 DurableAgentWorkflow.set_approvals,
                 WorkflowApprovalSubmission(
                     approvals=validated.approval_map,
@@ -1927,6 +1929,7 @@ class AgentSessionService(BaseWorkspaceService):
                     attempt=attempt,
                 )
             raise
+        return resumed is not False
 
     async def _continue_with_approvals(
         self,
@@ -2008,7 +2011,7 @@ class AgentSessionService(BaseWorkspaceService):
             submission_key=submission_key,
         )
 
-        await self._submit_approval_update(
+        did_resume = await self._submit_approval_update(
             agent_session=agent_session,
             curr_run_id=curr_run_id,
             attempt=attempt,
@@ -2021,6 +2024,7 @@ class AgentSessionService(BaseWorkspaceService):
             workflow_id=str(workflow_id),
             session_id=str(session_id),
             new_stream_id=str(attempt.stream_id),
+            resumed=did_resume,
         )
 
         return ChatResponse(
@@ -2589,6 +2593,20 @@ class AgentSessionService(BaseWorkspaceService):
             if isinstance(block, dict) and block.get("type") == "tool_use"
         ]
 
+    @classmethod
+    def _assistant_row_tool_call_ids(cls, entry: AgentSessionHistory) -> set[str]:
+        """Return tool_use IDs on an assistant history row, else empty."""
+        if entry.content.get("type") != "assistant":
+            return set()
+        message = entry.content.get("message", {})
+        if not isinstance(message, dict):
+            return set()
+        return {
+            tool_use_id
+            for tool_use in cls._extract_tool_uses_from_message(message)
+            if isinstance(tool_use_id := tool_use.get("id"), str)
+        }
+
     # =========================================================================
     # Approval Flow: Replace Interrupt Entries
     # =========================================================================
@@ -2626,30 +2644,68 @@ class AgentSessionService(BaseWorkspaceService):
 
         tool_call_ids = {tr.tool_call_id for tr in tool_results}
 
-        # Find the assistant message containing these tool_uses so we only delete
-        # interrupt artifacts that follow the pending tool call.
+        # Find the assistant rows containing these tool_uses so we only delete
+        # interrupt artifacts that follow the pending tool calls. Claude Code
+        # writes parallel tool calls as one assistant JSONL row per tool_use
+        # block, with every row of the batch sharing the API message id — so
+        # the pending IDs are unioned across rows of one message only; calls
+        # from different assistant turns must never be reconciled together.
+        # The tool_result entry must be anchored after the LAST such row,
+        # which is the first one encountered walking in reverse.
+        #
+        # `message.id` is best-effort: some SDK rows omit it. When it's
+        # present on the anchor row, union any earlier row sharing that id
+        # (order-independent). When it's absent, fall back to unioning only
+        # immediately adjacent assistant rows with no id of their own — a
+        # gap (any non-assistant row, or one that does carry an id) means a
+        # different assistant turn has begun.
         history = await self.get_session_history(session_id)
         assistant_entry: AgentSessionHistory | None = None
+        anchor_index: int | None = None
+        anchor_message_id: str | None = None
+        covered_tool_call_ids: set[str] = set()
 
-        for entry in reversed(history):
-            if entry.content.get("type") == "assistant":
-                tool_uses = self._extract_tool_uses_from_message(
-                    entry.content.get("message", {})
-                )
-                assistant_tool_call_ids = {
-                    tool_use_id
-                    for tool_use in tool_uses
-                    if isinstance(tool_use_id := tool_use.get("id"), str)
-                }
-                if tool_call_ids.issubset(assistant_tool_call_ids):
-                    assistant_entry = entry
+        for index in range(len(history) - 1, -1, -1):
+            entry = history[index]
+            row_tool_call_ids = self._assistant_row_tool_call_ids(entry)
+            matched = tool_call_ids & row_tool_call_ids
+            if not matched:
+                if assistant_entry is not None and anchor_message_id is None:
+                    # No message id to key off of: an unrelated row breaks
+                    # the contiguous run of the current batch.
                     break
+                continue
 
-        if assistant_entry is None:
+            message = entry.content.get("message", {})
+            message_id = message.get("id") if isinstance(message, dict) else None
+            message_id = message_id if isinstance(message_id, str) else None
+
+            if assistant_entry is None:
+                assistant_entry = entry
+                anchor_message_id = message_id
+            elif anchor_message_id is not None:
+                if message_id != anchor_message_id:
+                    continue
+            elif (
+                anchor_index is None
+                or index != anchor_index - 1
+                or message_id is not None
+            ):
+                # Not contiguous with the last unioned row, or this row has
+                # its own id - it belongs to a different batch/turn.
+                break
+
+            anchor_index = index
+            covered_tool_call_ids |= matched
+            if tool_call_ids.issubset(covered_tool_call_ids):
+                break
+
+        if assistant_entry is None or not tool_call_ids.issubset(covered_tool_call_ids):
             logger.warning(
-                "Could not find assistant message with tool_use for continuation",
+                "Could not find assistant message(s) with tool_use for continuation",
                 session_id=session_id,
                 tool_call_ids=tool_call_ids,
+                covered_tool_call_ids=covered_tool_call_ids,
             )
             return
 

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -47,6 +47,12 @@ import tracecat.agent.adapter.vercel
 import tracecat.artifacts.projection as artifact_projection
 from tracecat import config
 from tracecat.agent.approvals.enums import ApprovalStatus
+from tracecat.agent.approvals.types import (
+    BooleanApprovalDecision,
+    PersistedApprovalDecision,
+    ToolApprovedDecision,
+    ToolDeniedDecision,
+)
 from tracecat.agent.cancellation import signal_turn_cancel
 from tracecat.agent.common.stream_types import (
     ApprovalStreamStatus,
@@ -211,33 +217,38 @@ def _approval_decision_fields(
     """Map a deferred approval result into Approval row update fields."""
     status: ApprovalStatus
     reason: str | None = None
-    decision: bool | dict[str, Any] | None = None
+    decision: PersistedApprovalDecision
 
     match result:
         case bool(value):
             status = ApprovalStatus.APPROVED if value else ApprovalStatus.REJECTED
-            decision = value
+            if decision_metadata:
+                boolean_decision: BooleanApprovalDecision = {
+                    "value": value,
+                    "metadata": decision_metadata,
+                }
+                decision = boolean_decision
+            else:
+                decision = value
         case ToolApproved(override_args=override_args):
             status = ApprovalStatus.APPROVED
-            decision = {"kind": "tool-approved"}
+            approved_decision: ToolApprovedDecision = {"kind": "tool-approved"}
             if override_args is not None:
-                decision["override_args"] = override_args
+                approved_decision["override_args"] = override_args
+            if decision_metadata:
+                approved_decision["metadata"] = decision_metadata
+            decision = approved_decision
         case ToolDenied(message=message):
             status = ApprovalStatus.REJECTED
             reason = message
-            decision = {"kind": "tool-denied"}
+            denied_decision: ToolDeniedDecision = {"kind": "tool-denied"}
             if message:
-                decision["message"] = message
+                denied_decision["message"] = message
+            if decision_metadata:
+                denied_decision["metadata"] = decision_metadata
+            decision = denied_decision
         case _:
             raise ValueError(f"Unsupported approval result: {type(result)}")
-
-    if decision_metadata:
-        if isinstance(decision, dict):
-            decision = {**decision, "metadata": decision_metadata}
-        elif isinstance(decision, bool):
-            decision = {"value": decision, "metadata": decision_metadata}
-        else:
-            decision = {"metadata": decision_metadata}
 
     return {
         "status": status,

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -7,11 +7,11 @@ import contextlib
 import copy
 import hashlib
 import uuid
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from functools import partial
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import orjson
 from pydantic_ai.messages import (
@@ -48,6 +48,11 @@ import tracecat.artifacts.projection as artifact_projection
 from tracecat import config
 from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.agent.cancellation import signal_turn_cancel
+from tracecat.agent.common.stream_types import (
+    ApprovalStreamStatus,
+    ToolCallContent,
+    UnifiedStreamEvent,
+)
 from tracecat.agent.common.types import MCPServerConfig
 from tracecat.agent.llm import LLMCompletionError
 from tracecat.agent.mcp.metadata import sanitize_message_tool_inputs
@@ -109,6 +114,7 @@ from tracecat.db.models import (
     Approval,
     Case,
     Chat,
+    User,
     Workflow,
 )
 from tracecat.dsl.client import get_temporal_client
@@ -120,6 +126,7 @@ from tracecat.exceptions import (
 )
 from tracecat.identifiers import UserID
 from tracecat.logger import logger
+from tracecat.redis.client import RedisClient, get_redis_client
 from tracecat.service import BaseWorkspaceService
 from tracecat.tiers.entitlements import check_entitlement
 from tracecat.tiers.enums import Entitlement
@@ -137,6 +144,7 @@ if TYPE_CHECKING:
     from tracecat.agent.executor.activity import ToolExecutionResult
 
 AUTO_TITLE_SERVICE_ID = "tracecat-api"
+APPROVAL_CONTINUATION_DEDUP_TTL_SECONDS = 5 * 60
 _background_tasks: set[asyncio.Task[None]] = set()
 
 
@@ -192,6 +200,52 @@ class SessionHistoryData:
     sdk_session_id: str
     sdk_session_data: str
     is_fork: bool = False  # If True, SDK should use fork_session=True
+
+
+def _approval_decision_fields(
+    result: Any,
+    *,
+    approved_by: uuid.UUID | None,
+    decision_metadata: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Map a deferred approval result into Approval row update fields."""
+    status: ApprovalStatus
+    reason: str | None = None
+    decision: bool | dict[str, Any] | None = None
+
+    match result:
+        case bool(value):
+            status = ApprovalStatus.APPROVED if value else ApprovalStatus.REJECTED
+            decision = value
+        case ToolApproved(override_args=override_args):
+            status = ApprovalStatus.APPROVED
+            decision = {"kind": "tool-approved"}
+            if override_args is not None:
+                decision["override_args"] = override_args
+        case ToolDenied(message=message):
+            status = ApprovalStatus.REJECTED
+            reason = message
+            decision = {"kind": "tool-denied"}
+            if message:
+                decision["message"] = message
+        case _:
+            raise ValueError(f"Unsupported approval result: {type(result)}")
+
+    if decision_metadata:
+        if isinstance(decision, dict):
+            decision = {**decision, "metadata": decision_metadata}
+        elif isinstance(decision, bool):
+            decision = {"value": decision, "metadata": decision_metadata}
+        else:
+            decision = {"metadata": decision_metadata}
+
+    return {
+        "status": status,
+        "reason": reason,
+        "decision": decision,
+        "approved_by": approved_by,
+        "approved_at": datetime.now(tz=UTC),
+    }
 
 
 @dataclass(frozen=True)
@@ -1189,6 +1243,123 @@ class AgentSessionService(BaseWorkspaceService):
         result = await self.session.execute(stmt)
         return set(result.scalars().all())
 
+    async def _apply_submitted_approval_decisions(
+        self,
+        *,
+        session_id: uuid.UUID,
+        approval_map: Mapping[str, Any],
+        decision_metadata: Mapping[str, dict[str, Any]],
+    ) -> None:
+        """Persist accepted approval decisions before the full set resumes."""
+        if not approval_map:
+            return
+
+        tool_call_ids = list(approval_map)
+        stmt = (
+            select(Approval)
+            .where(
+                Approval.workspace_id == self.workspace_id,
+                Approval.session_id == session_id,
+                Approval.tool_call_id.in_(tool_call_ids),
+                Approval.status == ApprovalStatus.PENDING,
+            )
+            .with_for_update()
+        )
+        result = await self.session.execute(stmt)
+        approvals_by_tool_id = {
+            approval.tool_call_id: approval for approval in result.scalars().all()
+        }
+        approved_by = await self._existing_user_id(self.role.user_id)
+
+        for tool_call_id, approval_result in approval_map.items():
+            approval = approvals_by_tool_id.get(tool_call_id)
+            if approval is None:
+                logger.warning(
+                    "Accepted approval decision has no persisted approval row",
+                    session_id=str(session_id),
+                    tool_call_id=tool_call_id,
+                )
+                continue
+            for field, value in _approval_decision_fields(
+                approval_result,
+                approved_by=approved_by,
+                decision_metadata=decision_metadata.get(tool_call_id),
+            ).items():
+                setattr(approval, field, value)
+
+        await self.session.commit()
+
+    async def _existing_user_id(self, user_id: uuid.UUID | None) -> uuid.UUID | None:
+        """Return ``user_id`` only when it can satisfy Approval.approved_by."""
+        if user_id is None:
+            return None
+        stmt = select(User).where(cast(Any, User.id) == user_id)
+        result = await self.session.execute(stmt)
+        user = result.scalar_one_or_none()
+        return user.id if user else None
+
+    async def _approval_stream_items(
+        self,
+        *,
+        session_id: uuid.UUID,
+        tool_call_ids: Sequence[str],
+    ) -> list[ToolCallContent]:
+        """Return the active approval batch as stream items for UI replay.
+
+        Only pending approvals plus the just-submitted ``tool_call_ids`` are
+        replayed. Terminal approvals from earlier turns must stay out of the
+        payload: the client drops an entire ``data-approval-request`` part when
+        any contained tool call already has a terminal tool state, which would
+        hide the still-pending cards.
+        """
+        stmt = (
+            select(Approval)
+            .where(
+                Approval.workspace_id == self.workspace_id,
+                Approval.session_id == session_id,
+                or_(
+                    Approval.status == ApprovalStatus.PENDING,
+                    Approval.tool_call_id.in_(tool_call_ids),
+                ),
+            )
+            .order_by(Approval.created_at, Approval.id)
+        )
+        result = await self.session.execute(stmt)
+        return [
+            ToolCallContent(
+                id=approval.tool_call_id,
+                name=approval.tool_name,
+                input=approval.tool_call_args or {},
+                status=cast(ApprovalStreamStatus, approval.status.value),
+                decision=approval.decision,
+                reason=approval.reason,
+            )
+            for approval in result.scalars().all()
+        ]
+
+    async def _emit_approval_idle_segment(
+        self,
+        *,
+        session_id: uuid.UUID,
+        stream_id: uuid.UUID | None,
+        tool_call_ids: Sequence[str],
+    ) -> None:
+        """Emit the latest approval state and a non-terminal Redis boundary."""
+        if self.workspace_id is None:
+            return
+        stream = await AgentStream.new(
+            workspace_id=self.workspace_id,
+            session_id=session_id,
+            stream_id=stream_id,
+        )
+        if approval_items := await self._approval_stream_items(
+            session_id=session_id, tool_call_ids=tool_call_ids
+        ):
+            await stream.append(
+                UnifiedStreamEvent.approval_request_event(approval_items).to_dict()
+            )
+        await stream.finish_idle_segment()
+
     @staticmethod
     def _approval_submission_key(
         *,
@@ -2005,19 +2176,85 @@ class AgentSessionService(BaseWorkspaceService):
             run_id=curr_run_id,
             tool_call_ids=tuple(validated.approval_map.keys()),
         )
-        attempt = await self._prepare_approval_continuation_attempt(
-            agent_session=agent_session,
-            curr_run_id=curr_run_id,
+        attempt = await self._existing_approval_continuation_attempt(
+            agent_session,
             submission_key=submission_key,
         )
+        dedup_client: RedisClient | None = None
+        claimed_submission = False
+        if attempt is None:
+            try:
+                dedup_client = await get_redis_client()
+                claimed_submission = await dedup_client.set_if_not_exists(
+                    submission_key,
+                    source,
+                    expire_seconds=APPROVAL_CONTINUATION_DEDUP_TTL_SECONDS,
+                )
+            except Exception as exc:
+                dedup_client = None
+                logger.warning(
+                    "Approval continuation dedup unavailable; proceeding best-effort",
+                    session_id=str(session_id),
+                    run_id=str(curr_run_id),
+                    source=source,
+                    error=str(exc),
+                )
 
-        did_resume = await self._submit_approval_update(
-            agent_session=agent_session,
-            curr_run_id=curr_run_id,
-            attempt=attempt,
-            validated=validated,
-            handle=handle,
-        )
+            if dedup_client is not None and not claimed_submission:
+                logger.info(
+                    "Skipping concurrent approval continuation submission",
+                    session_id=str(session_id),
+                    run_id=str(curr_run_id),
+                    source=source,
+                    submission_key=submission_key,
+                )
+                return None
+
+            try:
+                attempt = await self._prepare_approval_continuation_attempt(
+                    agent_session=agent_session,
+                    curr_run_id=curr_run_id,
+                    submission_key=submission_key,
+                )
+            except Exception:
+                if dedup_client is not None and claimed_submission:
+                    with contextlib.suppress(Exception):
+                        await dedup_client.delete(submission_key)
+                raise
+
+        try:
+            did_resume = await self._submit_approval_update(
+                agent_session=agent_session,
+                curr_run_id=curr_run_id,
+                attempt=attempt,
+                validated=validated,
+                handle=handle,
+            )
+        except BaseException as exc:
+            is_ambiguous = isinstance(
+                exc, (WorkflowUpdateRPCTimeoutOrCancelledError, RPCError)
+            )
+            if (
+                dedup_client is not None
+                and claimed_submission
+                and isinstance(exc, Exception)
+                and not is_ambiguous
+            ):
+                with contextlib.suppress(Exception):
+                    await dedup_client.delete(submission_key)
+            raise
+
+        if not did_resume:
+            await self._apply_submitted_approval_decisions(
+                session_id=session_id,
+                approval_map=validated.approval_map,
+                decision_metadata=validated.decision_metadata,
+            )
+            await self._emit_approval_idle_segment(
+                session_id=session_id,
+                stream_id=attempt.stream_id,
+                tool_call_ids=list(validated.approval_map),
+            )
 
         logger.info(
             "Approval decisions submitted successfully",

--- a/tracecat/agent/stream/connector.py
+++ b/tracecat/agent/stream/connector.py
@@ -164,6 +164,22 @@ class AgentStream:
         last_data = orjson.loads(last_entries[0][1][tokens.DATA_KEY])
         return last_data != {tokens.END_TOKEN: tokens.END_TOKEN_VALUE}
 
+    async def finish_idle_segment(self) -> None:
+        """Emit a non-terminal boundary for a paused live turn.
+
+        Approval continuations can accept a partial decision set without resuming
+        the workflow. Current readers need a stream boundary so they can finish,
+        but future replay must not treat that boundary as the turn's terminal
+        frame once more output has been appended.
+        """
+        await self.append(
+            {
+                tokens.END_TOKEN: tokens.END_TOKEN_VALUE,
+                "terminal": False,
+                "reason": "approval_pending",
+            }
+        )
+
     async def clear_buffer(self) -> None:
         """Delete the stream buffer for this key.
 
@@ -236,6 +252,10 @@ class AgentStream:
                 data = orjson.loads(fields[tokens.DATA_KEY])
                 current_id = msg_id
                 match data:
+                    case {tokens.END_TOKEN: tokens.END_TOKEN_VALUE, "terminal": False}:
+                        if await self._has_entry_after(msg_id):
+                            continue
+                        yield StreamEnd(id=msg_id)
                     case {tokens.END_TOKEN: tokens.END_TOKEN_VALUE}:
                         stream_completed = True
                         yield StreamEnd(id=msg_id)
@@ -315,6 +335,15 @@ class AgentStream:
             # cursor (Last-Event-ID). We only expire the buffer after terminal.
             if stream_completed:
                 await self._expire_completed_stream()
+
+    async def _has_entry_after(self, msg_id: str) -> bool:
+        """Return True when this Redis stream has an entry after ``msg_id``."""
+        entries = await self.client.xrange(
+            self._stream_key,
+            min_id=f"({msg_id}",
+            count=1,
+        )
+        return bool(entries)
 
     async def stream_events(
         self,

--- a/tracecat/chat/schemas.py
+++ b/tracecat/chat/schemas.py
@@ -11,6 +11,7 @@ from pydantic_ai.tools import ToolApproved, ToolDenied
 
 from tracecat.agent.adapter import vercel
 from tracecat.agent.approvals.enums import ApprovalStatus
+from tracecat.agent.approvals.types import PersistedApprovalDecision
 from tracecat.agent.common.stream_types import HarnessType
 from tracecat.agent.mcp.metadata import sanitize_message_tool_inputs
 from tracecat.agent.session.types import AgentSessionEntity
@@ -209,7 +210,7 @@ class ApprovalRead(BaseModel):
     tool_call_args: dict[str, Any] | None = None
     status: ApprovalStatus
     reason: str | None = None
-    decision: bool | dict[str, Any] | None = None
+    decision: PersistedApprovalDecision | None = None
     approved_by: uuid.UUID | None = None
     approved_at: datetime | None = None
     created_at: datetime

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -48,6 +48,7 @@ from sqlalchemy.orm import (
 
 from tracecat import config
 from tracecat.agent.approvals.enums import ApprovalStatus
+from tracecat.agent.approvals.types import PersistedApprovalDecision
 from tracecat.auth.schemas import UserRole
 from tracecat.auth.secrets import get_signing_secret
 from tracecat.authz.enums import ScopeSource
@@ -2673,7 +2674,7 @@ class Approval(WorkspaceModel):
         nullable=True,
         doc="Optional reason for approval decision",
     )
-    decision: Mapped[bool | dict[str, Any] | None] = mapped_column(
+    decision: Mapped[PersistedApprovalDecision | None] = mapped_column(
         JSONB,
         nullable=True,
         doc=(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds batched approvals for parallel tool calls with partial submissions, typed persisted decisions across API/DB/UI, replay in the UI, and stable streaming for concurrent viewers; runs resume only after the whole batch is decided. Conflicting resubmissions now return 409 and settled decisions are preserved.

- New Features
  - Persisted decisions unify under `PersistedApprovalDecision` (boolean-with-metadata, `tool-approved`, `tool-denied`) across schemas/DB/adapters/UI; approval cards pre-fill overrides, lock submitted items, keep resolved cards visible while the batch is pending, and replay includes per-item `status`/`decision`/`reason`.
  - Partial batches accumulate across events; the server accepts selected decisions and `set_approvals` returns readiness. SSE headers are standardized for all streams, with Vercel streams including `x-vercel-ai-ui-message-stream`.

- Bug Fixes
  - Deduplicate pending approval parts by tool call ID and accumulate parallel approval requests across separate events and replays.
  - Stabilized multi-viewer streams with a non-terminal idle boundary and routing by active stream id; resubmissions that contradict settled decisions return 409 to avoid overwrites.

<sup>Written for commit ddd90ab9df1905b426dc7bd20d78d627fcec42c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

