### PR TITLE
fix(agents): escape workflow ID schema quantifiers

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/types.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/types.py
@@ -28,7 +28,7 @@ class AgentWorkflowID(str):
 
         return core_schema.json_or_python_schema(
             json_schema=core_schema.str_schema(
-                pattern=rf"^{cls._prefix}[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+                pattern=rf"^{cls._prefix}[0-9a-f]{{8}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{12}}$"
             ),
             python_schema=python_schema,
             serialization=core_schema.plain_serializer_function_ser_schema(

--- a/tests/unit/test_agent_workflow_id.py
+++ b/tests/unit/test_agent_workflow_id.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+from tracecat_ee.agent.types import AgentWorkflowID
+
+
+def test_agent_workflow_id_json_schema_accepts_uuid_shape() -> None:
+    session_id = uuid.UUID("00000000-0000-0000-0000-000000000003")
+
+    value = TypeAdapter(AgentWorkflowID).validate_json(f'"agent/{session_id}"')
+
+    assert value == f"agent/{session_id}"
+
+
+def test_agent_workflow_id_json_schema_rejects_literal_quantifier_shape() -> None:
+    with pytest.raises(ValidationError):
+        TypeAdapter(AgentWorkflowID).validate_json('"agent/a8-b4-c4-d4-e12"')


### PR DESCRIPTION
### Motivation
- The JSON-schema regex for `AgentWorkflowID` was written in an f-string using single braces (e.g. `{8}`), which are interpreted as Python replacement fields and produced an incorrect pattern for `agent/<uuid>` validation.
- The bug only affected the Pydantic JSON-schema path (the Python validation path already uses `uuid.UUID(...)`), so add a small, targeted fix and regression coverage.

### Description
- Escape the quantifier braces in the JSON-schema pattern in `packages/tracecat-ee/tracecat_ee/agent/types.py` so the pattern becomes `core_schema.str_schema(pattern=rf"^{cls._prefix}[0-9a-f]{{8}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{12}}$")` which matches `agent/<uuid>` as intended.
- Add `tests/unit/test_agent_workflow_id.py` with two regression tests that assert a valid `agent/<uuid>` is accepted and the previously accepted literal-quantifier shape (e.g. `agent/a8-b4-c4-d4-e12`) is rejected by the JSON-schema path.

### Testing
- Ran `uv run ruff check` and `uv run ruff format --check` against the modified files, and they passed.
- Verified runtime behavior with a focused `PYTHONPATH=packages/tracecat-ee python` check that uses `TypeAdapter(AgentWorkflowID).validate_json(...)` to assert acceptance/rejection, and it succeeded.
- Attempting to run `uv run pytest tests/unit/test_agent_workflow_id.py -q` in the local environment was blocked by autouse test fixtures that require a PostgreSQL instance on `127.0.0.1:5432`, so a full pytest run could not complete locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43e2182d4c83208761803979871863)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the JSON-schema regex for AgentWorkflowID by escaping quantifier braces so `agent/<uuid>` validates correctly and literal-quantifier strings are rejected. Added regression tests for both valid UUID shape and the previously accepted `agent/a8-b4-c4-d4-e12` pattern.

<sup>Written for commit f729612ff393614c4eefcd14d2b164b281530ab7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

