### PR TITLE
feat(cases): add include_payload param to cases search

### DIFF
--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -8289,6 +8289,18 @@ export const $CaseReadMinimal = {
       ],
       title: "Field Values",
     },
+    payload: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Payload",
+    },
     num_tasks_completed: {
       type: "integer",
       title: "Num Tasks Completed",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -9458,6 +9458,7 @@ export const tablesImportCsv = (
  * @param data.includeRows Include linked table rows
  * @param data.fieldIds Include only the requested custom field IDs
  * @param data.includeDurations Include case duration values
+ * @param data.includePayload Include case payload
  * @returns CursorPaginatedResponse_CaseReadMinimal_ Successful Response
  * @throws ApiError
  */
@@ -9479,6 +9480,7 @@ export const casesListCases = (
       include_rows: data.includeRows,
       field_ids: data.fieldIds,
       include_durations: data.includeDurations,
+      include_payload: data.includePayload,
     },
     errors: {
       422: "Validation Error",
@@ -9537,6 +9539,7 @@ export const casesCreateCase = (
  * @param data.includeRows Include linked table rows
  * @param data.fieldIds Include only the requested custom field IDs
  * @param data.includeDurations Include case duration values
+ * @param data.includePayload Include case payload
  * @returns CursorPaginatedResponse_CaseReadMinimal_ Successful Response
  * @throws ApiError
  */
@@ -9570,6 +9573,7 @@ export const casesSearchCases = (
       include_rows: data.includeRows,
       field_ids: data.fieldIds,
       include_durations: data.includeDurations,
+      include_payload: data.includePayload,
     },
     errors: {
       422: "Validation Error",

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2203,6 +2203,9 @@ export type CaseReadMinimal = {
   field_values?: {
     [key: string]: unknown
   } | null
+  payload?: {
+    [key: string]: unknown
+  } | null
   num_tasks_completed?: number
   num_tasks_total?: number
 }
@@ -12354,6 +12357,10 @@ export type CasesListCasesData = {
    */
   includeDurations?: boolean
   /**
+   * Include case payload
+   */
+  includePayload?: boolean
+  /**
    * Include linked table rows
    */
   includeRows?: boolean
@@ -12417,6 +12424,10 @@ export type CasesSearchCasesData = {
    * Include case duration values
    */
   includeDurations?: boolean
+  /**
+   * Include case payload
+   */
+  includePayload?: boolean
   /**
    * Include linked table rows
    */

--- a/packages/tracecat-registry/tracecat_registry/sdk/cases.py
+++ b/packages/tracecat-registry/tracecat_registry/sdk/cases.py
@@ -189,6 +189,7 @@ class CasesClient:
         order_by: str | Unset = UNSET,
         sort: Literal["asc", "desc"] | Unset = UNSET,
         include_rows: bool | Unset = UNSET,
+        include_payload: bool | Unset = UNSET,
     ) -> types.CaseListResponse:
         """List cases using default server-side filtering.
 
@@ -213,6 +214,8 @@ class CasesClient:
             params["sort"] = sort
         if is_set(include_rows):
             params["include_rows"] = include_rows
+        if is_set(include_payload):
+            params["include_payload"] = include_payload
 
         return await self._client.get("/cases", params=params)
 
@@ -236,6 +239,7 @@ class CasesClient:
         updated_after: datetime | str | Unset = UNSET,
         updated_before: datetime | str | Unset = UNSET,
         include_rows: bool | Unset = UNSET,
+        include_payload: bool | Unset = UNSET,
     ) -> types.CaseListResponse:
         """Search cases with filtering and pagination."""
         params: dict[str, Any] = {"limit": limit}
@@ -285,6 +289,10 @@ class CasesClient:
                 if isinstance(updated_before, datetime)
                 else updated_before
             )
+        if is_set(include_rows):
+            params["include_rows"] = include_rows
+        if is_set(include_payload):
+            params["include_payload"] = include_payload
 
         return await self._client.get("/cases/search", params=params)
 

--- a/tests/unit/api/test_api_cases.py
+++ b/tests/unit/api/test_api_cases.py
@@ -1108,6 +1108,53 @@ async def test_search_cases_hydrates_requested_fields_and_durations(
 
 
 @pytest.mark.anyio
+async def test_search_cases_forwards_include_payload(
+    client: TestClient,
+    test_admin_role: Role,
+    mock_case: Case,
+) -> None:
+    """Test GET /cases/search forwards the include_payload flag to the service."""
+    with patch.object(cases_router, "CasesService") as MockService:
+        mock_svc = AsyncMock()
+        mock_case_read = CaseReadMinimal(
+            id=mock_case.id,
+            created_at=mock_case.created_at,
+            updated_at=mock_case.updated_at,
+            short_id=mock_case.short_id,
+            summary=mock_case.summary,
+            status=mock_case.status,
+            priority=mock_case.priority,
+            severity=mock_case.severity,
+            assignee=None,
+            tags=[],
+            dropdown_values=[],
+            payload={"alert_id": "abc-123"},
+            num_tasks_completed=0,
+            num_tasks_total=0,
+        )
+        mock_svc.search_cases.return_value = CursorPaginatedResponse(
+            items=[mock_case_read],
+            next_cursor=None,
+            prev_cursor=None,
+            has_more=False,
+            has_previous=False,
+        )
+        MockService.return_value = mock_svc
+
+        response = client.get(
+            "/cases/search",
+            params=[
+                ("workspace_id", str(test_admin_role.workspace_id)),
+                ("include_payload", "true"),
+            ],
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["items"][0]["payload"] == {"alert_id": "abc-123"}
+        assert mock_svc.search_cases.call_args.kwargs["include_payload"] is True
+
+
+@pytest.mark.anyio
 async def test_search_cases_validates_field_ids_even_when_page_is_empty(
     client: TestClient,
     test_admin_role: Role,

--- a/tests/unit/test_cases_service.py
+++ b/tests/unit/test_cases_service.py
@@ -1147,6 +1147,31 @@ class TestCasesService:
 
         assert "durations" in loader_calls
 
+    async def test_search_cases_gates_payload(
+        self, cases_service: CasesService
+    ) -> None:
+        """Case payload should only be returned when include_payload=True."""
+        payload = {"alert_id": "abc-123", "score": 42}
+        await cases_service.create_case(
+            CaseCreate(
+                summary="Payload case",
+                description="Case with a payload",
+                status=CaseStatus.NEW,
+                priority=CasePriority.MEDIUM,
+                severity=CaseSeverity.LOW,
+                payload=payload,
+            )
+        )
+        params = CursorPaginationParams(limit=10, cursor=None, reverse=False)
+
+        default_response = await cases_service.search_cases(params=params)
+        assert default_response.items[0].payload is None
+
+        with_payload = await cases_service.search_cases(
+            params=params, include_payload=True
+        )
+        assert with_payload.items[0].payload == payload
+
     async def test_search_cases_tag_filter_uses_or_logic(
         self, cases_service: CasesService
     ) -> None:

--- a/tracecat/cases/internal_router.py
+++ b/tracecat/cases/internal_router.py
@@ -145,6 +145,7 @@ async def list_cases(
         None, description="Include only the requested custom field IDs"
     ),
     include_durations: bool = Query(False, description="Include case duration values"),
+    include_payload: bool = Query(False, description="Include case payload"),
 ) -> CursorPaginatedResponse[CaseReadMinimal]:
     service = CasesService(session, role)
 
@@ -156,6 +157,7 @@ async def list_cases(
             order_by=order_by,
             sort=sort,
             include_durations=include_durations,
+            include_payload=include_payload,
         )
     except ValueError as e:
         logger.warning(f"Invalid request for list cases: {e}")
@@ -268,6 +270,7 @@ async def search_cases(
         None, description="Include only the requested custom field IDs"
     ),
     include_durations: bool = Query(False, description="Include case duration values"),
+    include_payload: bool = Query(False, description="Include case payload"),
 ) -> CursorPaginatedResponse[CaseReadMinimal]:
     service = CasesService(session, role)
 
@@ -320,6 +323,7 @@ async def search_cases(
             order_by=order_by,
             sort=sort,
             include_durations=include_durations,
+            include_payload=include_payload,
         )
         if include_rows and cases.items:
             rows_service = CaseTableRowsService(session, role)

--- a/tracecat/cases/router.py
+++ b/tracecat/cases/router.py
@@ -183,6 +183,7 @@ async def list_cases(
         None, description="Include only the requested custom field IDs"
     ),
     include_durations: bool = Query(False, description="Include case duration values"),
+    include_payload: bool = Query(False, description="Include case payload"),
 ) -> CursorPaginatedResponse[CaseReadMinimal]:
     """List cases with default filtering and sorting options."""
     service = CasesService(session, role)
@@ -195,6 +196,7 @@ async def list_cases(
             order_by=order_by,
             sort=sort,
             include_durations=include_durations,
+            include_payload=include_payload,
         )
     except ValueError as e:
         logger.warning(f"Invalid request for list cases: {e}")
@@ -322,6 +324,7 @@ async def search_cases(
         None, description="Include only the requested custom field IDs"
     ),
     include_durations: bool = Query(False, description="Include case duration values"),
+    include_payload: bool = Query(False, description="Include case payload"),
 ) -> CursorPaginatedResponse[CaseReadMinimal]:
     """Search cases with cursor-based pagination, filtering, and sorting."""
     service = CasesService(session, role)
@@ -358,6 +361,7 @@ async def search_cases(
             order_by=order_by,
             sort=sort,
             include_durations=include_durations,
+            include_payload=include_payload,
         )
     except ValueError as e:
         logger.warning(f"Invalid request for search cases: {e}")

--- a/tracecat/cases/schemas.py
+++ b/tracecat/cases/schemas.py
@@ -55,6 +55,7 @@ class CaseReadMinimal(Schema):
     rows: list[CaseTableRowRead] = Field(default_factory=list)
     durations: list[CaseDurationRead] | None = None
     field_values: dict[str, Any] | None = None
+    payload: dict[str, Any] | None = None
     num_tasks_completed: int = Field(default=0)
     num_tasks_total: int = Field(default=0)
 

--- a/tracecat/cases/service.py
+++ b/tracecat/cases/service.py
@@ -390,6 +390,7 @@ class CasesService(BaseWorkspaceService):
         | None = None,
         sort: Literal["asc", "desc"] | None = None,
         include_durations: bool = False,
+        include_payload: bool = False,
     ) -> CursorPaginatedResponse[CaseReadMinimal]:
         """Search cases with cursor-based pagination and filtering."""
         paginator = BaseCursorPaginator(self.session)
@@ -665,6 +666,7 @@ class CasesService(BaseWorkspaceService):
                     tags=tag_reads,
                     dropdown_values=dropdown_reads,
                     durations=duration_reads,
+                    payload=case.payload if include_payload else None,
                     num_tasks_completed=task_counts[case.id]["completed"],
                     num_tasks_total=task_counts[case.id]["total"],
                 )
@@ -777,6 +779,7 @@ class CasesService(BaseWorkspaceService):
         | None = None,
         sort: Literal["asc", "desc"] | None = None,
         include_durations: bool = False,
+        include_payload: bool = False,
     ) -> CursorPaginatedResponse[CaseReadMinimal]:
         """List cases with a simplified default search query."""
         return await self.search_cases(
@@ -784,6 +787,7 @@ class CasesService(BaseWorkspaceService):
             order_by=order_by,
             sort=sort,
             include_durations=include_durations,
+            include_payload=include_payload,
         )
 
     async def get_case(


### PR DESCRIPTION
## Summary

Adds an `include_payload` query parameter to `GET /cases/search` and `GET /cases`, mirroring the existing `include_durations` flag. When set, the case `payload` is surfaced in the `CaseReadMinimal` search/list results; otherwise it is `null`.

`payload` is a plain column already loaded with every case row, so no query/eager-loading change is required — the flag only controls whether the value is populated in the response (keeping default search responses lean).

## Changes

- **Schema**: add `payload: dict[str, Any] | None = None` to `CaseReadMinimal`.
- **Service**: `search_cases()` and `list_cases()` accept `include_payload: bool = False`; payload is populated only when the flag is set.
- **Routers**: `include_payload` query param added to the search + list endpoints in both the public (`router.py`) and internal (`internal_router.py`) routers, forwarded to the service.
- **Registry SDK**: thread `include_payload` through `list_cases()` and `search_cases()`. Also fixes a latent bug where the SDK `search_cases` declared `include_rows` but never sent it as a request param.
- **Frontend client**: regenerated (`include_payload` / `includePayload` on the cases list + search clients and `CaseReadMinimal` type).
- **Tests**: service-level test asserting payload is gated (absent unless `include_payload=True`), and a route-level test asserting the flag is forwarded and surfaced.

## Notes

- No entitlement gating on `include_payload` (payload is core case data, ungated on `CaseRead`), unlike `include_durations`.
- When `include_payload=False`, the response includes `"payload": null` rather than omitting the key entirely. A serializer to drop the key when unrequested was intentionally deferred as a follow-up.

## Verification

- New + existing durations tests pass.
- `ruff check`, `ruff format --check`, `basedpyright`, and frontend `tsc` clean on all changed files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an include_payload query param to cases list/search so clients can request the case payload in CaseReadMinimal; by default payload is null to keep responses lean. Updates the `tracecat_registry` SDK and frontend clients to support the flag.

- **New Features**
  - Add include_payload to GET /cases and /cases/search (public and internal). When true, CaseReadMinimal.payload is populated; otherwise null.
  - Service and schema updated to carry payload without extra queries.
  - Frontend client regenerated: includePayload param and payload on CaseReadMinimal.
  - `tracecat_registry` SDK supports include_payload for list/search.

- **Bug Fixes**
  - SDK search_cases now sends the include_rows request param.

<sup>Written for commit 3096ea97bc22c607c640f5889fc058761a95f2ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

