### PR TITLE
refactor(agents): move workspace catalog subset selection to org-level

### DIFF
--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -41,7 +41,10 @@ import {
   RbacListContainer,
   RbacListItem,
 } from "@/components/organization/rbac-list-item"
-import { WorkspaceModelAccessSection } from "@/components/organization/workspace-model-access-section"
+import {
+  WORKSPACE_MODEL_ACCESS_REQUIRED_SCOPES,
+  WorkspaceModelAccessSection,
+} from "@/components/organization/workspace-model-access-section"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -1887,7 +1890,10 @@ export function OrgSettingsAgentForm() {
   const queryClient = useQueryClient()
   const { hasEntitlement } = useEntitlements()
   const agentAddonsEnabled = hasEntitlement("agent_addons")
-  const canManageWorkspaceModelAccess = useScopeCheck("agent:create") === true
+  const canManageWorkspaceModelAccess =
+    useScopeCheck(undefined, WORKSPACE_MODEL_ACCESS_REQUIRED_SCOPES, {
+      all: true,
+    }) === true
   const [credentialsProvider, setCredentialsProvider] = useState<string | null>(
     null
   )

--- a/frontend/src/components/organization/org-settings-agent.tsx
+++ b/frontend/src/components/organization/org-settings-agent.tsx
@@ -32,6 +32,7 @@ import {
   type VertexAICatalogCreate,
   validateCustomProviderConnection,
 } from "@/client"
+import { useScopeCheck } from "@/components/auth/scope-guard"
 import { ProviderIcon } from "@/components/icons"
 import { CenteredSpinner } from "@/components/loading/spinner"
 import { AlertNotification } from "@/components/notifications"
@@ -40,6 +41,7 @@ import {
   RbacListContainer,
   RbacListItem,
 } from "@/components/organization/rbac-list-item"
+import { WorkspaceModelAccessSection } from "@/components/organization/workspace-model-access-section"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -1885,6 +1887,7 @@ export function OrgSettingsAgentForm() {
   const queryClient = useQueryClient()
   const { hasEntitlement } = useEntitlements()
   const agentAddonsEnabled = hasEntitlement("agent_addons")
+  const canManageWorkspaceModelAccess = useScopeCheck("agent:create") === true
   const [credentialsProvider, setCredentialsProvider] = useState<string | null>(
     null
   )
@@ -2647,7 +2650,7 @@ export function OrgSettingsAgentForm() {
         <div className="space-y-1">
           <p className="text-xs text-muted-foreground">
             {agentAddonsEnabled
-              ? "The platform catalog stays shared, while each workspace can still restrict itself to a smaller subset of the organization-enabled catalog."
+              ? "The platform catalog stays shared, and workspace subsets are managed at the organization level."
               : "Connect providers here. Upgrade to manage which organization-level models are enabled."}
           </p>
         </div>
@@ -2865,6 +2868,22 @@ export function OrgSettingsAgentForm() {
           </Card>
         )}
       </section>
+
+      {agentAddonsEnabled && canManageWorkspaceModelAccess ? (
+        <section className="space-y-4">
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold tracking-tight">
+              Workspace model access
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Restrict each workspace to a subset of the organization-enabled
+              catalog. Workspaces without a subset inherit every
+              organization-enabled model.
+            </p>
+          </div>
+          <WorkspaceModelAccessSection />
+        </section>
+      ) : null}
 
       <AgentCredentialsDialog
         isOpen={credentialsProvider !== null}

--- a/frontend/src/components/organization/workspace-model-access-section.tsx
+++ b/frontend/src/components/organization/workspace-model-access-section.tsx
@@ -19,7 +19,9 @@ import {
   listCatalog,
   listCustomProviders,
   listEnabledModels,
+  workspacesListWorkspaces,
 } from "@/client"
+import { useScopeCheck } from "@/components/auth/scope-guard"
 import { ProviderIcon } from "@/components/icons"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
@@ -44,10 +46,15 @@ import {
 import { Switch } from "@/components/ui/switch"
 import { toast } from "@/components/ui/use-toast"
 import { getApiErrorDetail, retryHandler } from "@/lib/errors"
-import { useWorkspaceManager } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 
 const CURSOR_PAGE_SIZE = 100
+export const WORKSPACE_MODEL_ACCESS_REQUIRED_SCOPES = [
+  "agent:read",
+  "agent:create",
+  "agent:delete",
+  "org:workspace:read",
+]
 
 const workspaceModelAccessSchema = z
   .object({
@@ -190,8 +197,21 @@ export function WorkspaceModelAccessSection() {
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<
     string | undefined
   >()
-  const { workspaces, workspacesLoading, workspacesError } =
-    useWorkspaceManager()
+  const canManageWorkspaceModelAccess =
+    useScopeCheck(undefined, WORKSPACE_MODEL_ACCESS_REQUIRED_SCOPES, {
+      all: true,
+    }) === true
+  const {
+    data: workspaces,
+    error: workspacesError,
+    isLoading: workspacesLoading,
+  } = useQuery<WorkspaceReadMinimal[], ApiError>({
+    queryKey: ["workspaces"],
+    queryFn: async () => await workspacesListWorkspaces(),
+    staleTime: 5 * 60 * 1000,
+    retry: retryHandler,
+    enabled: canManageWorkspaceModelAccess,
+  })
   const orderedWorkspaces = useMemo(
     () => [...(workspaces ?? [])].sort(compareWorkspaces),
     [workspaces]
@@ -209,6 +229,10 @@ export function WorkspaceModelAccessSection() {
     }
     setSelectedWorkspaceId(undefined)
   }, [selectedWorkspace, selectedWorkspaceId])
+
+  if (!canManageWorkspaceModelAccess) {
+    return null
+  }
 
   if (workspacesLoading) {
     return (

--- a/frontend/src/components/organization/workspace-model-access-section.tsx
+++ b/frontend/src/components/organization/workspace-model-access-section.tsx
@@ -11,7 +11,7 @@ import type {
   AgentCustomProviderRead,
   AgentModelAccessRead,
   ApiError,
-  WorkspaceRead,
+  WorkspaceReadMinimal,
 } from "@/client"
 import {
   disableModel,
@@ -34,14 +34,22 @@ import {
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { toast } from "@/components/ui/use-toast"
 import { getApiErrorDetail, retryHandler } from "@/lib/errors"
+import { useWorkspaceManager } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
 
 const CURSOR_PAGE_SIZE = 100
 
-const workspaceModelSettingsSchema = z
+const workspaceModelAccessSchema = z
   .object({
     inherit_all: z.boolean().default(true),
     catalog_ids: z.array(z.string()).default([]),
@@ -58,7 +66,7 @@ const workspaceModelSettingsSchema = z
     })
   })
 
-type WorkspaceModelSettingsForm = z.infer<typeof workspaceModelSettingsSchema>
+type WorkspaceModelAccessForm = z.infer<typeof workspaceModelAccessSchema>
 
 function getProviderIconId(provider?: string | null): string {
   switch (provider) {
@@ -164,20 +172,122 @@ function getModelSourceLabel(
   return getProviderDisplayLabel(entry.model_provider)
 }
 
+function compareWorkspaces(
+  left: WorkspaceReadMinimal,
+  right: WorkspaceReadMinimal
+) {
+  const nameComparison = left.name.localeCompare(right.name)
+  if (nameComparison !== 0) {
+    return nameComparison
+  }
+  return left.id.localeCompare(right.id)
+}
+
+/**
+ * Select a workspace and manage its AI model subset from organization settings.
+ */
+export function WorkspaceModelAccessSection() {
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<
+    string | undefined
+  >()
+  const { workspaces, workspacesLoading, workspacesError } =
+    useWorkspaceManager()
+  const orderedWorkspaces = useMemo(
+    () => [...(workspaces ?? [])].sort(compareWorkspaces),
+    [workspaces]
+  )
+  const selectedWorkspace = orderedWorkspaces.find(
+    (workspace) => workspace.id === selectedWorkspaceId
+  )
+
+  useEffect(() => {
+    if (!selectedWorkspaceId) {
+      return
+    }
+    if (selectedWorkspace) {
+      return
+    }
+    setSelectedWorkspaceId(undefined)
+  }, [selectedWorkspace, selectedWorkspaceId])
+
+  if (workspacesLoading) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (workspacesError) {
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Unable to load workspaces</AlertTitle>
+        <AlertDescription>
+          {getApiErrorDetail(workspacesError) ?? "Something went wrong."}
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (!orderedWorkspaces.length) {
+    return (
+      <div className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
+        No workspaces are available.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <Select
+        onValueChange={setSelectedWorkspaceId}
+        value={selectedWorkspaceId}
+      >
+        <SelectTrigger className="max-w-sm">
+          <SelectValue placeholder="Select a workspace" />
+        </SelectTrigger>
+        <SelectContent>
+          {orderedWorkspaces.map((workspace) => (
+            <SelectItem key={workspace.id} value={workspace.id}>
+              {workspace.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {selectedWorkspace ? (
+        <WorkspaceModelAccessEditor
+          key={selectedWorkspace.id}
+          workspaceId={selectedWorkspace.id}
+          workspaceName={selectedWorkspace.name}
+        />
+      ) : (
+        <div className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
+          Choose a workspace to manage its AI model access.
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface WorkspaceModelAccessEditorProps {
+  workspaceId: string
+  workspaceName: string
+}
+
 /**
  * Manage workspace AI model availability with the branch-style inherit/subset
  * UI, backed by the current catalog and access APIs.
  */
-export function WorkspaceModelSettings({
-  workspace,
-}: {
-  workspace: WorkspaceRead
-}) {
+function WorkspaceModelAccessEditor({
+  workspaceId,
+  workspaceName,
+}: WorkspaceModelAccessEditorProps) {
   const queryClient = useQueryClient()
   const [modelQuery, setModelQuery] = useState("")
   const lastSyncedFormValuesRef = useRef<string | null>(null)
-  const form = useForm<WorkspaceModelSettingsForm>({
-    resolver: zodResolver(workspaceModelSettingsSchema),
+  const form = useForm<WorkspaceModelAccessForm>({
+    resolver: zodResolver(workspaceModelAccessSchema),
     mode: "onChange",
     defaultValues: {
       inherit_all: true,
@@ -230,9 +340,9 @@ export function WorkspaceModelSettings({
   const workspaceAccessRows = useMemo(
     () =>
       (enabledAccessRows ?? []).filter(
-        (row) => row.workspace_id === workspace.id
+        (row) => row.workspace_id === workspaceId
       ),
-    [enabledAccessRows, workspace.id]
+    [enabledAccessRows, workspaceId]
   )
   const orgEnabledCatalogIds = useMemo(
     () => new Set(orgEnabledAccessRows.map((row) => row.catalog_id)),
@@ -331,7 +441,7 @@ export function WorkspaceModelSettings({
   }, [modelQuery, organizationEnabledEntries, providersById])
 
   const updateWorkspaceModelSubset = useMutation({
-    mutationFn: async (values: WorkspaceModelSettingsForm) => {
+    mutationFn: async (values: WorkspaceModelAccessForm) => {
       const desiredCatalogIds = new Set(values.catalog_ids)
       const accessRowsToDisable = values.inherit_all
         ? workspaceAccessRows
@@ -353,7 +463,7 @@ export function WorkspaceModelSettings({
         await enableModel({
           requestBody: {
             catalog_id: catalogId,
-            workspace_id: workspace.id,
+            workspace_id: workspaceId,
           },
         })
       }
@@ -364,11 +474,11 @@ export function WorkspaceModelSettings({
         queryKey: ["organization", "agent-model-access"],
       })
       void queryClient.invalidateQueries({
-        queryKey: ["workspace", workspace.id, "agent-model-access"],
+        queryKey: ["workspace", workspaceId, "agent-models"],
       })
       toast({
         title: "Workspace models updated",
-        description: `Saved the AI model settings for ${workspace.name}.`,
+        description: `Saved the AI model settings for ${workspaceName}.`,
       })
     },
     onError: (error: ApiError) => {
@@ -382,7 +492,7 @@ export function WorkspaceModelSettings({
     },
   })
 
-  async function onSubmit(values: WorkspaceModelSettingsForm) {
+  async function onSubmit(values: WorkspaceModelAccessForm) {
     await updateWorkspaceModelSubset.mutateAsync(values)
   }
 

--- a/frontend/src/components/settings/settings-modal-context.tsx
+++ b/frontend/src/components/settings/settings-modal-context.tsx
@@ -6,7 +6,6 @@ export type SettingsSection =
   | "profile"
   | "workspace-general"
   | "workspace-runtime"
-  | "workspace-models"
   | "workspace-files"
   | "workspace-sync"
 

--- a/frontend/src/components/settings/settings-modal.tsx
+++ b/frontend/src/components/settings/settings-modal.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import {
-  Cpu,
   FileIcon,
   GitBranchIcon,
   LockIcon,
@@ -214,13 +213,6 @@ function SettingsModalContent() {
                         icon={WorkflowIcon}
                         label="Workflows"
                         section="workspace-runtime"
-                        activeSection={displayedSection}
-                        onSelect={setActiveSection}
-                      />
-                      <NavItem
-                        icon={Cpu}
-                        label="AI models"
-                        section="workspace-models"
                         activeSection={displayedSection}
                         onSelect={setActiveSection}
                       />

--- a/frontend/src/components/settings/workspace-settings-container.tsx
+++ b/frontend/src/components/settings/workspace-settings-container.tsx
@@ -7,7 +7,6 @@ import { EntitlementRequiredEmptyState } from "@/components/entitlement-required
 import type { SettingsSection } from "@/components/settings/settings-modal-context"
 import { WorkspaceFilesSettings } from "@/components/settings/workspace-files-settings"
 import { WorkspaceGeneralSettings } from "@/components/settings/workspace-general-settings"
-import { WorkspaceModelSettings } from "@/components/settings/workspace-model-settings"
 import { WorkspaceRuntimeSettings } from "@/components/settings/workspace-runtime-settings"
 import { WorkspaceSyncSettings } from "@/components/settings/workspace-sync-settings"
 import { Button } from "@/components/ui/button"
@@ -53,32 +52,6 @@ export function WorkspaceSettingsContainer({
       return <WorkspaceGeneralSettings workspace={workspace} />
     case "workspace-runtime":
       return <WorkspaceRuntimeSettings workspace={workspace} />
-    case "workspace-models":
-      return hasEntitlement("agent_addons") ? (
-        <WorkspaceModelSettings workspace={workspace} />
-      ) : (
-        <div className="flex flex-1 items-center justify-center py-12">
-          <EntitlementRequiredEmptyState
-            title="Upgrade required"
-            description="Workspace AI model subset controls are unavailable on your current plan."
-          >
-            <Button
-              variant="link"
-              asChild
-              className="text-muted-foreground"
-              size="sm"
-            >
-              <a
-                href="https://tracecat.com"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Learn more <ArrowUpRight className="size-4" />
-              </a>
-            </Button>
-          </EntitlementRequiredEmptyState>
-        </div>
-      )
     case "workspace-files":
       return <WorkspaceFilesSettings workspace={workspace} />
     case "workspace-sync":

--- a/frontend/tests/settings-modal.test.tsx
+++ b/frontend/tests/settings-modal.test.tsx
@@ -149,6 +149,9 @@ describe("SettingsModal workspace navigation", () => {
     expect(
       screen.getByRole("button", { name: "Workflows" })
     ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "AI models" })
+    ).not.toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Files" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Git sync" })).toBeInTheDocument()
   })


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved workspace model subset management from workspace settings to organization settings to centralize control. Removed the workspace-level “AI models” tab and added an org section with a workspace selector and stricter permission gating.

- **Refactors**
  - Added `WorkspaceModelAccessSection` in org settings with per-workspace selection; workspaces inherit all by default.
  - Gated access by `agent_addons` and all scopes in `WORKSPACE_MODEL_ACCESS_REQUIRED_SCOPES` via `useScopeCheck({ all: true })`.
  - Switched to `WorkspaceReadMinimal` and listed workspaces via `workspacesListWorkspaces`; split UI into a selector and a scoped editor.
  - Removed the workspace “AI models” tab and related code; updated query invalidation to `["workspace", workspaceId, "agent-models"]`; adjusted tests to not expect the tab.

<sup>Written for commit 70e0e660501f7ab28ad8bd296c6a1caf005d9468. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



