### PR TITLE
feat(sync): add GitLab workspace sync

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -13547,6 +13547,68 @@ export const $GitHubWebhookAttributes = {
   description: "Type definition for GitHub webhook attributes.",
 } as const
 
+export const $GitLabTokenCredentialsRequest = {
+  properties: {
+    base_url: {
+      type: "string",
+      title: "Base Url",
+      description: "Base URL for GitLab.com or a self-managed GitLab instance.",
+      default: "https://gitlab.com",
+    },
+    token: {
+      type: "string",
+      format: "password",
+      title: "Token",
+      description: "GitLab personal/project/group access token with api scope.",
+      writeOnly: true,
+    },
+  },
+  type: "object",
+  required: ["token"],
+  title: "GitLabTokenCredentialsRequest",
+  description: "Request to register or update GitLab token credentials.",
+} as const
+
+export const $GitLabTokenCredentialsStatus = {
+  properties: {
+    exists: {
+      type: "boolean",
+      title: "Exists",
+    },
+    is_corrupted: {
+      type: "boolean",
+      title: "Is Corrupted",
+      default: false,
+    },
+    base_url: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Base Url",
+    },
+    created_at: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Created At",
+    },
+  },
+  type: "object",
+  required: ["exists"],
+  title: "GitLabTokenCredentialsStatus",
+  description: "Status of GitLab token credentials.",
+} as const
+
 export const $GitSettingsRead = {
   properties: {
     git_allowed_domains: {
@@ -31898,6 +31960,16 @@ export const $WorkspaceReadMinimal = {
 
 export const $WorkspaceSettingsRead = {
   properties: {
+    git_provider: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/VcsProvider",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
     git_repo_url: {
       anyOf: [
         {
@@ -32001,6 +32073,16 @@ export const $WorkspaceSettingsRead = {
 
 export const $WorkspaceSettingsUpdate = {
   properties: {
+    git_provider: {
+      anyOf: [
+        {
+          $ref: "#/components/schemas/VcsProvider",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
     git_repo_url: {
       anyOf: [
         {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -31528,11 +31528,6 @@ export const $WorkflowSyncPullRequest = {
         "Apply schedule definitions from Git. Defaults off to preserve destination schedules.",
       default: false,
     },
-    provider: {
-      $ref: "#/components/schemas/VcsProvider",
-      description: "VCS provider for the configured repository.",
-      default: "github",
-    },
   },
   type: "object",
   required: ["commit_sha"],
@@ -32296,11 +32291,6 @@ export const $WorkspaceSyncExportPreviewRequest = {
       description:
         "Repository ref to compare the projected export against. When omitted, the preview only returns the export manifest summary.",
     },
-    provider: {
-      $ref: "#/components/schemas/VcsProvider",
-      description: "VCS provider to read the comparison ref from.",
-      default: "github",
-    },
   },
   type: "object",
   title: "WorkspaceSyncExportPreviewRequest",
@@ -32353,11 +32343,6 @@ export const $WorkspaceSyncExportRequest = {
       ],
       title: "Resources",
       description: "Specific resources to export, or ``None`` to export all.",
-    },
-    provider: {
-      $ref: "#/components/schemas/VcsProvider",
-      description: "VCS provider to push to.",
-      default: "github",
     },
     include_schedules: {
       type: "boolean",

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -13287,6 +13287,28 @@ export const $GitHubAppCredentialsRequest = {
   description: "Request to register or update GitHub App credentials.",
 } as const
 
+export const $GitHubAppCredentialsSaveResponse = {
+  properties: {
+    message: {
+      type: "string",
+      title: "Message",
+    },
+    action: {
+      type: "string",
+      enum: ["created", "updated"],
+      title: "Action",
+    },
+    app_id: {
+      type: "string",
+      title: "App Id",
+    },
+  },
+  type: "object",
+  required: ["message", "action", "app_id"],
+  title: "GitHubAppCredentialsSaveResponse",
+  description: "Response after creating or updating GitHub App credentials.",
+} as const
+
 export const $GitHubAppCredentialsStatus = {
   properties: {
     exists: {
@@ -13567,6 +13589,28 @@ export const $GitLabTokenCredentialsRequest = {
   required: ["token"],
   title: "GitLabTokenCredentialsRequest",
   description: "Request to register or update GitLab token credentials.",
+} as const
+
+export const $GitLabTokenCredentialsSaveResponse = {
+  properties: {
+    message: {
+      type: "string",
+      title: "Message",
+    },
+    action: {
+      type: "string",
+      enum: ["created", "updated"],
+      title: "Action",
+    },
+    base_url: {
+      type: "string",
+      title: "Base Url",
+    },
+  },
+  type: "object",
+  required: ["message", "action", "base_url"],
+  title: "GitLabTokenCredentialsSaveResponse",
+  description: "Response after creating or updating GitLab token credentials.",
 } as const
 
 export const $GitLabTokenCredentialsStatus = {

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -3273,7 +3273,6 @@ export const workflowsListWorkflowRepositories = (
  * @param data.workspaceId
  * @param data.branch Branch name to fetch commits from
  * @param data.limit Maximum number of commits to return
- * @param data.provider VCS provider for the configured repository.
  * @returns GitCommitInfo Successful Response
  * @throws ApiError
  */
@@ -3289,7 +3288,6 @@ export const workflowsListWorkflowCommits = (
     query: {
       branch: data.branch,
       limit: data.limit,
-      provider: data.provider,
     },
     errors: {
       422: "Validation Error",
@@ -3303,7 +3301,6 @@ export const workflowsListWorkflowCommits = (
  * @param data The data for the request.
  * @param data.workspaceId
  * @param data.limit Maximum number of branches to return
- * @param data.provider VCS provider for the configured repository.
  * @returns GitBranchInfo Successful Response
  * @throws ApiError
  */
@@ -3318,7 +3315,6 @@ export const workflowsListWorkflowBranches = (
     },
     query: {
       limit: data.limit,
-      provider: data.provider,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -788,14 +788,18 @@ import type {
   VariablesUpdateVariableByIdData,
   VariablesUpdateVariableByIdResponse,
   VcsDeleteGithubAppCredentialsResponse,
+  VcsDeleteGitlabTokenCredentialsResponse,
   VcsGetGithubAppCredentialsStatusResponse,
   VcsGetGithubAppManifestResponse,
+  VcsGetGitlabTokenCredentialsStatusResponse,
   VcsGithubAppInstallCallbackData,
   VcsGithubAppInstallCallbackResponse,
   VcsGithubWebhookData,
   VcsGithubWebhookResponse,
   VcsSaveGithubAppCredentialsData,
   VcsSaveGithubAppCredentialsResponse,
+  VcsSaveGitlabTokenCredentialsData,
+  VcsSaveGitlabTokenCredentialsResponse,
   WatchtowerDisableWatchtowerAgentData,
   WatchtowerDisableWatchtowerAgentResponse,
   WatchtowerEnableWatchtowerAgentData,
@@ -3261,7 +3265,7 @@ export const workflowsListWorkflowRepositories = (
 
 /**
  * List Workflow Commits
- * Get commit list for workflow repository via GitHub App.
+ * Get commit list for the configured workspace repository.
  *
  * Returns a list of commits from the repository configured in workspace settings,
  * suitable for use in workflow pull operations.
@@ -3269,6 +3273,7 @@ export const workflowsListWorkflowRepositories = (
  * @param data.workspaceId
  * @param data.branch Branch name to fetch commits from
  * @param data.limit Maximum number of commits to return
+ * @param data.provider VCS provider for the configured repository.
  * @returns GitCommitInfo Successful Response
  * @throws ApiError
  */
@@ -3284,6 +3289,7 @@ export const workflowsListWorkflowCommits = (
     query: {
       branch: data.branch,
       limit: data.limit,
+      provider: data.provider,
     },
     errors: {
       422: "Validation Error",
@@ -3293,10 +3299,11 @@ export const workflowsListWorkflowCommits = (
 
 /**
  * List Workflow Branches
- * Get branch list for workflow repository via GitHub App.
+ * Get branch list for the configured workspace repository.
  * @param data The data for the request.
  * @param data.workspaceId
  * @param data.limit Maximum number of branches to return
+ * @param data.provider VCS provider for the configured repository.
  * @returns GitBranchInfo Successful Response
  * @throws ApiError
  */
@@ -3311,6 +3318,7 @@ export const workflowsListWorkflowBranches = (
     },
     query: {
       limit: data.limit,
+      provider: data.provider,
     },
     errors: {
       422: "Validation Error",
@@ -12013,6 +12021,56 @@ export const vcsGetGithubAppCredentialsStatus =
     return __request(OpenAPI, {
       method: "GET",
       url: "/organization/vcs/github/credentials/status",
+    })
+  }
+
+/**
+ * Save Gitlab Token Credentials
+ * Save GitLab token credentials (create if new or update existing).
+ * @param data The data for the request.
+ * @param data.requestBody
+ * @returns string Successful Response
+ * @throws ApiError
+ */
+export const vcsSaveGitlabTokenCredentials = (
+  data: VcsSaveGitlabTokenCredentialsData
+): CancelablePromise<VcsSaveGitlabTokenCredentialsResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/organization/vcs/gitlab/credentials",
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Delete Gitlab Token Credentials
+ * Delete GitLab token credentials.
+ * @returns void Successful Response
+ * @throws ApiError
+ */
+export const vcsDeleteGitlabTokenCredentials =
+  (): CancelablePromise<VcsDeleteGitlabTokenCredentialsResponse> => {
+    return __request(OpenAPI, {
+      method: "DELETE",
+      url: "/organization/vcs/gitlab/credentials",
+    })
+  }
+
+/**
+ * Get Gitlab Token Credentials Status
+ * Get the status of GitLab token credentials.
+ * @returns GitLabTokenCredentialsStatus Successful Response
+ * @throws ApiError
+ */
+export const vcsGetGitlabTokenCredentialsStatus =
+  (): CancelablePromise<VcsGetGitlabTokenCredentialsStatusResponse> => {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/organization/vcs/gitlab/credentials/status",
     })
   }
 

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -11979,7 +11979,7 @@ export const vcsGithubWebhook = (
  * Save GitHub App credentials (register new or update existing).
  * @param data The data for the request.
  * @param data.requestBody
- * @returns string Successful Response
+ * @returns GitHubAppCredentialsSaveResponse Successful Response
  * @throws ApiError
  */
 export const vcsSaveGithubAppCredentials = (
@@ -12029,7 +12029,7 @@ export const vcsGetGithubAppCredentialsStatus =
  * Save GitLab token credentials (create if new or update existing).
  * @param data The data for the request.
  * @param data.requestBody
- * @returns string Successful Response
+ * @returns GitLabTokenCredentialsSaveResponse Successful Response
  * @throws ApiError
  */
 export const vcsSaveGitlabTokenCredentials = (

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -4032,6 +4032,30 @@ export type GitHubWebhookAttributes = {
   active: boolean
 }
 
+/**
+ * Request to register or update GitLab token credentials.
+ */
+export type GitLabTokenCredentialsRequest = {
+  /**
+   * Base URL for GitLab.com or a self-managed GitLab instance.
+   */
+  base_url?: string
+  /**
+   * GitLab personal/project/group access token with api scope.
+   */
+  token: string
+}
+
+/**
+ * Status of GitLab token credentials.
+ */
+export type GitLabTokenCredentialsStatus = {
+  exists: boolean
+  is_corrupted?: boolean
+  base_url?: string | null
+  created_at?: string | null
+}
+
 export type GitSettingsRead = {
   git_allowed_domains: Array<string>
   git_repo_url?: string | null
@@ -9471,6 +9495,7 @@ export type WorkspaceReadMinimal = {
 }
 
 export type WorkspaceSettingsRead = {
+  git_provider?: VcsProvider | null
   git_repo_url?: string | null
   workflow_unlimited_timeout_enabled?: boolean | null
   workflow_default_timeout_seconds?: number | null
@@ -9488,6 +9513,7 @@ export type WorkspaceSettingsRead = {
 }
 
 export type WorkspaceSettingsUpdate = {
+  git_provider?: VcsProvider | null
   git_repo_url?: string | null
   /**
    * Allow workflows to run indefinitely without timeout constraints. When enabled, individual workflow timeout settings are ignored.
@@ -10499,6 +10525,10 @@ export type WorkflowsListWorkflowCommitsData = {
    * Maximum number of commits to return
    */
   limit?: number
+  /**
+   * VCS provider for the configured repository.
+   */
+  provider?: VcsProvider
   workspaceId: string
 }
 
@@ -10509,6 +10539,10 @@ export type WorkflowsListWorkflowBranchesData = {
    * Maximum number of branches to return
    */
   limit?: number
+  /**
+   * VCS provider for the configured repository.
+   */
+  provider?: VcsProvider
   workspaceId: string
 }
 
@@ -13259,6 +13293,19 @@ export type VcsDeleteGithubAppCredentialsResponse = void
 
 export type VcsGetGithubAppCredentialsStatusResponse =
   GitHubAppCredentialsStatus
+
+export type VcsSaveGitlabTokenCredentialsData = {
+  requestBody: GitLabTokenCredentialsRequest
+}
+
+export type VcsSaveGitlabTokenCredentialsResponse = {
+  [key: string]: string
+}
+
+export type VcsDeleteGitlabTokenCredentialsResponse = void
+
+export type VcsGetGitlabTokenCredentialsStatusResponse =
+  GitLabTokenCredentialsStatus
 
 export type UsersGetMyScopesData = {
   workspaceId?: string | null
@@ -19545,6 +19592,41 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: GitHubAppCredentialsStatus
+      }
+    }
+  }
+  "/organization/vcs/gitlab/credentials": {
+    post: {
+      req: VcsSaveGitlabTokenCredentialsData
+      res: {
+        /**
+         * Successful Response
+         */
+        201: {
+          [key: string]: string
+        }
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+    delete: {
+      res: {
+        /**
+         * Successful Response
+         */
+        204: void
+      }
+    }
+  }
+  "/organization/vcs/gitlab/credentials/status": {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: GitLabTokenCredentialsStatus
       }
     }
   }

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -9414,10 +9414,6 @@ export type WorkflowSyncPullRequest = {
    * Apply schedule definitions from Git. Defaults off to preserve destination schedules.
    */
   sync_schedules?: boolean
-  /**
-   * VCS provider for the configured repository.
-   */
-  provider?: VcsProvider
 }
 
 export type WorkflowTagCreate = {
@@ -9600,10 +9596,6 @@ export type WorkspaceSyncExportPreviewRequest = {
    * Repository ref to compare the projected export against. When omitted, the preview only returns the export manifest summary.
    */
   compare_ref?: string | null
-  /**
-   * VCS provider to read the comparison ref from.
-   */
-  provider?: VcsProvider
 }
 
 /**
@@ -9630,10 +9622,6 @@ export type WorkspaceSyncExportRequest = {
    * Specific resources to export, or ``None`` to export all.
    */
   resources?: Array<ResourceRef> | null
-  /**
-   * VCS provider to push to.
-   */
-  provider?: VcsProvider
   /**
    * Whether to include workflow schedules in the export.
    */
@@ -10545,10 +10533,6 @@ export type WorkflowsListWorkflowCommitsData = {
    * Maximum number of commits to return
    */
   limit?: number
-  /**
-   * VCS provider for the configured repository.
-   */
-  provider?: VcsProvider
   workspaceId: string
 }
 
@@ -10559,10 +10543,6 @@ export type WorkflowsListWorkflowBranchesData = {
    * Maximum number of branches to return
    */
   limit?: number
-  /**
-   * VCS provider for the configured repository.
-   */
-  provider?: VcsProvider
   workspaceId: string
 }
 

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -3963,6 +3963,17 @@ export type GitHubAppCredentialsRequest = {
 }
 
 /**
+ * Response after creating or updating GitHub App credentials.
+ */
+export type GitHubAppCredentialsSaveResponse = {
+  message: string
+  action: "created" | "updated"
+  app_id: string
+}
+
+export type action2 = "created" | "updated"
+
+/**
  * Status of GitHub App credentials.
  */
 export type GitHubAppCredentialsStatus = {
@@ -4044,6 +4055,15 @@ export type GitLabTokenCredentialsRequest = {
    * GitLab personal/project/group access token with api scope.
    */
   token: string
+}
+
+/**
+ * Response after creating or updating GitLab token credentials.
+ */
+export type GitLabTokenCredentialsSaveResponse = {
+  message: string
+  action: "created" | "updated"
+  base_url: string
 }
 
 /**
@@ -13285,9 +13305,8 @@ export type VcsSaveGithubAppCredentialsData = {
   requestBody: GitHubAppCredentialsRequest
 }
 
-export type VcsSaveGithubAppCredentialsResponse = {
-  [key: string]: string
-}
+export type VcsSaveGithubAppCredentialsResponse =
+  GitHubAppCredentialsSaveResponse
 
 export type VcsDeleteGithubAppCredentialsResponse = void
 
@@ -13298,9 +13317,8 @@ export type VcsSaveGitlabTokenCredentialsData = {
   requestBody: GitLabTokenCredentialsRequest
 }
 
-export type VcsSaveGitlabTokenCredentialsResponse = {
-  [key: string]: string
-}
+export type VcsSaveGitlabTokenCredentialsResponse =
+  GitLabTokenCredentialsSaveResponse
 
 export type VcsDeleteGitlabTokenCredentialsResponse = void
 
@@ -19567,9 +19585,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        201: {
-          [key: string]: string
-        }
+        201: GitHubAppCredentialsSaveResponse
         /**
          * Validation Error
          */
@@ -19602,9 +19618,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        201: {
-          [key: string]: string
-        }
+        201: GitLabTokenCredentialsSaveResponse
         /**
          * Validation Error
          */

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -25,6 +25,7 @@ import type {
   GitBranchInfo,
   ValidationDetail,
   ValidationResult,
+  VcsProvider,
   WorkflowDslPublish,
 } from "@/client"
 import { ApiError, workflowsListWorkflowBranches } from "@/client"
@@ -192,6 +193,7 @@ export function BuilderNav() {
         <WorkflowSaveActions
           workflow={workflow}
           workspaceId={workspaceId}
+          provider={workspace.settings?.git_provider ?? "github"}
           validationErrors={validationErrors}
           onSave={handleCommit}
           onPublish={publishWorkflow}
@@ -581,12 +583,14 @@ export function WorkflowManualTrigger({
 function WorkflowSaveActions({
   workflow,
   workspaceId,
+  provider,
   validationErrors,
   onSave,
   onPublish,
 }: {
   workflow: { version?: number | null; git_sync_branch?: string | null }
   workspaceId: string
+  provider: VcsProvider
   validationErrors: ValidationResult[] | null
   onSave: () => Promise<void>
   onPublish: (params: WorkflowDslPublish) => Promise<unknown>
@@ -688,6 +692,7 @@ function WorkflowSaveActions({
   const pushWarning = getWorkspaceSyncPushWarning({
     outcome: pushOutcome,
     defaultBranch,
+    provider,
   })
   const publishDisabled =
     isPublishing ||
@@ -883,6 +888,7 @@ function WorkflowSaveActions({
                     <WorkspaceSyncPushModeTabs
                       value={pushMode}
                       onValueChange={setPushMode}
+                      provider={provider}
                     />
                   </div>
                   <WorkspaceSyncPushWarning
@@ -911,6 +917,7 @@ function WorkflowSaveActions({
                           outcome: pushOutcome,
                           isCreatingBranch,
                           isPending: false,
+                          provider,
                         })}
                       </>
                     )}

--- a/frontend/src/components/nav/builder-nav.tsx
+++ b/frontend/src/components/nav/builder-nav.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useQuery } from "@tanstack/react-query"
 import {
   AlertTriangleIcon,
   ChevronDownIcon,
@@ -22,13 +21,12 @@ import React from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 import type {
-  GitBranchInfo,
   ValidationDetail,
   ValidationResult,
   VcsProvider,
   WorkflowDslPublish,
 } from "@/client"
-import { ApiError, workflowsListWorkflowBranches } from "@/client"
+import { ApiError } from "@/client"
 import { ExportMenuItem } from "@/components/export-workflow-dropdown-item"
 import { Spinner } from "@/components/loading/spinner"
 import {
@@ -95,6 +93,7 @@ import {
 } from "@/components/workspace-sync/push-target-policy"
 import { useEntitlements } from "@/hooks/use-entitlements"
 import { useWorkspaceDetails } from "@/hooks/use-workspace"
+import { useRepositoryBranches } from "@/hooks/use-workspace-sync"
 import type { TracecatApiError } from "@/lib/errors"
 import {
   useCreateDraftWorkflowExecution,
@@ -194,6 +193,7 @@ export function BuilderNav() {
           workflow={workflow}
           workspaceId={workspaceId}
           provider={workspace.settings?.git_provider ?? "github"}
+          gitRepoUrl={workspace.settings?.git_repo_url || undefined}
           validationErrors={validationErrors}
           onSave={handleCommit}
           onPublish={publishWorkflow}
@@ -584,6 +584,7 @@ function WorkflowSaveActions({
   workflow,
   workspaceId,
   provider,
+  gitRepoUrl,
   validationErrors,
   onSave,
   onPublish,
@@ -591,6 +592,7 @@ function WorkflowSaveActions({
   workflow: { version?: number | null; git_sync_branch?: string | null }
   workspaceId: string
   provider: VcsProvider
+  gitRepoUrl?: string
   validationErrors: ValidationResult[] | null
   onSave: () => Promise<void>
   onPublish: (params: WorkflowDslPublish) => Promise<unknown>
@@ -606,18 +608,13 @@ function WorkflowSaveActions({
     () => buildRandomSyncBranchName("sync/workflow"),
     []
   )
-  const { data: repoBranches, isLoading: branchesLoading } = useQuery<
-    Array<GitBranchInfo>,
-    ApiError
-  >({
-    queryKey: ["workflow-sync-branches", workspaceId],
-    queryFn: async () =>
-      await workflowsListWorkflowBranches({
-        workspaceId,
-        limit: 200,
-      }),
-    enabled: isGitSyncEnabled && publishOpen,
-  })
+  const { branches: repoBranches, branchesIsLoading: branchesLoading } =
+    useRepositoryBranches(workspaceId, {
+      enabled: isGitSyncEnabled && publishOpen,
+      gitRepoUrl,
+      provider,
+      limit: 200,
+    })
   const hasBranches = (repoBranches?.length ?? 0) > 0
 
   const publishForm = useForm<TPublishForm>({

--- a/frontend/src/components/organization/org-vcs-gitlab.tsx
+++ b/frontend/src/components/organization/org-vcs-gitlab.tsx
@@ -1,0 +1,285 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import {
+  AlertTriangleIcon,
+  CheckCircle2Icon,
+  GitBranchIcon,
+  Trash2Icon,
+} from "lucide-react"
+import { useEffect, useState } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import { CenteredSpinner } from "@/components/loading/spinner"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { useToast } from "@/components/ui/use-toast"
+import {
+  useDeleteGitLabTokenCredentials,
+  useGitLabTokenCredentials,
+  useGitLabTokenCredentialsStatus,
+} from "@/lib/hooks"
+
+const gitLabTokenFormSchema = z.object({
+  base_url: z
+    .string()
+    .trim()
+    .url("Please enter a valid URL")
+    .default("https://gitlab.com"),
+  token: z.string().min(1, "Token is required"),
+})
+
+type GitLabTokenFormData = z.infer<typeof gitLabTokenFormSchema>
+
+export function GitLabTokenSetup() {
+  const {
+    credentialsStatus,
+    credentialsStatusIsLoading,
+    refetchCredentialsStatus,
+  } = useGitLabTokenCredentialsStatus()
+  const { deleteCredentials } = useDeleteGitLabTokenCredentials()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const { toast } = useToast()
+
+  const isConfigured = credentialsStatus?.exists ?? false
+  const isCorrupted = credentialsStatus?.is_corrupted ?? false
+
+  async function handleDelete() {
+    try {
+      await deleteCredentials.mutateAsync()
+      setDeleteDialogOpen(false)
+      toast({
+        title: "GitLab credentials deleted",
+        description: "GitLab workspace sync has been disconnected.",
+      })
+    } catch (error) {
+      toast({
+        title: "Error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Failed to delete credentials",
+        variant: "destructive",
+      })
+    }
+  }
+
+  if (credentialsStatusIsLoading) {
+    return <CenteredSpinner />
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between rounded-lg border p-4">
+        <div className="flex items-center gap-3">
+          {isCorrupted ? (
+            <AlertTriangleIcon className="size-5 text-amber-500" />
+          ) : isConfigured ? (
+            <CheckCircle2Icon className="size-5 text-green-500" />
+          ) : (
+            <GitBranchIcon className="size-5 text-muted-foreground" />
+          )}
+          <div>
+            <p className="text-sm font-medium">GitLab</p>
+            <p className="text-xs text-muted-foreground">
+              {isCorrupted
+                ? "Stored credentials are unreadable. Re-enter the GitLab token to reconnect."
+                : isConfigured
+                  ? `Base URL: ${credentialsStatus?.base_url ?? "unknown"}`
+                  : "Not connected"}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {isConfigured ? (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setDialogOpen(true)}
+              >
+                {isCorrupted ? "Reconnect" : "Update"}
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => setDeleteDialogOpen(true)}
+              >
+                <Trash2Icon className="size-3.5" />
+              </Button>
+            </>
+          ) : (
+            <Button size="sm" onClick={() => setDialogOpen(true)}>
+              Connect
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <GitLabConnectionDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        existingBaseUrl={credentialsStatus?.base_url ?? undefined}
+        onFormSuccess={() => {
+          setDialogOpen(false)
+          refetchCredentialsStatus()
+          toast({
+            title: "GitLab credentials saved",
+            description: "GitLab workspace sync credentials are ready.",
+          })
+        }}
+      />
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete GitLab credentials</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete the GitLab token credentials?
+              GitLab workspace sync will stop working until credentials are
+              reconnected.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteCredentials.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={deleteCredentials.isPending}
+              className="bg-destructive hover:bg-destructive/90"
+            >
+              {deleteCredentials.isPending ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+function GitLabConnectionDialog({
+  open,
+  onOpenChange,
+  existingBaseUrl,
+  onFormSuccess,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  existingBaseUrl?: string
+  onFormSuccess: () => void
+}) {
+  const { saveCredentials } = useGitLabTokenCredentials()
+  const form = useForm<GitLabTokenFormData>({
+    resolver: zodResolver(gitLabTokenFormSchema),
+    defaultValues: {
+      base_url: existingBaseUrl ?? "https://gitlab.com",
+      token: "",
+    },
+  })
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    form.reset({
+      base_url: existingBaseUrl ?? "https://gitlab.com",
+      token: "",
+    })
+  }, [existingBaseUrl, form, open])
+
+  async function onSubmit(values: GitLabTokenFormData) {
+    await saveCredentials.mutateAsync(values)
+    onFormSuccess()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>GitLab credentials</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="base_url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Base URL</FormLabel>
+                  <FormControl>
+                    <Input placeholder="https://gitlab.com" {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Use your self-managed GitLab URL when not using GitLab.com.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="token"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Token</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      autoComplete="off"
+                      placeholder="glpat-..."
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Requires GitLab API access for branch, commit, and merge
+                    request operations.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="flex justify-end gap-2 pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={saveCredentials.isPending}>
+                {saveCredentials.isPending ? "Saving..." : "Save"}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/organization/org-vcs-gitlab.tsx
+++ b/frontend/src/components/organization/org-vcs-gitlab.tsx
@@ -223,7 +223,7 @@ function GitLabConnectionDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>GitLab credentials</DialogTitle>
+          <DialogTitle>GitLab workspace sync credential</DialogTitle>
         </DialogHeader>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
@@ -248,7 +248,7 @@ function GitLabConnectionDialog({
               name="token"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Token</FormLabel>
+                  <FormLabel>Credential token</FormLabel>
                   <FormControl>
                     <Input
                       type="password"
@@ -258,8 +258,10 @@ function GitLabConnectionDialog({
                     />
                   </FormControl>
                   <FormDescription>
-                    Requires GitLab API access for branch, commit, and merge
-                    request operations.
+                    Use a GitLab project or group access token with the api
+                    scope. Tracecat stores this token as the GitLab credential
+                    for workspace sync; prefer it over a personal access token
+                    for long-lived sync.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/frontend/src/components/organization/org-vcs-gitlab.tsx
+++ b/frontend/src/components/organization/org-vcs-gitlab.tsx
@@ -51,7 +51,7 @@ const gitLabTokenFormSchema = z.object({
     .trim()
     .url("Please enter a valid URL")
     .default("https://gitlab.com"),
-  token: z.string().min(1, "Token is required"),
+  token: z.string().trim().min(1, "Token is required"),
 })
 
 type GitLabTokenFormData = z.infer<typeof gitLabTokenFormSchema>
@@ -196,6 +196,7 @@ function GitLabConnectionDialog({
   onFormSuccess: () => void
 }) {
   const { saveCredentials } = useGitLabTokenCredentials()
+  const { toast } = useToast()
   const form = useForm<GitLabTokenFormData>({
     resolver: zodResolver(gitLabTokenFormSchema),
     defaultValues: {
@@ -215,8 +216,19 @@ function GitLabConnectionDialog({
   }, [existingBaseUrl, form, open])
 
   async function onSubmit(values: GitLabTokenFormData) {
-    await saveCredentials.mutateAsync(values)
-    onFormSuccess()
+    try {
+      await saveCredentials.mutateAsync(values)
+      onFormSuccess()
+    } catch (error) {
+      toast({
+        title: "Error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Failed to save GitLab credentials",
+        variant: "destructive",
+      })
+    }
   }
 
   return (

--- a/frontend/src/components/organization/org-vcs-settings.tsx
+++ b/frontend/src/components/organization/org-vcs-settings.tsx
@@ -5,7 +5,7 @@ import { GitLabTokenSetup } from "@/components/organization/org-vcs-gitlab"
 
 export function OrgVCSSettings() {
   return (
-    <div className="space-y-8">
+    <div className="space-y-4">
       <GitHubAppSetup />
       <GitLabTokenSetup />
     </div>

--- a/frontend/src/components/organization/org-vcs-settings.tsx
+++ b/frontend/src/components/organization/org-vcs-settings.tsx
@@ -1,11 +1,13 @@
 "use client"
 
 import { GitHubAppSetup } from "@/components/organization/org-vcs-github"
+import { GitLabTokenSetup } from "@/components/organization/org-vcs-gitlab"
 
 export function OrgVCSSettings() {
   return (
     <div className="space-y-8">
       <GitHubAppSetup />
+      <GitLabTokenSetup />
     </div>
   )
 }

--- a/frontend/src/components/settings/workspace-sync-settings.tsx
+++ b/frontend/src/components/settings/workspace-sync-settings.tsx
@@ -8,7 +8,7 @@ import {
   PencilIcon,
 } from "lucide-react"
 import { useState } from "react"
-import type { WorkspaceRead } from "@/client"
+import type { VcsProvider, WorkspaceRead } from "@/client"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -41,11 +41,15 @@ export function WorkspaceSyncSettings({
   workspace,
 }: WorkspaceSyncSettingsProps) {
   const persistedGitUrl = workspace.settings?.git_repo_url || undefined
+  const persistedProvider: VcsProvider =
+    workspace.settings?.git_provider ?? "github"
   const {
     repositories = [],
     repositoriesIsLoading,
     repositoriesError,
-  } = useGitHubAppRepositories(workspace.id)
+  } = useGitHubAppRepositories(workspace.id, {
+    enabled: persistedProvider === "github",
+  })
 
   const [isEditingConnection, setIsEditingConnection] = useState(false)
   const [mode, setMode] = useState<SyncMode>("push")
@@ -57,6 +61,7 @@ export function WorkspaceSyncSettings({
   } = useRepositoryBranches(workspace.id, {
     enabled: Boolean(persistedGitUrl),
     gitRepoUrl: persistedGitUrl,
+    provider: persistedProvider,
     limit: 200,
   })
   const baseBranch = getWorkspaceSyncBaseBranch(persistedGitUrl, repoBranches)
@@ -66,6 +71,7 @@ export function WorkspaceSyncSettings({
     {
       branch: baseBranch,
       gitRepoUrl: persistedGitUrl,
+      provider: persistedProvider,
       limit: 20,
       enabled: Boolean(persistedGitUrl) && Boolean(baseBranch),
     }
@@ -80,6 +86,7 @@ export function WorkspaceSyncSettings({
         <WorkspaceSyncConnectionForm
           workspaceId={workspace.id}
           persistedGitUrl={persistedGitUrl}
+          persistedProvider={persistedProvider}
           repositories={repositories}
           repositoriesIsLoading={repositoriesIsLoading}
           repositoriesError={repositoriesError}
@@ -139,6 +146,7 @@ export function WorkspaceSyncSettings({
             <WorkspaceSyncPushTab
               workspaceId={workspace.id}
               persistedGitUrl={persistedGitUrl}
+              provider={persistedProvider}
               repoDisplayName={repoDisplayName}
               repoBranches={repoBranches}
               baseBranch={baseBranch}
@@ -150,6 +158,7 @@ export function WorkspaceSyncSettings({
           <TabsContent value="pull" className="space-y-4">
             <WorkspaceSyncPullTab
               workspaceId={workspace.id}
+              provider={persistedProvider}
               commits={commits}
               commitsIsLoading={commitsIsLoading}
               commitsError={commitsError}

--- a/frontend/src/components/workspace-sync/connection-form.tsx
+++ b/frontend/src/components/workspace-sync/connection-form.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { useEffect, useState } from "react"
 import { useForm, useWatch } from "react-hook-form"
 import { z } from "zod"
-import type { GitHubAppRepository } from "@/client"
+import type { GitHubAppRepository, VcsProvider } from "@/client"
 import { Button } from "@/components/ui/button"
 import {
   Form,
@@ -29,8 +29,11 @@ import { validateGitSshUrl } from "@/lib/git"
 import { useWorkspaceSettings } from "@/lib/hooks"
 
 type RepositoryInputMode = "select" | "manual"
+const vcsProviderOptions = ["github", "gitlab"] as const
+type WorkspaceSyncConnectionProvider = (typeof vcsProviderOptions)[number]
 
 export const syncSettingsSchema = z.object({
+  git_provider: z.enum(vcsProviderOptions).default("github"),
   git_repo_url: z
     .string()
     .nullish()
@@ -43,6 +46,7 @@ type SyncSettingsForm = z.infer<typeof syncSettingsSchema>
 interface WorkspaceSyncConnectionFormProps {
   workspaceId: string
   persistedGitUrl: string | undefined
+  persistedProvider: VcsProvider
   repositories: GitHubAppRepository[]
   repositoriesIsLoading: boolean
   repositoriesError: unknown
@@ -57,6 +61,7 @@ interface WorkspaceSyncConnectionFormProps {
 export function WorkspaceSyncConnectionForm({
   workspaceId,
   persistedGitUrl,
+  persistedProvider,
   repositories,
   repositoriesIsLoading,
   repositoriesError,
@@ -68,18 +73,26 @@ export function WorkspaceSyncConnectionForm({
     resolver: zodResolver(syncSettingsSchema),
     mode: "onChange",
     defaultValues: {
+      git_provider: toConnectionProvider(persistedProvider),
       git_repo_url: persistedGitUrl ?? "",
     },
+  })
+  const currentProvider = useWatch({
+    control: form.control,
+    name: "git_provider",
   })
   const currentGitRepoUrl = useWatch({
     control: form.control,
     name: "git_repo_url",
   })
 
-  const hasRepositoryOptions = repositories.length > 0
-  const currentGitUrlMatchesRepository = repositories.some((repository) =>
-    matchesRepositoryGitUrl(currentGitRepoUrl, repository)
-  )
+  const isGitHubProvider = currentProvider === "github"
+  const hasRepositoryOptions = isGitHubProvider && repositories.length > 0
+  const currentGitUrlMatchesRepository =
+    isGitHubProvider &&
+    repositories.some((repository) =>
+      matchesRepositoryGitUrl(currentGitRepoUrl, repository)
+    )
   const [repositoryInputMode, setRepositoryInputMode] =
     useState<RepositoryInputMode>("select")
   const [hasSelectedRepositoryInputMode, setHasSelectedRepositoryInputMode] =
@@ -87,6 +100,7 @@ export function WorkspaceSyncConnectionForm({
   useEffect(() => {
     if (
       !hasSelectedRepositoryInputMode &&
+      isGitHubProvider &&
       hasRepositoryOptions &&
       !repositoriesIsLoading &&
       currentGitRepoUrl &&
@@ -99,6 +113,7 @@ export function WorkspaceSyncConnectionForm({
     currentGitUrlMatchesRepository,
     hasSelectedRepositoryInputMode,
     hasRepositoryOptions,
+    isGitHubProvider,
     repositoriesIsLoading,
   ])
   function handleRepositoryInputModeChange(mode: RepositoryInputMode) {
@@ -107,13 +122,17 @@ export function WorkspaceSyncConnectionForm({
   }
 
   const shouldShowRepositoryModeTabs =
-    hasRepositoryOptions && !repositoriesIsLoading
+    isGitHubProvider && hasRepositoryOptions && !repositoriesIsLoading
   const shouldShowRepositorySelect =
-    repositoriesIsLoading ||
-    (hasRepositoryOptions && repositoryInputMode === "select")
+    isGitHubProvider &&
+    (repositoriesIsLoading ||
+      (hasRepositoryOptions && repositoryInputMode === "select"))
   let repositoryDescription =
     "Git URL of the remote repository. Must use git+ssh scheme."
-  if (hasRepositoryOptions && repositoryInputMode === "select") {
+  if (currentProvider === "gitlab") {
+    repositoryDescription =
+      "Enter a GitLab git+ssh URL. Nested groups and self-managed hosts are supported."
+  } else if (hasRepositoryOptions && repositoryInputMode === "select") {
     repositoryDescription =
       "Select a repository granted to the connected GitHub App installation."
   } else if (hasRepositoryOptions) {
@@ -125,12 +144,13 @@ export function WorkspaceSyncConnectionForm({
 
   async function onSubmit(values: SyncSettingsForm) {
     const selectedRepository =
-      repositoryInputMode === "select"
+      values.git_provider === "github" && repositoryInputMode === "select"
         ? findMatchingRepository(values.git_repo_url, repositories)
         : undefined
 
     await updateWorkspace({
       settings: {
+        git_provider: values.git_provider,
         git_repo_url: selectedRepository
           ? getRepositoryGitUrl(selectedRepository)
           : values.git_repo_url,
@@ -142,6 +162,26 @@ export function WorkspaceSyncConnectionForm({
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="git_provider"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Provider</FormLabel>
+              <ToggleTabs<WorkspaceSyncConnectionProvider>
+                value={field.value}
+                onValueChange={field.onChange}
+                showTooltips={false}
+                options={[
+                  { value: "github", content: "GitHub" },
+                  { value: "gitlab", content: "GitLab" },
+                ]}
+              />
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
         <FormField
           control={form.control}
           name="git_repo_url"
@@ -209,7 +249,11 @@ export function WorkspaceSyncConnectionForm({
                 <FormControl>
                   <Input
                     aria-invalid={fieldState.invalid}
-                    placeholder="git+ssh://git@github.com/my-org/my-repo.git"
+                    placeholder={
+                      currentProvider === "gitlab"
+                        ? "git+ssh://git@gitlab.com/my-org/my-group/my-repo.git"
+                        : "git+ssh://git@github.com/my-org/my-repo.git"
+                    }
                     {...field}
                     value={field.value ?? ""}
                   />
@@ -278,4 +322,10 @@ function getRepositorySelectValue(
 ) {
   const repository = findMatchingRepository(gitUrl, repositories)
   return repository?.git_url ?? gitUrl ?? ""
+}
+
+function toConnectionProvider(
+  provider: VcsProvider
+): WorkspaceSyncConnectionProvider {
+  return provider === "gitlab" ? "gitlab" : "github"
 }

--- a/frontend/src/components/workspace-sync/connection-form.tsx
+++ b/frontend/src/components/workspace-sync/connection-form.tsx
@@ -166,7 +166,7 @@ export function WorkspaceSyncConnectionForm({
           control={form.control}
           name="git_provider"
           render={({ field }) => (
-            <FormItem>
+            <FormItem className="flex flex-col items-start">
               <FormLabel>Provider</FormLabel>
               <ToggleTabs<WorkspaceSyncConnectionProvider>
                 value={field.value}

--- a/frontend/src/components/workspace-sync/connection-form.tsx
+++ b/frontend/src/components/workspace-sync/connection-form.tsx
@@ -68,12 +68,16 @@ export function WorkspaceSyncConnectionForm({
   onClose,
 }: WorkspaceSyncConnectionFormProps) {
   const { updateWorkspace, isUpdating } = useWorkspaceSettings(workspaceId)
+  const initialProvider = toConnectionProvider(persistedProvider)
+  const hasUnsupportedPersistedProvider = initialProvider === undefined
+  const [hasConfirmedSupportedProvider, setHasConfirmedSupportedProvider] =
+    useState(!hasUnsupportedPersistedProvider)
 
   const form = useForm<SyncSettingsForm>({
     resolver: zodResolver(syncSettingsSchema),
     mode: "onChange",
     defaultValues: {
-      git_provider: toConnectionProvider(persistedProvider),
+      git_provider: initialProvider ?? "github",
       git_repo_url: persistedGitUrl ?? "",
     },
   })
@@ -120,9 +124,18 @@ export function WorkspaceSyncConnectionForm({
     setHasSelectedRepositoryInputMode(true)
     setRepositoryInputMode(mode)
   }
+  function handleProviderChange(provider: WorkspaceSyncConnectionProvider) {
+    setHasConfirmedSupportedProvider(true)
+    form.setValue("git_provider", provider, {
+      shouldDirty: true,
+      shouldValidate: true,
+    })
+  }
 
   const shouldShowRepositoryModeTabs =
     isGitHubProvider && hasRepositoryOptions && !repositoriesIsLoading
+  const mustChooseSupportedProvider =
+    hasUnsupportedPersistedProvider && !hasConfirmedSupportedProvider
   const shouldShowRepositorySelect =
     isGitHubProvider &&
     (repositoriesIsLoading ||
@@ -170,13 +183,19 @@ export function WorkspaceSyncConnectionForm({
               <FormLabel>Provider</FormLabel>
               <ToggleTabs<WorkspaceSyncConnectionProvider>
                 value={field.value}
-                onValueChange={field.onChange}
+                onValueChange={handleProviderChange}
                 showTooltips={false}
                 options={[
                   { value: "github", content: "GitHub" },
                   { value: "gitlab", content: "GitLab" },
                 ]}
               />
+              {mustChooseSupportedProvider && (
+                <FormDescription className="text-amber-700">
+                  The saved provider "{persistedProvider}" is not supported.
+                  Choose GitHub or GitLab before saving.
+                </FormDescription>
+              )}
               <FormMessage />
             </FormItem>
           )}
@@ -266,7 +285,11 @@ export function WorkspaceSyncConnectionForm({
         />
 
         <div className="flex items-center gap-2">
-          <Button type="submit" disabled={isUpdating} size="sm">
+          <Button
+            type="submit"
+            disabled={isUpdating || mustChooseSupportedProvider}
+            size="sm"
+          >
             {isUpdating ? "Saving..." : "Save"}
           </Button>
           {persistedGitUrl && (
@@ -326,6 +349,9 @@ function getRepositorySelectValue(
 
 function toConnectionProvider(
   provider: VcsProvider
-): WorkspaceSyncConnectionProvider {
-  return provider === "gitlab" ? "gitlab" : "github"
+): WorkspaceSyncConnectionProvider | undefined {
+  if (provider === "github" || provider === "gitlab") {
+    return provider
+  }
+  return undefined
 }

--- a/frontend/src/components/workspace-sync/pull-tab.tsx
+++ b/frontend/src/components/workspace-sync/pull-tab.tsx
@@ -94,7 +94,6 @@ export function WorkspaceSyncPullTab({
       const result = await pullWorkflows({
         commit_sha: effectivePullSha,
         dry_run: true,
-        provider,
         sync_schedules: syncSchedules,
       })
       setPullPreview(result)
@@ -128,7 +127,6 @@ export function WorkspaceSyncPullTab({
     try {
       const result = await pullWorkflows({
         commit_sha: effectivePullSha,
-        provider,
         sync_schedules: syncSchedules,
       })
       setPullResult(result)

--- a/frontend/src/components/workspace-sync/pull-tab.tsx
+++ b/frontend/src/components/workspace-sync/pull-tab.tsx
@@ -9,7 +9,7 @@ import {
   XCircleIcon,
 } from "lucide-react"
 import { useEffect, useState } from "react"
-import type { GitCommitInfo, PullResult } from "@/client"
+import type { GitCommitInfo, PullResult, VcsProvider } from "@/client"
 import { CommitSelector } from "@/components/registry/commit-selector"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -29,6 +29,7 @@ import { cn } from "@/lib/utils"
 
 interface WorkspaceSyncPullTabProps {
   workspaceId: string
+  provider: VcsProvider
   commits: GitCommitInfo[] | undefined
   commitsIsLoading: boolean
   commitsError: Error | null
@@ -40,6 +41,7 @@ interface WorkspaceSyncPullTabProps {
  */
 export function WorkspaceSyncPullTab({
   workspaceId,
+  provider,
   commits,
   commitsIsLoading,
   commitsError,
@@ -78,7 +80,7 @@ export function WorkspaceSyncPullTab({
     setPullPreview(null)
     setPullPreviewOptions(null)
     setPullResult(null)
-  }, [effectivePullSha, syncSchedules])
+  }, [effectivePullSha, provider, syncSchedules])
 
   async function handlePreviewPull() {
     if (!effectivePullSha) {
@@ -92,6 +94,7 @@ export function WorkspaceSyncPullTab({
       const result = await pullWorkflows({
         commit_sha: effectivePullSha,
         dry_run: true,
+        provider,
         sync_schedules: syncSchedules,
       })
       setPullPreview(result)
@@ -125,6 +128,7 @@ export function WorkspaceSyncPullTab({
     try {
       const result = await pullWorkflows({
         commit_sha: effectivePullSha,
+        provider,
         sync_schedules: syncSchedules,
       })
       setPullResult(result)

--- a/frontend/src/components/workspace-sync/push-tab.tsx
+++ b/frontend/src/components/workspace-sync/push-tab.tsx
@@ -125,7 +125,6 @@ export function WorkspaceSyncPushTab({
         branch: targetBranch,
         create_pr: pushOutcome.createPr,
         include_schedules: false,
-        provider,
       })
       toast({
         title: result.commit.pr_url

--- a/frontend/src/components/workspace-sync/push-tab.tsx
+++ b/frontend/src/components/workspace-sync/push-tab.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowUpIcon, GitPullRequestIcon, Loader2Icon } from "lucide-react"
 import { useEffect, useState } from "react"
-import type { GitBranchInfo } from "@/client"
+import type { GitBranchInfo, VcsProvider } from "@/client"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -12,6 +12,7 @@ import {
   WorkspaceSyncBranchSelector,
 } from "@/components/workspace-sync/branch-target-selector"
 import {
+  getReviewRequestLabel,
   getWorkspaceSyncPushButtonLabel,
   getWorkspaceSyncPushOutcome,
   getWorkspaceSyncPushResultLabel,
@@ -28,6 +29,7 @@ import { getApiErrorDetail } from "@/lib/errors"
 interface WorkspaceSyncPushTabProps {
   workspaceId: string
   persistedGitUrl: string | undefined
+  provider: VcsProvider
   repoDisplayName: string | null
   repoBranches: GitBranchInfo[] | undefined
   baseBranch: string | undefined
@@ -42,6 +44,7 @@ interface WorkspaceSyncPushTabProps {
 export function WorkspaceSyncPushTab({
   workspaceId,
   persistedGitUrl,
+  provider,
   repoDisplayName,
   repoBranches,
   baseBranch,
@@ -76,6 +79,7 @@ export function WorkspaceSyncPushTab({
     refetchPreview: refetchExportPreview,
   } = useWorkspaceSyncExportPreview(workspaceId, {
     compareRef: exportCompareRef,
+    provider,
     enabled: false,
   })
   const visibleExportPreview = exportPreviewRequested
@@ -96,7 +100,12 @@ export function WorkspaceSyncPushTab({
     outcome: pushOutcome,
     defaultBranch: baseBranch,
     allowDirectPush: false,
+    provider,
   })
+  const reviewRequestTitle =
+    getReviewRequestLabel(provider) === "merge request"
+      ? "Merge request"
+      : "Pull request"
   const exportDisabled =
     exportWorkspaceIsPending ||
     branchesIsLoading ||
@@ -107,7 +116,7 @@ export function WorkspaceSyncPushTab({
 
   useEffect(() => {
     setExportPreviewRequested(false)
-  }, [exportCompareRef, persistedGitUrl])
+  }, [exportCompareRef, persistedGitUrl, provider])
 
   async function onExport() {
     try {
@@ -116,11 +125,11 @@ export function WorkspaceSyncPushTab({
         branch: targetBranch,
         create_pr: pushOutcome.createPr,
         include_schedules: false,
-        provider: "github",
+        provider,
       })
       toast({
         title: result.commit.pr_url
-          ? "Pull request ready"
+          ? `${reviewRequestTitle} ready`
           : "Workspace config pushed",
         description:
           result.commit.pr_url ?? result.commit.sha ?? result.commit.message,
@@ -200,6 +209,7 @@ export function WorkspaceSyncPushTab({
             {getWorkspaceSyncPushResultLabel({
               outcome: pushOutcome,
               defaultBranch: baseBranch,
+              provider,
             })}
           </span>
         </div>
@@ -221,6 +231,7 @@ export function WorkspaceSyncPushTab({
             outcome: pushOutcome,
             isCreatingBranch,
             isPending: exportWorkspaceIsPending,
+            provider,
           })}
         </Button>
       </div>

--- a/frontend/src/components/workspace-sync/push-target-policy.tsx
+++ b/frontend/src/components/workspace-sync/push-target-policy.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { GitBranchIcon, GitPullRequestIcon } from "lucide-react"
+import type { VcsProvider } from "@/client"
 import { ToggleTabs } from "@/components/ui/toggle-tabs"
 import { cn } from "@/lib/utils"
 
@@ -24,12 +25,14 @@ interface WorkspaceSyncPushButtonLabelOptions {
   outcome: WorkspaceSyncPushOutcome
   isCreatingBranch: boolean
   isPending: boolean
+  provider?: VcsProvider
 }
 
 interface WorkspaceSyncPushMessageOptions {
   outcome: WorkspaceSyncPushOutcome
   defaultBranch: string | undefined
   allowDirectPush?: boolean
+  provider?: VcsProvider
 }
 
 interface WorkspaceSyncPushModeTabsProps {
@@ -64,7 +67,9 @@ export function getWorkspaceSyncPushButtonLabel({
   outcome,
   isCreatingBranch,
   isPending,
+  provider = "github",
 }: WorkspaceSyncPushButtonLabelOptions): string {
+  const reviewRequestAbbreviation = getReviewRequestAbbreviation(provider)
   if (isPending) {
     return "Pushing..."
   }
@@ -72,17 +77,18 @@ export function getWorkspaceSyncPushButtonLabel({
     return "Push directly"
   }
   if (isCreatingBranch) {
-    return "Push & open PR"
+    return `Push & open ${reviewRequestAbbreviation}`
   }
-  return "Update branch & open PR"
+  return `Update branch & open ${reviewRequestAbbreviation}`
 }
 
 export function getWorkspaceSyncPushResultLabel({
   outcome,
   defaultBranch,
+  provider = "github",
 }: WorkspaceSyncPushMessageOptions): string {
   if (outcome.willCreatePr) {
-    return `PR into ${defaultBranch ?? "default branch"}`
+    return `${getReviewRequestAbbreviation(provider)} into ${defaultBranch ?? "default branch"}`
   }
   if (outcome.isPullRequestBlocked) {
     return "Choose a non-default branch"
@@ -94,20 +100,30 @@ export function getWorkspaceSyncPushWarning({
   outcome,
   defaultBranch,
   allowDirectPush = true,
+  provider = "github",
 }: WorkspaceSyncPushMessageOptions): string | null {
+  const reviewRequestLabel = getReviewRequestLabel(provider)
   if (outcome.isPullRequestBlocked) {
     if (!allowDirectPush) {
-      return `Select or create a non-default branch to open a pull request into ${defaultBranch ?? "the default branch"}.`
+      return `Select or create a non-default branch to open a ${reviewRequestLabel} into ${defaultBranch ?? "the default branch"}.`
     }
-    return `Select or create a non-default branch to open a pull request into ${defaultBranch ?? "the default branch"}, or switch to direct push.`
+    return `Select or create a non-default branch to open a ${reviewRequestLabel} into ${defaultBranch ?? "the default branch"}, or switch to direct push.`
   }
   if (!outcome.createPr && outcome.targetIsDefault) {
-    return `This commits directly to ${defaultBranch ?? "the default branch"}. No pull request will be created.`
+    return `This commits directly to ${defaultBranch ?? "the default branch"}. No ${reviewRequestLabel} will be created.`
   }
   if (!outcome.createPr) {
-    return "This commits directly to the selected branch. No pull request will be created."
+    return `This commits directly to the selected branch. No ${reviewRequestLabel} will be created.`
   }
   return null
+}
+
+export function getReviewRequestAbbreviation(provider: VcsProvider): string {
+  return provider === "gitlab" ? "MR" : "PR"
+}
+
+export function getReviewRequestLabel(provider: VcsProvider): string {
+  return provider === "gitlab" ? "merge request" : "pull request"
 }
 
 /**

--- a/frontend/src/components/workspace-sync/push-target-policy.tsx
+++ b/frontend/src/components/workspace-sync/push-target-policy.tsx
@@ -25,19 +25,20 @@ interface WorkspaceSyncPushButtonLabelOptions {
   outcome: WorkspaceSyncPushOutcome
   isCreatingBranch: boolean
   isPending: boolean
-  provider?: VcsProvider
+  provider: VcsProvider
 }
 
 interface WorkspaceSyncPushMessageOptions {
   outcome: WorkspaceSyncPushOutcome
   defaultBranch: string | undefined
   allowDirectPush?: boolean
-  provider?: VcsProvider
+  provider: VcsProvider
 }
 
 interface WorkspaceSyncPushModeTabsProps {
   value: WorkspaceSyncPushMode
   onValueChange: (value: WorkspaceSyncPushMode) => void
+  provider: VcsProvider
   size?: "sm" | "md" | "lg"
 }
 
@@ -67,7 +68,7 @@ export function getWorkspaceSyncPushButtonLabel({
   outcome,
   isCreatingBranch,
   isPending,
-  provider = "github",
+  provider,
 }: WorkspaceSyncPushButtonLabelOptions): string {
   const reviewRequestAbbreviation = getReviewRequestAbbreviation(provider)
   if (isPending) {
@@ -85,7 +86,7 @@ export function getWorkspaceSyncPushButtonLabel({
 export function getWorkspaceSyncPushResultLabel({
   outcome,
   defaultBranch,
-  provider = "github",
+  provider,
 }: WorkspaceSyncPushMessageOptions): string {
   if (outcome.willCreatePr) {
     return `${getReviewRequestAbbreviation(provider)} into ${defaultBranch ?? "default branch"}`
@@ -100,7 +101,7 @@ export function getWorkspaceSyncPushWarning({
   outcome,
   defaultBranch,
   allowDirectPush = true,
-  provider = "github",
+  provider,
 }: WorkspaceSyncPushMessageOptions): string | null {
   const reviewRequestLabel = getReviewRequestLabel(provider)
   if (outcome.isPullRequestBlocked) {
@@ -158,8 +159,10 @@ export function WorkspaceSyncPushWarning({
 export function WorkspaceSyncPushModeTabs({
   value,
   onValueChange,
+  provider,
   size = "sm",
 }: WorkspaceSyncPushModeTabsProps) {
+  const reviewRequestAbbreviation = getReviewRequestAbbreviation(provider)
   return (
     <ToggleTabs<WorkspaceSyncPushMode>
       value={value}
@@ -172,7 +175,7 @@ export function WorkspaceSyncPushModeTabs({
           content: (
             <span className="flex items-center gap-1.5">
               <GitPullRequestIcon className="size-3.5" />
-              Open PR
+              Open {reviewRequestAbbreviation}
             </span>
           ),
         },

--- a/frontend/src/components/workspace-sync/resource-sync-actions.tsx
+++ b/frontend/src/components/workspace-sync/resource-sync-actions.tsx
@@ -7,7 +7,7 @@ import {
   LayersIcon,
 } from "lucide-react"
 import { type ReactNode, useEffect, useMemo, useState } from "react"
-import type { ResourceRef, SyncResourceType } from "@/client"
+import type { ResourceRef, SyncResourceType, VcsProvider } from "@/client"
 import { useScopeCheck } from "@/components/auth/scope-guard"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -35,6 +35,8 @@ import {
   getWorkspaceSyncPreviewResourceTotal,
 } from "@/components/workspace-sync/push-resource-manifest"
 import {
+  getReviewRequestAbbreviation,
+  getReviewRequestLabel,
   getWorkspaceSyncPushButtonLabel,
   getWorkspaceSyncPushOutcome,
   getWorkspaceSyncPushResultLabel,
@@ -77,6 +79,7 @@ export function WorkspaceResourceSyncActions({
   const { exportWorkspace, exportWorkspaceIsPending } =
     useWorkspaceSyncExport(workspaceId)
   const gitRepoUrl = workspace?.settings?.git_repo_url || undefined
+  const provider: VcsProvider = workspace?.settings?.git_provider ?? "github"
   const {
     branches: repoBranches,
     branchesIsLoading,
@@ -84,6 +87,7 @@ export function WorkspaceResourceSyncActions({
   } = useRepositoryBranches(workspaceId, {
     enabled: open && Boolean(workspace?.settings?.git_repo_url),
     gitRepoUrl,
+    provider,
     limit: 200,
   })
 
@@ -111,6 +115,7 @@ export function WorkspaceResourceSyncActions({
     useWorkspaceSyncExportPreview(workspaceId, {
       resources: resourceRefs,
       compareRef,
+      provider,
       enabled: false,
     })
   const [previewRequested, setPreviewRequested] = useState(false)
@@ -131,7 +136,11 @@ export function WorkspaceResourceSyncActions({
     outcome: pushOutcome,
     defaultBranch: baseBranch,
     allowDirectPush: false,
+    provider,
   })
+  const reviewRequestLabel = getReviewRequestLabel(provider)
+  const reviewRequestTitle =
+    reviewRequestLabel === "merge request" ? "Merge request" : "Pull request"
   const previewErrorMessage = previewError
     ? (getApiErrorDetail(previewError) ?? "Request failed")
     : undefined
@@ -155,7 +164,7 @@ export function WorkspaceResourceSyncActions({
 
   useEffect(() => {
     setPreviewRequested(false)
-  }, [compareRef])
+  }, [compareRef, provider])
 
   if (!canPushWorkspaceSync) {
     return null
@@ -172,19 +181,19 @@ export function WorkspaceResourceSyncActions({
         branch: targetBranch,
         create_pr: pushOutcome.createPr,
         include_schedules: false,
-        provider: "github",
+        provider,
         resources: resourceRefs,
       })
       const prUrl = result.commit.pr_url
       toast({
-        title: prUrl ? "Pull request ready" : "Push complete",
+        title: prUrl ? `${reviewRequestTitle} ready` : "Push complete",
         description: result.commit.message ?? result.commit.sha ?? undefined,
         action: prUrl ? (
           <ToastAction
-            altText="Open pull request"
+            altText={`Open ${reviewRequestLabel}`}
             onClick={() => window.open(prUrl, "_blank", "noopener,noreferrer")}
           >
-            View PR
+            View {getReviewRequestAbbreviation(provider)}
           </ToastAction>
         ) : undefined,
       })
@@ -235,6 +244,7 @@ export function WorkspaceResourceSyncActions({
               targetBranch={targetBranch}
               defaultBranch={baseBranch}
               outcome={pushOutcome}
+              provider={provider}
             />
 
             <PushResourcePreview
@@ -320,6 +330,7 @@ export function WorkspaceResourceSyncActions({
                 outcome: pushOutcome,
                 isCreatingBranch,
                 isPending: exportWorkspaceIsPending,
+                provider,
               })}
             </Button>
           </div>
@@ -335,6 +346,7 @@ interface PushFlowProps {
   targetBranch: string
   defaultBranch: string | undefined
   outcome: ReturnType<typeof getWorkspaceSyncPushOutcome>
+  provider: VcsProvider
 }
 
 /**
@@ -348,6 +360,7 @@ function PushFlow({
   targetBranch,
   defaultBranch,
   outcome,
+  provider,
 }: PushFlowProps) {
   return (
     <div className="flex items-stretch gap-2 rounded-lg border bg-muted/30 p-3">
@@ -390,7 +403,11 @@ function PushFlow({
           )
         }
         title="Result"
-        value={getWorkspaceSyncPushResultLabel({ outcome, defaultBranch })}
+        value={getWorkspaceSyncPushResultLabel({
+          outcome,
+          defaultBranch,
+          provider,
+        })}
       />
     </div>
   )

--- a/frontend/src/components/workspace-sync/resource-sync-actions.tsx
+++ b/frontend/src/components/workspace-sync/resource-sync-actions.tsx
@@ -181,7 +181,6 @@ export function WorkspaceResourceSyncActions({
         branch: targetBranch,
         create_pr: pushOutcome.createPr,
         include_schedules: false,
-        provider,
         resources: resourceRefs,
       })
       const prUrl = result.commit.pr_url

--- a/frontend/src/hooks/use-workspace-sync.ts
+++ b/frontend/src/hooks/use-workspace-sync.ts
@@ -211,10 +211,12 @@ export function useRepositoryBranches(
   workspaceId: string,
   options?: {
     gitRepoUrl?: string
+    provider?: VcsProvider
     limit?: number
     enabled?: boolean
   }
 ) {
+  const provider = options?.provider ?? "github"
   const {
     data: branches,
     isLoading: branchesIsLoading,
@@ -224,6 +226,7 @@ export function useRepositoryBranches(
       "workflow-sync-branches",
       workspaceId,
       options?.gitRepoUrl ?? "__workspace_repo__",
+      provider,
       options?.limit ?? 200,
     ],
     queryFn: async (): Promise<GitBranchInfo[]> => {
@@ -233,6 +236,7 @@ export function useRepositoryBranches(
 
       return await workflowsListWorkflowBranches({
         limit: options?.limit ?? 200,
+        provider,
         workspaceId,
       })
     },
@@ -254,11 +258,13 @@ export function useRepositoryCommits(
   workspaceId: string,
   options?: {
     gitRepoUrl?: string
+    provider?: VcsProvider
     branch?: string
     limit?: number
     enabled?: boolean
   }
 ) {
+  const provider = options?.provider ?? "github"
   const {
     data: commits,
     isLoading: commitsIsLoading,
@@ -268,6 +274,7 @@ export function useRepositoryCommits(
       "repository_commits",
       workspaceId,
       options?.gitRepoUrl ?? "__workspace_repo__",
+      provider,
       options?.branch ?? "main",
       options?.limit ?? 10,
     ],
@@ -279,6 +286,7 @@ export function useRepositoryCommits(
       const response = await workflowsListWorkflowCommits({
         branch: options?.branch ?? "main",
         limit: options?.limit ?? 10,
+        provider,
         workspaceId,
       })
 

--- a/frontend/src/hooks/use-workspace-sync.ts
+++ b/frontend/src/hooks/use-workspace-sync.ts
@@ -21,7 +21,6 @@ interface WorkflowPullOptions {
   commit_sha: string
   dry_run?: boolean
   sync_schedules?: boolean
-  provider?: VcsProvider
 }
 
 /**
@@ -41,7 +40,6 @@ export function useWorkflowSync(workspaceId: string) {
         commit_sha: options.commit_sha,
         dry_run: options.dry_run ?? false,
         sync_schedules: options.sync_schedules ?? false,
-        provider: options.provider ?? "github",
       }
 
       const response = await workflowsPullWorkflows({
@@ -185,7 +183,6 @@ export function useWorkspaceSyncExportPreview(
           resources: isFullWorkspacePreview ? undefined : normalizedResources,
           include_schedules: includeSchedules,
           compare_ref: compareRef,
-          provider,
         },
       })
     },
@@ -236,7 +233,6 @@ export function useRepositoryBranches(
 
       return await workflowsListWorkflowBranches({
         limit: options?.limit ?? 200,
-        provider,
         workspaceId,
       })
     },
@@ -286,7 +282,6 @@ export function useRepositoryCommits(
       const response = await workflowsListWorkflowCommits({
         branch: options?.branch ?? "main",
         limit: options?.limit ?? 10,
-        provider,
         workspaceId,
       })
 

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -2772,9 +2772,7 @@ export function useGitLabTokenCredentials() {
       return await vcsSaveGitlabTokenCredentials({ requestBody: data })
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["gitlab-token-credentials-status"],
-      })
+      invalidateGitLabTokenCredentialQueries(queryClient)
     },
   })
 
@@ -2791,15 +2789,25 @@ export function useDeleteGitLabTokenCredentials() {
       await vcsDeleteGitlabTokenCredentials()
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["gitlab-token-credentials-status"],
-      })
+      invalidateGitLabTokenCredentialQueries(queryClient)
     },
   })
 
   return {
     deleteCredentials,
   }
+}
+
+function invalidateGitLabTokenCredentialQueries(queryClient: QueryClient) {
+  queryClient.invalidateQueries({
+    queryKey: ["gitlab-token-credentials-status"],
+  })
+  queryClient.invalidateQueries({
+    queryKey: ["workflow-sync-branches"],
+  })
+  queryClient.invalidateQueries({
+    queryKey: ["repository_commits"],
+  })
 }
 
 export function useOrgAgentSettings() {

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -319,16 +319,22 @@ import {
   type VariableUpdate,
   type VcsGetGithubAppCredentialsStatusResponse,
   type VcsGetGithubAppManifestResponse,
+  type VcsGetGitlabTokenCredentialsStatusResponse,
   type VcsSaveGithubAppCredentialsData,
   type VcsSaveGithubAppCredentialsResponse,
+  type VcsSaveGitlabTokenCredentialsData,
+  type VcsSaveGitlabTokenCredentialsResponse,
   variablesCreateVariable,
   variablesDeleteVariableById,
   variablesListVariables,
   variablesUpdateVariableById,
   vcsDeleteGithubAppCredentials,
+  vcsDeleteGitlabTokenCredentials,
   vcsGetGithubAppCredentialsStatus,
   vcsGetGithubAppManifest,
+  vcsGetGitlabTokenCredentialsStatus,
   vcsSaveGithubAppCredentials,
+  vcsSaveGitlabTokenCredentials,
   type WebhookUpdate,
   type WorkflowDirectoryItem,
   type WorkflowExecutionCreate,
@@ -2651,7 +2657,10 @@ export function useGitHubAppCredentialsStatus() {
 /**
  * Fetch repositories granted to the configured GitHub App installation.
  */
-export function useGitHubAppRepositories(workspaceId: string) {
+export function useGitHubAppRepositories(
+  workspaceId: string,
+  options?: { enabled?: boolean }
+) {
   const {
     data: repositories,
     isLoading: repositoriesIsLoading,
@@ -2661,7 +2670,7 @@ export function useGitHubAppRepositories(workspaceId: string) {
     queryKey: ["github-app-repositories", workspaceId],
     queryFn: async () =>
       await workflowsListWorkflowRepositories({ workspaceId }),
-    enabled: Boolean(workspaceId),
+    enabled: Boolean(workspaceId) && options?.enabled !== false,
     retry: false,
   })
 
@@ -2723,6 +2732,67 @@ export function useDeleteGitHubAppCredentials() {
       })
       queryClient.invalidateQueries({
         queryKey: ["github-app-repositories"],
+      })
+    },
+  })
+
+  return {
+    deleteCredentials,
+  }
+}
+
+export function useGitLabTokenCredentialsStatus() {
+  const {
+    data: credentialsStatus,
+    isLoading: credentialsStatusIsLoading,
+    error: credentialsStatusError,
+    refetch: refetchCredentialsStatus,
+  } = useQuery<VcsGetGitlabTokenCredentialsStatusResponse>({
+    queryKey: ["gitlab-token-credentials-status"],
+    queryFn: async () => await vcsGetGitlabTokenCredentialsStatus(),
+  })
+
+  return {
+    credentialsStatus,
+    credentialsStatusIsLoading,
+    credentialsStatusError,
+    refetchCredentialsStatus,
+  }
+}
+
+export function useGitLabTokenCredentials() {
+  const queryClient = useQueryClient()
+
+  const saveCredentials = useMutation<
+    VcsSaveGitlabTokenCredentialsResponse,
+    ApiError,
+    VcsSaveGitlabTokenCredentialsData["requestBody"]
+  >({
+    mutationFn: async (data) => {
+      return await vcsSaveGitlabTokenCredentials({ requestBody: data })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["gitlab-token-credentials-status"],
+      })
+    },
+  })
+
+  return {
+    saveCredentials,
+  }
+}
+
+export function useDeleteGitLabTokenCredentials() {
+  const queryClient = useQueryClient()
+
+  const deleteCredentials = useMutation<void, ApiError>({
+    mutationFn: async () => {
+      await vcsDeleteGitlabTokenCredentials()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["gitlab-token-credentials-status"],
       })
     },
   })

--- a/frontend/tests/github-app-credentials-hooks.test.tsx
+++ b/frontend/tests/github-app-credentials-hooks.test.tsx
@@ -56,7 +56,11 @@ describe("GitHub App credential hooks", () => {
       },
     })
     jest.clearAllMocks()
-    mockSaveGitHubAppCredentials.mockResolvedValue({ status: "ok" })
+    mockSaveGitHubAppCredentials.mockResolvedValue({
+      message: "GitHub App credentials created successfully",
+      action: "created",
+      app_id: "123456",
+    })
     mockDeleteGitHubAppCredentials.mockResolvedValue(undefined)
   })
 

--- a/frontend/tests/github-app-credentials-hooks.test.tsx
+++ b/frontend/tests/github-app-credentials-hooks.test.tsx
@@ -4,11 +4,15 @@ import type { ReactNode } from "react"
 import type { GitHubAppRepository } from "@/client"
 import {
   vcsDeleteGithubAppCredentials,
+  vcsDeleteGitlabTokenCredentials,
   vcsSaveGithubAppCredentials,
+  vcsSaveGitlabTokenCredentials,
 } from "@/client"
 import {
   useDeleteGitHubAppCredentials,
+  useDeleteGitLabTokenCredentials,
   useGitHubAppCredentials,
+  useGitLabTokenCredentials,
 } from "@/lib/hooks"
 
 jest.mock("@/client", () => {
@@ -16,7 +20,9 @@ jest.mock("@/client", () => {
   return {
     ...actual,
     vcsDeleteGithubAppCredentials: jest.fn(),
+    vcsDeleteGitlabTokenCredentials: jest.fn(),
     vcsSaveGithubAppCredentials: jest.fn(),
+    vcsSaveGitlabTokenCredentials: jest.fn(),
   }
 })
 
@@ -28,6 +34,14 @@ const mockSaveGitHubAppCredentials =
 const mockDeleteGitHubAppCredentials =
   vcsDeleteGithubAppCredentials as jest.MockedFunction<
     typeof vcsDeleteGithubAppCredentials
+  >
+const mockSaveGitLabTokenCredentials =
+  vcsSaveGitlabTokenCredentials as jest.MockedFunction<
+    typeof vcsSaveGitlabTokenCredentials
+  >
+const mockDeleteGitLabTokenCredentials =
+  vcsDeleteGitlabTokenCredentials as jest.MockedFunction<
+    typeof vcsDeleteGitlabTokenCredentials
   >
 
 const cachedRepositories: GitHubAppRepository[] = [
@@ -62,6 +76,12 @@ describe("GitHub App credential hooks", () => {
       app_id: "123456",
     })
     mockDeleteGitHubAppCredentials.mockResolvedValue(undefined)
+    mockSaveGitLabTokenCredentials.mockResolvedValue({
+      message: "GitLab token credentials created successfully",
+      action: "created",
+      base_url: "https://gitlab.example.test",
+    })
+    mockDeleteGitLabTokenCredentials.mockResolvedValue(undefined)
   })
 
   function wrapper({ children }: { children: ReactNode }) {
@@ -103,5 +123,46 @@ describe("GitHub App credential hooks", () => {
     expect(
       queryClient.getQueryData(["github-app-repositories", "workspace-1"])
     ).toEqual([])
+  })
+
+  it("invalidates GitLab credential-dependent repository queries when credentials are saved", async () => {
+    const invalidateQueries = jest.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useGitLabTokenCredentials(), {
+      wrapper,
+    })
+
+    await result.current.saveCredentials.mutateAsync({
+      base_url: "https://gitlab.example.test",
+      token: "token",
+    })
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["gitlab-token-credentials-status"],
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["workflow-sync-branches"],
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["repository_commits"],
+    })
+  })
+
+  it("invalidates GitLab credential-dependent repository queries when credentials are deleted", async () => {
+    const invalidateQueries = jest.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useDeleteGitLabTokenCredentials(), {
+      wrapper,
+    })
+
+    await result.current.deleteCredentials.mutateAsync()
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["gitlab-token-credentials-status"],
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["workflow-sync-branches"],
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["repository_commits"],
+    })
   })
 })

--- a/frontend/tests/use-workspace-sync.test.tsx
+++ b/frontend/tests/use-workspace-sync.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { renderHook } from "@testing-library/react"
+import { renderHook, waitFor } from "@testing-library/react"
 import type { ReactNode } from "react"
 import {
   workflowsListWorkflowBranches,
@@ -82,6 +82,7 @@ describe("workspace sync repository queries", () => {
           "workflow-sync-branches",
           "workspace-1",
           "git+ssh://git@github.com/test/repo-a.git",
+          "github",
           200,
         ],
       })
@@ -92,6 +93,7 @@ describe("workspace sync repository queries", () => {
           "workflow-sync-branches",
           "workspace-1",
           "git+ssh://git@github.com/test/repo-b.git",
+          "github",
           200,
         ],
       })
@@ -126,6 +128,7 @@ describe("workspace sync repository queries", () => {
           "repository_commits",
           "workspace-1",
           "git+ssh://git@github.com/test/repo-a.git",
+          "github",
           "main",
           10,
         ],
@@ -137,10 +140,57 @@ describe("workspace sync repository queries", () => {
           "repository_commits",
           "workspace-1",
           "git+ssh://git@github.com/test/repo-b.git",
+          "github",
           "main",
           10,
         ],
       })
     ).toBeDefined()
+  })
+
+  it("passes provider through branch requests", async () => {
+    const wrapper = createWrapper(queryClient)
+
+    renderHook(
+      () =>
+        useRepositoryBranches("workspace-1", {
+          gitRepoUrl: "git+ssh://git@gitlab.com/test/repo.git",
+          provider: "gitlab",
+          limit: 50,
+        }),
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      expect(mockWorkflowsListWorkflowBranches).toHaveBeenCalledWith({
+        limit: 50,
+        provider: "gitlab",
+        workspaceId: "workspace-1",
+      })
+    })
+  })
+
+  it("passes provider through commit requests", async () => {
+    const wrapper = createWrapper(queryClient)
+
+    renderHook(
+      () =>
+        useRepositoryCommits("workspace-1", {
+          branch: "release",
+          gitRepoUrl: "git+ssh://git@gitlab.com/test/repo.git",
+          provider: "gitlab",
+          limit: 25,
+        }),
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      expect(mockWorkflowsListWorkflowCommits).toHaveBeenCalledWith({
+        branch: "release",
+        limit: 25,
+        provider: "gitlab",
+        workspaceId: "workspace-1",
+      })
+    })
   })
 })

--- a/frontend/tests/use-workspace-sync.test.tsx
+++ b/frontend/tests/use-workspace-sync.test.tsx
@@ -148,7 +148,7 @@ describe("workspace sync repository queries", () => {
     ).toBeDefined()
   })
 
-  it("passes provider through branch requests", async () => {
+  it("omits provider from branch requests (server derives it)", async () => {
     const wrapper = createWrapper(queryClient)
 
     renderHook(
@@ -164,13 +164,12 @@ describe("workspace sync repository queries", () => {
     await waitFor(() => {
       expect(mockWorkflowsListWorkflowBranches).toHaveBeenCalledWith({
         limit: 50,
-        provider: "gitlab",
         workspaceId: "workspace-1",
       })
     })
   })
 
-  it("passes provider through commit requests", async () => {
+  it("omits provider from commit requests (server derives it)", async () => {
     const wrapper = createWrapper(queryClient)
 
     renderHook(
@@ -188,7 +187,6 @@ describe("workspace sync repository queries", () => {
       expect(mockWorkflowsListWorkflowCommits).toHaveBeenCalledWith({
         branch: "release",
         limit: 25,
-        provider: "gitlab",
         workspaceId: "workspace-1",
       })
     })

--- a/frontend/tests/use-workspace-sync.test.tsx
+++ b/frontend/tests/use-workspace-sync.test.tsx
@@ -100,6 +100,52 @@ describe("workspace sync repository queries", () => {
     ).toBeDefined()
   })
 
+  it("keys branch queries by provider", () => {
+    const wrapper = createWrapper(queryClient)
+
+    renderHook(
+      () =>
+        useRepositoryBranches("workspace-1", {
+          enabled: false,
+          gitRepoUrl: "git+ssh://git@example.com/test/repo.git",
+          provider: "github",
+        }),
+      { wrapper }
+    )
+    renderHook(
+      () =>
+        useRepositoryBranches("workspace-1", {
+          enabled: false,
+          gitRepoUrl: "git+ssh://git@example.com/test/repo.git",
+          provider: "gitlab",
+        }),
+      { wrapper }
+    )
+
+    expect(
+      queryClient.getQueryCache().find({
+        queryKey: [
+          "workflow-sync-branches",
+          "workspace-1",
+          "git+ssh://git@example.com/test/repo.git",
+          "github",
+          200,
+        ],
+      })
+    ).toBeDefined()
+    expect(
+      queryClient.getQueryCache().find({
+        queryKey: [
+          "workflow-sync-branches",
+          "workspace-1",
+          "git+ssh://git@example.com/test/repo.git",
+          "gitlab",
+          200,
+        ],
+      })
+    ).toBeDefined()
+  })
+
   it("keys commit queries by configured git URL", () => {
     const wrapper = createWrapper(queryClient)
 

--- a/frontend/tests/workspace-sync-push-target-policy.test.ts
+++ b/frontend/tests/workspace-sync-push-target-policy.test.ts
@@ -1,4 +1,9 @@
-import { getWorkspaceSyncPushOutcome } from "@/components/workspace-sync/push-target-policy"
+import {
+  getWorkspaceSyncPushButtonLabel,
+  getWorkspaceSyncPushOutcome,
+  getWorkspaceSyncPushResultLabel,
+  getWorkspaceSyncPushWarning,
+} from "@/components/workspace-sync/push-target-policy"
 
 describe("getWorkspaceSyncPushOutcome", () => {
   it("blocks pull request mode when a new branch name matches the default branch", () => {
@@ -12,5 +17,42 @@ describe("getWorkspaceSyncPushOutcome", () => {
     expect(outcome.targetIsDefault).toBe(true)
     expect(outcome.isPullRequestBlocked).toBe(true)
     expect(outcome.willCreatePr).toBe(false)
+  })
+
+  it("uses GitLab merge request wording when provider is GitLab", () => {
+    const outcome = getWorkspaceSyncPushOutcome({
+      mode: "pull-request",
+      targetBranch: "sync/workspace",
+      defaultBranch: "main",
+      isCreatingBranch: true,
+    })
+
+    expect(
+      getWorkspaceSyncPushButtonLabel({
+        outcome,
+        isCreatingBranch: true,
+        isPending: false,
+        provider: "gitlab",
+      })
+    ).toBe("Push & open MR")
+    expect(
+      getWorkspaceSyncPushResultLabel({
+        outcome,
+        defaultBranch: "main",
+        provider: "gitlab",
+      })
+    ).toBe("MR into main")
+    expect(
+      getWorkspaceSyncPushWarning({
+        outcome: {
+          ...outcome,
+          createPr: false,
+          willCreatePr: false,
+          targetIsDefault: true,
+        },
+        defaultBranch: "main",
+        provider: "gitlab",
+      })
+    ).toBe("This commits directly to main. No merge request will be created.")
   })
 })

--- a/frontend/tests/workspace-sync-settings.test.tsx
+++ b/frontend/tests/workspace-sync-settings.test.tsx
@@ -225,6 +225,35 @@ describe("WorkspaceSyncSettings", () => {
     })
   })
 
+  it("requires an explicit supported provider choice for unsupported persisted providers", async () => {
+    const user = userEvent.setup()
+    render(
+      <WorkspaceSyncSettings
+        workspace={setupHooks({ gitProvider: "bitbucket" })}
+      />
+    )
+
+    expect(
+      screen.getByText(/The saved provider "bitbucket" is not supported/)
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled()
+
+    await user.click(screen.getByRole("button", { name: "GitLab" }))
+    const gitlabUrl =
+      "git+ssh://git@gitlab.com/test-org/subgroup/custom-repo.git"
+    await user.type(screen.getByLabelText("Remote repository URL"), gitlabUrl)
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(mockUpdateWorkspace).toHaveBeenCalledWith({
+        settings: {
+          git_provider: "gitlab",
+          git_repo_url: gitlabUrl,
+        },
+      })
+    })
+  })
+
   it("selects an app repository when repository options are available", async () => {
     const user = userEvent.setup()
     render(<WorkspaceSyncSettings workspace={setupHooks()} />)

--- a/frontend/tests/workspace-sync-settings.test.tsx
+++ b/frontend/tests/workspace-sync-settings.test.tsx
@@ -564,7 +564,6 @@ describe("WorkspaceSyncSettings", () => {
       expect(mockPullWorkflows).toHaveBeenCalledWith({
         commit_sha: commitSha,
         dry_run: true,
-        provider: "github",
         sync_schedules: false,
       })
     })

--- a/frontend/tests/workspace-sync-settings.test.tsx
+++ b/frontend/tests/workspace-sync-settings.test.tsx
@@ -9,6 +9,7 @@ import type {
   GitCommitInfo,
   GitHubAppRepository,
   PullResult,
+  VcsProvider,
   WorkspaceRead,
   WorkspaceSyncExportPreview,
 } from "@/client"
@@ -103,11 +104,13 @@ const workspace = {
 
 function setupHooks({
   gitRepoUrl = null,
+  gitProvider = null,
   repositoryHook = {},
   branches = [],
   commits = [],
 }: {
   gitRepoUrl?: string | null
+  gitProvider?: VcsProvider | null
   repositoryHook?: Partial<ReturnType<typeof useGitHubAppRepositories>>
   branches?: GitBranchInfo[]
   commits?: GitCommitInfo[]
@@ -156,6 +159,7 @@ function setupHooks({
     ...workspace,
     settings: {
       ...workspace.settings,
+      git_provider: gitProvider,
       git_repo_url: gitRepoUrl,
     },
   }
@@ -182,7 +186,40 @@ describe("WorkspaceSyncSettings", () => {
     await waitFor(() => {
       expect(mockUpdateWorkspace).toHaveBeenCalledWith({
         settings: {
+          git_provider: "github",
           git_repo_url: customUrl,
+        },
+      })
+    })
+  })
+
+  it("saves a GitLab manual URL and suppresses the GitHub repository picker", async () => {
+    const user = userEvent.setup()
+    render(
+      <WorkspaceSyncSettings
+        workspace={setupHooks({ gitProvider: "gitlab" })}
+      />
+    )
+
+    expect(useGitHubAppRepositories).toHaveBeenCalledWith("workspace-1", {
+      enabled: false,
+    })
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
+    expect(screen.getByLabelText("Remote repository URL")).toHaveAttribute(
+      "placeholder",
+      "git+ssh://git@gitlab.com/my-org/my-group/my-repo.git"
+    )
+
+    const gitlabUrl =
+      "git+ssh://git@gitlab.com/test-org/subgroup/custom-repo.git"
+    await user.type(screen.getByLabelText("Remote repository URL"), gitlabUrl)
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(mockUpdateWorkspace).toHaveBeenCalledWith({
+        settings: {
+          git_provider: "gitlab",
+          git_repo_url: gitlabUrl,
         },
       })
     })
@@ -201,6 +238,7 @@ describe("WorkspaceSyncSettings", () => {
     await waitFor(() => {
       expect(mockUpdateWorkspace).toHaveBeenCalledWith({
         settings: {
+          git_provider: "github",
           git_repo_url: repositories[0].git_url,
         },
       })
@@ -220,6 +258,7 @@ describe("WorkspaceSyncSettings", () => {
     await waitFor(() => {
       expect(mockUpdateWorkspace).toHaveBeenCalledWith({
         settings: {
+          git_provider: "github",
           git_repo_url: `${repositories[1].git_url}@trunk`,
         },
       })
@@ -323,6 +362,38 @@ describe("WorkspaceSyncSettings", () => {
     expect(screen.getByRole("button", { name: "Select" })).toHaveAttribute(
       "aria-current",
       "true"
+    )
+  })
+
+  it("passes the persisted GitLab provider into repository health checks", () => {
+    const gitlabUrl =
+      "git+ssh://git@gitlab.com/test-org/subgroup/custom-repo.git"
+    render(
+      <WorkspaceSyncSettings
+        workspace={setupHooks({
+          gitRepoUrl: gitlabUrl,
+          gitProvider: "gitlab",
+          branches: [{ name: "main", is_default: true }],
+        })}
+      />
+    )
+
+    expect(useGitHubAppRepositories).toHaveBeenCalledWith("workspace-1", {
+      enabled: false,
+    })
+    expect(useRepositoryBranches).toHaveBeenCalledWith(
+      "workspace-1",
+      expect.objectContaining({
+        gitRepoUrl: gitlabUrl,
+        provider: "gitlab",
+      })
+    )
+    expect(useRepositoryCommits).toHaveBeenCalledWith(
+      "workspace-1",
+      expect.objectContaining({
+        gitRepoUrl: gitlabUrl,
+        provider: "gitlab",
+      })
     )
   })
 
@@ -493,6 +564,7 @@ describe("WorkspaceSyncSettings", () => {
       expect(mockPullWorkflows).toHaveBeenCalledWith({
         commit_sha: commitSha,
         dry_run: true,
+        provider: "github",
         sync_schedules: false,
       })
     })

--- a/packages/tracecat-registry/tracecat_registry/core/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/core/cases.py
@@ -324,7 +324,7 @@ async def get_linked_case_rows(
         Doc("The ID of the case to retrieve."),
     ],
 ) -> list[types.CaseTableRowRead]:
-    case = await get_context().cases.get_case(case_id, include_rows=True)
+    case = await ctx.cases.aio.get_case(case_id, include_rows=True)
     return case["rows"]
 
 

--- a/tests/support/fake_vcs.py
+++ b/tests/support/fake_vcs.py
@@ -66,6 +66,7 @@ class FakeVcsTransport:
             commit_sha=commit.sha,
             tree_sha=commit.tree_sha,
             files=dict(commit.files),
+            blob_paths=frozenset(commit.files),
         )
 
     async def write_files(

--- a/tests/support/fake_vcs.py
+++ b/tests/support/fake_vcs.py
@@ -38,7 +38,7 @@ class FakeVcsServer:
         role: Any,
     ) -> VcsSyncTransport:
         del session, role
-        if provider != VcsProvider.GITHUB:
+        if provider not in {VcsProvider.GITHUB, VcsProvider.GITLAB}:
             raise TracecatValidationError(f"Unsupported fake VCS provider: {provider}")
         return FakeVcsTransport(server=self)
 

--- a/tests/unit/api/test_api_actor_roles.py
+++ b/tests/unit/api/test_api_actor_roles.py
@@ -555,6 +555,9 @@ def test_github_manifest_flow_routes_remain_user_only() -> None:
         (vcs_router.save_github_app_credentials, "role"),
         (vcs_router.delete_github_app_credentials, "role"),
         (vcs_router.get_github_app_credentials_status, "role"),
+        (vcs_router.save_gitlab_token_credentials, "role"),
+        (vcs_router.delete_gitlab_token_credentials, "role"),
+        (vcs_router.get_gitlab_token_credentials_status, "role"),
     ]
 
     for endpoint, role_param in endpoints:

--- a/tests/unit/api/test_api_workflow_store_publish.py
+++ b/tests/unit/api/test_api_workflow_store_publish.py
@@ -247,3 +247,37 @@ async def test_list_workflow_branches_github_error_returns_400(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "Unable to access repository" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        (
+            "/workflows/sync/export",
+            {"message": "Sync workspace", "branch": "sync/workspace"},
+        ),
+        ("/workflows/sync/export/preview", {}),
+    ],
+)
+@pytest.mark.anyio
+async def test_workspace_sync_export_routes_map_service_construction_errors_to_400(
+    client: TestClient,
+    test_admin_role: Role,
+    path: str,
+    payload: dict[str, object],
+) -> None:
+    with patch("tracecat.workflow.store.router.WorkspaceSyncService") as mock_sync_cls:
+        mock_sync_cls.for_workspace = AsyncMock(
+            side_effect=TracecatSettingsError(
+                "Unsupported Git provider configured for this workspace: unknown"
+            )
+        )
+
+        response = client.post(
+            path,
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json=payload,
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Unsupported Git provider configured" in response.json()["detail"]

--- a/tests/unit/api/test_api_workflow_store_publish.py
+++ b/tests/unit/api/test_api_workflow_store_publish.py
@@ -190,7 +190,7 @@ async def test_list_workflow_branches_success(
             GitBranchInfo(name="main", is_default=True),
             GitBranchInfo(name="feature/workflow-publish", is_default=False),
         ]
-        mock_sync_cls.return_value = mock_sync_svc
+        mock_sync_cls.for_workspace = AsyncMock(return_value=mock_sync_svc)
 
         response = client.get(
             "/workflows/sync/branches",
@@ -216,7 +216,7 @@ async def test_list_workflow_branches_missing_repo_returns_400(
         mock_sync_svc.list_branches.side_effect = TracecatSettingsError(
             "Git repository URL not configured for this workspace."
         )
-        mock_sync_cls.return_value = mock_sync_svc
+        mock_sync_cls.for_workspace = AsyncMock(return_value=mock_sync_svc)
 
         response = client.get(
             "/workflows/sync/branches",
@@ -238,7 +238,7 @@ async def test_list_workflow_branches_github_error_returns_400(
         mock_sync_svc.list_branches.side_effect = GitHubAppError(
             "Unable to access repository"
         )
-        mock_sync_cls.return_value = mock_sync_svc
+        mock_sync_cls.for_workspace = AsyncMock(return_value=mock_sync_svc)
 
         response = client.get(
             "/workflows/sync/branches",

--- a/tests/unit/api/test_api_workflow_store_publish.py
+++ b/tests/unit/api/test_api_workflow_store_publish.py
@@ -11,6 +11,7 @@ from tracecat.auth.types import Role
 from tracecat.exceptions import TracecatSettingsError, TracecatValidationError
 from tracecat.registry.repositories.schemas import GitBranchInfo
 from tracecat.vcs.github.app import GitHubAppError
+from tracecat.vcs.gitlab.app import GitLabError
 from tracecat.workflow.store.schemas import WorkflowDslPublishResult
 
 
@@ -132,6 +133,49 @@ async def test_publish_workflow_invalid_branch_returns_400(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "short branch name" in response.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_publish_workflow_vcs_provider_error_returns_400(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Test publish maps VCS provider errors to 400."""
+    workflow_id = str(uuid.uuid4())
+    workflow = Mock()
+    workflow.id = uuid.UUID(workflow_id)
+
+    definition = Mock()
+    definition.content = _sample_dsl_content()
+    definition.workflow = workflow
+
+    with (
+        patch(
+            "tracecat.workflow.store.router.WorkflowDefinitionsService"
+        ) as mock_defn_cls,
+        patch("tracecat.workflow.store.router.WorkflowStoreService") as mock_store_cls,
+    ):
+        mock_defn_svc = AsyncMock()
+        mock_defn_svc.get_definition_by_workflow_id.return_value = definition
+        mock_defn_cls.return_value = mock_defn_svc
+
+        mock_store_svc = AsyncMock()
+        mock_store_svc.publish_workflow_dsl.side_effect = GitLabError(
+            "Failed to retrieve GitLab token credentials: credentials not found"
+        )
+        mock_store_cls.return_value = mock_store_svc
+
+        response = client.post(
+            f"/workflows/{workflow_id}/publish",
+            params={"workspace_id": str(test_admin_role.workspace_id)},
+            json={
+                "branch": "feature/shared-workflow",
+                "create_pr": True,
+            },
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "GitLab token credentials" in response.json()["detail"]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_case_fields_service.py
+++ b/tests/unit/test_case_fields_service.py
@@ -239,15 +239,24 @@ class TestCaseFieldsService:
         )
         session.add(definition)
         await session.flush()
-        mapping = WorkspaceSyncResourceMapping(
+        old_local_id = uuid.uuid5(definition.id, "external_ref")
+        github_mapping = WorkspaceSyncResourceMapping(
             workspace_id=svc_role.workspace_id,
             provider=VcsProvider.GITHUB.value,
             resource_type=SyncResourceType.CASE_FIELD.value,
             source_id="external_ref",
             source_path="case_fields/external_ref.yml",
-            local_id=uuid.uuid5(definition.id, "external_ref"),
+            local_id=old_local_id,
         )
-        session.add(mapping)
+        gitlab_mapping = WorkspaceSyncResourceMapping(
+            workspace_id=svc_role.workspace_id,
+            provider=VcsProvider.GITLAB.value,
+            resource_type=SyncResourceType.CASE_FIELD.value,
+            source_id="external_ref",
+            source_path="case_fields/external_ref.yml",
+            local_id=old_local_id,
+        )
+        session.add_all([github_mapping, gitlab_mapping])
         await session.flush()
 
         with patch.object(case_fields_service.editor, "update_column"):
@@ -256,10 +265,15 @@ class TestCaseFieldsService:
                 CaseFieldUpdate(name="vendor_ticket_id"),
             )
 
-        await session.refresh(mapping)
-        assert mapping.source_id == "external_ref"
-        assert mapping.source_path == "case_fields/external_ref.yml"
-        assert mapping.local_id == uuid.uuid5(definition.id, "vendor_ticket_id")
+        new_local_id = uuid.uuid5(definition.id, "vendor_ticket_id")
+        await session.refresh(github_mapping)
+        await session.refresh(gitlab_mapping)
+        assert github_mapping.source_id == "external_ref"
+        assert github_mapping.source_path == "case_fields/external_ref.yml"
+        assert github_mapping.local_id == new_local_id
+        assert gitlab_mapping.source_id == "external_ref"
+        assert gitlab_mapping.source_path == "case_fields/external_ref.yml"
+        assert gitlab_mapping.local_id == new_local_id
 
     async def test_update_field_required_on_closure_without_schema_entry(
         self, case_fields_service: CaseFieldsService

--- a/tests/unit/test_gitlab_vcs.py
+++ b/tests/unit/test_gitlab_vcs.py
@@ -324,6 +324,14 @@ def _git_url_with_ssh_port() -> GitUrl:
     )
 
 
+def _git_url_with_ssh_alias() -> GitUrl:
+    return GitUrl(
+        host="ssh.gitlab.example.test",
+        org="group/subgroup",
+        repo="project",
+    )
+
+
 def _manifest() -> str:
     return canonical_json_text(WorkspaceManifest())
 
@@ -422,6 +430,19 @@ async def test_gitlab_transport_allows_repo_ssh_port_on_same_instance() -> None:
     transport = _MockGitLabTransport(api=api)
 
     snapshot = await transport.read_files(url=_git_url_with_ssh_port(), ref="main")
+
+    assert snapshot.commit_sha == "0" * 39 + "1"
+
+
+@pytest.mark.anyio
+async def test_gitlab_transport_allows_repo_ssh_host_alias() -> None:
+    api = _MockGitLabApi(
+        project_path="group/subgroup/project",
+        files={MANIFEST_FILENAME: _manifest()},
+    )
+    transport = _MockGitLabTransport(api=api)
+
+    snapshot = await transport.read_files(url=_git_url_with_ssh_alias(), ref="main")
 
     assert snapshot.commit_sha == "0" * 39 + "1"
 

--- a/tests/unit/test_gitlab_vcs.py
+++ b/tests/unit/test_gitlab_vcs.py
@@ -17,7 +17,11 @@ from pydantic import SecretStr
 
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import ADMIN_SCOPES
-from tracecat.exceptions import ScopeDeniedError, TracecatNotFoundError
+from tracecat.exceptions import (
+    ScopeDeniedError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
 from tracecat.git.types import GitUrl
 from tracecat.secrets.schemas import SecretKeyValue
 from tracecat.sync import PushStatus
@@ -332,6 +336,22 @@ def _git_url_with_ssh_alias() -> GitUrl:
     )
 
 
+def _git_url_with_foreign_host() -> GitUrl:
+    return GitUrl(
+        host="github.com",
+        org="group/subgroup",
+        repo="project",
+    )
+
+
+def _git_url_with_lookalike_host() -> GitUrl:
+    return GitUrl(
+        host="evilgitlab.example.test",
+        org="group/subgroup",
+        repo="project",
+    )
+
+
 def _manifest() -> str:
     return canonical_json_text(WorkspaceManifest())
 
@@ -445,6 +465,26 @@ async def test_gitlab_transport_allows_repo_ssh_host_alias() -> None:
     snapshot = await transport.read_files(url=_git_url_with_ssh_alias(), ref="main")
 
     assert snapshot.commit_sha == "0" * 39 + "1"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "url",
+    [
+        _git_url_with_foreign_host(),
+        _git_url_with_lookalike_host(),
+    ],
+    ids=["foreign_host", "lookalike_host"],
+)
+async def test_gitlab_transport_rejects_repo_host_mismatch(url: GitUrl) -> None:
+    api = _MockGitLabApi(
+        project_path="group/subgroup/project",
+        files={MANIFEST_FILENAME: _manifest()},
+    )
+    transport = _MockGitLabTransport(api=api)
+
+    with pytest.raises(TracecatValidationError):
+        await transport.read_files(url=url, ref="main")
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_gitlab_vcs.py
+++ b/tests/unit/test_gitlab_vcs.py
@@ -27,12 +27,14 @@ from tracecat.workspace_sync.schemas import MANIFEST_FILENAME, WorkspaceManifest
 from tracecat.workspace_sync.serialization import canonical_json_text
 from tracecat.workspace_sync.transport import GitLabWorkspaceSyncTransport
 
+type _FileContent = str | bytes
+
 
 @dataclass(frozen=True)
 class _Commit:
     sha: str
     message: str
-    files: dict[str, str]
+    files: dict[str, _FileContent]
 
 
 class _MockGitLabApi:
@@ -42,7 +44,7 @@ class _MockGitLabApi:
         self,
         *,
         project_path: str,
-        files: Mapping[str, str],
+        files: Mapping[str, _FileContent],
         default_branch: str = "main",
     ) -> None:
         self.project_path = project_path
@@ -56,7 +58,7 @@ class _MockGitLabApi:
         self._commits: dict[str, _Commit] = {}
         self._branches: dict[str, str] = {}
         self._commit_branches: dict[str, str] = {}
-        self._blobs: dict[str, str] = {}
+        self._blobs: dict[str, _FileContent] = {}
         self._merge_requests: list[dict[str, Any]] = []
         initial = self._new_commit(
             branch=default_branch,
@@ -147,7 +149,11 @@ class _MockGitLabApi:
                 )
                 if blob_id not in self._blobs:
                     return httpx.Response(404, json={"message": "404 Blob Not Found"})
-                return httpx.Response(200, content=self._blobs[blob_id].encode())
+                content = self._blobs[blob_id]
+                return httpx.Response(
+                    200,
+                    content=content if isinstance(content, bytes) else content.encode(),
+                )
             if request.method == "POST" and subpath == "/repository/commits":
                 payload = json.loads(request.content.decode())
                 self.commit_payloads.append(payload)
@@ -240,7 +246,7 @@ class _MockGitLabApi:
         self._merge_requests.append(mr)
         return mr
 
-    def files_at_ref(self, ref: str) -> dict[str, str]:
+    def files_at_ref(self, ref: str) -> dict[str, _FileContent]:
         return dict(self._commit_at_ref(ref).files)
 
     def _commit_at_ref(self, ref: str) -> _Commit:
@@ -252,7 +258,7 @@ class _MockGitLabApi:
         *,
         branch: str,
         message: str,
-        files: dict[str, str],
+        files: dict[str, _FileContent],
     ) -> _Commit:
         self._counter += 1
         sha = f"{self._counter:040x}"
@@ -465,6 +471,47 @@ async def test_gitlab_transport_commits_create_update_delete_actions() -> None:
             "content": "new",
         },
         {"action": "delete", "file_path": "workflows/stale.yml"},
+    ]
+
+
+@pytest.mark.anyio
+async def test_gitlab_transport_uses_binary_blob_paths_for_write_actions() -> None:
+    api = _MockGitLabApi(
+        project_path="group/subgroup/project",
+        files={
+            MANIFEST_FILENAME: _manifest(),
+            "workflows/replace.yml": b"\xff\xfe",
+            "workflows/stale.bin": b"\x80\x81",
+            "README.md": "preserved",
+        },
+    )
+    transport = _MockGitLabTransport(api=api)
+
+    result = await transport.write_files(
+        url=_git_url(),
+        files={
+            MANIFEST_FILENAME: _manifest(),
+            "workflows/replace.yml": "text replacement",
+        },
+        message="Sync workspace",
+        branch="sync/workspace",
+        create_pr=False,
+        delete_missing_paths_under=("workflows",),
+    )
+
+    assert result.status is PushStatus.COMMITTED
+    assert api.files_at_ref("sync/workspace") == {
+        MANIFEST_FILENAME: _manifest(),
+        "workflows/replace.yml": "text replacement",
+        "README.md": "preserved",
+    }
+    assert api.commit_payloads[0]["actions"] == [
+        {
+            "action": "update",
+            "file_path": "workflows/replace.yml",
+            "content": "text replacement",
+        },
+        {"action": "delete", "file_path": "workflows/stale.bin"},
     ]
 
 

--- a/tests/unit/test_gitlab_vcs.py
+++ b/tests/unit/test_gitlab_vcs.py
@@ -1,0 +1,455 @@
+"""Tests for GitLab workspace sync transport."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from urllib.parse import quote, unquote
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from tracecat.auth.types import Role
+from tracecat.authz.scopes import ADMIN_SCOPES
+from tracecat.git.types import GitUrl
+from tracecat.sync import PushStatus
+from tracecat.vcs.gitlab.schemas import GitLabTokenCredentials
+from tracecat.workspace_sync.schemas import MANIFEST_FILENAME, WorkspaceManifest
+from tracecat.workspace_sync.serialization import canonical_json_text
+from tracecat.workspace_sync.transport import GitLabWorkspaceSyncTransport
+
+
+@dataclass(frozen=True)
+class _Commit:
+    sha: str
+    message: str
+    files: dict[str, str]
+
+
+class _MockGitLabApi:
+    """Small in-memory subset of the GitLab REST API used by the transport."""
+
+    def __init__(self, *, project_path: str, files: Mapping[str, str]) -> None:
+        self.project_path = project_path
+        self.encoded_project_path = quote(project_path, safe="")
+        self.raw_paths: list[str] = []
+        self.commit_payloads: list[dict[str, Any]] = []
+        self.merge_request_payloads: list[dict[str, Any]] = []
+        self._counter = 0
+        self._commits: dict[str, _Commit] = {}
+        self._branches: dict[str, str] = {}
+        self._commit_branches: dict[str, str] = {}
+        self._blobs: dict[str, str] = {}
+        self._merge_requests: list[dict[str, Any]] = []
+        initial = self._new_commit(
+            branch="main",
+            message="Initial commit",
+            files=dict(files),
+        )
+        self._branches["main"] = initial.sha
+
+    def response(self, request: httpx.Request) -> httpx.Response:
+        raw_path = request.url.raw_path.split(b"?", maxsplit=1)[0].decode()
+        self.raw_paths.append(raw_path)
+        prefix = f"/api/v4/projects/{self.encoded_project_path}"
+        if not raw_path.startswith(prefix):
+            return httpx.Response(404, json={"message": "Project Not Found"})
+
+        subpath = raw_path[len(prefix) :]
+        try:
+            if request.method == "GET" and subpath == "/repository/branches":
+                return self._json(
+                    [
+                        {"name": branch, "default": branch == "main"}
+                        for branch in sorted(self._branches)
+                    ]
+                )
+            if request.method == "GET" and subpath.startswith("/repository/branches/"):
+                branch = unquote(subpath.removeprefix("/repository/branches/"))
+                if branch not in self._branches:
+                    return httpx.Response(404, json={"message": "404 Branch Not Found"})
+                return self._json({"name": branch, "default": branch == "main"})
+            if request.method == "POST" and subpath == "/repository/branches":
+                branch = request.url.params["branch"]
+                ref = request.url.params["ref"]
+                self._branches[branch] = self._commit_at_ref(ref).sha
+                return self._json({"name": branch, "default": False}, status_code=201)
+            if request.method == "GET" and subpath == "/repository/commits":
+                branch = request.url.params.get("ref_name", "main")
+                commits = [
+                    commit
+                    for sha, commit in self._commits.items()
+                    if self._commit_branches.get(sha) == branch
+                ]
+                commits.sort(key=lambda commit: commit.sha, reverse=True)
+                return self._json(
+                    [
+                        {
+                            "id": commit.sha,
+                            "message": commit.message,
+                            "author_name": "GitLab User",
+                            "author_email": "gitlab@example.test",
+                            "authored_date": "2026-01-01T00:00:00Z",
+                        }
+                        for commit in commits
+                    ]
+                )
+            if request.method == "GET" and subpath.startswith("/repository/commits/"):
+                ref = unquote(subpath.removeprefix("/repository/commits/"))
+                commit = self._commit_at_ref(ref)
+                return self._json({"id": commit.sha, "message": commit.message})
+            if request.method == "GET" and subpath == "/repository/tree":
+                ref = request.url.params["ref"]
+                commit = self._commit_at_ref(ref)
+                tree: list[dict[str, str]] = []
+                for path, content in sorted(commit.files.items()):
+                    blob_id = f"{commit.sha}:{path}"
+                    self._blobs[blob_id] = content
+                    tree.append({"id": blob_id, "type": "blob", "path": path})
+                return self._json(tree)
+            if (
+                request.method == "GET"
+                and subpath.startswith("/repository/blobs/")
+                and subpath.endswith("/raw")
+            ):
+                blob_id = unquote(
+                    subpath.removeprefix("/repository/blobs/").removesuffix("/raw")
+                )
+                if blob_id not in self._blobs:
+                    return httpx.Response(404, json={"message": "404 Blob Not Found"})
+                return httpx.Response(200, content=self._blobs[blob_id].encode())
+            if request.method == "POST" and subpath == "/repository/commits":
+                payload = json.loads(request.content.decode())
+                self.commit_payloads.append(payload)
+                commit = self.commit_actions(
+                    branch=payload["branch"],
+                    message=payload["commit_message"],
+                    actions=payload["actions"],
+                )
+                return self._json({"id": commit.sha}, status_code=201)
+            if request.method == "GET" and subpath == "/repository/compare":
+                base_commit = self._commit_at_ref(request.url.params["from"])
+                target_commit = self._commit_at_ref(request.url.params["to"])
+                return self._json(
+                    {
+                        "commits": []
+                        if base_commit.sha == target_commit.sha
+                        else [{"id": target_commit.sha}]
+                    }
+                )
+            if request.method == "GET" and subpath == "/merge_requests":
+                source_branch = request.url.params.get("source_branch")
+                target_branch = request.url.params.get("target_branch")
+                state = request.url.params.get("state")
+                return self._json(
+                    [
+                        mr
+                        for mr in self._merge_requests
+                        if mr["source_branch"] == source_branch
+                        and mr["target_branch"] == target_branch
+                        and mr["state"] == state
+                    ]
+                )
+            if request.method == "POST" and subpath == "/merge_requests":
+                payload = json.loads(request.content.decode())
+                self.merge_request_payloads.append(payload)
+                mr = self.add_merge_request(
+                    source_branch=payload["source_branch"],
+                    target_branch=payload["target_branch"],
+                    title=payload["title"],
+                )
+                return self._json(mr, status_code=201)
+        except KeyError as e:
+            return httpx.Response(404, json={"message": f"Not Found: {str(e)}"})
+
+        return httpx.Response(404, json={"message": f"Unhandled path {subpath}"})
+
+    def create_branch(self, branch: str, ref: str) -> None:
+        self._branches[branch] = self._commit_at_ref(ref).sha
+
+    def commit_actions(
+        self,
+        *,
+        branch: str,
+        message: str,
+        actions: list[dict[str, str]],
+    ) -> _Commit:
+        current = self._commit_at_ref(branch)
+        files = dict(current.files)
+        for action in actions:
+            file_path = action["file_path"]
+            match action["action"]:
+                case "create" | "update":
+                    files[file_path] = action["content"]
+                case "delete":
+                    files.pop(file_path, None)
+                case unexpected:
+                    raise ValueError(f"Unexpected action {unexpected}")
+        commit = self._new_commit(branch=branch, message=message, files=files)
+        self._branches[branch] = commit.sha
+        return commit
+
+    def add_merge_request(
+        self,
+        *,
+        source_branch: str,
+        target_branch: str,
+        title: str = "Sync",
+    ) -> dict[str, Any]:
+        iid = len(self._merge_requests) + 1
+        mr = {
+            "iid": iid,
+            "title": title,
+            "source_branch": source_branch,
+            "target_branch": target_branch,
+            "state": "opened",
+            "web_url": (
+                f"https://gitlab.example.test/{self.project_path}/-/merge_requests/{iid}"
+            ),
+        }
+        self._merge_requests.append(mr)
+        return mr
+
+    def files_at_ref(self, ref: str) -> dict[str, str]:
+        return dict(self._commit_at_ref(ref).files)
+
+    def _commit_at_ref(self, ref: str) -> _Commit:
+        sha = self._branches.get(ref, ref)
+        return self._commits[sha]
+
+    def _new_commit(
+        self,
+        *,
+        branch: str,
+        message: str,
+        files: dict[str, str],
+    ) -> _Commit:
+        self._counter += 1
+        sha = f"{self._counter:040x}"
+        commit = _Commit(sha=sha, message=message, files=dict(files))
+        self._commits[sha] = commit
+        self._commit_branches[sha] = branch
+        return commit
+
+    @staticmethod
+    def _json(value: Any, *, status_code: int = 200) -> httpx.Response:
+        return httpx.Response(status_code, json=value)
+
+
+class _MockGitLabTransport(GitLabWorkspaceSyncTransport):
+    def __init__(self, *, api: _MockGitLabApi) -> None:
+        self._api = api
+        super().__init__(
+            session=AsyncMock(),
+            role=Role(
+                type="user",
+                workspace_id=uuid.uuid4(),
+                organization_id=uuid.uuid4(),
+                user_id=None,
+                service_id="tracecat-api",
+                scopes=ADMIN_SCOPES,
+            ),
+        )
+
+    async def _credentials(self) -> GitLabTokenCredentials:
+        return GitLabTokenCredentials(
+            base_url="https://gitlab.example.test",
+            token=SecretStr("test-token"),
+        )
+
+    def _client(self, credentials: GitLabTokenCredentials) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=f"{credentials.base_url}/api/v4",
+            headers={"PRIVATE-TOKEN": credentials.token.get_secret_value()},
+            transport=httpx.MockTransport(self._api.response),
+        )
+
+
+def _git_url() -> GitUrl:
+    return GitUrl(
+        host="gitlab.example.test",
+        org="group/subgroup",
+        repo="project",
+    )
+
+
+def _manifest() -> str:
+    return canonical_json_text(WorkspaceManifest())
+
+
+@pytest.mark.anyio
+async def test_gitlab_transport_encodes_nested_project_path_and_lists_refs() -> None:
+    api = _MockGitLabApi(
+        project_path="group/subgroup/project",
+        files={MANIFEST_FILENAME: _manifest()},
+    )
+    api.commit_actions(
+        branch="main",
+        message="Second commit",
+        actions=[{"action": "create", "file_path": "workflows/a.yml", "content": "a"}],
+    )
+    transport = _MockGitLabTransport(api=api)
+
+    branches = await transport.list_branches(url=_git_url(), limit=10)
+    commits = await transport.list_commits(url=_git_url(), branch="main", limit=10)
+
+    assert [(branch.name, branch.is_default) for branch in branches] == [("main", True)]
+    assert commits[0].message == "Second commit"
+    assert (
+        "/api/v4/projects/group%2Fsubgroup%2Fproject/repository/branches"
+        in api.raw_paths
+    )
+
+
+@pytest.mark.anyio
+async def test_gitlab_transport_reads_manifest_roots_and_blobs() -> None:
+    api = _MockGitLabApi(
+        project_path="group/subgroup/project",
+        files={
+            MANIFEST_FILENAME: _manifest(),
+            "workflows/a.yml": "workflow",
+            "README.md": "outside managed roots",
+        },
+    )
+    transport = _MockGitLabTransport(api=api)
+
+    snapshot = await transport.read_files(url=_git_url(), ref="main")
+
+    assert snapshot.commit_sha == "0" * 39 + "1"
+    assert snapshot.tree_sha is None
+    assert snapshot.files == {
+        MANIFEST_FILENAME: _manifest(),
+        "workflows/a.yml": "workflow",
+    }
+
+
+@pytest.mark.anyio
+async def test_gitlab_transport_commits_create_update_delete_actions() -> None:
+    api = _MockGitLabApi(
+        project_path="group/subgroup/project",
+        files={
+            MANIFEST_FILENAME: _manifest(),
+            "workflows/old.yml": "old",
+            "workflows/stale.yml": "stale",
+            "README.md": "preserved",
+        },
+    )
+    transport = _MockGitLabTransport(api=api)
+
+    result = await transport.write_files(
+        url=_git_url(),
+        files={
+            MANIFEST_FILENAME: _manifest(),
+            "workflows/old.yml": "new",
+            "workflows/new.yml": "created",
+        },
+        message="Sync workspace",
+        branch="sync/workspace",
+        create_pr=False,
+        delete_missing_paths_under=("workflows",),
+    )
+
+    assert result.status is PushStatus.COMMITTED
+    assert result.ref == "sync/workspace"
+    assert result.base_ref == "main"
+    assert api.files_at_ref("sync/workspace") == {
+        MANIFEST_FILENAME: _manifest(),
+        "workflows/old.yml": "new",
+        "workflows/new.yml": "created",
+        "README.md": "preserved",
+    }
+    assert api.commit_payloads[0]["actions"] == [
+        {
+            "action": "create",
+            "file_path": "workflows/new.yml",
+            "content": "created",
+        },
+        {
+            "action": "update",
+            "file_path": "workflows/old.yml",
+            "content": "new",
+        },
+        {"action": "delete", "file_path": "workflows/stale.yml"},
+    ]
+
+
+@pytest.mark.anyio
+async def test_gitlab_transport_noop_reuses_existing_merge_request() -> None:
+    api = _MockGitLabApi(
+        project_path="group/subgroup/project",
+        files={MANIFEST_FILENAME: _manifest(), "workflows/a.yml": "main"},
+    )
+    api.create_branch("sync/workspace", "main")
+    api.commit_actions(
+        branch="sync/workspace",
+        message="Existing branch commit",
+        actions=[
+            {
+                "action": "update",
+                "file_path": "workflows/a.yml",
+                "content": "branch",
+            }
+        ],
+    )
+    existing_mr = api.add_merge_request(
+        source_branch="sync/workspace",
+        target_branch="main",
+    )
+    transport = _MockGitLabTransport(api=api)
+
+    result = await transport.write_files(
+        url=_git_url(),
+        files={MANIFEST_FILENAME: _manifest(), "workflows/a.yml": "branch"},
+        message="Sync workspace",
+        branch="sync/workspace",
+        create_pr=True,
+        delete_missing_paths_under=("workflows",),
+    )
+
+    assert result.status is PushStatus.NO_OP
+    assert result.pr_url == existing_mr["web_url"]
+    assert result.pr_number == existing_mr["iid"]
+    assert result.pr_reused is True
+    assert api.commit_payloads == []
+    assert api.merge_request_payloads == []
+
+
+@pytest.mark.anyio
+async def test_gitlab_transport_creates_merge_request_after_commit() -> None:
+    api = _MockGitLabApi(
+        project_path="group/subgroup/project",
+        files={MANIFEST_FILENAME: _manifest(), "workflows/a.yml": "main"},
+    )
+    transport = _MockGitLabTransport(api=api)
+
+    with patch("tracecat.workspace_sync.transport.WorkspaceService") as workspace_cls:
+        workspace_service = AsyncMock()
+        workspace_service.get_workspace.return_value = type(
+            "WorkspaceStub",
+            (),
+            {"name": "Sync workspace"},
+        )()
+        workspace_cls.return_value = workspace_service
+
+        result = await transport.write_files(
+            url=_git_url(),
+            files={MANIFEST_FILENAME: _manifest(), "workflows/a.yml": "branch"},
+            message="Sync workspace",
+            branch="sync/workspace",
+            create_pr=True,
+            delete_missing_paths_under=("workflows",),
+        )
+
+    assert result.status is PushStatus.COMMITTED
+    assert result.pr_url == (
+        "https://gitlab.example.test/group/subgroup/project/-/merge_requests/1"
+    )
+    assert result.pr_number == 1
+    assert result.pr_reused is False
+    assert api.merge_request_payloads[0]["source_branch"] == "sync/workspace"
+    assert api.merge_request_payloads[0]["target_branch"] == "main"

--- a/tests/unit/test_gitlab_vcs.py
+++ b/tests/unit/test_gitlab_vcs.py
@@ -34,9 +34,16 @@ class _Commit:
 class _MockGitLabApi:
     """Small in-memory subset of the GitLab REST API used by the transport."""
 
-    def __init__(self, *, project_path: str, files: Mapping[str, str]) -> None:
+    def __init__(
+        self,
+        *,
+        project_path: str,
+        files: Mapping[str, str],
+        default_branch: str = "main",
+    ) -> None:
         self.project_path = project_path
         self.encoded_project_path = quote(project_path, safe="")
+        self.default_branch = default_branch
         self.raw_paths: list[str] = []
         self.commit_payloads: list[dict[str, Any]] = []
         self.merge_request_payloads: list[dict[str, Any]] = []
@@ -47,11 +54,11 @@ class _MockGitLabApi:
         self._blobs: dict[str, str] = {}
         self._merge_requests: list[dict[str, Any]] = []
         initial = self._new_commit(
-            branch="main",
+            branch=default_branch,
             message="Initial commit",
             files=dict(files),
         )
-        self._branches["main"] = initial.sha
+        self._branches[default_branch] = initial.sha
 
     def response(self, request: httpx.Request) -> httpx.Response:
         raw_path = request.url.raw_path.split(b"?", maxsplit=1)[0].decode()
@@ -63,17 +70,29 @@ class _MockGitLabApi:
         subpath = raw_path[len(prefix) :]
         try:
             if request.method == "GET" and subpath == "/repository/branches":
+                page = int(request.url.params.get("page", "1"))
+                per_page = int(request.url.params.get("per_page", "100"))
+                branches = sorted(self._branches)
+                start = (page - 1) * per_page
+                end = start + per_page
+                next_page = str(page + 1) if end < len(branches) else ""
                 return self._json(
                     [
-                        {"name": branch, "default": branch == "main"}
-                        for branch in sorted(self._branches)
-                    ]
+                        {
+                            "name": branch,
+                            "default": branch == self.default_branch,
+                        }
+                        for branch in branches[start:end]
+                    ],
+                    headers={"x-next-page": next_page},
                 )
             if request.method == "GET" and subpath.startswith("/repository/branches/"):
                 branch = unquote(subpath.removeprefix("/repository/branches/"))
                 if branch not in self._branches:
                     return httpx.Response(404, json={"message": "404 Branch Not Found"})
-                return self._json({"name": branch, "default": branch == "main"})
+                return self._json(
+                    {"name": branch, "default": branch == self.default_branch}
+                )
             if request.method == "POST" and subpath == "/repository/branches":
                 branch = request.url.params["branch"]
                 ref = request.url.params["ref"]
@@ -237,8 +256,13 @@ class _MockGitLabApi:
         return commit
 
     @staticmethod
-    def _json(value: Any, *, status_code: int = 200) -> httpx.Response:
-        return httpx.Response(status_code, json=value)
+    def _json(
+        value: Any,
+        *,
+        status_code: int = 200,
+        headers: Mapping[str, str] | None = None,
+    ) -> httpx.Response:
+        return httpx.Response(status_code, json=value, headers=headers)
 
 
 class _MockGitLabTransport(GitLabWorkspaceSyncTransport):
@@ -273,6 +297,14 @@ class _MockGitLabTransport(GitLabWorkspaceSyncTransport):
 def _git_url() -> GitUrl:
     return GitUrl(
         host="gitlab.example.test",
+        org="group/subgroup",
+        repo="project",
+    )
+
+
+def _git_url_with_ssh_port() -> GitUrl:
+    return GitUrl(
+        host="gitlab.example.test:2222",
         org="group/subgroup",
         repo="project",
     )
@@ -326,6 +358,19 @@ async def test_gitlab_transport_reads_manifest_roots_and_blobs() -> None:
         MANIFEST_FILENAME: _manifest(),
         "workflows/a.yml": "workflow",
     }
+
+
+@pytest.mark.anyio
+async def test_gitlab_transport_allows_repo_ssh_port_on_same_instance() -> None:
+    api = _MockGitLabApi(
+        project_path="group/subgroup/project",
+        files={MANIFEST_FILENAME: _manifest()},
+    )
+    transport = _MockGitLabTransport(api=api)
+
+    snapshot = await transport.read_files(url=_git_url_with_ssh_port(), ref="main")
+
+    assert snapshot.commit_sha == "0" * 39 + "1"
 
 
 @pytest.mark.anyio
@@ -453,3 +498,40 @@ async def test_gitlab_transport_creates_merge_request_after_commit() -> None:
     assert result.pr_reused is False
     assert api.merge_request_payloads[0]["source_branch"] == "sync/workspace"
     assert api.merge_request_payloads[0]["target_branch"] == "main"
+
+
+@pytest.mark.anyio
+async def test_gitlab_transport_resolves_default_branch_beyond_first_page() -> None:
+    api = _MockGitLabApi(
+        project_path="group/subgroup/project",
+        files={MANIFEST_FILENAME: _manifest(), "workflows/a.yml": "main"},
+        default_branch="zz-default",
+    )
+    for index in range(105):
+        api.create_branch(f"branch-{index:03d}", "zz-default")
+    transport = _MockGitLabTransport(api=api)
+
+    with patch("tracecat.workspace_sync.transport.WorkspaceService") as workspace_cls:
+        workspace_service = AsyncMock()
+        workspace_service.get_workspace.return_value = type(
+            "WorkspaceStub",
+            (),
+            {"name": "Sync workspace"},
+        )()
+        workspace_cls.return_value = workspace_service
+
+        result = await transport.write_files(
+            url=GitUrl(
+                host="gitlab.example.test",
+                org="group/subgroup",
+                repo="project",
+            ),
+            files={MANIFEST_FILENAME: _manifest(), "workflows/a.yml": "branch"},
+            message="Sync workspace",
+            branch="sync/workspace",
+            create_pr=True,
+            delete_missing_paths_under=("workflows",),
+        )
+
+    assert result.status is PushStatus.COMMITTED
+    assert api.merge_request_payloads[0]["target_branch"] == "zz-default"

--- a/tests/unit/test_gitlab_vcs.py
+++ b/tests/unit/test_gitlab_vcs.py
@@ -49,6 +49,7 @@ class _MockGitLabApi:
         self.encoded_project_path = quote(project_path, safe="")
         self.default_branch = default_branch
         self.raw_paths: list[str] = []
+        self.requests: list[tuple[str, str]] = []
         self.commit_payloads: list[dict[str, Any]] = []
         self.merge_request_payloads: list[dict[str, Any]] = []
         self._counter = 0
@@ -67,6 +68,7 @@ class _MockGitLabApi:
     def response(self, request: httpx.Request) -> httpx.Response:
         raw_path = request.url.raw_path.split(b"?", maxsplit=1)[0].decode()
         self.raw_paths.append(raw_path)
+        self.requests.append((request.method, raw_path))
         prefix = f"/api/v4/projects/{self.encoded_project_path}"
         if not raw_path.startswith(prefix):
             return httpx.Response(404, json={"message": "Project Not Found"})
@@ -541,6 +543,64 @@ async def test_gitlab_transport_creates_merge_request_after_commit() -> None:
     assert result.pr_reused is False
     assert api.merge_request_payloads[0]["source_branch"] == "sync/workspace"
     assert api.merge_request_payloads[0]["target_branch"] == "main"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("url", "pr_base_branch"),
+    [
+        (_git_url(), "release/base"),
+        (
+            GitUrl(
+                host="gitlab.example.test",
+                org="group/subgroup",
+                repo="project",
+                ref="release/base",
+            ),
+            None,
+        ),
+    ],
+    ids=["pr-base-branch", "url-ref"],
+)
+async def test_gitlab_transport_skips_branch_list_when_base_is_explicit(
+    url: GitUrl,
+    pr_base_branch: str | None,
+) -> None:
+    api = _MockGitLabApi(
+        project_path="group/subgroup/project",
+        files={MANIFEST_FILENAME: _manifest(), "workflows/a.yml": "base"},
+        default_branch="zz-default",
+    )
+    api.create_branch("release/base", "zz-default")
+    for index in range(105):
+        api.create_branch(f"branch-{index:03d}", "zz-default")
+    transport = _MockGitLabTransport(api=api)
+
+    with patch("tracecat.workspace_sync.transport.WorkspaceService") as workspace_cls:
+        workspace_service = AsyncMock()
+        workspace_service.get_workspace.return_value = type(
+            "WorkspaceStub",
+            (),
+            {"name": "Sync workspace"},
+        )()
+        workspace_cls.return_value = workspace_service
+
+        result = await transport.write_files(
+            url=url,
+            files={MANIFEST_FILENAME: _manifest(), "workflows/a.yml": "branch"},
+            message="Sync workspace",
+            branch="sync/workspace",
+            create_pr=True,
+            pr_base_branch=pr_base_branch,
+            delete_missing_paths_under=("workflows",),
+        )
+
+    branch_list_path = (
+        f"/api/v4/projects/{api.encoded_project_path}/repository/branches"
+    )
+    assert ("GET", branch_list_path) not in api.requests
+    assert result.status is PushStatus.COMMITTED
+    assert api.merge_request_payloads[0]["target_branch"] == "release/base"
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_gitlab_vcs.py
+++ b/tests/unit/test_gitlab_vcs.py
@@ -6,6 +6,7 @@ import json
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
 from urllib.parse import quote, unquote
@@ -16,8 +17,11 @@ from pydantic import SecretStr
 
 from tracecat.auth.types import Role
 from tracecat.authz.scopes import ADMIN_SCOPES
+from tracecat.exceptions import ScopeDeniedError, TracecatNotFoundError
 from tracecat.git.types import GitUrl
+from tracecat.secrets.schemas import SecretKeyValue
 from tracecat.sync import PushStatus
+from tracecat.vcs.gitlab.app import GITLAB_TOKEN_SECRET_NAME, GitLabTokenService
 from tracecat.vcs.gitlab.schemas import GitLabTokenCredentials
 from tracecat.workspace_sync.schemas import MANIFEST_FILENAME, WorkspaceManifest
 from tracecat.workspace_sync.serialization import canonical_json_text
@@ -314,6 +318,17 @@ def _manifest() -> str:
     return canonical_json_text(WorkspaceManifest())
 
 
+def _gitlab_settings_role(*scopes: str) -> Role:
+    return Role(
+        type="user",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+        scopes=frozenset(scopes),
+    )
+
+
 @pytest.mark.anyio
 async def test_gitlab_transport_encodes_nested_project_path_and_lists_refs() -> None:
     api = _MockGitLabApi(
@@ -535,3 +550,100 @@ async def test_gitlab_transport_resolves_default_branch_beyond_first_page() -> N
 
     assert result.status is PushStatus.COMMITTED
     assert api.merge_request_payloads[0]["target_branch"] == "zz-default"
+
+
+@pytest.mark.anyio
+async def test_gitlab_token_save_creates_org_secret_with_settings_scope() -> None:
+    created_params: list[Any] = []
+
+    class FakeSecretsService:
+        def __init__(self, *, session: Any, role: Role) -> None:
+            del session, role
+
+        async def _get_org_secret_by_name(
+            self, secret_name: str, environment: str | None = None
+        ) -> Any:
+            del secret_name, environment
+            raise TracecatNotFoundError("missing")
+
+        async def _create_org_secret(self, params: Any) -> None:
+            created_params.append(params)
+
+    service = GitLabTokenService(
+        session=AsyncMock(),
+        role=_gitlab_settings_role("org:settings:update"),
+    )
+
+    with (
+        patch.object(service, "require_entitlement", new=AsyncMock()),
+        patch("tracecat.vcs.gitlab.app.SecretsService", FakeSecretsService),
+    ):
+        credentials, was_created = await service.save_gitlab_token_credentials(
+            base_url="https://gitlab.example.test",
+            token=SecretStr("new-token"),
+        )
+
+    assert credentials.base_url == "https://gitlab.example.test"
+    assert was_created is True
+    assert created_params[0].name == GITLAB_TOKEN_SECRET_NAME
+
+
+@pytest.mark.anyio
+async def test_gitlab_token_save_updates_org_secret_with_settings_scope() -> None:
+    existing_secret = SimpleNamespace(id=uuid.uuid4(), encrypted_keys=b"encrypted")
+    updated_calls: list[tuple[Any, Any]] = []
+
+    class FakeSecretsService:
+        def __init__(self, *, session: Any, role: Role) -> None:
+            del session, role
+
+        async def _get_org_secret_by_name(
+            self, secret_name: str, environment: str | None = None
+        ) -> Any:
+            del secret_name, environment
+            return existing_secret
+
+        def decrypt_keys(self, encrypted_keys: bytes) -> list[SecretKeyValue]:
+            assert encrypted_keys == b"encrypted"
+            return [
+                SecretKeyValue(
+                    key="base_url",
+                    value=SecretStr("https://gitlab.example.test"),
+                ),
+                SecretKeyValue(key="token", value=SecretStr("old-token")),
+            ]
+
+        async def _update_org_secret(self, secret: Any, params: Any) -> None:
+            updated_calls.append((secret, params))
+
+    service = GitLabTokenService(
+        session=AsyncMock(),
+        role=_gitlab_settings_role("org:settings:update"),
+    )
+
+    with (
+        patch.object(service, "require_entitlement", new=AsyncMock()),
+        patch("tracecat.vcs.gitlab.app.SecretsService", FakeSecretsService),
+    ):
+        credentials, was_created = await service.save_gitlab_token_credentials(
+            base_url="https://gitlab.example.test",
+            token=SecretStr("new-token"),
+        )
+
+    assert credentials.token.get_secret_value() == "new-token"
+    assert was_created is False
+    assert updated_calls[0][0] is existing_secret
+
+
+@pytest.mark.anyio
+async def test_gitlab_token_status_requires_settings_read_scope() -> None:
+    service = GitLabTokenService(
+        session=AsyncMock(),
+        role=_gitlab_settings_role(),
+    )
+
+    with patch.object(service, "require_entitlement", new=AsyncMock()):
+        with pytest.raises(ScopeDeniedError) as exc_info:
+            await service.get_gitlab_token_credentials_status()
+
+    assert "org:settings:read" in exc_info.value.missing_scopes

--- a/tests/unit/test_gitlab_vcs.py
+++ b/tests/unit/test_gitlab_vcs.py
@@ -354,6 +354,34 @@ async def test_gitlab_transport_encodes_nested_project_path_and_lists_refs() -> 
 
 
 @pytest.mark.anyio
+async def test_gitlab_transport_list_branches_includes_default_beyond_limit() -> None:
+    api = _MockGitLabApi(
+        project_path="group/subgroup/project",
+        files={MANIFEST_FILENAME: _manifest()},
+        default_branch="zz-default",
+    )
+    for index in range(105):
+        api.create_branch(f"branch-{index:03d}", "zz-default")
+    transport = _MockGitLabTransport(api=api)
+
+    branches = await transport.list_branches(url=_git_url(), limit=10)
+
+    assert len(branches) == 10
+    assert [(branch.name, branch.is_default) for branch in branches] == [
+        ("branch-000", False),
+        ("branch-001", False),
+        ("branch-002", False),
+        ("branch-003", False),
+        ("branch-004", False),
+        ("branch-005", False),
+        ("branch-006", False),
+        ("branch-007", False),
+        ("branch-008", False),
+        ("zz-default", True),
+    ]
+
+
+@pytest.mark.anyio
 async def test_gitlab_transport_reads_manifest_roots_and_blobs() -> None:
     api = _MockGitLabApi(
         project_path="group/subgroup/project",

--- a/tests/unit/test_gitlab_vcs.py
+++ b/tests/unit/test_gitlab_vcs.py
@@ -77,6 +77,8 @@ class _MockGitLabApi:
 
         subpath = raw_path[len(prefix) :]
         try:
+            if request.method == "GET" and subpath == "":
+                return self._json({"default_branch": self.default_branch})
             if request.method == "GET" and subpath == "/repository/branches":
                 page = int(request.url.params.get("page", "1"))
                 per_page = int(request.url.params.get("per_page", "100"))
@@ -651,7 +653,7 @@ async def test_gitlab_transport_skips_branch_list_when_base_is_explicit(
 
 
 @pytest.mark.anyio
-async def test_gitlab_transport_resolves_default_branch_beyond_first_page() -> None:
+async def test_gitlab_transport_resolves_default_base_without_branch_scan() -> None:
     api = _MockGitLabApi(
         project_path="group/subgroup/project",
         files={MANIFEST_FILENAME: _manifest(), "workflows/a.yml": "main"},
@@ -684,6 +686,10 @@ async def test_gitlab_transport_resolves_default_branch_beyond_first_page() -> N
         )
 
     assert result.status is PushStatus.COMMITTED
+    project_path = f"/api/v4/projects/{api.encoded_project_path}"
+    branch_list_path = f"{project_path}/repository/branches"
+    assert ("GET", project_path) in api.requests
+    assert ("GET", branch_list_path) not in api.requests
     assert api.merge_request_payloads[0]["target_branch"] == "zz-default"
 
 

--- a/tests/unit/test_route_scope_guards.py
+++ b/tests/unit/test_route_scope_guards.py
@@ -503,6 +503,9 @@ async def test_integration_scope_guards(
         (vcs_router.save_github_app_credentials, "org:settings:update"),
         (vcs_router.delete_github_app_credentials, "org:settings:delete"),
         (vcs_router.get_github_app_credentials_status, "org:settings:read"),
+        (vcs_router.save_gitlab_token_credentials, "org:settings:update"),
+        (vcs_router.delete_gitlab_token_credentials, "org:settings:delete"),
+        (vcs_router.get_gitlab_token_credentials_status, "org:settings:read"),
     ],
 )
 async def test_vcs_scope_guards(endpoint: AsyncEndpoint, required_scope: str) -> None:

--- a/tests/unit/test_vcs_router.py
+++ b/tests/unit/test_vcs_router.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Never
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from tracecat.auth.types import Role
+from tracecat.exceptions import EntitlementRequired
+from tracecat.tiers.enums import Entitlement
+from tracecat.vcs import router as vcs_router
+from tracecat.vcs.schemas import GitLabTokenCredentialsRequest
+
+
+class _EntitlementFailingGitLabTokenService:
+    def __init__(self, *, session: Any, role: Role) -> None:
+        del session, role
+
+    def _raise_entitlement(self) -> Never:
+        raise EntitlementRequired(Entitlement.GIT_SYNC)
+
+    async def save_gitlab_token_credentials(
+        self, *, base_url: str, token: SecretStr
+    ) -> tuple[Any, bool]:
+        del base_url, token
+        self._raise_entitlement()
+
+    async def delete_gitlab_token_credentials(self) -> None:
+        self._raise_entitlement()
+
+    async def get_gitlab_token_credentials_status(self) -> dict[str, Any]:
+        self._raise_entitlement()
+
+
+def _org_settings_role(scope: str) -> Role:
+    return Role(
+        type="user",
+        workspace_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        service_id="tracecat-api",
+        scopes=frozenset({scope}),
+    )
+
+
+@pytest.mark.anyio
+async def test_save_gitlab_credentials_reraises_entitlement_required() -> None:
+    with patch.object(
+        vcs_router,
+        "GitLabTokenService",
+        _EntitlementFailingGitLabTokenService,
+    ):
+        with pytest.raises(EntitlementRequired, match=Entitlement.GIT_SYNC.value):
+            await vcs_router.save_gitlab_token_credentials(
+                session=AsyncMock(),
+                role=_org_settings_role("org:settings:update"),
+                request=GitLabTokenCredentialsRequest(
+                    base_url="https://gitlab.example.test",
+                    token=SecretStr("test-token"),
+                ),
+            )
+
+
+@pytest.mark.anyio
+async def test_delete_gitlab_credentials_reraises_entitlement_required() -> None:
+    with patch.object(
+        vcs_router,
+        "GitLabTokenService",
+        _EntitlementFailingGitLabTokenService,
+    ):
+        with pytest.raises(EntitlementRequired, match=Entitlement.GIT_SYNC.value):
+            await vcs_router.delete_gitlab_token_credentials(
+                session=AsyncMock(),
+                role=_org_settings_role("org:settings:delete"),
+            )
+
+
+@pytest.mark.anyio
+async def test_gitlab_credentials_status_reraises_entitlement_required() -> None:
+    with patch.object(
+        vcs_router,
+        "GitLabTokenService",
+        _EntitlementFailingGitLabTokenService,
+    ):
+        with pytest.raises(EntitlementRequired, match=Entitlement.GIT_SYNC.value):
+            await vcs_router.get_gitlab_token_credentials_status(
+                session=AsyncMock(),
+                role=_org_settings_role("org:settings:read"),
+            )

--- a/tests/unit/test_workflow_store_service.py
+++ b/tests/unit/test_workflow_store_service.py
@@ -85,7 +85,10 @@ async def test_publish_workflow_uses_workspace_sync_service(
         ),
     )
 
-    with patch("tracecat.workflow.store.service.WorkspaceSyncService") as sync_cls:
+    with patch(
+        "tracecat.workflow.store.service.WorkspaceSyncService.for_workspace",
+        new_callable=AsyncMock,
+    ) as for_workspace:
         sync_service = AsyncMock()
         sync_service.export_workflow.return_value = WorkspaceSyncExportResult(
             commit=CommitInfo(
@@ -97,7 +100,7 @@ async def test_publish_workflow_uses_workspace_sync_service(
             ),
             files=[],
         )
-        sync_cls.return_value = sync_service
+        for_workspace.return_value = sync_service
 
         result = await workflow_store_service.publish_workflow_dsl(
             workflow_id=workflow_id,
@@ -107,6 +110,10 @@ async def test_publish_workflow_uses_workspace_sync_service(
         )
 
     assert result.branch == "feature/test"
+    for_workspace.assert_awaited_once_with(
+        session=workflow_store_service.session,
+        role=workflow_store_service.role,
+    )
     call_kwargs = sync_service.export_workflow.call_args.kwargs
     assert call_kwargs["workflow"] is workflow
     assert call_kwargs["dsl"] is sample_dsl
@@ -210,7 +217,10 @@ async def test_publish_workflow_legacy_branch_still_creates_pr(
     workflow_id = WorkflowUUID.new_uuid4()
     workflow = _workflow_fixture(workflow_id, case_trigger=None)
 
-    with patch("tracecat.workflow.store.service.WorkspaceSyncService") as sync_cls:
+    with patch(
+        "tracecat.workflow.store.service.WorkspaceSyncService.for_workspace",
+        new_callable=AsyncMock,
+    ) as for_workspace:
         sync_service = AsyncMock()
         sync_service.export_workflow.return_value = WorkspaceSyncExportResult(
             commit=CommitInfo(
@@ -224,7 +234,7 @@ async def test_publish_workflow_legacy_branch_still_creates_pr(
             ),
             files=[],
         )
-        sync_cls.return_value = sync_service
+        for_workspace.return_value = sync_service
 
         await workflow_store_service.publish_workflow_dsl(
             workflow_id=workflow_id,
@@ -233,6 +243,10 @@ async def test_publish_workflow_legacy_branch_still_creates_pr(
             workflow=cast(Workflow, workflow),
         )
 
+    for_workspace.assert_awaited_once_with(
+        session=workflow_store_service.session,
+        role=workflow_store_service.role,
+    )
     params = sync_service.export_workflow.call_args.kwargs["params"]
     assert params.branch.startswith("tracecat-sync-")
     assert params.create_pr is True
@@ -253,7 +267,10 @@ async def test_publish_workflow_includes_configured_case_trigger(
         ),
     )
 
-    with patch("tracecat.workflow.store.service.WorkspaceSyncService") as sync_cls:
+    with patch(
+        "tracecat.workflow.store.service.WorkspaceSyncService.for_workspace",
+        new_callable=AsyncMock,
+    ) as for_workspace:
         sync_service = AsyncMock()
         sync_service.export_workflow.return_value = WorkspaceSyncExportResult(
             commit=CommitInfo(
@@ -265,7 +282,7 @@ async def test_publish_workflow_includes_configured_case_trigger(
             ),
             files=[],
         )
-        sync_cls.return_value = sync_service
+        for_workspace.return_value = sync_service
 
         await workflow_store_service.publish_workflow_dsl(
             workflow_id=workflow_id,
@@ -274,4 +291,8 @@ async def test_publish_workflow_includes_configured_case_trigger(
             workflow=cast(Workflow, workflow),
         )
 
+    for_workspace.assert_awaited_once_with(
+        session=workflow_store_service.session,
+        role=workflow_store_service.role,
+    )
     sync_service.export_workflow.assert_awaited_once()

--- a/tests/unit/test_workspace_service.py
+++ b/tests/unit/test_workspace_service.py
@@ -27,6 +27,7 @@ from tracecat.exceptions import (
     TracecatValidationError,
 )
 from tracecat.invitations.enums import InvitationStatus
+from tracecat.workspace_sync.enums import VcsProvider
 from tracecat.workspaces.schemas import (
     WorkspaceInvitationCreate,
     WorkspaceSearch,
@@ -520,6 +521,14 @@ def test_workspace_settings_update_rejects_invalid_git_urls(invalid_url: str) ->
         WorkspaceSettingsUpdate(git_repo_url=invalid_url)
 
     assert "Must be a valid Git SSH URL" in str(exc_info.value)
+
+
+def test_workspace_settings_update_rejects_unsupported_git_provider() -> None:
+    """Workspace settings should reject providers without sync transport support."""
+    with pytest.raises(ValueError) as exc_info:
+        WorkspaceSettingsUpdate(git_provider=VcsProvider.BITBUCKET)
+
+    assert "bitbucket workspace sync is not implemented yet" in str(exc_info.value)
 
 
 # =============================================================================

--- a/tests/unit/test_workspace_sync_acceptance_contract.py
+++ b/tests/unit/test_workspace_sync_acceptance_contract.py
@@ -932,7 +932,6 @@ async def test_source_export_target_pull_preserves_projected_workspace(
                 message="Push source workspace",
                 branch="sync/source-to-target",
                 create_pr=False,
-                provider=provider,
             )
         )
         assert first_export.commit.status is PushStatus.COMMITTED
@@ -967,7 +966,6 @@ async def test_source_export_target_pull_preserves_projected_workspace(
                 message="Push source workspace update",
                 branch="sync/source-to-target",
                 create_pr=False,
-                provider=provider,
             )
         )
         assert second_export.commit.status is PushStatus.COMMITTED

--- a/tests/unit/test_workspace_sync_acceptance_contract.py
+++ b/tests/unit/test_workspace_sync_acceptance_contract.py
@@ -914,6 +914,18 @@ async def test_source_export_target_pull_preserves_projected_workspace(
             provider=provider,
         )
         assert source_pull.success is True
+        source_table = await session.scalar(
+            select(Table).where(
+                Table.workspace_id == svc_role.workspace_id,
+                Table.name == "qa_indicators",
+            )
+        )
+        assert source_table is not None
+        with source_service._mapping_provider_scope(provider):
+            table_source_ids = await TABLE_RESOURCE_ADAPTER.source_ids_by_local_id(
+                source_service
+            )
+        assert table_source_ids.get(source_table.id) == "qa_indicators"
 
         first_export = await source_service.export_workspace(
             WorkspaceSyncExportRequest(
@@ -940,6 +952,19 @@ async def test_source_export_target_pull_preserves_projected_workspace(
         # Exercise a representative update batch before the second push/pull:
         # mapped-resource renames, metadata edits, and one new resource.
         await _mutate_source_workspace_for_roundtrip_update(session, role=svc_role)
+        renamed_source_table = await session.scalar(
+            select(Table).where(
+                Table.workspace_id == svc_role.workspace_id,
+                Table.name == "qa_indicators_roundtrip",
+            )
+        )
+        assert renamed_source_table is not None
+        assert renamed_source_table.id == source_table.id
+        with source_service._mapping_provider_scope(provider):
+            renamed_table_source_ids = (
+                await TABLE_RESOURCE_ADAPTER.source_ids_by_local_id(source_service)
+            )
+        assert renamed_table_source_ids.get(renamed_source_table.id) == "qa_indicators"
         second_export = await source_service.export_workspace(
             WorkspaceSyncExportRequest(
                 message="Push source workspace update",
@@ -950,12 +975,19 @@ async def test_source_export_target_pull_preserves_projected_workspace(
         )
         assert second_export.commit.status is PushStatus.COMMITTED
         assert second_export.commit.sha is not None
+        with source_service._mapping_provider_scope(provider):
+            source_projection = await source_service.project_workspace(
+                create_missing_mappings=False
+            )
+        assert f"{TABLE_ROOT}/qa_indicators/table.yml" in source_projection.files
+        assert (
+            f"{TABLE_ROOT}/qa_indicators_roundtrip/table.yml"
+            not in source_projection.files
+        )
         # Confirm the fake VCS commit stores exactly what source projection emits.
         assert (
             fake_vcs.repo_files(git_url, ref=second_export.commit.sha)
-            == (
-                await source_service.project_workspace(create_missing_mappings=False)
-            ).files
+            == source_projection.files
         )
 
         second_target_pull = await target_service.pull(

--- a/tests/unit/test_workspace_sync_acceptance_contract.py
+++ b/tests/unit/test_workspace_sync_acceptance_contract.py
@@ -832,9 +832,31 @@ async def test_project_workspace_exports_supported_non_workflow_resources(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("provider", "repo_url", "git_url"),
+    [
+        (
+            VcsProvider.GITHUB,
+            "git+ssh://git@github.com/TracecatHQ/git-sync-qa.git",
+            GitUrl(host="github.com", org="TracecatHQ", repo="git-sync-qa"),
+        ),
+        (
+            VcsProvider.GITLAB,
+            "git+ssh://git@gitlab.example.test/TracecatHQ/platform/git-sync-qa.git",
+            GitUrl(
+                host="gitlab.example.test",
+                org="TracecatHQ/platform",
+                repo="git-sync-qa",
+            ),
+        ),
+    ],
+)
 async def test_source_export_target_pull_preserves_projected_workspace(
     session: AsyncSession,
     svc_role: Role,
+    provider: VcsProvider,
+    repo_url: str,
+    git_url: GitUrl,
 ) -> None:
     """Round-trip a workspace through VCS and assert target parity.
 
@@ -845,19 +867,19 @@ async def test_source_export_target_pull_preserves_projected_workspace(
     metadata edits, and an added resource.
     """
     assert svc_role.workspace_id is not None
-    repo_url = "git+ssh://git@github.com/TracecatHQ/git-sync-qa.git"
-    git_url = GitUrl(host="github.com", org="TracecatHQ", repo="git-sync-qa")
     fake_vcs = FakeVcsServer()
     await _set_workspace_git_repo_url(
         session,
         workspace_id=svc_role.workspace_id,
         repo_url=repo_url,
+        provider=provider,
     )
     target_role = await _create_workspace_role(
         session,
         source_role=svc_role,
         workspace_name="target-workspace",
         repo_url=repo_url,
+        provider=provider,
     )
     source_service = WorkspaceSyncService(
         session=session,
@@ -870,7 +892,7 @@ async def test_source_export_target_pull_preserves_projected_workspace(
         transport_factory=fake_vcs.transport_factory,
     )
     seed_transport = fake_vcs.transport_factory(
-        VcsProvider.GITHUB,
+        provider,
         session=session,
         role=svc_role,
     )
@@ -888,7 +910,8 @@ async def test_source_export_target_pull_preserves_projected_workspace(
         AsyncMock(return_value=RegistryLock(origins={}, actions={})),
     ):
         source_pull = await source_service.pull(
-            options=PullOptions(commit_sha=seed_commit.sha)
+            options=PullOptions(commit_sha=seed_commit.sha),
+            provider=provider,
         )
         assert source_pull.success is True
 
@@ -897,16 +920,22 @@ async def test_source_export_target_pull_preserves_projected_workspace(
                 message="Push source workspace",
                 branch="sync/source-to-target",
                 create_pr=False,
+                provider=provider,
             )
         )
         assert first_export.commit.status is PushStatus.COMMITTED
         assert first_export.commit.sha is not None
 
         first_target_pull = await target_service.pull(
-            options=PullOptions(commit_sha=first_export.commit.sha)
+            options=PullOptions(commit_sha=first_export.commit.sha),
+            provider=provider,
         )
         assert first_target_pull.success is True
-        await _assert_projected_workspaces_match(source_service, target_service)
+        await _assert_projected_workspaces_match(
+            source_service,
+            target_service,
+            provider=provider,
+        )
 
         # Exercise a representative update batch before the second push/pull:
         # mapped-resource renames, metadata edits, and one new resource.
@@ -916,6 +945,7 @@ async def test_source_export_target_pull_preserves_projected_workspace(
                 message="Push source workspace update",
                 branch="sync/source-to-target",
                 create_pr=False,
+                provider=provider,
             )
         )
         assert second_export.commit.status is PushStatus.COMMITTED
@@ -929,11 +959,16 @@ async def test_source_export_target_pull_preserves_projected_workspace(
         )
 
         second_target_pull = await target_service.pull(
-            options=PullOptions(commit_sha=second_export.commit.sha)
+            options=PullOptions(commit_sha=second_export.commit.sha),
+            provider=provider,
         )
 
     assert second_target_pull.success is True
-    await _assert_projected_workspaces_match(source_service, target_service)
+    await _assert_projected_workspaces_match(
+        source_service,
+        target_service,
+        provider=provider,
+    )
 
 
 @pytest.mark.anyio
@@ -5157,6 +5192,7 @@ async def _set_workspace_git_repo_url(
     *,
     workspace_id: uuid.UUID,
     repo_url: str,
+    provider: VcsProvider = VcsProvider.GITHUB,
 ) -> None:
     workspace = await session.scalar(
         select(Workspace).where(Workspace.id == workspace_id)
@@ -5164,6 +5200,7 @@ async def _set_workspace_git_repo_url(
     assert workspace is not None
     workspace.settings = {
         **(workspace.settings or {}),
+        "git_provider": provider,
         "git_repo_url": repo_url,
     }
     session.add(workspace)
@@ -5176,12 +5213,13 @@ async def _create_workspace_role(
     source_role: Role,
     workspace_name: str,
     repo_url: str,
+    provider: VcsProvider = VcsProvider.GITHUB,
 ) -> Role:
     assert source_role.organization_id is not None
     workspace = Workspace(
         name=workspace_name,
         organization_id=source_role.organization_id,
-        settings={"git_repo_url": repo_url},
+        settings={"git_provider": provider, "git_repo_url": repo_url},
     )
     session.add(workspace)
     await session.flush()
@@ -5287,14 +5325,20 @@ async def _refresh_workspace_for_fixture_cleanup(
 async def _assert_projected_workspaces_match(
     source_service: WorkspaceSyncService,
     target_service: WorkspaceSyncService,
+    *,
+    provider: VcsProvider = VcsProvider.GITHUB,
 ) -> None:
     """Compare canonical sync files, not DB IDs or other local-only state."""
-    source_projection = await source_service.project_workspace(
-        create_missing_mappings=False
-    )
-    target_projection = await target_service.project_workspace(
-        create_missing_mappings=False
-    )
+    with (
+        source_service._mapping_provider_scope(provider),
+        target_service._mapping_provider_scope(provider),
+    ):
+        source_projection = await source_service.project_workspace(
+            create_missing_mappings=False
+        )
+        target_projection = await target_service.project_workspace(
+            create_missing_mappings=False
+        )
     assert target_projection.files == source_projection.files
 
 

--- a/tests/unit/test_workspace_sync_acceptance_contract.py
+++ b/tests/unit/test_workspace_sync_acceptance_contract.py
@@ -5369,6 +5369,7 @@ async def _mapping_for(
     role: Role,
     resource_type: SyncResourceType,
     source_id: str,
+    provider: VcsProvider = VcsProvider.GITHUB,
 ) -> WorkspaceSyncResourceMapping | None:
     """Look up a workspace's sync mapping for one Git source identifier."""
     workspace_id = role.workspace_id
@@ -5376,7 +5377,7 @@ async def _mapping_for(
     return await session.scalar(
         select(WorkspaceSyncResourceMapping).where(
             WorkspaceSyncResourceMapping.workspace_id == workspace_id,
-            WorkspaceSyncResourceMapping.provider == VcsProvider.GITHUB.value,
+            WorkspaceSyncResourceMapping.provider == provider.value,
             WorkspaceSyncResourceMapping.resource_type == resource_type.value,
             WorkspaceSyncResourceMapping.source_id == source_id,
         )

--- a/tests/unit/test_workspace_sync_acceptance_contract.py
+++ b/tests/unit/test_workspace_sync_acceptance_contract.py
@@ -884,11 +884,13 @@ async def test_source_export_target_pull_preserves_projected_workspace(
     source_service = WorkspaceSyncService(
         session=session,
         role=svc_role,
+        provider=provider,
         transport_factory=fake_vcs.transport_factory,
     )
     target_service = WorkspaceSyncService(
         session=session,
         role=target_role,
+        provider=provider,
         transport_factory=fake_vcs.transport_factory,
     )
     seed_transport = fake_vcs.transport_factory(
@@ -911,7 +913,6 @@ async def test_source_export_target_pull_preserves_projected_workspace(
     ):
         source_pull = await source_service.pull(
             options=PullOptions(commit_sha=seed_commit.sha),
-            provider=provider,
         )
         assert source_pull.success is True
         source_table = await session.scalar(
@@ -921,10 +922,9 @@ async def test_source_export_target_pull_preserves_projected_workspace(
             )
         )
         assert source_table is not None
-        with source_service._mapping_provider_scope(provider):
-            table_source_ids = await TABLE_RESOURCE_ADAPTER.source_ids_by_local_id(
-                source_service
-            )
+        table_source_ids = await TABLE_RESOURCE_ADAPTER.source_ids_by_local_id(
+            source_service
+        )
         assert table_source_ids.get(source_table.id) == "qa_indicators"
 
         first_export = await source_service.export_workspace(
@@ -940,13 +940,11 @@ async def test_source_export_target_pull_preserves_projected_workspace(
 
         first_target_pull = await target_service.pull(
             options=PullOptions(commit_sha=first_export.commit.sha),
-            provider=provider,
         )
         assert first_target_pull.success is True
         await _assert_projected_workspaces_match(
             source_service,
             target_service,
-            provider=provider,
         )
 
         # Exercise a representative update batch before the second push/pull:
@@ -960,10 +958,9 @@ async def test_source_export_target_pull_preserves_projected_workspace(
         )
         assert renamed_source_table is not None
         assert renamed_source_table.id == source_table.id
-        with source_service._mapping_provider_scope(provider):
-            renamed_table_source_ids = (
-                await TABLE_RESOURCE_ADAPTER.source_ids_by_local_id(source_service)
-            )
+        renamed_table_source_ids = await TABLE_RESOURCE_ADAPTER.source_ids_by_local_id(
+            source_service
+        )
         assert renamed_table_source_ids.get(renamed_source_table.id) == "qa_indicators"
         second_export = await source_service.export_workspace(
             WorkspaceSyncExportRequest(
@@ -975,10 +972,9 @@ async def test_source_export_target_pull_preserves_projected_workspace(
         )
         assert second_export.commit.status is PushStatus.COMMITTED
         assert second_export.commit.sha is not None
-        with source_service._mapping_provider_scope(provider):
-            source_projection = await source_service.project_workspace(
-                create_missing_mappings=False
-            )
+        source_projection = await source_service.project_workspace(
+            create_missing_mappings=False
+        )
         assert f"{TABLE_ROOT}/qa_indicators/table.yml" in source_projection.files
         assert (
             f"{TABLE_ROOT}/qa_indicators_roundtrip/table.yml"
@@ -992,14 +988,12 @@ async def test_source_export_target_pull_preserves_projected_workspace(
 
         second_target_pull = await target_service.pull(
             options=PullOptions(commit_sha=second_export.commit.sha),
-            provider=provider,
         )
 
     assert second_target_pull.success is True
     await _assert_projected_workspaces_match(
         source_service,
         target_service,
-        provider=provider,
     )
 
 
@@ -5357,20 +5351,17 @@ async def _refresh_workspace_for_fixture_cleanup(
 async def _assert_projected_workspaces_match(
     source_service: WorkspaceSyncService,
     target_service: WorkspaceSyncService,
-    *,
-    provider: VcsProvider = VcsProvider.GITHUB,
 ) -> None:
-    """Compare canonical sync files, not DB IDs or other local-only state."""
-    with (
-        source_service._mapping_provider_scope(provider),
-        target_service._mapping_provider_scope(provider),
-    ):
-        source_projection = await source_service.project_workspace(
-            create_missing_mappings=False
-        )
-        target_projection = await target_service.project_workspace(
-            create_missing_mappings=False
-        )
+    """Compare canonical sync files, not DB IDs or other local-only state.
+
+    Each service projects under the provider it was constructed with.
+    """
+    source_projection = await source_service.project_workspace(
+        create_missing_mappings=False
+    )
+    target_projection = await target_service.project_workspace(
+        create_missing_mappings=False
+    )
     assert target_projection.files == source_projection.files
 
 

--- a/tests/unit/test_workspace_sync_acceptance_contract.py
+++ b/tests/unit/test_workspace_sync_acceptance_contract.py
@@ -5391,6 +5391,7 @@ async def _assert_mapping_targets(
     resource_type: SyncResourceType,
     source_id: str,
     local_id: uuid.UUID,
+    provider: VcsProvider = VcsProvider.GITHUB,
 ) -> None:
     """Assert a sync mapping exists and points at the expected local row."""
     mapping = await _mapping_for(
@@ -5398,6 +5399,7 @@ async def _assert_mapping_targets(
         role=role,
         resource_type=resource_type,
         source_id=source_id,
+        provider=provider,
     )
     assert mapping is not None
     assert mapping.local_id == local_id

--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -1314,6 +1314,68 @@ async def test_export_workspace_commits_mapping_changes(
 
 
 @pytest.mark.anyio
+async def test_gitlab_export_uses_gitlab_transport_and_mapping_context(
+    workspace_sync_service: WorkspaceSyncService,
+) -> None:
+    projection = WorkspaceProjection(
+        manifest=WorkspaceManifest(),
+        spec=WorkspaceSpec(),
+        files={MANIFEST_FILENAME: canonical_json_text(WorkspaceManifest())},
+    )
+    transport = AsyncMock()
+    transport.write_files.return_value = CommitInfo(
+        status=PushStatus.COMMITTED,
+        sha="c" * 40,
+        ref="sync/workspace",
+        base_ref="main",
+        pr_url=None,
+        pr_number=None,
+        pr_reused=False,
+        message="Committed workspace sync changes.",
+    )
+    providers_seen: list[VcsProvider] = []
+
+    async def workspace_git_url(*, provider: VcsProvider) -> GitUrl:
+        providers_seen.append(provider)
+        return GitUrl(
+            host="gitlab.example.test",
+            org="TracecatHQ/platform",
+            repo="sync",
+        )
+
+    async def project_workspace(**_kwargs: Any) -> WorkspaceProjection:
+        assert workspace_sync_service._mapping_provider is VcsProvider.GITLAB
+        return projection
+
+    def transport_factory(
+        provider: VcsProvider,
+        *,
+        session: Any,
+        role: Any,
+    ) -> Any:
+        del session, role
+        providers_seen.append(provider)
+        return transport
+
+    workspace_sync_service._workspace_git_url = workspace_git_url
+    workspace_sync_service.project_workspace = project_workspace
+    workspace_sync_service._transport_factory = transport_factory
+
+    result = await workspace_sync_service.export_workspace(
+        WorkspaceSyncExportRequest(
+            message="Push workspace",
+            branch="sync/workspace",
+            create_pr=True,
+            provider=VcsProvider.GITLAB,
+        )
+    )
+
+    assert result.files == [MANIFEST_FILENAME]
+    assert providers_seen == [VcsProvider.GITLAB, VcsProvider.GITLAB]
+    assert workspace_sync_service._mapping_provider is VcsProvider.GITHUB
+
+
+@pytest.mark.anyio
 async def test_full_export_deletes_stale_sync_files(
     workspace_sync_service: WorkspaceSyncService,
 ) -> None:
@@ -1643,11 +1705,11 @@ async def test_github_read_files_uses_commit_tree_sha(
     assert MANIFEST_FILENAME in snapshot.files
 
 
-def test_gitlab_and_bitbucket_transports_are_explicitly_unsupported() -> None:
-    for provider in (VcsProvider.GITLAB, VcsProvider.BITBUCKET):
-        error = unsupported_transport(provider)
-        assert isinstance(error, TracecatValidationError)
-        assert provider.value in str(error)
+def test_bitbucket_transport_is_explicitly_unsupported() -> None:
+    error = unsupported_transport(VcsProvider.BITBUCKET)
+
+    assert isinstance(error, TracecatValidationError)
+    assert VcsProvider.BITBUCKET.value in str(error)
 
 
 def _legacy_workflow_yaml(source_id: str, *, title: str) -> str:

--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -1372,7 +1372,6 @@ async def test_gitlab_export_uses_gitlab_transport_and_mapping_context(
             message="Push workspace",
             branch="sync/workspace",
             create_pr=True,
-            provider=VcsProvider.GITLAB,
         )
     )
 

--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -1334,6 +1334,11 @@ async def test_gitlab_export_uses_gitlab_transport_and_mapping_context(
         message="Committed workspace sync changes.",
     )
     providers_seen: list[VcsProvider] = []
+    service = WorkspaceSyncService(
+        session=workspace_sync_service.session,
+        role=workspace_sync_service.role,
+        provider=VcsProvider.GITLAB,
+    )
 
     async def workspace_git_url(*, provider: VcsProvider) -> GitUrl:
         providers_seen.append(provider)
@@ -1344,7 +1349,8 @@ async def test_gitlab_export_uses_gitlab_transport_and_mapping_context(
         )
 
     async def project_workspace(**_kwargs: Any) -> WorkspaceProjection:
-        assert workspace_sync_service._mapping_provider is VcsProvider.GITLAB
+        # The provider is fixed at construction, so mapping reads stay on GitLab.
+        assert service._mapping_provider is VcsProvider.GITLAB
         return projection
 
     def transport_factory(
@@ -1357,11 +1363,11 @@ async def test_gitlab_export_uses_gitlab_transport_and_mapping_context(
         providers_seen.append(provider)
         return transport
 
-    workspace_sync_service._workspace_git_url = workspace_git_url
-    workspace_sync_service.project_workspace = project_workspace
-    workspace_sync_service._transport_factory = transport_factory
+    service._workspace_git_url = workspace_git_url
+    service.project_workspace = project_workspace
+    service._transport_factory = transport_factory
 
-    result = await workspace_sync_service.export_workspace(
+    result = await service.export_workspace(
         WorkspaceSyncExportRequest(
             message="Push workspace",
             branch="sync/workspace",
@@ -1372,7 +1378,7 @@ async def test_gitlab_export_uses_gitlab_transport_and_mapping_context(
 
     assert result.files == [MANIFEST_FILENAME]
     assert providers_seen == [VcsProvider.GITLAB, VcsProvider.GITLAB]
-    assert workspace_sync_service._mapping_provider is VcsProvider.GITHUB
+    assert service._mapping_provider is VcsProvider.GITLAB
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_workspace_sync_service.py
+++ b/tests/unit/test_workspace_sync_service.py
@@ -20,6 +20,7 @@ from tracecat.dsl.schemas import ActionStatement
 from tracecat.exceptions import (
     EntitlementRequired,
     ScopeDeniedError,
+    TracecatSettingsError,
     TracecatValidationError,
 )
 from tracecat.git.types import GitUrl
@@ -1340,8 +1341,8 @@ async def test_gitlab_export_uses_gitlab_transport_and_mapping_context(
         provider=VcsProvider.GITLAB,
     )
 
-    async def workspace_git_url(*, provider: VcsProvider) -> GitUrl:
-        providers_seen.append(provider)
+    async def workspace_git_url() -> GitUrl:
+        providers_seen.append(service._mapping_provider)
         return GitUrl(
             host="gitlab.example.test",
             org="TracecatHQ/platform",
@@ -1378,6 +1379,30 @@ async def test_gitlab_export_uses_gitlab_transport_and_mapping_context(
     assert result.files == [MANIFEST_FILENAME]
     assert providers_seen == [VcsProvider.GITLAB, VcsProvider.GITLAB]
     assert service._mapping_provider is VcsProvider.GITLAB
+
+
+@pytest.mark.anyio
+async def test_for_workspace_rejects_malformed_git_provider(
+    workspace_sync_service: WorkspaceSyncService,
+) -> None:
+    workspace = SimpleNamespace(settings={"git_provider": "gitlab-self-managed"})
+    workspace_service = AsyncMock()
+    workspace_service.get_workspace.return_value = workspace
+
+    with patch(
+        "tracecat.workspace_sync.service.WorkspaceService",
+        return_value=workspace_service,
+    ):
+        with pytest.raises(TracecatSettingsError) as exc_info:
+            await WorkspaceSyncService.for_workspace(
+                session=workspace_sync_service.session,
+                role=workspace_sync_service.role,
+            )
+
+    assert "Unsupported Git provider configured" in str(exc_info.value)
+    workspace_service.get_workspace.assert_awaited_once_with(
+        workspace_sync_service.role.workspace_id
+    )
 
 
 @pytest.mark.anyio

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -134,7 +134,7 @@ from tracecat.tables.service import (
     validate_identifier,
 )
 from tracecat.tiers.enums import Entitlement
-from tracecat.workspace_sync.enums import SyncResourceType, VcsProvider
+from tracecat.workspace_sync.enums import SyncResourceType
 
 
 def _normalize_filter_values(values: Any) -> list[Any]:
@@ -1420,7 +1420,7 @@ class CaseFieldsService(CustomFieldsService):
         old_field_id: str,
         new_field_id: str,
     ) -> None:
-        """Move a case-field sync mapping to the renamed schema key."""
+        """Move case-field sync mappings to the renamed schema key."""
         definition = await self.session.scalar(
             sa.select(CaseFields).where(CaseFields.workspace_id == self.workspace_id)
         )
@@ -1428,20 +1428,23 @@ class CaseFieldsService(CustomFieldsService):
             return
 
         old_local_id = uuid.uuid5(definition.id, old_field_id)
-        mapping = await self.session.scalar(
-            sa.select(WorkspaceSyncResourceMapping).where(
-                WorkspaceSyncResourceMapping.workspace_id == self.workspace_id,
-                WorkspaceSyncResourceMapping.provider == VcsProvider.GITHUB.value,
-                WorkspaceSyncResourceMapping.resource_type
-                == SyncResourceType.CASE_FIELD.value,
-                WorkspaceSyncResourceMapping.local_id == old_local_id,
+        mappings = (
+            await self.session.scalars(
+                sa.select(WorkspaceSyncResourceMapping).where(
+                    WorkspaceSyncResourceMapping.workspace_id == self.workspace_id,
+                    WorkspaceSyncResourceMapping.resource_type
+                    == SyncResourceType.CASE_FIELD.value,
+                    WorkspaceSyncResourceMapping.local_id == old_local_id,
+                )
             )
-        )
-        if mapping is None:
+        ).all()
+        if not mappings:
             return
 
-        mapping.local_id = uuid.uuid5(definition.id, new_field_id)
-        self.session.add(mapping)
+        new_local_id = uuid.uuid5(definition.id, new_field_id)
+        for mapping in mappings:
+            mapping.local_id = new_local_id
+            self.session.add(mapping)
         await self.session.flush()
 
     @require_scope("case:delete")

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -382,6 +382,10 @@ class SecretsService(BaseOrgService):
     @audit_log(resource_type="organization_secret", action="create")
     async def create_org_secret(self, params: SecretCreate) -> None:
         """Create a new organization secret."""
+        await self._create_org_secret(params)
+
+    async def _create_org_secret(self, params: SecretCreate) -> None:
+        """Create an organization secret for callers with their own access gate."""
         if params.type == SecretType.SSH_KEY:
             validate_ssh_key_values(params.keys)
         elif params.type == SecretType.MTLS:
@@ -405,6 +409,12 @@ class SecretsService(BaseOrgService):
     async def update_org_secret(
         self, secret: OrganizationSecret, params: SecretUpdate
     ) -> None:
+        await self._update_org_secret(secret=secret, params=params)
+
+    async def _update_org_secret(
+        self, secret: OrganizationSecret, params: SecretUpdate
+    ) -> None:
+        """Update an organization secret for callers with their own access gate."""
         await self._update_secret(secret=secret, params=params)
 
     @require_scope("org:secret:delete")
@@ -413,6 +423,10 @@ class SecretsService(BaseOrgService):
         action="delete",
     )
     async def delete_org_secret(self, org_secret: OrganizationSecret) -> None:
+        await self._delete_org_secret(org_secret)
+
+    async def _delete_org_secret(self, org_secret: OrganizationSecret) -> None:
+        """Delete an organization secret for callers with their own access gate."""
         await self._delete_secret(org_secret)
 
     @require_scope("org:secret:read")

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -379,11 +379,11 @@ class SecretsService(BaseOrgService):
         return await self._get_github_app_org_secret()
 
     @require_scope("org:secret:create")
-    @audit_log(resource_type="organization_secret", action="create")
     async def create_org_secret(self, params: SecretCreate) -> None:
         """Create a new organization secret."""
         await self._create_org_secret(params)
 
+    @audit_log(resource_type="organization_secret", action="create")
     async def _create_org_secret(self, params: SecretCreate) -> None:
         """Create an organization secret for callers with their own access gate."""
         if params.type == SecretType.SSH_KEY:
@@ -405,12 +405,12 @@ class SecretsService(BaseOrgService):
         await self.session.commit()
 
     @require_scope("org:secret:update")
-    @audit_log(resource_type="organization_secret", action="update")
     async def update_org_secret(
         self, secret: OrganizationSecret, params: SecretUpdate
     ) -> None:
         await self._update_org_secret(secret=secret, params=params)
 
+    @audit_log(resource_type="organization_secret", action="update")
     async def _update_org_secret(
         self, secret: OrganizationSecret, params: SecretUpdate
     ) -> None:
@@ -418,13 +418,13 @@ class SecretsService(BaseOrgService):
         await self._update_secret(secret=secret, params=params)
 
     @require_scope("org:secret:delete")
+    async def delete_org_secret(self, org_secret: OrganizationSecret) -> None:
+        await self._delete_org_secret(org_secret)
+
     @audit_log(
         resource_type="organization_secret",
         action="delete",
     )
-    async def delete_org_secret(self, org_secret: OrganizationSecret) -> None:
-        await self._delete_org_secret(org_secret)
-
     async def _delete_org_secret(self, org_secret: OrganizationSecret) -> None:
         """Delete an organization secret for callers with their own access gate."""
         await self._delete_secret(org_secret)

--- a/tracecat/vcs/exceptions.py
+++ b/tracecat/vcs/exceptions.py
@@ -1,0 +1,7 @@
+"""VCS provider exceptions."""
+
+from tracecat.exceptions import TracecatException
+
+
+class VcsProviderError(TracecatException):
+    """User-facing VCS provider operation error."""

--- a/tracecat/vcs/github/app.py
+++ b/tracecat/vcs/github/app.py
@@ -21,6 +21,7 @@ from tracecat.secrets.schemas import SecretCreate, SecretKeyValue, SecretUpdate
 from tracecat.secrets.service import SecretsService
 from tracecat.service import BaseOrgService, requires_entitlement
 from tracecat.tiers.enums import Entitlement
+from tracecat.vcs.exceptions import VcsProviderError
 from tracecat.vcs.github.schemas import (
     GitHubAppConfig,
     GitHubAppCredentials,
@@ -28,7 +29,7 @@ from tracecat.vcs.github.schemas import (
 )
 
 
-class GitHubAppError(TracecatException):
+class GitHubAppError(VcsProviderError):
     """GitHub App operation error."""
 
 

--- a/tracecat/vcs/gitlab/__init__.py
+++ b/tracecat/vcs/gitlab/__init__.py
@@ -1,0 +1,1 @@
+"""GitLab VCS integration."""

--- a/tracecat/vcs/gitlab/app.py
+++ b/tracecat/vcs/gitlab/app.py
@@ -26,6 +26,14 @@ class GitLabError(TracecatException):
     """GitLab operation error."""
 
 
+class GitLabApiError(GitLabError):
+    """GitLab REST API operation error with structured status code."""
+
+    def __init__(self, message: str, *, status_code: int, detail: Any | None = None):
+        super().__init__(message, detail=detail)
+        self.status_code = status_code
+
+
 class GitLabTokenSecretState(StrEnum):
     """State of the stored GitLab token org secret."""
 

--- a/tracecat/vcs/gitlab/app.py
+++ b/tracecat/vcs/gitlab/app.py
@@ -17,12 +17,13 @@ from tracecat.secrets.schemas import SecretCreate, SecretKeyValue, SecretUpdate
 from tracecat.secrets.service import SecretsService
 from tracecat.service import BaseOrgService, requires_entitlement
 from tracecat.tiers.enums import Entitlement
+from tracecat.vcs.exceptions import VcsProviderError
 from tracecat.vcs.gitlab.schemas import GitLabTokenCredentials
 
 GITLAB_TOKEN_SECRET_NAME = "gitlab-token-credentials"
 
 
-class GitLabError(TracecatException):
+class GitLabError(VcsProviderError):
     """GitLab operation error."""
 
 

--- a/tracecat/vcs/gitlab/app.py
+++ b/tracecat/vcs/gitlab/app.py
@@ -1,0 +1,199 @@
+"""GitLab token service for workspace sync."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from cryptography.fernet import InvalidToken
+from pydantic import SecretStr
+from pydantic import ValidationError as PydanticValidationError
+
+from tracecat.authz.controls import require_scope
+from tracecat.db.models import OrganizationSecret
+from tracecat.exceptions import TracecatException, TracecatNotFoundError
+from tracecat.secrets.enums import SecretType
+from tracecat.secrets.schemas import SecretCreate, SecretKeyValue, SecretUpdate
+from tracecat.secrets.service import SecretsService
+from tracecat.service import BaseOrgService, requires_entitlement
+from tracecat.tiers.enums import Entitlement
+from tracecat.vcs.gitlab.schemas import GitLabTokenCredentials
+
+GITLAB_TOKEN_SECRET_NAME = "gitlab-token-credentials"
+
+
+class GitLabError(TracecatException):
+    """GitLab operation error."""
+
+
+class GitLabTokenSecretState(StrEnum):
+    """State of the stored GitLab token org secret."""
+
+    MISSING = "missing"
+    VALID = "valid"
+    CORRUPTED = "corrupted"
+
+
+class GitLabTokenService(BaseOrgService):
+    """Organization-level GitLab token credentials."""
+
+    service_name = "gitlab_token"
+
+    def _build_secret_keys(
+        self,
+        *,
+        base_url: str,
+        token: SecretStr,
+    ) -> list[SecretKeyValue]:
+        credentials = GitLabTokenCredentials(base_url=base_url, token=token)
+        return [
+            SecretKeyValue(key="base_url", value=SecretStr(credentials.base_url)),
+            SecretKeyValue(key="token", value=credentials.token),
+        ]
+
+    async def _get_gitlab_token_secret_state(
+        self,
+    ) -> tuple[
+        GitLabTokenSecretState,
+        OrganizationSecret | None,
+        GitLabTokenCredentials | None,
+    ]:
+        """Classify the GitLab token secret without failing on corruption."""
+        secrets_service = SecretsService(session=self.session, role=self.role)
+        try:
+            secret = await secrets_service._get_org_secret_by_name(
+                GITLAB_TOKEN_SECRET_NAME
+            )
+        except TracecatNotFoundError:
+            return GitLabTokenSecretState.MISSING, None, None
+
+        try:
+            decrypted_keys = secrets_service.decrypt_keys(secret.encrypted_keys)
+            key_dict = {kv.key: kv.value.get_secret_value() for kv in decrypted_keys}
+            credentials = GitLabTokenCredentials.model_validate(key_dict)
+        except (InvalidToken, PydanticValidationError, ValueError) as e:
+            self.logger.warning(
+                "Stored GitLab token credentials are corrupted; allowing reconfiguration",
+                secret_id=str(secret.id),
+                error_type=type(e).__name__,
+                error=str(e),
+            )
+            return GitLabTokenSecretState.CORRUPTED, secret, None
+
+        return GitLabTokenSecretState.VALID, secret, credentials
+
+    @requires_entitlement(Entitlement.GIT_SYNC)
+    @require_scope("org:settings:update")
+    async def save_gitlab_token_credentials(
+        self,
+        *,
+        base_url: str,
+        token: SecretStr,
+    ) -> tuple[GitLabTokenCredentials, bool]:
+        """Save GitLab token credentials, replacing corrupt values when needed."""
+        credentials = GitLabTokenCredentials(base_url=base_url, token=token)
+        secret_state, secret, _existing = await self._get_gitlab_token_secret_state()
+        secret_keys = self._build_secret_keys(
+            base_url=credentials.base_url,
+            token=credentials.token,
+        )
+        secrets_service = SecretsService(session=self.session, role=self.role)
+
+        match secret_state:
+            case GitLabTokenSecretState.MISSING:
+                await secrets_service.create_org_secret(
+                    SecretCreate(
+                        name=GITLAB_TOKEN_SECRET_NAME,
+                        type=SecretType.CUSTOM,
+                        description="GitLab token credentials for workspace synchronization",
+                        keys=secret_keys,
+                        tags={"purpose": "gitlab-token", "provider": "gitlab"},
+                    )
+                )
+                self.logger.info("Created GitLab token credentials")
+                return credentials, True
+            case GitLabTokenSecretState.VALID | GitLabTokenSecretState.CORRUPTED:
+                if secret is None:
+                    raise GitLabError(
+                        "Stored GitLab token credentials could not be recovered."
+                    )
+                await secrets_service.update_org_secret(
+                    secret,
+                    SecretUpdate(keys=secret_keys),
+                )
+                self.logger.info(
+                    "Updated GitLab token credentials",
+                    recovered_corrupted=secret_state
+                    is GitLabTokenSecretState.CORRUPTED,
+                )
+                return credentials, False
+
+        raise GitLabError("Failed to save GitLab token credentials")
+
+    @requires_entitlement(Entitlement.GIT_SYNC)
+    @require_scope("org:settings:delete")
+    async def delete_gitlab_token_credentials(self) -> None:
+        """Delete GitLab token credentials for the organization."""
+        try:
+            secrets_service = SecretsService(session=self.session, role=self.role)
+            secret = await secrets_service.get_org_secret_by_name(
+                GITLAB_TOKEN_SECRET_NAME
+            )
+            await secrets_service.delete_org_secret(secret)
+            self.logger.info("Deleted GitLab token credentials")
+        except TracecatNotFoundError as e:
+            raise GitLabError(
+                "Failed to delete GitLab token credentials: credentials not found"
+            ) from e
+        except TracecatException as e:
+            raise GitLabError("Failed to delete GitLab token credentials") from e
+
+    @requires_entitlement(Entitlement.GIT_SYNC)
+    async def get_gitlab_token_credentials_status(self) -> dict[str, Any]:
+        """Return GitLab credential status without exposing the token."""
+        secret_state, secret, credentials = await self._get_gitlab_token_secret_state()
+        match secret_state:
+            case GitLabTokenSecretState.VALID if secret and credentials:
+                return {
+                    "exists": True,
+                    "is_corrupted": False,
+                    "base_url": credentials.base_url,
+                    "created_at": secret.created_at.isoformat()
+                    if secret.created_at
+                    else None,
+                }
+            case GitLabTokenSecretState.CORRUPTED if secret:
+                return {
+                    "exists": True,
+                    "is_corrupted": True,
+                    "base_url": None,
+                    "created_at": secret.created_at.isoformat()
+                    if secret.created_at
+                    else None,
+                }
+            case _:
+                return {
+                    "exists": False,
+                    "is_corrupted": False,
+                    "base_url": None,
+                    "created_at": None,
+                }
+
+    @requires_entitlement(Entitlement.GIT_SYNC)
+    @require_scope("workflow:sync", "workspace_sync:sync", require_all=False)
+    async def get_gitlab_token_credentials(self) -> GitLabTokenCredentials:
+        """Retrieve GitLab credentials for workspace sync API calls."""
+        secret_state, _secret, credentials = await self._get_gitlab_token_secret_state()
+        match secret_state:
+            case GitLabTokenSecretState.MISSING:
+                raise GitLabError(
+                    "Failed to retrieve GitLab token credentials: credentials not found"
+                )
+            case GitLabTokenSecretState.CORRUPTED:
+                raise GitLabError(
+                    "Failed to retrieve GitLab token credentials: invalid credential data"
+                )
+            case GitLabTokenSecretState.VALID if credentials:
+                return credentials
+
+        raise GitLabError("Failed to retrieve GitLab token credentials")

--- a/tracecat/vcs/gitlab/app.py
+++ b/tracecat/vcs/gitlab/app.py
@@ -109,7 +109,7 @@ class GitLabTokenService(BaseOrgService):
 
         match secret_state:
             case GitLabTokenSecretState.MISSING:
-                await secrets_service.create_org_secret(
+                await secrets_service._create_org_secret(
                     SecretCreate(
                         name=GITLAB_TOKEN_SECRET_NAME,
                         type=SecretType.CUSTOM,
@@ -125,7 +125,7 @@ class GitLabTokenService(BaseOrgService):
                     raise GitLabError(
                         "Stored GitLab token credentials could not be recovered."
                     )
-                await secrets_service.update_org_secret(
+                await secrets_service._update_org_secret(
                     secret,
                     SecretUpdate(keys=secret_keys),
                 )
@@ -144,10 +144,10 @@ class GitLabTokenService(BaseOrgService):
         """Delete GitLab token credentials for the organization."""
         try:
             secrets_service = SecretsService(session=self.session, role=self.role)
-            secret = await secrets_service.get_org_secret_by_name(
+            secret = await secrets_service._get_org_secret_by_name(
                 GITLAB_TOKEN_SECRET_NAME
             )
-            await secrets_service.delete_org_secret(secret)
+            await secrets_service._delete_org_secret(secret)
             self.logger.info("Deleted GitLab token credentials")
         except TracecatNotFoundError as e:
             raise GitLabError(
@@ -157,6 +157,7 @@ class GitLabTokenService(BaseOrgService):
             raise GitLabError("Failed to delete GitLab token credentials") from e
 
     @requires_entitlement(Entitlement.GIT_SYNC)
+    @require_scope("org:settings:read")
     async def get_gitlab_token_credentials_status(self) -> dict[str, Any]:
         """Return GitLab credential status without exposing the token."""
         secret_state, secret, credentials = await self._get_gitlab_token_secret_state()

--- a/tracecat/vcs/gitlab/schemas.py
+++ b/tracecat/vcs/gitlab/schemas.py
@@ -1,0 +1,28 @@
+"""GitLab token credential models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, SecretStr, field_validator
+
+
+class GitLabTokenCredentials(BaseModel):
+    """GitLab REST API credentials for organization-level workspace sync."""
+
+    base_url: str = Field(
+        default="https://gitlab.com",
+        description="Base URL for GitLab.com or a self-managed GitLab instance.",
+    )
+    token: SecretStr = Field(
+        ...,
+        description="GitLab personal/project/group access token with api scope.",
+    )
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, value: str) -> str:
+        cleaned = value.strip().rstrip("/")
+        if not cleaned:
+            raise ValueError("GitLab base URL is required.")
+        if not cleaned.startswith(("https://", "http://")):
+            raise ValueError("GitLab base URL must start with http:// or https://.")
+        return cleaned

--- a/tracecat/vcs/gitlab/types.py
+++ b/tracecat/vcs/gitlab/types.py
@@ -1,0 +1,116 @@
+"""Typed payloads for the GitLab REST API."""
+
+from __future__ import annotations
+
+from typing import Literal, NotRequired, TypedDict
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class GitLabListCommitsParams(TypedDict):
+    """Query params for listing commits on a branch."""
+
+    ref_name: str
+
+
+class GitLabTreeParams(TypedDict):
+    """Query params for listing a repository tree."""
+
+    recursive: str
+    ref: str
+
+
+class GitLabCreateBranchParams(TypedDict):
+    """Query params for creating a branch."""
+
+    branch: str
+    ref: str
+
+
+class GitLabListMergeRequestsParams(TypedDict):
+    """Query params for finding open merge requests between two branches."""
+
+    state: Literal["opened"]
+    source_branch: str
+    target_branch: str
+
+
+class GitLabCreateMergeRequestPayload(TypedDict):
+    """JSON body for creating a merge request."""
+
+    source_branch: str
+    target_branch: str
+    title: str
+    description: str
+
+
+GitLabCompareParams = TypedDict("GitLabCompareParams", {"from": str, "to": str})
+"""Query params for comparing two refs (``from`` is a Python keyword)."""
+
+
+class GitLabCommitAction(TypedDict):
+    """A single file action in a GitLab commit-actions payload."""
+
+    action: Literal["create", "update", "delete"]
+    file_path: str
+    content: NotRequired[str]
+
+
+class GitLabCreateCommitPayload(TypedDict):
+    """JSON body for creating a commit via the commit-actions API."""
+
+    branch: str
+    commit_message: str
+    actions: list[GitLabCommitAction]
+
+
+class GitLabCommit(BaseModel):
+    """A GitLab commit, as returned by commit, compare, and create endpoints."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(min_length=1)
+    short_id: str | None = None
+    title: str | None = None
+    message: str | None = None
+    author_name: str | None = None
+    author_email: str | None = None
+    authored_date: str | None = None
+    committed_date: str | None = None
+    created_at: str | None = None
+
+
+class GitLabTreeEntry(BaseModel):
+    """A single entry in a GitLab repository tree listing."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(min_length=1)
+    path: str = Field(min_length=1)
+    type: str | None = None
+
+
+class GitLabBranch(BaseModel):
+    """A GitLab repository branch."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str = Field(min_length=1)
+    default: bool = False
+
+
+class GitLabMergeRequest(BaseModel):
+    """A GitLab merge request."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    iid: int
+    web_url: str | None = None
+
+
+class GitLabCompareResult(BaseModel):
+    """A GitLab branch comparison."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    commits: list[GitLabCommit] = Field(default_factory=list)

--- a/tracecat/vcs/gitlab/types.py
+++ b/tracecat/vcs/gitlab/types.py
@@ -99,6 +99,14 @@ class GitLabBranch(BaseModel):
     default: bool = False
 
 
+class GitLabProject(BaseModel):
+    """A GitLab project."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    default_branch: str | None = None
+
+
 class GitLabMergeRequest(BaseModel):
     """A GitLab merge request."""
 

--- a/tracecat/vcs/router.py
+++ b/tracecat/vcs/router.py
@@ -14,9 +14,11 @@ from tracecat.vcs.github.manifest import generate_github_app_manifest
 from tracecat.vcs.gitlab.app import GitLabError, GitLabTokenService
 from tracecat.vcs.schemas import (
     GitHubAppCredentialsRequest,
+    GitHubAppCredentialsSaveResponse,
     GitHubAppCredentialsStatus,
     GitHubAppManifestResponse,
     GitLabTokenCredentialsRequest,
+    GitLabTokenCredentialsSaveResponse,
     GitLabTokenCredentialsStatus,
 )
 
@@ -128,14 +130,18 @@ async def github_webhook(*, payload: dict[str, Any]) -> dict[str, str]:
         ) from e
 
 
-@github_router.post("/credentials", status_code=status.HTTP_201_CREATED)
+@github_router.post(
+    "/credentials",
+    status_code=status.HTTP_201_CREATED,
+    response_model=GitHubAppCredentialsSaveResponse,
+)
 @require_scope("org:settings:update")
 async def save_github_app_credentials(
     *,
     session: AsyncDBSession,
     role: OrgUserRole,
     request: GitHubAppCredentialsRequest,
-) -> dict[str, str]:
+) -> GitHubAppCredentialsSaveResponse:
     """Save GitHub App credentials (register new or update existing)."""
     # Organization-level operation, no specific checks needed since this is org VCS
     try:
@@ -153,11 +159,11 @@ async def save_github_app_credentials(
             app_id=request.app_id,
         )
 
-        return {
-            "message": f"GitHub App credentials {action} successfully",
-            "action": action,
-            "app_id": config.app_id or request.app_id,
-        }
+        return GitHubAppCredentialsSaveResponse(
+            message=f"GitHub App credentials {action} successfully",
+            action=action,
+            app_id=config.app_id or request.app_id,
+        )
 
     except GitHubAppError as e:
         logger.error(
@@ -233,14 +239,18 @@ async def get_github_app_credentials_status(
         ) from e
 
 
-@gitlab_router.post("/credentials", status_code=status.HTTP_201_CREATED)
+@gitlab_router.post(
+    "/credentials",
+    status_code=status.HTTP_201_CREATED,
+    response_model=GitLabTokenCredentialsSaveResponse,
+)
 @require_scope("org:settings:update")
 async def save_gitlab_token_credentials(
     *,
     session: AsyncDBSession,
     role: OrgUserRole,
     request: GitLabTokenCredentialsRequest,
-) -> dict[str, str]:
+) -> GitLabTokenCredentialsSaveResponse:
     """Save GitLab token credentials (create if new or update existing)."""
     try:
         gitlab_service = GitLabTokenService(session=session, role=role)
@@ -249,11 +259,11 @@ async def save_gitlab_token_credentials(
             token=request.token,
         )
         action = "created" if was_created else "updated"
-        return {
-            "message": f"GitLab token credentials {action} successfully",
-            "action": action,
-            "base_url": credentials.base_url,
-        }
+        return GitLabTokenCredentialsSaveResponse(
+            message=f"GitLab token credentials {action} successfully",
+            action=action,
+            base_url=credentials.base_url,
+        )
     except (GitLabError, ValueError) as e:
         logger.error("Failed to save GitLab token credentials", error=str(e))
         raise HTTPException(

--- a/tracecat/vcs/router.py
+++ b/tracecat/vcs/router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException, Query, status
 from tracecat.auth.dependencies import OrgUserRole
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
+from tracecat.exceptions import EntitlementRequired
 from tracecat.logger import logger
 from tracecat.vcs.github.app import GitHubAppError, GitHubAppService
 from tracecat.vcs.github.flows import handle_manifest_conversion
@@ -270,6 +271,8 @@ async def save_gitlab_token_credentials(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to save GitLab token credentials: {str(e)}",
         ) from e
+    except EntitlementRequired:
+        raise
     except Exception as e:
         logger.error(
             "Error saving GitLab token credentials",
@@ -299,6 +302,8 @@ async def delete_gitlab_token_credentials(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to delete GitLab token credentials: {str(e)}",
         ) from e
+    except EntitlementRequired:
+        raise
     except Exception as e:
         logger.error("Error deleting GitLab token credentials", error=str(e))
         raise HTTPException(
@@ -319,6 +324,8 @@ async def get_gitlab_token_credentials_status(
         gitlab_service = GitLabTokenService(session=session, role=role)
         status_data = await gitlab_service.get_gitlab_token_credentials_status()
         return GitLabTokenCredentialsStatus(**status_data)
+    except EntitlementRequired:
+        raise
     except Exception as e:
         logger.error(
             "Error getting GitLab token credentials status",

--- a/tracecat/vcs/router.py
+++ b/tracecat/vcs/router.py
@@ -11,10 +11,13 @@ from tracecat.logger import logger
 from tracecat.vcs.github.app import GitHubAppError, GitHubAppService
 from tracecat.vcs.github.flows import handle_manifest_conversion
 from tracecat.vcs.github.manifest import generate_github_app_manifest
+from tracecat.vcs.gitlab.app import GitLabError, GitLabTokenService
 from tracecat.vcs.schemas import (
     GitHubAppCredentialsRequest,
     GitHubAppCredentialsStatus,
     GitHubAppManifestResponse,
+    GitLabTokenCredentialsRequest,
+    GitLabTokenCredentialsStatus,
 )
 
 org_router = APIRouter(prefix="/organization/vcs", tags=["vcs", "organization"])
@@ -22,6 +25,9 @@ org_router = APIRouter(prefix="/organization/vcs", tags=["vcs", "organization"])
 
 github_router = APIRouter(prefix="/github", tags=["vcs", "github", "organization"])
 """Manage GitHub App for organization-level features."""
+
+gitlab_router = APIRouter(prefix="/gitlab", tags=["vcs", "gitlab", "organization"])
+"""Manage GitLab token credentials for organization-level features."""
 
 
 @github_router.get("/manifest", response_model=GitHubAppManifestResponse)
@@ -227,5 +233,96 @@ async def get_github_app_credentials_status(
         ) from e
 
 
-# Mount GitHub sub-router to organization VCS router after all endpoints are defined
+@gitlab_router.post("/credentials", status_code=status.HTTP_201_CREATED)
+@require_scope("org:settings:update")
+async def save_gitlab_token_credentials(
+    *,
+    session: AsyncDBSession,
+    role: OrgUserRole,
+    request: GitLabTokenCredentialsRequest,
+) -> dict[str, str]:
+    """Save GitLab token credentials (create if new or update existing)."""
+    try:
+        gitlab_service = GitLabTokenService(session=session, role=role)
+        credentials, was_created = (
+            await gitlab_service.save_gitlab_token_credentials(
+                base_url=request.base_url,
+                token=request.token,
+            )
+        )
+        action = "created" if was_created else "updated"
+        return {
+            "message": f"GitLab token credentials {action} successfully",
+            "action": action,
+            "base_url": credentials.base_url,
+        }
+    except (GitLabError, ValueError) as e:
+        logger.error("Failed to save GitLab token credentials", error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Failed to save GitLab token credentials: {str(e)}",
+        ) from e
+    except Exception as e:
+        logger.error(
+            "Error saving GitLab token credentials",
+            error_type=type(e).__name__,
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error while saving credentials",
+        ) from e
+
+
+@gitlab_router.delete("/credentials", status_code=status.HTTP_204_NO_CONTENT)
+@require_scope("org:settings:delete")
+async def delete_gitlab_token_credentials(
+    *,
+    session: AsyncDBSession,
+    role: OrgUserRole,
+) -> None:
+    """Delete GitLab token credentials."""
+    try:
+        gitlab_service = GitLabTokenService(session=session, role=role)
+        await gitlab_service.delete_gitlab_token_credentials()
+    except GitLabError as e:
+        logger.error("Failed to delete GitLab token credentials", error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Failed to delete GitLab token credentials: {str(e)}",
+        ) from e
+    except Exception as e:
+        logger.error("Error deleting GitLab token credentials", error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error while deleting credentials",
+        ) from e
+
+
+@gitlab_router.get("/credentials/status", response_model=GitLabTokenCredentialsStatus)
+@require_scope("org:settings:read")
+async def get_gitlab_token_credentials_status(
+    *,
+    session: AsyncDBSession,
+    role: OrgUserRole,
+) -> GitLabTokenCredentialsStatus:
+    """Get the status of GitLab token credentials."""
+    try:
+        gitlab_service = GitLabTokenService(session=session, role=role)
+        status_data = await gitlab_service.get_gitlab_token_credentials_status()
+        return GitLabTokenCredentialsStatus(**status_data)
+    except Exception as e:
+        logger.error(
+            "Error getting GitLab token credentials status",
+            error_type=type(e).__name__,
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error while getting credentials status",
+        ) from e
+
+
+# Mount VCS sub-routers after all endpoints are defined.
 org_router.include_router(github_router)
+org_router.include_router(gitlab_router)

--- a/tracecat/vcs/router.py
+++ b/tracecat/vcs/router.py
@@ -244,11 +244,9 @@ async def save_gitlab_token_credentials(
     """Save GitLab token credentials (create if new or update existing)."""
     try:
         gitlab_service = GitLabTokenService(session=session, role=role)
-        credentials, was_created = (
-            await gitlab_service.save_gitlab_token_credentials(
-                base_url=request.base_url,
-                token=request.token,
-            )
+        credentials, was_created = await gitlab_service.save_gitlab_token_credentials(
+            base_url=request.base_url,
+            token=request.token,
         )
         action = "created" if was_created else "updated"
         return {

--- a/tracecat/vcs/schemas.py
+++ b/tracecat/vcs/schemas.py
@@ -43,3 +43,25 @@ class GitHubAppManifestResponse(BaseModel):
 
     manifest: GitHubAppManifest
     instructions: list[str]
+
+
+class GitLabTokenCredentialsRequest(BaseModel):
+    """Request to register or update GitLab token credentials."""
+
+    base_url: str = Field(
+        default="https://gitlab.com",
+        description="Base URL for GitLab.com or a self-managed GitLab instance.",
+    )
+    token: SecretStr = Field(
+        ...,
+        description="GitLab personal/project/group access token with api scope.",
+    )
+
+
+class GitLabTokenCredentialsStatus(BaseModel):
+    """Status of GitLab token credentials."""
+
+    exists: bool
+    is_corrupted: bool = False
+    base_url: str | None = None
+    created_at: str | None = None

--- a/tracecat/vcs/schemas.py
+++ b/tracecat/vcs/schemas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, Field, SecretStr
 
 from tracecat.vcs.github.manifest import GitHubAppManifest
@@ -45,6 +47,14 @@ class GitHubAppManifestResponse(BaseModel):
     instructions: list[str]
 
 
+class GitHubAppCredentialsSaveResponse(BaseModel):
+    """Response after creating or updating GitHub App credentials."""
+
+    message: str
+    action: Literal["created", "updated"]
+    app_id: str
+
+
 class GitLabTokenCredentialsRequest(BaseModel):
     """Request to register or update GitLab token credentials."""
 
@@ -65,3 +75,11 @@ class GitLabTokenCredentialsStatus(BaseModel):
     is_corrupted: bool = False
     base_url: str | None = None
     created_at: str | None = None
+
+
+class GitLabTokenCredentialsSaveResponse(BaseModel):
+    """Response after creating or updating GitLab token credentials."""
+
+    message: str
+    action: Literal["created", "updated"]
+    base_url: str

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -26,7 +26,6 @@ from tracecat.workflow.store.schemas import (
     WorkflowSyncPullRequest,
 )
 from tracecat.workflow.store.service import WorkflowStoreService
-from tracecat.workspace_sync.enums import VcsProvider
 from tracecat.workspace_sync.schemas import (
     WorkspaceSyncExportPreview,
     WorkspaceSyncExportPreviewRequest,
@@ -138,10 +137,6 @@ async def list_workflow_commits(
         ge=config.TRACECAT__LIMIT_MIN,
         le=config.TRACECAT__LIMIT_CURSOR_MAX,
     ),
-    provider: VcsProvider = Query(
-        default=VcsProvider.GITHUB,
-        description="VCS provider for the configured repository.",
-    ),
 ) -> list[GitCommitInfo]:
     """Get commit list for the configured workspace repository.
 
@@ -155,8 +150,8 @@ async def list_workflow_commits(
         )
 
     try:
-        sync_service = WorkspaceSyncService(
-            session=session, role=role, provider=provider
+        sync_service = await WorkspaceSyncService.for_workspace(
+            session=session, role=role
         )
         return await sync_service.list_commits(
             branch=branch,
@@ -202,10 +197,6 @@ async def list_workflow_branches(
         ge=config.TRACECAT__LIMIT_MIN,
         le=config.TRACECAT__LIMIT_CURSOR_MAX,
     ),
-    provider: VcsProvider = Query(
-        default=VcsProvider.GITHUB,
-        description="VCS provider for the configured repository.",
-    ),
 ) -> list[GitBranchInfo]:
     """Get branch list for the configured workspace repository."""
     if not role.workspace_id:
@@ -215,8 +206,8 @@ async def list_workflow_branches(
         )
 
     try:
-        sync_service = WorkspaceSyncService(
-            session=session, role=role, provider=provider
+        sync_service = await WorkspaceSyncService.for_workspace(
+            session=session, role=role
         )
         return await sync_service.list_branches(limit=limit)
     except HTTPException:
@@ -261,9 +252,7 @@ async def export_workspace_sync(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Workspace ID is required",
         )
-    sync_service = WorkspaceSyncService(
-        session=session, role=role, provider=params.provider
-    )
+    sync_service = await WorkspaceSyncService.for_workspace(session=session, role=role)
     try:
         return await sync_service.export_workspace(params)
     except TracecatNotFoundError as e:
@@ -296,9 +285,7 @@ async def preview_export_workspace_sync(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Workspace ID is required",
         )
-    sync_service = WorkspaceSyncService(
-        session=session, role=role, provider=params.provider
-    )
+    sync_service = await WorkspaceSyncService.for_workspace(session=session, role=role)
     try:
         return await sync_service.preview_export_workspace(params)
     except TracecatNotFoundError as e:
@@ -342,8 +329,8 @@ async def pull_workflows(
             commit_sha=params.commit_sha,
             dry_run=params.dry_run,
         )
-        sync_service = WorkspaceSyncService(
-            session=session, role=role, provider=params.provider
+        sync_service = await WorkspaceSyncService.for_workspace(
+            session=session, role=role
         )
         return await sync_service.pull(
             options=pull_options,

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -18,6 +18,7 @@ from tracecat.registry.repositories.schemas import GitBranchInfo, GitCommitInfo
 from tracecat.sync import PullOptions, PullResult
 from tracecat.vcs.github.app import GitHubAppError, GitHubAppService
 from tracecat.vcs.github.schemas import GitHubAppRepository
+from tracecat.vcs.gitlab.app import GitLabError
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.store.schemas import (
     WorkflowDslPublish,
@@ -32,6 +33,7 @@ from tracecat.workspace_sync.schemas import (
     WorkspaceSyncExportResult,
 )
 from tracecat.workspace_sync.service import WorkspaceSyncService
+from tracecat.workspace_sync.enums import VcsProvider
 
 router = APIRouter(prefix="/workflows", tags=["workflows"])
 
@@ -136,8 +138,12 @@ async def list_workflow_commits(
         ge=config.TRACECAT__LIMIT_MIN,
         le=config.TRACECAT__LIMIT_CURSOR_MAX,
     ),
+    provider: VcsProvider = Query(
+        default=VcsProvider.GITHUB,
+        description="VCS provider for the configured repository.",
+    ),
 ) -> list[GitCommitInfo]:
-    """Get commit list for workflow repository via GitHub App.
+    """Get commit list for the configured workspace repository.
 
     Returns a list of commits from the repository configured in workspace settings,
     suitable for use in workflow pull operations.
@@ -153,6 +159,7 @@ async def list_workflow_commits(
         return await sync_service.list_commits(
             branch=branch,
             limit=limit,
+            provider=provider,
         )
     except HTTPException:
         raise
@@ -161,7 +168,12 @@ async def list_workflow_commits(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         ) from e
-    except (TracecatSettingsError, TracecatValidationError, GitHubAppError) as e:
+    except (
+        TracecatSettingsError,
+        TracecatValidationError,
+        GitHubAppError,
+        GitLabError,
+    ) as e:
         logger.error("Git sync error fetching commits", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -189,8 +201,12 @@ async def list_workflow_branches(
         ge=config.TRACECAT__LIMIT_MIN,
         le=config.TRACECAT__LIMIT_CURSOR_MAX,
     ),
+    provider: VcsProvider = Query(
+        default=VcsProvider.GITHUB,
+        description="VCS provider for the configured repository.",
+    ),
 ) -> list[GitBranchInfo]:
-    """Get branch list for workflow repository via GitHub App."""
+    """Get branch list for the configured workspace repository."""
     if not role.workspace_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -199,7 +215,7 @@ async def list_workflow_branches(
 
     try:
         sync_service = WorkspaceSyncService(session=session, role=role)
-        return await sync_service.list_branches(limit=limit)
+        return await sync_service.list_branches(limit=limit, provider=provider)
     except HTTPException:
         raise
     except TracecatNotFoundError as e:
@@ -207,7 +223,12 @@ async def list_workflow_branches(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         ) from e
-    except (TracecatSettingsError, TracecatValidationError, GitHubAppError) as e:
+    except (
+        TracecatSettingsError,
+        TracecatValidationError,
+        GitHubAppError,
+        GitLabError,
+    ) as e:
         logger.error("Git sync error fetching branches", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -245,7 +266,12 @@ async def export_workspace_sync(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         ) from e
-    except (TracecatSettingsError, TracecatValidationError, GitHubAppError) as e:
+    except (
+        TracecatSettingsError,
+        TracecatValidationError,
+        GitHubAppError,
+        GitLabError,
+    ) as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
@@ -273,7 +299,12 @@ async def preview_export_workspace_sync(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         ) from e
-    except (TracecatSettingsError, TracecatValidationError, GitHubAppError) as e:
+    except (
+        TracecatSettingsError,
+        TracecatValidationError,
+        GitHubAppError,
+        GitLabError,
+    ) as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
@@ -323,7 +354,12 @@ async def pull_workflows(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         ) from e
-    except (TracecatSettingsError, TracecatValidationError, GitHubAppError) as e:
+    except (
+        TracecatSettingsError,
+        TracecatValidationError,
+        GitHubAppError,
+        GitLabError,
+    ) as e:
         logger.error("Git sync error during workflow pull", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -26,6 +26,7 @@ from tracecat.workflow.store.schemas import (
     WorkflowSyncPullRequest,
 )
 from tracecat.workflow.store.service import WorkflowStoreService
+from tracecat.workspace_sync.enums import VcsProvider
 from tracecat.workspace_sync.schemas import (
     WorkspaceSyncExportPreview,
     WorkspaceSyncExportPreviewRequest,
@@ -33,7 +34,6 @@ from tracecat.workspace_sync.schemas import (
     WorkspaceSyncExportResult,
 )
 from tracecat.workspace_sync.service import WorkspaceSyncService
-from tracecat.workspace_sync.enums import VcsProvider
 
 router = APIRouter(prefix="/workflows", tags=["workflows"])
 

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -155,11 +155,12 @@ async def list_workflow_commits(
         )
 
     try:
-        sync_service = WorkspaceSyncService(session=session, role=role)
+        sync_service = WorkspaceSyncService(
+            session=session, role=role, provider=provider
+        )
         return await sync_service.list_commits(
             branch=branch,
             limit=limit,
-            provider=provider,
         )
     except HTTPException:
         raise
@@ -214,8 +215,10 @@ async def list_workflow_branches(
         )
 
     try:
-        sync_service = WorkspaceSyncService(session=session, role=role)
-        return await sync_service.list_branches(limit=limit, provider=provider)
+        sync_service = WorkspaceSyncService(
+            session=session, role=role, provider=provider
+        )
+        return await sync_service.list_branches(limit=limit)
     except HTTPException:
         raise
     except TracecatNotFoundError as e:
@@ -258,7 +261,9 @@ async def export_workspace_sync(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Workspace ID is required",
         )
-    sync_service = WorkspaceSyncService(session=session, role=role)
+    sync_service = WorkspaceSyncService(
+        session=session, role=role, provider=params.provider
+    )
     try:
         return await sync_service.export_workspace(params)
     except TracecatNotFoundError as e:
@@ -291,7 +296,9 @@ async def preview_export_workspace_sync(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Workspace ID is required",
         )
-    sync_service = WorkspaceSyncService(session=session, role=role)
+    sync_service = WorkspaceSyncService(
+        session=session, role=role, provider=params.provider
+    )
     try:
         return await sync_service.preview_export_workspace(params)
     except TracecatNotFoundError as e:
@@ -335,10 +342,11 @@ async def pull_workflows(
             commit_sha=params.commit_sha,
             dry_run=params.dry_run,
         )
-        sync_service = WorkspaceSyncService(session=session, role=role)
+        sync_service = WorkspaceSyncService(
+            session=session, role=role, provider=params.provider
+        )
         return await sync_service.pull(
             options=pull_options,
-            provider=params.provider,
             sync_schedules=params.sync_schedules,
         )
     except ValueError as e:

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -16,9 +16,9 @@ from tracecat.identifiers.workflow import AnyWorkflowIDPath
 from tracecat.logger import logger
 from tracecat.registry.repositories.schemas import GitBranchInfo, GitCommitInfo
 from tracecat.sync import PullOptions, PullResult
+from tracecat.vcs.exceptions import VcsProviderError
 from tracecat.vcs.github.app import GitHubAppError, GitHubAppService
 from tracecat.vcs.github.schemas import GitHubAppRepository
-from tracecat.vcs.gitlab.app import GitLabError
 from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.store.schemas import (
     WorkflowDslPublish,
@@ -86,7 +86,7 @@ async def publish_workflow(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         ) from e
-    except GitHubAppError as e:
+    except VcsProviderError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
@@ -167,8 +167,7 @@ async def list_workflow_commits(
     except (
         TracecatSettingsError,
         TracecatValidationError,
-        GitHubAppError,
-        GitLabError,
+        VcsProviderError,
     ) as e:
         logger.error("Git sync error fetching commits", exc_info=True)
         raise HTTPException(
@@ -220,8 +219,7 @@ async def list_workflow_branches(
     except (
         TracecatSettingsError,
         TracecatValidationError,
-        GitHubAppError,
-        GitLabError,
+        VcsProviderError,
     ) as e:
         logger.error("Git sync error fetching branches", exc_info=True)
         raise HTTPException(
@@ -265,8 +263,7 @@ async def export_workspace_sync(
     except (
         TracecatSettingsError,
         TracecatValidationError,
-        GitHubAppError,
-        GitLabError,
+        VcsProviderError,
     ) as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -300,8 +297,7 @@ async def preview_export_workspace_sync(
     except (
         TracecatSettingsError,
         TracecatValidationError,
-        GitHubAppError,
-        GitLabError,
+        VcsProviderError,
     ) as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -356,8 +352,7 @@ async def pull_workflows(
     except (
         TracecatSettingsError,
         TracecatValidationError,
-        GitHubAppError,
-        GitLabError,
+        VcsProviderError,
     ) as e:
         logger.error("Git sync error during workflow pull", exc_info=True)
         raise HTTPException(

--- a/tracecat/workflow/store/router.py
+++ b/tracecat/workflow/store/router.py
@@ -252,8 +252,10 @@ async def export_workspace_sync(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Workspace ID is required",
         )
-    sync_service = await WorkspaceSyncService.for_workspace(session=session, role=role)
     try:
+        sync_service = await WorkspaceSyncService.for_workspace(
+            session=session, role=role
+        )
         return await sync_service.export_workspace(params)
     except TracecatNotFoundError as e:
         raise HTTPException(
@@ -285,8 +287,10 @@ async def preview_export_workspace_sync(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Workspace ID is required",
         )
-    sync_service = await WorkspaceSyncService.for_workspace(session=session, role=role)
     try:
+        sync_service = await WorkspaceSyncService.for_workspace(
+            session=session, role=role
+        )
         return await sync_service.preview_export_workspace(params)
     except TracecatNotFoundError as e:
         raise HTTPException(

--- a/tracecat/workflow/store/schemas.py
+++ b/tracecat/workflow/store/schemas.py
@@ -14,7 +14,6 @@ from tracecat.cases.enums import CaseEventType
 from tracecat.dsl.common import DSLInput
 from tracecat.identifiers.workflow import WorkflowID, WorkflowIDShort
 from tracecat.store import Source
-from tracecat.workspace_sync.enums import VcsProvider
 
 # TODO(deps): This is only supported starting pydantic 2.11+
 WorkflowSource = Source[WorkflowID]
@@ -96,11 +95,6 @@ class WorkflowSyncPullRequest(BaseModel):
     sync_schedules: bool = Field(
         default=False,
         description="Apply schedule definitions from Git. Defaults off to preserve destination schedules.",
-    )
-
-    provider: VcsProvider = Field(
-        default=VcsProvider.GITHUB,
-        description="VCS provider for the configured repository.",
     )
 
 

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -82,7 +82,9 @@ class WorkflowStoreService(BaseWorkspaceService):
             include_schedules=False,
         )
 
-        sync_service = WorkspaceSyncService(session=self.session, role=self.role)
+        sync_service = WorkspaceSyncService(
+            session=self.session, role=self.role, provider=export_params.provider
+        )
         export_result = await sync_service.export_workflow(
             workflow=workflow,
             dsl=dsl,

--- a/tracecat/workflow/store/service.py
+++ b/tracecat/workflow/store/service.py
@@ -82,8 +82,8 @@ class WorkflowStoreService(BaseWorkspaceService):
             include_schedules=False,
         )
 
-        sync_service = WorkspaceSyncService(
-            session=self.session, role=self.role, provider=export_params.provider
+        sync_service = await WorkspaceSyncService.for_workspace(
+            session=self.session, role=self.role
         )
         export_result = await sync_service.export_workflow(
             workflow=workflow,

--- a/tracecat/workspace_sync/adapters/__init__.py
+++ b/tracecat/workspace_sync/adapters/__init__.py
@@ -17,6 +17,7 @@ from tracecat.workspace_sync.adapters.base import (
     ProjectedResource,
     ResourceAdapter,
     ResourceProjection,
+    SyncMappingService,
 )
 from tracecat.workspace_sync.adapters.registry import (
     AGENT_PRESET_RESOURCE_ADAPTER,
@@ -58,5 +59,6 @@ __all__ = [
     "ProjectedResource",
     "ResourceAdapter",
     "ResourceProjection",
+    "SyncMappingService",
     "workspace_spec_from_maps",
 ]

--- a/tracecat/workspace_sync/adapters/agent_preset.py
+++ b/tracecat/workspace_sync/adapters/agent_preset.py
@@ -26,7 +26,6 @@ from tracecat.db.models import (
     SkillVersion,
 )
 from tracecat.exceptions import TracecatValidationError
-from tracecat.service import BaseWorkspaceService
 from tracecat.sync import PullDiagnostic, serializable_validation_errors
 from tracecat.workspace_sync.adapters.base import (
     DirectoryManifestAdapter,
@@ -35,6 +34,7 @@ from tracecat.workspace_sync.adapters.base import (
     ProjectedResource,
     ResourceDependencyRefs,
     ResourceProjection,
+    SyncMappingService,
     path_parts,
 )
 from tracecat.workspace_sync.enums import SyncResourceType
@@ -159,7 +159,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         return updated
 
     async def project(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> ResourceProjection:
         """Project agent presets into Git specs."""
         stmt = self._projection_stmt(workspace_service)
@@ -168,7 +168,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def project_dependency_refs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         refs: ResourceDependencyRefs,
     ) -> ResourceProjection:
         """Project presets selected directly or referenced by slug."""
@@ -223,7 +223,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
         )
 
     def _projection_stmt(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> sa.Select[tuple[AgentPreset]]:
         """Build the base eager-loaded preset projection query."""
         return (
@@ -239,7 +239,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _projection_from_presets(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         presets: list[AgentPreset],
         versions_by_preset_id: Mapping[uuid.UUID, set[int]] | None = None,
     ) -> ResourceProjection:
@@ -274,7 +274,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _version_specs_for_preset(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         preset: AgentPreset,
         version_numbers: set[int],
@@ -321,7 +321,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _skill_bindings_for_versions(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         version_ids: list[uuid.UUID],
     ) -> dict[uuid.UUID, list[AgentPresetSkillBinding]]:
         """Return slug/version skill bindings grouped by preset version id."""
@@ -359,7 +359,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _skill_bindings_for_version(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         version: AgentPresetVersion,
     ) -> list[AgentPresetSkillBinding]:
         """Return slug/version skill bindings for an immutable preset version."""
@@ -386,7 +386,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def import_specs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         workspace_spec: WorkspaceSpec,
     ) -> list[ImportedResource]:
         """Reconcile agent preset specs into the local database.
@@ -615,7 +615,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _preset_for_import(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
         spec: AgentPresetResourceSpec,
@@ -657,7 +657,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _preset_by_source_id(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
     ) -> AgentPreset | None:
@@ -671,7 +671,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _ensure_agent_folder(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         folder_path: str | None,
     ) -> AgentFolder | None:
         """Resolve ``folder_path`` to an :class:`AgentFolder`, creating segments.
@@ -713,7 +713,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _replace_agent_tags(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         preset: AgentPreset,
         tag_names: list[str],
     ) -> None:
@@ -759,7 +759,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _resolved_subagents_config(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         spec: AgentPresetResourceSpec | AgentPresetVersionResourceSpec,
     ) -> dict[str, Any]:
         """Build the subagents config dict for ``spec``.
@@ -800,7 +800,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _resolved_subagent_target(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         subagent: AgentPresetSubagentRef,
     ) -> tuple[AgentPreset, AgentPresetVersion] | None:
         """Resolve a subagent ref to its child preset and desired version."""
@@ -836,7 +836,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _current_version_for_preset(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         preset: AgentPreset,
     ) -> AgentPresetVersion | None:
         """Return ``preset``'s current :class:`AgentPresetVersion`, if pinned."""
@@ -852,7 +852,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _version_matches_preset(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         version: AgentPresetVersion,
         preset: AgentPreset,
         skill_targets: list[tuple[Skill, SkillVersion]],
@@ -891,7 +891,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _create_agent_preset_version(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         preset: AgentPreset,
     ) -> AgentPresetVersion:
         """Create the next :class:`AgentPresetVersion` snapshotting ``preset``.
@@ -919,7 +919,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _upsert_agent_preset_version(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         preset: AgentPreset,
         version: AgentPresetVersionResourceSpec,
@@ -995,7 +995,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _replace_head_skill_bindings(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         preset: AgentPreset,
         skill_targets: list[tuple[Skill, SkillVersion]],
     ) -> None:
@@ -1021,7 +1021,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _replace_version_skill_bindings(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         version: AgentPresetVersion,
         skill_targets: list[tuple[Skill, SkillVersion]],
     ) -> None:
@@ -1047,7 +1047,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _skill_binding_targets_for_spec(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         spec: AgentPresetResourceSpec | AgentPresetVersionResourceSpec,
     ) -> list[tuple[Skill, SkillVersion]]:
         """Resolve ``spec``'s skill bindings to ``(skill, version)`` pairs.
@@ -1069,7 +1069,7 @@ class AgentPresetAdapter(DirectoryManifestAdapter):
 
     async def _skill_binding_targets(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         binding: AgentPresetSkillBinding,
     ) -> tuple[Skill | None, SkillVersion | None]:
         """Resolve one skill binding to its ``(skill, version)`` pair.

--- a/tracecat/workspace_sync/adapters/base.py
+++ b/tracecat/workspace_sync/adapters/base.py
@@ -19,9 +19,11 @@ from typing import Any, ClassVar, Literal, NamedTuple, Protocol, cast
 
 from pydantic import BaseModel
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import InstrumentedAttribute, Mapped
 from sqlalchemy.sql.base import ExecutableOption
 
+from tracecat.auth.types import Role
 from tracecat.db.models import WorkspaceSyncResourceMapping
 from tracecat.service import BaseWorkspaceService
 from tracecat.sync import PullDiagnostic
@@ -168,14 +170,31 @@ _TEMP_NAME_PREFIX = "__tracecat_sync_tmp_"
 """Prefix for placeholder names rows are parked under during a rename swap."""
 
 
-def _sync_mapping_provider_value(workspace_service: BaseWorkspaceService) -> str:
-    """Return the VCS provider namespace for workspace sync resource mappings."""
-    provider = getattr(workspace_service, "_mapping_provider_value", None)
-    if isinstance(provider, str):
-        return provider
-    if isinstance(provider, VcsProvider):
-        return provider.value
-    return VcsProvider.GITHUB.value
+class SyncMappingService(BaseWorkspaceService):
+    """Workspace service that namespaces sync resource mappings by VCS provider.
+
+    The resource adapters read and write :class:`WorkspaceSyncResourceMapping`
+    rows scoped to a provider; every service that drives them
+    (``WorkspaceSyncService``, the projector, and the importer) extends this base
+    so the active provider is part of the static contract instead of being
+    duck-typed at the call site.
+    """
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        role: Role | None = None,
+        *,
+        mapping_provider: VcsProvider = VcsProvider.GITHUB,
+    ) -> None:
+        """Initialize with the provider namespace for sync resource mappings."""
+        super().__init__(session=session, role=role)
+        self._mapping_provider = mapping_provider
+
+    @property
+    def _mapping_provider_value(self) -> str:
+        """Provider value used for workspace sync resource mappings."""
+        return self._mapping_provider.value
 
 
 def find_duplicates(values: Iterable[str]) -> list[str]:
@@ -271,7 +290,7 @@ class NameSwapPlan[ModelT: _WorkspaceRow]:
 
     async def ensure_available(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
         name: str,
@@ -393,7 +412,7 @@ class ResourceAdapter(ABC):
 
     # -- database projection and import -----------------------------------
     async def project(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> ResourceProjection:
         """Project this resource type's database rows into Git specs.
 
@@ -404,7 +423,7 @@ class ResourceAdapter(ABC):
 
     async def project_dependency_refs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         refs: ResourceDependencyRefs,
     ) -> ResourceProjection:
         """Project resources addressed by dependency-closure refs.
@@ -442,7 +461,7 @@ class ResourceAdapter(ABC):
 
     async def import_specs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         workspace_spec: WorkspaceSpec,
     ) -> list[ImportedResource]:
         """Reconcile this resource type's Git spec slice into the local database.
@@ -504,7 +523,7 @@ class ResourceAdapter(ABC):
 
     async def source_ids_by_local_id(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
     ) -> dict[uuid.UUID, str]:
         """Load this resource type's ``local_id`` -> ``source_id`` sync mappings.
 
@@ -517,21 +536,21 @@ class ResourceAdapter(ABC):
         ).where(
             WorkspaceSyncResourceMapping.workspace_id == workspace_service.workspace_id,
             WorkspaceSyncResourceMapping.provider
-            == _sync_mapping_provider_value(workspace_service),
+            == workspace_service._mapping_provider_value,
             WorkspaceSyncResourceMapping.resource_type == self.resource_type.value,
         )
         return dict((await workspace_service.session.execute(stmt)).tuples().all())
 
     async def local_id_for_source_id(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         source_id: str,
     ) -> uuid.UUID | None:
         """Resolve a single ``source_id`` to its mapped ``local_id``, if any."""
         stmt = select(WorkspaceSyncResourceMapping.local_id).where(
             WorkspaceSyncResourceMapping.workspace_id == workspace_service.workspace_id,
             WorkspaceSyncResourceMapping.provider
-            == _sync_mapping_provider_value(workspace_service),
+            == workspace_service._mapping_provider_value,
             WorkspaceSyncResourceMapping.resource_type == self.resource_type.value,
             WorkspaceSyncResourceMapping.source_id == source_id,
         )
@@ -539,7 +558,7 @@ class ResourceAdapter(ABC):
 
     async def local_ids_by_source_id(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         source_ids: Iterable[str],
     ) -> dict[str, uuid.UUID]:
         """Bulk-resolve ``source_id`` values to their mapped ``local_id`` UUIDs.
@@ -556,14 +575,14 @@ class ResourceAdapter(ABC):
         ).where(
             WorkspaceSyncResourceMapping.workspace_id == workspace_service.workspace_id,
             WorkspaceSyncResourceMapping.provider
-            == _sync_mapping_provider_value(workspace_service),
+            == workspace_service._mapping_provider_value,
             WorkspaceSyncResourceMapping.resource_type == self.resource_type.value,
             WorkspaceSyncResourceMapping.source_id.in_(source_id_values),
         )
         return dict((await workspace_service.session.execute(stmt)).tuples().all())
 
     async def source_id_assigner(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> _SourceIdAssigner:
         """Build a :class:`_SourceIdAssigner` seeded with this type's mappings.
 
@@ -575,7 +594,7 @@ class ResourceAdapter(ABC):
 
     async def _row_by_source_id[ModelT: _WorkspaceRow](
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
         model: type[ModelT],
@@ -600,7 +619,7 @@ class ResourceAdapter(ABC):
 
     async def plan_name_swap[ModelT: _WorkspaceRow](
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         targets: Mapping[str, str],
         model: type[ModelT],
@@ -715,7 +734,7 @@ class ResourceAdapter(ABC):
 
     async def _park_changing_names[ModelT: _WorkspaceRow](
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         plan: NameSwapPlan[ModelT],
         *,
         temp_prefix: str,
@@ -752,7 +771,7 @@ class ResourceAdapter(ABC):
 
     async def _reserved_names_by_scope[ModelT: _WorkspaceRow](
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         plan: NameSwapPlan[ModelT],
     ) -> dict[str | None, set[str]]:
         """In-use names plus batch targets, bucketed by scope value.

--- a/tracecat/workspace_sync/adapters/base.py
+++ b/tracecat/workspace_sync/adapters/base.py
@@ -168,6 +168,16 @@ _TEMP_NAME_PREFIX = "__tracecat_sync_tmp_"
 """Prefix for placeholder names rows are parked under during a rename swap."""
 
 
+def _sync_mapping_provider_value(workspace_service: BaseWorkspaceService) -> str:
+    """Return the VCS provider namespace for workspace sync resource mappings."""
+    provider = getattr(workspace_service, "_mapping_provider_value", None)
+    if isinstance(provider, str):
+        return provider
+    if isinstance(provider, VcsProvider):
+        return provider.value
+    return VcsProvider.GITHUB.value
+
+
 def find_duplicates(values: Iterable[str]) -> list[str]:
     """Return the sorted distinct values that appear more than once."""
     seen: set[str] = set()
@@ -506,7 +516,8 @@ class ResourceAdapter(ABC):
             WorkspaceSyncResourceMapping.source_id,
         ).where(
             WorkspaceSyncResourceMapping.workspace_id == workspace_service.workspace_id,
-            WorkspaceSyncResourceMapping.provider == VcsProvider.GITHUB.value,
+            WorkspaceSyncResourceMapping.provider
+            == _sync_mapping_provider_value(workspace_service),
             WorkspaceSyncResourceMapping.resource_type == self.resource_type.value,
         )
         return dict((await workspace_service.session.execute(stmt)).tuples().all())
@@ -519,7 +530,8 @@ class ResourceAdapter(ABC):
         """Resolve a single ``source_id`` to its mapped ``local_id``, if any."""
         stmt = select(WorkspaceSyncResourceMapping.local_id).where(
             WorkspaceSyncResourceMapping.workspace_id == workspace_service.workspace_id,
-            WorkspaceSyncResourceMapping.provider == VcsProvider.GITHUB.value,
+            WorkspaceSyncResourceMapping.provider
+            == _sync_mapping_provider_value(workspace_service),
             WorkspaceSyncResourceMapping.resource_type == self.resource_type.value,
             WorkspaceSyncResourceMapping.source_id == source_id,
         )
@@ -543,7 +555,8 @@ class ResourceAdapter(ABC):
             WorkspaceSyncResourceMapping.local_id,
         ).where(
             WorkspaceSyncResourceMapping.workspace_id == workspace_service.workspace_id,
-            WorkspaceSyncResourceMapping.provider == VcsProvider.GITHUB.value,
+            WorkspaceSyncResourceMapping.provider
+            == _sync_mapping_provider_value(workspace_service),
             WorkspaceSyncResourceMapping.resource_type == self.resource_type.value,
             WorkspaceSyncResourceMapping.source_id.in_(source_id_values),
         )

--- a/tracecat/workspace_sync/adapters/base.py
+++ b/tracecat/workspace_sync/adapters/base.py
@@ -176,8 +176,8 @@ class SyncMappingService(BaseWorkspaceService):
     The resource adapters read and write :class:`WorkspaceSyncResourceMapping`
     rows scoped to a provider; every service that drives them
     (``WorkspaceSyncService``, the projector, and the importer) extends this base
-    so the active provider is part of the static contract instead of being
-    duck-typed at the call site.
+    and fixes the provider at construction so the active provider is part of the
+    static contract instead of being duck-typed at the call site.
     """
 
     def __init__(

--- a/tracecat/workspace_sync/adapters/case_dropdown.py
+++ b/tracecat/workspace_sync/adapters/case_dropdown.py
@@ -7,7 +7,6 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from tracecat.db.models import CaseDropdownDefinition, CaseDropdownOption
-from tracecat.service import BaseWorkspaceService
 from tracecat.tiers.enums import Entitlement
 from tracecat.workspace_sync.adapters.base import (
     FlatManifestAdapter,
@@ -15,6 +14,7 @@ from tracecat.workspace_sync.adapters.base import (
     NameSwapPlan,
     ProjectedResource,
     ResourceProjection,
+    SyncMappingService,
 )
 from tracecat.workspace_sync.enums import SyncResourceType
 from tracecat.workspace_sync.schemas import (
@@ -37,7 +37,7 @@ class CaseDropdownAdapter(FlatManifestAdapter):
     root = CASE_DROPDOWN_ROOT
 
     async def project(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> ResourceProjection:
         """Project case dropdown definitions, with their options, into specs."""
         # Eager-load options so each definition serializes in one pass; order by
@@ -90,7 +90,7 @@ class CaseDropdownAdapter(FlatManifestAdapter):
 
     async def import_specs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         workspace_spec: WorkspaceSpec,
     ) -> list[ImportedResource]:
         """Reconcile dropdown specs, syncing each definition's options in place."""
@@ -174,7 +174,7 @@ class CaseDropdownAdapter(FlatManifestAdapter):
 
     async def _dropdown_for_import(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
         swap: NameSwapPlan[CaseDropdownDefinition],
@@ -223,7 +223,7 @@ class CaseDropdownAdapter(FlatManifestAdapter):
 
     async def _dropdown_by_source_id(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
     ) -> CaseDropdownDefinition | None:

--- a/tracecat/workspace_sync/adapters/case_duration.py
+++ b/tracecat/workspace_sync/adapters/case_duration.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel
 from sqlalchemy import select
 
 from tracecat.db.models import CaseDurationDefinition
-from tracecat.service import BaseWorkspaceService
 from tracecat.tiers.enums import Entitlement
 from tracecat.workspace_sync.adapters.base import (
     FlatManifestAdapter,
@@ -14,6 +13,7 @@ from tracecat.workspace_sync.adapters.base import (
     NameSwapPlan,
     ProjectedResource,
     ResourceProjection,
+    SyncMappingService,
 )
 from tracecat.workspace_sync.enums import SyncResourceType
 from tracecat.workspace_sync.schemas import (
@@ -39,7 +39,7 @@ class CaseDurationAdapter(FlatManifestAdapter):
     import_identity_noun = "name"
 
     async def project(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> ResourceProjection:
         """Project case duration definitions, with their anchors, into specs."""
         stmt = (
@@ -82,7 +82,7 @@ class CaseDurationAdapter(FlatManifestAdapter):
 
     async def import_specs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         workspace_spec: WorkspaceSpec,
     ) -> list[ImportedResource]:
         """Reconcile duration specs, creating or updating each definition."""
@@ -137,7 +137,7 @@ class CaseDurationAdapter(FlatManifestAdapter):
 
     async def _duration_for_import(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
         spec: CaseDurationResourceSpec,
@@ -175,7 +175,7 @@ class CaseDurationAdapter(FlatManifestAdapter):
 
     async def _duration_by_source_id(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
     ) -> CaseDurationDefinition | None:

--- a/tracecat/workspace_sync/adapters/case_field.py
+++ b/tracecat/workspace_sync/adapters/case_field.py
@@ -14,13 +14,13 @@ from tracecat.cases.enums import CaseFieldKind
 from tracecat.cases.schemas import CaseFieldCreate, CaseFieldUpdate
 from tracecat.cases.service import CaseFieldsService
 from tracecat.db.models import CaseFields
-from tracecat.service import BaseWorkspaceService
 from tracecat.tables.enums import SqlType
 from tracecat.workspace_sync.adapters.base import (
     FlatManifestAdapter,
     ImportedResource,
     ProjectedResource,
     ResourceProjection,
+    SyncMappingService,
     find_duplicates,
     sql_type,
 )
@@ -50,7 +50,7 @@ class CaseFieldAdapter(FlatManifestAdapter):
     import_identity_noun = "name"
 
     async def project(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> ResourceProjection:
         """Project each entry of the workspace case fields schema into a spec."""
         # All case fields live in one workspace-wide schema row; absence means
@@ -87,7 +87,7 @@ class CaseFieldAdapter(FlatManifestAdapter):
 
     async def import_specs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         workspace_spec: WorkspaceSpec,
     ) -> list[ImportedResource]:
         """Reconcile field specs, creating new columns or updating schema entries."""
@@ -191,7 +191,7 @@ class CaseFieldAdapter(FlatManifestAdapter):
 
     async def _field_id_for_import(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         definition: CaseFields | None,
         current_schema: Mapping[str, Any],
@@ -214,7 +214,7 @@ class CaseFieldAdapter(FlatManifestAdapter):
 
     async def _release_changing_mapped_fields(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         field_service: CaseFieldsService,
         fields: Mapping[str, CaseFieldResourceSpec],

--- a/tracecat/workspace_sync/adapters/case_tag.py
+++ b/tracecat/workspace_sync/adapters/case_tag.py
@@ -11,12 +11,12 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 from tracecat.db.models import CaseTag
-from tracecat.service import BaseWorkspaceService
 from tracecat.workspace_sync.adapters.base import (
     FlatManifestAdapter,
     ImportedResource,
     ProjectedResource,
     ResourceProjection,
+    SyncMappingService,
 )
 from tracecat.workspace_sync.enums import SyncResourceType
 from tracecat.workspace_sync.schemas import (
@@ -40,7 +40,7 @@ class CaseTagAdapter(FlatManifestAdapter):
     import_identity_noun = "name"
 
     async def project(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> ResourceProjection:
         """Project case tags into specs."""
         # Deterministic order (ref, then id) keeps the serialized output stable.
@@ -65,7 +65,7 @@ class CaseTagAdapter(FlatManifestAdapter):
 
     async def import_specs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         workspace_spec: WorkspaceSpec,
     ) -> list[ImportedResource]:
         """Reconcile case tag specs, resolving name collisions before persisting.

--- a/tracecat/workspace_sync/adapters/secret_metadata.py
+++ b/tracecat/workspace_sync/adapters/secret_metadata.py
@@ -10,7 +10,6 @@ from tracecat.db.models import Secret
 from tracecat.secrets.enums import SecretType
 from tracecat.secrets.schemas import SecretKeyValue
 from tracecat.secrets.service import SecretsService
-from tracecat.service import BaseWorkspaceService
 from tracecat.workspace_sync.adapters.base import (
     EnvironmentScopedManifestAdapter,
     ImportedResource,
@@ -18,6 +17,7 @@ from tracecat.workspace_sync.adapters.base import (
     ProjectedResource,
     ResourceDependencyRefs,
     ResourceProjection,
+    SyncMappingService,
 )
 from tracecat.workspace_sync.enums import SyncResourceType
 from tracecat.workspace_sync.schemas import (
@@ -41,7 +41,7 @@ class SecretMetadataAdapter(EnvironmentScopedManifestAdapter):
     import_identity_noun = "target"
 
     async def project(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> ResourceProjection:
         """Project secrets into specs, emitting only key names, not their values."""
         stmt = self._projection_stmt(workspace_service)
@@ -50,7 +50,7 @@ class SecretMetadataAdapter(EnvironmentScopedManifestAdapter):
 
     async def project_dependency_refs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         refs: ResourceDependencyRefs,
     ) -> ResourceProjection:
         """Project secret metadata selected directly or referenced by name."""
@@ -88,7 +88,7 @@ class SecretMetadataAdapter(EnvironmentScopedManifestAdapter):
         return await self._projection_from_secrets(workspace_service, secrets)
 
     def _projection_stmt(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> sa.Select[tuple[Secret]]:
         """Build the base secret metadata projection query."""
         return (
@@ -99,7 +99,7 @@ class SecretMetadataAdapter(EnvironmentScopedManifestAdapter):
 
     async def _projection_from_secrets(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         secrets: list[Secret],
     ) -> ResourceProjection:
         """Build sync specs from secret rows."""
@@ -133,7 +133,7 @@ class SecretMetadataAdapter(EnvironmentScopedManifestAdapter):
 
     async def import_specs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         workspace_spec: WorkspaceSpec,
     ) -> list[ImportedResource]:
         """Reconcile secret metadata specs, preserving existing key values.
@@ -226,7 +226,7 @@ class SecretMetadataAdapter(EnvironmentScopedManifestAdapter):
 
     async def _secret_for_import(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
         spec: SecretMetadataResourceSpec,
@@ -257,7 +257,7 @@ class SecretMetadataAdapter(EnvironmentScopedManifestAdapter):
 
     async def _secret_by_source_id(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
     ) -> Secret | None:

--- a/tracecat/workspace_sync/adapters/skill.py
+++ b/tracecat/workspace_sync/adapters/skill.py
@@ -28,7 +28,6 @@ from tracecat.db.models import (
     SkillVersionFile,
 )
 from tracecat.exceptions import TracecatValidationError
-from tracecat.service import BaseWorkspaceService
 from tracecat.storage import blob
 from tracecat.sync import PullDiagnostic, serializable_validation_errors
 from tracecat.workspace_sync.adapters.base import (
@@ -38,6 +37,7 @@ from tracecat.workspace_sync.adapters.base import (
     ProjectedResource,
     ResourceDependencyRefs,
     ResourceProjection,
+    SyncMappingService,
     path_parts,
 )
 from tracecat.workspace_sync.enums import SyncResourceType
@@ -310,7 +310,7 @@ class SkillAdapter(DirectoryManifestAdapter):
                 )
 
     async def project(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> ResourceProjection:
         """Project skills and the version snapshots needed to preserve pins."""
         stmt = self._projection_stmt(workspace_service)
@@ -326,7 +326,7 @@ class SkillAdapter(DirectoryManifestAdapter):
 
     async def project_dependency_refs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         refs: ResourceDependencyRefs,
     ) -> ResourceProjection:
         """Project skills selected directly or referenced by slug."""
@@ -370,7 +370,7 @@ class SkillAdapter(DirectoryManifestAdapter):
         )
 
     def _projection_stmt(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> sa.Select[tuple[Skill]]:
         """Build the base eager-loaded skill projection query."""
         return (
@@ -385,7 +385,7 @@ class SkillAdapter(DirectoryManifestAdapter):
 
     async def _projection_from_skills(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         skills: list[Skill],
         versions_by_skill_id: Mapping[uuid.UUID, set[int]] | None = None,
     ) -> ResourceProjection:
@@ -420,7 +420,7 @@ class SkillAdapter(DirectoryManifestAdapter):
 
     async def _exported_bound_versions_by_skill(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
     ) -> dict[uuid.UUID, set[int]]:
         """Return skill versions bound by exported agent preset state."""
         head_stmt = (
@@ -458,7 +458,7 @@ class SkillAdapter(DirectoryManifestAdapter):
 
     async def _version_specs_for_skill(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         skill: Skill,
         version_numbers: set[int],
@@ -505,7 +505,7 @@ class SkillAdapter(DirectoryManifestAdapter):
 
     async def _skill_version_rows(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         version_id: uuid.UUID,
     ) -> list[tuple[SkillVersionFile, SkillBlob]]:
         """Return a version's files joined to their blobs, ordered by path."""
@@ -529,7 +529,7 @@ class SkillAdapter(DirectoryManifestAdapter):
 
     async def import_specs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         workspace_spec: WorkspaceSpec,
     ) -> list[ImportedResource]:
         """Reconcile skill specs into the local database.
@@ -626,7 +626,7 @@ class SkillAdapter(DirectoryManifestAdapter):
 
     async def _upsert_skill_version(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         skill_service: SkillService,
         *,
         skill: Skill,
@@ -719,7 +719,7 @@ class SkillAdapter(DirectoryManifestAdapter):
 
     async def _skill_for_import(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
         spec: SkillResourceSpec,
@@ -758,7 +758,7 @@ class SkillAdapter(DirectoryManifestAdapter):
 
     async def _skill_by_source_id(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
     ) -> Skill | None:

--- a/tracecat/workspace_sync/adapters/table.py
+++ b/tracecat/workspace_sync/adapters/table.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm import selectinload
 
 from tracecat.db.models import Table, TableColumn
 from tracecat.exceptions import TracecatNotFoundError
-from tracecat.service import BaseWorkspaceService
 from tracecat.tables.schemas import (
     TableColumnCreate,
     TableColumnUpdate,
@@ -25,6 +24,7 @@ from tracecat.workspace_sync.adapters.base import (
     ProjectedResource,
     ResourceDependencyRefs,
     ResourceProjection,
+    SyncMappingService,
     sql_type,
 )
 from tracecat.workspace_sync.enums import SyncResourceType
@@ -59,7 +59,7 @@ class TableAdapter(DirectoryManifestAdapter):
     import_identity_noun = "name"
 
     async def project(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> ResourceProjection:
         """Project workspace table metadata and column schema into specs."""
         stmt = self._projection_stmt(workspace_service)
@@ -68,7 +68,7 @@ class TableAdapter(DirectoryManifestAdapter):
 
     async def project_dependency_refs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         refs: ResourceDependencyRefs,
     ) -> ResourceProjection:
         """Project tables selected directly or referenced by table name."""
@@ -105,7 +105,7 @@ class TableAdapter(DirectoryManifestAdapter):
         return await self._projection_from_tables(workspace_service, tables)
 
     def _projection_stmt(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> sa.Select[tuple[Table]]:
         """Build the base eager-loaded table projection query."""
         return (
@@ -117,7 +117,7 @@ class TableAdapter(DirectoryManifestAdapter):
 
     async def _projection_from_tables(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         tables: list[Table],
     ) -> ResourceProjection:
         """Build sync specs from eager-loaded table rows."""
@@ -155,7 +155,7 @@ class TableAdapter(DirectoryManifestAdapter):
 
     async def import_specs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         workspace_spec: WorkspaceSpec,
     ) -> list[ImportedResource]:
         """Reconcile table specs into the database.
@@ -262,7 +262,7 @@ class TableAdapter(DirectoryManifestAdapter):
 
     async def _table_by_source_id(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         source_id: str,
     ) -> Table | None:
         """Load the mapped :class:`Table` (with columns) for ``source_id``, if any."""

--- a/tracecat/workspace_sync/adapters/variable.py
+++ b/tracecat/workspace_sync/adapters/variable.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel
 from sqlalchemy import select
 
 from tracecat.db.models import WorkspaceVariable
-from tracecat.service import BaseWorkspaceService
 from tracecat.workspace_sync.adapters.base import (
     EnvironmentScopedManifestAdapter,
     ImportedResource,
@@ -17,6 +16,7 @@ from tracecat.workspace_sync.adapters.base import (
     ProjectedResource,
     ResourceDependencyRefs,
     ResourceProjection,
+    SyncMappingService,
 )
 from tracecat.workspace_sync.enums import SyncResourceType
 from tracecat.workspace_sync.schemas import (
@@ -49,7 +49,7 @@ class VariableAdapter(EnvironmentScopedManifestAdapter):
     import_identity_noun = "target"
 
     async def project(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> ResourceProjection:
         """Project workspace variables into specs, recording key names but no values."""
         stmt = self._projection_stmt(workspace_service)
@@ -60,7 +60,7 @@ class VariableAdapter(EnvironmentScopedManifestAdapter):
 
     async def project_dependency_refs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         refs: ResourceDependencyRefs,
     ) -> ResourceProjection:
         """Project variables selected directly or referenced by name."""
@@ -100,7 +100,7 @@ class VariableAdapter(EnvironmentScopedManifestAdapter):
         return await self._projection_from_variables(workspace_service, variables)
 
     def _projection_stmt(
-        self, workspace_service: BaseWorkspaceService
+        self, workspace_service: SyncMappingService
     ) -> sa.Select[tuple[WorkspaceVariable]]:
         """Build the base variable projection query."""
         return (
@@ -115,7 +115,7 @@ class VariableAdapter(EnvironmentScopedManifestAdapter):
 
     async def _projection_from_variables(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         variables: list[WorkspaceVariable],
     ) -> ResourceProjection:
         """Build sync specs from variable rows."""
@@ -141,7 +141,7 @@ class VariableAdapter(EnvironmentScopedManifestAdapter):
 
     async def import_specs(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         workspace_spec: WorkspaceSpec,
     ) -> list[ImportedResource]:
         """Reconcile variable specs into the database, preserving existing values.
@@ -210,7 +210,7 @@ class VariableAdapter(EnvironmentScopedManifestAdapter):
 
     async def _variable_for_import(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
         spec: VariableResourceSpec,
@@ -244,7 +244,7 @@ class VariableAdapter(EnvironmentScopedManifestAdapter):
 
     async def _variable_by_source_id(
         self,
-        workspace_service: BaseWorkspaceService,
+        workspace_service: SyncMappingService,
         *,
         source_id: str,
     ) -> WorkspaceVariable | None:

--- a/tracecat/workspace_sync/importer.py
+++ b/tracecat/workspace_sync/importer.py
@@ -7,40 +7,20 @@ order.
 
 from __future__ import annotations
 
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from tracecat.auth.types import Role
-from tracecat.service import BaseWorkspaceService
 from tracecat.workspace_sync.adapters import (
     NON_WORKFLOW_IMPORT_ADAPTERS,
     ImportedResource,
+    SyncMappingService,
 )
-from tracecat.workspace_sync.enums import VcsProvider
 from tracecat.workspace_sync.schemas import WorkspaceSpec
 
 __all__ = ["ImportedResource", "WorkspaceResourceImportService"]
 
 
-class WorkspaceResourceImportService(BaseWorkspaceService):
+class WorkspaceResourceImportService(SyncMappingService):
     """Reconcile non-workflow workspace sync resource specs into the DB."""
 
     service_name = "workspace_resource_import"
-
-    def __init__(
-        self,
-        session: AsyncSession,
-        role: Role | None = None,
-        *,
-        mapping_provider: VcsProvider = VcsProvider.GITHUB,
-    ) -> None:
-        """Initialize the importer with the provider namespace for sync mappings."""
-        super().__init__(session=session, role=role)
-        self._mapping_provider = mapping_provider
-
-    @property
-    def _mapping_provider_value(self) -> str:
-        """Provider value used for workspace sync resource mappings."""
-        return self._mapping_provider.value
 
     async def import_non_workflow_resources(
         self,

--- a/tracecat/workspace_sync/importer.py
+++ b/tracecat/workspace_sync/importer.py
@@ -7,11 +7,15 @@ order.
 
 from __future__ import annotations
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
 from tracecat.service import BaseWorkspaceService
 from tracecat.workspace_sync.adapters import (
     NON_WORKFLOW_IMPORT_ADAPTERS,
     ImportedResource,
 )
+from tracecat.workspace_sync.enums import VcsProvider
 from tracecat.workspace_sync.schemas import WorkspaceSpec
 
 __all__ = ["ImportedResource", "WorkspaceResourceImportService"]
@@ -21,6 +25,22 @@ class WorkspaceResourceImportService(BaseWorkspaceService):
     """Reconcile non-workflow workspace sync resource specs into the DB."""
 
     service_name = "workspace_resource_import"
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        role: Role | None = None,
+        *,
+        mapping_provider: VcsProvider = VcsProvider.GITHUB,
+    ) -> None:
+        """Initialize the importer with the provider namespace for sync mappings."""
+        super().__init__(session=session, role=role)
+        self._mapping_provider = mapping_provider
+
+    @property
+    def _mapping_provider_value(self) -> str:
+        """Provider value used for workspace sync resource mappings."""
+        return self._mapping_provider.value
 
     async def import_non_workflow_resources(
         self,

--- a/tracecat/workspace_sync/projector.py
+++ b/tracecat/workspace_sync/projector.py
@@ -10,13 +10,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tracecat.auth.types import Role
 from tracecat.service import BaseWorkspaceService
 from tracecat.workspace_sync.adapters import (
     NON_WORKFLOW_RESOURCE_ADAPTERS,
     ProjectedResource,
     workspace_spec_from_maps,
 )
-from tracecat.workspace_sync.enums import SyncResourceType
+from tracecat.workspace_sync.enums import SyncResourceType, VcsProvider
 from tracecat.workspace_sync.schemas import WorkspaceSpec
 
 __all__ = [
@@ -40,6 +43,22 @@ class WorkspaceResourceProjector(BaseWorkspaceService):
     """Project non-workflow workspace config resources into sync specs."""
 
     service_name = "workspace_resource_projector"
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        role: Role | None = None,
+        *,
+        mapping_provider: VcsProvider = VcsProvider.GITHUB,
+    ) -> None:
+        """Initialize the projector with the provider namespace for sync mappings."""
+        super().__init__(session=session, role=role)
+        self._mapping_provider = mapping_provider
+
+    @property
+    def _mapping_provider_value(self) -> str:
+        """Provider value used for workspace sync resource mappings."""
+        return self._mapping_provider.value
 
     async def project_non_workflow_resources(
         self,

--- a/tracecat/workspace_sync/projector.py
+++ b/tracecat/workspace_sync/projector.py
@@ -10,16 +10,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from tracecat.auth.types import Role
-from tracecat.service import BaseWorkspaceService
 from tracecat.workspace_sync.adapters import (
     NON_WORKFLOW_RESOURCE_ADAPTERS,
     ProjectedResource,
+    SyncMappingService,
     workspace_spec_from_maps,
 )
-from tracecat.workspace_sync.enums import SyncResourceType, VcsProvider
+from tracecat.workspace_sync.enums import SyncResourceType
 from tracecat.workspace_sync.schemas import WorkspaceSpec
 
 __all__ = [
@@ -39,26 +36,10 @@ class WorkspaceResourceProjection:
     """Flattened identities linking each ``source_id`` to its ``local_id``."""
 
 
-class WorkspaceResourceProjector(BaseWorkspaceService):
+class WorkspaceResourceProjector(SyncMappingService):
     """Project non-workflow workspace config resources into sync specs."""
 
     service_name = "workspace_resource_projector"
-
-    def __init__(
-        self,
-        session: AsyncSession,
-        role: Role | None = None,
-        *,
-        mapping_provider: VcsProvider = VcsProvider.GITHUB,
-    ) -> None:
-        """Initialize the projector with the provider namespace for sync mappings."""
-        super().__init__(session=session, role=role)
-        self._mapping_provider = mapping_provider
-
-    @property
-    def _mapping_provider_value(self) -> str:
-        """Provider value used for workspace sync resource mappings."""
-        return self._mapping_provider.value
 
     async def project_non_workflow_resources(
         self,

--- a/tracecat/workspace_sync/schemas.py
+++ b/tracecat/workspace_sync/schemas.py
@@ -19,7 +19,7 @@ from tracecat.workflow.store.schemas import (
     RemoteWorkflowTag,
     WorkflowDslPublishResult,
 )
-from tracecat.workspace_sync.enums import SyncResourceType, VcsProvider
+from tracecat.workspace_sync.enums import SyncResourceType
 
 MANIFEST_FILENAME = "tracecat.json"
 WORKFLOW_ROOT = "workflows"
@@ -867,9 +867,6 @@ class WorkspaceSyncExportRequest(BaseModel):
         default=None,
         description="Specific resources to export, or ``None`` to export all.",
     )
-    provider: VcsProvider = Field(
-        default=VcsProvider.GITHUB, description="VCS provider to push to."
-    )
     include_schedules: bool = Field(
         default=False,
         description="Whether to include workflow schedules in the export.",
@@ -902,10 +899,6 @@ class WorkspaceSyncExportPreviewRequest(BaseModel):
             "Repository ref to compare the projected export against. When omitted, "
             "the preview only returns the export manifest summary."
         ),
-    )
-    provider: VcsProvider = Field(
-        default=VcsProvider.GITHUB,
-        description="VCS provider to read the comparison ref from.",
     )
 
 

--- a/tracecat/workspace_sync/service.py
+++ b/tracecat/workspace_sync/service.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import re
 import uuid
 from collections import Counter, deque
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from difflib import unified_diff
 from typing import Any, cast
@@ -159,6 +160,7 @@ class WorkspaceSyncService(BaseWorkspaceService):
         """
         super().__init__(session=session, role=role)
         self._transport_factory = transport_factory
+        self._mapping_provider = VcsProvider.GITHUB
 
     async def export_workspace(
         self,
@@ -167,37 +169,38 @@ class WorkspaceSyncService(BaseWorkspaceService):
         """Export selected or all syncable resources to a branch and optional PR."""
         self._require_workspace_sync_scope()
         self._validate_export_params(params)
-        url = await self._workspace_git_url(provider=params.provider)
-        resource_ids = await self._local_ids_from_resource_refs(params.resources)
-        projection = await self.project_workspace(
-            resource_ids=resource_ids,
-            include_schedules=params.include_schedules,
-            create_missing_mappings=True,
-        )
-        self._require_projected_export_scopes(projection.spec)
-        self._validate_projected_workspace_dependencies(projection.spec)
-        delete_missing_paths_under = await self._export_delete_roots(
-            projection,
-            full_workspace_export=resource_ids is None,
-            resource_ids=resource_ids,
-        )
-        transport = self._transport_for_provider(
-            params.provider,
-        )
-        commit = await transport.write_files(
-            url=url,
-            files=projection.files,
-            message=params.message,
-            branch=params.branch,
-            create_pr=params.create_pr,
-            pr_base_branch=params.pr_base_branch,
-            delete_missing_paths_under=delete_missing_paths_under,
-        )
-        await self.session.commit()
-        return WorkspaceSyncExportResult(
-            commit=commit,
-            files=sorted(projection.files),
-        )
+        with self._mapping_provider_scope(params.provider):
+            url = await self._workspace_git_url(provider=params.provider)
+            resource_ids = await self._local_ids_from_resource_refs(params.resources)
+            projection = await self.project_workspace(
+                resource_ids=resource_ids,
+                include_schedules=params.include_schedules,
+                create_missing_mappings=True,
+            )
+            self._require_projected_export_scopes(projection.spec)
+            self._validate_projected_workspace_dependencies(projection.spec)
+            delete_missing_paths_under = await self._export_delete_roots(
+                projection,
+                full_workspace_export=resource_ids is None,
+                resource_ids=resource_ids,
+            )
+            transport = self._transport_for_provider(
+                params.provider,
+            )
+            commit = await transport.write_files(
+                url=url,
+                files=projection.files,
+                message=params.message,
+                branch=params.branch,
+                create_pr=params.create_pr,
+                pr_base_branch=params.pr_base_branch,
+                delete_missing_paths_under=delete_missing_paths_under,
+            )
+            await self.session.commit()
+            return WorkspaceSyncExportResult(
+                commit=commit,
+                files=sorted(projection.files),
+            )
 
     async def preview_export_workspace(
         self,
@@ -211,35 +214,38 @@ class WorkspaceSyncService(BaseWorkspaceService):
         resources pulled in transitively by the dependency closure.
         """
         self._require_workspace_sync_scope()
-        resource_ids = await self._local_ids_from_resource_refs(params.resources)
-        projection = await self.project_workspace(
-            resource_ids=resource_ids,
-            include_schedules=params.include_schedules,
-            create_missing_mappings=False,
-        )
-        self._require_projected_export_scopes(projection.spec)
-        self._validate_projected_workspace_dependencies(projection.spec)
-        resource_diffs: list[PullResourceDiff] = []
-        if params.compare_ref:
-            url = await self._workspace_git_url(provider=params.provider)
-            transport = self._transport_for_provider(params.provider)
-            remote_tree = await transport.read_files(url=url, ref=params.compare_ref)
-            delete_missing_paths_under = await self._export_delete_roots(
-                projection,
-                full_workspace_export=resource_ids is None,
+        with self._mapping_provider_scope(params.provider):
+            resource_ids = await self._local_ids_from_resource_refs(params.resources)
+            projection = await self.project_workspace(
                 resource_ids=resource_ids,
+                include_schedules=params.include_schedules,
+                create_missing_mappings=False,
             )
-            resource_diffs = self._resource_diffs_for_export(
-                projection,
-                remote_tree,
-                delete_missing_paths_under=delete_missing_paths_under,
+            self._require_projected_export_scopes(projection.spec)
+            self._validate_projected_workspace_dependencies(projection.spec)
+            resource_diffs: list[PullResourceDiff] = []
+            if params.compare_ref:
+                url = await self._workspace_git_url(provider=params.provider)
+                transport = self._transport_for_provider(params.provider)
+                remote_tree = await transport.read_files(
+                    url=url, ref=params.compare_ref
+                )
+                delete_missing_paths_under = await self._export_delete_roots(
+                    projection,
+                    full_workspace_export=resource_ids is None,
+                    resource_ids=resource_ids,
+                )
+                resource_diffs = self._resource_diffs_for_export(
+                    projection,
+                    remote_tree,
+                    delete_missing_paths_under=delete_missing_paths_under,
+                )
+            return WorkspaceSyncExportPreview(
+                resource_counts=projection.spec.resource_count_map(),
+                files=sorted(projection.files),
+                resources=_preview_resources_from_spec(projection.spec),
+                resource_diffs=resource_diffs,
             )
-        return WorkspaceSyncExportPreview(
-            resource_counts=projection.spec.resource_count_map(),
-            files=sorted(projection.files),
-            resources=_preview_resources_from_spec(projection.spec),
-            resource_diffs=resource_diffs,
-        )
 
     async def export_workflow(
         self,
@@ -256,29 +262,33 @@ class WorkspaceSyncService(BaseWorkspaceService):
         """
         self._require_workflow_export_scope()
         self._validate_export_params(params)
-        url = await self._workspace_git_url(provider=params.provider)
-        projection = await self.project_workspace(
-            workflow_ids=[WorkflowUUID.new(workflow.id)],
-            include_schedules=params.include_schedules,
-            create_missing_mappings=True,
-            workflow_dsl_overrides={workflow.id: dsl},
-        )
-        self._validate_projected_workspace_dependencies(projection.spec)
-        transport = self._transport_for_provider(
-            params.provider,
-        )
-        commit = await transport.write_files(
-            url=url,
-            files=projection.files,
-            message=params.message,
-            branch=params.branch,
-            create_pr=params.create_pr,
-            pr_base_branch=params.pr_base_branch,
-        )
-        workflow.git_sync_branch = commit.ref
-        self.session.add(workflow)
-        await self.session.commit()
-        return WorkspaceSyncExportResult(commit=commit, files=sorted(projection.files))
+        with self._mapping_provider_scope(params.provider):
+            url = await self._workspace_git_url(provider=params.provider)
+            projection = await self.project_workspace(
+                workflow_ids=[WorkflowUUID.new(workflow.id)],
+                include_schedules=params.include_schedules,
+                create_missing_mappings=True,
+                workflow_dsl_overrides={workflow.id: dsl},
+            )
+            self._validate_projected_workspace_dependencies(projection.spec)
+            transport = self._transport_for_provider(
+                params.provider,
+            )
+            commit = await transport.write_files(
+                url=url,
+                files=projection.files,
+                message=params.message,
+                branch=params.branch,
+                create_pr=params.create_pr,
+                pr_base_branch=params.pr_base_branch,
+            )
+            workflow.git_sync_branch = commit.ref
+            self.session.add(workflow)
+            await self.session.commit()
+            return WorkspaceSyncExportResult(
+                commit=commit,
+                files=sorted(projection.files),
+            )
 
     async def pull(
         self,
@@ -312,76 +322,77 @@ class WorkspaceSyncService(BaseWorkspaceService):
                 message="commit_sha is required",
             )
 
-        # Read the repository tree at that commit and parse it into a spec.
-        url = await self._workspace_git_url(provider=provider)
-        transport = self._transport_for_provider(
-            provider,
-        )
-        remote_tree = await transport.read_files(url=url, ref=options.commit_sha)
-        snapshot, diagnostics = await self.parse_files(
-            remote_tree.files,
-            commit_sha=remote_tree.commit_sha,
-            tree_sha=remote_tree.tree_sha,
-        )
-        resource_counts = self._resource_counts_from_spec(snapshot.spec)
-        # Parse/manifest problems abort before we touch the database.
-        if diagnostics:
-            return PullResult(
-                success=False,
-                commit_sha=snapshot.commit_sha,
-                workflows_found=len(snapshot.spec.workflows),
-                workflows_imported=0,
-                diagnostics=diagnostics,
-                message=f"Failed to validate workspace spec: {len(diagnostics)} issue(s)",
-                resource_counts=resource_counts,
-                files=sorted(snapshot.files),
-                resources=_sync_preview_resources_from_spec(snapshot.spec),
+        with self._mapping_provider_scope(provider):
+            # Read the repository tree at that commit and parse it into a spec.
+            url = await self._workspace_git_url(provider=provider)
+            transport = self._transport_for_provider(
+                provider,
             )
-        await self._require_spec_entitlements(snapshot.spec)
-        self._require_pull_scopes(snapshot.spec, dry_run=options.dry_run)
-        # A dry run previews the diff and validates workflows but never writes.
-        if options.dry_run:
-            resource_diffs = await self._resource_diffs_for_pull(
-                snapshot,
-                sync_schedules=sync_schedules,
+            remote_tree = await transport.read_files(url=url, ref=options.commit_sha)
+            snapshot, diagnostics = await self.parse_files(
+                remote_tree.files,
+                commit_sha=remote_tree.commit_sha,
+                tree_sha=remote_tree.tree_sha,
             )
-            workflow_diagnostics = await self._validate_workflow_import(snapshot)
-            if workflow_diagnostics:
+            resource_counts = self._resource_counts_from_spec(snapshot.spec)
+            # Parse/manifest problems abort before we touch the database.
+            if diagnostics:
                 return PullResult(
                     success=False,
                     commit_sha=snapshot.commit_sha,
                     workflows_found=len(snapshot.spec.workflows),
                     workflows_imported=0,
-                    diagnostics=workflow_diagnostics,
+                    diagnostics=diagnostics,
+                    message=f"Failed to validate workspace spec: {len(diagnostics)} issue(s)",
+                    resource_counts=resource_counts,
+                    files=sorted(snapshot.files),
+                    resources=_sync_preview_resources_from_spec(snapshot.spec),
+                )
+            await self._require_spec_entitlements(snapshot.spec)
+            self._require_pull_scopes(snapshot.spec, dry_run=options.dry_run)
+            # A dry run previews the diff and validates workflows but never writes.
+            if options.dry_run:
+                resource_diffs = await self._resource_diffs_for_pull(
+                    snapshot,
+                    sync_schedules=sync_schedules,
+                )
+                workflow_diagnostics = await self._validate_workflow_import(snapshot)
+                if workflow_diagnostics:
+                    return PullResult(
+                        success=False,
+                        commit_sha=snapshot.commit_sha,
+                        workflows_found=len(snapshot.spec.workflows),
+                        workflows_imported=0,
+                        diagnostics=workflow_diagnostics,
+                        message=(
+                            f"Import failed: {len(workflow_diagnostics)} validation "
+                            "error(s) found"
+                        ),
+                        resource_counts=resource_counts,
+                        resource_diffs=resource_diffs,
+                        files=sorted(snapshot.files),
+                        resources=_sync_preview_resources_from_spec(snapshot.spec),
+                    )
+                return PullResult(
+                    success=True,
+                    commit_sha=snapshot.commit_sha,
+                    workflows_found=len(snapshot.spec.workflows),
+                    workflows_imported=0,
+                    diagnostics=[],
                     message=(
-                        f"Import failed: {len(workflow_diagnostics)} validation "
-                        "error(s) found"
+                        "Dry run completed - "
+                        f"{len(resource_diffs)} resource change(s) detected"
                     ),
                     resource_counts=resource_counts,
                     resource_diffs=resource_diffs,
                     files=sorted(snapshot.files),
                     resources=_sync_preview_resources_from_spec(snapshot.spec),
                 )
-            return PullResult(
-                success=True,
-                commit_sha=snapshot.commit_sha,
-                workflows_found=len(snapshot.spec.workflows),
-                workflows_imported=0,
-                diagnostics=[],
-                message=(
-                    "Dry run completed - "
-                    f"{len(resource_diffs)} resource change(s) detected"
-                ),
-                resource_counts=resource_counts,
-                resource_diffs=resource_diffs,
-                files=sorted(snapshot.files),
-                resources=_sync_preview_resources_from_spec(snapshot.spec),
+            # Real pull: reconcile the snapshot into the database.
+            return await self._import_snapshot(
+                snapshot,
+                sync_schedules=sync_schedules,
             )
-        # Real pull: reconcile the snapshot into the database.
-        return await self._import_snapshot(
-            snapshot,
-            sync_schedules=sync_schedules,
-        )
 
     async def project_workspace(
         self,
@@ -636,6 +647,21 @@ class WorkspaceSyncService(BaseWorkspaceService):
             session=self.session,
             role=self.role,
         )
+
+    @contextmanager
+    def _mapping_provider_scope(self, provider: VcsProvider) -> Iterator[None]:
+        """Use ``provider`` for sync mapping reads and writes within a request."""
+        previous_provider = self._mapping_provider
+        self._mapping_provider = provider
+        try:
+            yield
+        finally:
+            self._mapping_provider = previous_provider
+
+    @property
+    def _mapping_provider_value(self) -> str:
+        """Provider value used for workspace sync resource mappings."""
+        return self._mapping_provider.value
 
     def _require_workspace_sync_scope(self) -> None:
         """Require the feature-level workspace sync RBAC scope."""
@@ -1758,7 +1784,7 @@ class WorkspaceSyncService(BaseWorkspaceService):
         """Return the sync mapping for ``(resource_type, source_id)``, if any."""
         stmt = select(WorkspaceSyncResourceMapping).where(
             WorkspaceSyncResourceMapping.workspace_id == self.workspace_id,
-            WorkspaceSyncResourceMapping.provider == VcsProvider.GITHUB.value,
+            WorkspaceSyncResourceMapping.provider == self._mapping_provider_value,
             WorkspaceSyncResourceMapping.resource_type == resource_type,
             WorkspaceSyncResourceMapping.source_id == source_id,
         )
@@ -1776,7 +1802,7 @@ class WorkspaceSyncService(BaseWorkspaceService):
                 continue
             stmt = select(WorkspaceSyncResourceMapping).where(
                 WorkspaceSyncResourceMapping.workspace_id == self.workspace_id,
-                WorkspaceSyncResourceMapping.provider == VcsProvider.GITHUB.value,
+                WorkspaceSyncResourceMapping.provider == self._mapping_provider_value,
                 WorkspaceSyncResourceMapping.resource_type == resource_type,
                 WorkspaceSyncResourceMapping.source_id.in_(source_ids),
             )
@@ -1796,7 +1822,7 @@ class WorkspaceSyncService(BaseWorkspaceService):
                 continue
             stmt = select(WorkspaceSyncResourceMapping).where(
                 WorkspaceSyncResourceMapping.workspace_id == self.workspace_id,
-                WorkspaceSyncResourceMapping.provider == VcsProvider.GITHUB.value,
+                WorkspaceSyncResourceMapping.provider == self._mapping_provider_value,
                 WorkspaceSyncResourceMapping.resource_type == resource_type,
                 WorkspaceSyncResourceMapping.local_id.in_(local_ids),
             )
@@ -1813,7 +1839,7 @@ class WorkspaceSyncService(BaseWorkspaceService):
         """Return the sync mapping for ``(resource_type, local_id)``, if any."""
         stmt = select(WorkspaceSyncResourceMapping).where(
             WorkspaceSyncResourceMapping.workspace_id == self.workspace_id,
-            WorkspaceSyncResourceMapping.provider == VcsProvider.GITHUB.value,
+            WorkspaceSyncResourceMapping.provider == self._mapping_provider_value,
             WorkspaceSyncResourceMapping.resource_type == resource_type,
             WorkspaceSyncResourceMapping.local_id == local_id,
         )
@@ -1878,7 +1904,7 @@ class WorkspaceSyncService(BaseWorkspaceService):
                 if mapping is None:
                     mapping = WorkspaceSyncResourceMapping(
                         workspace_id=self.workspace_id,
-                        provider=VcsProvider.GITHUB.value,
+                        provider=self._mapping_provider_value,
                         resource_type=target.resource_type,
                         source_id=target.source_id,
                         local_id=target.local_id,

--- a/tracecat/workspace_sync/service.py
+++ b/tracecat/workspace_sync/service.py
@@ -163,6 +163,40 @@ class WorkspaceSyncService(SyncMappingService):
         super().__init__(session=session, role=role, mapping_provider=provider)
         self._transport_factory = transport_factory
 
+    @classmethod
+    async def for_workspace(
+        cls,
+        session: AsyncSession,
+        role: Role,
+        *,
+        transport_factory: VcsTransportFactory | None = None,
+    ) -> WorkspaceSyncService:
+        """Construct the service using the provider configured in workspace settings.
+
+        The VCS provider is workspace state (``git_provider``), not a request
+        input: it selects which organization VCS connection this workspace syncs
+        through and must agree with the ``git_repo_url`` resolved from the same
+        settings. Resolving it here keeps a single server-side source of truth
+        rather than trusting a client-supplied value.
+        """
+        workspace_id = role.workspace_id
+        if workspace_id is None:
+            raise TracecatNotFoundError("Workspace not found")
+        workspace = await WorkspaceService(session=session, role=role).get_workspace(
+            workspace_id
+        )
+        if workspace is None:
+            raise TracecatNotFoundError("Workspace not found")
+        settings = workspace.settings
+        raw_provider = settings.get("git_provider") if settings else None
+        provider = VcsProvider(raw_provider) if raw_provider else VcsProvider.GITHUB
+        return cls(
+            session,
+            role,
+            provider=provider,
+            transport_factory=transport_factory,
+        )
+
     async def export_workspace(
         self,
         params: WorkspaceSyncExportRequest,

--- a/tracecat/workspace_sync/service.py
+++ b/tracecat/workspace_sync/service.py
@@ -1959,8 +1959,7 @@ class WorkspaceSyncService(BaseWorkspaceService):
         """Resolve the workspace's configured Git repository URL.
 
         Raises :class:`TracecatSettingsError` when no URL is configured or it is
-        invalid, and :class:`TracecatValidationError` for providers other than
-        GitHub, which is the only one currently supported.
+        invalid, and :class:`TracecatValidationError` for unsupported providers.
         """
         workspace = await self._workspace()
         repo_url = (
@@ -1970,12 +1969,16 @@ class WorkspaceSyncService(BaseWorkspaceService):
             raise TracecatSettingsError(
                 "Git repository URL not configured for this workspace."
             )
-        if provider != VcsProvider.GITHUB:
-            raise TracecatValidationError(
-                f"{provider.value} workspace sync is not implemented yet."
-            )
         try:
-            return parse_git_url(repo_url, allowed_domains={"github.com"})
+            match provider:
+                case VcsProvider.GITHUB:
+                    return parse_git_url(repo_url, allowed_domains={"github.com"})
+                case VcsProvider.GITLAB:
+                    return parse_git_url(repo_url)
+                case VcsProvider.BITBUCKET:
+                    raise TracecatValidationError(
+                        f"{provider.value} workspace sync is not implemented yet."
+                    )
         except ValueError as e:
             raise TracecatSettingsError(
                 f"Invalid Git repository URL configured for this workspace: {e}"

--- a/tracecat/workspace_sync/service.py
+++ b/tracecat/workspace_sync/service.py
@@ -189,7 +189,12 @@ class WorkspaceSyncService(SyncMappingService):
             raise TracecatNotFoundError("Workspace not found")
         settings = workspace.settings
         raw_provider = settings.get("git_provider") if settings else None
-        provider = VcsProvider(raw_provider) if raw_provider else VcsProvider.GITHUB
+        try:
+            provider = VcsProvider(raw_provider) if raw_provider else VcsProvider.GITHUB
+        except ValueError as e:
+            raise TracecatSettingsError(
+                f"Unsupported Git provider configured for this workspace: {raw_provider}"
+            ) from e
         return cls(
             session,
             role,
@@ -204,7 +209,7 @@ class WorkspaceSyncService(SyncMappingService):
         """Export selected or all syncable resources to a branch and optional PR."""
         self._require_workspace_sync_scope()
         self._validate_export_params(params)
-        url = await self._workspace_git_url(provider=self._mapping_provider)
+        url = await self._workspace_git_url()
         resource_ids = await self._local_ids_from_resource_refs(params.resources)
         projection = await self.project_workspace(
             resource_ids=resource_ids,
@@ -218,7 +223,7 @@ class WorkspaceSyncService(SyncMappingService):
             full_workspace_export=resource_ids is None,
             resource_ids=resource_ids,
         )
-        transport = self._transport_for_provider(self._mapping_provider)
+        transport = self._transport_for_provider()
         commit = await transport.write_files(
             url=url,
             files=projection.files,
@@ -256,8 +261,8 @@ class WorkspaceSyncService(SyncMappingService):
         self._validate_projected_workspace_dependencies(projection.spec)
         resource_diffs: list[PullResourceDiff] = []
         if params.compare_ref:
-            url = await self._workspace_git_url(provider=self._mapping_provider)
-            transport = self._transport_for_provider(self._mapping_provider)
+            url = await self._workspace_git_url()
+            transport = self._transport_for_provider()
             remote_tree = await transport.read_files(url=url, ref=params.compare_ref)
             delete_missing_paths_under = await self._export_delete_roots(
                 projection,
@@ -291,7 +296,7 @@ class WorkspaceSyncService(SyncMappingService):
         """
         self._require_workflow_export_scope()
         self._validate_export_params(params)
-        url = await self._workspace_git_url(provider=self._mapping_provider)
+        url = await self._workspace_git_url()
         projection = await self.project_workspace(
             workflow_ids=[WorkflowUUID.new(workflow.id)],
             include_schedules=params.include_schedules,
@@ -299,7 +304,7 @@ class WorkspaceSyncService(SyncMappingService):
             workflow_dsl_overrides={workflow.id: dsl},
         )
         self._validate_projected_workspace_dependencies(projection.spec)
-        transport = self._transport_for_provider(self._mapping_provider)
+        transport = self._transport_for_provider()
         commit = await transport.write_files(
             url=url,
             files=projection.files,
@@ -348,8 +353,8 @@ class WorkspaceSyncService(SyncMappingService):
             )
 
         # Read the repository tree at that commit and parse it into a spec.
-        url = await self._workspace_git_url(provider=self._mapping_provider)
-        transport = self._transport_for_provider(self._mapping_provider)
+        url = await self._workspace_git_url()
+        transport = self._transport_for_provider()
         remote_tree = await transport.read_files(url=url, ref=options.commit_sha)
         snapshot, diagnostics = await self.parse_files(
             remote_tree.files,
@@ -644,8 +649,8 @@ class WorkspaceSyncService(SyncMappingService):
     ) -> list[GitCommitInfo]:
         """List recent commits on ``branch`` for the workspace repository."""
         self._require_sync_operation_scope()
-        url = await self._workspace_git_url(provider=self._mapping_provider)
-        transport = self._transport_for_provider(self._mapping_provider)
+        url = await self._workspace_git_url()
+        transport = self._transport_for_provider()
         return await transport.list_commits(url=url, branch=branch, limit=limit)
 
     async def list_branches(
@@ -655,15 +660,15 @@ class WorkspaceSyncService(SyncMappingService):
     ) -> list[GitBranchInfo]:
         """List branches for the workspace repository."""
         self._require_sync_operation_scope()
-        url = await self._workspace_git_url(provider=self._mapping_provider)
-        transport = self._transport_for_provider(self._mapping_provider)
+        url = await self._workspace_git_url()
+        transport = self._transport_for_provider()
         return await transport.list_branches(url=url, limit=limit)
 
-    def _transport_for_provider(self, provider: VcsProvider) -> VcsSyncTransport:
-        """Build the VCS transport for ``provider`` using the configured factory."""
+    def _transport_for_provider(self) -> VcsSyncTransport:
+        """Build the VCS transport for the workspace provider using the factory."""
         factory = self._transport_factory or vcs_transport_for_provider
         return factory(
-            provider,
+            self._mapping_provider,
             session=self.session,
             role=self.role,
         )
@@ -1988,12 +1993,13 @@ class WorkspaceSyncService(SyncMappingService):
         """Return whether ``spec`` carries any non-workflow resource."""
         return any(adapter.specs(spec) for adapter in NON_WORKFLOW_RESOURCE_ADAPTERS)
 
-    async def _workspace_git_url(self, *, provider: VcsProvider) -> GitUrl:
+    async def _workspace_git_url(self) -> GitUrl:
         """Resolve the workspace's configured Git repository URL.
 
         Raises :class:`TracecatSettingsError` when no URL is configured or it is
         invalid, and :class:`TracecatValidationError` for unsupported providers.
         """
+        provider = self._mapping_provider
         workspace = await self._workspace()
         repo_url = (
             workspace.settings.get("git_repo_url") if workspace.settings else None

--- a/tracecat/workspace_sync/service.py
+++ b/tracecat/workspace_sync/service.py
@@ -35,7 +35,6 @@ from tracecat.git.types import GitUrl
 from tracecat.git.utils import parse_git_url
 from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.registry.repositories.schemas import GitBranchInfo, GitCommitInfo
-from tracecat.service import BaseWorkspaceService
 from tracecat.sync import (
     PullDiagnostic,
     PullOptions,
@@ -65,6 +64,7 @@ from tracecat.workspace_sync.adapters import (
 from tracecat.workspace_sync.adapters.base import (
     DirectoryManifestAdapter,
     ResourceDependencyRefs,
+    SyncMappingService,
     VersionedSlug,
 )
 from tracecat.workspace_sync.enums import SyncResourceType, VcsProvider
@@ -141,7 +141,7 @@ class SyncMappingTarget:
     local_id: uuid.UUID
 
 
-class WorkspaceSyncService(BaseWorkspaceService):
+class WorkspaceSyncService(SyncMappingService):
     """Direct workspace import/export over a VCS provider."""
 
     service_name = "workspace_sync"
@@ -160,7 +160,6 @@ class WorkspaceSyncService(BaseWorkspaceService):
         """
         super().__init__(session=session, role=role)
         self._transport_factory = transport_factory
-        self._mapping_provider = VcsProvider.GITHUB
 
     async def export_workspace(
         self,
@@ -657,11 +656,6 @@ class WorkspaceSyncService(BaseWorkspaceService):
             yield
         finally:
             self._mapping_provider = previous_provider
-
-    @property
-    def _mapping_provider_value(self) -> str:
-        """Provider value used for workspace sync resource mappings."""
-        return self._mapping_provider.value
 
     def _require_workspace_sync_scope(self) -> None:
         """Require the feature-level workspace sync RBAC scope."""

--- a/tracecat/workspace_sync/service.py
+++ b/tracecat/workspace_sync/service.py
@@ -913,6 +913,7 @@ class WorkspaceSyncService(BaseWorkspaceService):
                     imported_resources = await WorkspaceResourceImportService(
                         session=self.session,
                         role=self.role,
+                        mapping_provider=self._mapping_provider,
                     ).import_non_workflow_resources(snapshot.spec)
                 await workflow_importer.import_workflows(
                     remote_workflows,
@@ -1331,6 +1332,7 @@ class WorkspaceSyncService(BaseWorkspaceService):
             projection = await WorkspaceResourceProjector(
                 session=self.session,
                 role=self.role,
+                mapping_provider=self._mapping_provider,
             ).project_non_workflow_resources(resource_types=entitled_resource_types)
             return await self._augment_full_workspace_version_closure(
                 projection,

--- a/tracecat/workspace_sync/service.py
+++ b/tracecat/workspace_sync/service.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import re
 import uuid
 from collections import Counter, deque
-from collections.abc import Iterator, Mapping, Sequence
-from contextlib import contextmanager
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from difflib import unified_diff
 from typing import Any, cast
@@ -151,14 +150,17 @@ class WorkspaceSyncService(SyncMappingService):
         session: AsyncSession,
         role: Role | None = None,
         *,
+        provider: VcsProvider = VcsProvider.GITHUB,
         transport_factory: VcsTransportFactory | None = None,
     ) -> None:
-        """Initialize the service, optionally with a custom VCS transport factory.
+        """Initialize the service for ``provider``.
 
-        ``transport_factory`` overrides :func:`vcs_transport_for_provider`, which
-        lets tests substitute an in-memory transport.
+        ``provider`` selects the VCS the operation reads from and writes to, and
+        namespaces this workspace's sync mappings. ``transport_factory`` overrides
+        :func:`vcs_transport_for_provider`, which lets tests substitute an
+        in-memory transport.
         """
-        super().__init__(session=session, role=role)
+        super().__init__(session=session, role=role, mapping_provider=provider)
         self._transport_factory = transport_factory
 
     async def export_workspace(
@@ -168,38 +170,35 @@ class WorkspaceSyncService(SyncMappingService):
         """Export selected or all syncable resources to a branch and optional PR."""
         self._require_workspace_sync_scope()
         self._validate_export_params(params)
-        with self._mapping_provider_scope(params.provider):
-            url = await self._workspace_git_url(provider=params.provider)
-            resource_ids = await self._local_ids_from_resource_refs(params.resources)
-            projection = await self.project_workspace(
-                resource_ids=resource_ids,
-                include_schedules=params.include_schedules,
-                create_missing_mappings=True,
-            )
-            self._require_projected_export_scopes(projection.spec)
-            self._validate_projected_workspace_dependencies(projection.spec)
-            delete_missing_paths_under = await self._export_delete_roots(
-                projection,
-                full_workspace_export=resource_ids is None,
-                resource_ids=resource_ids,
-            )
-            transport = self._transport_for_provider(
-                params.provider,
-            )
-            commit = await transport.write_files(
-                url=url,
-                files=projection.files,
-                message=params.message,
-                branch=params.branch,
-                create_pr=params.create_pr,
-                pr_base_branch=params.pr_base_branch,
-                delete_missing_paths_under=delete_missing_paths_under,
-            )
-            await self.session.commit()
-            return WorkspaceSyncExportResult(
-                commit=commit,
-                files=sorted(projection.files),
-            )
+        url = await self._workspace_git_url(provider=self._mapping_provider)
+        resource_ids = await self._local_ids_from_resource_refs(params.resources)
+        projection = await self.project_workspace(
+            resource_ids=resource_ids,
+            include_schedules=params.include_schedules,
+            create_missing_mappings=True,
+        )
+        self._require_projected_export_scopes(projection.spec)
+        self._validate_projected_workspace_dependencies(projection.spec)
+        delete_missing_paths_under = await self._export_delete_roots(
+            projection,
+            full_workspace_export=resource_ids is None,
+            resource_ids=resource_ids,
+        )
+        transport = self._transport_for_provider(self._mapping_provider)
+        commit = await transport.write_files(
+            url=url,
+            files=projection.files,
+            message=params.message,
+            branch=params.branch,
+            create_pr=params.create_pr,
+            pr_base_branch=params.pr_base_branch,
+            delete_missing_paths_under=delete_missing_paths_under,
+        )
+        await self.session.commit()
+        return WorkspaceSyncExportResult(
+            commit=commit,
+            files=sorted(projection.files),
+        )
 
     async def preview_export_workspace(
         self,
@@ -213,38 +212,35 @@ class WorkspaceSyncService(SyncMappingService):
         resources pulled in transitively by the dependency closure.
         """
         self._require_workspace_sync_scope()
-        with self._mapping_provider_scope(params.provider):
-            resource_ids = await self._local_ids_from_resource_refs(params.resources)
-            projection = await self.project_workspace(
+        resource_ids = await self._local_ids_from_resource_refs(params.resources)
+        projection = await self.project_workspace(
+            resource_ids=resource_ids,
+            include_schedules=params.include_schedules,
+            create_missing_mappings=False,
+        )
+        self._require_projected_export_scopes(projection.spec)
+        self._validate_projected_workspace_dependencies(projection.spec)
+        resource_diffs: list[PullResourceDiff] = []
+        if params.compare_ref:
+            url = await self._workspace_git_url(provider=self._mapping_provider)
+            transport = self._transport_for_provider(self._mapping_provider)
+            remote_tree = await transport.read_files(url=url, ref=params.compare_ref)
+            delete_missing_paths_under = await self._export_delete_roots(
+                projection,
+                full_workspace_export=resource_ids is None,
                 resource_ids=resource_ids,
-                include_schedules=params.include_schedules,
-                create_missing_mappings=False,
             )
-            self._require_projected_export_scopes(projection.spec)
-            self._validate_projected_workspace_dependencies(projection.spec)
-            resource_diffs: list[PullResourceDiff] = []
-            if params.compare_ref:
-                url = await self._workspace_git_url(provider=params.provider)
-                transport = self._transport_for_provider(params.provider)
-                remote_tree = await transport.read_files(
-                    url=url, ref=params.compare_ref
-                )
-                delete_missing_paths_under = await self._export_delete_roots(
-                    projection,
-                    full_workspace_export=resource_ids is None,
-                    resource_ids=resource_ids,
-                )
-                resource_diffs = self._resource_diffs_for_export(
-                    projection,
-                    remote_tree,
-                    delete_missing_paths_under=delete_missing_paths_under,
-                )
-            return WorkspaceSyncExportPreview(
-                resource_counts=projection.spec.resource_count_map(),
-                files=sorted(projection.files),
-                resources=_preview_resources_from_spec(projection.spec),
-                resource_diffs=resource_diffs,
+            resource_diffs = self._resource_diffs_for_export(
+                projection,
+                remote_tree,
+                delete_missing_paths_under=delete_missing_paths_under,
             )
+        return WorkspaceSyncExportPreview(
+            resource_counts=projection.spec.resource_count_map(),
+            files=sorted(projection.files),
+            resources=_preview_resources_from_spec(projection.spec),
+            resource_diffs=resource_diffs,
+        )
 
     async def export_workflow(
         self,
@@ -261,39 +257,35 @@ class WorkspaceSyncService(SyncMappingService):
         """
         self._require_workflow_export_scope()
         self._validate_export_params(params)
-        with self._mapping_provider_scope(params.provider):
-            url = await self._workspace_git_url(provider=params.provider)
-            projection = await self.project_workspace(
-                workflow_ids=[WorkflowUUID.new(workflow.id)],
-                include_schedules=params.include_schedules,
-                create_missing_mappings=True,
-                workflow_dsl_overrides={workflow.id: dsl},
-            )
-            self._validate_projected_workspace_dependencies(projection.spec)
-            transport = self._transport_for_provider(
-                params.provider,
-            )
-            commit = await transport.write_files(
-                url=url,
-                files=projection.files,
-                message=params.message,
-                branch=params.branch,
-                create_pr=params.create_pr,
-                pr_base_branch=params.pr_base_branch,
-            )
-            workflow.git_sync_branch = commit.ref
-            self.session.add(workflow)
-            await self.session.commit()
-            return WorkspaceSyncExportResult(
-                commit=commit,
-                files=sorted(projection.files),
-            )
+        url = await self._workspace_git_url(provider=self._mapping_provider)
+        projection = await self.project_workspace(
+            workflow_ids=[WorkflowUUID.new(workflow.id)],
+            include_schedules=params.include_schedules,
+            create_missing_mappings=True,
+            workflow_dsl_overrides={workflow.id: dsl},
+        )
+        self._validate_projected_workspace_dependencies(projection.spec)
+        transport = self._transport_for_provider(self._mapping_provider)
+        commit = await transport.write_files(
+            url=url,
+            files=projection.files,
+            message=params.message,
+            branch=params.branch,
+            create_pr=params.create_pr,
+            pr_base_branch=params.pr_base_branch,
+        )
+        workflow.git_sync_branch = commit.ref
+        self.session.add(workflow)
+        await self.session.commit()
+        return WorkspaceSyncExportResult(
+            commit=commit,
+            files=sorted(projection.files),
+        )
 
     async def pull(
         self,
         *,
         options: PullOptions,
-        provider: VcsProvider = VcsProvider.GITHUB,
         sync_schedules: bool = False,
     ) -> PullResult:
         """Import a workspace spec from the configured repository.
@@ -321,77 +313,74 @@ class WorkspaceSyncService(SyncMappingService):
                 message="commit_sha is required",
             )
 
-        with self._mapping_provider_scope(provider):
-            # Read the repository tree at that commit and parse it into a spec.
-            url = await self._workspace_git_url(provider=provider)
-            transport = self._transport_for_provider(
-                provider,
+        # Read the repository tree at that commit and parse it into a spec.
+        url = await self._workspace_git_url(provider=self._mapping_provider)
+        transport = self._transport_for_provider(self._mapping_provider)
+        remote_tree = await transport.read_files(url=url, ref=options.commit_sha)
+        snapshot, diagnostics = await self.parse_files(
+            remote_tree.files,
+            commit_sha=remote_tree.commit_sha,
+            tree_sha=remote_tree.tree_sha,
+        )
+        resource_counts = self._resource_counts_from_spec(snapshot.spec)
+        # Parse/manifest problems abort before we touch the database.
+        if diagnostics:
+            return PullResult(
+                success=False,
+                commit_sha=snapshot.commit_sha,
+                workflows_found=len(snapshot.spec.workflows),
+                workflows_imported=0,
+                diagnostics=diagnostics,
+                message=f"Failed to validate workspace spec: {len(diagnostics)} issue(s)",
+                resource_counts=resource_counts,
+                files=sorted(snapshot.files),
+                resources=_sync_preview_resources_from_spec(snapshot.spec),
             )
-            remote_tree = await transport.read_files(url=url, ref=options.commit_sha)
-            snapshot, diagnostics = await self.parse_files(
-                remote_tree.files,
-                commit_sha=remote_tree.commit_sha,
-                tree_sha=remote_tree.tree_sha,
+        await self._require_spec_entitlements(snapshot.spec)
+        self._require_pull_scopes(snapshot.spec, dry_run=options.dry_run)
+        # A dry run previews the diff and validates workflows but never writes.
+        if options.dry_run:
+            resource_diffs = await self._resource_diffs_for_pull(
+                snapshot,
+                sync_schedules=sync_schedules,
             )
-            resource_counts = self._resource_counts_from_spec(snapshot.spec)
-            # Parse/manifest problems abort before we touch the database.
-            if diagnostics:
+            workflow_diagnostics = await self._validate_workflow_import(snapshot)
+            if workflow_diagnostics:
                 return PullResult(
                     success=False,
                     commit_sha=snapshot.commit_sha,
                     workflows_found=len(snapshot.spec.workflows),
                     workflows_imported=0,
-                    diagnostics=diagnostics,
-                    message=f"Failed to validate workspace spec: {len(diagnostics)} issue(s)",
-                    resource_counts=resource_counts,
-                    files=sorted(snapshot.files),
-                    resources=_sync_preview_resources_from_spec(snapshot.spec),
-                )
-            await self._require_spec_entitlements(snapshot.spec)
-            self._require_pull_scopes(snapshot.spec, dry_run=options.dry_run)
-            # A dry run previews the diff and validates workflows but never writes.
-            if options.dry_run:
-                resource_diffs = await self._resource_diffs_for_pull(
-                    snapshot,
-                    sync_schedules=sync_schedules,
-                )
-                workflow_diagnostics = await self._validate_workflow_import(snapshot)
-                if workflow_diagnostics:
-                    return PullResult(
-                        success=False,
-                        commit_sha=snapshot.commit_sha,
-                        workflows_found=len(snapshot.spec.workflows),
-                        workflows_imported=0,
-                        diagnostics=workflow_diagnostics,
-                        message=(
-                            f"Import failed: {len(workflow_diagnostics)} validation "
-                            "error(s) found"
-                        ),
-                        resource_counts=resource_counts,
-                        resource_diffs=resource_diffs,
-                        files=sorted(snapshot.files),
-                        resources=_sync_preview_resources_from_spec(snapshot.spec),
-                    )
-                return PullResult(
-                    success=True,
-                    commit_sha=snapshot.commit_sha,
-                    workflows_found=len(snapshot.spec.workflows),
-                    workflows_imported=0,
-                    diagnostics=[],
+                    diagnostics=workflow_diagnostics,
                     message=(
-                        "Dry run completed - "
-                        f"{len(resource_diffs)} resource change(s) detected"
+                        f"Import failed: {len(workflow_diagnostics)} validation "
+                        "error(s) found"
                     ),
                     resource_counts=resource_counts,
                     resource_diffs=resource_diffs,
                     files=sorted(snapshot.files),
                     resources=_sync_preview_resources_from_spec(snapshot.spec),
                 )
-            # Real pull: reconcile the snapshot into the database.
-            return await self._import_snapshot(
-                snapshot,
-                sync_schedules=sync_schedules,
+            return PullResult(
+                success=True,
+                commit_sha=snapshot.commit_sha,
+                workflows_found=len(snapshot.spec.workflows),
+                workflows_imported=0,
+                diagnostics=[],
+                message=(
+                    "Dry run completed - "
+                    f"{len(resource_diffs)} resource change(s) detected"
+                ),
+                resource_counts=resource_counts,
+                resource_diffs=resource_diffs,
+                files=sorted(snapshot.files),
+                resources=_sync_preview_resources_from_spec(snapshot.spec),
             )
+        # Real pull: reconcile the snapshot into the database.
+        return await self._import_snapshot(
+            snapshot,
+            sync_schedules=sync_schedules,
+        )
 
     async def project_workspace(
         self,
@@ -618,24 +607,22 @@ class WorkspaceSyncService(SyncMappingService):
         *,
         branch: str = "main",
         limit: int = 10,
-        provider: VcsProvider = VcsProvider.GITHUB,
     ) -> list[GitCommitInfo]:
         """List recent commits on ``branch`` for the workspace repository."""
         self._require_sync_operation_scope()
-        url = await self._workspace_git_url(provider=provider)
-        transport = self._transport_for_provider(provider)
+        url = await self._workspace_git_url(provider=self._mapping_provider)
+        transport = self._transport_for_provider(self._mapping_provider)
         return await transport.list_commits(url=url, branch=branch, limit=limit)
 
     async def list_branches(
         self,
         *,
         limit: int = 100,
-        provider: VcsProvider = VcsProvider.GITHUB,
     ) -> list[GitBranchInfo]:
         """List branches for the workspace repository."""
         self._require_sync_operation_scope()
-        url = await self._workspace_git_url(provider=provider)
-        transport = self._transport_for_provider(provider)
+        url = await self._workspace_git_url(provider=self._mapping_provider)
+        transport = self._transport_for_provider(self._mapping_provider)
         return await transport.list_branches(url=url, limit=limit)
 
     def _transport_for_provider(self, provider: VcsProvider) -> VcsSyncTransport:
@@ -646,16 +633,6 @@ class WorkspaceSyncService(SyncMappingService):
             session=self.session,
             role=self.role,
         )
-
-    @contextmanager
-    def _mapping_provider_scope(self, provider: VcsProvider) -> Iterator[None]:
-        """Use ``provider`` for sync mapping reads and writes within a request."""
-        previous_provider = self._mapping_provider
-        self._mapping_provider = provider
-        try:
-            yield
-        finally:
-            self._mapping_provider = previous_provider
 
     def _require_workspace_sync_scope(self) -> None:
         """Require the feature-level workspace sync RBAC scope."""

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -687,7 +687,7 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             branches = await self._list_branches_with_client(
                 client=client,
                 url=url,
-                limit=_GITLAB_PAGE_SIZE,
+                limit=None,
             )
             default_branch = (
                 next((item.name for item in branches if item.is_default), None)
@@ -955,7 +955,7 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         *,
         client: httpx.AsyncClient,
         url: GitUrl,
-        limit: int,
+        limit: int | None,
     ) -> list[GitBranchInfo]:
         """List branches using an existing GitLab client."""
         project_id = _gitlab_project_id(url)
@@ -1167,12 +1167,9 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
 
 
 def _gitlab_instance_host(value: str) -> str:
-    """Return the lowercased ``host[:port]`` for a GitLab URL or bare host."""
+    """Return the lowercased hostname for a GitLab URL or bare host."""
     parsed = urlparse(value if "://" in value else f"//{value}")
-    host = (parsed.hostname or "").lower()
-    if parsed.port:
-        return f"{host}:{parsed.port}"
-    return host
+    return (parsed.hostname or "").lower()
 
 
 def _gitlab_project_id(url: GitUrl) -> str:

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import itertools
-from collections.abc import Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
 from urllib.parse import quote
@@ -148,7 +148,95 @@ _GITLAB_BLOB_CONCURRENCY = 8
 """Maximum concurrent GitLab blob calls during sync reads."""
 
 
-class GitHubWorkspaceSyncTransport(BaseWorkspaceService):
+class BaseWorkspaceSyncTransport(BaseWorkspaceService):
+    """Shared, provider-neutral helpers for workspace sync transports.
+
+    The GitHub and GitLab transports differ in how they authenticate, list
+    blobs, and write commits, but agree on which files a snapshot contains, how
+    export inputs are validated, and what the generated PR/MR body says. Those
+    provider-neutral pieces live here so both transports stay in lockstep.
+    """
+
+    @staticmethod
+    def _normalize_commit_message(files: dict[str, str], message: str) -> str:
+        """Validate export inputs and return the stripped commit message."""
+        if not files:
+            raise ValueError("At least one file is required for workspace sync export")
+        message = message.strip()
+        if not message:
+            raise ValueError("A non-empty commit message is required")
+        return message
+
+    async def _select_snapshot_files(
+        self,
+        *,
+        blob_paths: Sequence[str],
+        fetch_text: Callable[[str], Awaitable[str | None]],
+    ) -> dict[str, str]:
+        """Decode the manifest and managed-resource blobs from a commit tree.
+
+        ``blob_paths`` lists every blob path in the tree; ``fetch_text`` loads and
+        UTF-8 decodes one path, returning ``None`` for binary blobs. The manifest
+        (when present) selects the resource roots; only paths under those roots
+        are read. Shared by the GitHub and GitLab readers, which differ only in
+        how blobs are listed and fetched.
+        """
+        paths = set(blob_paths)
+
+        async def fetch_path(path: str) -> tuple[str, str | None]:
+            """Fetch ``path`` and preserve its identity through gather."""
+            return path, await fetch_text(path)
+
+        files: dict[str, str] = {}
+        resource_roots = manifest_resource_roots(WorkspaceManifest())
+        if MANIFEST_FILENAME in paths:
+            manifest_content = await fetch_text(MANIFEST_FILENAME)
+            if manifest_content is not None:
+                files[MANIFEST_FILENAME] = manifest_content
+                try:
+                    manifest = workspace_manifest_from_json(manifest_content)
+                    resource_roots = manifest_resource_roots(manifest)
+                except Exception:
+                    pass
+
+        resource_paths = [
+            path
+            for path in sorted(paths)
+            if path != MANIFEST_FILENAME
+            and any(path.startswith(f"{root}/") for root in resource_roots)
+        ]
+        for path, content in await asyncio.gather(
+            *(fetch_path(path) for path in resource_paths)
+        ):
+            if content is not None:
+                files[path] = content
+        return files
+
+    async def _sync_request_body(self) -> str:
+        """Render the shared PR/MR description with workspace attribution."""
+        workspace = await WorkspaceService(
+            session=self.session,
+            role=self.role,
+        ).get_workspace(self.workspace_id)
+        if workspace is None:
+            raise TracecatNotFoundError("Workspace not found")
+
+        current_user = None
+        if self.role.user_id is not None:
+            try:
+                current_user = await self.session.get(User, self.role.user_id)
+            except Exception:
+                current_user = None
+
+        published_by = current_user.email if current_user else "<unknown>"
+        return (
+            "Automated workspace sync from Tracecat\n\n"
+            f"**Workspace:** {workspace.name}\n"
+            f"**Published by:** {published_by}"
+        )
+
+
+class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
     """GitHub App transport for workspace sync."""
 
     service_name = "workspace_github_sync"
@@ -194,33 +282,10 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceService):
                 except UnicodeDecodeError:
                     return None
 
-            async def fetch_path(path: str) -> tuple[str, str | None]:
-                """Fetch ``path`` and preserve its identity through gather."""
-                return path, await fetch_text(path)
-
-            files: dict[str, str] = {}
-            resource_roots = manifest_resource_roots(WorkspaceManifest())
-            if MANIFEST_FILENAME in blob_shas:
-                manifest_content = await fetch_text(MANIFEST_FILENAME)
-                if manifest_content is not None:
-                    files[MANIFEST_FILENAME] = manifest_content
-                    try:
-                        manifest = workspace_manifest_from_json(manifest_content)
-                        resource_roots = manifest_resource_roots(manifest)
-                    except Exception:
-                        pass
-
-            resource_paths = [
-                path
-                for path in sorted(blob_shas)
-                if path != MANIFEST_FILENAME
-                and any(path.startswith(f"{root}/") for root in resource_roots)
-            ]
-            for path, content in await asyncio.gather(
-                *(fetch_path(path) for path in resource_paths)
-            ):
-                if content is not None:
-                    files[path] = content
+            files = await self._select_snapshot_files(
+                blob_paths=list(blob_shas),
+                fetch_text=fetch_text,
+            )
             return VcsTreeSnapshot(
                 commit_sha=commit.sha,
                 tree_sha=tree_sha,
@@ -251,11 +316,7 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceService):
         reusing or opening a pull request when ``create_pr`` is set and the
         branch diverges from its base.
         """
-        if not files:
-            raise ValueError("At least one file is required for workspace sync export")
-        message = message.strip()
-        if not message:
-            raise ValueError("A non-empty commit message is required")
+        message = self._normalize_commit_message(files, message)
 
         gh_svc = GitHubAppService(session=self.session, role=self.role)
         gh = await gh_svc.get_github_client_for_repo(url)
@@ -549,29 +610,10 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceService):
         if existing_pr is not None:
             return existing_pr.html_url, existing_pr.number, True
 
-        workspace = await WorkspaceService(
-            session=self.session,
-            role=self.role,
-        ).get_workspace(self.workspace_id)
-        if workspace is None:
-            raise TracecatNotFoundError("Workspace not found")
-
-        current_user = None
-        if self.role.user_id is not None:
-            try:
-                current_user = await self.session.get(User, self.role.user_id)
-            except Exception:
-                current_user = None
-
-        published_by = current_user.email if current_user else "<unknown>"
         pr = await asyncio.to_thread(
             repo.create_pull,
             title=title,
-            body=(
-                "Automated workspace sync from Tracecat\n\n"
-                f"**Workspace:** {workspace.name}\n"
-                f"**Published by:** {published_by}"
-            ),
+            body=await self._sync_request_body(),
             head=branch_name,
             base=base_branch_name,
         )
@@ -593,7 +635,7 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceService):
         return (getattr(comparison, "ahead_by", None) or 0) > 0
 
 
-class GitLabWorkspaceSyncTransport(BaseWorkspaceService):
+class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
     """GitLab token-backed REST transport for workspace sync."""
 
     service_name = "workspace_gitlab_sync"
@@ -621,11 +663,7 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceService):
         delete_missing_paths_under: Sequence[str] = (),
     ) -> CommitInfo:
         """Commit ``files`` to ``branch``, optionally opening a merge request."""
-        if not files:
-            raise ValueError("At least one file is required for workspace sync export")
-        message = message.strip()
-        if not message:
-            raise ValueError("A non-empty commit message is required")
+        message = self._normalize_commit_message(files, message)
 
         credentials = await self._credentials()
         async with self._client(credentials) as client:
@@ -870,34 +908,10 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceService):
             except UnicodeDecodeError:
                 return None
 
-        async def fetch_path(path: str) -> tuple[str, str | None]:
-            """Fetch ``path`` and preserve identity through gather."""
-            return path, await fetch_text(path)
-
-        files: dict[str, str] = {}
-        resource_roots = manifest_resource_roots(WorkspaceManifest())
-        if MANIFEST_FILENAME in blob_shas:
-            manifest_content = await fetch_text(MANIFEST_FILENAME)
-            if manifest_content is not None:
-                files[MANIFEST_FILENAME] = manifest_content
-                try:
-                    manifest = workspace_manifest_from_json(manifest_content)
-                    resource_roots = manifest_resource_roots(manifest)
-                except Exception:
-                    pass
-
-        resource_paths = [
-            path
-            for path in sorted(blob_shas)
-            if path != MANIFEST_FILENAME
-            and any(path.startswith(f"{root}/") for root in resource_roots)
-        ]
-        for path, content in await asyncio.gather(
-            *(fetch_path(path) for path in resource_paths)
-        ):
-            if content is not None:
-                files[path] = content
-
+        files = await self._select_snapshot_files(
+            blob_paths=list(blob_shas),
+            fetch_text=fetch_text,
+        )
         return VcsTreeSnapshot(
             commit_sha=commit_sha,
             tree_sha=None,
@@ -984,21 +998,6 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceService):
             mr = existing[0]
             return str(mr.get("web_url") or ""), _int_or_none(mr.get("iid")), True
 
-        workspace = await WorkspaceService(
-            session=self.session,
-            role=self.role,
-        ).get_workspace(self.workspace_id)
-        if workspace is None:
-            raise TracecatNotFoundError("Workspace not found")
-
-        current_user = None
-        if self.role.user_id is not None:
-            try:
-                current_user = await self.session.get(User, self.role.user_id)
-            except Exception:
-                current_user = None
-
-        published_by = current_user.email if current_user else "<unknown>"
         mr_data = await self._gitlab_json(
             client,
             "POST",
@@ -1007,11 +1006,7 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceService):
                 "source_branch": branch_name,
                 "target_branch": base_branch_name,
                 "title": title,
-                "description": (
-                    "Automated workspace sync from Tracecat\n\n"
-                    f"**Workspace:** {workspace.name}\n"
-                    f"**Published by:** {published_by}"
-                ),
+                "description": await self._sync_request_body(),
             },
         )
         if not isinstance(mr_data, dict):

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequenc
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import Any, Protocol
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 
 import httpx
 from github.GithubException import GithubException
@@ -874,25 +874,9 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         )
 
     @asynccontextmanager
-    async def _authed_client(self, url: GitUrl) -> AsyncIterator[httpx.AsyncClient]:
-        """Yield an authenticated client, asserting the repo lives on the instance.
-
-        The API host comes from the organization GitLab connection's ``base_url``
-        while the project path comes from the workspace ``git_repo_url``. Guarding
-        that they reference the same host prevents a workspace URL from silently
-        resolving against a different GitLab instance than the one the token
-        authenticates to.
-        """
+    async def _authed_client(self, _url: GitUrl) -> AsyncIterator[httpx.AsyncClient]:
+        """Yield an authenticated client for the configured GitLab instance."""
         credentials = await self._credentials()
-        expected_host = _gitlab_instance_host(credentials.base_url)
-        repo_host = _gitlab_instance_host(url.host)
-        if expected_host and repo_host != expected_host:
-            raise TracecatValidationError(
-                f"Workspace repository host '{url.host}' does not match the "
-                f"configured GitLab instance '{expected_host}'. Update the "
-                "workspace Git URL or the organization GitLab connection so they "
-                "reference the same host."
-            )
         async with self._client(credentials) as client:
             yield client
 
@@ -1237,12 +1221,6 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             return response.json()
         except ValueError as e:
             raise GitLabError("GitLab response was not valid JSON") from e
-
-
-def _gitlab_instance_host(value: str) -> str:
-    """Return the lowercased hostname for a GitLab URL or bare host."""
-    parsed = urlparse(value if "://" in value else f"//{value}")
-    return (parsed.hostname or "").lower()
 
 
 def _gitlab_project_id(url: GitUrl) -> str:

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import asyncio
 import base64
 import itertools
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, Protocol
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import httpx
 from github.GithubException import GithubException
@@ -664,8 +665,7 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         ref: str,
     ) -> VcsTreeSnapshot:
         """Read the manifest and managed resource files at ``ref``."""
-        credentials = await self._credentials()
-        async with self._client(credentials) as client:
+        async with self._authed_client(url) as client:
             return await self._read_files_with_client(client=client, url=url, ref=ref)
 
     async def write_files(
@@ -682,8 +682,7 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         """Commit ``files`` to ``branch``, optionally opening a merge request."""
         message = self._normalize_commit_message(files, message)
 
-        credentials = await self._credentials()
-        async with self._client(credentials) as client:
+        async with self._authed_client(url) as client:
             project_id = _gitlab_project_id(url)
             branches = await self._list_branches_with_client(
                 client=client,
@@ -822,8 +821,7 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         limit: int = 10,
     ) -> list[GitCommitInfo]:
         """Return up to ``limit`` most recent commits on ``branch``."""
-        credentials = await self._credentials()
-        async with self._client(credentials) as client:
+        async with self._authed_client(url) as client:
             project_id = _gitlab_project_id(url)
             commits_params: GitLabListCommitsParams = {"ref_name": branch}
             raw_commits = await self._gitlab_list(
@@ -855,8 +853,7 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         limit: int = 100,
     ) -> list[GitBranchInfo]:
         """Return up to ``limit`` branches, flagging the repository default."""
-        credentials = await self._credentials()
-        async with self._client(credentials) as client:
+        async with self._authed_client(url) as client:
             return await self._list_branches_with_client(
                 client=client,
                 url=url,
@@ -877,6 +874,29 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             headers={"PRIVATE-TOKEN": credentials.token.get_secret_value()},
             timeout=30.0,
         )
+
+    @asynccontextmanager
+    async def _authed_client(self, url: GitUrl) -> AsyncIterator[httpx.AsyncClient]:
+        """Yield an authenticated client, asserting the repo lives on the instance.
+
+        The API host comes from the organization GitLab connection's ``base_url``
+        while the project path comes from the workspace ``git_repo_url``. Guarding
+        that they reference the same host prevents a workspace URL from silently
+        resolving against a different GitLab instance than the one the token
+        authenticates to.
+        """
+        credentials = await self._credentials()
+        expected_host = _gitlab_instance_host(credentials.base_url)
+        repo_host = _gitlab_instance_host(url.host)
+        if expected_host and repo_host != expected_host:
+            raise TracecatValidationError(
+                f"Workspace repository host '{url.host}' does not match the "
+                f"configured GitLab instance '{expected_host}'. Update the "
+                "workspace Git URL or the organization GitLab connection so they "
+                "reference the same host."
+            )
+        async with self._client(credentials) as client:
+            yield client
 
     async def _read_files_with_client(
         self,
@@ -1144,6 +1164,15 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             return response.json()
         except ValueError as e:
             raise GitLabError("GitLab response was not valid JSON") from e
+
+
+def _gitlab_instance_host(value: str) -> str:
+    """Return the lowercased ``host[:port]`` for a GitLab URL or bare host."""
+    parsed = urlparse(value if "://" in value else f"//{value}")
+    host = (parsed.hostname or "").lower()
+    if parsed.port:
+        return f"{host}:{parsed.port}"
+    return host
 
 
 def _gitlab_project_id(url: GitUrl) -> str:

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -959,10 +959,10 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
     ) -> list[GitBranchInfo]:
         """List branches using an existing GitLab client."""
         project_id = _gitlab_project_id(url)
-        raw_branches = await self._gitlab_list(
+        branch_path = f"/projects/{project_id}/repository/branches"
+        raw_branches = await self._gitlab_branches_including_default(
             client,
-            f"/projects/{project_id}/repository/branches",
-            model=GitLabBranch,
+            branch_path,
             limit=limit,
         )
         return [
@@ -1001,6 +1001,66 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             f"/projects/{project_id}/repository/branches",
             params=create_branch_params,
         )
+
+    async def _gitlab_branches_including_default(
+        self,
+        client: httpx.AsyncClient,
+        path: str,
+        *,
+        limit: int | None,
+    ) -> list[GitLabBranch]:
+        """Collect branches, continuing past ``limit`` until the default is known."""
+        if limit is not None and limit <= 0:
+            return []
+
+        branches: list[GitLabBranch] = []
+        default_branch: GitLabBranch | None = None
+        page = 1
+        while True:
+            response = await self._gitlab_response(
+                client,
+                "GET",
+                path,
+                params={"page": page, "per_page": _GITLAB_PAGE_SIZE},
+            )
+            data = self._json(response)
+            if not isinstance(data, list):
+                raise GitLabError("GitLab list response was invalid")
+            try:
+                page_branches = [GitLabBranch.model_validate(item) for item in data]
+            except PydanticValidationError as e:
+                raise GitLabError("GitLab list response was invalid") from e
+
+            if default_branch is None:
+                default_branch = next(
+                    (branch for branch in page_branches if branch.default),
+                    None,
+                )
+
+            if limit is None:
+                branches.extend(page_branches)
+            else:
+                remaining = limit - len(branches)
+                if remaining > 0:
+                    branches.extend(page_branches[:remaining])
+
+            next_page = response.headers.get("x-next-page")
+            if limit is not None and len(branches) >= limit and default_branch:
+                break
+            if not next_page:
+                break
+            try:
+                page = int(next_page)
+            except ValueError as e:
+                raise GitLabError("GitLab pagination response was invalid") from e
+
+        if (
+            limit is not None
+            and default_branch is not None
+            and all(branch.name != default_branch.name for branch in branches)
+        ):
+            branches = [*branches[: limit - 1], default_branch]
+        return branches
 
     async def _upsert_merge_request(
         self,

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequenc
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import Any, Protocol
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import httpx
 from github.GithubException import GithubException
@@ -874,9 +874,31 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         )
 
     @asynccontextmanager
-    async def _authed_client(self, _url: GitUrl) -> AsyncIterator[httpx.AsyncClient]:
-        """Yield an authenticated client for the configured GitLab instance."""
+    async def _authed_client(self, url: GitUrl) -> AsyncIterator[httpx.AsyncClient]:
+        """Yield an authenticated client, asserting the repo lives on the instance.
+
+        The API host comes from the organization GitLab connection's ``base_url``
+        while the project path comes from the workspace ``git_repo_url``. Guarding
+        that they reference the same host prevents a workspace URL from silently
+        resolving against a different GitLab instance than the one the token
+        authenticates to.
+
+        Dedicated SSH host aliases (for example ``ssh.gitlab.example.test`` or
+        ``altssh.gitlab.com``) are allowed as subdomains of the configured
+        instance host, and ports are ignored so custom SSH ports still match.
+        """
         credentials = await self._credentials()
+        expected_host = _gitlab_instance_host(credentials.base_url)
+        repo_host = _gitlab_instance_host(url.host)
+        if expected_host and not (
+            repo_host == expected_host or repo_host.endswith(f".{expected_host}")
+        ):
+            raise TracecatValidationError(
+                f"Workspace repository host '{url.host}' does not match the "
+                f"configured GitLab instance '{expected_host}'. Update the "
+                "workspace Git URL or the organization GitLab connection so they "
+                "reference the same host."
+            )
         async with self._client(credentials) as client:
             yield client
 
@@ -1221,6 +1243,12 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             return response.json()
         except ValueError as e:
             raise GitLabError("GitLab response was not valid JSON") from e
+
+
+def _gitlab_instance_host(value: str) -> str:
+    """Return the lowercased hostname for a GitLab URL or bare host."""
+    parsed = urlparse(value if "://" in value else f"//{value}")
+    return (parsed.hostname or "").lower()
 
 
 def _gitlab_project_id(url: GitUrl) -> str:

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -7,7 +7,7 @@ import base64
 import itertools
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Protocol
 from urllib.parse import quote, urlparse
 
@@ -61,6 +61,8 @@ class VcsTreeSnapshot:
     """SHA of the commit's root tree, when the provider exposes it."""
     files: dict[str, str]
     """Map of repository path to decoded UTF-8 file content."""
+    blob_paths: frozenset[str] = field(default_factory=frozenset)
+    """All blob paths present in the tree, including non-UTF-8 blobs."""
 
 
 class VcsSyncTransport(Protocol):
@@ -308,6 +310,7 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                 commit_sha=commit.sha,
                 tree_sha=tree_sha,
                 files=files,
+                blob_paths=frozenset(blob_shas),
             )
         except GithubException as e:
             raise GitHubAppError(f"GitHub API error: {e.status} - {e.data}") from e
@@ -727,6 +730,7 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                 url=url,
                 ref=branch,
             )
+            current_blob_paths = current.blob_paths or frozenset(current.files)
             changed_files = {
                 path: content
                 for path, content in sorted(files.items())
@@ -735,7 +739,7 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             managed_roots = _normalized_roots(delete_missing_paths_under)
             stale_paths = {
                 path
-                for path in current.files
+                for path in current_blob_paths
                 if path not in files and _path_is_under_roots(path, managed_roots)
             }
 
@@ -772,7 +776,7 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             for path, content in sorted(changed_files.items()):
                 actions.append(
                     {
-                        "action": "update" if path in current.files else "create",
+                        "action": "update" if path in current_blob_paths else "create",
                         "file_path": path,
                         "content": content,
                     }
@@ -949,6 +953,7 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             commit_sha=commit_sha,
             tree_sha=None,
             files=files,
+            blob_paths=frozenset(blob_shas),
         )
 
     async def _list_branches_with_client(

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -38,6 +38,7 @@ from tracecat.vcs.gitlab.types import (
     GitLabListCommitsParams,
     GitLabListMergeRequestsParams,
     GitLabMergeRequest,
+    GitLabProject,
     GitLabTreeEntry,
     GitLabTreeParams,
 )
@@ -689,16 +690,8 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             project_id = _gitlab_project_id(url)
             base_branch_name = pr_base_branch or url.ref
             if base_branch_name is None:
-                branches = await self._list_branches_with_client(
-                    client=client,
-                    url=url,
-                    limit=None,
-                )
-                base_branch_name = (
-                    next((item.name for item in branches if item.is_default), None)
-                    or (branches[0].name if branches else None)
-                    or "main"
-                )
+                project = await self._get_project(client=client, project_id=project_id)
+                base_branch_name = project.default_branch or "main"
             if create_pr and branch == base_branch_name:
                 raise TracecatValidationError(
                     "create_pr exports must target a non-base branch"
@@ -989,6 +982,20 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             "GET",
             f"/projects/{project_id}/repository/branches/{quote(branch, safe='')}",
             model=GitLabBranch,
+        )
+
+    async def _get_project(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        project_id: str,
+    ) -> GitLabProject:
+        """Return a GitLab project object or raise a structured API error."""
+        return await self._gitlab_model(
+            client,
+            "GET",
+            f"/projects/{project_id}",
+            model=GitLabProject,
         )
 
     async def _create_branch(

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -8,7 +8,9 @@ import itertools
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
+from urllib.parse import quote
 
+import httpx
 from github.GithubException import GithubException
 from github.InputGitTreeElement import InputGitTreeElement
 
@@ -19,6 +21,8 @@ from tracecat.registry.repositories.schemas import GitBranchInfo, GitCommitInfo
 from tracecat.service import BaseWorkspaceService
 from tracecat.sync import CommitInfo, PushStatus
 from tracecat.vcs.github.app import GitHubAppError, GitHubAppService
+from tracecat.vcs.gitlab.app import GitLabApiError, GitLabError, GitLabTokenService
+from tracecat.vcs.gitlab.schemas import GitLabTokenCredentials
 from tracecat.workspace_sync.enums import VcsProvider
 from tracecat.workspace_sync.schemas import (
     MANIFEST_FILENAME,
@@ -100,7 +104,7 @@ def unsupported_transport(provider: VcsProvider) -> TracecatValidationError:
     """Build the error raised for providers without a sync transport yet."""
     return TracecatValidationError(
         f"{provider.value} workspace sync is not implemented yet. "
-        "GitLab and Bitbucket will use token-backed VCS transports in a later pass."
+        "Bitbucket will use a token-backed VCS transport in a later pass."
     )
 
 
@@ -118,7 +122,9 @@ def vcs_transport_for_provider(
     match provider:
         case VcsProvider.GITHUB:
             return GitHubWorkspaceSyncTransport(session=session, role=role)
-        case VcsProvider.GITLAB | VcsProvider.BITBUCKET:
+        case VcsProvider.GITLAB:
+            return GitLabWorkspaceSyncTransport(session=session, role=role)
+        case VcsProvider.BITBUCKET:
             raise unsupported_transport(provider)
 
 
@@ -134,6 +140,12 @@ def _path_is_under_roots(path: str, roots: Sequence[str]) -> bool:
 
 _GITHUB_BLOB_CONCURRENCY = 8
 """Maximum concurrent GitHub blob/content calls during sync reads and writes."""
+
+_GITLAB_PAGE_SIZE = 100
+"""GitLab REST page size used for workspace sync reads."""
+
+_GITLAB_BLOB_CONCURRENCY = 8
+"""Maximum concurrent GitLab blob calls during sync reads."""
 
 
 class GitHubWorkspaceSyncTransport(BaseWorkspaceService):
@@ -579,3 +591,560 @@ class GitHubWorkspaceSyncTransport(BaseWorkspaceService):
             branch_name,
         )
         return (getattr(comparison, "ahead_by", None) or 0) > 0
+
+
+class GitLabWorkspaceSyncTransport(BaseWorkspaceService):
+    """GitLab token-backed REST transport for workspace sync."""
+
+    service_name = "workspace_gitlab_sync"
+
+    async def read_files(
+        self,
+        *,
+        url: GitUrl,
+        ref: str,
+    ) -> VcsTreeSnapshot:
+        """Read the manifest and managed resource files at ``ref``."""
+        credentials = await self._credentials()
+        async with self._client(credentials) as client:
+            return await self._read_files_with_client(client=client, url=url, ref=ref)
+
+    async def write_files(
+        self,
+        *,
+        url: GitUrl,
+        files: dict[str, str],
+        message: str,
+        branch: str,
+        create_pr: bool,
+        pr_base_branch: str | None = None,
+        delete_missing_paths_under: Sequence[str] = (),
+    ) -> CommitInfo:
+        """Commit ``files`` to ``branch``, optionally opening a merge request."""
+        if not files:
+            raise ValueError("At least one file is required for workspace sync export")
+        message = message.strip()
+        if not message:
+            raise ValueError("A non-empty commit message is required")
+
+        credentials = await self._credentials()
+        async with self._client(credentials) as client:
+            project_id = _gitlab_project_id(url)
+            branches = await self._list_branches_with_client(
+                client=client,
+                url=url,
+                limit=_GITLAB_PAGE_SIZE,
+            )
+            default_branch = (
+                next((item.name for item in branches if item.is_default), None)
+                or (branches[0].name if branches else None)
+                or "main"
+            )
+            base_branch_name = pr_base_branch or url.ref or default_branch
+            if create_pr and branch == base_branch_name:
+                raise TracecatValidationError(
+                    "create_pr exports must target a non-base branch"
+                )
+
+            await self._get_branch(
+                client=client,
+                project_id=project_id,
+                branch=base_branch_name,
+            )
+            try:
+                await self._get_branch(
+                    client=client,
+                    project_id=project_id,
+                    branch=branch,
+                )
+            except GitLabApiError as e:
+                if e.status_code != 404:
+                    raise
+                await self._create_branch(
+                    client=client,
+                    project_id=project_id,
+                    branch=branch,
+                    ref=base_branch_name,
+                )
+
+            current = await self._read_files_with_client(
+                client=client,
+                url=url,
+                ref=branch,
+            )
+            changed_files = {
+                path: content
+                for path, content in sorted(files.items())
+                if current.files.get(path) != content
+            }
+            managed_roots = _normalized_roots(delete_missing_paths_under)
+            stale_paths = {
+                path
+                for path in current.files
+                if path not in files and _path_is_under_roots(path, managed_roots)
+            }
+
+            pr_url: str | None = None
+            pr_number: int | None = None
+            pr_reused = False
+            if not changed_files and not stale_paths:
+                branch_has_commits = await self._branch_has_commits_between(
+                    client=client,
+                    project_id=project_id,
+                    base_branch_name=base_branch_name,
+                    branch_name=branch,
+                )
+                if create_pr and branch_has_commits:
+                    pr_url, pr_number, pr_reused = await self._upsert_merge_request(
+                        client=client,
+                        project_id=project_id,
+                        title=message,
+                        branch_name=branch,
+                        base_branch_name=base_branch_name,
+                    )
+                return CommitInfo(
+                    status=PushStatus.NO_OP,
+                    sha=None,
+                    ref=branch,
+                    base_ref=base_branch_name,
+                    pr_url=pr_url,
+                    pr_number=pr_number,
+                    pr_reused=pr_reused,
+                    message="No changes detected; nothing to commit.",
+                )
+
+            actions: list[dict[str, str]] = []
+            for path, content in sorted(changed_files.items()):
+                actions.append(
+                    {
+                        "action": "update" if path in current.files else "create",
+                        "file_path": path,
+                        "content": content,
+                    }
+                )
+            for path in sorted(stale_paths):
+                actions.append({"action": "delete", "file_path": path})
+
+            commit_data = await self._gitlab_json(
+                client,
+                "POST",
+                f"/projects/{project_id}/repository/commits",
+                json={
+                    "branch": branch,
+                    "commit_message": message,
+                    "actions": actions,
+                },
+            )
+            if not isinstance(commit_data, dict) or not commit_data.get("id"):
+                raise GitLabError("GitLab commit response did not include a commit id")
+            commit_sha = str(commit_data["id"])
+
+            if create_pr:
+                pr_url, pr_number, pr_reused = await self._upsert_merge_request(
+                    client=client,
+                    project_id=project_id,
+                    title=message,
+                    branch_name=branch,
+                    base_branch_name=base_branch_name,
+                )
+
+            return CommitInfo(
+                status=PushStatus.COMMITTED,
+                sha=commit_sha,
+                ref=branch,
+                base_ref=base_branch_name,
+                pr_url=pr_url,
+                pr_number=pr_number,
+                pr_reused=pr_reused,
+                message="Committed workspace sync changes.",
+            )
+
+    async def list_commits(
+        self,
+        *,
+        url: GitUrl,
+        branch: str = "main",
+        limit: int = 10,
+    ) -> list[GitCommitInfo]:
+        """Return up to ``limit`` most recent commits on ``branch``."""
+        credentials = await self._credentials()
+        async with self._client(credentials) as client:
+            project_id = _gitlab_project_id(url)
+            raw_commits = await self._gitlab_list(
+                client,
+                f"/projects/{project_id}/repository/commits",
+                params={"ref_name": branch},
+                limit=limit,
+            )
+        return [
+            GitCommitInfo(
+                sha=str(commit.get("id") or commit.get("short_id") or ""),
+                message=str(commit.get("message") or commit.get("title") or ""),
+                author=str(commit.get("author_name") or "Unknown"),
+                author_email=str(commit.get("author_email") or ""),
+                date=str(
+                    commit.get("authored_date")
+                    or commit.get("committed_date")
+                    or commit.get("created_at")
+                    or ""
+                ),
+                tags=[],
+            )
+            for commit in raw_commits
+            if isinstance(commit, dict)
+        ]
+
+    async def list_branches(
+        self,
+        *,
+        url: GitUrl,
+        limit: int = 100,
+    ) -> list[GitBranchInfo]:
+        """Return up to ``limit`` branches, flagging the repository default."""
+        credentials = await self._credentials()
+        async with self._client(credentials) as client:
+            return await self._list_branches_with_client(
+                client=client,
+                url=url,
+                limit=limit,
+            )
+
+    async def _credentials(self) -> GitLabTokenCredentials:
+        """Load organization GitLab token credentials."""
+        return await GitLabTokenService(
+            session=self.session,
+            role=self.role,
+        ).get_gitlab_token_credentials()
+
+    def _client(self, credentials: GitLabTokenCredentials) -> httpx.AsyncClient:
+        """Build an authenticated GitLab REST API client."""
+        return httpx.AsyncClient(
+            base_url=f"{credentials.base_url}/api/v4",
+            headers={"PRIVATE-TOKEN": credentials.token.get_secret_value()},
+            timeout=30.0,
+        )
+
+    async def _read_files_with_client(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        url: GitUrl,
+        ref: str,
+    ) -> VcsTreeSnapshot:
+        """Read workspace sync files with an existing GitLab client."""
+        project_id = _gitlab_project_id(url)
+        commit_data = await self._gitlab_json(
+            client,
+            "GET",
+            f"/projects/{project_id}/repository/commits/{quote(ref, safe='')}",
+        )
+        if not isinstance(commit_data, dict) or not commit_data.get("id"):
+            raise GitLabError("GitLab commit response did not include a commit id")
+        commit_sha = str(commit_data["id"])
+
+        tree_entries = await self._gitlab_list(
+            client,
+            f"/projects/{project_id}/repository/tree",
+            params={"recursive": "true", "ref": commit_sha},
+        )
+        blob_shas = {
+            str(item["path"]): str(item["id"])
+            for item in tree_entries
+            if isinstance(item, dict)
+            and item.get("type") == "blob"
+            and item.get("path")
+            and item.get("id")
+        }
+        blob_semaphore = asyncio.Semaphore(_GITLAB_BLOB_CONCURRENCY)
+
+        async def fetch_text(path: str) -> str | None:
+            """Fetch a blob raw payload and decode it as UTF-8."""
+            async with blob_semaphore:
+                response = await self._gitlab_response(
+                    client,
+                    "GET",
+                    f"/projects/{project_id}/repository/blobs/{quote(blob_shas[path], safe='')}/raw",
+                )
+            try:
+                return response.content.decode("utf-8")
+            except UnicodeDecodeError:
+                return None
+
+        async def fetch_path(path: str) -> tuple[str, str | None]:
+            """Fetch ``path`` and preserve identity through gather."""
+            return path, await fetch_text(path)
+
+        files: dict[str, str] = {}
+        resource_roots = manifest_resource_roots(WorkspaceManifest())
+        if MANIFEST_FILENAME in blob_shas:
+            manifest_content = await fetch_text(MANIFEST_FILENAME)
+            if manifest_content is not None:
+                files[MANIFEST_FILENAME] = manifest_content
+                try:
+                    manifest = workspace_manifest_from_json(manifest_content)
+                    resource_roots = manifest_resource_roots(manifest)
+                except Exception:
+                    pass
+
+        resource_paths = [
+            path
+            for path in sorted(blob_shas)
+            if path != MANIFEST_FILENAME
+            and any(path.startswith(f"{root}/") for root in resource_roots)
+        ]
+        for path, content in await asyncio.gather(
+            *(fetch_path(path) for path in resource_paths)
+        ):
+            if content is not None:
+                files[path] = content
+
+        return VcsTreeSnapshot(
+            commit_sha=commit_sha,
+            tree_sha=None,
+            files=files,
+        )
+
+    async def _list_branches_with_client(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        url: GitUrl,
+        limit: int,
+    ) -> list[GitBranchInfo]:
+        """List branches using an existing GitLab client."""
+        project_id = _gitlab_project_id(url)
+        raw_branches = await self._gitlab_list(
+            client,
+            f"/projects/{project_id}/repository/branches",
+            limit=limit,
+        )
+        return [
+            GitBranchInfo(
+                name=str(branch.get("name") or ""),
+                is_default=bool(branch.get("default")),
+            )
+            for branch in raw_branches
+            if isinstance(branch, dict) and branch.get("name")
+        ]
+
+    async def _get_branch(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        project_id: str,
+        branch: str,
+    ) -> dict[str, Any]:
+        """Return a GitLab branch object or raise a structured API error."""
+        branch_data = await self._gitlab_json(
+            client,
+            "GET",
+            f"/projects/{project_id}/repository/branches/{quote(branch, safe='')}",
+        )
+        if not isinstance(branch_data, dict):
+            raise GitLabError("GitLab branch response was invalid")
+        return branch_data
+
+    async def _create_branch(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        project_id: str,
+        branch: str,
+        ref: str,
+    ) -> None:
+        """Create ``branch`` from ``ref``."""
+        await self._gitlab_json(
+            client,
+            "POST",
+            f"/projects/{project_id}/repository/branches",
+            params={"branch": branch, "ref": ref},
+        )
+
+    async def _upsert_merge_request(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        project_id: str,
+        title: str,
+        branch_name: str,
+        base_branch_name: str,
+    ) -> tuple[str | None, int | None, bool]:
+        """Reuse or open the sync merge request for ``branch_name``."""
+        existing = await self._gitlab_list(
+            client,
+            f"/projects/{project_id}/merge_requests",
+            params={
+                "state": "opened",
+                "source_branch": branch_name,
+                "target_branch": base_branch_name,
+            },
+            limit=1,
+        )
+        if existing and isinstance(existing[0], dict):
+            mr = existing[0]
+            return str(mr.get("web_url") or ""), _int_or_none(mr.get("iid")), True
+
+        workspace = await WorkspaceService(
+            session=self.session,
+            role=self.role,
+        ).get_workspace(self.workspace_id)
+        if workspace is None:
+            raise TracecatNotFoundError("Workspace not found")
+
+        current_user = None
+        if self.role.user_id is not None:
+            try:
+                current_user = await self.session.get(User, self.role.user_id)
+            except Exception:
+                current_user = None
+
+        published_by = current_user.email if current_user else "<unknown>"
+        mr_data = await self._gitlab_json(
+            client,
+            "POST",
+            f"/projects/{project_id}/merge_requests",
+            json={
+                "source_branch": branch_name,
+                "target_branch": base_branch_name,
+                "title": title,
+                "description": (
+                    "Automated workspace sync from Tracecat\n\n"
+                    f"**Workspace:** {workspace.name}\n"
+                    f"**Published by:** {published_by}"
+                ),
+            },
+        )
+        if not isinstance(mr_data, dict):
+            raise GitLabError("GitLab merge request response was invalid")
+        return (
+            str(mr_data.get("web_url") or ""),
+            _int_or_none(mr_data.get("iid")),
+            False,
+        )
+
+    async def _branch_has_commits_between(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        project_id: str,
+        base_branch_name: str,
+        branch_name: str,
+    ) -> bool:
+        """Return whether ``branch_name`` is ahead of ``base_branch_name``."""
+        comparison = await self._gitlab_json(
+            client,
+            "GET",
+            f"/projects/{project_id}/repository/compare",
+            params={"from": base_branch_name, "to": branch_name},
+        )
+        return bool(
+            isinstance(comparison, dict)
+            and isinstance(comparison.get("commits"), list)
+            and comparison["commits"]
+        )
+
+    async def _gitlab_list(
+        self,
+        client: httpx.AsyncClient,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        limit: int | None = None,
+    ) -> list[Any]:
+        """Collect a paginated GitLab list response."""
+        results: list[Any] = []
+        page = 1
+        while True:
+            page_params = {
+                **(params or {}),
+                "page": page,
+                "per_page": _GITLAB_PAGE_SIZE,
+            }
+            response = await self._gitlab_response(
+                client,
+                "GET",
+                path,
+                params=page_params,
+            )
+            data = self._json(response)
+            if not isinstance(data, list):
+                raise GitLabError("GitLab list response was invalid")
+            results.extend(data)
+            if limit is not None and len(results) >= limit:
+                return results[:limit]
+            next_page = response.headers.get("x-next-page")
+            if not next_page:
+                return results
+            try:
+                page = int(next_page)
+            except ValueError as e:
+                raise GitLabError("GitLab pagination response was invalid") from e
+
+    async def _gitlab_json(
+        self,
+        client: httpx.AsyncClient,
+        method: str,
+        path: str,
+        **kwargs: Any,
+    ) -> Any:
+        """Return a decoded GitLab JSON response."""
+        response = await self._gitlab_response(client, method, path, **kwargs)
+        if response.status_code == 204 or not response.content:
+            return None
+        return self._json(response)
+
+    async def _gitlab_response(
+        self,
+        client: httpx.AsyncClient,
+        method: str,
+        path: str,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Return a GitLab response, raising structured API errors."""
+        try:
+            response = await client.request(method, path, **kwargs)
+        except httpx.HTTPError as e:
+            raise GitLabError(f"GitLab API request failed: {str(e)}") from e
+        if response.status_code >= 400:
+            message = _gitlab_error_message(response)
+            raise GitLabApiError(
+                f"GitLab API error: {response.status_code} - {message}",
+                status_code=response.status_code,
+                detail={"status_code": response.status_code, "message": message},
+            )
+        return response
+
+    def _json(self, response: httpx.Response) -> Any:
+        """Decode a GitLab JSON response."""
+        try:
+            return response.json()
+        except ValueError as e:
+            raise GitLabError("GitLab response was not valid JSON") from e
+
+
+def _gitlab_project_id(url: GitUrl) -> str:
+    """Return GitLab's URL-encoded ``namespace/project`` identifier."""
+    return quote(f"{url.org}/{url.repo}", safe="")
+
+
+def _gitlab_error_message(response: httpx.Response) -> str:
+    """Extract a readable GitLab error without branching on error strings."""
+    try:
+        payload = response.json()
+    except ValueError:
+        return response.text[:500]
+    if isinstance(payload, dict):
+        message = payload.get("message") or payload.get("error_description")
+        if isinstance(message, str):
+            return message
+        if isinstance(message, dict):
+            return str(message)
+    return str(payload)
+
+
+def _int_or_none(value: Any) -> int | None:
+    """Best-effort conversion for provider PR/MR ids."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import itertools
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
 from urllib.parse import quote
@@ -13,6 +13,8 @@ from urllib.parse import quote
 import httpx
 from github.GithubException import GithubException
 from github.InputGitTreeElement import InputGitTreeElement
+from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
 
 from tracecat.db.models import User
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
@@ -23,6 +25,21 @@ from tracecat.sync import CommitInfo, PushStatus
 from tracecat.vcs.github.app import GitHubAppError, GitHubAppService
 from tracecat.vcs.gitlab.app import GitLabApiError, GitLabError, GitLabTokenService
 from tracecat.vcs.gitlab.schemas import GitLabTokenCredentials
+from tracecat.vcs.gitlab.types import (
+    GitLabBranch,
+    GitLabCommit,
+    GitLabCommitAction,
+    GitLabCompareParams,
+    GitLabCompareResult,
+    GitLabCreateBranchParams,
+    GitLabCreateCommitPayload,
+    GitLabCreateMergeRequestPayload,
+    GitLabListCommitsParams,
+    GitLabListMergeRequestsParams,
+    GitLabMergeRequest,
+    GitLabTreeEntry,
+    GitLabTreeParams,
+)
 from tracecat.workspace_sync.enums import VcsProvider
 from tracecat.workspace_sync.schemas import (
     MANIFEST_FILENAME,
@@ -751,7 +768,7 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                     message="No changes detected; nothing to commit.",
                 )
 
-            actions: list[dict[str, str]] = []
+            actions: list[GitLabCommitAction] = []
             for path, content in sorted(changed_files.items()):
                 actions.append(
                     {
@@ -763,19 +780,19 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             for path in sorted(stale_paths):
                 actions.append({"action": "delete", "file_path": path})
 
-            commit_data = await self._gitlab_json(
+            commit_payload: GitLabCreateCommitPayload = {
+                "branch": branch,
+                "commit_message": message,
+                "actions": actions,
+            }
+            commit = await self._gitlab_model(
                 client,
                 "POST",
                 f"/projects/{project_id}/repository/commits",
-                json={
-                    "branch": branch,
-                    "commit_message": message,
-                    "actions": actions,
-                },
+                model=GitLabCommit,
+                json=commit_payload,
             )
-            if not isinstance(commit_data, dict) or not commit_data.get("id"):
-                raise GitLabError("GitLab commit response did not include a commit id")
-            commit_sha = str(commit_data["id"])
+            commit_sha = commit.id
 
             if create_pr:
                 pr_url, pr_number, pr_reused = await self._upsert_merge_request(
@@ -808,28 +825,27 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         credentials = await self._credentials()
         async with self._client(credentials) as client:
             project_id = _gitlab_project_id(url)
+            commits_params: GitLabListCommitsParams = {"ref_name": branch}
             raw_commits = await self._gitlab_list(
                 client,
                 f"/projects/{project_id}/repository/commits",
-                params={"ref_name": branch},
+                model=GitLabCommit,
+                params=commits_params,
                 limit=limit,
             )
         return [
             GitCommitInfo(
-                sha=str(commit.get("id") or commit.get("short_id") or ""),
-                message=str(commit.get("message") or commit.get("title") or ""),
-                author=str(commit.get("author_name") or "Unknown"),
-                author_email=str(commit.get("author_email") or ""),
-                date=str(
-                    commit.get("authored_date")
-                    or commit.get("committed_date")
-                    or commit.get("created_at")
-                    or ""
-                ),
+                sha=commit.id,
+                message=commit.message or commit.title or "",
+                author=commit.author_name or "Unknown",
+                author_email=commit.author_email or "",
+                date=commit.authored_date
+                or commit.committed_date
+                or commit.created_at
+                or "",
                 tags=[],
             )
             for commit in raw_commits
-            if isinstance(commit, dict)
         ]
 
     async def list_branches(
@@ -871,27 +887,23 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
     ) -> VcsTreeSnapshot:
         """Read workspace sync files with an existing GitLab client."""
         project_id = _gitlab_project_id(url)
-        commit_data = await self._gitlab_json(
+        commit = await self._gitlab_model(
             client,
             "GET",
             f"/projects/{project_id}/repository/commits/{quote(ref, safe='')}",
+            model=GitLabCommit,
         )
-        if not isinstance(commit_data, dict) or not commit_data.get("id"):
-            raise GitLabError("GitLab commit response did not include a commit id")
-        commit_sha = str(commit_data["id"])
+        commit_sha = commit.id
 
+        tree_params: GitLabTreeParams = {"recursive": "true", "ref": commit_sha}
         tree_entries = await self._gitlab_list(
             client,
             f"/projects/{project_id}/repository/tree",
-            params={"recursive": "true", "ref": commit_sha},
+            model=GitLabTreeEntry,
+            params=tree_params,
         )
         blob_shas = {
-            str(item["path"]): str(item["id"])
-            for item in tree_entries
-            if isinstance(item, dict)
-            and item.get("type") == "blob"
-            and item.get("path")
-            and item.get("id")
+            entry.path: entry.id for entry in tree_entries if entry.type == "blob"
         }
         blob_semaphore = asyncio.Semaphore(_GITLAB_BLOB_CONCURRENCY)
 
@@ -930,15 +942,12 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         raw_branches = await self._gitlab_list(
             client,
             f"/projects/{project_id}/repository/branches",
+            model=GitLabBranch,
             limit=limit,
         )
         return [
-            GitBranchInfo(
-                name=str(branch.get("name") or ""),
-                is_default=bool(branch.get("default")),
-            )
+            GitBranchInfo(name=branch.name, is_default=branch.default)
             for branch in raw_branches
-            if isinstance(branch, dict) and branch.get("name")
         ]
 
     async def _get_branch(
@@ -947,16 +956,14 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         client: httpx.AsyncClient,
         project_id: str,
         branch: str,
-    ) -> dict[str, Any]:
+    ) -> GitLabBranch:
         """Return a GitLab branch object or raise a structured API error."""
-        branch_data = await self._gitlab_json(
+        return await self._gitlab_model(
             client,
             "GET",
             f"/projects/{project_id}/repository/branches/{quote(branch, safe='')}",
+            model=GitLabBranch,
         )
-        if not isinstance(branch_data, dict):
-            raise GitLabError("GitLab branch response was invalid")
-        return branch_data
 
     async def _create_branch(
         self,
@@ -967,11 +974,12 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         ref: str,
     ) -> None:
         """Create ``branch`` from ``ref``."""
+        create_branch_params: GitLabCreateBranchParams = {"branch": branch, "ref": ref}
         await self._gitlab_json(
             client,
             "POST",
             f"/projects/{project_id}/repository/branches",
-            params={"branch": branch, "ref": ref},
+            params=create_branch_params,
         )
 
     async def _upsert_merge_request(
@@ -984,38 +992,36 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         base_branch_name: str,
     ) -> tuple[str | None, int | None, bool]:
         """Reuse or open the sync merge request for ``branch_name``."""
+        list_mr_params: GitLabListMergeRequestsParams = {
+            "state": "opened",
+            "source_branch": branch_name,
+            "target_branch": base_branch_name,
+        }
         existing = await self._gitlab_list(
             client,
             f"/projects/{project_id}/merge_requests",
-            params={
-                "state": "opened",
-                "source_branch": branch_name,
-                "target_branch": base_branch_name,
-            },
+            model=GitLabMergeRequest,
+            params=list_mr_params,
             limit=1,
         )
-        if existing and isinstance(existing[0], dict):
+        if existing:
             mr = existing[0]
-            return str(mr.get("web_url") or ""), _int_or_none(mr.get("iid")), True
+            return mr.web_url, mr.iid, True
 
-        mr_data = await self._gitlab_json(
+        create_mr_payload: GitLabCreateMergeRequestPayload = {
+            "source_branch": branch_name,
+            "target_branch": base_branch_name,
+            "title": title,
+            "description": await self._sync_request_body(),
+        }
+        mr = await self._gitlab_model(
             client,
             "POST",
             f"/projects/{project_id}/merge_requests",
-            json={
-                "source_branch": branch_name,
-                "target_branch": base_branch_name,
-                "title": title,
-                "description": await self._sync_request_body(),
-            },
+            model=GitLabMergeRequest,
+            json=create_mr_payload,
         )
-        if not isinstance(mr_data, dict):
-            raise GitLabError("GitLab merge request response was invalid")
-        return (
-            str(mr_data.get("web_url") or ""),
-            _int_or_none(mr_data.get("iid")),
-            False,
-        )
+        return mr.web_url, mr.iid, False
 
     async def _branch_has_commits_between(
         self,
@@ -1026,28 +1032,30 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
         branch_name: str,
     ) -> bool:
         """Return whether ``branch_name`` is ahead of ``base_branch_name``."""
-        comparison = await self._gitlab_json(
+        compare_params: GitLabCompareParams = {
+            "from": base_branch_name,
+            "to": branch_name,
+        }
+        comparison = await self._gitlab_model(
             client,
             "GET",
             f"/projects/{project_id}/repository/compare",
-            params={"from": base_branch_name, "to": branch_name},
+            model=GitLabCompareResult,
+            params=compare_params,
         )
-        return bool(
-            isinstance(comparison, dict)
-            and isinstance(comparison.get("commits"), list)
-            and comparison["commits"]
-        )
+        return bool(comparison.commits)
 
-    async def _gitlab_list(
+    async def _gitlab_list[ModelT: BaseModel](
         self,
         client: httpx.AsyncClient,
         path: str,
         *,
-        params: dict[str, Any] | None = None,
+        model: type[ModelT],
+        params: Mapping[str, Any] | None = None,
         limit: int | None = None,
-    ) -> list[Any]:
-        """Collect a paginated GitLab list response."""
-        results: list[Any] = []
+    ) -> list[ModelT]:
+        """Collect and validate a paginated GitLab list response."""
+        results: list[ModelT] = []
         page = 1
         while True:
             page_params = {
@@ -1064,7 +1072,10 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
             data = self._json(response)
             if not isinstance(data, list):
                 raise GitLabError("GitLab list response was invalid")
-            results.extend(data)
+            try:
+                results.extend(model.model_validate(item) for item in data)
+            except PydanticValidationError as e:
+                raise GitLabError("GitLab list response was invalid") from e
             if limit is not None and len(results) >= limit:
                 return results[:limit]
             next_page = response.headers.get("x-next-page")
@@ -1074,6 +1085,24 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
                 page = int(next_page)
             except ValueError as e:
                 raise GitLabError("GitLab pagination response was invalid") from e
+
+    async def _gitlab_model[ModelT: BaseModel](
+        self,
+        client: httpx.AsyncClient,
+        method: str,
+        path: str,
+        *,
+        model: type[ModelT],
+        **kwargs: Any,
+    ) -> ModelT:
+        """Return a GitLab JSON response validated against ``model``."""
+        data = await self._gitlab_json(client, method, path, **kwargs)
+        if not isinstance(data, dict):
+            raise GitLabError(f"GitLab {model.__name__} response was invalid")
+        try:
+            return model.model_validate(data)
+        except PydanticValidationError as e:
+            raise GitLabError(f"GitLab {model.__name__} response was invalid") from e
 
     async def _gitlab_json(
         self,
@@ -1135,11 +1164,3 @@ def _gitlab_error_message(response: httpx.Response) -> str:
         if isinstance(message, dict):
             return str(message)
     return str(payload)
-
-
-def _int_or_none(value: Any) -> int | None:
-    """Best-effort conversion for provider PR/MR ids."""
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None

--- a/tracecat/workspace_sync/transport.py
+++ b/tracecat/workspace_sync/transport.py
@@ -684,17 +684,18 @@ class GitLabWorkspaceSyncTransport(BaseWorkspaceSyncTransport):
 
         async with self._authed_client(url) as client:
             project_id = _gitlab_project_id(url)
-            branches = await self._list_branches_with_client(
-                client=client,
-                url=url,
-                limit=None,
-            )
-            default_branch = (
-                next((item.name for item in branches if item.is_default), None)
-                or (branches[0].name if branches else None)
-                or "main"
-            )
-            base_branch_name = pr_base_branch or url.ref or default_branch
+            base_branch_name = pr_base_branch or url.ref
+            if base_branch_name is None:
+                branches = await self._list_branches_with_client(
+                    client=client,
+                    url=url,
+                    limit=None,
+                )
+                base_branch_name = (
+                    next((item.name for item in branches if item.is_default), None)
+                    or (branches[0].name if branches else None)
+                    or "main"
+                )
             if create_pr and branch == base_branch_name:
                 raise TracecatValidationError(
                     "create_pr exports must target a non-base branch"

--- a/tracecat/workspaces/schemas.py
+++ b/tracecat/workspaces/schemas.py
@@ -10,12 +10,14 @@ from tracecat.core.schemas import Schema
 from tracecat.git.constants import GIT_SSH_URL_REGEX
 from tracecat.identifiers import InvitationID, OrganizationID, UserID, WorkspaceID
 from tracecat.invitations.enums import InvitationStatus
+from tracecat.workspace_sync.enums import VcsProvider
 
 # === Workspace === #
 
 
 # DTO
 class WorkspaceSettings(TypedDict):
+    git_provider: NotRequired[VcsProvider | None]
     git_repo_url: NotRequired[str | None]
     workflow_unlimited_timeout_enabled: NotRequired[bool | None]
     workflow_default_timeout_seconds: NotRequired[int | None]
@@ -26,6 +28,7 @@ class WorkspaceSettings(TypedDict):
 
 # Schema
 class WorkspaceSettingsRead(Schema):
+    git_provider: VcsProvider | None = None
     git_repo_url: str | None = None
     workflow_unlimited_timeout_enabled: bool | None = None
     workflow_default_timeout_seconds: int | None = None
@@ -51,6 +54,7 @@ class WorkspaceSettingsRead(Schema):
 
 
 class WorkspaceSettingsUpdate(Schema):
+    git_provider: VcsProvider | None = None
     git_repo_url: str | None = None
     workflow_unlimited_timeout_enabled: bool | None = Field(
         default=None,

--- a/tracecat/workspaces/schemas.py
+++ b/tracecat/workspaces/schemas.py
@@ -78,6 +78,16 @@ class WorkspaceSettingsUpdate(Schema):
         description="Whether to validate file content matches declared MIME type using magic number detection. Defaults to true for security.",
     )
 
+    @field_validator("git_provider")
+    @classmethod
+    def validate_git_provider(cls, value: VcsProvider | None) -> VcsProvider | None:
+        """Restrict writable workspace sync providers to implemented transports."""
+        if value is VcsProvider.BITBUCKET:
+            raise ValueError(
+                "bitbucket workspace sync is not implemented yet. Use github or gitlab."
+            )
+        return value
+
     @field_validator("git_repo_url", mode="before")
     @classmethod
     def validate_git_repo_url(cls, value: str | None) -> str | None:


### PR DESCRIPTION
## Summary
- Adds GitLab as a first-class workspace Git sync provider using direct GitLab REST calls.
- Adds organization-level GitLab token credential save/status/delete flows.
- Threads persisted VCS provider through workspace settings, branch/commit loading, push preview/export, resource pushes, and pull.
- Adds GitLab transport coverage plus frontend provider-aware tests.
- Fixes an existing registry typecheck issue in `core.cases.get_linked_case_rows` that blocked the repo commit hook.

## Verification
- `corepack pnpm -C frontend generate-client-ci`
- `uv run pytest tests/unit/test_workspace_service.py tests/unit/test_workspace_sync_service.py tests/unit/test_gitlab_vcs.py tests/unit/api/test_api_workflow_store_publish.py -q`
- `uv run pytest tests/unit/test_route_scope_guards.py::test_vcs_scope_guards tests/unit/api/test_api_actor_roles.py::test_github_manifest_flow_routes_remain_user_only -q`
- `corepack pnpm -C frontend test -- workspace-sync-settings.test.tsx use-workspace-sync.test.tsx`
- `corepack pnpm -C frontend check`
- `corepack pnpm -C frontend run typecheck`
- `uv run ruff check <changed backend files>`
- `uv run ruff format --check <changed backend files>`
- `uv run basedpyright <changed backend files>`
- `git diff --check`
- Commit hook suite passed during `uv run git commit`: Ruff, frontend client generation/check/typecheck, full basedpyright, Biome, gitleaks.

## Real GitLab QA
- Project: https://gitlab.com/daryl34-group/tracecat-git-sync-qa-20260630
- Configured GitLab org credentials and saved a GitLab workspace connection.
- Verified GitLab branch/commit loading, push preview, branch creation, MR creation, MR reuse, no-op push, and pull preview/apply.
- Extended QA covered multiple workflows plus variable and case tag metadata.
- Remote branch delete-on-push worked for a stale workflow file.
- Pull applies present remote resources; deleting a remote case tag file did not delete the existing local case tag.
- Variable values stayed local-only while metadata updated from Git.

## Screenshots

### Tracecat pull completed
![Tracecat pull completed](https://github.com/user-attachments/assets/3be9f4d4-7382-4739-ba1e-2903c7261a17)

### Tracecat workspace after QA
![Tracecat workspace after QA](https://github.com/user-attachments/assets/63acdb08-21c3-4127-aee7-24fd07a78b55)

### GitLab MR !2 merged
![GitLab MR !2 merged](https://github.com/user-attachments/assets/bc91db2a-45f8-4c51-ad33-a3dfffa82d12)

### GitLab remote pull commit
![GitLab remote pull commit](https://github.com/user-attachments/assets/8d93da62-efdb-48a0-b48f-7bee8c37d239)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GitLab as a workspace Git sync provider with org-level token auth and full sync (branches/commits, push with MRs, pull) driven by workspace settings. Consolidates provider handling, types credential save responses, and updates the UI to be provider-aware.

- **Refactors**
  - Introduced SyncMappingService; provider is fixed at WorkspaceSyncService construction, stored in workspace settings, and resolved via `WorkspaceSyncService.for_workspace` across routers and publish.
  - Consolidated GitHub/GitLab transports into a shared base; added typed GitLab REST payloads and typed save responses for both providers; regenerated the client.
  - Removed provider params from branches/commits/export/preview/pull APIs and clients; routes infer the provider from settings and the frontend hooks stop sending a provider.
  - Namespaced resource mappings by provider throughout adapters/services and added tests asserting provider-scoped mapping behavior; added `org-vcs-gitlab` setup UI and provider-aware sync screens.

- **Bug Fixes**
  - Generalized provider errors via VcsProviderError; publish and workflow routes now return 400 for provider failures, and GitLab token endpoints preserve entitlement errors.
  - GitLab: fetch default base directly and include it in lists; support SSH URLs with custom ports and allow SSH host aliases; validate/sanitize `base_url`, reject repo URLs whose host doesn’t match the configured instance, skip branch scans when an explicit base ref is provided, and track blob paths to prune deleted files on push.
  - Settings: reject unsupported `git_provider`; only load GitHub repos when provider is `github`.
  - Preserve GitLab resource mappings across syncs and keep audit logs for GitLab credential save/delete.
  - Case fields: on rename, move workspace sync mappings for both GitHub and GitLab to keep links intact.
  - Key workflow publish and branch queries by provider to avoid mixing GitHub/GitLab cache results.

<sup>Written for commit 60ddc5218e95b355a7618e65d851b67ab34199a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

