### PR TITLE
perf(dsl): build loop regions in a single pass

### DIFF
--- a/tracecat/dsl/scheduler.py
+++ b/tracecat/dsl/scheduler.py
@@ -225,16 +225,9 @@ class DSLScheduler:
         dst_ref, edge_type = adj
         return dst_ref, edge_type.value
 
-    def _scope_is_descendant(self, scope: str, ancestor_scope: str) -> bool:
-        curr_scope = scope
-        while curr_scope is not None:
-            if curr_scope == ancestor_scope:
-                return True
-            curr_scope = self.scope_hierarchy.get(curr_scope)
-        return False
-
     def _build_loop_regions(self) -> dict[str, LoopRegion]:
-        regions: dict[str, LoopRegion] = {}
+        # Phase 1: validate each loop.end and map loop scope -> end ref.
+        loop_end_by_scope: dict[str, str] = {}
         for stmt in self.dsl.actions:
             if stmt.action != PlatformAction.LOOP_END:
                 continue
@@ -260,23 +253,37 @@ class DSLScheduler:
                 raise RuntimeError(
                     f"Loop end action {stmt.ref!r} does not match a loop start action"
                 )
-            if loop_scope in regions:
+            if loop_scope in loop_end_by_scope:
                 raise RuntimeError(
                     f"Loop start action {loop_scope!r} has multiple loop end actions"
                 )
+            loop_end_by_scope[loop_scope] = stmt.ref
 
-            members = frozenset(
-                ref
-                for ref, scope in self.action_scopes.items()
-                if self._scope_is_descendant(scope, loop_scope)
-            )
-            regions[loop_scope] = LoopRegion(
+        # Phase 2: assign membership in a single pass over all actions. Walk each
+        # action's scope chain upward once; every loop scope on the chain claims
+        # the action. O(actions x depth) total, vs O(loops x actions x depth)
+        # from re-walking the chain per loop.
+        members_by_scope: dict[str, set[str]] = {
+            scope: set() for scope in loop_end_by_scope
+        }
+        for ref, scope in self.action_scopes.items():
+            curr_scope: str | None = scope
+            while curr_scope is not None:
+                if (members := members_by_scope.get(curr_scope)) is not None:
+                    members.add(ref)
+                curr_scope = self.scope_hierarchy.get(curr_scope)
+
+        return {
+            loop_scope: LoopRegion(
                 start_ref=loop_scope,
-                end_ref=stmt.ref,
+                end_ref=end_ref,
                 scope_ref=loop_scope,
-                members=members | {stmt.ref},
+                # The end ref's own scope is the parent (it closes the loop scope),
+                # so it never appears in members_by_scope via the walk above.
+                members=frozenset(members_by_scope[loop_scope] | {end_ref}),
             )
-        return regions
+            for loop_scope, end_ref in loop_end_by_scope.items()
+        }
 
     @staticmethod
     def _stream_within(stream_id: StreamID, base_stream_id: StreamID) -> bool:


### PR DESCRIPTION
## Summary

- `DSLScheduler._build_loop_regions` rescanned **every** action and walked the scope hierarchy for **each** `core.loop.end`, making it O(loops × actions × depth). `DSLScheduler.__init__` is a fully synchronous constructor (no `await`) that Temporal re-runs in full on every workflow replay (cache eviction, worker failover, reset), so this cost repeated on every activation for loop-heavy DAGs.
- Rewrite it as two passes: validate each `loop.end` (unchanged checks/error messages), then do a single O(actions × depth) sweep that walks each action's scope chain once, claiming membership for every loop scope encountered along the way.
- `_scope_is_descendant` is now unused (it was only called from the old membership comprehension) and is removed.
- Output is unchanged: same `LoopRegion` membership semantics, including the `end_ref` union (the loop-end action's own scope is its parent, not a descendant, so it never appears via the walk and still needs the explicit union).

This addresses the algorithmic half of a previously investigated `[TMPRL1101]` deadlock-detector trip (synchronous scheduler construction not yielding within Temporal's 2s budget); the worker-concurrency mitigation for the same incident shipped separately in #2917. A follow-up "don't rebuild the static plan on every replay" change is intentionally out of scope for this PR — it needs a workflow-definition-version cache key that isn't currently plumbed into the scheduler.

## Test plan

- [x] `uv run ruff check` / `ruff format --check` on the changed file
- [x] `uv run basedpyright` — 0 errors
- [x] `tests/unit/test_dsl_scope_validation.py` — 26 passed
- [x] `tests/temporal/test_loop_control_flow.py` — 10 passed (nested loops, loop-inside-scatter, skip propagation)
- [x] `tests/temporal` (full suite, `-n auto`) — 168 passed, 16 skipped, 5 failed; the 5 failures (`requires_api`-marked table/secret tests) reproduce identically on unmodified `main` in this environment, confirming they're pre-existing and unrelated to this change


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build loop regions in a single pass to reduce scheduler construction from O(loops × actions × depth) to O(actions × depth). This cuts the synchronous `DSLScheduler.__init__` cost on Temporal replays and addresses the algorithmic side of `[TMPRL1101]`.

- **Refactors**
  - Rewrote `DSLScheduler._build_loop_regions` into two phases: validate `loop.end`s, then a single sweep that assigns membership while walking each action’s scope chain once.
  - Preserved behavior: same `LoopRegion` membership semantics, including explicit `end_ref` union.
  - Removed unused `_scope_is_descendant`.

<sup>Written for commit 5308aab0558e996b2cc271adea21358b2491d799. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

