### PR TITLE
fix(engine): materialize custom registry artifacts in the pool backend

### DIFF
--- a/tracecat/executor/backends/pool/backend.py
+++ b/tracecat/executor/backends/pool/backend.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from tracecat.executor.action_runner import get_action_runner
 from tracecat.executor.backends.base import ExecutorBackend
 from tracecat.executor.backends.pool.pool import (
     get_worker_pool,
@@ -24,6 +25,8 @@ from tracecat.executor.backends.registry_helpers import get_registry_artifact_ur
 from tracecat.logger import logger
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from tracecat.auth.types import Role
     from tracecat.dsl.schemas import RunActionInput
     from tracecat.executor.schemas import ExecutorResult, ResolvedContext
@@ -64,12 +67,39 @@ class PoolBackend(ExecutorBackend):
             task_ref=input.task.ref,
         )
 
+        # Materialize custom registry artifacts on the host so the warm
+        # worker can import custom UDF modules. The pool sandbox has no
+        # DB/network access, so the host downloads and extracts everything
+        # to the shared registry cache dir, which is bind-mounted into the
+        # sandbox. The worker then adds the extracted paths to sys.path.
+        registry_paths: list[Path] = []
+        try:
+            artifact_uris = await self._get_artifact_uris(input, role)
+            if artifact_uris:
+                runner = get_action_runner()
+                registry_paths = await runner.resolve_registry_paths(artifact_uris)
+                if registry_paths:
+                    logger.debug(
+                        "Materialized registry artifacts for pool worker",
+                        action=action_name,
+                        task_ref=input.task.ref,
+                        count=len(registry_paths),
+                    )
+        except Exception as e:
+            logger.warning(
+                "Failed to materialize registry artifacts, continuing without them",
+                action=action_name,
+                task_ref=input.task.ref,
+                error=str(e),
+            )
+
         pool = await get_worker_pool()
         return await pool.execute(
             input=input,
             role=role,
             resolved_context=resolved_context,
             timeout=timeout,
+            registry_paths=registry_paths,
         )
 
     async def _get_artifact_uris(

--- a/tracecat/executor/backends/pool/pool.py
+++ b/tracecat/executor/backends/pool/pool.py
@@ -978,6 +978,7 @@ class WorkerPool:
         role: Role,
         resolved_context: ResolvedContext,
         timeout: float = 300.0,
+        registry_paths: list[Path] | None = None,
     ) -> ExecutorResult:
         """Execute a task on an available pool worker.
 
@@ -986,6 +987,9 @@ class WorkerPool:
             role: The Role for authorization
             resolved_context: Pre-resolved secrets, variables, and action impl
             timeout: Execution timeout in seconds
+            registry_paths: Pre-materialized registry artifact paths for the
+                worker to add to sys.path. The host resolves these so the
+                sandboxed worker doesn't need DB/network access.
         """
         if not self._started:
             raise RuntimeError("Worker pool not started")
@@ -1008,12 +1012,13 @@ class WorkerPool:
             task_ref=task_ref,
             worker_active_tasks=worker.active_tasks,
             worker_completed=worker.tasks_completed,
+            registry_paths=len(registry_paths) if registry_paths else 0,
         )
 
         start_time = time.monotonic()
         try:
             result = await self._execute_on_worker(
-                worker, input, role, resolved_context, timeout
+                worker, input, role, resolved_context, timeout, registry_paths
             )
             # Track latency for successful execution
             elapsed_ms = (time.monotonic() - start_time) * 1000
@@ -1093,6 +1098,7 @@ class WorkerPool:
         role: Role,
         resolved_context: ResolvedContext,
         timeout: float,
+        registry_paths: list[Path] | None = None,
     ) -> ExecutorResult:
         """Execute task on a pool worker via Unix socket."""
 
@@ -1113,6 +1119,7 @@ class WorkerPool:
             "role": role.model_dump(mode="json"),
             "resolved_context": resolved_context.model_dump(mode="json"),
             "secret_env": secret_projection.env,
+            "registry_paths": [str(p) for p in registry_paths] if registry_paths else [],
         }
         request_bytes = orjson.dumps(request)
 

--- a/tracecat/executor/backends/pool/worker.py
+++ b/tracecat/executor/backends/pool/worker.py
@@ -52,6 +52,28 @@ from tracecat.logger import logger  # noqa: E402
 # Track tarball paths already added to sys.path to avoid duplicates
 _added_tarball_paths: set[str] = set()
 
