### PR TITLE
feat(integrations): restore okta mcp

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -1142,14 +1142,93 @@
     {
       "slug": "okta-mcp",
       "docs": "https://github.com/okta/okta-mcp-server",
-      "research_notes": "Official server is okta/okta-mcp-server (Python, built on Okta Python SDK), STDIO transport. The documented installation paths are Docker/docker-compose or a local checkout launched with `uv run --directory /path/to/okta-mcp-server okta-mcp-server`; Okta's docs do not document a hosted remote MCP endpoint, nor a one-shot `uvx`/`pip install <name>`/`npx` package launch. The previous catalog row had a loose STDIO recipe with no allowlisted launch command/package, so it has been removed until there is a supported connect path.\n\nOkta also documents an MCP Server Registration API for Okta for AI Agents, but that is for registering/trusting MCP servers as resource servers; it is not a hosted remote Okta Admin MCP endpoint for this catalog entry.\n\nAuth details for a future connection recipe: users supply Okta OAuth app config + credentials (OKTA_CLIENT_ID, OKTA_ORG_URL, OKTA_SCOPES, and for browserless use OKTA_PRIVATE_KEY + OKTA_KEY_ID). Underlying mechanism is OAuth2 against the user's own Okta org domain, via Device Authorization Grant or Private Key JWT. This is not a remote-MCP DCR sign-in.\n\nNote there are popular third-party servers (fctr-id/okta-mcp-server, kapilduraphe/okta-mcp-server), but okta/okta-mcp-server is the first-party official one.",
-      "sources": [
+      "connection_spec": {
+        "server_type": "stdio",
+        "auth_type": "CUSTOM",
+        "stdio_command": "uvx",
+        "stdio_args": [
+          "--from",
+          "git+https://github.com/okta/okta-mcp-server.git@5cda0b8eb580b31c61572116343dd8cf083950c5",
+          "okta-mcp-server"
+        ],
+        "stdio_env": [
+          "OKTA_ORG_URL",
+          "OKTA_CLIENT_ID",
+          "OKTA_SCOPES",
+          "OKTA_PRIVATE_KEY",
+          "OKTA_KEY_ID"
+        ],
+        "packages": [
+          {
+            "manager": "uvx",
+            "command": "uvx",
+            "args": [
+              "--from",
+              "git+https://github.com/okta/okta-mcp-server.git@5cda0b8eb580b31c61572116343dd8cf083950c5",
+              "okta-mcp-server"
+            ],
+            "package": "git+https://github.com/okta/okta-mcp-server.git@5cda0b8eb580b31c61572116343dd8cf083950c5"
+          }
+        ],
+        "credentials": [
+          {
+            "key": "OKTA_ORG_URL",
+            "label": "Okta Org URL",
+            "description": "Your Okta organization URL, e.g. https://your-org.okta.com",
+            "required": true,
+            "secret": false,
+            "type": "url",
+            "placeholder": "https://your-org.okta.com",
+            "target": "stdio_env"
+          },
+          {
+            "key": "OKTA_CLIENT_ID",
+            "label": "Okta OAuth Client ID",
+            "description": "Client ID of the Okta OAuth application authorized for the MCP server.",
+            "required": true,
+            "secret": true,
+            "target": "stdio_env"
+          },
+          {
+            "key": "OKTA_SCOPES",
+            "label": "Okta Scopes",
+            "description": "Space-separated Okta API scopes to request, e.g. \"okta.users.read okta.groups.read\". Each scope must also be granted to the OAuth app (Okta API Scopes tab) or the token request is rejected. Leave the default and adjust to match the scopes you have granted. Do not blank this out: an empty value makes the server request 'openid', which is invalid for the client-credentials grant.",
+            "required": true,
+            "secret": false,
+            "default_value": "okta.users.read okta.groups.read",
+            "placeholder": "okta.users.read okta.groups.read",
+            "target": "stdio_env"
+          },
+          {
+            "key": "OKTA_PRIVATE_KEY",
+            "label": "Okta Private Key",
+            "description": "RSA private key in PEM format (the private.pem downloaded when you generated the key pair on the Okta API Services app). Store the key as a workspace secret and reference it here, e.g. ${{ SECRETS.okta.PRIVATE_KEY }} — the secret editor accepts a pasted multi-line PEM, while this JSON field cannot hold raw newlines. Pasting the PEM directly here is not supported.",
+            "required": true,
+            "secret": true,
+            "default_value": "${{ SECRETS.okta.PRIVATE_KEY }}",
+            "placeholder": "${{ SECRETS.okta.PRIVATE_KEY }}",
+            "target": "stdio_env"
+          },
+          {
+            "key": "OKTA_KEY_ID",
+            "label": "Okta Key ID (KID)",
+            "description": "Key ID (kid) shown for the public/private key pair on the Okta API Services app, paired with the private key above. Enter it directly, or reference a workspace secret, e.g. ${{ SECRETS.okta.KEY_ID }}.",
+            "required": true,
+            "secret": true,
+            "target": "stdio_env"
+          }
+        ],
+        "confidence": "high",
+        "docker_only": false,
+        "research_notes": "Official server is okta/okta-mcp-server (Python, built on Okta Python SDK), STDIO transport, console script `okta-mcp-server` (entry point okta_mcp_server:main). Launched via `uvx --from git+https://github.com/okta/okta-mcp-server.git@<sha> okta-mcp-server` (not published to PyPI/npm, so uvx installs from the git+ spec). PINNED to commit 5cda0b8eb580b31c61572116343dd8cf083950c5 (pyproject version 1.1.1, the GA-release merge on main dated 2026-06-24). The repo publishes NO git tags and NO GitHub releases, so a tag ref like @v1.1.1 does not resolve; the commit SHA is the only reproducible pin. To bump, find the new GA commit on main and replace the SHA in stdio_args + packages. We support ONLY the browserless Private Key JWT flow (the interactive Device Authorization browser flow is intentionally not offered: it requires a human to approve a device code and cannot complete in a headless server). So OKTA_ORG_URL, OKTA_CLIENT_ID, OKTA_PRIVATE_KEY, OKTA_KEY_ID, and OKTA_SCOPES are ALL required. The server enables browserless auth only when BOTH OKTA_PRIVATE_KEY and OKTA_KEY_ID are set (auth_manager.py: `if self.private_key and self.key_id`); if either is missing it silently falls back to device flow. VERIFIED against a real org: (1) OKTA_ORG_URL must be the org/OIDC-issuer host (e.g. https://your-org.okta.com), NOT the admin console host (https://your-org-admin.okta.com), which 302-redirects /oauth2/v1/* to /error/404. (2) Each requested scope must be GRANTED to the API Services app (Okta API Scopes tab) or the token endpoint returns 400 consent_required ('not allowed any of the requested scopes'); the app also needs an admin role for the scopes to return data. (3) Blank OKTA_SCOPES is NOT valid: the server then requests 'openid', which the client-credentials grant rejects with 400 invalid_scope — hence OKTA_SCOPES carries a default and is required. (4) The PEM private key should be stored as a workspace secret and referenced via ${{ SECRETS.okta.PRIVATE_KEY }}; stdio_env resolves SECRETS/VARS template expressions at launch (preset/service.py _resolve_stdio_env). This avoids two problems with inline paste: the stdio_env JSON field cannot hold raw newlines, and a pasted PEM with leading indentation corrupts the base64. The secret editor's textarea accepts a multi-line PEM cleanly. We intentionally do NOT normalize PEMs inline in the MCP path (no precedent there); the secret-reference path is the supported convention. PYTHON_KEYRING_BACKEND is NOT included: it is Docker-only in Okta's README (containers lack a system keyring) and browserless Private Key JWT does not use the keyring. OAuth2 runs against the user's own Okta org domain, not a remote-MCP DCR sign-in. Third-party servers exist (fctr-id, kapilduraphe) but okta/okta-mcp-server is the first-party official one.",
+        "sources": [
         "https://github.com/okta/okta-mcp-server",
         "https://raw.githubusercontent.com/okta/okta-mcp-server/main/README.md",
         "https://developer.okta.com/docs/guides/start-mcp-server/main/",
         "https://developer.okta.com/blog/2025/09/22/okta-mcp-server",
         "https://developer.okta.com/docs/concepts/mcp-server/"
-      ]
+        ]
+      }
     },
     {
       "slug": "hashicorp-vault-mcp",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores the Okta MCP integration with a reproducible `stdio` connection that runs `okta-mcp-server` via `uvx` pinned to a specific Git commit. Enables headless Private Key JWT auth with clear required credentials and defaults.

- **New Features**
  - Adds `connection_spec` for `okta-mcp` using `uvx` and the `okta-mcp-server` entrypoint, pinned to a Git commit for consistent installs.
  - Requires `OKTA_ORG_URL`, `OKTA_CLIENT_ID`, `OKTA_PRIVATE_KEY`, `OKTA_KEY_ID`, and `OKTA_SCOPES` (default: "okta.users.read okta.groups.read"); store the PEM in a workspace secret.
  - Supports only Private Key JWT (no device flow); use your org URL (not admin) and ensure requested scopes are granted in Okta.

<sup>Written for commit 00a83a4e8b553eb3d472caeff7e7551085207848. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

