### PR TITLE
feat(agents): preserve last error

### DIFF
--- a/alembic/versions/e32940d12293_add_agent_session_run_status.py
+++ b/alembic/versions/e32940d12293_add_agent_session_run_status.py
@@ -1,0 +1,53 @@
+"""add agent session last_error
+
+Adds a terminal error summary (``last_error``) to ``agent_session``. This is the
+sole persisted run-outcome signal: it is present iff the most recent run ended
+in error and is cleared when the next turn starts. The inbox reads it to route a
+session into its Error group instead of describing a fail-fast Temporal
+execution, which surfaced stale errors on old, healthy sessions.
+
+Errors are run-ending, so the latest error is always the latest outcome; no
+separate status enum is needed. A partial index supports the only predicate the
+inbox uses (``last_error IS NOT NULL``) without indexing the text payload.
+
+Purely additive: the column is nullable and unbackfilled. A NULL last_error
+means "no recorded error" (legacy / never-run / clean), so existing sessions are
+not flipped into the Error group. The turn lifecycle populates it going forward.
+
+Revision ID: e32940d12293
+Revises: 574d19d8c16c
+Create Date: 2026-06-30 14:10:33.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e32940d12293"
+down_revision: str | None = "574d19d8c16c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_session",
+        sa.Column("last_error", sa.Text(), nullable=True),
+    )
+    # Partial index: the inbox only ever filters on presence, so index the
+    # errored rows (a small minority) rather than the text values.
+    op.create_index(
+        "ix_agent_session_last_error_present",
+        "agent_session",
+        ["id"],
+        unique=False,
+        postgresql_where=sa.text("last_error IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_session_last_error_present", table_name="agent_session")
+    op.drop_column("agent_session", "last_error")

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3661,6 +3661,17 @@ export const $AgentSessionRead = {
       ],
       title: "Harness Type",
     },
+    last_error: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Error",
+    },
     last_stream_id: {
       anyOf: [
         {
@@ -3843,6 +3854,17 @@ export const $AgentSessionReadVercel = {
         },
       ],
       title: "Harness Type",
+    },
+    last_error: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Error",
     },
     last_stream_id: {
       anyOf: [
@@ -4034,6 +4056,17 @@ export const $AgentSessionReadWithMessages = {
         },
       ],
       title: "Harness Type",
+    },
+    last_error: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Last Error",
     },
     last_stream_id: {
       anyOf: [

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -879,6 +879,7 @@ export type AgentSessionRead = {
   agent_preset_version_id: string | null
   agents_binding?: ResolvedAgentsConfig | null
   harness_type: string | null
+  last_error?: string | null
   last_stream_id?: string | null
   artifacts?: Array<Artifact>
   parent_session_id?: string | null
@@ -905,6 +906,7 @@ export type AgentSessionReadVercel = {
   agent_preset_version_id: string | null
   agents_binding?: ResolvedAgentsConfig | null
   harness_type: string | null
+  last_error?: string | null
   last_stream_id?: string | null
   artifacts?: Array<Artifact>
   parent_session_id?: string | null
@@ -935,6 +937,7 @@ export type AgentSessionReadWithMessages = {
   agent_preset_version_id: string | null
   agents_binding?: ResolvedAgentsConfig | null
   harness_type: string | null
+  last_error?: string | null
   last_stream_id?: string | null
   artifacts?: Array<Artifact>
   parent_session_id?: string | null

--- a/frontend/src/components/chat/chat-history-dropdown.tsx
+++ b/frontend/src/components/chat/chat-history-dropdown.tsx
@@ -5,6 +5,7 @@ import { Check, ChevronDown, Loader2 } from "lucide-react"
 import { useState } from "react"
 
 import type { AgentSessionsListSessionsResponse } from "@/client"
+import { ChatLastErrorIndicator } from "@/components/chat/chat-last-error-indicator"
 import { Button } from "@/components/ui/button"
 import {
   Command,
@@ -108,7 +109,12 @@ export function ChatHistoryDropdown({
                     className="flex items-start justify-between gap-2 py-2 text-xs"
                   >
                     <div className="flex min-w-0 flex-col">
-                      <span className="truncate font-medium">{chat.title}</span>
+                      <div className="flex items-center gap-1.5">
+                        <span className="truncate font-medium">
+                          {chat.title}
+                        </span>
+                        <ChatLastErrorIndicator session={chat} />
+                      </div>
                       <span className="text-xs text-muted-foreground">
                         {formatDistanceToNow(new Date(chat.created_at), {
                           addSuffix: true,

--- a/frontend/src/components/chat/chat-last-error-indicator.tsx
+++ b/frontend/src/components/chat/chat-last-error-indicator.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { getSessionLastError, type SessionOrChat } from "@/lib/chat"
+import { cn } from "@/lib/utils"
+
+interface ChatLastErrorIndicatorProps {
+  /**
+   * A session/chat row. Either arm of the session/chat union; the error is read
+   * off the AgentSession arms, so legacy chats (no last_error) render nothing.
+   */
+  session: SessionOrChat
+  className?: string
+}
+
+/**
+ * Compact indicator for a session whose most recent run errored.
+ *
+ * Renders nothing when there is no persisted error, so it is safe to drop into
+ * any chat-list row. The full error reason is shown on hover rather than inline
+ * to keep list rows scannable.
+ */
+export function ChatLastErrorIndicator({
+  session,
+  className,
+}: ChatLastErrorIndicatorProps) {
+  const lastError = getSessionLastError(session)
+  if (!lastError) {
+    return null
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <AlertTriangle
+            className={cn("size-3.5 shrink-0 text-destructive", className)}
+            aria-label="Last run failed"
+          />
+        </TooltipTrigger>
+        <TooltipContent className="max-w-xs">
+          <p className="text-xs font-medium">Last run failed</p>
+          <p className="mt-1 whitespace-pre-wrap break-words text-xs text-muted-foreground">
+            {lastError}
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/frontend/src/components/chat/chat-list.tsx
+++ b/frontend/src/components/chat/chat-list.tsx
@@ -3,6 +3,7 @@
 import { MessageCircle, Plus } from "lucide-react"
 import { useState } from "react"
 import { $AgentSessionEntity, type AgentSessionEntity } from "@/client"
+import { ChatLastErrorIndicator } from "@/components/chat/chat-last-error-indicator"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -128,7 +129,10 @@ export function ChatList({
               >
                 <div className="flex items-start justify-between gap-2">
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium truncate">{chat.title}</p>
+                    <div className="flex items-center gap-1.5">
+                      <p className="font-medium truncate">{chat.title}</p>
+                      <ChatLastErrorIndicator session={chat} />
+                    </div>
                     <p className="text-xs text-muted-foreground">
                       {new Date(chat.created_at).toLocaleString()}
                     </p>

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -109,6 +109,7 @@ import {
 import type { ModelInfo } from "@/lib/chat"
 import {
   ENTITY_TO_INVALIDATION,
+  getSessionLastError,
   toUIMessage,
   transformMessages,
 } from "@/lib/chat"
@@ -385,6 +386,22 @@ export function ChatSessionPane({
     onData,
     resume,
   })
+
+  // Prefer the live streaming error; fall back to the persisted last_error so a
+  // reopened session whose last run failed still surfaces why (the live error
+  // only exists during/right after the failing run).
+  //
+  // Suppress the persisted error the moment a new turn starts — optimistically
+  // on submit, before the backend clears last_error — because the new run will
+  // produce its own outcome (a fresh error or a reply) that supersedes it.
+  // The live error is always the current run's, so it is never suppressed.
+  const hasNewTurnStarted =
+    optimisticMessageText !== null ||
+    status === "submitted" ||
+    status === "streaming"
+  const persistedError =
+    hasNewTurnStarted || !chat ? null : getSessionLastError(chat)
+  const displayedError = lastError ?? persistedError
 
   // useChat seeds `messages` only on mount. Re-seed when the server transcript
   // *advances* (e.g. an approval resolves), but never on a plain mismatch — post
@@ -1265,7 +1282,7 @@ export function ChatSessionPane({
   const showEmptyHero =
     isWorkspaceChat &&
     !isReadonly &&
-    !lastError &&
+    !displayedError &&
     !optimisticMessageText &&
     !isWaitingForResponse &&
     !transformedMessages.some(messageHasVisibleParts)
@@ -1292,10 +1309,14 @@ export function ChatSessionPane({
             resize={status === "streaming" ? "instant" : "smooth"}
           >
             <ConversationContent className={chatContentCenterClass}>
-              {lastError && (
+              {displayedError && (
                 <Alert variant="destructive" className="mb-4">
-                  <AlertTitle>Unable to continue with this model</AlertTitle>
-                  <AlertDescription>{lastError}</AlertDescription>
+                  <AlertTitle>
+                    {lastError
+                      ? "Unable to continue with this model"
+                      : "Last run failed"}
+                  </AlertTitle>
+                  <AlertDescription>{displayedError}</AlertDescription>
                 </Alert>
               )}
               {optimisticMessageText ? (

--- a/frontend/src/components/inbox/inbox-detail.tsx
+++ b/frontend/src/components/inbox/inbox-detail.tsx
@@ -149,6 +149,8 @@ export function InboxDetail({
     )
   }
 
+  // The persisted last_error banner is rendered by ChatSessionPane itself (from
+  // the session's last_error), so the inbox detail doesn't duplicate it here.
   return (
     <ChatSessionPane
       chat={chat}

--- a/frontend/src/hooks/use-inbox.ts
+++ b/frontend/src/hooks/use-inbox.ts
@@ -184,6 +184,10 @@ function inboxItemToSessionItem(item: InboxItemRead): InboxSessionItem {
     pendingApprovalCount:
       (item.metadata?.pending_count as number) ??
       (item.status === "pending" ? 1 : 0),
+    lastError:
+      typeof item.metadata?.last_error === "string"
+        ? item.metadata.last_error
+        : null,
   }
 }
 

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -158,6 +158,12 @@ export interface InboxSessionItem {
   statusPriority: number
   statusTone: AgentStatusTone
   pendingApprovalCount: number
+  /**
+   * Terminal error summary for the most recent run, when it failed.
+   * Surfaced because terminal errors are not persisted into the replayable
+   * message history, so the detail pane has nothing else to show on reopen.
+   */
+  lastError: string | null
 }
 
 export function enrichAgentSession(

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -1,6 +1,13 @@
 import type { QueryClient } from "@tanstack/react-query"
 import * as ai from "ai"
-import type { AgentSessionEntity, UIMessage } from "@/client"
+import type {
+  AgentSessionEntity,
+  AgentSessionRead,
+  AgentSessionReadVercel,
+  ChatReadMinimal,
+  ChatReadVercel,
+  UIMessage,
+} from "@/client"
 import type { ApprovalCard } from "@/hooks/use-chat"
 import { invalidateCaseActivityQueries } from "@/lib/cases/invalidation"
 
@@ -23,6 +30,28 @@ export function isAgentSessionEntity(
     value === "approval" ||
     value === "external_channel"
   )
+}
+
+/**
+ * Either arm of a session/chat union, in list (`*Read`) or Vercel
+ * (`*ReadVercel`) shape. Only the AgentSession arms carry `last_error`; the
+ * legacy Chat arms do not, which is what lets `getSessionLastError` narrow.
+ */
+export type SessionOrChat =
+  | AgentSessionRead
+  | AgentSessionReadVercel
+  | ChatReadMinimal
+  | ChatReadVercel
+
+/**
+ * Read the persisted terminal error of a session's most recent run.
+ *
+ * Present iff the last run errored (errors are run-ending and clear on the next
+ * turn). Lives only on the AgentSession arms of the union — legacy Chat rows
+ * have no such field — so this returns null for those arms.
+ */
+export function getSessionLastError(session: SessionOrChat): string | null {
+  return "last_error" in session ? (session.last_error ?? null) : null
 }
 
 /**

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -124,10 +124,21 @@ class ApplyApprovalResultsActivityInputs(BaseModel):
 
 
 class EmitSessionErrorInputs(BaseModel):
+    role: Role
     session_id: uuid.UUID
     workspace_id: uuid.UUID
     message: str
     active_stream_id: uuid.UUID | None = None
+    # When False, only persist last_error and skip the SSE stream. The runtime
+    # error path has already streamed the error inline via the loopback, so it
+    # persists-only; pre-stream failures stream too.
+    should_stream: bool = True
+
+
+# Cap stored error summaries so a runaway traceback can't bloat the session row
+# or the inbox payload. The detail banner only needs a short, human-readable
+# reason.
+MAX_LAST_ERROR_LEN = 2000
 
 
 def _stored_user_mcp_tool_policy(
@@ -473,11 +484,42 @@ class AgentActivities:
 
     @activity.defn
     async def emit_session_error(self, args: EmitSessionErrorInputs) -> None:
-        """Push a terminal error onto the session's SSE stream.
+        """Finalize a terminal agent error.
 
-        Used by workflow outer-scope handlers to surface pre-runtime failures
-        to the chat UI, since those happen before the loopback is wired up.
+        Persists ``last_error`` on the session (the sole durable run-outcome
+        signal the inbox reads) and, for pre-stream failures, also pushes the
+        error onto the SSE stream since those happen before the loopback is
+        wired up. The runtime path streams inline already and passes
+        ``should_stream=False`` to persist-only.
+
+        Best-effort: a persistence failure must not mask the agent's real error
+        or abort propagation, so it is logged and swallowed.
         """