+# Track host-resolved registry paths already added to sys.path
+_added_registry_paths: set[str] = set()
+
+
+def _add_registry_paths_to_sys_path(paths: list[str]) -> None:
+    """Add host-resolved registry artifact paths to sys.path.
+
+    Called per-task with paths materialized by the host process. Unlike
+    _ensure_tarball_paths_in_sys_path() which scans the cache dir for
+    pre-existing tarball directories, this accepts explicit paths from
+    the request that the host resolved just before sending.
+    """
+    for path_str in paths:
+        if path_str not in _added_registry_paths and path_str not in sys.path:
+            sys.path.insert(0, path_str)
+            _added_registry_paths.add(path_str)
+            logger.debug(
+                "Added registry artifact path to sys.path",
+                path=path_str,
+                worker_id=_worker_id,
+            )
+
 
 def _ensure_tarball_paths_in_sys_path() -> None:
     """Ensure all tarball extraction directories are in sys.path.
@@ -134,6 +156,13 @@ async def handle_task(request: dict[str, Any]) -> dict[str, Any]:
 
         # Ensure tarball paths are in sys.path for custom registry modules
         _ensure_tarball_paths_in_sys_path()
+
+        # Add host-resolved registry artifact paths to sys.path so UDFs in
+        # custom registry packages can be imported. The host materialized
+        # the artifacts (downloaded + extracted) before sending the request.
+        registry_paths = request.get("registry_paths", [])
+        if registry_paths:
+            _add_registry_paths_to_sys_path(registry_paths)
 
         # Set the role context for actions that need it (e.g., core.cases, core.table)
         ctx_role.set(role)


### PR DESCRIPTION
## Problem

The pool executor backend skips custom registry artifact materialization for UDF actions. When a custom registry package (Python module using `@registry.register`) is synced via `sync_custom_registry`, the squashfs/tarball artifact in S3 is never downloaded or extracted before the pool worker attempts to import the UDF module. This causes `ModuleNotFoundError` at runtime.

| Backend | UDF execution path | Materializes custom registry? |
|---|---|---|
| Ephemeral | `runner.execute_action(artifact_uris=...)` | Yes |
| Direct | Same as ephemeral (subclass) | Yes |
| Pool | Sends directly to warm worker via Unix socket | **No** |

The builtin `tracecat_registry` works in the pool because it's baked into the container image at `/app/packages/tracecat-registry`. Custom registries have no equivalent pre-installation path.

## Solution

Materialize registry artifacts on the **host** process and pass the resolved paths to the warm worker:

1. **`PoolBackend._execute()`** — calls `_get_artifact_uris()` then `ActionRunner.resolve_registry_paths()` to download and extract custom registry artifacts before dispatching to the pool
2. **`WorkerPool.execute()` / `_execute_on_worker()`** — accepts a `registry_paths` parameter and includes it in the worker request payload
3. **`handle_task()` in worker** — adds resolved paths to `sys.path` before executing the action

This mirrors the ephemeral backend's artifact flow while preserving the pool architecture: the host handles DB/network access (S3 download), the sandboxed worker stays untrusted with only execution responsibility.

Artifact materialization failures are non-fatal — the worker will log a warning and continue. Existing actions (builtin registry, template-only UDFs, `core.script.run_python`) are unaffected.

## Changes

- `tracecat/executor/backends/pool/backend.py` — materialize artifacts in `_execute()` before dispatching to pool
- `tracecat/executor/backends/pool/pool.py` — thread `registry_paths` through `execute()` to worker request
- `tracecat/executor/backends/pool/worker.py` — add `_add_registry_paths_to_sys_path()` and call it in `handle_task()`

Closes #2895


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ModuleNotFoundError for UDF actions from custom registries on the pool backend by materializing artifacts on the host and passing resolved paths to workers. Workers add these paths to `sys.path` before execution (closes #2895).

- **Bug Fixes**
  - Materialize custom registry artifacts in `PoolBackend._execute()` using `resolve_registry_paths()` and the shared cache.
  - Pass `registry_paths` through `WorkerPool.execute()` and `_execute_on_worker()` into the worker request.
  - In `worker.handle_task()`, add paths to `sys.path` via `_add_registry_paths_to_sys_path()`.
  - Failures to materialize log a warning and continue; builtin `tracecat_registry` remains unaffected.

<sup>Written for commit 157f1731ff182c84af217ab8a45ea0a03f5310df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

