### PR TITLE
fix(ui): keyboard selection and dismiss dead-state in tag combobox

### DIFF
--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -15,6 +15,9 @@ global.TransformStream = TransformStream
 global.ReadableStream = ReadableStream
 global.WritableStream = WritableStream
 
+// jsdom does not implement scrollIntoView (used by cmdk selection)
+Element.prototype.scrollIntoView = jest.fn()
+
 // Mock next-runtime-env
 jest.mock("next-runtime-env", () => ({
   env: jest.fn((key) => process.env[key] || ""),

--- a/frontend/src/components/tags-input.tsx
+++ b/frontend/src/components/tags-input.tsx
@@ -98,6 +98,9 @@ export function MultiTagCommandInput({
   const inputRef = useRef<HTMLInputElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  // Enter only selects once the user has typed or navigated, so tabbing into
+  // the field and pressing Enter doesn't add an arbitrary tag
+  const hasNavigatedRef = useRef(false)
   const value = useMemo(() => {
     if (typeof valueProp === "string") {
       return [valueProp]
@@ -141,6 +144,15 @@ export function MultiTagCommandInput({
     return filterActions(filtered, inputValue).map((result) => result.obj)
   }, [suggestions, inputValue, valueSet, filterActions])
 
+  // Offer an explicit "Add <text>" row so custom tags stay reachable even
+  // when the typed text fuzzy-matches existing suggestions
+  const customTagText = allowCustomTags ? inputValue.trim() : ""
+  const showCustomRow =
+    customTagText.length > 0 &&
+    !valueSet.has(customTagText) &&
+    !filteredSuggestions.some((s) => s.value === customTagText)
+  const rowCount = filteredSuggestions.length + (showCustomRow ? 1 : 0)
+
   const handleSelect = (suggestion: Suggestion) => {
     if (suggestion.locked) {
       suggestion.onSelect?.()
@@ -152,9 +164,23 @@ export function MultiTagCommandInput({
     const newValue = [...value, suggestion.value]
     onChange?.(newValue)
     setInputValue("")
-    setHighlightedIndex(-1)
+    setHighlightedIndex(0)
+    hasNavigatedRef.current = false
 
     // Keep dropdown open and focused for multiple selections
+    setTimeout(() => inputRef.current?.focus(), 0)
+  }
+
+  const handleAddCustomTag = () => {
+    if (!customTagText || valueSet.has(customTagText)) return
+    if (maxTags && value.length >= maxTags) return
+
+    const newValue = [...value, customTagText]
+    onChange?.(newValue)
+    setInputValue("")
+    setHighlightedIndex(0)
+    hasNavigatedRef.current = false
+
     setTimeout(() => inputRef.current?.focus(), 0)
   }
 
@@ -165,37 +191,58 @@ export function MultiTagCommandInput({
 
   const handleInputChange = (val: string) => {
     setInputValue(val)
-    setHighlightedIndex(-1) // Reset highlight when typing
+    setHighlightedIndex(0) // Highlight the top match when typing
+    if (!disableSuggestions) {
+      setOpen(true) // Reopen the dropdown if it was dismissed
+    }
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown" && open && rowCount > 0) {
+      e.preventDefault()
+      hasNavigatedRef.current = true
+      setHighlightedIndex((index) => Math.min(index + 1, rowCount - 1))
+      return
+    }
+
+    if (e.key === "ArrowUp" && open && rowCount > 0) {
+      e.preventDefault()
+      hasNavigatedRef.current = true
+      setHighlightedIndex((index) => Math.max(index - 1, 0))
+      return
+    }
+
     if (e.key === "Enter") {
       // Always prevent default form submission when Enter is pressed
       e.preventDefault()
       e.stopPropagation()
 
-      if (allowCustomTags && inputValue.trim()) {
-        // Don't add if it already exists or if we've hit the max
-        if (
-          valueSet.has(inputValue.trim()) ||
-          (maxTags && value.length >= maxTags)
-        ) {
-          return
+      const canSelectHighlighted =
+        inputValue.trim().length > 0 || hasNavigatedRef.current
+      if (
+        open &&
+        canSelectHighlighted &&
+        highlightedIndex >= 0 &&
+        highlightedIndex < rowCount
+      ) {
+        const suggestion = filteredSuggestions[highlightedIndex]
+        if (suggestion) {
+          handleSelect(suggestion)
+        } else {
+          handleAddCustomTag()
         }
-
-        const newValue = [...value, inputValue.trim()]
-        onChange?.(newValue)
-        setInputValue("")
-        setHighlightedIndex(-1)
+        return
       }
+
+      handleAddCustomTag()
     }
   }
 
   const handleFocus = () => {
     if (!disableSuggestions) {
       setOpen(true) // Only show dropdown when suggestions are enabled
-      // Set to first item if there are suggestions, otherwise -1
-      setHighlightedIndex(filteredSuggestions.length > 0 ? 0 : -1)
+      setHighlightedIndex(0)
+      hasNavigatedRef.current = false
     }
   }
 
@@ -271,9 +318,26 @@ export function MultiTagCommandInput({
           className="mt-1 w-[var(--radix-popover-trigger-width)] p-0"
           align="start"
           onOpenAutoFocus={(e) => e.preventDefault()}
+          onInteractOutside={(e) => {
+            // Clicks inside the input container (e.g. repositioning the
+            // cursor) must not dismiss the dropdown
+            if (
+              e.target instanceof Node &&
+              containerRef.current?.contains(e.target)
+            ) {
+              e.preventDefault()
+            }
+          }}
         >
           <Command
             shouldFilter={false}
+            value={`${highlightedIndex}`}
+            onValueChange={(nextValue) => {
+              const index = Number.parseInt(nextValue, 10)
+              if (!Number.isNaN(index)) {
+                setHighlightedIndex(index)
+              }
+            }}
             onKeyDown={(e) => {
               // Prevent Command from handling arrow keys and enter
               if (["ArrowDown", "ArrowUp", "Enter"].includes(e.key)) {
@@ -295,9 +359,7 @@ export function MultiTagCommandInput({
                       data-suggestion-index={index}
                       className={cn(
                         "flex cursor-pointer gap-2",
-                        suggestion.locked && "text-muted-foreground",
-                        index === highlightedIndex &&
-                          "bg-accent text-accent-foreground"
+                        suggestion.locked && "text-muted-foreground"
                       )}
                     >
                       {suggestion.icon && (
@@ -328,6 +390,19 @@ export function MultiTagCommandInput({
                     </CommandItem>
                   )
                 })}
+                {showCustomRow && (
+                  <CommandItem
+                    key="__custom-tag__"
+                    value={`${filteredSuggestions.length}`}
+                    onSelect={handleAddCustomTag}
+                    onMouseDown={(e) => e.preventDefault()}
+                    className="flex cursor-pointer gap-2"
+                  >
+                    <span className="text-xs text-muted-foreground">
+                      Add &quot;{customTagText}&quot;
+                    </span>
+                  </CommandItem>
+                )}
               </CommandList>
             </ScrollArea>
           </Command>

--- a/frontend/tests/tags-input.test.tsx
+++ b/frontend/tests/tags-input.test.tsx
@@ -73,4 +73,169 @@ describe("MultiTagCommandInput", () => {
 
     expect(handleChange).toHaveBeenCalledWith([unsafeValue])
   })
+
+  describe("keyboard selection", () => {
+    const suggestions = [
+      {
+        id: "a",
+        label: "Alpha tool",
+        value: "tools.alpha.run",
+        description: "Alpha",
+        group: "tools",
+      },
+      {
+        id: "b",
+        label: "Beta tool",
+        value: "tools.beta.run",
+        description: "Beta",
+        group: "tools",
+      },
+      {
+        id: "g",
+        label: "Gamma tool",
+        value: "tools.gamma.run",
+        description: "Gamma",
+        group: "tools",
+      },
+    ]
+    const searchKeys: Array<"label" | "value" | "description" | "group"> = [
+      "label",
+      "value",
+      "description",
+      "group",
+    ]
+
+    it("selects the highlighted suggestion on Enter instead of adding raw text", () => {
+      const handleChange = jest.fn()
+      render(
+        <MultiTagCommandInput
+          onChange={handleChange}
+          suggestions={suggestions}
+          searchKeys={searchKeys}
+          allowCustomTags
+        />
+      )
+
+      const input = screen.getByPlaceholderText("Add tags...")
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: "gamma" } })
+      fireEvent.keyDown(input, { key: "Enter" })
+
+      expect(handleChange).toHaveBeenCalledWith(["tools.gamma.run"])
+    })
+
+    it("moves the highlight with arrow keys before selecting", () => {
+      const handleChange = jest.fn()
+      render(
+        <MultiTagCommandInput
+          onChange={handleChange}
+          suggestions={suggestions}
+          searchKeys={searchKeys}
+        />
+      )
+
+      const input = screen.getByPlaceholderText("Add tags...")
+      fireEvent.focus(input)
+      fireEvent.keyDown(input, { key: "ArrowDown" })
+      fireEvent.keyDown(input, { key: "Enter" })
+
+      expect(handleChange).toHaveBeenCalledWith(["tools.beta.run"])
+    })
+
+    it("adds a custom tag through the explicit add row", () => {
+      const handleChange = jest.fn()
+      render(
+        <MultiTagCommandInput
+          onChange={handleChange}
+          suggestions={suggestions}
+          searchKeys={searchKeys}
+          allowCustomTags
+        />
+      )
+
+      const input = screen.getByPlaceholderText("Add tags...")
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: "tools.custom.thing" } })
+
+      const addRow = screen.getByText('Add "tools.custom.thing"')
+      fireEvent.mouseDown(addRow)
+      fireEvent.click(addRow)
+
+      expect(handleChange).toHaveBeenCalledWith(["tools.custom.thing"])
+    })
+
+    it("does nothing on Enter before typing or navigating", () => {
+      const handleChange = jest.fn()
+      render(
+        <MultiTagCommandInput
+          onChange={handleChange}
+          suggestions={suggestions}
+          searchKeys={searchKeys}
+          allowCustomTags
+        />
+      )
+
+      const input = screen.getByPlaceholderText("Add tags...")
+      fireEvent.focus(input)
+      fireEvent.keyDown(input, { key: "Enter" })
+
+      expect(handleChange).not.toHaveBeenCalled()
+    })
+
+    it("keeps the dropdown open when clicking inside the input container", () => {
+      render(
+        <MultiTagCommandInput
+          suggestions={suggestions}
+          searchKeys={searchKeys}
+        />
+      )
+
+      const input = screen.getByPlaceholderText("Add tags...")
+      fireEvent.focus(input)
+      expect(screen.getByText("Alpha tool")).toBeInTheDocument()
+
+      // Radix treats pointerdown outside the portaled content as a dismiss;
+      // a click inside the anchor container must not close the dropdown
+      fireEvent.pointerDown(input)
+      expect(screen.getByText("Alpha tool")).toBeInTheDocument()
+    })
+
+    it("reopens the dropdown when typing after it was dismissed", () => {
+      render(
+        <MultiTagCommandInput
+          suggestions={suggestions}
+          searchKeys={searchKeys}
+        />
+      )
+
+      const input = screen.getByPlaceholderText("Add tags...")
+      fireEvent.focus(input)
+      expect(screen.getByText("Alpha tool")).toBeInTheDocument()
+
+      fireEvent.blur(input)
+      expect(screen.queryByText("Alpha tool")).not.toBeInTheDocument()
+
+      fireEvent.change(input, { target: { value: "beta" } })
+      expect(screen.getByText("Beta tool")).toBeInTheDocument()
+    })
+
+    it("adds a custom tag on Enter when nothing matches", () => {
+      const handleChange = jest.fn()
+      render(
+        <MultiTagCommandInput
+          onChange={handleChange}
+          suggestions={suggestions}
+          searchKeys={searchKeys}
+          allowCustomTags
+        />
+      )
+
+      const input = screen.getByPlaceholderText("Add tags...")
+      fireEvent.focus(input)
+      fireEvent.change(input, { target: { value: "zzzzqqqq" } })
+      fireEvent.keyDown(input, { key: "Enter" })
+
+      expect(handleChange).toHaveBeenCalledWith(["zzzzqqqq"])
+    })
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes keyboard selection and the dropdown dismiss “dead-state” in the tag combobox for more predictable, keyboard-friendly tagging. Adds an explicit “Add "<text>"” row to reliably create custom tags.

- **Bug Fixes**
  - Enter only selects after typing or navigating; tab-in + Enter does nothing.
  - Arrow keys move the highlight; typing auto-highlights the top match; Enter picks the highlighted row.
  - Adds “Add "<text>"” row for custom tags; Enter selects it when no match exists.
  - Dropdown stays open when clicking inside the input container and reopens on typing after a dismiss.
  - Resets highlight and refocuses after selection for smoother multi-select.
  - Test env: mock `Element.prototype.scrollIntoView` for `jsdom` to support `cmdk` list behavior.

<sup>Written for commit 9181be4ee18aae84c7f6288f137cf3f0379c53a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

