### PR TITLE
feat(agents): chat interrupts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,5 +27,8 @@
         "*.github.com"
       ]
     }
+  },
+  "enabledPlugins": {
+    "codex@openai-codex": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,8 +27,5 @@
         "*.github.com"
       ]
     }
-  },
-  "enabledPlugins": {
-    "codex@openai-codex": true
   }
 }

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -3378,6 +3378,44 @@ export const $AgentSessionArtifactsRead = {
   description: "Response schema for persisted agent session artifacts.",
 } as const
 
+export const $AgentSessionCancelRequest = {
+  properties: {
+    reason: {
+      type: "string",
+      const: "user_cancel",
+      title: "Reason",
+      default: "user_cancel",
+    },
+  },
+  type: "object",
+  title: "AgentSessionCancelRequest",
+  description: "Request schema for cancelling the active agent session turn.",
+} as const
+
+export const $AgentSessionCancelResponse = {
+  properties: {
+    session_id: {
+      type: "string",
+      format: "uuid",
+      title: "Session Id",
+    },
+    run_id: {
+      type: "string",
+      format: "uuid",
+      title: "Run Id",
+    },
+    reason: {
+      type: "string",
+      title: "Reason",
+    },
+  },
+  type: "object",
+  required: ["session_id", "run_id", "reason"],
+  title: "AgentSessionCancelResponse",
+  description:
+    "Response schema for an accepted agent session cancellation request.",
+} as const
+
 export const $AgentSessionCreate = {
   properties: {
     id: {

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -9256,6 +9256,19 @@ export const $ChatMessage = {
       description:
         "Compaction status data for badge rendering (for kind=COMPACTION)",
     },
+    cancelled: {
+      anyOf: [
+        {
+          additionalProperties: true,
+          type: "object",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Cancelled",
+      description: "Turn-cancelled marker data (for kind=CANCELLED)",
+    },
   },
   type: "object",
   required: ["id"],
@@ -9265,7 +9278,8 @@ export const $ChatMessage = {
 This model supports multiple message kinds:
 - kind=CHAT_MESSAGE: Contains message field with user/assistant content
 - kind=APPROVAL_REQUEST/APPROVAL_DECISION: Contains approval field with approval data
-- kind=COMPACTION: Contains compaction field with compaction status data`,
+- kind=COMPACTION: Contains compaction field with compaction status data
+- kind=CANCELLED: Contains cancelled field with turn-cancelled marker data`,
 } as const
 
 export const $ChatRead = {
@@ -16887,6 +16901,7 @@ export const $MessageKind = {
     "approval-decision",
     "internal",
     "compaction",
+    "cancelled",
   ],
   title: "MessageKind",
   description: "The type/kind of message stored in the chat.",

--- a/frontend/src/client/services.gen.ts
+++ b/frontend/src/client/services.gen.ts
@@ -168,6 +168,8 @@ import type {
   AgentPresetsRestoreAgentPresetVersionResponse,
   AgentPresetsUpdateAgentPresetData,
   AgentPresetsUpdateAgentPresetResponse,
+  AgentSessionsCancelSessionData,
+  AgentSessionsCancelSessionResponse,
   AgentSessionsCreateSessionData,
   AgentSessionsCreateSessionResponse,
   AgentSessionsDeleteSessionData,
@@ -6838,6 +6840,34 @@ export const agentSessionsForkSession = (
   return __request(OpenAPI, {
     method: "POST",
     url: "/workspaces/{workspace_id}/agent/sessions/{session_id}/fork",
+    path: {
+      session_id: data.sessionId,
+      workspace_id: data.workspaceId,
+    },
+    body: data.requestBody,
+    mediaType: "application/json",
+    errors: {
+      422: "Validation Error",
+    },
+  })
+}
+
+/**
+ * Cancel Session
+ * Request graceful cancellation for the active agent session turn.
+ * @param data The data for the request.
+ * @param data.sessionId
+ * @param data.workspaceId
+ * @param data.requestBody
+ * @returns AgentSessionCancelResponse Successful Response
+ * @throws ApiError
+ */
+export const agentSessionsCancelSession = (
+  data: AgentSessionsCancelSessionData
+): CancelablePromise<AgentSessionsCancelSessionResponse> => {
+  return __request(OpenAPI, {
+    method: "POST",
+    url: "/workspaces/{workspace_id}/agent/sessions/{session_id}/cancel",
     path: {
       session_id: data.sessionId,
       workspace_id: data.workspaceId,

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -2434,6 +2434,7 @@ export type ChannelType = "slack"
  * - kind=CHAT_MESSAGE: Contains message field with user/assistant content
  * - kind=APPROVAL_REQUEST/APPROVAL_DECISION: Contains approval field with approval data
  * - kind=COMPACTION: Contains compaction field with compaction status data
+ * - kind=CANCELLED: Contains cancelled field with turn-cancelled marker data
  */
 export type ChatMessage = {
   /**
@@ -2464,6 +2465,12 @@ export type ChatMessage = {
    * Compaction status data for badge rendering (for kind=COMPACTION)
    */
   compaction?: {
+    [key: string]: unknown
+  } | null
+  /**
+   * Turn-cancelled marker data (for kind=CANCELLED)
+   */
+  cancelled?: {
     [key: string]: unknown
   } | null
 }
@@ -5154,6 +5161,7 @@ export type MessageKind =
   | "approval-decision"
   | "internal"
   | "compaction"
+  | "cancelled"
 
 export type ModelConfig = {
   /**

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -784,6 +784,22 @@ export type AgentSessionArtifactsRead = {
 }
 
 /**
+ * Request schema for cancelling the active agent session turn.
+ */
+export type AgentSessionCancelRequest = {
+  reason?: "user_cancel"
+}
+
+/**
+ * Response schema for an accepted agent session cancellation request.
+ */
+export type AgentSessionCancelResponse = {
+  session_id: string
+  run_id: string
+  reason: string
+}
+
+/**
  * Request schema for creating an agent session.
  */
 export type AgentSessionCreate = {
@@ -11619,6 +11635,14 @@ export type AgentSessionsForkSessionData = {
 
 export type AgentSessionsForkSessionResponse = AgentSessionRead
 
+export type AgentSessionsCancelSessionData = {
+  requestBody?: AgentSessionCancelRequest | null
+  sessionId: string
+  workspaceId: string
+}
+
+export type AgentSessionsCancelSessionResponse = AgentSessionCancelResponse
+
 export type ApprovalsSubmitApprovalsData = {
   requestBody: ApprovalSubmission
   sessionId: string
@@ -16811,6 +16835,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: AgentSessionRead
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError
+      }
+    }
+  }
+  "/workspaces/{workspace_id}/agent/sessions/{session_id}/cancel": {
+    post: {
+      req: AgentSessionsCancelSessionData
+      res: {
+        /**
+         * Successful Response
+         */
+        200: AgentSessionCancelResponse
         /**
          * Validation Error
          */

--- a/frontend/src/components/ai-elements/tool.tsx
+++ b/frontend/src/components/ai-elements/tool.tsx
@@ -4,6 +4,7 @@ import type { DynamicToolUIPart, ToolUIPart } from "ai"
 import {
   ChevronDownIcon,
   CircleCheckIcon,
+  CircleSlashIcon,
   ClockIcon,
   DownloadIcon,
   WrenchIcon,
@@ -52,7 +53,12 @@ type LegacyToolState =
   | "approval-requested"
   | "approval-responded"
   | "output-denied"
-type ToolState = ToolPart["state"] | LegacyToolState
+/**
+ * Display-only state for tool calls that never completed because the user
+ * stopped the turn. Derived at render time; never sent to or by the server.
+ */
+type InterruptedToolState = "output-interrupted"
+type ToolState = ToolPart["state"] | LegacyToolState | InterruptedToolState
 
 export type ToolHeaderProps = {
   title?: string
@@ -71,6 +77,7 @@ const statusLabels: Record<ToolState, string> = {
   "output-available": "Completed",
   "output-denied": "Error",
   "output-error": "Error",
+  "output-interrupted": "Interrupted",
 }
 
 const statusIcons: Record<ToolState, ReactNode> = {
@@ -94,6 +101,9 @@ const statusIcons: Record<ToolState, ReactNode> = {
   ),
   "output-error": (
     <XCircleIcon className="size-4 fill-rose-500 stroke-background" />
+  ),
+  "output-interrupted": (
+    <CircleSlashIcon className="size-3.5 text-muted-foreground" />
   ),
 }
 

--- a/frontend/src/components/chat/chat-session-pane.test.tsx
+++ b/frontend/src/components/chat/chat-session-pane.test.tsx
@@ -54,6 +54,10 @@ jest.mock("@/hooks/use-chat", () => ({
     isUpdating: false,
     updateChat: jest.fn(),
   }),
+  useCancelChatTurn: () => ({
+    cancelChatTurn: jest.fn(),
+    isCancellingChatTurn: false,
+  }),
   useVercelChat: () => mockUseVercelChatResult,
 }))
 

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -114,6 +114,7 @@ import type { ModelInfo } from "@/lib/chat"
 import {
   CANCELLED_DATA_PART_TYPE,
   ENTITY_TO_INVALIDATION,
+  getCancelledPartToolCallIds,
   getSessionLastError,
   isInterruptArtifactError,
   toUIMessage,
@@ -150,6 +151,25 @@ type ToolSuggestion = {
 
 function messageHasVisibleParts(message: UIMessage): boolean {
   return message.parts.some((part) => part.type !== ARTIFACT_DATA_PART_TYPE)
+}
+
+/**
+ * Whether a part counts as assistant content when attributing a cancelled
+ * marker to the message the user stopped. Structural parts (step-start) and
+ * data-* markers can share a message with the live-streamed cancelled marker,
+ * and must not stop the marker from tagging the preceding content message
+ * that holds the interrupted tool calls.
+ */
+function isCancelAttributionContentPart(
+  part: UIMessage["parts"][number]
+): boolean {
+  if (part.type === "step-start" || part.type.startsWith("data-")) {
+    return false
+  }
+  if (part.type === "text" || part.type === "reasoning") {
+    return typeof part.text === "string" && part.text.trim().length > 0
+  }
+  return true
 }
 
 /** Message ids and their part types — compares two transcripts by shape. */
@@ -415,6 +435,14 @@ export function ChatSessionPane({
   // *advances* (e.g. an approval resolves), but never on a plain mismatch — post
   // -stream the live list legitimately leads the not-yet-refetched server copy,
   // and adopting then would drop the just-streamed turn.
+  //
+  // A shape *advance* alone is not proof the server copy is current: onFinish's
+  // refetch races finalize_turn (which clears curr_run_id and unhides the
+  // active turn's DB rows), so on turn N the refetch often returns a transcript
+  // that newly includes turn N-1 (shape advanced) while still hiding turn N.
+  // Adopting that copy would blank the just-streamed turn until the next
+  // refetch. A lagging copy in that race is always *shorter* than the live
+  // list, so only adopt when the server copy would not drop live messages.
   const lastServerShapeRef = useRef<string | null>(null)
   useEffect(() => {
     const serverShape = transcriptShape(uiMessages)
@@ -424,8 +452,10 @@ export function ChatSessionPane({
     }
     if (serverShape === lastServerShapeRef.current) return
     lastServerShapeRef.current = serverShape
-    if (status === "ready") setMessages(uiMessages) // don't clobber a live stream
-  }, [status, uiMessages, setMessages])
+    if (status !== "ready") return // don't clobber a live stream
+    if (uiMessages.length < messages.length) return // server copy lags the live list
+    setMessages(uiMessages)
+  }, [status, uiMessages, messages, setMessages])
 
   useEffect(() => {
     onStatusChange?.(status)
@@ -1057,22 +1087,34 @@ export function ChatSessionPane({
     [messages]
   )
 
-  // Messages whose turn the user stopped. The live stream appends the
-  // data-cancelled part to the assistant message itself, while reloaded
-  // history renders the persisted marker as a standalone system message that
-  // follows the assistant content — cover both so interrupted tool calls in
-  // the preceding message render accurately.
-  const cancelledTurnMessageIds = useMemo(() => {
+  // Messages whose turn the user stopped, plus the tool calls those
+  // interrupts aborted. The live stream appends the data-cancelled part to
+  // the assistant message itself, while reloaded history renders the
+  // persisted marker as a standalone system message that follows the
+  // assistant content — cover both so interrupted tool calls in the
+  // preceding message render accurately. The marker's `tool_call_ids`
+  // payload is the structured signal recorded by the backend at interrupt
+  // time; tool call IDs are globally unique, so one session-wide set works.
+  const { cancelledTurnMessageIds, interruptedToolCallIds } = useMemo(() => {
     const ids = new Set<string>()
+    const toolCallIds = new Set<string>()
     let lastContentMessageId: string | null = null
     for (const message of transformedMessages) {
       const parts = message.parts ?? []
-      const hasCancelledPart = parts.some(
-        (part) => part.type === CANCELLED_DATA_PART_TYPE
-      )
-      const hasContentParts = parts.some(
-        (part) => part.type !== CANCELLED_DATA_PART_TYPE
-      )
+      let hasCancelledPart = false
+      let hasContentParts = false
+      for (const part of parts) {
+        if (part.type === CANCELLED_DATA_PART_TYPE) {
+          hasCancelledPart = true
+          for (const toolCallId of getCancelledPartToolCallIds(
+            (part as { data?: unknown }).data
+          )) {
+            toolCallIds.add(toolCallId)
+          }
+        } else if (isCancelAttributionContentPart(part)) {
+          hasContentParts = true
+        }
+      }
       if (hasCancelledPart) {
         ids.add(message.id)
         if (!hasContentParts && lastContentMessageId) {
@@ -1083,7 +1125,7 @@ export function ChatSessionPane({
         lastContentMessageId = message.id
       }
     }
-    return ids
+    return { cancelledTurnMessageIds: ids, interruptedToolCallIds: toolCallIds }
   }, [transformedMessages])
 
   const invalidateEntityQueries = useCallback(
@@ -1403,6 +1445,7 @@ export function ChatSessionPane({
                         status={status}
                         isLastMessage={isLastMessage}
                         turnCancelled={cancelledTurnMessageIds.has(id)}
+                        interruptedToolCallIds={interruptedToolCallIds}
                         onSubmitApprovals={handleSubmitApprovals}
                       />
                     ))}
@@ -1792,6 +1835,8 @@ function PromptModelIndicator({ modelInfo }: { modelInfo: ModelInfo }) {
   )
 }
 
+const EMPTY_INTERRUPTED_TOOL_CALL_IDS: ReadonlySet<string> = new Set()
+
 export function MessagePart({
   part,
   partIdx,
@@ -1800,6 +1845,7 @@ export function MessagePart({
   status,
   isLastMessage,
   turnCancelled = false,
+  interruptedToolCallIds = EMPTY_INTERRUPTED_TOOL_CALL_IDS,
   onSubmitApprovals,
 }: {
   part: UIMessagePart<UIDataTypes, UITools>
@@ -1809,6 +1855,11 @@ export function MessagePart({
   status?: ChatStatus
   isLastMessage: boolean
   turnCancelled?: boolean
+  /**
+   * Tool call IDs the backend marked as aborted by a user interrupt
+   * (structured metadata from the data-cancelled part).
+   */
+  interruptedToolCallIds?: ReadonlySet<string>
   onSubmitApprovals?: (decisions: ApprovalDecision[]) => Promise<void>
 }) {
   if (part.type === CANCELLED_DATA_PART_TYPE) {
@@ -1882,14 +1933,22 @@ export function MessagePart({
     // In a turn the user stopped, tool calls that never completed (still
     // pending) or that only "failed" because the SDK aborted them are
     // interruptions, not tool errors — don't show a stale spinner or leak
-    // internal abort messages.
+    // internal abort messages. The backend reports aborted calls as
+    // structured metadata (interruptedToolCallIds); the error-text substring
+    // check is a legacy fallback for histories persisted before that
+    // metadata existed.
     const isPendingState =
       part.state === "input-streaming" || part.state === "input-available"
+    // The structured ids are authoritative on their own: the backend records
+    // them at interrupt time, so they apply even when the cancelled marker
+    // landed in a different message than the tool calls it aborted. The
+    // state/error-text heuristics still require the turn-level flag.
     const isInterrupted =
-      turnCancelled &&
-      (isPendingState ||
-        (typeof derivedErrorText === "string" &&
-          isInterruptArtifactError(derivedErrorText)))
+      interruptedToolCallIds.has(part.toolCallId) ||
+      (turnCancelled &&
+        (isPendingState ||
+          (typeof derivedErrorText === "string" &&
+            isInterruptArtifactError(derivedErrorText))))
     let derivedState: ToolHeaderProps["state"]
     if (isInterrupted) {
       derivedState = "output-interrupted"
@@ -1988,6 +2047,7 @@ const MemoizedMessagePart = memo(MessagePart, (prev, next) => {
     prev.status !== next.status ||
     prev.isLastMessage !== next.isLastMessage ||
     prev.turnCancelled !== next.turnCancelled ||
+    prev.interruptedToolCallIds !== next.interruptedToolCallIds ||
     prev.onSubmitApprovals !== next.onSubmitApprovals
   ) {
     return false

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -104,6 +104,7 @@ import {
   type ApprovalCard,
   makeContinueMessage,
   parseChatError,
+  useCancelChatTurn,
   useUpdateChat,
   useVercelChat,
 } from "@/hooks/use-chat"
@@ -348,6 +349,8 @@ export function ChatSessionPane({
   >(null)
   const optimisticMessageKnownTextPartKeysRef = useRef<Set<string>>(new Set())
   const { updateChat, isUpdating: isUpdatingTools } = useUpdateChat(workspaceId)
+  const { cancelChatTurn, isCancellingChatTurn } =
+    useCancelChatTurn(workspaceId)
   const { registryActions, registryActionsIsLoading } =
     useBuilderRegistryActions()
   const sessionMcpEnabled = mcpEnabled && entityType === "copilot"
@@ -494,6 +497,27 @@ export function ChatSessionPane({
   const isOptimisticBeforeSendPending = optimisticMessageText !== null
   const isInputDisabled =
     isReadonly || inputDisabled || isOptimisticBeforeSendPending || !canSubmit
+
+  const isGeneratingTurn = status === "submitted" || status === "streaming"
+  const [cancelRequested, setCancelRequested] = useState(false)
+
+  useEffect(() => {
+    if (!isGeneratingTurn) setCancelRequested(false)
+  }, [isGeneratingTurn])
+
+  const handleStop = useCallback(async () => {
+    if (!chat?.id || cancelRequested) return
+    setCancelRequested(true)
+    try {
+      await cancelChatTurn({ chatId: chat.id })
+    } catch (error) {
+      setCancelRequested(false)
+      toast({
+        title: "Failed to stop run",
+        description: parseChatError(error),
+      })
+    }
+  }, [cancelChatTurn, cancelRequested, chat?.id])
   const isInputDisabledRef = useRef(isInputDisabled)
   isInputDisabledRef.current = isInputDisabled
   const wasInputDisabledRef = useRef(isInputDisabled)
@@ -1251,7 +1275,12 @@ export function ChatSessionPane({
             ) : null}
           </PromptInputTools>
           <PromptInputSubmit
-            disabled={isInputDisabled || !input.trim()}
+            disabled={
+              isGeneratingTurn
+                ? isCancellingChatTurn || cancelRequested
+                : isInputDisabled || !input.trim()
+            }
+            onStop={() => void handleStop()}
             status={status}
             className="size-7 text-muted-foreground/80"
           />
@@ -1747,6 +1776,19 @@ export function MessagePart({
   isLastMessage: boolean
   onSubmitApprovals?: (decisions: ApprovalDecision[]) => Promise<void>
 }) {
+  if (part.type === "data-cancelled") {
+    return (
+      <div
+        key={`${id}-${partIdx}`}
+        className="flex w-full justify-center py-1.5"
+      >
+        <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground">
+          Chat stopped
+        </div>
+      </div>
+    )
+  }
+
   if (part.type === "data-approval-request") {
     const payload = (part as { data?: unknown }).data
     const approvals: ApprovalCard[] = Array.isArray(payload)

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -85,6 +85,7 @@ import {
   Tool,
   ToolContent,
   ToolHeader,
+  type ToolHeaderProps,
   ToolInput,
   ToolOutput,
 } from "@/components/ai-elements/tool"
@@ -111,8 +112,10 @@ import {
 import { useOverflowBadges } from "@/hooks/use-overflow-badges"
 import type { ModelInfo } from "@/lib/chat"
 import {
+  CANCELLED_DATA_PART_TYPE,
   ENTITY_TO_INVALIDATION,
   getSessionLastError,
+  isInterruptArtifactError,
   toUIMessage,
   transformMessages,
 } from "@/lib/chat"
@@ -1054,6 +1057,35 @@ export function ChatSessionPane({
     [messages]
   )
 
+  // Messages whose turn the user stopped. The live stream appends the
+  // data-cancelled part to the assistant message itself, while reloaded
+  // history renders the persisted marker as a standalone system message that
+  // follows the assistant content — cover both so interrupted tool calls in
+  // the preceding message render accurately.
+  const cancelledTurnMessageIds = useMemo(() => {
+    const ids = new Set<string>()
+    let lastContentMessageId: string | null = null
+    for (const message of transformedMessages) {
+      const parts = message.parts ?? []
+      const hasCancelledPart = parts.some(
+        (part) => part.type === CANCELLED_DATA_PART_TYPE
+      )
+      const hasContentParts = parts.some(
+        (part) => part.type !== CANCELLED_DATA_PART_TYPE
+      )
+      if (hasCancelledPart) {
+        ids.add(message.id)
+        if (!hasContentParts && lastContentMessageId) {
+          ids.add(lastContentMessageId)
+        }
+      }
+      if (hasContentParts) {
+        lastContentMessageId = message.id
+      }
+    }
+    return ids
+  }, [transformedMessages])
+
   const invalidateEntityQueries = useCallback(
     (toolNames: string[]) => {
       if (!entityType || !entityId) {
@@ -1370,6 +1402,7 @@ export function ChatSessionPane({
                         role={role}
                         status={status}
                         isLastMessage={isLastMessage}
+                        turnCancelled={cancelledTurnMessageIds.has(id)}
                         onSubmitApprovals={handleSubmitApprovals}
                       />
                     ))}
@@ -1766,6 +1799,7 @@ export function MessagePart({
   role,
   status,
   isLastMessage,
+  turnCancelled = false,
   onSubmitApprovals,
 }: {
   part: UIMessagePart<UIDataTypes, UITools>
@@ -1774,17 +1808,14 @@ export function MessagePart({
   role: UIMessage["role"]
   status?: ChatStatus
   isLastMessage: boolean
+  turnCancelled?: boolean
   onSubmitApprovals?: (decisions: ApprovalDecision[]) => Promise<void>
 }) {
-  if (part.type === "data-cancelled") {
+  if (part.type === CANCELLED_DATA_PART_TYPE) {
     return (
-      <div
-        key={`${id}-${partIdx}`}
-        className="flex w-full justify-center py-1.5"
-      >
-        <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground">
-          Chat stopped
-        </div>
+      <div key={`${id}-${partIdx}`} className="w-full py-2">
+        <span className="text-xs text-muted-foreground">Interrupted</span>
+        <div className="mt-2 border-t" />
       </div>
     )
   }
@@ -1848,9 +1879,25 @@ export function MessagePart({
         ? (outputAsAny as { errorText?: string }).errorText
         : undefined
     const derivedErrorText = partErrorText ?? outputErrorText
-    const derivedState = derivedErrorText
-      ? ("output-error" as const)
-      : part.state
+    // In a turn the user stopped, tool calls that never completed (still
+    // pending) or that only "failed" because the SDK aborted them are
+    // interruptions, not tool errors — don't show a stale spinner or leak
+    // internal abort messages.
+    const isPendingState =
+      part.state === "input-streaming" || part.state === "input-available"
+    const isInterrupted =
+      turnCancelled &&
+      (isPendingState ||
+        (typeof derivedErrorText === "string" &&
+          isInterruptArtifactError(derivedErrorText)))
+    let derivedState: ToolHeaderProps["state"]
+    if (isInterrupted) {
+      derivedState = "output-interrupted"
+    } else if (derivedErrorText) {
+      derivedState = "output-error"
+    } else {
+      derivedState = part.state
+    }
     return (
       <Tool key={`${id}-${partIdx}`}>
         <ToolHeader
@@ -1861,7 +1908,13 @@ export function MessagePart({
         />
         <ToolContent>
           <ToolInput input={part.input} />
-          <ToolOutput output={part.output} errorText={derivedErrorText} />
+          {isInterrupted ? (
+            <div className="text-[11px] text-muted-foreground">
+              Stopped before completion
+            </div>
+          ) : (
+            <ToolOutput output={part.output} errorText={derivedErrorText} />
+          )}
         </ToolContent>
       </Tool>
     )
@@ -1934,6 +1987,7 @@ const MemoizedMessagePart = memo(MessagePart, (prev, next) => {
     prev.role !== next.role ||
     prev.status !== next.status ||
     prev.isLastMessage !== next.isLastMessage ||
+    prev.turnCancelled !== next.turnCancelled ||
     prev.onSubmitApprovals !== next.onSubmitApprovals
   ) {
     return false

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -15,6 +15,7 @@ import {
   type AgentSessionCreate,
   type AgentSessionEntity,
   type AgentSessionRead,
+  type AgentSessionsCancelSessionResponse,
   type AgentSessionsGetSessionResponse,
   type AgentSessionsGetSessionVercelResponse,
   type AgentSessionsListSessionsResponse,
@@ -22,6 +23,7 @@ import {
   type AgentSessionsRemoveSessionArtifactResponse,
   type AgentSessionUpdate,
   type ApiError,
+  agentSessionsCancelSession,
   agentSessionsCreateSession,
   agentSessionsDeleteSession,
   agentSessionsGetSession,
@@ -420,6 +422,41 @@ export function useDeleteChat(workspaceId: string) {
     deleteChat: mutation.mutateAsync,
     isDeleting: mutation.isPending,
     deleteError: mutation.error,
+  }
+}
+
+/** Request cancellation for the currently running agent turn. */
+export function useCancelChatTurn(workspaceId: string) {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation<
+    AgentSessionsCancelSessionResponse,
+    ApiError,
+    { chatId: string }
+  >({
+    mutationFn: ({ chatId }) =>
+      agentSessionsCancelSession({
+        sessionId: chatId,
+        workspaceId,
+        requestBody: { reason: "user_cancel" },
+      }),
+    onSettled: (_, __, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["chat", variables.chatId, workspaceId],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["chat", variables.chatId, workspaceId, "vercel"],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["chats", workspaceId],
+      })
+    },
+  })
+
+  return {
+    cancelChatTurn: mutation.mutateAsync,
+    isCancellingChatTurn: mutation.isPending,
+    cancelChatTurnError: mutation.error,
   }
 }
 

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -25,23 +25,59 @@ type ToolState = ai.ToolUIPart["state"] | LegacyToolState
 export const CANCELLED_DATA_PART_TYPE = "data-cancelled"
 
 /**
+ * Payload of a {@link CANCELLED_DATA_PART_TYPE} part. `tool_call_ids` is the
+ * structured interrupt signal: the backend loopback records which tool calls
+ * the interrupt aborted mid-flight (by cancel-then-error ordering, not error
+ * text) and carries them on both the live stream event and the persisted
+ * marker row.
+ */
+export type CancelledPartData = {
+  reason?: string | null
+  tool_call_ids?: string[] | null
+}
+
+/**
+ * Extract the interrupted tool call IDs from a cancelled data part's payload.
+ * Returns an empty array for legacy payloads that predate the field.
+ */
+export function getCancelledPartToolCallIds(data: unknown): string[] {
+  if (!data || typeof data !== "object") {
+    return []
+  }
+  const toolCallIds = (data as CancelledPartData).tool_call_ids
+  if (!Array.isArray(toolCallIds)) {
+    return []
+  }
+  return toolCallIds.filter((id): id is string => typeof id === "string")
+}
+
+/**
  * Error strings the Claude SDK records for tool calls that were aborted by a
- * user interrupt rather than failing on their own. These leak runtime
- * internals, so interrupted turns render them as an "Interrupted" tool state
- * instead of an error.
+ * user interrupt rather than failing on their own.
+ *
+ * LEGACY FALLBACK ONLY: new cancelled turns carry structured interrupt
+ * metadata (`tool_call_ids` on the data-cancelled part, see
+ * {@link getCancelledPartToolCallIds}) and the UI prefers that signal. This
+ * substring check remains solely for histories persisted before the
+ * structured metadata existed, whose markers lack `tool_call_ids`. Do not add
+ * new patterns; extend the structured signal instead.
  */
 const INTERRUPT_ARTIFACT_ERROR_PATTERNS = [
   "MCP error -32001",
   "The operation was aborted",
   "Request was aborted",
   "[Request interrupted by user",
+  // The SDK's tool-denial phrasing: recorded when a pending approval is
+  // resolved by the interrupt. New turns report these via `tool_call_ids`.
   "doesn't want to take this action",
 ]
 
 /**
  * Whether a tool error text is an artifact of the user stopping the turn
  * (SDK/MCP abort plumbing) rather than a genuine tool failure. Only
- * meaningful for messages in a cancelled turn.
+ * meaningful for messages in a cancelled turn, and only consulted when the
+ * turn's cancelled marker carries no structured `tool_call_ids` (legacy
+ * histories).
  */
 export function isInterruptArtifactError(errorText: string): boolean {
   return INTERRUPT_ARTIFACT_ERROR_PATTERNS.some((pattern) =>

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -18,6 +18,37 @@ type LegacyToolState =
   | "output-denied"
 type ToolState = ai.ToolUIPart["state"] | LegacyToolState
 
+/**
+ * UI data part identifier for turn-cancelled markers. Streamed live at the
+ * point of interruption and persisted server-side so reloads keep the marker.
+ */
+export const CANCELLED_DATA_PART_TYPE = "data-cancelled"
+
+/**
+ * Error strings the Claude SDK records for tool calls that were aborted by a
+ * user interrupt rather than failing on their own. These leak runtime
+ * internals, so interrupted turns render them as an "Interrupted" tool state
+ * instead of an error.
+ */
+const INTERRUPT_ARTIFACT_ERROR_PATTERNS = [
+  "MCP error -32001",
+  "The operation was aborted",
+  "Request was aborted",
+  "[Request interrupted by user",
+  "doesn't want to take this action",
+]
+
+/**
+ * Whether a tool error text is an artifact of the user stopping the turn
+ * (SDK/MCP abort plumbing) rather than a genuine tool failure. Only
+ * meaningful for messages in a cancelled turn.
+ */
+export function isInterruptArtifactError(errorText: string): boolean {
+  return INTERRUPT_ARTIFACT_ERROR_PATTERNS.some((pattern) =>
+    errorText.includes(pattern)
+  )
+}
+
 export function isAgentSessionEntity(
   value: unknown
 ): value is AgentSessionEntity {

--- a/frontend/tests/chat-session-pane.test.tsx
+++ b/frontend/tests/chat-session-pane.test.tsx
@@ -216,6 +216,109 @@ describe("ChatSessionPane", () => {
     expect(screen.getByText("Agent: case-management")).toBeInTheDocument()
   })
 
+  it("renders the stop divider for a cancelled turn marker", () => {
+    const cancelledPart = {
+      type: "data-cancelled",
+      data: { reason: "user_cancel" },
+    } as unknown as Parameters<typeof MessagePart>[0]["part"]
+
+    render(
+      <TooltipProvider>
+        <MessagePart
+          part={cancelledPart}
+          partIdx={0}
+          id="msg-cancelled"
+          role="assistant"
+          isLastMessage
+          status="ready"
+        />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByText("Interrupted")).toBeInTheDocument()
+    expect(screen.queryByText("Chat stopped")).not.toBeInTheDocument()
+  })
+
+  it("marks pending tool calls as interrupted in a cancelled turn", () => {
+    const pendingToolPart = {
+      type: "tool-core__table__list_tables",
+      toolCallId: "tc-pending-1",
+      state: "input-available",
+      input: {},
+    } as unknown as Parameters<typeof MessagePart>[0]["part"]
+
+    render(
+      <TooltipProvider>
+        <MessagePart
+          part={pendingToolPart}
+          partIdx={0}
+          id="msg-pending-tool"
+          role="assistant"
+          isLastMessage
+          status="ready"
+          turnCancelled
+        />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByText("Interrupted")).toBeInTheDocument()
+    expect(screen.queryByText("In progress")).not.toBeInTheDocument()
+  })
+
+  it("renders SDK abort errors as interrupted instead of leaking them", () => {
+    const abortedToolPart = {
+      type: "tool-core__table__list_tables",
+      toolCallId: "tc-aborted-1",
+      state: "output-error",
+      input: {},
+      errorText: "MCP error -32001: AbortError: The operation was aborted.",
+    } as unknown as Parameters<typeof MessagePart>[0]["part"]
+
+    render(
+      <TooltipProvider>
+        <MessagePart
+          part={abortedToolPart}
+          partIdx={0}
+          id="msg-aborted-tool"
+          role="assistant"
+          isLastMessage
+          status="ready"
+          turnCancelled
+        />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByText("Interrupted")).toBeInTheDocument()
+    expect(screen.queryByText("Error")).not.toBeInTheDocument()
+  })
+
+  it("keeps genuine tool errors as errors in a cancelled turn", () => {
+    const failedToolPart = {
+      type: "tool-core__table__list_tables",
+      toolCallId: "tc-failed-1",
+      state: "output-error",
+      input: {},
+      errorText: "Table not found: alerts",
+    } as unknown as Parameters<typeof MessagePart>[0]["part"]
+
+    render(
+      <TooltipProvider>
+        <MessagePart
+          part={failedToolPart}
+          partIdx={0}
+          id="msg-failed-tool"
+          role="assistant"
+          isLastMessage
+          status="ready"
+          turnCancelled
+        />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByText("Error")).toBeInTheDocument()
+    expect(screen.queryByText("Interrupted")).not.toBeInTheDocument()
+  })
+
   function mockUseVercelChatStatus(status: "ready" | "submitted") {
     mockUseVercelChat.mockReturnValue({
       sendMessage: jest.fn(),

--- a/frontend/tests/chat-session-pane.test.tsx
+++ b/frontend/tests/chat-session-pane.test.tsx
@@ -15,6 +15,10 @@ jest.mock("@/hooks/use-chat", () => ({
   useVercelChat: jest.fn(),
   useGetChat: jest.fn(() => ({ chat: null })),
   useUpdateChat: jest.fn(() => ({ updateChat: jest.fn(), isUpdating: false })),
+  useCancelChatTurn: jest.fn(() => ({
+    cancelChatTurn: jest.fn(),
+    isCancellingChatTurn: false,
+  })),
   parseChatError: (error: unknown) =>
     error instanceof Error ? error.message : "Chat error",
   makeContinueMessage: (decisions: unknown) => ({

--- a/frontend/tests/chat-session-pane.test.tsx
+++ b/frontend/tests/chat-session-pane.test.tsx
@@ -292,6 +292,66 @@ describe("ChatSessionPane", () => {
     expect(screen.queryByText("Error")).not.toBeInTheDocument()
   })
 
+  it("marks tool calls listed in the structured interrupt metadata as interrupted", () => {
+    // Backend-recorded abort casualty: the error text is generic (no abort
+    // phrasing), so only the structured tool_call_ids signal can flag it.
+    const abortedToolPart = {
+      type: "tool-core__table__list_tables",
+      toolCallId: "tc-structured-1",
+      state: "output-error",
+      input: {},
+      errorText: "connection reset",
+    } as unknown as Parameters<typeof MessagePart>[0]["part"]
+
+    render(
+      <TooltipProvider>
+        <MessagePart
+          part={abortedToolPart}
+          partIdx={0}
+          id="msg-structured-tool"
+          role="assistant"
+          isLastMessage
+          status="ready"
+          turnCancelled
+          interruptedToolCallIds={new Set(["tc-structured-1"])}
+        />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByText("Interrupted")).toBeInTheDocument()
+    expect(screen.queryByText("Error")).not.toBeInTheDocument()
+  })
+
+  it("marks structurally interrupted tool calls even without the turn flag", () => {
+    // Live streams can land the cancelled marker on a different message than
+    // the tool calls it aborted, so the message holding the tools never gets
+    // turnCancelled. The backend-recorded ids must flag them on their own.
+    const abortedToolPart = {
+      type: "tool-core__table__list_tables",
+      toolCallId: "tc-structured-2",
+      state: "output-error",
+      input: {},
+      errorText: "MCP error -32001: AbortError: The operation was aborted.",
+    } as unknown as Parameters<typeof MessagePart>[0]["part"]
+
+    render(
+      <TooltipProvider>
+        <MessagePart
+          part={abortedToolPart}
+          partIdx={0}
+          id="msg-structured-tool-no-flag"
+          role="assistant"
+          isLastMessage
+          status="ready"
+          interruptedToolCallIds={new Set(["tc-structured-2"])}
+        />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByText("Interrupted")).toBeInTheDocument()
+    expect(screen.queryByText("Error")).not.toBeInTheDocument()
+  })
+
   it("keeps genuine tool errors as errors in a cancelled turn", () => {
     const failedToolPart = {
       type: "tool-core__table__list_tables",
@@ -1471,6 +1531,39 @@ describe("ChatSessionPane", () => {
 
       expect(setMessages).toHaveBeenCalledTimes(1)
       expect(setMessages.mock.calls[0][0]).toHaveLength(2)
+    })
+
+    // Regression: onFinish's refetch races finalize_turn, so on turn N the
+    // server copy can *advance* (turn N-1's rows become visible) while still
+    // hiding the just-streamed turn N. Adopting it would blank turn N. The
+    // pane must only adopt a server copy that doesn't drop live messages.
+    it("does not adopt an advanced server copy that is shorter than the live list", () => {
+      const setMessages = jest.fn()
+      // Live list holds turns 1 and 2 (turn 2 just streamed).
+      const live = [
+        userTurn("m1", "turn one"),
+        userTurn("m2", "reply one"),
+        userTurn("m3", "turn two"),
+        userTurn("m4", "reply two"),
+      ]
+      mockLiveMessages(live, setMessages)
+
+      // Mount: server only has turn 1's user message (mid-turn filter hid the
+      // rest while turn 1 was live).
+      const { rerender } = render(renderSubject([userTurn("m1", "turn one")]))
+      expect(setMessages).not.toHaveBeenCalled()
+
+      // Racing refetch: turn 1 now fully visible (shape advanced) but turn 2
+      // is still hidden behind curr_run_id. Shorter than live — must not adopt.
+      rerender(
+        renderSubject([userTurn("m1", "turn one"), userTurn("m2", "reply one")])
+      )
+      expect(setMessages).not.toHaveBeenCalled()
+
+      // Post-finalize refetch: full transcript. Now safe to adopt.
+      rerender(renderSubject(live))
+      expect(setMessages).toHaveBeenCalledTimes(1)
+      expect(setMessages.mock.calls[0][0]).toHaveLength(4)
     })
   })
 })

--- a/frontend/tests/memo-render-count.test.tsx
+++ b/frontend/tests/memo-render-count.test.tsx
@@ -58,6 +58,10 @@ jest.mock("@/hooks/use-chat", () => ({
   useVercelChat: jest.fn(),
   useGetChat: jest.fn(() => ({ chat: null })),
   useUpdateChat: jest.fn(() => ({ updateChat: jest.fn(), isUpdating: false })),
+  useCancelChatTurn: jest.fn(() => ({
+    cancelChatTurn: jest.fn(),
+    isCancellingChatTurn: false,
+  })),
   parseChatError: (error: unknown) =>
     error instanceof Error ? error.message : "Chat error",
   makeContinueMessage: jest.fn(),

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -147,6 +147,15 @@ class EmitSessionCancelledInputs(BaseModel):
     session_id: uuid.UUID
     workspace_id: uuid.UUID
     reason: str | None = None
+    # Tool calls the interrupt aborted mid-flight (from the executor result).
+    # Persisted with the cancelled marker so reloads render them as
+    # "interrupted" instead of surfacing SDK abort artifacts as tool errors.
+    interrupted_tool_call_ids: list[str] | None = None
+    # The cancelled run's id, derived replay-safely by the workflow from its
+    # own workflow id. Pins the marker row to this run instead of the session
+    # row's curr_run_id, which may already point at a newer turn by the time
+    # the cancelled workflow finalizes.
+    curr_run_id: uuid.UUID | None = None
     active_stream_id: uuid.UUID | None = None
     emit_stream: bool = True
     """Whether to also push the cancelled/done frames onto the live stream.
@@ -560,7 +569,12 @@ class AgentActivities:
 
         ctx_role.set(args.role)
         async with AgentSessionService.with_session(role=args.role) as service:
-            await service.append_cancelled_marker(args.session_id, reason=args.reason)
+            await service.append_cancelled_marker(
+                args.session_id,
+                reason=args.reason,
+                interrupted_tool_call_ids=args.interrupted_tool_call_ids,
+                curr_run_id=args.curr_run_id,
+            )
 
         if not args.emit_stream:
             return
@@ -570,7 +584,12 @@ class AgentActivities:
             workspace_id=args.workspace_id,
             stream_id=args.active_stream_id,
         )
-        await stream.append(UnifiedStreamEvent.cancelled_event(reason=args.reason))
+        await stream.append(
+            UnifiedStreamEvent.cancelled_event(
+                reason=args.reason,
+                tool_call_ids=args.interrupted_tool_call_ids,
+            )
+        )
         await stream.done()
 
     @activity.defn

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -12,6 +12,7 @@ from pydantic import (
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
+from tracecat.agent.common.stream_types import UnifiedStreamEvent
 from tracecat.agent.common.types import (
     MCPHttpServerConfig,
     MCPServerConfig,
@@ -139,6 +140,13 @@ class EmitSessionErrorInputs(BaseModel):
 # or the inbox payload. The detail banner only needs a short, human-readable
 # reason.
 MAX_LAST_ERROR_LEN = 2000
+
+
+class EmitSessionCancelledInputs(BaseModel):
+    session_id: uuid.UUID
+    workspace_id: uuid.UUID
+    reason: str | None = None
+    active_stream_id: uuid.UUID | None = None
 
 
 def _stored_user_mcp_tool_policy(
@@ -526,6 +534,22 @@ class AgentActivities:
             stream_id=args.active_stream_id,
         )
         await stream.error(args.message)
+        await stream.done()
+
+    @activity.defn
+    async def emit_session_cancelled(self, args: EmitSessionCancelledInputs) -> None:
+        """Push an advisory cancelled-turn notice onto the session's SSE stream.
+
+        Used by workflow branches that cancel while waiting on approval, since
+        those happen outside a running executor activity and never reach the
+        loopback's own cancelled-notice emission.
+        """
+        stream = await AgentStream.new(
+            session_id=args.session_id,
+            workspace_id=args.workspace_id,
+            stream_id=args.active_stream_id,
+        )
+        await stream.append(UnifiedStreamEvent.cancelled_event(reason=args.reason))
         await stream.done()
 
     @activity.defn

--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -143,10 +143,18 @@ MAX_LAST_ERROR_LEN = 2000
 
 
 class EmitSessionCancelledInputs(BaseModel):
+    role: Role
     session_id: uuid.UUID
     workspace_id: uuid.UUID
     reason: str | None = None
     active_stream_id: uuid.UUID | None = None
+    emit_stream: bool = True
+    """Whether to also push the cancelled/done frames onto the live stream.
+
+    False when the executor loopback already emitted them (a second done
+    marker would race the client's stream teardown); the activity then only
+    persists the timeline marker row.
+    """
 
 
 def _stored_user_mcp_tool_policy(
@@ -538,12 +546,25 @@ class AgentActivities:
 
     @activity.defn
     async def emit_session_cancelled(self, args: EmitSessionCancelledInputs) -> None:
-        """Push an advisory cancelled-turn notice onto the session's SSE stream.
+        """Record a cancelled turn: persist the timeline marker, then stream it.
 
-        Used by workflow branches that cancel while waiting on approval, since
-        those happen outside a running executor activity and never reach the
-        loopback's own cancelled-notice emission.
+        Every cancelled turn persists a marker row so the "stopped by user"
+        divider survives DB reloads. Stream emission is conditional: approval
+        -wait cancels happen outside a running executor activity and must push
+        the cancelled/done frames here, while executor cancels already emitted
+        them from the loopback (``emit_stream=False``).
         """
+        # Local import: tracecat.agent.session.service imports tracecat_ee
+        # modules, so a top-level import here would create a cycle.
+        from tracecat.agent.session.service import AgentSessionService
+
+        ctx_role.set(args.role)
+        async with AgentSessionService.with_session(role=args.role) as service:
+            await service.append_cancelled_marker(args.session_id, reason=args.reason)
+
+        if not args.emit_stream:
+            return
+
         stream = await AgentStream.new(
             session_id=args.session_id,
             workspace_id=args.workspace_id,

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -1052,34 +1051,24 @@ class DurableAgentWorkflow:
             heartbeat_timeout=timedelta(seconds=60),
             retry_policy=RETRY_POLICIES["activity:fail_fast"],
         )
-        cancel_wait_task = asyncio.create_task(
-            workflow.wait_condition(lambda: self._cancel_requested)
+        # ActivityHandle is an asyncio.Task subclass, so .done() is valid.
+        # Neither wait_condition nor the handle poll emits history commands,
+        # so this race stays replay-safe.
+        await workflow.wait_condition(
+            lambda: activity_handle.done() or self._cancel_requested
         )
-        try:
-            done, _pending = await asyncio.wait(
-                [activity_handle, cancel_wait_task],
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-
-            if activity_handle in done:
-                return await activity_handle
-
+        if not activity_handle.done():
             activity_handle.cancel()
-            try:
-                return await activity_handle
-            except ActivityError as e:
-                if self._cancel_requested and isinstance(
-                    e.cause, TemporalCancelledError
-                ):
-                    return AgentExecutorResult(
-                        success=True,
-                        cancelled=True,
-                        cancelled_reason=self._cancel_reason or "user_cancel",
-                    )
-                raise
-        finally:
-            if not cancel_wait_task.done():
-                cancel_wait_task.cancel()
+        try:
+            return await activity_handle
+        except ActivityError as e:
+            if self._cancel_requested and isinstance(e.cause, TemporalCancelledError):
+                return AgentExecutorResult(
+                    success=True,
+                    cancelled=True,
+                    cancelled_reason=self._cancel_reason or "user_cancel",
+                )
+            raise
 
     async def _run_with_agent_executor(
         self, args: AgentWorkflowArgs, cfg: AgentConfig
@@ -1241,13 +1230,9 @@ class DurableAgentWorkflow:
                     session_id=self.session_id,
                     reason=result.cancelled_reason,
                 )
-                message_history = await self._load_terminal_message_history(result)
-                return AgentOutput(
-                    output=None,
-                    message_history=message_history,
-                    duration=(datetime.now(UTC) - info.start_time).total_seconds(),
-                    usage=RunUsage(requests=0, input_tokens=0, output_tokens=0),
-                    session_id=self.session_id,
+                # Executor loopback already emitted the cancelled notice.
+                return await self._cancelled_turn_output(
+                    result, info, emit_cancelled=False
                 )
 
             if not result.success:
@@ -1305,14 +1290,8 @@ class DurableAgentWorkflow:
                         }
                     )
                     await self.approvals.handle_decisions()
-                    await self._emit_session_cancelled()
-                    message_history = await self._load_terminal_message_history(result)
-                    return AgentOutput(
-                        output=None,
-                        message_history=message_history,
-                        duration=(datetime.now(UTC) - info.start_time).total_seconds(),
-                        usage=RunUsage(requests=0, input_tokens=0, output_tokens=0),
-                        session_id=self.session_id,
+                    return await self._cancelled_turn_output(
+                        result, info, emit_cancelled=True
                     )
                 # Persist approval decisions to DB (atomic with chat messages)
                 await self.approvals.handle_decisions()
@@ -1322,14 +1301,8 @@ class DurableAgentWorkflow:
                         session_id=self.session_id,
                         reason=self._cancel_reason,
                     )
-                    await self._emit_session_cancelled()
-                    message_history = await self._load_terminal_message_history(result)
-                    return AgentOutput(
-                        output=None,
-                        message_history=message_history,
-                        duration=(datetime.now(UTC) - info.start_time).total_seconds(),
-                        usage=RunUsage(requests=0, input_tokens=0, output_tokens=0),
-                        session_id=self.session_id,
+                    return await self._cancelled_turn_output(
+                        result, info, emit_cancelled=True
                     )
 
                 # Execute approved tools and reconcile the SDK transcript.
@@ -1343,14 +1316,8 @@ class DurableAgentWorkflow:
                         session_id=self.session_id,
                         reason=self._cancel_reason,
                     )
-                    await self._emit_session_cancelled()
-                    message_history = await self._load_terminal_message_history(result)
-                    return AgentOutput(
-                        output=None,
-                        message_history=message_history,
-                        duration=(datetime.now(UTC) - info.start_time).total_seconds(),
-                        usage=RunUsage(requests=0, input_tokens=0, output_tokens=0),
-                        session_id=self.session_id,
+                    return await self._cancelled_turn_output(
+                        result, info, emit_cancelled=True
                     )
 
                 tool_results: list[ToolExecutionResult] = []
@@ -1416,6 +1383,31 @@ class DurableAgentWorkflow:
                 ),
                 session_id=self.session_id,
             )
+
+    async def _cancelled_turn_output(
+        self,
+        result: AgentExecutorResult,
+        info: workflow.Info,
+        *,
+        emit_cancelled: bool,
+    ) -> AgentOutput:
+        """Build the terminal output for a cancelled turn.
+
+        The executor-cancel loopback already emitted the cancelled notice, so
+        that path passes emit_cancelled=False. Approval-wait cancels have not
+        emitted yet and must do so before loading history to preserve the
+        activity command order at every call site.
+        """
+        if emit_cancelled:
+            await self._emit_session_cancelled()
+        message_history = await self._load_terminal_message_history(result)
+        return AgentOutput(
+            output=None,
+            message_history=message_history,
+            duration=(datetime.now(UTC) - info.start_time).total_seconds(),
+            usage=RunUsage(requests=0, input_tokens=0, output_tokens=0),
+            session_id=self.session_id,
+        )
 
     async def _load_terminal_message_history(
         self,

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -8,7 +9,13 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field
 from temporalio import workflow
 from temporalio.common import TypedSearchAttributes
-from temporalio.exceptions import ActivityError, ApplicationError
+from temporalio.exceptions import (
+    ActivityError,
+    ApplicationError,
+)
+from temporalio.exceptions import (
+    CancelledError as TemporalCancelledError,
+)
 
 with workflow.unsafe.imports_passed_through():
     from pydantic_ai.messages import ToolCallPart
@@ -125,6 +132,12 @@ EMIT_PRE_STREAM_SESSION_ERRORS_PATCH = (
 PERSIST_SESSION_ERROR_PATCH = (
     "tracecat_ee.agent.workflows.durable.persist_session_error"
 )
+# Temporal patch IDs are persisted in each workflow execution's history. Use a
+# stable, unique ID for every command-producing workflow change, and never reuse
+# an ID for another change. Keep both branches until old histories that lack the
+# marker have aged out, then use workflow.deprecate_patch(...) before removing
+# the marker entirely in a later cleanup.
+AGENT_REQUEST_CANCEL_PATCH = "durable-agent-request-cancel-v1"
 
 
 @dataclass(frozen=True, slots=True)
@@ -416,6 +429,10 @@ class WorkflowApprovalSubmission(BaseModel):
     decision_metadata: dict[str, dict[str, Any]] | None = None
 
 
+class WorkflowCancelRequest(BaseModel):
+    reason: Literal["user_cancel"] = "user_cancel"
+
+
 def _resolve_agent_output(
     *,
     output: Any,
@@ -485,6 +502,8 @@ class DurableAgentWorkflow:
         self.approvals = ApprovalManager(role=self.role)
         self.max_requests = args.agent_args.max_requests
         self.max_tool_calls = args.agent_args.max_tool_calls
+        self._cancel_requested: bool = False
+        self._cancel_reason: str | None = None
 
     def _upsert_tracecat_search_attributes(self) -> None:
         """Ensure direct agent runs have core Tracecat search attributes.
@@ -957,6 +976,78 @@ class DurableAgentWorkflow:
                     + ", ".join(sorted(unexpected_metadata_ids))
                 )
 
+    @workflow.update
+    def request_cancel(self, request: WorkflowCancelRequest) -> None:
+        request = WorkflowCancelRequest.model_validate(request)
+        logger.info(
+            "Agent cancellation requested",
+            session_id=self.session_id,
+            reason=request.reason,
+        )
+        if self._cancel_reason is None:
+            self._cancel_reason = request.reason
+        self._cancel_requested = True
+
+    @request_cancel.validator
+    def validate_request_cancel(self, request: WorkflowCancelRequest) -> None:
+        WorkflowCancelRequest.model_validate(request)
+
+    async def _run_agent_activity_turn(
+        self, executor_input: AgentExecutorInput
+    ) -> AgentExecutorResult:
+        """Run one executor activity turn with update-driven cancellation."""
+        if not workflow.patched(AGENT_REQUEST_CANCEL_PATCH):
+            return await workflow.execute_activity(
+                run_agent_activity,
+                executor_input,
+                task_queue=config.TRACECAT__AGENT_EXECUTOR_QUEUE,
+                start_to_close_timeout=timedelta(
+                    seconds=config.TRACECAT__AGENT_SANDBOX_TIMEOUT
+                ),
+                heartbeat_timeout=timedelta(seconds=60),
+                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
+
+        activity_handle = workflow.start_activity(
+            run_agent_activity,
+            executor_input,
+            cancellation_type=workflow.ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+            task_queue=config.TRACECAT__AGENT_EXECUTOR_QUEUE,
+            start_to_close_timeout=timedelta(
+                seconds=config.TRACECAT__AGENT_SANDBOX_TIMEOUT
+            ),
+            heartbeat_timeout=timedelta(seconds=10),
+            retry_policy=RETRY_POLICIES["activity:fail_fast"],
+        )
+        cancel_wait_task = asyncio.create_task(
+            workflow.wait_condition(lambda: self._cancel_requested)
+        )
+        try:
+            done, _pending = await asyncio.wait(
+                [activity_handle, cancel_wait_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            if activity_handle in done:
+                return await activity_handle
+
+            activity_handle.cancel()
+            try:
+                return await activity_handle
+            except ActivityError as e:
+                if self._cancel_requested and isinstance(
+                    e.cause, TemporalCancelledError
+                ):
+                    return AgentExecutorResult(
+                        success=True,
+                        cancelled=True,
+                        cancelled_reason=self._cancel_reason or "user_cancel",
+                    )
+                raise
+        finally:
+            if not cancel_wait_task.done():
+                cancel_wait_task.cancel()
+
     async def _run_with_agent_executor(
         self, args: AgentWorkflowArgs, cfg: AgentConfig
     ) -> AgentOutput:
@@ -1109,16 +1200,22 @@ class DurableAgentWorkflow:
         while True:
             logger.info("Executing agent turn", turn=self._turn)
 
-            result = await workflow.execute_activity(
-                run_agent_activity,
-                executor_input,
-                task_queue=config.TRACECAT__AGENT_EXECUTOR_QUEUE,
-                start_to_close_timeout=timedelta(
-                    seconds=config.TRACECAT__AGENT_SANDBOX_TIMEOUT
-                ),
-                heartbeat_timeout=timedelta(seconds=60),
-                retry_policy=RETRY_POLICIES["activity:fail_fast"],
-            )
+            result = await self._run_agent_activity_turn(executor_input)
+
+            if result.cancelled:
+                logger.info(
+                    "Agent turn cancelled",
+                    session_id=self.session_id,
+                    reason=result.cancelled_reason,
+                )
+                message_history = await self._load_terminal_message_history(result)
+                return AgentOutput(
+                    output=None,
+                    message_history=message_history,
+                    duration=(datetime.now(UTC) - info.start_time).total_seconds(),
+                    usage=RunUsage(requests=0, input_tokens=0, output_tokens=0),
+                    session_id=self.session_id,
+                )
 
             if not result.success:
                 # Missing means a legacy activity result from before the flag
@@ -1156,15 +1253,69 @@ class DurableAgentWorkflow:
                         tool_call_parts,
                         request_metadata=request_metadata,
                     )
-                # Wait for approval signal
-                await self.approvals.wait()
+                # Wait for either approval decisions or a user cancellation.
+                await workflow.wait_condition(
+                    lambda: self.approvals.is_ready() or self._cancel_requested
+                )
+                if self._cancel_requested:
+                    logger.info(
+                        "Agent turn cancelled while waiting for approval",
+                        session_id=self.session_id,
+                        reason=self._cancel_reason,
+                    )
+                    self.approvals.set(
+                        {
+                            item.id: ToolDenied(
+                                message="Cancelled while waiting for approval"
+                            )
+                            for item in result.approval_items or []
+                        }
+                    )
+                    await self.approvals.handle_decisions()
+                    message_history = await self._load_terminal_message_history(result)
+                    return AgentOutput(
+                        output=None,
+                        message_history=message_history,
+                        duration=(datetime.now(UTC) - info.start_time).total_seconds(),
+                        usage=RunUsage(requests=0, input_tokens=0, output_tokens=0),
+                        session_id=self.session_id,
+                    )
                 # Persist approval decisions to DB (atomic with chat messages)
                 await self.approvals.handle_decisions()
+                if self._cancel_requested:
+                    logger.info(
+                        "Agent turn cancelled after approval decisions",
+                        session_id=self.session_id,
+                        reason=self._cancel_reason,
+                    )
+                    message_history = await self._load_terminal_message_history(result)
+                    return AgentOutput(
+                        output=None,
+                        message_history=message_history,
+                        duration=(datetime.now(UTC) - info.start_time).total_seconds(),
+                        usage=RunUsage(requests=0, input_tokens=0, output_tokens=0),
+                        session_id=self.session_id,
+                    )
 
                 # Execute approved tools and reconcile the SDK transcript.
                 approved_tools, denied_tools = self._build_tool_lists_from_approvals(
                     result.approval_items or []
                 )
+
+                if self._cancel_requested:
+                    logger.info(
+                        "Agent turn cancelled before approved tool execution",
+                        session_id=self.session_id,
+                        reason=self._cancel_reason,
+                    )
+                    message_history = await self._load_terminal_message_history(result)
+                    return AgentOutput(
+                        output=None,
+                        message_history=message_history,
+                        duration=(datetime.now(UTC) - info.start_time).total_seconds(),
+                        usage=RunUsage(requests=0, input_tokens=0, output_tokens=0),
+                        session_id=self.session_id,
+                    )
 
                 tool_results: list[ToolExecutionResult] = []
                 if approved_tools or denied_tools:

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -111,6 +111,7 @@ with workflow.unsafe.imports_passed_through():
         BuildAgentToolDefsArgs,
         BuildToolDefsArgs,
         BuildToolDefsResult,
+        EmitSessionCancelledInputs,
         EmitSessionErrorInputs,
         ExecuteRemoteMCPToolArgs,
     )
@@ -942,6 +943,38 @@ class DurableAgentWorkflow:
                 error=str(emit_error),
             )
 
+    async def _emit_session_cancelled(self) -> None:
+        """Emit the advisory cancelled-turn stream event for approval-wait cancels.
+
+        Cancellation during the mid-turn executor activity flows through the
+        loopback handler, which emits this notice itself. Cancelling while
+        waiting on approval decisions never starts (or has already finished)
+        that activity, so the workflow must emit the notice directly here to
+        keep the chat UI's "Chat stopped" signal consistent across both
+        cancellation paths.
+        """
+        try:
+            await workflow.execute_activity_method(
+                AgentActivities.emit_session_cancelled,
+                EmitSessionCancelledInputs(
+                    session_id=self.session_id,
+                    workspace_id=self.workspace_id,
+                    reason=self._cancel_reason or "user_cancel",
+                    # Chat turns pin a per-turn stream id; the client reads the
+                    # suffixed key, so the cancelled/done markers must land there.
+                    # None falls back to the per-session key for non-chat turns.
+                    active_stream_id=self.active_stream_id,
+                ),
+                start_to_close_timeout=timedelta(seconds=10),
+                retry_policy=RETRY_POLICIES["activity:fail_fast"],
+            )
+        except ActivityError as emit_error:
+            logger.warning(
+                "Failed to emit agent session cancelled notice",
+                session_id=self.session_id,
+                error=str(emit_error),
+            )
+
     @workflow.update
     def set_approvals(self, submission: WorkflowApprovalSubmission) -> None:
         submission = WorkflowApprovalSubmission.model_validate(submission)
@@ -1016,7 +1049,7 @@ class DurableAgentWorkflow:
             start_to_close_timeout=timedelta(
                 seconds=config.TRACECAT__AGENT_SANDBOX_TIMEOUT
             ),
-            heartbeat_timeout=timedelta(seconds=10),
+            heartbeat_timeout=timedelta(seconds=60),
             retry_policy=RETRY_POLICIES["activity:fail_fast"],
         )
         cancel_wait_task = asyncio.create_task(
@@ -1272,6 +1305,7 @@ class DurableAgentWorkflow:
                         }
                     )
                     await self.approvals.handle_decisions()
+                    await self._emit_session_cancelled()
                     message_history = await self._load_terminal_message_history(result)
                     return AgentOutput(
                         output=None,
@@ -1288,6 +1322,7 @@ class DurableAgentWorkflow:
                         session_id=self.session_id,
                         reason=self._cancel_reason,
                     )
+                    await self._emit_session_cancelled()
                     message_history = await self._load_terminal_message_history(result)
                     return AgentOutput(
                         output=None,
@@ -1308,6 +1343,7 @@ class DurableAgentWorkflow:
                         session_id=self.session_id,
                         reason=self._cancel_reason,
                     )
+                    await self._emit_session_cancelled()
                     message_history = await self._load_terminal_message_history(result)
                     return AgentOutput(
                         output=None,

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -208,42 +208,37 @@ def _apply_tool_approvals(
         spec.config.tool_approvals = build_result.tool_approvals
 
 
-async def _execute_remote_mcp_tool_call(
+def _start_remote_mcp_tool_call(
     tool_call: ApprovedToolCall,
     *,
     remote_tool_name: str,
     mcp_auth_token: str,
-) -> PendingToolResult:
+) -> workflow.ActivityHandle[str]:
     """Route an approved user MCP tool call through the trusted MCP router."""
-    raw_result = await workflow.execute_activity_method(
+    return workflow.start_activity_method(
         AgentActivities.execute_remote_mcp_tool,
         arg=ExecuteRemoteMCPToolArgs(
             mcp_auth_token=mcp_auth_token,
             tool_name=remote_tool_name,
             args=tool_call.args,
         ),
+        cancellation_type=workflow.ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
         start_to_close_timeout=timedelta(
             seconds=int(config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT)
         ),
         retry_policy=RETRY_POLICIES["activity:fail_fast"],
     )
-    return PendingToolResult(
-        tool_call_id=tool_call.tool_call_id,
-        tool_name=tool_call.tool_name,
-        tool_input=tool_call.args,
-        raw_result=raw_result,
-    )
 
 
-async def _execute_registry_tool_call(
+def _start_registry_tool_call(
     tool_call: ApprovedToolCall,
     *,
     registry_lock: RegistryLock,
     service_role: Role,
     logical_time: datetime,
-) -> PendingToolResult:
+) -> workflow.ActivityHandle[Any]:
     """Execute an approved registry action on the executor task queue."""
-    stored = await workflow.execute_activity(
+    return workflow.start_activity(
         ExecutorActivities.execute_action_activity,
         args=[
             _build_approved_tool_run_input(
@@ -257,6 +252,7 @@ async def _execute_registry_tool_call(
             service_role,
         ],
         task_queue=config.TRACECAT__EXECUTOR_QUEUE,
+        cancellation_type=workflow.ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
         start_to_close_timeout=timedelta(
             seconds=int(config.TRACECAT__EXECUTOR_CLIENT_TIMEOUT)
         ),
@@ -266,11 +262,20 @@ async def _execute_registry_tool_call(
         retry_policy=RETRY_POLICIES["activity:fail_fast"],
         priority=AGENT_TOOL_PRIORITY,
     )
+
+
+def _cancelled_tool_result(
+    tool_call: ApprovedToolCall, *, started: bool
+) -> PendingToolResult:
+    """Build the error result recorded for an approved tool skipped or stopped
+    by a user cancel request."""
+    phase = "during" if started else "before"
     return PendingToolResult(
         tool_call_id=tool_call.tool_call_id,
         tool_name=tool_call.tool_name,
         tool_input=tool_call.args,
-        stored_result=stored,
+        raw_result=f"Tool execution cancelled by user {phase} execution",
+        is_error=True,
     )
 
 
@@ -942,7 +947,12 @@ class DurableAgentWorkflow:
                 error=str(emit_error),
             )
 
-    async def _emit_session_cancelled(self, *, emit_stream: bool) -> None:
+    async def _emit_session_cancelled(
+        self,
+        *,
+        emit_stream: bool,
+        interrupted_tool_call_ids: list[str] | None = None,
+    ) -> None:
         """Record the cancelled turn (timeline marker + optional stream notice).
 
         The activity always persists the cancelled-marker history row so the
@@ -966,6 +976,13 @@ class DurableAgentWorkflow:
                     # None falls back to the per-session key for non-chat turns.
                     active_stream_id=self.active_stream_id,
                     emit_stream=emit_stream,
+                    interrupted_tool_call_ids=interrupted_tool_call_ids,
+                    # Pin the marker to this run explicitly: the session row's
+                    # curr_run_id may already point at a newer turn by the time
+                    # this cancelled workflow finalizes.
+                    curr_run_id=AgentWorkflowID.from_workflow_id(
+                        workflow.info().workflow_id
+                    ).session_id,
                 ),
                 start_to_close_timeout=timedelta(seconds=10),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
@@ -979,7 +996,6 @@ class DurableAgentWorkflow:
 
     @workflow.update
     def set_approvals(self, submission: WorkflowApprovalSubmission) -> None:
-        submission = WorkflowApprovalSubmission.model_validate(submission)
         logger.info(
             "Setting approvals",
             approvals=submission.approvals,
@@ -1013,7 +1029,6 @@ class DurableAgentWorkflow:
 
     @workflow.update
     def request_cancel(self, request: WorkflowCancelRequest) -> None:
-        request = WorkflowCancelRequest.model_validate(request)
         logger.info(
             "Agent cancellation requested",
             session_id=self.session_id,
@@ -1026,52 +1041,6 @@ class DurableAgentWorkflow:
     @request_cancel.validator
     def validate_request_cancel(self, request: WorkflowCancelRequest) -> None:
         WorkflowCancelRequest.model_validate(request)
-
-    async def _run_agent_activity_turn(
-        self, executor_input: AgentExecutorInput
-    ) -> AgentExecutorResult:
-        """Run one executor activity turn with update-driven cancellation."""
-        if not workflow.patched(AGENT_REQUEST_CANCEL_PATCH):
-            return await workflow.execute_activity(
-                run_agent_activity,
-                executor_input,
-                task_queue=config.TRACECAT__AGENT_EXECUTOR_QUEUE,
-                start_to_close_timeout=timedelta(
-                    seconds=config.TRACECAT__AGENT_SANDBOX_TIMEOUT
-                ),
-                heartbeat_timeout=timedelta(seconds=60),
-                retry_policy=RETRY_POLICIES["activity:fail_fast"],
-            )
-
-        activity_handle = workflow.start_activity(
-            run_agent_activity,
-            executor_input,
-            cancellation_type=workflow.ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
-            task_queue=config.TRACECAT__AGENT_EXECUTOR_QUEUE,
-            start_to_close_timeout=timedelta(
-                seconds=config.TRACECAT__AGENT_SANDBOX_TIMEOUT
-            ),
-            heartbeat_timeout=timedelta(seconds=60),
-            retry_policy=RETRY_POLICIES["activity:fail_fast"],
-        )
-        # ActivityHandle is an asyncio.Task subclass, so .done() is valid.
-        # Neither wait_condition nor the handle poll emits history commands,
-        # so this race stays replay-safe.
-        await workflow.wait_condition(
-            lambda: activity_handle.done() or self._cancel_requested
-        )
-        if not activity_handle.done():
-            activity_handle.cancel()
-        try:
-            return await activity_handle
-        except ActivityError as e:
-            if self._cancel_requested and isinstance(e.cause, TemporalCancelledError):
-                return AgentExecutorResult(
-                    success=True,
-                    cancelled=True,
-                    cancelled_reason=self._cancel_reason or "user_cancel",
-                )
-            raise
 
     async def _run_with_agent_executor(
         self, args: AgentWorkflowArgs, cfg: AgentConfig
@@ -1225,7 +1194,61 @@ class DurableAgentWorkflow:
         while True:
             logger.info("Executing agent turn", turn=self._turn)
 
-            result = await self._run_agent_activity_turn(executor_input)
+            # Run one executor activity turn with update-driven cancellation.
+            if not workflow.patched(AGENT_REQUEST_CANCEL_PATCH):
+                result = await workflow.execute_activity(
+                    run_agent_activity,
+                    executor_input,
+                    task_queue=config.TRACECAT__AGENT_EXECUTOR_QUEUE,
+                    start_to_close_timeout=timedelta(
+                        seconds=config.TRACECAT__AGENT_SANDBOX_TIMEOUT
+                    ),
+                    heartbeat_timeout=timedelta(seconds=60),
+                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                )
+            else:
+                activity_handle = workflow.start_activity(
+                    run_agent_activity,
+                    executor_input,
+                    cancellation_type=workflow.ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+                    task_queue=config.TRACECAT__AGENT_EXECUTOR_QUEUE,
+                    start_to_close_timeout=timedelta(
+                        seconds=config.TRACECAT__AGENT_SANDBOX_TIMEOUT
+                    ),
+                    heartbeat_timeout=timedelta(seconds=60),
+                    retry_policy=RETRY_POLICIES["activity:fail_fast"],
+                )
+                # ActivityHandle is an asyncio.Task subclass, so .done() is
+                # valid. Neither wait_condition nor the handle poll emits
+                # history commands, so this race stays replay-safe.
+                await workflow.wait_condition(
+                    lambda handle=activity_handle: (
+                        handle.done() or self._cancel_requested
+                    )
+                )
+                if not activity_handle.done():
+                    activity_handle.cancel()
+                try:
+                    result = await activity_handle
+                except ActivityError as e:
+                    if self._cancel_requested and isinstance(
+                        e.cause, TemporalCancelledError
+                    ):
+                        # The activity was cancelled without returning a
+                        # loopback result (never picked up, still in setup, or
+                        # hard-cancelled), so no executor wrote the cancelled/
+                        # done frames to the per-turn stream. Emit them here or
+                        # the client's SSE reader blocks until disconnect.
+                        return await self._cancelled_turn_output(
+                            AgentExecutorResult(
+                                success=True,
+                                cancelled=True,
+                                cancelled_reason=self._cancel_reason or "user_cancel",
+                            ),
+                            info,
+                            emit_cancelled=True,
+                        )
+                    raise
 
             if result.cancelled:
                 logger.info(
@@ -1324,8 +1347,12 @@ class DurableAgentWorkflow:
                     )
 
                 tool_results: list[ToolExecutionResult] = []
+                cancelled_tool_call_ids: list[str] = []
                 if approved_tools or denied_tools:
-                    tool_results = await self._execute_and_reconcile_approved_tools(
+                    (
+                        tool_results,
+                        cancelled_tool_call_ids,
+                    ) = await self._execute_and_reconcile_approved_tools(
                         approved_tools=approved_tools,
                         denied_tools=denied_tools,
                         registry_lock=root_registry_lock,
@@ -1336,6 +1363,26 @@ class DurableAgentWorkflow:
                         "Tool execution completed",
                         result_count=len(tool_results),
                         session_id=self.session_id,
+                    )
+
+                if self._cancel_requested:
+                    # A cancel arrived during approved tool execution. The
+                    # transcript has already been reconciled with cancelled
+                    # tool_result entries, so end the turn here instead of
+                    # resuming the executor. The executor result predates the
+                    # approved-tool run, so carry the aborted tool ids
+                    # explicitly or the marker misses them and the UI renders
+                    # the cancelled rows as tool errors.
+                    logger.info(
+                        "Agent turn cancelled during approved tool execution",
+                        session_id=self.session_id,
+                        reason=self._cancel_reason,
+                    )
+                    return await self._cancelled_turn_output(
+                        result,
+                        info,
+                        emit_cancelled=True,
+                        extra_interrupted_tool_call_ids=cancelled_tool_call_ids,
                     )
 
                 # Reload session metadata after reconciliation. Full SDK history
@@ -1393,6 +1440,7 @@ class DurableAgentWorkflow:
         info: workflow.Info,
         *,
         emit_cancelled: bool,
+        extra_interrupted_tool_call_ids: list[str] | None = None,
     ) -> AgentOutput:
         """Build the terminal output for a cancelled turn.
 
@@ -1401,8 +1449,19 @@ class DurableAgentWorkflow:
         persists the timeline marker. Approval-wait cancels have not emitted
         yet and pass emit_cancelled=True. Either way the marker is persisted
         before loading history so the terminal history includes it.
+
+        ``extra_interrupted_tool_call_ids`` carries tool calls aborted after
+        the executor result was produced (the approved-tool run), which the
+        result's own ``interrupted_tool_call_ids`` cannot know about.
         """
-        await self._emit_session_cancelled(emit_stream=emit_cancelled)
+        interrupted_ids = list(result.interrupted_tool_call_ids or [])
+        for tool_call_id in extra_interrupted_tool_call_ids or []:
+            if tool_call_id not in interrupted_ids:
+                interrupted_ids.append(tool_call_id)
+        await self._emit_session_cancelled(
+            emit_stream=emit_cancelled,
+            interrupted_tool_call_ids=interrupted_ids or None,
+        )
         message_history = await self._load_terminal_message_history(result)
         return AgentOutput(
             output=None,
@@ -1531,6 +1590,22 @@ class DurableAgentWorkflow:
 
         return approved, denied
 
+    async def _race_tool_activity_against_cancel[T](
+        self, handle: workflow.ActivityHandle[T]
+    ) -> T:
+        """Await an approved tool activity, cancelling it on a user cancel.
+
+        Mirrors the run_agent_activity cancel race: ActivityHandle is an
+        asyncio.Task subclass so .done() is valid, and neither wait_condition
+        nor the handle poll emits history commands, so this race stays
+        replay-safe when no cancel occurs. A cancelled handle raises
+        ActivityError with a CancelledError cause, handled by the caller.
+        """
+        await workflow.wait_condition(lambda: handle.done() or self._cancel_requested)
+        if not handle.done():
+            handle.cancel()
+        return await handle
+
     async def _execute_and_reconcile_approved_tools(
         self,
         *,
@@ -1539,7 +1614,10 @@ class DurableAgentWorkflow:
         registry_lock: RegistryLock,
         mcp_auth_token: str,
         active_stream_id: uuid.UUID | None,
-    ) -> list:
+    ) -> tuple[list, list[str]]:
+        """Returns the reconciled results and the tool call ids the user's
+        cancel aborted (cancelled in flight or never started), so the caller
+        can carry them on the cancelled marker for the UI."""
         logical_time = workflow.now()
         service_role = build_tracecat_mcp_role(
             workspace_id=self.role.workspace_id,
@@ -1547,24 +1625,70 @@ class DurableAgentWorkflow:
             user_id=self.role.user_id,
         )
         pending_results: list[PendingToolResult] = []
-        for tool_call in approved_tools:
+        cancelled_tool_call_ids: list[str] = []
+        for index, tool_call in enumerate(approved_tools):
+            if self._cancel_requested:
+                # Stop launching new tool activities once a cancel arrives;
+                # every not-yet-started tool still needs a tool_result entry.
+                skipped_calls = approved_tools[index:]
+                cancelled_tool_call_ids.extend(
+                    skipped.tool_call_id for skipped in skipped_calls
+                )
+                pending_results.extend(
+                    _cancelled_tool_result(skipped, started=False)
+                    for skipped in skipped_calls
+                )
+                break
             remote_mcp_tool_name = _approved_user_mcp_tool_name(tool_call.tool_name)
             try:
                 if remote_mcp_tool_name is not None:
-                    result = await _execute_remote_mcp_tool_call(
-                        tool_call,
-                        remote_tool_name=remote_mcp_tool_name,
-                        mcp_auth_token=mcp_auth_token,
+                    raw_result = await self._race_tool_activity_against_cancel(
+                        _start_remote_mcp_tool_call(
+                            tool_call,
+                            remote_tool_name=remote_mcp_tool_name,
+                            mcp_auth_token=mcp_auth_token,
+                        )
+                    )
+                    result = PendingToolResult(
+                        tool_call_id=tool_call.tool_call_id,
+                        tool_name=tool_call.tool_name,
+                        tool_input=tool_call.args,
+                        raw_result=raw_result,
                     )
                 else:
-                    result = await _execute_registry_tool_call(
-                        tool_call,
-                        registry_lock=registry_lock,
-                        service_role=service_role,
-                        logical_time=logical_time,
+                    stored = await self._race_tool_activity_against_cancel(
+                        _start_registry_tool_call(
+                            tool_call,
+                            registry_lock=registry_lock,
+                            service_role=service_role,
+                            logical_time=logical_time,
+                        )
+                    )
+                    result = PendingToolResult(
+                        tool_call_id=tool_call.tool_call_id,
+                        tool_name=tool_call.tool_name,
+                        tool_input=tool_call.args,
+                        stored_result=stored,
                     )
                 pending_results.append(result)
             except ActivityError as e:
+                if self._cancel_requested and isinstance(
+                    e.cause, TemporalCancelledError
+                ):
+                    # The in-flight tool activity was cancelled by the user.
+                    skipped_calls = approved_tools[index + 1 :]
+                    cancelled_tool_call_ids.append(tool_call.tool_call_id)
+                    cancelled_tool_call_ids.extend(
+                        skipped.tool_call_id for skipped in skipped_calls
+                    )
+                    pending_results.append(
+                        _cancelled_tool_result(tool_call, started=True)
+                    )
+                    pending_results.extend(
+                        _cancelled_tool_result(skipped, started=False)
+                        for skipped in skipped_calls
+                    )
+                    break
                 pending_results.append(
                     PendingToolResult(
                         tool_call_id=tool_call.tool_call_id,
@@ -1597,4 +1721,4 @@ class DurableAgentWorkflow:
             start_to_close_timeout=timedelta(seconds=300),
             retry_policy=RETRY_POLICIES["activity:fail_fast"],
         )
-        return reconcile.results
+        return reconcile.results, cancelled_tool_call_ids

--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -942,20 +942,22 @@ class DurableAgentWorkflow:
                 error=str(emit_error),
             )
 
-    async def _emit_session_cancelled(self) -> None:
-        """Emit the advisory cancelled-turn stream event for approval-wait cancels.
+    async def _emit_session_cancelled(self, *, emit_stream: bool) -> None:
+        """Record the cancelled turn (timeline marker + optional stream notice).
 
-        Cancellation during the mid-turn executor activity flows through the
-        loopback handler, which emits this notice itself. Cancelling while
-        waiting on approval decisions never starts (or has already finished)
-        that activity, so the workflow must emit the notice directly here to
-        keep the chat UI's "Chat stopped" signal consistent across both
-        cancellation paths.
+        The activity always persists the cancelled-marker history row so the
+        divider survives DB reloads. Stream emission depends on the cancel
+        path: cancellation during the mid-turn executor activity flows through
+        the loopback handler, which emits the stream notice itself
+        (``emit_stream=False`` here); cancelling while waiting on approval
+        decisions never starts (or has already finished) that activity, so the
+        workflow must emit the notice too (``emit_stream=True``).
         """
         try:
             await workflow.execute_activity_method(
                 AgentActivities.emit_session_cancelled,
                 EmitSessionCancelledInputs(
+                    role=self.role,
                     session_id=self.session_id,
                     workspace_id=self.workspace_id,
                     reason=self._cancel_reason or "user_cancel",
@@ -963,6 +965,7 @@ class DurableAgentWorkflow:
                     # suffixed key, so the cancelled/done markers must land there.
                     # None falls back to the per-session key for non-chat turns.
                     active_stream_id=self.active_stream_id,
+                    emit_stream=emit_stream,
                 ),
                 start_to_close_timeout=timedelta(seconds=10),
                 retry_policy=RETRY_POLICIES["activity:fail_fast"],
@@ -1230,7 +1233,7 @@ class DurableAgentWorkflow:
                     session_id=self.session_id,
                     reason=result.cancelled_reason,
                 )
-                # Executor loopback already emitted the cancelled notice.
+                # Executor loopback already emitted the cancelled stream notice.
                 return await self._cancelled_turn_output(
                     result, info, emit_cancelled=False
                 )
@@ -1393,13 +1396,13 @@ class DurableAgentWorkflow:
     ) -> AgentOutput:
         """Build the terminal output for a cancelled turn.
 
-        The executor-cancel loopback already emitted the cancelled notice, so
-        that path passes emit_cancelled=False. Approval-wait cancels have not
-        emitted yet and must do so before loading history to preserve the
-        activity command order at every call site.
+        The executor-cancel loopback already emitted the cancelled stream
+        notice, so that path passes emit_cancelled=False and the activity only
+        persists the timeline marker. Approval-wait cancels have not emitted
+        yet and pass emit_cancelled=True. Either way the marker is persisted
+        before loading history so the terminal history includes it.
         """
-        if emit_cancelled:
-            await self._emit_session_cancelled()
+        await self._emit_session_cancelled(emit_stream=emit_cancelled)
         message_history = await self._load_terminal_message_history(result)
         return AgentOutput(
             output=None,

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -1594,6 +1594,112 @@ class TestSandboxedAgentExecutorCancellation:
         assert result.error is None
         assert result.success is True
 
+    @pytest.mark.anyio
+    async def test_cancel_signal_interrupts_turn_without_task_cancellation(
+        self,
+        executor_input: AgentExecutorInput,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Regression: user stop must not depend on Temporal cancel delivery.
+
+        Temporal delivers activity cancellation via throttled heartbeat RPCs,
+        so a live turn can finish before ``asyncio.CancelledError`` is ever
+        raised in the activity. Here a cancel signal is written while the
+        activity keeps running normally (its task is never cancelled); the
+        executor must observe the signal out-of-band, interrupt the broker
+        turn, and report the turn as cancelled.
+        """
+        from tracecat.agent.executor.loopback import LoopbackHandler, LoopbackInput
+
+        executor_input.curr_run_id = uuid.uuid4()
+        executor = SandboxedAgentExecutor(input=executor_input)
+
+        job_dir = tmp_path / "job"
+        job_dir.mkdir()
+        executor._job_dir = job_dir
+        executor._llm_proxy = AsyncMock()
+
+        handler = LoopbackHandler(
+            input=LoopbackInput(
+                session_id=executor.input.session_id,
+                workspace_id=executor.input.workspace_id,
+            )
+        )
+
+        cancel_signalled = asyncio.Event()
+        interrupted = asyncio.Event()
+        interrupt_reasons: list[str] = []
+
+        async def fake_read_turn_cancel_signal(run_id: str) -> str | None:
+            assert run_id == str(executor_input.curr_run_id)
+            return "user_cancel" if cancel_signalled.is_set() else None
+
+        monkeypatch.setattr(
+            "tracecat.agent.executor.activity.read_turn_cancel_signal",
+            fake_read_turn_cancel_signal,
+        )
+        monkeypatch.setattr(
+            "tracecat.agent.executor.activity.TURN_CANCEL_POLL_INTERVAL_SECONDS",
+            0.01,
+        )
+
+        class FakeBroker:
+            def session_turn_lease(self, _session_id: str):
+                @asynccontextmanager
+                async def lease():
+                    yield
+
+                return lease()
+
+            async def run_turn_in_session_lease(
+                self, _request: Any, _handler: Any
+            ) -> None:
+                # Completes normally once interrupted - the activity task
+                # itself is never cancelled in this scenario.
+                await interrupted.wait()
+
+            async def interrupt_turn(self, _session_id: str, reason: str) -> bool:
+                interrupt_reasons.append(reason)
+                # Simulate the interrupted runtime finishing cleanly.
+                handler._result.success = True
+                interrupted.set()
+                return True
+
+            async def cancel_turn(self, _session_id: str) -> None:
+                raise AssertionError("Hard cancel must not fire on graceful stop")
+
+        monkeypatch.setattr(
+            "tracecat.agent.executor.activity.get_claude_runtime_broker",
+            lambda: FakeBroker(),
+        )
+
+        result = AgentExecutorResult(success=False, terminal_stream_error_emitted=False)
+
+        async def run_it() -> None:
+            await executor._run_with_broker(
+                result=result,
+                handler=handler,
+                init_payload=executor._build_runtime_init_payload(),
+                socket_dir=job_dir / "sockets",
+                llm_socket_path=job_dir / "sockets" / "llm.sock",
+                artifact_working_set=None,
+            )
+
+        task = asyncio.create_task(run_it())
+        # Let the executor reach the broker's blocking wait, then signal the
+        # cancel out-of-band instead of cancelling the task.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        cancel_signalled.set()
+        await asyncio.wait_for(task, timeout=5)
+
+        assert interrupt_reasons == ["user_cancel"]
+        assert result.cancelled is True
+        assert result.cancelled_reason == "user_cancel"
+        assert result.success is True
+        assert result.error is None
+
 
 class TestSandboxedAgentExecutorFilesystemPersistence:
     """Tests for feature-flagged agent work-dir hydration and snapshotting."""

--- a/tests/unit/test_agent_activities.py
+++ b/tests/unit/test_agent_activities.py
@@ -1448,6 +1448,153 @@ class TestSandboxedAgentExecutorHelpers:
         mock_with_session.assert_not_called()
 
 
+class TestSandboxedAgentExecutorCancellation:
+    """Tests for the graceful-cancellation branch in ``_run_with_broker``.
+
+    A cancelled turn must not be reported as a successful turn when the
+    interrupted runtime actually finished with an error - only the fact that
+    the cancellation itself was processed should be signaled via
+    ``result.cancelled``.
+    """
+
+    @pytest.fixture
+    def executor_input(
+        self,
+        mock_role: Role,
+        mock_session_id: uuid.UUID,
+        mock_agent_config: AgentConfig,
+    ) -> AgentExecutorInput:
+        return AgentExecutorInput(
+            session_id=mock_session_id,
+            workspace_id=mock_role.workspace_id or uuid.uuid4(),
+            user_prompt="Test prompt",
+            config=mock_agent_config,
+            role=mock_role,
+            mcp_auth_token="mock-jwt-token",
+            llm_gateway_auth_token="mock-llm-token",
+        )
+
+    async def _run_cancelled_turn(
+        self,
+        executor: SandboxedAgentExecutor,
+        *,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        loopback_result: LoopbackResult,
+    ) -> AgentExecutorResult:
+        """Drive ``_run_with_broker`` and cancel it before the turn completes."""
+        from tracecat.agent.executor.loopback import LoopbackHandler, LoopbackInput
+
+        job_dir = tmp_path / "job"
+        job_dir.mkdir()
+        executor._job_dir = job_dir
+        executor._llm_proxy = AsyncMock()
+
+        handler = LoopbackHandler(
+            input=LoopbackInput(
+                session_id=executor.input.session_id,
+                workspace_id=executor.input.workspace_id,
+            )
+        )
+
+        interrupted = asyncio.Event()
+
+        class FakeBroker:
+            def session_turn_lease(self, _session_id: str):
+                @asynccontextmanager
+                async def lease():
+                    yield
+
+                return lease()
+
+            async def run_turn_in_session_lease(
+                self, _request: Any, _handler: Any
+            ) -> None:
+                # Blocks until interrupted, mirroring a live runtime turn that
+                # keeps running until the graceful interrupt lands.
+                await interrupted.wait()
+
+            async def interrupt_turn(self, _session_id: str, _reason: str) -> None:
+                # Simulate the loopback handler observing the interrupted
+                # runtime's remaining events, including a terminal error, then
+                # let the in-flight broker turn task finish.
+                handler._result = loopback_result
+                interrupted.set()
+
+            async def cancel_turn(self, _session_id: str) -> None:
+                pass
+
+        monkeypatch.setattr(
+            "tracecat.agent.executor.activity.get_claude_runtime_broker",
+            lambda: FakeBroker(),
+        )
+
+        result = AgentExecutorResult(success=False, terminal_stream_error_emitted=False)
+
+        async def run_it() -> None:
+            await executor._run_with_broker(
+                result=result,
+                handler=handler,
+                init_payload=executor._build_runtime_init_payload(),
+                socket_dir=job_dir / "sockets",
+                llm_socket_path=job_dir / "sockets" / "llm.sock",
+                artifact_working_set=None,
+            )
+
+        task = asyncio.create_task(run_it())
+        # Yield control so the executor reaches the broker's blocking wait
+        # before cancellation is delivered.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        task.cancel()
+        await task
+        return result
+
+    @pytest.mark.anyio
+    async def test_cancellation_preserves_error_when_interrupted_turn_failed(
+        self,
+        executor_input: AgentExecutorInput,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A cancelled turn that ended with a runtime error must stay success=False."""
+        executor = SandboxedAgentExecutor(input=executor_input)
+
+        result = await self._run_cancelled_turn(
+            executor,
+            monkeypatch=monkeypatch,
+            tmp_path=tmp_path,
+            loopback_result=LoopbackResult(success=False, error="runtime crashed"),
+        )
+
+        assert result.cancelled is True
+        assert result.cancelled_reason == "user_cancel"
+        assert result.error == "runtime crashed"
+        assert result.success is False
+
+    @pytest.mark.anyio
+    async def test_cancellation_reports_success_when_interrupted_turn_clean(
+        self,
+        executor_input: AgentExecutorInput,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A cancelled turn with no runtime error is still a clean cancellation."""
+        executor = SandboxedAgentExecutor(input=executor_input)
+
+        result = await self._run_cancelled_turn(
+            executor,
+            monkeypatch=monkeypatch,
+            tmp_path=tmp_path,
+            loopback_result=LoopbackResult(success=False, error=None),
+        )
+
+        assert result.cancelled is True
+        assert result.cancelled_reason == "user_cancel"
+        assert result.error is None
+        assert result.success is True
+
+
 class TestSandboxedAgentExecutorFilesystemPersistence:
     """Tests for feature-flagged agent work-dir hydration and snapshotting."""
 

--- a/tests/unit/test_agent_executor_loopback.py
+++ b/tests/unit/test_agent_executor_loopback.py
@@ -282,6 +282,78 @@ def test_should_not_suppress_normal_tool_result_error() -> None:
 
 
 @pytest.mark.anyio
+async def test_interrupted_tool_call_ids_collected_from_cancel_state() -> None:
+    """Interrupt casualties are derived from cancel-then-error ordering and
+    unresolved calls - never from inspecting error text."""
+    handler = _make_handler()
+    stream = _FakeStream()
+    handler._stream_sink = stream
+
+    def _tool_start(tool_call_id: str) -> UnifiedStreamEvent:
+        return UnifiedStreamEvent(
+            type=StreamEventType.TOOL_CALL_START,
+            tool_call_id=tool_call_id,
+            tool_name="core.tables.list_tables",
+            tool_input={},
+        )
+
+    # Genuine failure before the interrupt: not an interrupt casualty, even
+    # though its error text looks abort-ish.
+    await handler.send_stream_event(_tool_start("tool-failed"))
+    await handler.send_stream_event(
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_RESULT,
+            tool_call_id="tool-failed",
+            tool_name="core.tables.list_tables",
+            tool_output="The operation was aborted: table not found",
+            is_error=True,
+        )
+    )
+
+    # Two calls are in flight when the user interrupts.
+    await handler.send_stream_event(_tool_start("tool-aborted"))
+    await handler.send_stream_event(_tool_start("tool-unresolved"))
+    handler.mark_cancelled("user_cancel")
+
+    # SDK abort artifact lands after cancellation; the other call never
+    # produces a result.
+    await handler.send_stream_event(
+        UnifiedStreamEvent(
+            type=StreamEventType.TOOL_RESULT,
+            tool_call_id="tool-aborted",
+            tool_name="core.tables.list_tables",
+            tool_output="request cancelled",
+            is_error=True,
+        )
+    )
+
+    await handler._emit_interrupt_notice_if_cancelled(stream)
+
+    result = handler.build_result()
+    assert result.interrupted_tool_call_ids == ["tool-aborted", "tool-unresolved"]
+
+    cancelled_events = [
+        call.args[0]
+        for call in stream.append.await_args_list
+        if call.args[0].type is StreamEventType.CANCELLED
+    ]
+    assert len(cancelled_events) == 1
+    assert cancelled_events[0].metadata == {
+        "reason": "user_cancel",
+        "tool_call_ids": ["tool-aborted", "tool-unresolved"],
+    }
+
+
+def test_interrupted_tool_call_ids_empty_without_cancellation() -> None:
+    handler = _make_handler()
+    handler._tool_names_by_call_id["tool-open"] = "core.tables.list_tables"
+
+    result = handler.build_result()
+
+    assert result.interrupted_tool_call_ids == []
+
+
+@pytest.mark.anyio
 async def test_tool_result_emits_artifact_side_effect_from_tracked_call() -> None:
     handler = _make_handler()
     stream = _FakeStream()

--- a/tests/unit/test_agent_session_messages.py
+++ b/tests/unit/test_agent_session_messages.py
@@ -81,6 +81,83 @@ async def test_list_messages_preserves_compaction_metadata() -> None:
 
 
 @pytest.mark.anyio
+async def test_list_messages_maps_cancelled_marker() -> None:
+    service, agent_session = _build_service()
+    cancelled_entry = SimpleNamespace(
+        id=uuid.uuid4(),
+        kind=MessageKind.CANCELLED.value,
+        content={
+            "type": "cancelled",
+            "reason": "user_cancel",
+            "timestamp": "2026-07-02T00:00:00Z",
+        },
+    )
+
+    service.get_session = AsyncMock(return_value=agent_session)
+    service.session.execute = AsyncMock(
+        side_effect=[
+            _mock_scalar_result([cancelled_entry]),
+            _mock_scalar_result([]),
+        ]
+    )
+
+    messages = await service.list_messages(agent_session.id)
+
+    assert len(messages) == 1
+    assert messages[0].kind == MessageKind.CANCELLED
+    assert messages[0].cancelled == {"reason": "user_cancel"}
+
+
+@pytest.mark.anyio
+async def test_load_session_history_omits_cancelled_marker_rows() -> None:
+    service, _ = _build_service()
+    session_id = uuid.uuid4()
+    sdk_session = SimpleNamespace(
+        id=session_id,
+        parent_session_id=None,
+        sdk_session_id="sdk-session-123",
+        curr_run_id=None,
+    )
+    entries = [
+        SimpleNamespace(
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "type": "user",
+                "uuid": "prompt-uuid",
+                "message": {"role": "user", "content": "List cases."},
+            },
+        ),
+        SimpleNamespace(
+            kind=MessageKind.CANCELLED.value,
+            content={
+                "type": "cancelled",
+                "reason": "user_cancel",
+                "timestamp": "2026-07-02T00:00:00Z",
+            },
+        ),
+        SimpleNamespace(
+            kind=MessageKind.CHAT_MESSAGE.value,
+            content={
+                "type": "assistant",
+                "uuid": "answer-uuid",
+                "parentUuid": "prompt-uuid",
+                "message": {"content": [{"type": "text", "text": "Stopped early."}]},
+            },
+        ),
+    ]
+
+    service.get_session = AsyncMock(return_value=sdk_session)
+    service.session.execute = AsyncMock(return_value=_mock_scalar_result(entries))
+
+    history = await service.load_session_history(session_id)
+
+    assert history is not None
+    lines = [orjson.loads(line) for line in history.sdk_session_data.splitlines()]
+    assert [line["uuid"] for line in lines] == ["prompt-uuid", "answer-uuid"]
+    assert "cancelled" not in history.sdk_session_data
+
+
+@pytest.mark.anyio
 async def test_load_session_history_omits_internal_rows_and_repairs_parent_chain() -> (
     None
 ):

--- a/tests/unit/test_agent_session_router.py
+++ b/tests/unit/test_agent_session_router.py
@@ -18,6 +18,7 @@ from tracecat.agent.common.stream_types import (
     UnifiedStreamEvent,
 )
 from tracecat.agent.session.router import (
+    cancel_session,
     fork_session,
     get_session,
     get_session_vercel,
@@ -26,7 +27,10 @@ from tracecat.agent.session.router import (
     send_message,
     stream_session_events,
 )
-from tracecat.agent.session.schemas import AgentSessionForkRequest
+from tracecat.agent.session.schemas import (
+    AgentSessionCancelRequest,
+    AgentSessionForkRequest,
+)
 from tracecat.agent.session.types import AgentSessionEntity, TurnLifecycle
 from tracecat.artifacts.schemas import CaseArtifact
 from tracecat.auth.types import Role
@@ -1042,6 +1046,46 @@ async def test_fork_session_requires_entitlement_for_workspace_chat_parent() -> 
             )
 
     fake_svc.fork_session.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_cancel_session_requires_entitlement_for_workspace_chat_parent() -> None:
+    agent_session = _agent_session_stub(
+        entity_type=AgentSessionEntity.WORKSPACE_CHAT,
+        curr_run_id=uuid.uuid4(),
+    )
+    role = Role(
+        type="service",
+        service_id="tracecat-api",
+        workspace_id=agent_session.workspace_id,
+        organization_id=uuid.uuid4(),
+        scopes=frozenset({"agent:execute"}),
+    )
+    fake_svc = SimpleNamespace(
+        get_session=AsyncMock(return_value=agent_session),
+        request_cancel=AsyncMock(return_value=None),
+    )
+
+    with (
+        patch(
+            "tracecat.agent.session.router.AgentSessionService",
+            return_value=fake_svc,
+        ),
+        patch(
+            "tracecat.agent.session.router.require_workspace_chat_entitlement_for_entity",
+            AsyncMock(side_effect=_deny_workspace_chat_entitlement),
+        ),
+    ):
+        raw_cancel_session = cast(Any, cancel_session).__wrapped__
+        with pytest.raises(EntitlementRequired):
+            await raw_cancel_session(
+                session_id=agent_session.id,
+                role=role,
+                session=AsyncMock(),
+                request=AgentSessionCancelRequest(),
+            )
+
+    fake_svc.request_cancel.assert_not_awaited()
 
 
 def _make_stream_role(workspace_id: uuid.UUID) -> Role:

--- a/tests/unit/test_vercel_adapter.py
+++ b/tests/unit/test_vercel_adapter.py
@@ -1,7 +1,8 @@
 from datetime import UTC, datetime
+from typing import cast
 from uuid import uuid4
 
-from tracecat.agent.adapter.vercel import convert_chat_messages_to_ui
+from tracecat.agent.adapter.vercel import DataUIPart, convert_chat_messages_to_ui
 from tracecat.agent.approvals.enums import ApprovalStatus
 from tracecat.chat.enums import MessageKind
 from tracecat.chat.schemas import ApprovalRead, ChatMessage
@@ -34,3 +35,21 @@ def test_convert_chat_messages_to_ui_skips_resolved_approval_request() -> None:
     messages = convert_chat_messages_to_ui([_approval_message(ApprovalStatus.APPROVED)])
 
     assert messages == []
+
+
+def test_convert_chat_messages_to_ui_emits_cancelled_marker() -> None:
+    messages = convert_chat_messages_to_ui(
+        [
+            ChatMessage(
+                id=str(uuid4()),
+                kind=MessageKind.CANCELLED,
+                cancelled={"reason": "user_cancel"},
+            )
+        ]
+    )
+
+    assert len(messages) == 1
+    assert messages[0].role == "system"
+    part = cast(DataUIPart, messages[0].parts[0])
+    assert part["type"] == "data-cancelled"
+    assert part["data"] == {"reason": "user_cancel"}

--- a/tests/unit/test_vercel_adapter.py
+++ b/tests/unit/test_vercel_adapter.py
@@ -2,8 +2,16 @@ from datetime import UTC, datetime
 from typing import cast
 from uuid import uuid4
 
-from tracecat.agent.adapter.vercel import DataUIPart, convert_chat_messages_to_ui
+import pytest
+
+from tracecat.agent.adapter.vercel import (
+    DataEventPayload,
+    DataUIPart,
+    VercelStreamContext,
+    convert_chat_messages_to_ui,
+)
 from tracecat.agent.approvals.enums import ApprovalStatus
+from tracecat.agent.common.stream_types import UnifiedStreamEvent
 from tracecat.chat.enums import MessageKind
 from tracecat.chat.schemas import ApprovalRead, ChatMessage
 
@@ -53,3 +61,47 @@ def test_convert_chat_messages_to_ui_emits_cancelled_marker() -> None:
     part = cast(DataUIPart, messages[0].parts[0])
     assert part["type"] == "data-cancelled"
     assert part["data"] == {"reason": "user_cancel"}
+
+
+def test_convert_chat_messages_to_ui_cancelled_marker_carries_tool_call_ids() -> None:
+    """Structured interrupt metadata survives the DB reload path."""
+    messages = convert_chat_messages_to_ui(
+        [
+            ChatMessage(
+                id=str(uuid4()),
+                kind=MessageKind.CANCELLED,
+                cancelled={
+                    "reason": "user_cancel",
+                    "tool_call_ids": ["toolu_aborted"],
+                },
+            )
+        ]
+    )
+
+    assert len(messages) == 1
+    part = cast(DataUIPart, messages[0].parts[0])
+    assert part["type"] == "data-cancelled"
+    assert part["data"] == {
+        "reason": "user_cancel",
+        "tool_call_ids": ["toolu_aborted"],
+    }
+
+
+@pytest.mark.anyio
+async def test_stream_cancelled_event_carries_tool_call_ids() -> None:
+    """Structured interrupt metadata survives the live-stream path."""
+    context = VercelStreamContext(message_id="msg_test")
+    event = UnifiedStreamEvent.cancelled_event(
+        reason="user_cancel",
+        tool_call_ids=["toolu_aborted", "toolu_unresolved"],
+    )
+
+    payloads = [payload async for payload in context.handle_event(event)]
+
+    data_payloads = [p for p in payloads if isinstance(p, DataEventPayload)]
+    assert len(data_payloads) == 1
+    assert data_payloads[0].type == "data-cancelled"
+    assert data_payloads[0].data == {
+        "reason": "user_cancel",
+        "tool_call_ids": ["toolu_aborted", "toolu_unresolved"],
+    }

--- a/tests/unit/test_worker_activity_registration.py
+++ b/tests/unit/test_worker_activity_registration.py
@@ -240,9 +240,12 @@ async def test_agent_executor_worker_treats_empty_numeric_env_vars_as_defaults(
             max_concurrent_activities: int,
             disable_eager_activity_execution: bool,
             activity_executor: ThreadPoolExecutor,
+            max_heartbeat_throttle_interval: timedelta,
+            default_heartbeat_throttle_interval: timedelta,
             graceful_shutdown_timeout: timedelta,
         ) -> None:
             del client, activities, workflow_runner, disable_eager_activity_execution
+            del max_heartbeat_throttle_interval, default_heartbeat_throttle_interval
             captured["task_queue"] = task_queue
             captured["max_concurrent_activities"] = max_concurrent_activities
             captured["threadpool_max_workers"] = activity_executor._max_workers

--- a/tracecat/agent/adapter/vercel.py
+++ b/tracecat/agent/adapter/vercel.py
@@ -1069,9 +1069,23 @@ class VercelStreamContext:
             case StreamEventType.CANCELLED:
                 metadata = event.metadata or {}
                 reason = metadata.get("reason")
+                raw_tool_call_ids = metadata.get("tool_call_ids")
+                tool_call_ids = [
+                    item
+                    for item in (
+                        raw_tool_call_ids if isinstance(raw_tool_call_ids, list) else []
+                    )
+                    if isinstance(item, str)
+                ]
                 yield DataEventPayload(
                     type=CANCELLED_DATA_PART_TYPE,
-                    data={"reason": reason if isinstance(reason, str) else None},
+                    data={
+                        "reason": reason if isinstance(reason, str) else None,
+                        # Structured interrupt metadata: the tool calls this
+                        # interrupt aborted, so the UI can render them as
+                        # "interrupted" without inspecting error text.
+                        "tool_call_ids": tool_call_ids,
+                    },
                 )
 
             case StreamEventType.ERROR:

--- a/tracecat/agent/adapter/vercel.py
+++ b/tracecat/agent/adapter/vercel.py
@@ -1586,6 +1586,23 @@ def convert_chat_messages_to_ui(
             mutable_messages.append(mutable_message)
             continue
 
+        # Handle turn-cancelled markers from DB (kind=CANCELLED)
+        # These render as the "stopped by user" divider in the timeline
+        if chat_message.kind == MessageKind.CANCELLED:
+            mutable_messages.append(
+                MutableMessage(
+                    id=chat_message.id,
+                    role="system",
+                    parts=[
+                        DataUIPart(
+                            type=CANCELLED_DATA_PART_TYPE,
+                            data=chat_message.cancelled or {"reason": None},
+                        )
+                    ],
+                )
+            )
+            continue
+
         # Handle approval request bubbles from DB (kind=APPROVAL_REQUEST)
         # These are inserted by list_messages() when loading session history
         if chat_message.kind == MessageKind.APPROVAL_REQUEST and chat_message.approval:

--- a/tracecat/agent/adapter/vercel.py
+++ b/tracecat/agent/adapter/vercel.py
@@ -80,6 +80,7 @@ from tracecat.artifacts.schemas import ARTIFACT_DATA_PART_TYPE
 from tracecat.chat.constants import (
     APPROVAL_DATA_PART_TYPE,
     APPROVAL_REQUEST_HEADER,
+    CANCELLED_DATA_PART_TYPE,
     COMPACTION_DATA_PART_TYPE,
 )
 from tracecat.chat.enums import MessageKind
@@ -1063,6 +1064,14 @@ class VercelStreamContext:
                 yield DataEventPayload(
                     type=ARTIFACT_DATA_PART_TYPE,
                     data=event.artifact_data.to_dict(),
+                )
+
+            case StreamEventType.CANCELLED:
+                metadata = event.metadata or {}
+                reason = metadata.get("reason")
+                yield DataEventPayload(
+                    type=CANCELLED_DATA_PART_TYPE,
+                    data={"reason": reason if isinstance(reason, str) else None},
                 )
 
             case StreamEventType.ERROR:

--- a/tracecat/agent/cancellation.py
+++ b/tracecat/agent/cancellation.py
@@ -1,0 +1,46 @@
+"""Out-of-band user-cancel signalling for agent turns.
+
+Temporal only delivers activity cancellation to a running activity via
+heartbeat RPC responses, and the SDK throttles outbound heartbeats to a
+fraction of the heartbeat timeout. A short agent turn can therefore finish
+normally before the executor ever learns that ``ActivityTaskCancelRequested``
+was recorded - especially with a single executor activity slot in local dev.
+
+To make stop reliably live, the API writes a Redis signal keyed by the turn's
+run id (the ``curr_run_id`` workflow token) when the user cancels, and the
+executor activity polls it directly while the turn runs. The Temporal
+cancellation path is kept as a fallback; this signal is the low-latency
+primary.
+"""
+
+from __future__ import annotations
+
+from tracecat.redis.client import get_redis_client
+
+TURN_CANCEL_SIGNAL_TTL_SECONDS = 600
+"""Signal expiry. Keys are scoped to a single turn's run id, so the TTL only
+bounds Redis growth for turns that end before the signal is consumed."""
+
+TURN_CANCEL_POLL_INTERVAL_SECONDS = 0.5
+"""How often the executor activity polls for a pending cancel signal."""
+
+
+def turn_cancel_key(run_id: str) -> str:
+    """Redis key holding the pending cancel reason for one agent turn."""
+    return f"agent:turn-cancel:{run_id}"
+
+
+async def signal_turn_cancel(run_id: str, *, reason: str) -> None:
+    """Record a user cancel request for the turn running under run_id."""
+    client = await get_redis_client()
+    await client.set(
+        turn_cancel_key(run_id),
+        reason,
+        expire_seconds=TURN_CANCEL_SIGNAL_TTL_SECONDS,
+    )
+
+
+async def read_turn_cancel_signal(run_id: str) -> str | None:
+    """Return the pending cancel reason for run_id, if one was signalled."""
+    client = await get_redis_client()
+    return await client.get(turn_cancel_key(run_id))

--- a/tracecat/agent/common/stream_types.py
+++ b/tracecat/agent/common/stream_types.py
@@ -65,6 +65,7 @@ class StreamEventType(StrEnum):
     # System/status events
     COMPACTION = "compaction"
     ARTIFACT = "artifact"
+    CANCELLED = "cancelled"
 
     # Control events
     ERROR = "error"
@@ -257,6 +258,14 @@ class UnifiedStreamEvent:
             type=StreamEventType.COMPACTION,
             metadata=event_metadata,
         )
+
+    @classmethod
+    def cancelled_event(cls, *, reason: str | None = None) -> UnifiedStreamEvent:
+        """Factory method for creating turn-cancelled status events."""
+        metadata: dict[str, Any] = {}
+        if reason is not None:
+            metadata["reason"] = reason
+        return cls(type=StreamEventType.CANCELLED, metadata=metadata)
 
     @classmethod
     def tool_result_event(

--- a/tracecat/agent/common/stream_types.py
+++ b/tracecat/agent/common/stream_types.py
@@ -260,11 +260,25 @@ class UnifiedStreamEvent:
         )
 
     @classmethod
-    def cancelled_event(cls, *, reason: str | None = None) -> UnifiedStreamEvent:
-        """Factory method for creating turn-cancelled status events."""
+    def cancelled_event(
+        cls,
+        *,
+        reason: str | None = None,
+        tool_call_ids: list[str] | None = None,
+    ) -> UnifiedStreamEvent:
+        """Factory method for creating turn-cancelled status events.
+
+        Args:
+            reason: Human/machine-readable cancellation reason.
+            tool_call_ids: Tool calls the interrupt aborted mid-flight. Clients
+                use these to render the affected tool calls as "interrupted"
+                instead of surfacing SDK abort artifacts as tool errors.
+        """
         metadata: dict[str, Any] = {}
         if reason is not None:
             metadata["reason"] = reason
+        if tool_call_ids:
+            metadata["tool_call_ids"] = list(tool_call_ids)
         return cls(type=StreamEventType.CANCELLED, metadata=metadata)
 
     @classmethod

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -22,6 +22,10 @@ from tracecat_ee.workspace_chat.skills import BUILTIN_SKILL_NAME_PREFIX
 
 from tracecat import config as app_config
 from tracecat.agent.artifacts.working_set import ArtifactWorkingSetInput
+from tracecat.agent.cancellation import (
+    TURN_CANCEL_POLL_INTERVAL_SECONDS,
+    read_turn_cancel_signal,
+)
 from tracecat.agent.common.config import (
     TRACECAT__AGENT_SANDBOX_MEMORY_MB,
     TRACECAT__AGENT_SANDBOX_TIMEOUT,
@@ -46,6 +50,7 @@ from tracecat.agent.filesystem import hydrate_agent_work_dir, persist_agent_work
 from tracecat.agent.llm_routing import get_litellm_route_model
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.runtime.claude_code.broker import (
+    ClaudeRuntimeBroker,
     ClaudeTurnRequest,
     ConcurrentSessionTurnError,
 )
@@ -559,6 +564,7 @@ class SandboxedAgentExecutor:
 
         broker_task: asyncio.Task[None] | None = None
         fatal_error_task: asyncio.Task[str] | None = None
+        cancel_signal_task: asyncio.Task[None] | None = None
         try:
             async with broker.session_turn_lease(str(self.input.session_id)):
                 broker_task = asyncio.create_task(
@@ -566,6 +572,13 @@ class SandboxedAgentExecutor:
                 )
                 self._log_benchmark_phase("broker_turn_dispatched")
 
+                cancel_signal_task = asyncio.create_task(
+                    self._watch_cancel_signal(
+                        broker=broker,
+                        handler=handler,
+                        broker_task=broker_task,
+                    )
+                )
                 fatal_error_task = asyncio.create_task(wait_fatal_error())
                 heartbeat_interval = 5
                 elapsed = 0
@@ -671,8 +684,79 @@ class SandboxedAgentExecutor:
             result.cancelled = True
             result.cancelled_reason = reason
         finally:
-            for task in (fatal_error_task, broker_task):
+            for task in (cancel_signal_task, fatal_error_task, broker_task):
                 await _cancel_task_with_timeout(task, task_name="agent_executor_task")
+
+    async def _watch_cancel_signal(
+        self,
+        *,
+        broker: ClaudeRuntimeBroker,
+        handler: LoopbackHandler,
+        broker_task: asyncio.Task[None],
+    ) -> None:
+        """Poll the out-of-band user-cancel signal and stop the turn on demand.
+
+        Temporal delivers activity cancellation only through throttled
+        heartbeat RPCs, so a turn can finish before the CancelledError branch
+        ever runs (see tracecat/agent/cancellation.py). This watcher reads the
+        Redis signal written by the cancel endpoint and drives the same
+        graceful interrupt directly, without depending on Temporal delivery.
+        The CancelledError branch stays as the fallback; the runtime dedupes
+        the interrupt if both fire.
+        """
+        run_id = self.input.curr_run_id
+        if run_id is None:
+            # Legacy/DSL turns have no pinned run id and no cancel endpoint.
+            return
+
+        reason: str | None = None
+        while reason is None:
+            try:
+                reason = await read_turn_cancel_signal(str(run_id))
+            except Exception as e:
+                logger.warning(
+                    "Failed to poll turn cancel signal",
+                    session_id=self.input.session_id,
+                    error=str(e),
+                )
+            if reason is None:
+                await asyncio.sleep(TURN_CANCEL_POLL_INTERVAL_SECONDS)
+
+        logger.info(
+            "Agent turn cancel signal received",
+            session_id=self.input.session_id,
+            run_id=str(run_id),
+            reason=reason,
+        )
+        handler.mark_cancelled(reason)
+        try:
+            async with asyncio.timeout(GRACEFUL_CANCEL_TIMEOUT_SECONDS):
+                # interrupt_turn no-ops while the runtime is still starting up
+                # (work-dir hydration) - retry until it reaches a live runtime
+                # or the turn ends on its own.
+                while not await broker.interrupt_turn(
+                    str(self.input.session_id), reason
+                ):
+                    if broker_task.done():
+                        return
+                    await asyncio.sleep(TURN_CANCEL_POLL_INTERVAL_SECONDS)
+                # Interrupt delivered; the runtime should now wind down and
+                # complete the broker turn. Exceptions surface to the main
+                # wait loop, not here.
+                await asyncio.wait({broker_task})
+        except TimeoutError:
+            logger.warning(
+                "Timed out gracefully stopping agent turn after cancel signal",
+                session_id=self.input.session_id,
+            )
+            await broker.cancel_turn(str(self.input.session_id))
+        except Exception as e:
+            logger.warning(
+                "Failed to gracefully stop agent turn after cancel signal",
+                session_id=self.input.session_id,
+                error=str(e),
+            )
+            await broker.cancel_turn(str(self.input.session_id))
 
     async def _create_job_directory(self) -> Path:
         """Create a temporary job directory with socket subdirectory."""

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -79,6 +79,7 @@ from .schemas import (
 )
 
 BROKER_TASK_CANCEL_TIMEOUT_SECONDS = 5.0
+GRACEFUL_CANCEL_TIMEOUT_SECONDS = 30.0
 
 
 class AgentExecutorInput(BaseModel):
@@ -144,6 +145,8 @@ class AgentExecutorResult(BaseModel):
     )
     result_usage: dict[str, Any] | None = None
     result_num_turns: int | None = None
+    cancelled: bool = False
+    cancelled_reason: str | None = None
 
 
 class ExecuteApprovedToolsInput(BaseModel):
@@ -509,6 +512,8 @@ class SandboxedAgentExecutor:
             result.output = loopback_result.output
         result.result_usage = loopback_result.result_usage
         result.result_num_turns = loopback_result.result_num_turns
+        result.cancelled = loopback_result.cancelled
+        result.cancelled_reason = loopback_result.cancelled_reason
 
     async def _run_with_broker(
         self,
@@ -562,7 +567,7 @@ class SandboxedAgentExecutor:
                 self._log_benchmark_phase("broker_turn_dispatched")
 
                 fatal_error_task = asyncio.create_task(wait_fatal_error())
-                heartbeat_interval = 30
+                heartbeat_interval = 5
                 elapsed = 0
 
                 while elapsed < self.timeout_seconds:
@@ -637,8 +642,33 @@ class SandboxedAgentExecutor:
             if not isinstance(e, ConcurrentSessionTurnError):
                 raise
         except asyncio.CancelledError:
-            await broker.cancel_turn(str(self.input.session_id))
-            raise
+            reason = "user_cancel"
+            logger.info(
+                "Agent activity cancellation requested",
+                session_id=self.input.session_id,
+                reason=reason,
+            )
+            handler.mark_cancelled(reason)
+            try:
+                async with asyncio.timeout(GRACEFUL_CANCEL_TIMEOUT_SECONDS):
+                    await broker.interrupt_turn(str(self.input.session_id), reason)
+                    if broker_task is not None:
+                        await broker_task
+            except TimeoutError:
+                logger.warning(
+                    "Timed out gracefully cancelling agent activity",
+                    session_id=self.input.session_id,
+                )
+                await broker.cancel_turn(str(self.input.session_id))
+                raise
+            except asyncio.CancelledError:
+                await broker.cancel_turn(str(self.input.session_id))
+                raise
+
+            self._apply_loopback_result(result, handler.build_result())
+            result.success = True
+            result.cancelled = True
+            result.cancelled_reason = reason
         finally:
             for task in (fatal_error_task, broker_task):
                 await _cancel_task_with_timeout(task, task_name="agent_executor_task")

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -666,7 +666,8 @@ class SandboxedAgentExecutor:
                 raise
 
             self._apply_loopback_result(result, handler.build_result())
-            result.success = True
+            if result.error is None:
+                result.success = True
             result.cancelled = True
             result.cancelled_reason = reason
         finally:

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -152,6 +152,9 @@ class AgentExecutorResult(BaseModel):
     result_num_turns: int | None = None
     cancelled: bool = False
     cancelled_reason: str | None = None
+    # Tool calls the interrupt aborted mid-flight (errored after cancellation
+    # or never resolved). None on legacy results that predate this field.
+    interrupted_tool_call_ids: list[str] | None = None
 
 
 class ExecuteApprovedToolsInput(BaseModel):
@@ -519,6 +522,9 @@ class SandboxedAgentExecutor:
         result.result_num_turns = loopback_result.result_num_turns
         result.cancelled = loopback_result.cancelled
         result.cancelled_reason = loopback_result.cancelled_reason
+        result.interrupted_tool_call_ids = (
+            loopback_result.interrupted_tool_call_ids or None
+        )
 
     async def _run_with_broker(
         self,
@@ -664,7 +670,17 @@ class SandboxedAgentExecutor:
             handler.mark_cancelled(reason)
             try:
                 async with asyncio.timeout(GRACEFUL_CANCEL_TIMEOUT_SECONDS):
-                    await broker.interrupt_turn(str(self.input.session_id), reason)
+                    # interrupt_turn no-ops while the runtime is still starting
+                    # up (work-dir hydration) - retry until it reaches a live
+                    # runtime or the turn ends on its own, mirroring the Redis
+                    # cancel-signal watcher. The runtime dedupes the interrupt
+                    # if both paths deliver it.
+                    while not await broker.interrupt_turn(
+                        str(self.input.session_id), reason
+                    ):
+                        if broker_task is None or broker_task.done():
+                            break
+                        await asyncio.sleep(TURN_CANCEL_POLL_INTERVAL_SECONDS)
                     if broker_task is not None:
                         await broker_task
             except TimeoutError:

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -383,9 +383,16 @@ class LoopbackHandler:
         if not self._result.cancelled or self._interrupt_notice_emitted:
             return
         self._interrupt_notice_emitted = True
-        await stream_sink.append(
-            UnifiedStreamEvent.cancelled_event(reason=self._result.cancelled_reason)
-        )
+        try:
+            await stream_sink.append(
+                UnifiedStreamEvent.cancelled_event(reason=self._result.cancelled_reason)
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to emit cancellation advisory event",
+                session_id=self.input.session_id,
+                error=str(e),
+            )
 
     async def emit_terminal_error(self, error: str) -> bool:
         """Emit a terminal error through the resolved stream sink.

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -113,6 +113,10 @@ class LoopbackResult:
     result_num_turns: int | None = None
     cancelled: bool = False
     cancelled_reason: str | None = None
+    # Tool calls the interrupt aborted mid-flight: calls that either errored
+    # after cancellation was requested or never produced a result. Empty for
+    # non-cancelled turns.
+    interrupted_tool_call_ids: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -269,6 +273,11 @@ class LoopbackHandler:
         self._persisted_line_uuids: set[str] = set()
         # Track pending approval tool IDs to suppress synthetic interruption results.
         self._pending_approval_tool_call_ids: set[str] = set()
+        # Tool calls that errored after cancellation was requested. Together
+        # with calls that never resolved, these are the interrupt casualties
+        # reported on the cancelled event/result (structured signal - no
+        # error-message inspection involved).
+        self._errored_after_cancel_tool_call_ids: set[str] = set()
         self._tool_names_by_call_id: dict[str, str] = {}
         self._tool_inputs_by_call_id: dict[str, dict[str, Any]] = {}
         self._received_result: bool = False
@@ -377,6 +386,23 @@ class LoopbackHandler:
         self._result.cancelled = True
         self._result.cancelled_reason = reason
 
+    def _collect_interrupted_tool_call_ids(self) -> list[str]:
+        """Resolve which tool calls the interrupt aborted, from tracked state.
+
+        Interrupt casualties are tool calls that errored after cancellation was
+        requested plus calls that never produced a result (still tracked in
+        ``_tool_names_by_call_id``, which pops entries on TOOL_RESULT). Also
+        records the outcome on the loopback result so the activity/workflow can
+        persist it with the cancelled marker.
+        """
+        if not self._result.cancelled:
+            return []
+        interrupted = self._errored_after_cancel_tool_call_ids | set(
+            self._tool_names_by_call_id
+        )
+        self._result.interrupted_tool_call_ids = sorted(interrupted)
+        return self._result.interrupted_tool_call_ids
+
     async def _emit_interrupt_notice_if_cancelled(
         self, stream_sink: LoopbackEventSink
     ) -> None:
@@ -385,7 +411,10 @@ class LoopbackHandler:
         self._interrupt_notice_emitted = True
         try:
             await stream_sink.append(
-                UnifiedStreamEvent.cancelled_event(reason=self._result.cancelled_reason)
+                UnifiedStreamEvent.cancelled_event(
+                    reason=self._result.cancelled_reason,
+                    tool_call_ids=self._collect_interrupted_tool_call_ids(),
+                )
             )
         except Exception as e:
             logger.warning(
@@ -567,12 +596,28 @@ class LoopbackHandler:
 
     def build_result(self) -> LoopbackResult:
         """Return the accumulated result state."""
+        # Idempotent refresh: hard-cancel/error exits can reach here without
+        # passing through the interrupt-notice emit path.
+        self._collect_interrupted_tool_call_ids()
         return self._result
 
     async def _handle_stream_event(self, event: UnifiedStreamEvent) -> bool:
         """Handle a stream event emitted by the runtime."""
         stream_sink = await self.prepare()
         self._track_tool_event(event)
+
+        # After an interrupt is requested, error results are abort artifacts
+        # from the SDK winding down in-flight tools, not genuine failures.
+        # Record them by state (cancel-then-error ordering), never by
+        # inspecting error text. Recorded before suppression so approval-flow
+        # synthetic results are covered too.
+        if (
+            self._result.cancelled
+            and event.type is StreamEventType.TOOL_RESULT
+            and event.is_error
+            and event.tool_call_id is not None
+        ):
+            self._errored_after_cancel_tool_call_ids.add(event.tool_call_id)
 
         if event.type == StreamEventType.APPROVAL_REQUEST:
             logger.info(

--- a/tracecat/agent/executor/loopback.py
+++ b/tracecat/agent/executor/loopback.py
@@ -111,6 +111,8 @@ class LoopbackResult:
     output: RuntimeOutput | None = None
     result_usage: ResultUsage | None = None
     result_num_turns: int | None = None
+    cancelled: bool = False
+    cancelled_reason: str | None = None
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -262,6 +264,7 @@ class LoopbackHandler:
         self._result = LoopbackResult(success=False)
         self._sdk_session_id: str | None = None  # Track SDK session ID for this run
         self._stream_done_emitted: bool = False  # Dedupe flag for stream.done()
+        self._interrupt_notice_emitted: bool = False  # Dedupe for cancelled event
         # Track which session lines have been persisted to avoid duplicates
         self._persisted_line_uuids: set[str] = set()
         # Track pending approval tool IDs to suppress synthetic interruption results.
@@ -362,6 +365,27 @@ class LoopbackHandler:
         await stream_sink.error(error)
         await self._emit_stream_done()
         self._result.terminal_stream_error_emitted = True
+
+    def mark_cancelled(self, reason: str) -> None:
+        """Record that the active runtime turn is expected to stop early.
+
+        Advisory only - the terminal "cancelled" notice is emitted from the
+        normal `_handle_done` path once the runtime actually finishes, so it
+        composes with `send_done()`'s existing dedup guard instead of racing
+        an immediate emit against runtime cleanup.
+        """
+        self._result.cancelled = True
+        self._result.cancelled_reason = reason
+
+    async def _emit_interrupt_notice_if_cancelled(
+        self, stream_sink: LoopbackEventSink
+    ) -> None:
+        if not self._result.cancelled or self._interrupt_notice_emitted:
+            return
+        self._interrupt_notice_emitted = True
+        await stream_sink.append(
+            UnifiedStreamEvent.cancelled_event(reason=self._result.cancelled_reason)
+        )
 
     async def emit_terminal_error(self, error: str) -> bool:
         """Emit a terminal error through the resolved stream sink.
@@ -762,6 +786,7 @@ class LoopbackHandler:
             self._result.error = validation_error
             return True
         self._result.success = True
+        await self._emit_interrupt_notice_if_cancelled(stream_sink)
         await self._emit_stream_done()
         return True
 
@@ -1010,7 +1035,11 @@ class LoopbackHandler:
 
     def _validate_runtime_completion(self) -> str | None:
         """Return a terminal error when runtime completion is missing a usable result."""
-        if self._result.approval_requested or self._result.error is not None:
+        if (
+            self._result.approval_requested
+            or self._result.error is not None
+            or self._result.cancelled
+        ):
             return None
         if not self._received_result:
             return "Runtime completed without final result"

--- a/tracecat/agent/executor_worker.py
+++ b/tracecat/agent/executor_worker.py
@@ -98,6 +98,14 @@ async def main(shutdown_event: asyncio.Event | None = None) -> None:
                 max_concurrent_activities=max_concurrent,
                 disable_eager_activity_execution=config.TEMPORAL__DISABLE_EAGER_ACTIVITY_EXECUTION,
                 activity_executor=executor,
+                # Activity cancellation is only delivered to a running activity
+                # via heartbeat RPC responses, and the SDK throttles those to
+                # 80% of the heartbeat timeout (48s at our 60s timeout) by
+                # default. Cap the throttle so Temporal-driven cancellation
+                # reaches long agent turns promptly; the Redis cancel signal
+                # (tracecat/agent/cancellation.py) remains the primary path.
+                max_heartbeat_throttle_interval=timedelta(seconds=5),
+                default_heartbeat_throttle_interval=timedelta(seconds=5),
                 graceful_shutdown_timeout=timedelta(
                     seconds=config.TRACECAT__AGENT_EXECUTOR_GRACEFUL_SHUTDOWN_TIMEOUT
                 ),

--- a/tracecat/agent/runtime/claude_code/broker.py
+++ b/tracecat/agent/runtime/claude_code/broker.py
@@ -31,6 +31,19 @@ class ConcurrentSessionTurnError(RuntimeError):
     """Raised when a second concurrent turn is started for the same session."""
 
 
+@dataclass(slots=True)
+class ActiveTurn:
+    """Bookkeeping for a broker-managed turn, keyed by session id.
+
+    ``runtime`` starts as ``None`` because the task is registered before the
+    session's ``ClaudeAgentRuntime`` is constructed (path mapping/hydration
+    happens first), then attached once available.
+    """
+
+    task: asyncio.Task[None]
+    runtime: ClaudeAgentRuntime | None = None
+
+
 @dataclass(frozen=True, slots=True)
 class ClaudeTurnRequest:
     """All inputs needed for one broker-managed Claude turn."""
@@ -51,7 +64,7 @@ class ClaudeRuntimeBroker:
     def __init__(self) -> None:
         self._closed = False
         self._leased_sessions: set[str] = set()
-        self._active_turns: dict[str, asyncio.Task[None]] = {}
+        self._active_turns: dict[str, ActiveTurn] = {}
         self._lock = asyncio.Lock()
 
     async def start(self) -> None:
@@ -62,7 +75,7 @@ class ClaudeRuntimeBroker:
         """Cancel any remaining active turns and reject future work."""
         async with self._lock:
             self._closed = True
-            active_tasks = list(self._active_turns.values())
+            active_tasks = [active.task for active in self._active_turns.values()]
         for task in active_tasks:
             task.cancel()
         for task in active_tasks:
@@ -126,7 +139,7 @@ class ClaudeRuntimeBroker:
                 raise ConcurrentSessionTurnError(
                     f"Session {session_key} already has an active turn"
                 )
-            self._active_turns[session_key] = current_task
+            self._active_turns[session_key] = ActiveTurn(task=current_task)
 
         try:
             await handler.prepare()
@@ -176,18 +189,36 @@ class ClaudeRuntimeBroker:
                 if artifact_prompt_fragment
                 else (),
             )
+            async with self._lock:
+                active = self._active_turns.get(session_key)
+                if active is not None and active.task is current_task:
+                    active.runtime = runtime
             await runtime.run(request.init_payload)
         finally:
             async with self._lock:
-                if self._active_turns.get(session_key) is current_task:
+                active = self._active_turns.get(session_key)
+                if active is not None and active.task is current_task:
                     self._active_turns.pop(session_key, None)
 
     async def cancel_turn(self, session_id: str) -> None:
         """Cancel an active turn for the provided session, if one exists."""
         async with self._lock:
-            task = self._active_turns.get(session_id)
-        if task is not None:
-            task.cancel()
+            active = self._active_turns.get(session_id)
+        if active is not None:
+            active.task.cancel()
+
+    async def interrupt_turn(self, session_id: str, reason: str) -> None:
+        """Gracefully interrupt an active turn's Claude SDK client, if any.
+
+        No-op if the turn hasn't constructed its runtime yet (still hydrating
+        the work dir) - the caller's timeout/hard-cancel fallback covers that
+        narrow window.
+        """
+        async with self._lock:
+            active = self._active_turns.get(session_id)
+        if active is None or active.runtime is None:
+            return
+        await active.runtime.interrupt(reason=reason)
 
     @staticmethod
     def _build_path_mapping(*, session_id: str) -> AgentSandboxPathMapping:

--- a/tracecat/agent/runtime/claude_code/broker.py
+++ b/tracecat/agent/runtime/claude_code/broker.py
@@ -78,11 +78,7 @@ class ClaudeRuntimeBroker:
             active_tasks = [active.task for active in self._active_turns.values()]
         for task in active_tasks:
             task.cancel()
-        for task in active_tasks:
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+        await asyncio.gather(*active_tasks, return_exceptions=True)
 
     async def run_turn(
         self,

--- a/tracecat/agent/runtime/claude_code/broker.py
+++ b/tracecat/agent/runtime/claude_code/broker.py
@@ -207,18 +207,20 @@ class ClaudeRuntimeBroker:
         if active is not None:
             active.task.cancel()
 
-    async def interrupt_turn(self, session_id: str, reason: str) -> None:
+    async def interrupt_turn(self, session_id: str, reason: str) -> bool:
         """Gracefully interrupt an active turn's Claude SDK client, if any.
 
-        No-op if the turn hasn't constructed its runtime yet (still hydrating
-        the work dir) - the caller's timeout/hard-cancel fallback covers that
-        narrow window.
+        Returns True once the interrupt was delivered to a live runtime.
+        Returns False (no-op) if the turn hasn't constructed its runtime yet
+        (still hydrating the work dir) - callers retry or rely on a
+        timeout/hard-cancel fallback for that narrow window.
         """
         async with self._lock:
             active = self._active_turns.get(session_id)
         if active is None or active.runtime is None:
-            return
+            return False
         await active.runtime.interrupt(reason=reason)
+        return True
 
     @staticmethod
     def _build_path_mapping(*, session_id: str) -> AgentSandboxPathMapping:

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -274,6 +274,11 @@ class ClaudeAgentRuntime:
         self._pending_approval_tool_ids: set[str] = set()
         self.client: ClaudeSDKClient | None = None
         self._was_interrupted: bool = False
+        self._interrupt_requested: str | None = None
+        self._interrupt_sent: bool = False
+        self._interrupt_lock = asyncio.Lock()
+        self._client_connected_event = asyncio.Event()
+        self._query_sent_event = asyncio.Event()
         # For incremental JSONL line tracking
         self._sdk_session_id: str | None = None
         self._last_seen_byte_offset: int = 0
@@ -872,6 +877,33 @@ class ClaudeAgentRuntime:
             self._was_interrupted = True
             await self.client.interrupt()
 
+    async def interrupt(self, *, reason: str) -> None:
+        """Gracefully stop the in-flight turn via the Claude SDK client.
+
+        Safe to call before the client has connected or before the query has
+        been sent - the request is recorded and applied once both have
+        happened, so a cancel requested early in a turn's lifecycle still
+        takes effect instead of racing the SDK client's own setup.
+        """
+        self._interrupt_requested = reason
+        await self._client_connected_event.wait()
+        await self._query_sent_event.wait()
+        await self._send_pending_interrupt()
+
+    async def _send_pending_interrupt(self) -> None:
+        async with self._interrupt_lock:
+            reason = self._interrupt_requested
+            if reason is None or self._interrupt_sent or self.client is None:
+                return
+            logger.info(
+                "Interrupting Claude runtime",
+                session_id=str(self._session_id),
+                reason=reason,
+            )
+            self._was_interrupted = True
+            self._interrupt_sent = True
+            await self.client.interrupt()
+
     async def _pre_tool_use_hook(
         self,
         input_data: HookInput,
@@ -1087,6 +1119,10 @@ class ClaudeAgentRuntime:
         self._sdk_session_id = None
         self._last_seen_byte_offset = 0
         self._session_flush_event.clear()
+        self._interrupt_requested = None
+        self._interrupt_sent = False
+        self._client_connected_event = asyncio.Event()
+        self._query_sent_event = asyncio.Event()
         self.registry_tools = payload.allowed_actions
         self.tool_approvals = payload.config.tool_approvals
         self._agents_enabled = payload.config.agents.enabled
@@ -1400,6 +1436,7 @@ class ClaudeAgentRuntime:
             logger.debug("Client created, entering context")
             async with client:
                 self.client = client
+                self._client_connected_event.set()
                 log_benchmark_phase("runtime_client_connected")
                 stderr_task = asyncio.create_task(drain_stderr())
                 session_flush_task = asyncio.create_task(
@@ -1422,6 +1459,8 @@ class ClaudeAgentRuntime:
                         )
                     await client.query(query_input)
                     log_benchmark_phase("runtime_query_sent")
+                    self._query_sent_event.set()
+                    await self._send_pending_interrupt()
 
                     await self._event_writer.send_log(
                         "debug", "Query sent, receiving response"

--- a/tracecat/agent/runtime/claude_code/runtime.py
+++ b/tracecat/agent/runtime/claude_code/runtime.py
@@ -884,6 +884,12 @@ class ClaudeAgentRuntime:
         been sent - the request is recorded and applied once both have
         happened, so a cancel requested early in a turn's lifecycle still
         takes effect instead of racing the SDK client's own setup.
+
+        May never return: if the turn dies before the client connects (e.g.
+        transport spawn or resume preparation fails in ``run()``), the
+        connected event is never set and this waits forever. Callers must
+        bound this with a timeout and fall back to hard-cancelling the turn
+        task, as ``run_agent_activity`` does with GRACEFUL_CANCEL_TIMEOUT.
         """
         self._interrupt_requested = reason
         await self._client_connected_event.wait()

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -17,6 +17,8 @@ from tracecat import config
 from tracecat.agent.adapter import vercel
 from tracecat.agent.session.schemas import (
     AgentSessionArtifactsRead,
+    AgentSessionCancelRequest,
+    AgentSessionCancelResponse,
     AgentSessionCreate,
     AgentSessionForkRequest,
     AgentSessionRead,
@@ -42,7 +44,11 @@ from tracecat.chat.schemas import (
     ContinueRunRequest,
 )
 from tracecat.db.dependencies import AsyncDBSession
-from tracecat.exceptions import EntitlementRequired, TracecatNotFoundError
+from tracecat.exceptions import (
+    EntitlementRequired,
+    TracecatConflictError,
+    TracecatNotFoundError,
+)
 from tracecat.logger import logger
 
 router = APIRouter(prefix="/agent/sessions", tags=["agent-sessions"])
@@ -674,9 +680,10 @@ async def stream_session_events(
 
     message_id = _bubble_id(session_id, curr_run_id)
 
-    # FAILED | TERMINATED (incl. failed-to-start): the workflow will not produce a
-    # terminal frame, so emit one ourselves and let the client refetch DB history.
-    if lifecycle is TurnLifecycle.FAILED:
+    # FAILED | TERMINATED (incl. failed-to-start) | CANCELLED: the workflow will
+    # not produce a terminal frame, so emit one ourselves and let the client
+    # refetch DB history.
+    if lifecycle in (TurnLifecycle.FAILED, TurnLifecycle.CANCELLED):
         finished = await AgentStream.new(
             session_id=session_id, workspace_id=workspace_id, stream_id=active_stream_id
         )
@@ -764,4 +771,29 @@ async def fork_session(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
+        ) from e
+
+
+@router.post("/{session_id}/cancel")
+@require_scope("agent:execute")
+async def cancel_session(
+    session_id: uuid.UUID,
+    role: WorkspaceActorRouteRole,
+    session: AsyncDBSession,
+    request: AgentSessionCancelRequest | None = None,
+) -> AgentSessionCancelResponse:
+    """Request graceful cancellation for the active agent session turn."""
+    svc = AgentSessionService(session, role)
+    reason = request.reason if request else "user_cancel"
+    try:
+        return await svc.request_cancel(session_id, reason=reason)
+    except TracecatNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from e
+    except TracecatConflictError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=e.detail or str(e),
         ) from e

--- a/tracecat/agent/session/router.py
+++ b/tracecat/agent/session/router.py
@@ -786,6 +786,15 @@ async def cancel_session(
     svc = AgentSessionService(session, role)
     reason = request.reason if request else "user_cancel"
     try:
+        agent_session = await svc.get_session(session_id)
+        if agent_session is None:
+            raise TracecatNotFoundError(f"Session with ID {session_id} not found")
+        await _require_workspace_chat_entitlement_for_session_tree(
+            svc=svc,
+            session=session,
+            role=role,
+            agent_session=agent_session,
+        )
         return await svc.request_cancel(session_id, reason=reason)
     except TracecatNotFoundError as e:
         raise HTTPException(

--- a/tracecat/agent/session/schemas.py
+++ b/tracecat/agent/session/schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -179,3 +179,17 @@ class AgentSessionForkRequest(BaseModel):
         description="Override entity type for the forked session. "
         "Use 'approval' for inbox forks to hide from main chat list.",
     )
+
+
+class AgentSessionCancelRequest(BaseModel):
+    """Request schema for cancelling the active agent session turn."""
+
+    reason: Literal["user_cancel"] = "user_cancel"
+
+
+class AgentSessionCancelResponse(BaseModel):
+    """Response schema for an accepted agent session cancellation request."""
+
+    session_id: uuid.UUID
+    run_id: uuid.UUID
+    reason: str

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -56,6 +56,7 @@ from tracecat.agent.runtime.claude_code.session_lines import (
 from tracecat.agent.schemas import RunAgentArgs
 from tracecat.agent.service import AgentManagementService
 from tracecat.agent.session.schemas import (
+    AgentSessionCancelResponse,
     AgentSessionCreate,
     AgentSessionRead,
     AgentSessionUpdate,
@@ -104,7 +105,11 @@ from tracecat.db.models import (
 )
 from tracecat.dsl.client import get_temporal_client
 from tracecat.dsl.common import RETRY_POLICIES
-from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
+from tracecat.exceptions import (
+    TracecatConflictError,
+    TracecatNotFoundError,
+    TracecatValidationError,
+)
 from tracecat.identifiers import UserID
 from tracecat.logger import logger
 from tracecat.redis.client import get_redis_client
@@ -1487,8 +1492,10 @@ class AgentSessionService(BaseWorkspaceService):
                 return TurnLifecycleResult(TurnLifecycle.RUNNING, curr_run_id)
             case WorkflowExecutionStatus.COMPLETED:
                 return TurnLifecycleResult(TurnLifecycle.COMPLETED, curr_run_id)
+            case WorkflowExecutionStatus.CANCELED:
+                return TurnLifecycleResult(TurnLifecycle.CANCELLED, curr_run_id)
             case _:
-                # FAILED | TERMINATED | CANCELED | TIMED_OUT
+                # FAILED | TERMINATED | TIMED_OUT
                 return TurnLifecycleResult(TurnLifecycle.FAILED, curr_run_id)
 
     async def validate_turn_request(
@@ -1678,6 +1685,61 @@ class AgentSessionService(BaseWorkspaceService):
         )
 
         return None
+
+    async def request_cancel(
+        self,
+        session_id: uuid.UUID,
+        *,
+        reason: Literal["user_cancel"] = "user_cancel",
+    ) -> AgentSessionCancelResponse:
+        """Request graceful cancellation for the active agent workflow turn.
+
+        Raises:
+            TracecatNotFoundError: If no session exists with this ID.
+            TracecatConflictError: If the session has no active (RUNNING) turn.
+        """
+        from tracecat_ee.agent.types import AgentWorkflowID
+        from tracecat_ee.agent.workflows.durable import (
+            DurableAgentWorkflow,
+            WorkflowCancelRequest,
+        )
+
+        agent_session = await self.get_session(session_id)
+        if agent_session is None:
+            raise TracecatNotFoundError(f"Session with ID {session_id} not found")
+
+        lifecycle, curr_run_id = await self.get_turn_lifecycle(agent_session)
+        if lifecycle is not TurnLifecycle.RUNNING or curr_run_id is None:
+            raise TracecatConflictError(
+                "Agent session does not have an active turn",
+                detail={"lifecycle": lifecycle.value},
+            )
+
+        client = await get_temporal_client()
+        workflow_id = AgentWorkflowID(curr_run_id)
+        handle = client.get_workflow_handle_for(
+            DurableAgentWorkflow.run,
+            str(workflow_id),
+        )
+
+        logger.info(
+            "Requesting agent turn cancellation",
+            workflow_id=str(workflow_id),
+            session_id=str(session_id),
+            run_id=str(curr_run_id),
+            reason=reason,
+        )
+
+        await handle.execute_update(
+            DurableAgentWorkflow.request_cancel,
+            WorkflowCancelRequest(reason=reason),
+        )
+
+        return AgentSessionCancelResponse(
+            session_id=session_id,
+            run_id=curr_run_id,
+            reason=reason,
+        )
 
     @contextlib.asynccontextmanager
     async def _build_agent_config(

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -836,6 +836,8 @@ class AgentSessionService(BaseWorkspaceService):
         session_id: uuid.UUID,
         *,
         reason: str | None = None,
+        interrupted_tool_call_ids: list[str] | None = None,
+        curr_run_id: uuid.UUID | None = None,
     ) -> None:
         """Persist a turn-cancelled marker row into the session history.
 
@@ -843,6 +845,16 @@ class AgentSessionService(BaseWorkspaceService):
         timeline after a reload; the live turn gets the equivalent signal from
         the ``cancelled`` stream event. It is not an SDK transcript line, so
         history hydration must skip it (see ``get_session_history_data``).
+
+        ``interrupted_tool_call_ids`` carries the tool calls the interrupt
+        aborted mid-flight so reloads can render them as "interrupted" instead
+        of surfacing SDK abort artifacts as tool errors.
+
+        ``curr_run_id`` pins the marker to the cancelled run. Callers that
+        know their run id (the workflow) must pass it: the session row's
+        ``curr_run_id`` may already point at a newer turn by the time the
+        cancelled workflow finalizes, which would tag the marker to the wrong
+        run and hide it while that turn is mid-flight.
         """
         agent_session = await self.get_session(session_id)
         if agent_session is None:
@@ -853,6 +865,8 @@ class AgentSessionService(BaseWorkspaceService):
             "reason": reason or "user_cancel",
             "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         }
+        if interrupted_tool_call_ids:
+            content["tool_call_ids"] = list(interrupted_tool_call_ids)
         # Tag with the active run id like other mid-turn rows so the marker
         # stays hidden from DB reloads until terminal cleanup reveals it
         # together with the rest of the turn.
@@ -862,7 +876,9 @@ class AgentSessionService(BaseWorkspaceService):
                 workspace_id=self.workspace_id,
                 content=content,
                 kind=MessageKind.CANCELLED.value,
-                curr_run_id=agent_session.curr_run_id,
+                curr_run_id=curr_run_id
+                if curr_run_id is not None
+                else agent_session.curr_run_id,
             )
         )
         await self.session.commit()
@@ -2173,13 +2189,27 @@ class AgentSessionService(BaseWorkspaceService):
                     continue
 
                 reason = content.get("reason")
+                raw_tool_call_ids = content.get("tool_call_ids")
+                tool_call_ids = [
+                    item
+                    for item in (
+                        raw_tool_call_ids if isinstance(raw_tool_call_ids, list) else []
+                    )
+                    if isinstance(item, str)
+                ]
+                cancelled_payload: dict[str, Any] = {
+                    "reason": reason if isinstance(reason, str) else None,
+                }
+                if tool_call_ids:
+                    # Structured interrupt metadata for the UI: tool calls
+                    # aborted by this interrupt. Omitted when empty to match
+                    # the marker row's write-side shape.
+                    cancelled_payload["tool_call_ids"] = tool_call_ids
                 messages.append(
                     ChatMessage(
                         id=str(entry.id),
                         kind=kind,
-                        cancelled={
-                            "reason": reason if isinstance(reason, str) else None
-                        },
+                        cancelled=cancelled_payload,
                     )
                 )
                 continue

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -41,6 +41,7 @@ import tracecat.agent.adapter.vercel
 import tracecat.artifacts.projection as artifact_projection
 from tracecat import config
 from tracecat.agent.approvals.enums import ApprovalStatus
+from tracecat.agent.cancellation import signal_turn_cancel
 from tracecat.agent.common.types import MCPServerConfig
 from tracecat.agent.llm import LLMCompletionError
 from tracecat.agent.mcp.metadata import sanitize_message_tool_inputs
@@ -830,6 +831,42 @@ class AgentSessionService(BaseWorkspaceService):
         await self.session.execute(stmt)
         await self.session.commit()
 
+    async def append_cancelled_marker(
+        self,
+        session_id: uuid.UUID,
+        *,
+        reason: str | None = None,
+    ) -> None:
+        """Persist a turn-cancelled marker row into the session history.
+
+        The marker renders as the "stopped by user" divider in the chat
+        timeline after a reload; the live turn gets the equivalent signal from
+        the ``cancelled`` stream event. It is not an SDK transcript line, so
+        history hydration must skip it (see ``get_session_history_data``).
+        """
+        agent_session = await self.get_session(session_id)
+        if agent_session is None:
+            raise TracecatNotFoundError(f"Session with ID {session_id} not found")
+
+        content: dict[str, Any] = {
+            "type": "cancelled",
+            "reason": reason or "user_cancel",
+            "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        }
+        # Tag with the active run id like other mid-turn rows so the marker
+        # stays hidden from DB reloads until terminal cleanup reveals it
+        # together with the rest of the turn.
+        self.session.add(
+            AgentSessionHistory(
+                session_id=session_id,
+                workspace_id=self.workspace_id,
+                content=content,
+                kind=MessageKind.CANCELLED.value,
+                curr_run_id=agent_session.curr_run_id,
+            )
+        )
+        await self.session.commit()
+
     async def clear_active_turn(
         self,
         session_id: uuid.UUID,
@@ -954,6 +991,11 @@ class AgentSessionService(BaseWorkspaceService):
             if entry.kind == MessageKind.INTERNAL.value:
                 if line_uuid is not None:
                     internal_uuids.add(line_uuid)
+                continue
+
+            # Cancelled markers are UI-only timeline rows, not SDK transcript
+            # lines - feeding one into the rebuilt JSONL would corrupt resume.
+            if entry.kind == MessageKind.CANCELLED.value:
                 continue
 
             if is_continuation_control_artifact(content, internal_uuids):
@@ -1736,6 +1778,22 @@ class AgentSessionService(BaseWorkspaceService):
             reason=reason,
         )
 
+        # Out-of-band fast path: the executor activity polls this signal and
+        # interrupts the live runtime directly. Temporal activity cancellation
+        # only reaches a running activity via throttled heartbeat RPCs, so a
+        # turn can otherwise finish before the cancel is ever delivered. Write
+        # it before the workflow update to minimize stop latency; best-effort
+        # because the update-driven path still cancels (slower) without it.
+        try:
+            await signal_turn_cancel(str(curr_run_id), reason=reason)
+        except Exception as e:
+            logger.warning(
+                "Failed to write turn cancel signal",
+                session_id=str(session_id),
+                run_id=str(curr_run_id),
+                error=str(e),
+            )
+
         await handle.execute_update(
             DurableAgentWorkflow.request_cancel,
             WorkflowCancelRequest(reason=reason),
@@ -2101,6 +2159,27 @@ class AgentSessionService(BaseWorkspaceService):
                         id=str(entry.id),
                         kind=kind,
                         compaction=compaction_data,
+                    )
+                )
+                continue
+
+            # Handle cancelled markers: divider rows showing where the user
+            # stopped an in-flight turn.
+            if entry.kind == MessageKind.CANCELLED.value:
+                kind = MessageKind.CANCELLED
+
+                # Filter by kinds if specified
+                if kinds and kind not in kinds:
+                    continue
+
+                reason = content.get("reason")
+                messages.append(
+                    ChatMessage(
+                        id=str(entry.id),
+                        kind=kind,
+                        cancelled={
+                            "reason": reason if isinstance(reason, str) else None
+                        },
                     )
                 )
                 continue

--- a/tracecat/agent/session/service.py
+++ b/tracecat/agent/session/service.py
@@ -1708,6 +1708,12 @@ class AgentSessionService(BaseWorkspaceService):
         if agent_session is None:
             raise TracecatNotFoundError(f"Session with ID {session_id} not found")
 
+        if (
+            AgentSessionEntity(agent_session.entity_type)
+            is AgentSessionEntity.WORKSPACE_CHAT
+        ):
+            await self.require_entitlement(Entitlement.WORKSPACE_CHAT)
+
         lifecycle, curr_run_id = await self.get_turn_lifecycle(agent_session)
         if lifecycle is not TurnLifecycle.RUNNING or curr_run_id is None:
             raise TracecatConflictError(

--- a/tracecat/agent/session/types.py
+++ b/tracecat/agent/session/types.py
@@ -16,12 +16,20 @@ class TurnLifecycle(StrEnum):
     - COMPLETED: turn done; canonical history is in the DB (-> 204).
     - FAILED: workflow failed/terminated (incl. failed-to-start); emit a
       terminal error frame + done so the client doesn't hang.
+    - CANCELLED: workflow's own Temporal execution status is CANCELED
+      (e.g. an operator called handle.cancel()/handle.terminate() directly).
+      This is defense-in-depth only: a normal user-initiated cancel goes
+      through the `request_cancel` workflow update, which lets the workflow
+      return normally, so get_turn_lifecycle reports it as COMPLETED, not
+      CANCELLED. The real "was this turn cancelled" signal for clients is
+      the `data-cancelled` stream event emitted mid-turn, not this value.
     """
 
     NONE = "none"
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
+    CANCELLED = "cancelled"
 
 
 class TurnLifecycleResult(NamedTuple):

--- a/tracecat/chat/constants.py
+++ b/tracecat/chat/constants.py
@@ -8,3 +8,6 @@ APPROVAL_DATA_PART_TYPE = "data-approval-request"
 
 COMPACTION_DATA_PART_TYPE = "data-compaction"
 """UI data part identifier for transient compaction status payloads."""
+
+CANCELLED_DATA_PART_TYPE = "data-cancelled"
+"""UI data part identifier for turn-cancelled notice payloads."""

--- a/tracecat/chat/enums.py
+++ b/tracecat/chat/enums.py
@@ -26,3 +26,6 @@ class MessageKind(StrEnum):
     COMPACTION = (
         "compaction"  # Compaction status badge shown when conversation is compacted
     )
+    CANCELLED = (
+        "cancelled"  # Marker shown where the user stopped an in-flight agent turn
+    )

--- a/tracecat/chat/schemas.py
+++ b/tracecat/chat/schemas.py
@@ -214,6 +214,7 @@ class ChatMessage(BaseModel):
     - kind=CHAT_MESSAGE: Contains message field with user/assistant content
     - kind=APPROVAL_REQUEST/APPROVAL_DECISION: Contains approval field with approval data
     - kind=COMPACTION: Contains compaction field with compaction status data
+    - kind=CANCELLED: Contains cancelled field with turn-cancelled marker data
     """
 
     id: str = Field(..., description="Unique message identifier")
@@ -232,6 +233,10 @@ class ChatMessage(BaseModel):
     compaction: dict[str, Any] | None = Field(
         default=None,
         description="Compaction status data for badge rendering (for kind=COMPACTION)",
+    )
+    cancelled: dict[str, Any] | None = Field(
+        default=None,
+        description="Turn-cancelled marker data (for kind=CANCELLED)",
     )
 
     @classmethod


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Stop control to interrupt an active agent turn with fast, graceful cancellation across workflow, runtime, and UI. Cancels use a low-latency Redis signal, preserve runtime errors, render an “Interrupted” divider, and mark affected tool calls as interrupted without surfacing abort noise.

- **New Features**
  - API: `POST /workspaces/{workspace_id}/agent/sessions/{session_id}/cancel` accepts `{ reason: "user_cancel" }`, returns `{ session_id, run_id, reason }`, responds `409` if no turn is running; enforces workspace chat entitlement.
  - Cancellation flow: Workflow `request_cancel` works mid-turn, during approvals, and before tool execution; writes a Redis signal keyed by `run_id` that the executor polls; emits a `data-cancelled` stream event with `tool_call_ids`; persists a `CANCELLED` message pinned to the cancelled `run_id` for reloads.
  - UI: Stop button added; submit is disabled while generating/cancelling; shows a centered “Interrupted” divider; aborted tool calls display “Interrupted” via a new `output-interrupted` state. Added `useCancelChatTurn` and support for `data-cancelled` parts in live streams and saved messages.

- **Bug Fixes**
  - Executor/Broker/Runtime: Eagerly queues `interrupt()` before client connect or query send, with a 30s hard-cancel fallback; tracks active turns with runtime handles; reports success only when the runtime had no error; derives `interrupted_tool_call_ids` from cancel-then-error ordering.
  - Router/Workflow/Streaming: Treats Temporal `CANCELLED` as terminal and emits a final frame; centralized cancelled-turn output helper ensures consistent final notices and history; worker caps heartbeat throttle at 5s so SDK-driven cancels arrive faster.

<sup>Written for commit 889627398faa7be388aa14d91153a10b8eaf1870. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