+        from tracecat.agent.session.service import AgentSessionService
+
+        ctx_role.set(args.role)
+        try:
+            async with AgentSessionService.with_session(role=args.role) as service:
+                agent_session = await service.get_session(args.session_id)
+                if agent_session is not None:
+                    agent_session.last_error = args.message[:MAX_LAST_ERROR_LEN]
+                    service.session.add(agent_session)
+                    await service.session.commit()
+                else:
+                    logger.warning(
+                        "Cannot persist error for unknown agent session",
+                        session_id=str(args.session_id),
+                    )
+        except Exception as e:
+            logger.warning(
+                "Failed to persist terminal agent session error",
+                session_id=str(args.session_id),
+                error=str(e),
+            )
+
+        if not args.should_stream:
+            return
+
         stream = await AgentStream.new(
             session_id=args.session_id,
             workspace_id=args.workspace_id,

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -122,6 +122,9 @@ BUILD_AGENT_TOOL_DEFINITIONS_PATCH = (
 EMIT_PRE_STREAM_SESSION_ERRORS_PATCH = (
     "tracecat_ee.agent.workflows.durable.emit_pre_stream_session_errors"
 )
+PERSIST_SESSION_ERROR_PATCH = (
+    "tracecat_ee.agent.workflows.durable.persist_session_error"
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -824,17 +827,25 @@ class DurableAgentWorkflow:
 
         try:
             cfg = await self._build_config(args)
+            # Success needs no write: last_error was already cleared at turn
+            # start, and last_error is the only persisted run-outcome signal.
             return await self._run_with_agent_executor(args, cfg)
         except ActivityError as e:
-            if workflow.patched(EMIT_PRE_STREAM_SESSION_ERRORS_PATCH):
-                await self._emit_session_error(_activity_error_message(e))
+            # Pre-stream failure: persist last_error and stream it (the loopback
+            # was not yet wired up to surface it inline).
+            await self._finalize_session_error(
+                _activity_error_message(e),
+                should_stream=workflow.patched(EMIT_PRE_STREAM_SESSION_ERRORS_PATCH),
+            )
             raise
         except ApplicationError as e:
-            if e.type == AGENT_TOOL_DEFINITION_ERROR or (
+            # Runtime errors stream inline via the loopback, so persist-only.
+            # Pre-stream errors (tool-definition / pre-runtime) stream too.
+            should_stream = e.type == AGENT_TOOL_DEFINITION_ERROR or (
                 e.type != AGENT_RUNTIME_EXECUTION_ERROR
                 and workflow.patched(EMIT_PRE_STREAM_SESSION_ERRORS_PATCH)
-            ):
-                await self._emit_session_error(e.message)
+            )
+            await self._finalize_session_error(e.message, should_stream=should_stream)
             raise
         finally:
             # Terminal boundary only: approval-pause awaits inside the executor
@@ -874,11 +885,25 @@ class DurableAgentWorkflow:
                 error=str(exc),
             )
 
-    async def _emit_session_error(self, message: str) -> None:
+    async def _finalize_session_error(
+        self, message: str, *, should_stream: bool
+    ) -> None:
+        """Persist last_error (and optionally stream it) on terminal failure.
+
+        Replay-gated and best-effort: the activity swallows its own persistence
+        failures, and we guard the schedule so finalizing never masks the
+        agent's real error or aborts the workflow's own error propagation.
+        """
+        if not workflow.patched(PERSIST_SESSION_ERROR_PATCH):
+            # Pre-patch histories kept their original pre-stream-only behavior,
+            # so preserve that command shape on replay.
+            if not should_stream:
+                return
         try:
             await workflow.execute_activity_method(
                 AgentActivities.emit_session_error,
                 EmitSessionErrorInputs(
+                    role=self.role,
                     session_id=self.session_id,
                     workspace_id=self.workspace_id,
                     message=message,
@@ -886,13 +911,14 @@ class DurableAgentWorkflow:
                     # suffixed key, so the error/done markers must land there.
                     # None falls back to the per-session key for non-chat turns.
                     active_stream_id=self.active_stream_id,
+                    should_stream=should_stream,
                 ),
                 start_to_close_timeout=timedelta(seconds=10),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
             )
         except ActivityError as emit_error:
             logger.warning(
-                "Failed to emit terminal agent session error",
+                "Failed to finalize terminal agent session error",
                 session_id=self.session_id,
                 error=str(emit_error),
             )

--- a/packages/tracecat-ee/tracecat_ee/inbox/providers/agent_runs.py
+++ b/packages/tracecat-ee/tracecat_ee/inbox/providers/agent_runs.py
@@ -6,6 +6,7 @@ import asyncio
 import uuid
 from collections.abc import Sequence
 from datetime import datetime
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal
 
 from sqlalchemy import String, and_, cast, distinct, func, or_, select
@@ -25,29 +26,58 @@ from tracecat.logger import logger
 from tracecat.pagination import BaseCursorPaginator, CursorPaginatedResponse
 from tracecat_ee.agent.types import AgentWorkflowID
 
+# The error signal is fully persisted (AgentSession.last_error), so Temporal is
+# only consulted to tell a genuinely-running run from one whose worker died.
 RUNNING_STATUSES = {
     WorkflowExecutionStatus.RUNNING,
     WorkflowExecutionStatus.CONTINUED_AS_NEW,
 }
-FAILED_STATUSES = {
+# A current run that ended in one of these without recording last_error died
+# mid-turn before it could finalize. CANCELED/COMPLETED are clean terminals.
+_ABNORMAL_TERMINAL_STATUSES = {
     WorkflowExecutionStatus.FAILED,
     WorkflowExecutionStatus.TIMED_OUT,
     WorkflowExecutionStatus.TERMINATED,
 }
+
+
+class RunStatus(StrEnum):
+    """Resolved display status for a session in the inbox.
+
+    Error is derived from the persisted ``last_error`` (errors are run-ending,
+    so the latest error is the latest outcome). Running is a transient,
+    live-only signal from describing the current run; a current run that has
+    already terminated without recording an error reconciles to ERROR (its
+    worker died mid-turn).
+    """
+
+    RUNNING = "running"
+    COMPLETED = "completed"
+    ERROR = "error"
+
+
+# The inbox UI keys its status tone/label off a Temporal-style status name in
+# item metadata. Map our resolved run status onto the names the frontend's
+# existing TEMPORAL_STATUS_MAP already understands so no UI change is required.
+_RUN_STATUS_TO_TEMPORAL_NAME: dict[RunStatus | None, str | None] = {
+    RunStatus.RUNNING: WorkflowExecutionStatus.RUNNING.name,
+    RunStatus.COMPLETED: WorkflowExecutionStatus.COMPLETED.name,
+    RunStatus.ERROR: WorkflowExecutionStatus.FAILED.name,
+    None: None,
+}
+
 
 # Harnesses whose root sessions surface in the inbox. These are the durable
 # agent harnesses; chat-only harnesses are handled inline in the chat UI and do
 # not appear here. Add a harness to this set to make its runs inbox-eligible.
 INBOX_HARNESS_TYPES = (HarnessType.CLAUDE_CODE,)
 
-# Group membership depends on live Temporal status, so grouped listing scans
-# sessions in batches and classifies after enrichment. Each scanned session may
-# cost a Temporal describe call, so the scan is hard-capped per request.
+# Group membership depends on persisted last_error plus a bounded live check for
+# the current run, so grouped listing scans sessions in batches and classifies
+# after enrichment. Each non-errored session with a current run may cost a
+# Temporal describe call, so the scan is hard-capped per request.
 GROUP_SCAN_BATCH_SIZE = 50
 GROUP_SCAN_MAX_SESSIONS = 300
-
-RUNNING_STATUS_NAMES = {s.name for s in RUNNING_STATUSES}
-FAILED_STATUS_NAMES = {s.name for s in FAILED_STATUSES}
 
 if TYPE_CHECKING:
     from tracecat.auth.types import Role
@@ -66,28 +96,48 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
         self.role = role
         self.workspace_id = role.workspace_id
 
-    async def _resolve_temporal_statuses(
+    async def _resolve_live_statuses(
         self,
         sessions: Sequence[AgentSession],
-    ) -> dict[uuid.UUID, WorkflowExecutionStatus]:
+    ) -> dict[uuid.UUID, RunStatus]:
+        """Resolve the display status for each session.
+
+        ``last_error`` is the source of truth for the error state: present iff
+        the most recent run errored. It is returned straight from the DB with no
+        Temporal call — this is what fixes the stale-error bug, where describing
+        an old fail-fast execution returned FAILED/TIMED_OUT/TERMINATED long
+        after the session was healthy.
+
+        For a non-errored session that still points at a current run, the live
+        execution is described to surface a real RUNNING indicator. If that run
+        has already terminated abnormally (or is no longer observable) without
+        recording an error, its worker died mid-turn, so it reconciles to ERROR;
+        a clean/terminated run is COMPLETED.
+        """
         if not sessions:
             return {}
 
-        session_pairs = [
-            (session.id, session.curr_run_id)
-            for session in sessions
-            if session.curr_run_id is not None
-        ]
-        if not session_pairs:
-            return {}
+        statuses: dict[uuid.UUID, RunStatus] = {}
+        to_describe: list[tuple[uuid.UUID, uuid.UUID]] = []
+        for session in sessions:
+            if session.last_error is not None:
+                statuses[session.id] = RunStatus.ERROR
+            elif session.curr_run_id is not None:
+                to_describe.append((session.id, session.curr_run_id))
+            # No error and no current run: legacy/clean session. Leave unset so
+            # callers fall back to approval signals (rejected -> error, else
+            # completed).
+
+        if not to_describe:
+            return statuses
 
         from tracecat_ee.agent.workflows.durable import DurableAgentWorkflow
 
         client = await get_temporal_client()
 
-        async def describe_status(
+        async def describe(
             session_id: uuid.UUID, run_id: uuid.UUID
-        ) -> tuple[uuid.UUID, WorkflowExecutionStatus | None]:
+        ) -> tuple[uuid.UUID, RunStatus]:
             try:
                 workflow_id = AgentWorkflowID(run_id)
                 handle = client.get_workflow_handle_for(
@@ -95,26 +145,30 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
                     str(workflow_id),
                 )
                 description = await handle.describe()
-                return session_id, description.status
             except Exception as exc:
+                # No longer observable (history gone / not found). The run is not
+                # errored on record and we can't confirm it; treat as completed
+                # rather than inventing an error for an old, healthy session.
                 logger.warning(
-                    "Failed to describe agent workflow for inbox status",
+                    "Failed to describe current agent workflow for inbox status",
                     session_id=str(session_id),
                     run_id=str(run_id),
                     error=str(exc),
                 )
-                return session_id, None
+                return session_id, RunStatus.COMPLETED
+            if description.status in RUNNING_STATUSES:
+                return session_id, RunStatus.RUNNING
+            if description.status in _ABNORMAL_TERMINAL_STATUSES:
+                # Terminated abnormally but no error was recorded: the worker
+                # died mid-turn before finalizing. Surface it as an error.
+                return session_id, RunStatus.ERROR
+            return session_id, RunStatus.COMPLETED
 
         results = await asyncio.gather(
-            *(
-                describe_status(session_id, run_id)
-                for session_id, run_id in session_pairs
-            )
+            *(describe(session_id, run_id) for session_id, run_id in to_describe)
         )
-        statuses: dict[uuid.UUID, WorkflowExecutionStatus] = {}
         for session_id, status in results:
-            if status is not None:
-                statuses[session_id] = status
+            statuses[session_id] = status
         return statuses
 
     def _base_query(
@@ -169,6 +223,7 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
                 AgentSession.entity_type,
                 AgentSession.entity_id,
                 AgentSession.curr_run_id,
+                AgentSession.last_error,
                 AgentSession.created_at,
                 AgentSession.updated_at,
                 raiseload=True,
@@ -452,17 +507,17 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
                 for s in sessions
             }
 
-        temporal_statuses = await self._resolve_temporal_statuses(sessions)
+        run_statuses = await self._resolve_live_statuses(sessions)
 
         classifications: dict[uuid.UUID, InboxGroup] = {}
         for s in sessions:
             if pending_counts.get(s.id, 0) > 0:
                 classifications[s.id] = InboxGroup.REVIEW_REQUIRED
                 continue
-            temporal_status = temporal_statuses.get(s.id)
-            if temporal_status in RUNNING_STATUSES:
+            run_status = run_statuses.get(s.id)
+            if run_status is RunStatus.RUNNING:
                 classifications[s.id] = InboxGroup.RUNNING
-            elif temporal_status in FAILED_STATUSES:
+            elif run_status is RunStatus.ERROR:
                 classifications[s.id] = InboxGroup.ERROR
             elif rejected_counts.get(s.id, 0) > 0:
                 classifications[s.id] = InboxGroup.ERROR
@@ -526,8 +581,33 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
                 pending_exists,
             )
         elif group is InboxGroup.RUNNING:
-            # Necessary (not sufficient) condition: a live Temporal run exists
-            base_stmt = base_stmt.where(AgentSession.curr_run_id.is_not(None))
+            # Necessary (not sufficient) condition: only a non-errored session
+            # with a current run can resolve to RUNNING. This also bounds the
+            # live describe fan-out to those sessions.
+            base_stmt = base_stmt.where(
+                AgentSession.last_error.is_(None),
+                AgentSession.curr_run_id.is_not(None),
+            )
+        elif group is InboxGroup.ERROR:
+            # Necessary (not sufficient) condition: a session lands in ERROR from
+            # a persisted error, a current run that reconciles to dead, or a
+            # rejected approval. Pre-filter to those so the scan skips the
+            # (common) clean-completed rows.
+            rejected_exists = (
+                select(Approval.id)
+                .where(
+                    Approval.session_id == AgentSession.id,
+                    Approval.status == ApprovalStatus.REJECTED,
+                )
+                .exists()
+            )
+            base_stmt = base_stmt.where(
+                or_(
+                    AgentSession.last_error.is_not(None),
+                    AgentSession.curr_run_id.is_not(None),
+                    rejected_exists,
+                )
+            )
 
         # Decode cursor as a scan-position keyset (sort_value + id of last
         # scanned session). This lets subsequent pages resume exactly where
@@ -690,7 +770,7 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
         # Fetch workflow metadata for sessions with entity_id
         workflow_ids = {s.entity_id for s in sessions if s.entity_id}
         workflows_by_id: dict[uuid.UUID, Workflow] = {}
-        temporal_statuses = await self._resolve_temporal_statuses(sessions)
+        run_statuses = await self._resolve_live_statuses(sessions)
 
         if workflow_ids:
             workflow_stmt = select(Workflow).where(
@@ -723,12 +803,16 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
             failed_count = sum(
                 1 for a in session_approvals if a.status == ApprovalStatus.REJECTED
             )
-            temporal_status = temporal_statuses.get(session.id)
-            temporal_status_name = temporal_status.name if temporal_status else None
+            run_status = run_statuses.get(session.id)
+            # Surface a Temporal-style status name the frontend's existing
+            # mapping understands. This is derived from the persisted run
+            # outcome, not a live describe of a stale execution.
+            temporal_status_name = _RUN_STATUS_TO_TEMPORAL_NAME.get(run_status)
+            last_error = session.last_error
 
             if pending_count > 0:
                 status = InboxItemStatus.PENDING
-            elif temporal_status in FAILED_STATUSES:
+            elif run_status is RunStatus.ERROR:
                 status = InboxItemStatus.FAILED
             elif failed_count > 0:
                 status = InboxItemStatus.FAILED
@@ -738,13 +822,15 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
             # Build preview text
             if pending_count > 0:
                 preview = f"{pending_count} pending approval{'s' if pending_count != 1 else ''}"
-            elif temporal_status in RUNNING_STATUSES:
+            elif run_status is RunStatus.RUNNING:
                 preview = "Execution in progress"
-            elif temporal_status in FAILED_STATUSES:
-                preview = "Execution failed"
+            elif run_status is RunStatus.ERROR:
+                # Prefer the persisted error summary so the list row hints at why
+                # without opening the run; fall back to a generic label.
+                preview = last_error or "Execution failed"
             elif failed_count > 0:
                 preview = f"{failed_count} rejected"
-            elif temporal_status is None and not session_approvals:
+            elif run_status is None and not session_approvals:
                 preview = "Agent session"
             else:
                 preview = "Execution completed"
@@ -781,6 +867,7 @@ class AgentRunsInboxProvider(BaseCursorPaginator):
                 "pending_count": pending_count,
                 "total_approvals": len(session_approvals),
                 "temporal_status": temporal_status_name,
+                "last_error": last_error,
                 "approvals": [
                     {
                         "id": str(a.id),

--- a/tests/temporal/test_durable_agent_workflow.py
+++ b/tests/temporal/test_durable_agent_workflow.py
@@ -541,12 +541,19 @@ async def test_agent_workflow_streams_tool_definition_error(
 
 @pytest.mark.anyio
 @pytest.mark.integration
-async def test_agent_workflow_does_not_duplicate_runtime_terminal_error(
+async def test_agent_workflow_persists_runtime_terminal_error_without_streaming(
     temporal_client: Client,
     agent_worker_factory,
     agent_workflow_args: AgentWorkflowArgs,
     mock_session_id: uuid.UUID,
 ) -> None:
+    """A runtime failure that already streamed its error persists last_error only.
+
+    ``terminal_stream_error_emitted=True`` means the loopback already pushed the
+    terminal error onto the SSE stream, so ``emit_session_error`` runs with
+    ``should_stream=False`` to record the durable last_error signal without
+    re-emitting a duplicate terminal marker.
+    """
     queue = f"test-agent-queue-{mock_session_id}"
     emitted_errors: list[EmitSessionErrorInputs] = []
 
@@ -584,7 +591,12 @@ async def test_agent_workflow_does_not_duplicate_runtime_terminal_error(
 
     assert isinstance(exc_info.value.cause, ApplicationError)
     assert "Agent execution failed: runtime exploded" in str(exc_info.value.cause)
-    assert emitted_errors == []
+    # Persist-only: exactly one emit, carrying last_error, with streaming off so
+    # the already-emitted terminal marker is not duplicated.
+    assert len(emitted_errors) == 1
+    assert emitted_errors[0].session_id == mock_session_id
+    assert emitted_errors[0].message == "Agent execution failed: runtime exploded"
+    assert emitted_errors[0].should_stream is False
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_runs_inbox_provider.py
+++ b/tests/unit/test_agent_runs_inbox_provider.py
@@ -375,7 +375,7 @@ async def test_classify_rejected_only_non_workflow_session_lands_in_error_group(
         return {}
 
     monkeypatch.setattr(provider, "_fetch_approval_counts", fetch_counts)
-    monkeypatch.setattr(provider, "_resolve_temporal_statuses", resolve_statuses)
+    monkeypatch.setattr(provider, "_resolve_live_statuses", resolve_statuses)
 
     classifications = await provider._classify_sessions_for_group(
         [rejected], group=InboxGroup.ERROR

--- a/tests/unit/test_agent_session_router.py
+++ b/tests/unit/test_agent_session_router.py
@@ -71,6 +71,7 @@ def _agent_session_stub(**overrides: Any) -> SimpleNamespace:
         "last_stream_id": None,
         "active_stream_id": None,
         "curr_run_id": None,
+        "last_error": None,
         "artifacts": [],
     }
     values.update(overrides)

--- a/tests/unit/test_durable_agent_workflow_search_attributes.py
+++ b/tests/unit/test_durable_agent_workflow_search_attributes.py
@@ -17,6 +17,7 @@ from tracecat_ee.agent.workflows.durable import (
     EMIT_PRE_STREAM_SESSION_ERRORS_PATCH,
     FINALIZE_TURN_PATCH,
     LOAD_TERMINAL_MESSAGE_HISTORY_PATCH,
+    PERSIST_SESSION_ERROR_PATCH,
     UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH,
     AgentWorkflowArgs,
     DurableAgentWorkflow,
@@ -240,7 +241,7 @@ async def test_run_skips_activity_error_emission_without_patch_marker() -> None:
     with (
         patch(
             "tracecat_ee.agent.workflows.durable.workflow.patched",
-            side_effect=[False, False, False],
+            side_effect=[False, False, False, False],
         ) as patched_mock,
         patch(
             "tracecat_ee.agent.workflows.durable.workflow.unsafe.is_replaying",
@@ -252,21 +253,26 @@ async def test_run_skips_activity_error_emission_without_patch_marker() -> None:
             "_run_with_agent_executor",
             AsyncMock(side_effect=activity_error),
         ),
-        patch.object(
-            workflow_instance,
-            "_emit_session_error",
+        # Let the real _finalize_session_error run so its patch-gated
+        # early-return is exercised; mock only the actual scheduling call.
+        patch(
+            "tracecat_ee.agent.workflows.durable.workflow.execute_activity_method",
             AsyncMock(),
-        ) as emit_error_mock,
+        ) as execute_activity_mock,
     ):
         with pytest.raises(ActivityError):
             await workflow_instance.run(workflow_args)
 
+    # Legacy replay (all patches off) on the pre-stream error path: should_stream
+    # resolves False, and _finalize_session_error early-returns before scheduling
+    # emit_session_error, preserving the legacy command shape.
     assert patched_mock.call_args_list == [
         ((UPSERT_TRACECAT_SEARCH_ATTRIBUTES_PATCH,),),
         ((EMIT_PRE_STREAM_SESSION_ERRORS_PATCH,),),
+        ((PERSIST_SESSION_ERROR_PATCH,),),
         ((FINALIZE_TURN_PATCH,),),
     ]
-    emit_error_mock.assert_not_awaited()
+    execute_activity_mock.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tracecat/agent/session/activities.py
+++ b/tracecat/agent/session/activities.py
@@ -207,9 +207,12 @@ async def create_session_activity(input: CreateSessionInput) -> CreateSessionRes
                     service.session.add(agent_session)
                     await service.session.commit()
 
-            # Set curr_run_id if provided (for workflow-initiated sessions)
+            # Set curr_run_id if provided (for workflow-initiated sessions) and
+            # clear any prior error. Clearing last_error here is what makes the
+            # previous run's error irrelevant once a new turn starts.
             if input.curr_run_id is not None:
                 agent_session.curr_run_id = input.curr_run_id
+                agent_session.last_error = None
                 service.session.add(agent_session)
                 await service.session.commit()
 

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -195,6 +195,7 @@ async def get_session(
                 else None
             ),
             harness_type=agent_session.harness_type,
+            last_error=agent_session.last_error,
             created_at=agent_session.created_at,
             updated_at=agent_session.updated_at,
             last_stream_id=agent_session.last_stream_id,
@@ -277,6 +278,7 @@ async def get_session_vercel(
                 else None
             ),
             harness_type=agent_session.harness_type,
+            last_error=agent_session.last_error,
             created_at=agent_session.created_at,
             updated_at=agent_session.updated_at,
             last_stream_id=agent_session.last_stream_id,

--- a/tracecat/agent/session/schemas.py
+++ b/tracecat/agent/session/schemas.py
@@ -133,6 +133,10 @@ class AgentSessionRead(BaseModel):
     agents_binding: ResolvedAgentsConfig | None = None
     # Harness
     harness_type: str | None
+    # Terminal error of the most recent run, present iff it failed (errors are
+    # run-ending). The detail pane reads this to show why the run failed, since
+    # terminal errors are not persisted into the replayable message history.
+    last_error: str | None = None
     # Stream tracking
     last_stream_id: str | None = None
     artifacts: list[Artifact] = Field(default_factory=list)

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -1372,9 +1372,15 @@ class AgentSessionService(BaseWorkspaceService):
             )
 
             # Pin run_id (approval lookups) and the per-turn stream id before
-            # launching the workflow.
+            # launching the workflow. Clear last_error in the same transaction
+            # that records the new run id: create_session_activity also clears
+            # it, but that runs inside the workflow on the agent worker. If the
+            # worker is queued/unavailable after a retry, the stale last_error
+            # would otherwise make _resolve_live_statuses report the old failure
+            # for a turn that is actually starting.
             agent_session.curr_run_id = run_id
             agent_session.active_stream_id = stream_id
+            agent_session.last_error = None
             self.session.add(agent_session)
             await self.session.commit()
 

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -2913,6 +2913,12 @@ class AgentSession(WorkspaceModel):
         index=True,
         doc="Per-turn stream id - Redis key suffix for the active turn's stream",
     )
+    # Terminal error summary for the most recent run
+    last_error: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        doc="Terminal error summary for the most recent run (cleared on next turn)",
+    )
     work_dir_snapshot: Mapped[dict[str, Any] | None] = mapped_column(
         JSONB,
         nullable=True,


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the last terminal agent error per session and surface it across inbox and chat. Inbox status now derives from `last_error` with a bounded live check for current runs, fixing stale errors from old Temporal executions.

- **New Features**
  - Add `last_error` to `agent_session` (2k cap). Cleared at turn start (including on schedule). Exposed via `AgentSessionRead*`.
  - Persist `last_error` on terminal failure via a best-effort activity. Runtime errors persist-only; pre-stream errors also stream. Replay/patch-gated to preserve legacy histories.
  - Inbox resolves status from `last_error`. Describes only non-errored sessions with `curr_run_id`; dead current runs reconcile to error. Maps to existing Temporal status names. Preview prefers error text. `last_error` included in item metadata.
  - Chat UI adds a compact warning icon with tooltip in chat lists/history and an error banner in the session pane. Prefers live streamed errors; falls back to persisted on reopen. Persisted error hides as soon as a new turn starts.

- **Migration**
  - Adds nullable `last_error` column and partial index `ix_agent_session_last_error_present`. No backfill or manual steps.

<sup>Written for commit e9408bfc5a3a5802c05868054dceae1cb0436b92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



https://github.com/user-attachments/assets/d892e0d6-26cf-4f9c-9358-e1250f38a828



