### PR TITLE
feat(integrations): freshservice mcp and actions

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
+++ b/packages/tracecat-ee/tracecat_ee/mcp/catalog/mcp_catalog_private.json
@@ -1620,6 +1620,80 @@
       }
     },
     {
+      "slug": "freshservice-mcp",
+      "docs": "https://support.freshservice.com/support/solutions/articles/50000012678-model-context-protocol-mcp-integration-in-freshservice-eap-",
+      "default_connection_option": "remote-oauth",
+      "connection_options": [
+        {
+          "id": "remote-oauth",
+          "label": "Remote OAuth",
+          "description": "Connect to Freshservice's hosted MCP server using OAuth dynamic discovery.",
+          "docs": "https://support.freshservice.com/support/solutions/articles/50000012678-model-context-protocol-mcp-integration-in-freshservice-eap-",
+          "connection_spec": {
+            "server_type": "http",
+            "auth_type": "OAUTH2",
+            "server_uri": "https://{FRESHSERVICE_DOMAIN}/mcp",
+            "scopes": [],
+            "oauth_authorization_endpoint": null,
+            "oauth_token_endpoint": null,
+            "credentials": [
+              {
+                "key": "FRESHSERVICE_DOMAIN",
+                "label": "Freshservice domain",
+                "description": "Your Freshservice domain, e.g. acme.freshservice.com. Freshservice MCP uses https://{FRESHSERVICE_DOMAIN}/mcp.",
+                "required": true,
+                "secret": false,
+                "target": "server_uri"
+              }
+            ],
+            "confidence": "high",
+            "docker_only": false,
+            "research_notes": "Freshservice's official EAP documentation describes a hosted MCP server at https://<your-freshservice-domain>/mcp. The integration is currently Beta/EAP for selected Freshservice Enterprise customers and requires administrator or agent privileges. OAuth is the recommended configuration path: clients connect over HTTP/streamable HTTP to the tenant MCP URL, then complete the browser authorization flow. Freshservice's docs show OAuth examples for Claude Connector, Cursor, Microsoft Copilot Studio, and VS Code; for clients that need a local stdio bridge, they recommend npx mcp-remote against the same remote URL. Because the actual MCP server is hosted by Freshservice, the catalog entry is modeled as HTTP, not stdio, and no npx/uvx/pip package is recorded. Authorization/token endpoints are discovered dynamically from the tenant MCP server, so explicit OAuth endpoints are left null. No OAuth scopes are documented.",
+            "sources": [
+              "https://support.freshservice.com/support/solutions/articles/50000012678-model-context-protocol-mcp-integration-in-freshservice-eap-"
+            ]
+          }
+        },
+        {
+          "id": "api-key",
+          "label": "API key",
+          "description": "Connect over HTTP with a Freshservice API key in the Authorization header.",
+          "docs": "https://support.freshservice.com/support/solutions/articles/50000012678-model-context-protocol-mcp-integration-in-freshservice-eap-",
+          "connection_spec": {
+            "server_type": "http",
+            "auth_type": "CUSTOM",
+            "server_uri": "https://{FRESHSERVICE_DOMAIN}/mcp",
+            "credentials": [
+              {
+                "key": "FRESHSERVICE_DOMAIN",
+                "label": "Freshservice domain",
+                "description": "Your Freshservice domain, e.g. acme.freshservice.com. Freshservice MCP uses https://{FRESHSERVICE_DOMAIN}/mcp.",
+                "required": true,
+                "secret": false,
+                "target": "server_uri"
+              },
+              {
+                "key": "Authorization",
+                "label": "Freshservice API key",
+                "description": "Freshservice API key sent as the Authorization header. Freshservice recommends OAuth 2.0 where possible.",
+                "required": true,
+                "secret": true,
+                "placeholder": "<API-KEY>",
+                "target": "http_header"
+              }
+            ],
+            "confidence": "high",
+            "docker_only": false,
+            "research_notes": "Freshservice documents API-key authentication as the OAuth alternative for MCP clients. The examples use HTTP transport to https://<your-freshservice-domain>/mcp with a custom Authorization header containing the API key. Freshservice explicitly recommends OAuth 2.0 as the best practice; this option exists for environments that cannot complete OAuth.",
+            "sources": [
+              "https://support.freshservice.com/support/solutions/articles/50000012678-model-context-protocol-mcp-integration-in-freshservice-eap-",
+              "https://api.freshservice.com/#authentication"
+            ]
+          }
+        }
+      ]
+    },
+    {
       "slug": "servicenow-mcp",
       "docs": "https://www.servicenow.com/docs/r/zurich/intelligent-experiences/mcp-platform-manager-landing.html",
       "connection_spec": {

--- a/packages/tracecat-registry/tracecat_registry/integrations/freshservice.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/freshservice.py
@@ -1,0 +1,810 @@
+"""Freshservice REST API integrations."""
+
+from collections.abc import Mapping
+from typing import Annotated, Any, Literal, TypedDict, cast
+from urllib.parse import parse_qs, urlparse, urlunparse
+
+import httpx
+from pydantic import Field
+
+from tracecat_registry import RegistrySecret, SecretNotFoundError, registry, secrets
+
+FRESHSERVICE_API_DOC_URL = "https://api.freshservice.com/"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+type FreshserviceMethod = Literal["GET", "POST", "PUT", "PATCH", "DELETE"]
+
+BaseUrlParam = Annotated[
+    str | None,
+    Field(
+        ...,
+        description=(
+            "Freshservice tenant URL or API URL. Defaults to "
+            "`FRESHSERVICE_BASE_URL`, e.g. `https://example.freshservice.com`."
+        ),
+    ),
+]
+QueryParamsParam = Annotated[
+    dict[str, Any] | None,
+    Field(..., description="Freshservice query parameters."),
+]
+RequestBodyParam = Annotated[
+    dict[str, Any] | None,
+    Field(..., description="Freshservice JSON request body."),
+]
+PerPageParam = Annotated[
+    int,
+    Field(..., ge=1, le=100, description="Freshservice `per_page` value."),
+]
+MaxPagesParam = Annotated[
+    int | None,
+    Field(..., ge=1, description="Maximum pages to fetch."),
+]
+
+
+class FreshservicePaginatedResult(TypedDict):
+    items: list[Any]
+    pages: int
+    next_page: int | None
+
+
+freshservice_secret = RegistrySecret(
+    name="freshservice",
+    keys=["FRESHSERVICE_API_KEY"],
+    optional_keys=["FRESHSERVICE_BASE_URL"],
+)
+"""Freshservice API credentials.
+
+- name: `freshservice`
+- keys:
+    - `FRESHSERVICE_API_KEY`
+- optional keys:
+    - `FRESHSERVICE_BASE_URL`
+"""
+
+
+def _drop_none(params: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in params.items() if value is not None}
+
+
+def _resolve_base_url(base_url: str | None) -> str:
+    resolved = (
+        base_url or secrets.get_or_default("FRESHSERVICE_BASE_URL") or ""
+    ).strip()
+    if not resolved:
+        raise SecretNotFoundError(
+            "Freshservice calls require `base_url` or `FRESHSERVICE_BASE_URL`, "
+            "e.g. `https://example.freshservice.com`."
+        )
+
+    if "://" not in resolved:
+        resolved = f"https://{resolved}"
+
+    parsed = urlparse(resolved.rstrip("/"))
+    path = parsed.path.rstrip("/")
+    if path == "/api/v2":
+        return urlunparse(parsed._replace(path=path))
+    if not path:
+        return f"{urlunparse(parsed._replace(path=''))}/api/v2"
+    return f"{urlunparse(parsed._replace(path=path))}/api/v2"
+
+
+def _normalize_path(path: str) -> str:
+    stripped = path.strip()
+    if not stripped:
+        raise ValueError("Freshservice API path cannot be empty.")
+    parsed = urlparse(stripped)
+    if parsed.scheme or parsed.netloc:
+        raise ValueError(
+            "Freshservice API path must be relative, e.g. `/tickets`, not a URL."
+        )
+    if stripped == "/api/v2":
+        return ""
+    if stripped.startswith("/api/v2/"):
+        stripped = stripped.removeprefix("/api/v2")
+    if not stripped.startswith("/"):
+        stripped = f"/{stripped}"
+    return stripped
+
+
+def _decode_response(response: httpx.Response) -> dict[str, Any] | list[Any]:
+    response.raise_for_status()
+    if not response.content:
+        return {"status": "success", "status_code": response.status_code}
+    try:
+        return cast(dict[str, Any] | list[Any], response.json())
+    except ValueError:
+        return {"status_code": response.status_code, "body": response.text}
+
+
+async def _request_freshservice_api(
+    *,
+    method: FreshserviceMethod,
+    path: str,
+    base_url: str | None = None,
+    query_params: dict[str, Any] | None = None,
+    json_body: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any] | list[Any]:
+    response, _ = await _request_freshservice_http(
+        method=method,
+        path=path,
+        base_url=base_url,
+        query_params=query_params,
+        json_body=json_body,
+        headers=headers,
+        timeout=timeout,
+    )
+    return response
+
+
+async def _request_freshservice_http(
+    *,
+    method: FreshserviceMethod,
+    path: str,
+    base_url: str | None = None,
+    query_params: dict[str, Any] | None = None,
+    json_body: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> tuple[dict[str, Any] | list[Any], httpx.Headers]:
+    resolved_base_url = _resolve_base_url(base_url)
+    url = f"{resolved_base_url}{_normalize_path(path)}"
+    request_headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    if headers:
+        request_headers.update(headers)
+
+    async with httpx.AsyncClient(
+        auth=httpx.BasicAuth(secrets.get("FRESHSERVICE_API_KEY"), "X"),
+        timeout=timeout,
+    ) as client:
+        response = await client.request(
+            method=method,
+            url=url,
+            params=query_params,
+            json=json_body,
+            headers=request_headers,
+        )
+    return _decode_response(response), response.headers
+
+
+def _extract_page_items(
+    response: dict[str, Any] | list[Any],
+    items_key: str | None,
+) -> list[Any]:
+    if isinstance(response, list):
+        return response
+
+    if items_key is not None:
+        if items_key not in response:
+            raise ValueError(f"Freshservice response field `{items_key}` is missing.")
+        value = response[items_key]
+        if not isinstance(value, list):
+            raise ValueError(
+                f"Freshservice response field `{items_key}` is not a list."
+            )
+        return value
+
+    list_fields = [key for key, value in response.items() if isinstance(value, list)]
+    if len(list_fields) == 1:
+        return cast(list[Any], response[list_fields[0]])
+    if not list_fields:
+        raise ValueError(
+            "Freshservice paginated response did not contain a list field; "
+            "pass `items_key` explicitly."
+        )
+    fields = ", ".join(sorted(list_fields))
+    raise ValueError(
+        "Freshservice paginated response contained multiple list fields "
+        f"({fields}); pass `items_key` explicitly."
+    )
+
+
+def _extract_next_page(headers: Mapping[str, str], fallback_page: int) -> int | None:
+    link_header = headers.get("link") or headers.get("Link")
+    if not link_header:
+        return None
+
+    for part in link_header.split(","):
+        if 'rel="next"' not in part and "rel=next" not in part:
+            continue
+        start = part.find("<")
+        end = part.find(">", start + 1)
+        if start == -1 or end == -1:
+            return fallback_page
+        query = parse_qs(urlparse(part[start + 1 : end]).query)
+        page_values = query.get("page")
+        if not page_values:
+            return fallback_page
+        try:
+            return int(page_values[0])
+        except ValueError:
+            return fallback_page
+    return None
+
+
+async def _call_paginated_endpoint(
+    *,
+    path: str,
+    query_params: dict[str, Any] | None = None,
+    items_key: str | None = None,
+    page: int = 1,
+    per_page: int = 30,
+    max_pages: int | None = None,
+    base_url: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> FreshservicePaginatedResult:
+    items: list[Any] = []
+    pages = 0
+    current_page = page
+
+    while True:
+        params = dict(query_params or {})
+        params["page"] = current_page
+        params["per_page"] = per_page
+        response, headers = await _request_freshservice_http(
+            method="GET",
+            path=path,
+            base_url=base_url,
+            query_params=params,
+            timeout=timeout,
+        )
+        page_items = _extract_page_items(response, items_key)
+        items.extend(page_items)
+        pages += 1
+
+        next_page = _extract_next_page(headers, current_page + 1)
+        if next_page is None or (max_pages is not None and pages >= max_pages):
+            return {"items": items, "pages": pages, "next_page": next_page}
+        current_page = next_page
+
+
+@registry.register(
+    default_title="Call endpoint",
+    description="Call a Freshservice REST API endpoint with API-key Basic auth.",
+    display_group="Freshservice",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def call_endpoint(
+    method: Annotated[
+        FreshserviceMethod,
+        Field(..., description="HTTP method for the Freshservice API request."),
+    ],
+    path: Annotated[
+        str,
+        Field(..., description="Freshservice API path, e.g. `/tickets`."),
+    ],
+    query_params: QueryParamsParam = None,
+    json_body: RequestBodyParam = None,
+    headers: Annotated[
+        dict[str, str] | None,
+        Field(..., description="Additional HTTP headers to send."),
+    ] = None,
+    base_url: BaseUrlParam = None,
+    timeout: Annotated[
+        float,
+        Field(..., ge=1, le=300, description="Request timeout in seconds."),
+    ] = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method=method,
+        path=path,
+        base_url=base_url,
+        query_params=query_params,
+        json_body=json_body,
+        headers=headers,
+        timeout=timeout,
+    )
+
+
+@registry.register(
+    default_title="Call paginated endpoint",
+    description="Call a Freshservice list endpoint and follow page/per_page pagination.",
+    display_group="Freshservice",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def call_paginated_endpoint(
+    path: Annotated[
+        str,
+        Field(..., description="Freshservice list API path, e.g. `/tickets`."),
+    ],
+    query_params: QueryParamsParam = None,
+    items_key: Annotated[
+        str | None,
+        Field(
+            ...,
+            description=(
+                "Response field containing the page items, e.g. `tickets`. "
+                "If omitted, Tracecat infers the only list-valued response field."
+            ),
+        ),
+    ] = None,
+    page: Annotated[
+        int,
+        Field(..., ge=1, description="Freshservice page number to start from."),
+    ] = 1,
+    per_page: PerPageParam = 30,
+    max_pages: MaxPagesParam = None,
+    base_url: BaseUrlParam = None,
+    timeout: Annotated[
+        float,
+        Field(..., ge=1, le=300, description="Request timeout in seconds."),
+    ] = DEFAULT_TIMEOUT_SECONDS,
+) -> FreshservicePaginatedResult:
+    return await _call_paginated_endpoint(
+        path=path,
+        query_params=query_params,
+        items_key=items_key,
+        page=page,
+        per_page=per_page,
+        max_pages=max_pages,
+        base_url=base_url,
+        timeout=timeout,
+    )
+
+
+@registry.register(
+    default_title="List tickets",
+    description="List Freshservice tickets with optional filters.",
+    display_group="Freshservice Tickets",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def list_tickets(
+    query_params: QueryParamsParam = None,
+    page: Annotated[
+        int,
+        Field(..., ge=1, description="Freshservice page number to start from."),
+    ] = 1,
+    per_page: PerPageParam = 30,
+    max_pages: MaxPagesParam = None,
+    base_url: BaseUrlParam = None,
+) -> FreshservicePaginatedResult:
+    return await _call_paginated_endpoint(
+        path="/tickets",
+        query_params=query_params,
+        items_key="tickets",
+        page=page,
+        per_page=per_page,
+        max_pages=max_pages,
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Get ticket",
+    description="Get a Freshservice ticket by ID.",
+    display_group="Freshservice Tickets",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def get_ticket(
+    ticket_id: Annotated[int, Field(..., description="Freshservice ticket ID.")],
+    include: Annotated[
+        str | None,
+        Field(..., description="Optional Freshservice include parameter."),
+    ] = None,
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="GET",
+        path=f"/tickets/{ticket_id}",
+        query_params=_drop_none({"include": include}) or None,
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Create ticket",
+    description="Create a Freshservice ticket.",
+    display_group="Freshservice Tickets",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def create_ticket(
+    ticket: Annotated[
+        dict[str, Any],
+        Field(
+            ...,
+            description=(
+                "Freshservice ticket payload, e.g. subject, description, "
+                "email/requester_id, priority, and status."
+            ),
+        ),
+    ],
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="POST",
+        path="/tickets",
+        json_body=ticket,
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Update ticket",
+    description="Update a Freshservice ticket.",
+    display_group="Freshservice Tickets",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def update_ticket(
+    ticket_id: Annotated[int, Field(..., description="Freshservice ticket ID.")],
+    ticket: Annotated[
+        dict[str, Any],
+        Field(..., description="Freshservice ticket fields to update."),
+    ],
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="PUT",
+        path=f"/tickets/{ticket_id}",
+        json_body=ticket,
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Delete ticket",
+    description="Delete a Freshservice ticket.",
+    display_group="Freshservice Tickets",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def delete_ticket(
+    ticket_id: Annotated[int, Field(..., description="Freshservice ticket ID.")],
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="DELETE",
+        path=f"/tickets/{ticket_id}",
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Create ticket note",
+    description="Add a note to a Freshservice ticket.",
+    display_group="Freshservice Ticket Conversations",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def create_ticket_note(
+    ticket_id: Annotated[int, Field(..., description="Freshservice ticket ID.")],
+    note: Annotated[
+        dict[str, Any],
+        Field(..., description="Freshservice note payload."),
+    ],
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="POST",
+        path=f"/tickets/{ticket_id}/notes",
+        json_body=note,
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Reply to ticket",
+    description="Add a reply to a Freshservice ticket.",
+    display_group="Freshservice Ticket Conversations",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def reply_to_ticket(
+    ticket_id: Annotated[int, Field(..., description="Freshservice ticket ID.")],
+    reply: Annotated[
+        dict[str, Any],
+        Field(..., description="Freshservice ticket reply payload."),
+    ],
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="POST",
+        path=f"/tickets/{ticket_id}/reply",
+        json_body=reply,
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="List requesters",
+    description="List Freshservice requesters with optional filters.",
+    display_group="Freshservice Requesters",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def list_requesters(
+    query_params: QueryParamsParam = None,
+    page: Annotated[
+        int,
+        Field(..., ge=1, description="Freshservice page number to start from."),
+    ] = 1,
+    per_page: PerPageParam = 30,
+    max_pages: MaxPagesParam = None,
+    base_url: BaseUrlParam = None,
+) -> FreshservicePaginatedResult:
+    return await _call_paginated_endpoint(
+        path="/requesters",
+        query_params=query_params,
+        items_key="requesters",
+        page=page,
+        per_page=per_page,
+        max_pages=max_pages,
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Get requester",
+    description="Get a Freshservice requester by ID.",
+    display_group="Freshservice Requesters",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def get_requester(
+    requester_id: Annotated[int, Field(..., description="Freshservice requester ID.")],
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="GET",
+        path=f"/requesters/{requester_id}",
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Create requester",
+    description="Create a Freshservice requester.",
+    display_group="Freshservice Requesters",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def create_requester(
+    requester: Annotated[
+        dict[str, Any],
+        Field(..., description="Freshservice requester payload."),
+    ],
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="POST",
+        path="/requesters",
+        json_body=requester,
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Update requester",
+    description="Update a Freshservice requester.",
+    display_group="Freshservice Requesters",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def update_requester(
+    requester_id: Annotated[int, Field(..., description="Freshservice requester ID.")],
+    requester: Annotated[
+        dict[str, Any],
+        Field(..., description="Freshservice requester fields to update."),
+    ],
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="PUT",
+        path=f"/requesters/{requester_id}",
+        json_body=requester,
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="List agents",
+    description="List Freshservice agents with optional filters.",
+    display_group="Freshservice Agents",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def list_agents(
+    query_params: QueryParamsParam = None,
+    page: Annotated[
+        int,
+        Field(..., ge=1, description="Freshservice page number to start from."),
+    ] = 1,
+    per_page: PerPageParam = 30,
+    max_pages: MaxPagesParam = None,
+    base_url: BaseUrlParam = None,
+) -> FreshservicePaginatedResult:
+    return await _call_paginated_endpoint(
+        path="/agents",
+        query_params=query_params,
+        items_key="agents",
+        page=page,
+        per_page=per_page,
+        max_pages=max_pages,
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Get agent",
+    description="Get a Freshservice agent by ID.",
+    display_group="Freshservice Agents",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def get_agent(
+    agent_id: Annotated[int, Field(..., description="Freshservice agent ID.")],
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="GET",
+        path=f"/agents/{agent_id}",
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="List groups",
+    description="List Freshservice groups with optional filters.",
+    display_group="Freshservice Groups",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def list_groups(
+    query_params: QueryParamsParam = None,
+    page: Annotated[
+        int,
+        Field(..., ge=1, description="Freshservice page number to start from."),
+    ] = 1,
+    per_page: PerPageParam = 30,
+    max_pages: MaxPagesParam = None,
+    base_url: BaseUrlParam = None,
+) -> FreshservicePaginatedResult:
+    return await _call_paginated_endpoint(
+        path="/groups",
+        query_params=query_params,
+        items_key="groups",
+        page=page,
+        per_page=per_page,
+        max_pages=max_pages,
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Get group",
+    description="Get a Freshservice group by ID.",
+    display_group="Freshservice Groups",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def get_group(
+    group_id: Annotated[int, Field(..., description="Freshservice group ID.")],
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="GET",
+        path=f"/groups/{group_id}",
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="List changes",
+    description="List Freshservice changes with optional filters.",
+    display_group="Freshservice Changes",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def list_changes(
+    query_params: QueryParamsParam = None,
+    page: Annotated[
+        int,
+        Field(..., ge=1, description="Freshservice page number to start from."),
+    ] = 1,
+    per_page: PerPageParam = 30,
+    max_pages: MaxPagesParam = None,
+    base_url: BaseUrlParam = None,
+) -> FreshservicePaginatedResult:
+    return await _call_paginated_endpoint(
+        path="/changes",
+        query_params=query_params,
+        items_key="changes",
+        page=page,
+        per_page=per_page,
+        max_pages=max_pages,
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Get change",
+    description="Get a Freshservice change by ID.",
+    display_group="Freshservice Changes",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def get_change(
+    change_id: Annotated[int, Field(..., description="Freshservice change ID.")],
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="GET",
+        path=f"/changes/{change_id}",
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Create change",
+    description="Create a Freshservice change.",
+    display_group="Freshservice Changes",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def create_change(
+    change: Annotated[
+        dict[str, Any],
+        Field(..., description="Freshservice change payload."),
+    ],
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="POST",
+        path="/changes",
+        json_body=change,
+        base_url=base_url,
+    )
+
+
+@registry.register(
+    default_title="Update change",
+    description="Update a Freshservice change.",
+    display_group="Freshservice Changes",
+    doc_url=FRESHSERVICE_API_DOC_URL,
+    namespace="tools.freshservice",
+    secrets=[freshservice_secret],
+)
+async def update_change(
+    change_id: Annotated[int, Field(..., description="Freshservice change ID.")],
+    change: Annotated[
+        dict[str, Any],
+        Field(..., description="Freshservice change fields to update."),
+    ],
+    base_url: BaseUrlParam = None,
+) -> dict[str, Any] | list[Any]:
+    return await _request_freshservice_api(
+        method="PUT",
+        path=f"/changes/{change_id}",
+        json_body=change,
+        base_url=base_url,
+    )

--- a/tests/registry/test_freshservice.py
+++ b/tests/registry/test_freshservice.py
@@ -1,0 +1,433 @@
+from base64 import b64encode
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from tracecat_registry import SecretNotFoundError
+from tracecat_registry.integrations import freshservice
+
+
+def _secret_getter(values: dict[str, str]) -> Any:
+    return lambda key, default=None: values.get(key, default)
+
+
+def test_freshservice_secret_form() -> None:
+    assert freshservice.freshservice_secret.name == "freshservice"
+    assert freshservice.freshservice_secret.keys == ["FRESHSERVICE_API_KEY"]
+    assert freshservice.freshservice_secret.optional_keys == ["FRESHSERVICE_BASE_URL"]
+
+
+def test_resolve_base_url_adds_scheme_and_api_path() -> None:
+    assert (
+        freshservice._resolve_base_url("example.freshservice.com")
+        == "https://example.freshservice.com/api/v2"
+    )
+    assert (
+        freshservice._resolve_base_url("https://example.freshservice.com/")
+        == "https://example.freshservice.com/api/v2"
+    )
+    assert (
+        freshservice._resolve_base_url("https://example.freshservice.com/api/v2/")
+        == "https://example.freshservice.com/api/v2"
+    )
+
+
+def test_resolve_base_url_uses_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        freshservice.secrets,
+        "get_or_default",
+        _secret_getter({"FRESHSERVICE_BASE_URL": "example.freshservice.com"}),
+    )
+
+    assert freshservice._resolve_base_url(None) == (
+        "https://example.freshservice.com/api/v2"
+    )
+
+
+def test_resolve_base_url_requires_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(freshservice.secrets, "get_or_default", _secret_getter({}))
+
+    with pytest.raises(SecretNotFoundError, match="Freshservice calls require"):
+        freshservice._resolve_base_url(None)
+
+
+def test_normalize_path_rejects_absolute_urls() -> None:
+    with pytest.raises(ValueError, match="must be relative"):
+        freshservice._normalize_path("https://example.freshservice.com/api/v2/tickets")
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_call_endpoint_uses_basic_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(freshservice.secrets, "get", lambda key: "api-key")
+    monkeypatch.setattr(freshservice.secrets, "get_or_default", _secret_getter({}))
+    route = respx.post(
+        "https://example.freshservice.com/api/v2/tickets",
+        params={"source": "tracecat"},
+    ).mock(return_value=httpx.Response(201, json={"ticket": {"id": 123}}))
+
+    result = await freshservice.call_endpoint(
+        method="POST",
+        path="/api/v2/tickets",
+        query_params={"source": "tracecat"},
+        json_body={"subject": "Test"},
+        base_url="example.freshservice.com",
+    )
+
+    assert result == {"ticket": {"id": 123}}
+    assert route.called
+    request = route.calls[0].request
+    assert request.headers["authorization"] == (
+        "Basic " + b64encode(b"api-key:X").decode()
+    )
+    assert request.headers["accept"] == "application/json"
+    assert request.headers["content-type"] == "application/json"
+
+
+@pytest.mark.anyio
+async def test_list_tickets_paginates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_request(
+        **kwargs: Any,
+    ) -> tuple[dict[str, Any], httpx.Headers]:
+        calls.append(kwargs)
+        page = kwargs["query_params"]["page"]
+        if page == 2:
+            return {"tickets": [{"id": 3}]}, httpx.Headers({})
+        return {"tickets": [{"id": 1}, {"id": 2}]}, httpx.Headers(
+            {
+                "link": (
+                    "<https://example.freshservice.com/api/v2/tickets?"
+                    'page=2&per_page=2>; rel="next"'
+                )
+            }
+        )
+
+    monkeypatch.setattr(freshservice, "_request_freshservice_http", fake_request)
+
+    result = await freshservice.list_tickets(
+        query_params={"filter": "new_and_my_open"},
+        page=1,
+        per_page=2,
+        base_url="https://example.freshservice.com",
+    )
+
+    assert result == {
+        "items": [{"id": 1}, {"id": 2}, {"id": 3}],
+        "pages": 2,
+        "next_page": None,
+    }
+    assert calls[0]["query_params"] == {
+        "filter": "new_and_my_open",
+        "page": 1,
+        "per_page": 2,
+    }
+    assert calls[1]["query_params"] == {
+        "filter": "new_and_my_open",
+        "page": 2,
+        "per_page": 2,
+    }
+
+
+def test_extract_next_page_follows_link_header() -> None:
+    headers = httpx.Headers(
+        {
+            "link": (
+                "<https://example.freshservice.com/api/v2/tickets?"
+                'page=3&per_page=30>; rel="next"'
+            )
+        }
+    )
+
+    assert freshservice._extract_next_page(headers, fallback_page=2) == 3
+    assert freshservice._extract_next_page(httpx.Headers({}), fallback_page=2) is None
+
+
+def test_extract_page_items_infers_single_list_field() -> None:
+    assert freshservice._extract_page_items(
+        {"tickets": [{"id": 1}], "meta": {"page": 1}}, items_key=None
+    ) == [{"id": 1}]
+
+
+def test_extract_page_items_requires_items_key_for_ambiguous_response() -> None:
+    with pytest.raises(ValueError, match="did not contain a list field"):
+        freshservice._extract_page_items({"meta": {"page": 1}}, items_key=None)
+    with pytest.raises(ValueError, match="multiple list fields"):
+        freshservice._extract_page_items(
+            {"tickets": [], "requesters": []}, items_key=None
+        )
+
+
+def test_extract_page_items_requires_present_list_items_key() -> None:
+    with pytest.raises(ValueError, match="field `requesters` is missing"):
+        freshservice._extract_page_items({"tickets": []}, items_key="requesters")
+    with pytest.raises(ValueError, match="field `tickets` is not a list"):
+        freshservice._extract_page_items({"tickets": {}}, items_key="tickets")
+
+
+@pytest.mark.anyio
+async def test_create_ticket_calls_tickets_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_request(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"ticket": {"id": 123}}
+
+    monkeypatch.setattr(freshservice, "_request_freshservice_api", fake_request)
+
+    result = await freshservice.create_ticket(
+        ticket={"subject": "Test", "priority": 1, "status": 2},
+        base_url="https://example.freshservice.com",
+    )
+
+    assert result == {"ticket": {"id": 123}}
+    assert calls == [
+        {
+            "method": "POST",
+            "path": "/tickets",
+            "json_body": {"subject": "Test", "priority": 1, "status": 2},
+            "base_url": "https://example.freshservice.com",
+        }
+    ]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("call", "expected"),
+    [
+        (
+            lambda: freshservice.get_ticket(
+                ticket_id=123,
+                include="conversations",
+                base_url="https://example.freshservice.com",
+            ),
+            {
+                "method": "GET",
+                "path": "/tickets/123",
+                "query_params": {"include": "conversations"},
+                "base_url": "https://example.freshservice.com",
+            },
+        ),
+        (
+            lambda: freshservice.update_ticket(
+                ticket_id=123,
+                ticket={"priority": 2},
+                base_url="https://example.freshservice.com",
+            ),
+            {
+                "method": "PUT",
+                "path": "/tickets/123",
+                "json_body": {"priority": 2},
+                "base_url": "https://example.freshservice.com",
+            },
+        ),
+        (
+            lambda: freshservice.delete_ticket(
+                ticket_id=123,
+                base_url="https://example.freshservice.com",
+            ),
+            {
+                "method": "DELETE",
+                "path": "/tickets/123",
+                "base_url": "https://example.freshservice.com",
+            },
+        ),
+        (
+            lambda: freshservice.create_ticket_note(
+                ticket_id=123,
+                note={"body": "note"},
+                base_url="https://example.freshservice.com",
+            ),
+            {
+                "method": "POST",
+                "path": "/tickets/123/notes",
+                "json_body": {"body": "note"},
+                "base_url": "https://example.freshservice.com",
+            },
+        ),
+        (
+            lambda: freshservice.reply_to_ticket(
+                ticket_id=123,
+                reply={"body": "reply"},
+                base_url="https://example.freshservice.com",
+            ),
+            {
+                "method": "POST",
+                "path": "/tickets/123/reply",
+                "json_body": {"body": "reply"},
+                "base_url": "https://example.freshservice.com",
+            },
+        ),
+        (
+            lambda: freshservice.get_requester(
+                requester_id=123,
+                base_url="https://example.freshservice.com",
+            ),
+            {
+                "method": "GET",
+                "path": "/requesters/123",
+                "base_url": "https://example.freshservice.com",
+            },
+        ),
+        (
+            lambda: freshservice.create_requester(
+                requester={"primary_email": "user@example.com"},
+                base_url="https://example.freshservice.com",
+            ),
+            {
+                "method": "POST",
+                "path": "/requesters",
+                "json_body": {"primary_email": "user@example.com"},
+                "base_url": "https://example.freshservice.com",
+            },
+        ),
+        (
+            lambda: freshservice.update_requester(
+                requester_id=123,
+                requester={"first_name": "A"},
+                base_url="https://example.freshservice.com",
+            ),
+            {
+                "method": "PUT",
+                "path": "/requesters/123",
+                "json_body": {"first_name": "A"},
+                "base_url": "https://example.freshservice.com",
+            },
+        ),
+        (
+            lambda: freshservice.get_agent(
+                agent_id=123,
+                base_url="https://example.freshservice.com",
+            ),
+            {
+                "method": "GET",
+                "path": "/agents/123",
+                "base_url": "https://example.freshservice.com",
+            },
+        ),
+        (
+            lambda: freshservice.get_group(
+                group_id=123,
+                base_url="https://example.freshservice.com",
+            ),
+            {
+                "method": "GET",
+                "path": "/groups/123",
+                "base_url": "https://example.freshservice.com",
+            },
+        ),
+        (
+            lambda: freshservice.get_change(
+                change_id=123,
+                base_url="https://example.freshservice.com",
+            ),
+            {
+                "method": "GET",
+                "path": "/changes/123",
+                "base_url": "https://example.freshservice.com",
+            },
+        ),
+        (
+            lambda: freshservice.create_change(
+                change={"subject": "Change"},
+                base_url="https://example.freshservice.com",
+            ),
+            {
+                "method": "POST",
+                "path": "/changes",
+                "json_body": {"subject": "Change"},
+                "base_url": "https://example.freshservice.com",
+            },
+        ),
+        (
+            lambda: freshservice.update_change(
+                change_id=123,
+                change={"priority": 1},
+                base_url="https://example.freshservice.com",
+            ),
+            {
+                "method": "PUT",
+                "path": "/changes/123",
+                "json_body": {"priority": 1},
+                "base_url": "https://example.freshservice.com",
+            },
+        ),
+    ],
+)
+async def test_resource_wrappers_use_documented_contracts(
+    monkeypatch: pytest.MonkeyPatch,
+    call: Callable[[], Any],
+    expected: dict[str, Any],
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_request(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(freshservice, "_request_freshservice_api", fake_request)
+
+    result = await call()
+
+    assert result == {"ok": True}
+    assert calls == [expected]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("call", "expected_path", "expected_items_key"),
+    [
+        (freshservice.list_tickets, "/tickets", "tickets"),
+        (freshservice.list_requesters, "/requesters", "requesters"),
+        (freshservice.list_agents, "/agents", "agents"),
+        (freshservice.list_groups, "/groups", "groups"),
+        (freshservice.list_changes, "/changes", "changes"),
+    ],
+)
+async def test_list_wrappers_use_documented_contracts(
+    monkeypatch: pytest.MonkeyPatch,
+    call: Callable[..., Any],
+    expected_path: str,
+    expected_items_key: str,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_paginated(**kwargs: Any) -> freshservice.FreshservicePaginatedResult:
+        calls.append(kwargs)
+        return {"items": [], "pages": 0, "next_page": None}
+
+    monkeypatch.setattr(freshservice, "_call_paginated_endpoint", fake_paginated)
+
+    result = await call(
+        query_params={"updated_since": "2026-01-01"},
+        page=2,
+        per_page=10,
+        max_pages=3,
+        base_url="https://example.freshservice.com",
+    )
+
+    assert result == {"items": [], "pages": 0, "next_page": None}
+    assert calls == [
+        {
+            "path": expected_path,
+            "query_params": {"updated_since": "2026-01-01"},
+            "items_key": expected_items_key,
+            "page": 2,
+            "per_page": 10,
+            "max_pages": 3,
+            "base_url": "https://example.freshservice.com",
+        }
+    ]

--- a/tracecat/integrations/catalog/mcp_catalog.json
+++ b/tracecat/integrations/catalog/mcp_catalog.json
@@ -219,6 +219,13 @@
       "icon": "https://www.google.com/s2/favicons?domain=www.atlassian.com&sz=128"
     },
     {
+      "slug": "freshservice-mcp",
+      "name": "Freshservice",
+      "description": "Create and manage Freshservice tickets, service requests, and ITSM records",
+      "category": "Ticketing",
+      "icon": "https://www.google.com/s2/favicons?domain=freshservice.com&sz=128"
+    },
+    {
       "slug": "servicenow-mcp",
       "name": "ServiceNow",
       "description": "Query and update ServiceNow ITSM records via the Zurich MCP server",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Freshservice integration with a new MCP catalog entry and a suite of `tools.freshservice` actions for REST API access (tickets, requesters, agents, groups, changes), including pagination and tests. This lets users create and manage Freshservice ITSM records and connect to Freshservice’s hosted MCP via Remote OAuth.

- **New Features**
  - Added `tools.freshservice` actions: `call_endpoint`, `call_paginated_endpoint`, tickets (list/get/create/update/delete, notes, replies), requesters (list/get/create/update), agents (list/get), groups (list/get), changes (list/get/create/update).
  - Basic auth with `FRESHSERVICE_API_KEY`; optional `FRESHSERVICE_BASE_URL` auto-normalizes (scheme + `/api/v2`); follows Link-header pagination.
  - New secret form `freshservice` with `FRESHSERVICE_API_KEY` (required) and `FRESHSERVICE_BASE_URL` (optional).
  - Added `freshservice-mcp` to public and private catalogs with Remote OAuth (dynamic discovery) and API key options; public tile included.
  - Tests cover auth headers, base URL/path resolution, pagination, and wrapper contracts.

<sup>Written for commit ecbd4cbb6142aa9b1063022ff41d1494d003c6ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

