### PR TITLE
feat(api): pluggable secrets backend + read-only HashiCorp Vault support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -168,3 +168,21 @@ PYTHONPATH=/home/apiuser/.local:/app/local_registry
 # Feature flags (comma-separated list)
 TRACECAT__FEATURE_FLAGS=""
 TRACECAT__EE_MULTI_TENANT=false
+
+# --- Secrets backend (optional) ---
+# Where workflow secret values live: 'db' (default, encrypted in Postgres)
+# or 'vault' (resolved from HashiCorp Vault at runtime, read-only).
+TRACECAT__SECRETS_BACKEND=db
+# Required when TRACECAT__SECRETS_BACKEND=vault
+TRACECAT__VAULT_ADDR=
+TRACECAT__VAULT_KV_MOUNT=secret
+TRACECAT__VAULT_PATH_PREFIX=tracecat
+# Auth: 'jwt' (projected Kubernetes service account token) or 'token' (dev only)
+TRACECAT__VAULT_AUTH_METHOD=jwt
+TRACECAT__VAULT_JWT_AUTH_MOUNT=jwt
+TRACECAT__VAULT_JWT_ROLE=
+TRACECAT__VAULT_JWT_TOKEN_PATH=/var/run/secrets/tokens/vault-token
+TRACECAT__VAULT_TOKEN=
+TRACECAT__VAULT_NAMESPACE=
+TRACECAT__VAULT_CACHE_TTL_SECONDS=45
+TRACECAT__VAULT_CACHE_MAX_SIZE=1024

--- a/alembic/versions/b3d1a9c47e02_add_secret_backend_marker.py
+++ b/alembic/versions/b3d1a9c47e02_add_secret_backend_marker.py
@@ -1,10 +1,15 @@
 """add secret backend marker
 
 Adds a ``backend`` column to all secret tables. It records which secrets
-backend owns a secret's values: ``db`` (default, values Fernet-encrypted in
+backend a row was created under: ``db`` (default, values Fernet-encrypted in
 ``encrypted_keys``) or an external backend such as ``vault``, in which case
 the row is a value-less registration (name, key names, type, environment)
 and values are resolved from the external backend at runtime.
+
+Runtime dispatch is currently global (``TRACECAT__SECRETS_BACKEND``); the
+marker is an integrity guard (the database backend refuses to serve
+external-backend registrations as empty values) and lays the groundwork for
+future per-secret backend dispatch.
 
 Purely additive: existing rows are backfilled to ``db`` via the server
 default, which matches their actual storage.

--- a/alembic/versions/b3d1a9c47e02_add_secret_backend_marker.py
+++ b/alembic/versions/b3d1a9c47e02_add_secret_backend_marker.py
@@ -1,0 +1,44 @@
+"""add secret backend marker
+
+Adds a ``backend`` column to all secret tables. It records which secrets
+backend owns a secret's values: ``db`` (default, values Fernet-encrypted in
+``encrypted_keys``) or an external backend such as ``vault``, in which case
+the row is a value-less registration (name, key names, type, environment)
+and values are resolved from the external backend at runtime.
+
+Purely additive: existing rows are backfilled to ``db`` via the server
+default, which matches their actual storage.
+
+Revision ID: b3d1a9c47e02
+Revises: e32940d12293
+Create Date: 2026-07-03 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b3d1a9c47e02"
+down_revision: str | None = "e32940d12293"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SECRET_TABLES = ("secret", "organization_secret", "platform_secret")
+
+
+def upgrade() -> None:
+    for table in _SECRET_TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "backend", sa.String(length=50), nullable=False, server_default="db"
+            ),
+        )
+
+
+def downgrade() -> None:
+    for table in _SECRET_TABLES:
+        op.drop_column(table, "backend")

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -150,6 +150,7 @@
               "self-hosting/aws-fargate",
               "self-hosting/kubernetes",
               "self-hosting/environment-variables",
+              "self-hosting/secrets-backends",
               "self-hosting/security"
             ]
           },

--- a/docs/self-hosting/secrets-backends.mdx
+++ b/docs/self-hosting/secrets-backends.mdx
@@ -130,6 +130,19 @@ the executor resolves values from Vault by secret name; a secret that exists
 in Vault but is referenced by a name with no matching path returns the usual
 "missing secret" error.
 
+In the UI, the workspace "Create credential" dialog detects the read-only
+backend (via the `secrets_backend_readonly` flag on `/info`), disables the
+value inputs, and submits a value-less registration. Registering
+organization secrets and structured `ssh_key`/`mtls`/`ca_cert` types is
+currently done through the API, e.g.:
+
+```bash
+curl -X POST "$TRACECAT_API/secrets" -H "Content-Type: application/json" \
+  -b "$SESSION" \
+  -d '{"name": "virustotal", "type": "custom", "environment": "default",
+       "keys": [{"key": "VIRUSTOTAL_API_KEY", "value": ""}]}'
+```
+
 OAuth integrations are out of scope for secrets backends and remain in the
 database (they require stateful token refresh).
 

--- a/docs/self-hosting/secrets-backends.mdx
+++ b/docs/self-hosting/secrets-backends.mdx
@@ -1,0 +1,144 @@
+---
+title: Secrets backends
+description: "Store workflow secret values in the Tracecat database (default) or resolve them from HashiCorp Vault at runtime."
+---
+
+Tracecat resolves workflow secrets through a pluggable secrets backend,
+selected with `TRACECAT__SECRETS_BACKEND`:
+
+- **`db`** (default): secret values are Fernet-encrypted with
+  `TRACECAT__DB_ENCRYPTION_KEY` and stored in the Tracecat database. This is
+  the existing behavior and requires no extra configuration.
+- **`vault`**: secret values live in HashiCorp Vault (KV v2) and are fetched
+  by the executor at workflow runtime. The Tracecat database only stores a
+  value-less *registration* of each secret (name, key names, type,
+  environment) so the UI and workflow validation keep working. Secret values
+  can never be written through Tracecat in this mode.
+
+The Vault backend is read-only by design: secrets stay under your
+organization's Vault governance (per-secret ACLs, audit, rotation, short
+leases) instead of being copied into a second store.
+
+## Vault backend
+
+### Environment variables
+
+| Variable | Default | Purpose |
+| :------- | :------ | :------ |
+| `TRACECAT__SECRETS_BACKEND` | `db` | Set to `vault` to resolve secret values from Vault. |
+| `TRACECAT__VAULT_ADDR` | — | Base URL of the Vault server, e.g. `https://vault.example.com:8200`. Required. |
+| `TRACECAT__VAULT_KV_MOUNT` | `secret` | Mount path of the KV v2 secrets engine. |
+| `TRACECAT__VAULT_PATH_PREFIX` | `tracecat` | Path prefix under the KV mount for all Tracecat secrets. |
+| `TRACECAT__VAULT_AUTH_METHOD` | `jwt` | `jwt` (projected Kubernetes service account token) or `token` (static token, development only). |
+| `TRACECAT__VAULT_JWT_AUTH_MOUNT` | `jwt` | Mount path of the Vault JWT auth method. |
+| `TRACECAT__VAULT_JWT_ROLE` | — | Vault JWT auth role, e.g. `tracecat-executor`. |
+| `TRACECAT__VAULT_JWT_TOKEN_PATH` | `/var/run/secrets/tokens/vault-token` | Path of the projected service account token file. |
+| `TRACECAT__VAULT_TOKEN` | — | Static Vault token when `TRACECAT__VAULT_AUTH_METHOD=token`. Development only. |
+| `TRACECAT__VAULT_NAMESPACE` | — | Optional Vault Enterprise namespace. |
+| `TRACECAT__VAULT_CACHE_TTL_SECONDS` | `45` | TTL of the in-process value cache. `0` disables caching. Keep below your Vault lease TTL. |
+| `TRACECAT__VAULT_CACHE_MAX_SIZE` | `1024` | Max entries in the in-process value cache (LRU). |
+
+### Path convention
+
+Secrets are read from KV v2 at:
+
+```
+{mount}/data/{prefix}/{scope}/{owner}/{environment}/{name}
+```
+
+- `scope` is `workspace` or `organization`.
+- `owner` is the workspace UUID for workspace secrets and the organization
+  UUID for organization secrets.
+- `environment` is the Tracecat secrets environment (default: `default`).
+- `name` is the Tracecat secret name, e.g. `virustotal`.
+
+Example: workspace secret `virustotal` in workspace
+`0195b0f9-...-7bd0` resolves to
+`secret/data/tracecat/workspace/0195b0f9-...-7bd0/default/virustotal`.
+
+The keys of the Vault secret's data map 1:1 to Tracecat secret keys:
+
+```bash
+vault kv put secret/tracecat/workspace/<workspace-id>/default/virustotal \
+  VIRUSTOTAL_API_KEY=xxxxx
+```
+
+SSH key secrets (`ssh_key` type, e.g. the registry Git SSH key registered as
+an organization secret) store the private key under the `PRIVATE_KEY` key:
+
+```bash
+vault kv put secret/tracecat/organization/<org-id>/default/tracecat_registry_ssh_key \
+  PRIVATE_KEY=@id_ed25519
+```
+
+### Authentication
+
+The default `jwt` method targets Kubernetes deployments where Vault cannot
+reach the kube-apiserver (isolated clusters, egress-only networking). The
+executor pod presents a projected service account token, which Vault
+validates *offline* against static public keys — only outbound connectivity
+from Tracecat to Vault is required.
+
+1. Export the cluster's JWKS once and configure the Vault JWT auth method:
+
+   ```bash
+   kubectl get --raw /openid/v1/jwks > cluster-jwks.json
+   vault auth enable jwt
+   vault write auth/jwt/config jwt_validation_pubkeys=@cluster-pubkeys.pem
+   # or: vault write auth/jwt/config jwks_url=... when the apiserver is reachable
+   ```
+
+2. Create a role bound to the executor's service account:
+
+   ```bash
+   vault write auth/jwt/role/tracecat-executor \
+     role_type=jwt \
+     user_claim=sub \
+     bound_audiences=vault \
+     bound_subject=system:serviceaccount:tracecat:tracecat-executor \
+     token_policies=tracecat-secrets-read \
+     token_ttl=10m
+   ```
+
+3. Grant read-only access to the Tracecat path prefix:
+
+   ```hcl
+   path "secret/data/tracecat/*" {
+     capabilities = ["read"]
+   }
+   ```
+
+4. Mount a projected token in the executor (and API) pod:
+
+   ```yaml
+   volumes:
+     - name: vault-token
+       projected:
+         sources:
+           - serviceAccountToken:
+               audience: vault
+               expirationSeconds: 600
+               path: vault-token
+   ```
+
+### Registrations
+
+With `TRACECAT__SECRETS_BACKEND=vault`, creating a secret in the Tracecat UI
+or API registers its name, key names, type, and environment — leave all
+values empty. Requests that include secret values are rejected. At runtime
+the executor resolves values from Vault by secret name; a secret that exists
+in Vault but is referenced by a name with no matching path returns the usual
+"missing secret" error.
+
+OAuth integrations are out of scope for secrets backends and remain in the
+database (they require stateful token refresh).
+
+### Security notes
+
+- Vault credentials (the projected token and the exchanged Vault token) and
+  resolved secret values exist only in the executor service process. Action
+  sandboxes receive per-action secret projections and can never read the
+  Vault token.
+- Values are cached in process memory with a short TTL (default 45s) to
+  avoid a network round-trip per resolution. Entries are dropped on read
+  errors, the cache is size-bounded, and values are never logged.

--- a/frontend/src/components/workspaces/create-credential-dialog.tsx
+++ b/frontend/src/components/workspaces/create-credential-dialog.tsx
@@ -57,7 +57,11 @@ import {
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { toast } from "@/components/ui/use-toast"
-import { useAwsAssumeRoleAccess, useWorkspaceSecrets } from "@/lib/hooks"
+import {
+  useAppInfo,
+  useAwsAssumeRoleAccess,
+  useWorkspaceSecrets,
+} from "@/lib/hooks"
 import { cn, copyToClipboard } from "@/lib/utils"
 import { useWorkspaceId } from "@/providers/workspace-id"
 
@@ -272,7 +276,11 @@ const validatePemField = (
   }
 }
 
-const createSecretSchema = z
+// When the secrets backend is read-only (e.g. Vault), secret values live in
+// the external backend and are not entered in Tracecat; the form registers
+// key names only, so value/PEM validation is skipped.
+const makeCreateSecretSchema = (secretsReadonly: boolean) =>
+  z
   .object({
     name: z
       .string()
@@ -396,8 +404,9 @@ const createSecretSchema = z
           })
         }
         // Only validate value if it's not an optional field from a template
-        // or if user has entered something
-        if (!item.isOptional && !item.value?.trim()) {
+        // or if user has entered something. Skipped entirely when the secrets
+        // backend is read-only (value comes from the external backend).
+        if (!secretsReadonly && !item.isOptional && !item.value?.trim()) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: ["keys", index, "value"],
@@ -405,6 +414,13 @@ const createSecretSchema = z
           })
         }
       })
+    }
+
+    // Structured secret types (ssh_key/mtls/ca_cert) require their PEM values
+    // only when Tracecat stores the values; in read-only mode the row is a
+    // value-less registration.
+    if (secretsReadonly) {
+      return
     }
 
     if (values.type === "ssh_key") {
@@ -449,7 +465,7 @@ const createSecretSchema = z
     }
   })
 
-type CreateSecretForm = z.infer<typeof createSecretSchema>
+type CreateSecretForm = z.infer<ReturnType<typeof makeCreateSecretSchema>>
 
 interface CreateCredentialDialogProps extends DialogProps {
   template?: SecretDefinition | null
@@ -466,6 +482,8 @@ export function CreateCredentialDialog({
 }: CreateCredentialDialogProps) {
   const selectedTool = template
   const workspaceId = useWorkspaceId()
+  const { appInfo } = useAppInfo()
+  const secretsReadonly = appInfo?.secrets_backend_readonly === true
   const { createSecret } = useWorkspaceSecrets(workspaceId, {
     listEnabled: false,
   })
@@ -485,6 +503,10 @@ export function CreateCredentialDialog({
   })
 
   // Form handling
+  const createSecretSchema = React.useMemo(
+    () => makeCreateSecretSchema(secretsReadonly),
+    [secretsReadonly]
+  )
   const methods = useForm<CreateSecretForm>({
     resolver: zodResolver(createSecretSchema),
     defaultValues: {
@@ -903,6 +925,17 @@ export function CreateCredentialDialog({
         </DialogHeader>
 
         <CreateSecretTooltip />
+        {secretsReadonly && (
+          <Alert>
+            <ShieldCheck className="size-4" />
+            <AlertTitle>Managed by an external secrets backend</AlertTitle>
+            <AlertDescription>
+              This deployment resolves secret values from an external backend
+              (e.g. Vault). Register the secret name and its key names here;
+              store the values in the external backend.
+            </AlertDescription>
+          </Alert>
+        )}
         <Form {...methods}>
           <form
             onSubmit={methods.handleSubmit(onSubmit, onValidationFailed)}
@@ -1479,14 +1512,18 @@ export function CreateCredentialDialog({
                                   {...register(
                                     `${inputKey}.${index}.value` as const,
                                     {
-                                      required: !field.isOptional,
+                                      required:
+                                        !field.isOptional && !secretsReadonly,
                                     }
                                   )}
                                   placeholder={
-                                    field.isOptional
-                                      ? "Value (optional)"
-                                      : "Value"
+                                    secretsReadonly
+                                      ? "Managed in Vault"
+                                      : field.isOptional
+                                        ? "Value (optional)"
+                                        : "Value"
                                   }
+                                  disabled={secretsReadonly}
                                   type="password"
                                 />
                               </FormControl>

--- a/frontend/src/lib/hooks.tsx
+++ b/frontend/src/lib/hooks.tsx
@@ -395,6 +395,9 @@ interface AppInfo {
   saml_enabled: boolean
   saml_enforced: boolean
   ee_multi_tenant: boolean
+  /** Secret values live in an external secrets backend (e.g. Vault); forms
+   * register key names only and must allow empty values. */
+  secrets_backend_readonly?: boolean
 }
 
 export type WorkspaceSecretListItem = SecretReadMinimal & {

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -46,14 +46,22 @@ async def test_auth_sandbox_with_secrets(mocker: pytest_mock.MockFixture, test_r
         tags={},
     )
 
-    mock_get_secrets = mocker.patch.object(
-        AuthSandbox, "_get_secrets", return_value=[mock_secret]
+    # The database backend fetches encrypted rows and decrypts them.
+    mock_secrets_service = mocker.AsyncMock(spec=SecretsService)
+    mock_secrets_service.search_secrets.return_value = [mock_secret]
+    mocker.patch(
+        "tracecat.secrets.backends.database.SecretsService.with_session",
+        return_value=mocker.AsyncMock(
+            __aenter__=mocker.AsyncMock(return_value=mock_secrets_service)
+        ),
     )
 
     async with AuthSandbox(secrets=["my_secret"]) as sandbox:
         assert sandbox.secrets == {"my_secret": {"SECRET_KEY": "my_secret_key"}}
 
-    mock_get_secrets.assert_called_once()
+    mock_secrets_service.search_secrets.assert_called_once_with(
+        SecretSearch(names={"my_secret"}, environment="default")
+    )
 
 
 @pytest.mark.anyio
@@ -81,7 +89,7 @@ async def test_auth_sandbox_missing_secret(mocker: pytest_mock.MockFixture, test
     mock_secrets_service = mocker.AsyncMock(spec=SecretsService)
     mock_secrets_service.search_secrets.return_value = []
     mocker.patch(
-        "tracecat.auth.sandbox.SecretsService.with_session",
+        "tracecat.secrets.backends.database.SecretsService.with_session",
         return_value=mocker.AsyncMock(
             __aenter__=mocker.AsyncMock(return_value=mock_secrets_service)
         ),
@@ -236,7 +244,7 @@ async def test_auth_sandbox_optional_secrets(
     mock_secrets_service = mocker.AsyncMock(spec=SecretsService)
     mock_secrets_service.search_secrets.return_value = [required_secret]
     mocker.patch(
-        "tracecat.auth.sandbox.SecretsService.with_session",
+        "tracecat.secrets.backends.database.SecretsService.with_session",
         return_value=mocker.AsyncMock(
             __aenter__=mocker.AsyncMock(return_value=mock_secrets_service)
         ),
@@ -323,7 +331,7 @@ async def test_auth_sandbox_all_secrets_present(
         optional_secret,
     ]
     mocker.patch(
-        "tracecat.auth.sandbox.SecretsService.with_session",
+        "tracecat.secrets.backends.database.SecretsService.with_session",
         return_value=mocker.AsyncMock(
             __aenter__=mocker.AsyncMock(return_value=mock_secrets_service)
         ),
@@ -380,7 +388,7 @@ async def test_auth_sandbox_optional_secret_with_all_keys(
     mock_secrets_service = mocker.AsyncMock(spec=SecretsService)
     mock_secrets_service.search_secrets.return_value = [optional_secret]
     mocker.patch(
-        "tracecat.auth.sandbox.SecretsService.with_session",
+        "tracecat.secrets.backends.database.SecretsService.with_session",
         return_value=mocker.AsyncMock(
             __aenter__=mocker.AsyncMock(return_value=mock_secrets_service)
         ),
@@ -407,7 +415,7 @@ async def test_auth_sandbox_missing_optional_secret(
     mock_secrets_service = mocker.AsyncMock(spec=SecretsService)
     mock_secrets_service.search_secrets.return_value = []
     mocker.patch(
-        "tracecat.auth.sandbox.SecretsService.with_session",
+        "tracecat.secrets.backends.database.SecretsService.with_session",
         return_value=mocker.AsyncMock(
             __aenter__=mocker.AsyncMock(return_value=mock_secrets_service)
         ),
@@ -449,7 +457,7 @@ async def test_auth_sandbox_optional_secret_missing_optional_key(
     mock_secrets_service = mocker.AsyncMock(spec=SecretsService)
     mock_secrets_service.search_secrets.return_value = [partial_optional_secret]
     mocker.patch(
-        "tracecat.auth.sandbox.SecretsService.with_session",
+        "tracecat.secrets.backends.database.SecretsService.with_session",
         return_value=mocker.AsyncMock(
             __aenter__=mocker.AsyncMock(return_value=mock_secrets_service)
         ),

--- a/tests/unit/test_secrets_backend.py
+++ b/tests/unit/test_secrets_backend.py
@@ -300,6 +300,97 @@ class TestVaultSecretsBackend:
                 scope="workspace",
                 role=test_backend_role,
             )
+        with pytest.raises(VaultSecretsError, match="Invalid"):
+            await backend.get_secret_values(
+                {"ok_name"}, "..", scope="workspace", role=test_backend_role
+            )
+
+    @respx.mock
+    async def test_unusual_names_are_percent_encoded(
+        self, vault_config, test_backend_role
+    ):
+        # Tracecat does not constrain environment names (e.g. "__FIRST__" is
+        # used in the test suite); segments are encoded, not rejected.
+        route = respx.get(
+            f"{VAULT_ADDR}/v1/secret/data/tracecat/workspace/{WORKSPACE_ID}"
+            "/__FIRST__/my%20secret"
+        ).mock(return_value=_kv_response({"K": "v"}))
+        backend = VaultSecretsBackend()
+        values = await backend.get_secret_values(
+            {"my secret"}, "__FIRST__", scope="workspace", role=test_backend_role
+        )
+        assert values == {"my secret": {"K": "v"}}
+        assert route.called
+
+
+class TestRegistrationOnlyWrites:
+    """When the backend is read-only, secret values must never reach the DB."""
+
+    def test_non_empty_values_rejected(self):
+        from pydantic import SecretStr
+
+        from tracecat.secrets.schemas import SecretKeyValue
+        from tracecat.secrets.service import SecretsService
+
+        with pytest.raises(ValueError, match="cannot be stored"):
+            SecretsService._assert_registration_only_keys(
+                [SecretKeyValue(key="K", value=SecretStr("v"))]
+            )
+
+    def test_empty_values_allowed(self):
+        from pydantic import SecretStr
+
+        from tracecat.secrets.schemas import SecretKeyValue
+        from tracecat.secrets.service import SecretsService
+
+        SecretsService._assert_registration_only_keys(
+            [SecretKeyValue(key="K", value=SecretStr(""))]
+        )
+
+
+@pytest.mark.anyio
+class TestDatabaseBackendRegistrationGuard:
+    """The db backend must not serve external-backend registrations as values."""
+
+    async def test_external_registration_rows_are_skipped(self, mocker):
+        import os
+        from datetime import datetime
+
+        from pydantic import SecretStr
+
+        from tracecat.db.models import Secret
+        from tracecat.secrets.encryption import encrypt_keyvalues
+        from tracecat.secrets.schemas import SecretKeyValue
+        from tracecat.secrets.service import SecretsService
+
+        registration = Secret(
+            name="vault_managed",
+            workspace_id=WORKSPACE_ID,
+            encrypted_keys=encrypt_keyvalues(
+                [SecretKeyValue(key="K", value=SecretStr(""))],
+                key=os.environ["TRACECAT__DB_ENCRYPTION_KEY"],
+            ),
+            backend="vault",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            tags={},
+        )
+        mock_service = mocker.AsyncMock(spec=SecretsService)
+        mock_service.search_secrets.return_value = [registration]
+        mocker.patch(
+            "tracecat.secrets.backends.database.SecretsService.with_session",
+            return_value=mocker.AsyncMock(
+                __aenter__=mocker.AsyncMock(return_value=mock_service)
+            ),
+        )
+        backend = DatabaseSecretsBackend()
+        values = await backend.get_secret_values(
+            {"vault_managed"},
+            "default",
+            scope="workspace",
+            role=None,
+        )
+        assert values == {}
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_secrets_backend.py
+++ b/tests/unit/test_secrets_backend.py
@@ -1,0 +1,360 @@
+"""Tests for pluggable secrets backends (factory, Vault backend, dispatch)."""
+
+import time
+import uuid
+
+import httpx
+import pytest
+import respx
+
+from tracecat import config
+from tracecat.auth.types import Role
+from tracecat.secrets.backend import (
+    get_secrets_backend,
+    reset_secrets_backend,
+)
+from tracecat.secrets.backends.database import DatabaseSecretsBackend
+from tracecat.secrets.backends.vault import VaultSecretsBackend, VaultSecretsError
+
+VAULT_ADDR = "http://vault.test:8200"
+
+WORKSPACE_ID = uuid.uuid4()
+ORG_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def test_backend_role() -> Role:
+    return Role(
+        type="service",
+        service_id="tracecat-service",
+        workspace_id=WORKSPACE_ID,
+        organization_id=ORG_ID,
+    )
+
+
+@pytest.fixture
+def vault_config(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(config, "TRACECAT__VAULT_ADDR", VAULT_ADDR)
+    monkeypatch.setattr(config, "TRACECAT__VAULT_KV_MOUNT", "secret")
+    monkeypatch.setattr(config, "TRACECAT__VAULT_PATH_PREFIX", "tracecat")
+    monkeypatch.setattr(config, "TRACECAT__VAULT_AUTH_METHOD", "token")
+    monkeypatch.setattr(config, "TRACECAT__VAULT_TOKEN", "dev-token")
+    monkeypatch.setattr(config, "TRACECAT__VAULT_NAMESPACE", None)
+    monkeypatch.setattr(config, "TRACECAT__VAULT_CACHE_TTL_SECONDS", 45.0)
+    monkeypatch.setattr(config, "TRACECAT__VAULT_CACHE_MAX_SIZE", 1024)
+    reset_secrets_backend()
+    yield
+    reset_secrets_backend()
+
+
+def _kv_url(scope: str, owner: uuid.UUID, environment: str, name: str) -> str:
+    return (
+        f"{VAULT_ADDR}/v1/secret/data/tracecat/{scope}/{owner}/{environment}/{name}"
+    )
+
+
+def _kv_response(data: dict[str, str]) -> httpx.Response:
+    return httpx.Response(200, json={"data": {"data": data, "metadata": {}}})
+
+
+class TestBackendFactory:
+    def test_default_is_database(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(config, "TRACECAT__SECRETS_BACKEND", "db")
+        reset_secrets_backend()
+        backend = get_secrets_backend()
+        assert isinstance(backend, DatabaseSecretsBackend)
+        assert backend.can_write is True
+        # Instances are cached per backend name
+        assert get_secrets_backend() is backend
+        reset_secrets_backend()
+
+    def test_unknown_backend_raises(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(config, "TRACECAT__SECRETS_BACKEND", "s3")
+        reset_secrets_backend()
+        with pytest.raises(ValueError, match="Unknown secrets backend"):
+            get_secrets_backend()
+        reset_secrets_backend()
+
+    def test_vault_backend_selected(
+        self, monkeypatch: pytest.MonkeyPatch, vault_config
+    ):
+        monkeypatch.setattr(config, "TRACECAT__SECRETS_BACKEND", "vault")
+        backend = get_secrets_backend()
+        assert isinstance(backend, VaultSecretsBackend)
+        assert backend.can_write is False
+
+    def test_vault_requires_addr(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(config, "TRACECAT__VAULT_ADDR", None)
+        with pytest.raises(VaultSecretsError, match="TRACECAT__VAULT_ADDR"):
+            VaultSecretsBackend()
+
+    def test_vault_rejects_unknown_auth_method(
+        self, monkeypatch: pytest.MonkeyPatch, vault_config
+    ):
+        monkeypatch.setattr(config, "TRACECAT__VAULT_AUTH_METHOD", "ldap")
+        with pytest.raises(VaultSecretsError, match="AUTH_METHOD"):
+            VaultSecretsBackend()
+
+
+@pytest.mark.anyio
+class TestVaultSecretsBackend:
+    @respx.mock
+    async def test_read_custom_secret(self, vault_config, test_backend_role):
+        route = respx.get(_kv_url("workspace", WORKSPACE_ID, "default", "my_secret")).mock(
+            return_value=_kv_response({"API_KEY": "s3cret", "USER": "alice"})
+        )
+        backend = VaultSecretsBackend()
+        values = await backend.get_secret_values(
+            {"my_secret"}, "default", scope="workspace", role=test_backend_role
+        )
+        assert values == {"my_secret": {"API_KEY": "s3cret", "USER": "alice"}}
+        assert route.called
+        request = route.calls.last.request
+        assert request.headers["X-Vault-Token"] == "dev-token"
+
+    @respx.mock
+    async def test_missing_secret_is_omitted(self, vault_config, test_backend_role):
+        respx.get(_kv_url("workspace", WORKSPACE_ID, "default", "nope")).mock(
+            return_value=httpx.Response(404, json={"errors": []})
+        )
+        backend = VaultSecretsBackend()
+        values = await backend.get_secret_values(
+            {"nope"}, "default", scope="workspace", role=test_backend_role
+        )
+        assert values == {}
+
+    @respx.mock
+    async def test_organization_scope_uses_org_path(
+        self, vault_config, test_backend_role
+    ):
+        route = respx.get(
+            _kv_url("organization", ORG_ID, "default", "tracecat_registry_ssh_key")
+        ).mock(return_value=_kv_response({"PRIVATE_KEY": "---key---"}))
+        backend = VaultSecretsBackend()
+        values = await backend.get_secret_values(
+            {"tracecat_registry_ssh_key"},
+            "default",
+            scope="organization",
+            role=test_backend_role,
+        )
+        assert values == {"tracecat_registry_ssh_key": {"PRIVATE_KEY": "---key---"}}
+        assert route.called
+
+    @respx.mock
+    async def test_cache_hit_avoids_second_read(self, vault_config, test_backend_role):
+        route = respx.get(_kv_url("workspace", WORKSPACE_ID, "default", "cached")).mock(
+            return_value=_kv_response({"K": "v"})
+        )
+        backend = VaultSecretsBackend()
+        for _ in range(3):
+            values = await backend.get_secret_values(
+                {"cached"}, "default", scope="workspace", role=test_backend_role
+            )
+            assert values == {"cached": {"K": "v"}}
+        assert route.call_count == 1
+
+    @respx.mock
+    async def test_cache_expires(
+        self, monkeypatch: pytest.MonkeyPatch, vault_config, test_backend_role
+    ):
+        monkeypatch.setattr(config, "TRACECAT__VAULT_CACHE_TTL_SECONDS", 0.05)
+        route = respx.get(_kv_url("workspace", WORKSPACE_ID, "default", "ttl")).mock(
+            return_value=_kv_response({"K": "v"})
+        )
+        backend = VaultSecretsBackend()
+        await backend.get_secret_values(
+            {"ttl"}, "default", scope="workspace", role=test_backend_role
+        )
+        time.sleep(0.06)
+        await backend.get_secret_values(
+            {"ttl"}, "default", scope="workspace", role=test_backend_role
+        )
+        assert route.call_count == 2
+
+    @respx.mock
+    async def test_cache_disabled_with_zero_ttl(
+        self, monkeypatch: pytest.MonkeyPatch, vault_config, test_backend_role
+    ):
+        monkeypatch.setattr(config, "TRACECAT__VAULT_CACHE_TTL_SECONDS", 0.0)
+        route = respx.get(_kv_url("workspace", WORKSPACE_ID, "default", "nocache")).mock(
+            return_value=_kv_response({"K": "v"})
+        )
+        backend = VaultSecretsBackend()
+        for _ in range(2):
+            await backend.get_secret_values(
+                {"nocache"}, "default", scope="workspace", role=test_backend_role
+            )
+        assert route.call_count == 2
+
+    @respx.mock
+    async def test_permission_denied_raises(self, vault_config, test_backend_role):
+        respx.get(_kv_url("workspace", WORKSPACE_ID, "default", "denied")).mock(
+            return_value=httpx.Response(403, json={"errors": ["permission denied"]})
+        )
+        backend = VaultSecretsBackend()
+        with pytest.raises(VaultSecretsError, match="denied access"):
+            await backend.get_secret_values(
+                {"denied"}, "default", scope="workspace", role=test_backend_role
+            )
+
+    @respx.mock
+    async def test_jwt_login_flow_and_token_reuse(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+        vault_config,
+        test_backend_role,
+    ):
+        token_file = tmp_path / "vault-token"
+        token_file.write_text("sa-jwt-token\n")
+        monkeypatch.setattr(config, "TRACECAT__VAULT_AUTH_METHOD", "jwt")
+        monkeypatch.setattr(config, "TRACECAT__VAULT_JWT_AUTH_MOUNT", "jwt")
+        monkeypatch.setattr(config, "TRACECAT__VAULT_JWT_ROLE", "tracecat-executor")
+        monkeypatch.setattr(
+            config, "TRACECAT__VAULT_JWT_TOKEN_PATH", str(token_file)
+        )
+        monkeypatch.setattr(config, "TRACECAT__VAULT_CACHE_TTL_SECONDS", 0.0)
+
+        login_route = respx.post(f"{VAULT_ADDR}/v1/auth/jwt/login").mock(
+            return_value=httpx.Response(
+                200,
+                json={"auth": {"client_token": "vault-tok", "lease_duration": 3600}},
+            )
+        )
+        kv_route = respx.get(_kv_url("workspace", WORKSPACE_ID, "default", "jwt_s")).mock(
+            return_value=_kv_response({"K": "v"})
+        )
+
+        backend = VaultSecretsBackend()
+        for _ in range(2):
+            values = await backend.get_secret_values(
+                {"jwt_s"}, "default", scope="workspace", role=test_backend_role
+            )
+            assert values == {"jwt_s": {"K": "v"}}
+
+        # Login happens once; the lease-cached token is reused.
+        assert login_route.call_count == 1
+        assert kv_route.call_count == 2
+        login_body = login_route.calls.last.request.content
+        assert b"sa-jwt-token" in login_body
+        assert b"tracecat-executor" in login_body
+        assert kv_route.calls.last.request.headers["X-Vault-Token"] == "vault-tok"
+
+    @respx.mock
+    async def test_auth_failure_clears_cached_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+        vault_config,
+        test_backend_role,
+    ):
+        token_file = tmp_path / "vault-token"
+        token_file.write_text("sa-jwt-token")
+        monkeypatch.setattr(config, "TRACECAT__VAULT_AUTH_METHOD", "jwt")
+        monkeypatch.setattr(config, "TRACECAT__VAULT_JWT_ROLE", "tracecat-executor")
+        monkeypatch.setattr(
+            config, "TRACECAT__VAULT_JWT_TOKEN_PATH", str(token_file)
+        )
+        monkeypatch.setattr(config, "TRACECAT__VAULT_CACHE_TTL_SECONDS", 0.0)
+
+        login_route = respx.post(f"{VAULT_ADDR}/v1/auth/jwt/login").mock(
+            return_value=httpx.Response(
+                200,
+                json={"auth": {"client_token": "vault-tok", "lease_duration": 3600}},
+            )
+        )
+        respx.get(_kv_url("workspace", WORKSPACE_ID, "default", "s")).mock(
+            return_value=httpx.Response(403, json={"errors": ["permission denied"]})
+        )
+
+        backend = VaultSecretsBackend()
+        for _ in range(2):
+            with pytest.raises(VaultSecretsError):
+                await backend.get_secret_values(
+                    {"s"}, "default", scope="workspace", role=test_backend_role
+                )
+        # 403 invalidates the cached Vault token, forcing a fresh login.
+        assert login_route.call_count == 2
+
+    async def test_workspace_scope_requires_workspace_id(self, vault_config):
+        backend = VaultSecretsBackend()
+        role = Role(type="service", service_id="tracecat-service")
+        with pytest.raises(VaultSecretsError, match="Workspace context"):
+            await backend.get_secret_values(
+                {"s"}, "default", scope="workspace", role=role
+            )
+
+    async def test_path_traversal_rejected(self, vault_config, test_backend_role):
+        backend = VaultSecretsBackend()
+        with pytest.raises(VaultSecretsError, match="Invalid"):
+            await backend.get_secret_values(
+                {"../../sys/policy"},
+                "default",
+                scope="workspace",
+                role=test_backend_role,
+            )
+        with pytest.raises(VaultSecretsError, match="Invalid"):
+            await backend.get_secret_values(
+                {"ok_name"},
+                "../other-env",
+                scope="workspace",
+                role=test_backend_role,
+            )
+
+
+@pytest.mark.anyio
+class TestExternalSshKeyDispatch:
+    """SecretsService resolves SSH keys via the backend when it is read-only."""
+
+    def _service(self, role: Role):
+        from tracecat.secrets.service import SecretsService
+
+        service = SecretsService.__new__(SecretsService)
+        service.role = role
+        return service
+
+    class _StubBackend:
+        def __init__(self, values: dict[str, dict[str, str]]):
+            self.values = values
+            self.calls: list[tuple[set[str], str, str]] = []
+
+        @property
+        def can_write(self) -> bool:
+            return False
+
+        async def get_secret_values(
+            self, names, environment, *, scope="workspace", role=None
+        ):
+            self.calls.append((set(names), environment, scope))
+            return {
+                name: kv for name, kv in self.values.items() if name in names
+            }
+
+        async def list_registrations(
+            self, environment=None, *, scope="workspace", role=None
+        ):
+            return []
+
+    async def test_ssh_key_resolved_from_backend(self, test_backend_role):
+        backend = self._StubBackend(
+            {"my_ssh_key": {"PRIVATE_KEY": "-----BEGIN KEY-----"}}
+        )
+        service = self._service(test_backend_role)
+        key = await service._get_ssh_key_from_backend(backend, "my_ssh_key", None)
+        # A trailing newline is enforced for libcrypto compatibility.
+        assert key.get_secret_value() == "-----BEGIN KEY-----\n"
+        assert backend.calls == [({"my_ssh_key"}, "default", "organization")]
+
+    async def test_single_key_fallback(self, test_backend_role):
+        backend = self._StubBackend({"legacy_key": {"legacy_name": "keydata\n"}})
+        service = self._service(test_backend_role)
+        key = await service._get_ssh_key_from_backend(backend, "legacy_key", None)
+        assert key.get_secret_value() == "keydata\n"
+
+    async def test_missing_ssh_key_raises(self, test_backend_role):
+        from tracecat.exceptions import TracecatCredentialsNotFoundError
+
+        backend = self._StubBackend({})
+        service = self._service(test_backend_role)
+        with pytest.raises(TracecatCredentialsNotFoundError, match="not found"):
+            await service._get_ssh_key_from_backend(backend, "absent", None)

--- a/tracecat/api/app.py
+++ b/tracecat/api/app.py
@@ -722,6 +722,9 @@ class AppInfo(BaseModel):
     saml_enabled: bool
     saml_enforced: bool
     ee_multi_tenant: bool
+    secrets_backend_readonly: bool
+    """True when secret values are managed by an external secrets backend
+    (e.g. Vault) and cannot be stored through Tracecat."""
 
 
 @app.get("/info", include_in_schema=False)
@@ -751,6 +754,7 @@ async def info(session: AsyncDBSessionBypass) -> AppInfo:
         saml_enabled=keyvalues["saml_enabled"],
         saml_enforced=keyvalues["saml_enforced"],
         ee_multi_tenant=config.TRACECAT__EE_MULTI_TENANT,
+        secrets_backend_readonly=config.TRACECAT__SECRETS_BACKEND != "db",
     )
 
 

--- a/tracecat/auth/sandbox.py
+++ b/tracecat/auth/sandbox.py
@@ -3,20 +3,16 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable
 from types import TracebackType
 from typing import Any, Self
 
-from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.auth.types import Role
 from tracecat.contexts import ctx_role
-from tracecat.db.models import BaseSecret
 from tracecat.exceptions import TracecatCredentialsError
 from tracecat.logger import logger
+from tracecat.secrets.backend import get_secrets_backend
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
-from tracecat.secrets.encryption import decrypt_keyvalues
-from tracecat.secrets.schemas import SecretKeyValue, SecretSearch
-from tracecat.secrets.service import SecretsService
 
 
 class AuthSandbox:
@@ -26,13 +22,17 @@ class AuthSandbox:
     ----------
     - This allows use of `os.environ` to access secrets in the environment in UDFs.
     - We wrap the execution of a UDF with this context manager to set secrets in the environment.
+
+    Secret values are resolved through the configured secrets backend
+    (`TRACECAT__SECRETS_BACKEND`): the database backend decrypts values stored
+    in Postgres, external backends (e.g. Vault) fetch them at runtime.
     """
 
     def __init__(
         self,
         role: Role | None = None,
         # This can be either 'my_secret.KEY' or 'my_secret'
-        # Keys that are passed here are fetched from the db
+        # Keys that are passed here are fetched from the secrets backend
         secrets: Iterable[str] | None = None,
         environment: str = DEFAULT_SECRETS_ENVIRONMENT,
         # Keys specified here will tell the sandbox to ignore if they are missing
@@ -40,16 +40,13 @@ class AuthSandbox:
     ):
         self._role = role or ctx_role.get()
         self._secret_paths = set(secrets or [])
-        self._secret_objs: Sequence[BaseSecret] = []
         self._context: dict[str, Any] = {}
         self._environment = environment
         self._optional_secrets = set(optional_secrets or [])
-        self._encryption_key = get_db_encryption_key()
 
     def __enter__(self) -> Self:
         if self._secret_paths:
-            self._secret_objs = asyncio.run(self._get_secrets())
-            self._set_secrets()
+            self._context = asyncio.run(self._get_secrets())
         return self
 
     def __exit__(
@@ -67,8 +64,7 @@ class AuthSandbox:
 
     async def __aenter__(self) -> Self:
         if self._secret_paths:
-            self._secret_objs = await self._get_secrets()
-            self._set_secrets()
+            self._context = await self._get_secrets()
         return self
 
     async def __aexit__(
@@ -84,44 +80,15 @@ class AuthSandbox:
         """Return secret names mapped to their secret key value pairs."""
         return self._context
 
-    def _iter_secrets(self) -> Iterator[tuple[str, SecretKeyValue]]:
-        """Iterate over the secrets."""
-        try:
-            for secret in self._secret_objs:
-                keyvalues = decrypt_keyvalues(
-                    secret.encrypted_keys, key=self._encryption_key
-                )
-                for kv in keyvalues:
-                    yield secret.name, kv
-        except Exception as e:
-            logger.error(f"Error decrypting secrets: {e!r}")
-            raise
-
-    def _set_secrets(self) -> None:
-        """Set secrets in the target."""
-        logger.info(
-            "Setting secrets",
-            paths=self._secret_paths,
-        )
-        for name, kv in self._iter_secrets():
-            if name not in self._context:
-                self._context[name] = {}
-            self._context[name][kv.key] = kv.value.get_secret_value()
-
     def _unset_secrets(self) -> None:
         logger.trace("Cleaning up secrets")
-        for secret in self._secret_objs:
-            if secret.name in self._context:
-                del self._context[secret.name]
+        self._context = {}
 
-    async def _get_secrets(self) -> Sequence[BaseSecret]:
-        """Retrieve secrets from a secrets manager."""
-        return await self._get_secrets_from_service()
-
-    async def _get_secrets_from_service(self) -> Sequence[BaseSecret]:
-        """Retrieve secrets from the secrets service."""
+    async def _get_secrets(self) -> dict[str, dict[str, str]]:
+        """Retrieve secret values from the configured secrets backend."""
+        backend = get_secrets_backend()
         logger.debug(
-            "Retrieving secrets directly from db",
+            "Retrieving secrets from backend",
             secret_names=self._secret_paths,
             role=self._role,
             environment=self._environment,
@@ -129,12 +96,14 @@ class AuthSandbox:
 
         # These are a combination of required and optional secrets
         unique_secret_names = {path.split(".")[0] for path in self._secret_paths}
-        async with SecretsService.with_session(role=self._role) as service:
-            logger.info("Retrieving secrets", secret_names=unique_secret_names)
+        logger.info("Retrieving secrets", secret_names=unique_secret_names)
 
-            secrets = await service.search_secrets(
-                SecretSearch(names=unique_secret_names, environment=self._environment)
-            )
+        secret_values = await backend.get_secret_values(
+            unique_secret_names,
+            self._environment,
+            scope="workspace",
+            role=self._role,
+        )
 
         # Filter out optional secrets
         unique_req_secret_names = {
@@ -143,9 +112,9 @@ class AuthSandbox:
             if secret_name not in self._optional_secrets
         }
         defined_req_secret_names = {
-            secret.name
-            for secret in secrets
-            if secret.name not in self._optional_secrets
+            secret_name
+            for secret_name in secret_values
+            if secret_name not in self._optional_secrets
         }
         logger.debug(
             "Retrieved secrets",
@@ -165,4 +134,4 @@ class AuthSandbox:
                 ],
             )
 
-        return secrets
+        return secret_values

--- a/tracecat/config.py
+++ b/tracecat/config.py
@@ -316,6 +316,52 @@ OAUTH_CLIENT_SECRET = OIDC_CLIENT_SECRET
 USER_AUTH_SECRET = os.environ.get("USER_AUTH_SECRET")
 TRACECAT__DB_ENCRYPTION_KEY = os.environ.get("TRACECAT__DB_ENCRYPTION_KEY")
 TRACECAT__SIGNING_SECRET = os.environ.get("TRACECAT__SIGNING_SECRET")
+
+# === Secrets backend === #
+TRACECAT__SECRETS_BACKEND = os.environ.get("TRACECAT__SECRETS_BACKEND", "db")
+"""Where workflow secret values live: 'db' (encrypted in the Tracecat
+database, default) or 'vault' (read from HashiCorp Vault at runtime)."""
+
+TRACECAT__VAULT_ADDR = os.environ.get("TRACECAT__VAULT_ADDR")
+"""Base URL of the Vault server, e.g. https://vault.example.com:8200."""
+
+TRACECAT__VAULT_KV_MOUNT = os.environ.get("TRACECAT__VAULT_KV_MOUNT", "secret")
+"""Mount path of the KV v2 secrets engine."""
+
+TRACECAT__VAULT_PATH_PREFIX = os.environ.get("TRACECAT__VAULT_PATH_PREFIX", "tracecat")
+"""Path prefix under the KV mount for all Tracecat secrets."""
+
+TRACECAT__VAULT_AUTH_METHOD = os.environ.get("TRACECAT__VAULT_AUTH_METHOD", "jwt")
+"""Vault auth method: 'jwt' (projected service account token) or 'token'
+(static token, development only)."""
+
+TRACECAT__VAULT_JWT_AUTH_MOUNT = os.environ.get("TRACECAT__VAULT_JWT_AUTH_MOUNT", "jwt")
+"""Mount path of the Vault JWT auth method."""
+
+TRACECAT__VAULT_JWT_ROLE = os.environ.get("TRACECAT__VAULT_JWT_ROLE")
+"""Vault JWT auth role to log in as, e.g. 'tracecat-executor'."""
+
+TRACECAT__VAULT_JWT_TOKEN_PATH = os.environ.get(
+    "TRACECAT__VAULT_JWT_TOKEN_PATH", "/var/run/secrets/tokens/vault-token"
+)
+"""Filesystem path of the projected service account token used for JWT login."""
+
+TRACECAT__VAULT_TOKEN = os.environ.get("TRACECAT__VAULT_TOKEN")
+"""Static Vault token for TRACECAT__VAULT_AUTH_METHOD=token. Development only."""
+
+TRACECAT__VAULT_NAMESPACE = os.environ.get("TRACECAT__VAULT_NAMESPACE")
+"""Optional Vault Enterprise namespace."""
+
+TRACECAT__VAULT_CACHE_TTL_SECONDS = bound_env(
+    "TRACECAT__VAULT_CACHE_TTL_SECONDS", 45.0, lower=0.0, upper=300.0
+)
+"""TTL for the in-process Vault value cache. 0 disables caching. Keep this
+below the Vault lease TTL of the secrets being served."""
+
+TRACECAT__VAULT_CACHE_MAX_SIZE = bound_env(
+    "TRACECAT__VAULT_CACHE_MAX_SIZE", 1024, lower=0, upper=100_000
+)
+"""Maximum number of entries in the in-process Vault value cache (LRU)."""
 TRACECAT__AWS_ASSUME_ROLE_ACCOUNT_ID = os.environ.get(
     "TRACECAT__AWS_ASSUME_ROLE_ACCOUNT_ID"
 )

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -662,8 +662,10 @@ class BaseSecret(Base):
     backend: Mapped[str] = mapped_column(
         String(50), nullable=False, default="db", server_default="db"
     )
-    """Secrets backend that owns this secret's values. For external backends
-    (e.g. 'vault') the row is a value-less registration."""
+    """Secrets backend the secret was created under. For external backends
+    (e.g. 'vault') the row is a value-less registration. Dispatch is global
+    via TRACECAT__SECRETS_BACKEND; this marker guards against serving
+    registrations as values and enables future per-secret dispatch."""
     environment: Mapped[str] = mapped_column(
         String(255),
         nullable=False,

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -659,6 +659,11 @@ class BaseSecret(Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     description: Mapped[str | None] = mapped_column(String(255), nullable=True)
     encrypted_keys: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    backend: Mapped[str] = mapped_column(
+        String(50), nullable=False, default="db", server_default="db"
+    )
+    """Secrets backend that owns this secret's values. For external backends
+    (e.g. 'vault') the row is a value-less registration."""
     environment: Mapped[str] = mapped_column(
         String(255),
         nullable=False,

--- a/tracecat/secrets/backend.py
+++ b/tracecat/secrets/backend.py
@@ -1,0 +1,117 @@
+"""Pluggable secrets backends.
+
+A secrets backend controls where workflow secret *values* live at runtime.
+The default ``db`` backend keeps today's behavior: values are Fernet-encrypted
+with ``TRACECAT__DB_ENCRYPTION_KEY`` and stored in the Tracecat database.
+External backends (e.g. HashiCorp Vault) resolve values from an external
+secret manager at execution time, while the database keeps a value-less
+*registration* of each secret (name, key names, type, environment) so the UI
+and workflow validation continue to work.
+
+Select the backend with ``TRACECAT__SECRETS_BACKEND`` (default: ``db``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol, runtime_checkable
+
+from tracecat import config
+from tracecat.auth.types import Role
+from tracecat.secrets.enums import SecretType
+
+SecretScope = Literal["workspace", "organization"]
+"""Ownership scope of a secret. Workspace secrets are resolved for workflow
+actions; organization secrets back registry SSH keys and similar org-level
+credentials."""
+
+
+@dataclass(frozen=True, slots=True)
+class SecretRegistration:
+    """Value-less description of a secret: what exists, not what it contains."""
+
+    name: str
+    keys: tuple[str, ...]
+    type: SecretType
+    environment: str
+
+
+@runtime_checkable
+class SecretsBackend(Protocol):
+    """Read interface for resolving secret values at runtime.
+
+    Implementations must never log secret values. Values returned from
+    :meth:`get_secret_values` are plaintext and must only live in the service
+    process that resolves action contexts - never in action sandboxes.
+    """
+
+    @property
+    def can_write(self) -> bool:
+        """Whether Tracecat owns value storage for this backend.
+
+        ``True`` only for the database backend. When ``False``, secret values
+        cannot be created or updated through Tracecat; the database only holds
+        registrations.
+        """
+        ...
+
+    async def get_secret_values(
+        self,
+        names: set[str],
+        environment: str,
+        *,
+        scope: SecretScope = "workspace",
+        role: Role | None = None,
+    ) -> dict[str, dict[str, str]]:
+        """Resolve plaintext values for the given secret names.
+
+        Returns ``{name: {key: value}}``. Names that do not exist are simply
+        omitted from the result; callers are responsible for enforcing
+        required vs. optional secrets.
+        """
+        ...
+
+    async def list_registrations(
+        self,
+        environment: str | None = None,
+        *,
+        scope: SecretScope = "workspace",
+        role: Role | None = None,
+    ) -> list[SecretRegistration]:
+        """List secret registrations (names/keys/types) without values."""
+        ...
+
+
+_backends: dict[str, SecretsBackend] = {}
+
+
+def get_secrets_backend() -> SecretsBackend:
+    """Return the process-wide secrets backend selected by config.
+
+    Instances are cached per backend name so external backends can reuse
+    auth sessions and their value cache across calls.
+    """
+    backend_name = config.TRACECAT__SECRETS_BACKEND
+    if (backend := _backends.get(backend_name)) is not None:
+        return backend
+    match backend_name:
+        case "db":
+            from tracecat.secrets.backends.database import DatabaseSecretsBackend
+
+            backend = DatabaseSecretsBackend()
+        case "vault":
+            from tracecat.secrets.backends.vault import VaultSecretsBackend
+
+            backend = VaultSecretsBackend()
+        case _:
+            raise ValueError(
+                f"Unknown secrets backend {backend_name!r}. "
+                "Expected one of: 'db', 'vault'."
+            )
+    _backends[backend_name] = backend
+    return backend
+
+
+def reset_secrets_backend() -> None:
+    """Drop cached backend instances. Intended for tests."""
+    _backends.clear()

--- a/tracecat/secrets/backends/__init__.py
+++ b/tracecat/secrets/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Secrets backend implementations. See ``tracecat.secrets.backend``."""

--- a/tracecat/secrets/backends/database.py
+++ b/tracecat/secrets/backends/database.py
@@ -1,0 +1,115 @@
+"""Database secrets backend: encrypted values stored in the Tracecat DB.
+
+This is the default backend and preserves the pre-backend behavior exactly:
+values are fetched via :class:`SecretsService` and decrypted with the Fernet
+key from ``TRACECAT__DB_ENCRYPTION_KEY``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from tracecat.auth.secrets import get_db_encryption_key
+from tracecat.auth.types import Role
+from tracecat.db.models import BaseSecret
+from tracecat.exceptions import TracecatNotFoundError
+from tracecat.logger import logger
+from tracecat.secrets.backend import SecretRegistration, SecretScope
+from tracecat.secrets.encryption import decrypt_keyvalues
+from tracecat.secrets.enums import SecretType
+from tracecat.secrets.schemas import SecretSearch
+from tracecat.secrets.service import SecretsService
+
+
+class DatabaseSecretsBackend:
+    """Resolve secret values from the Tracecat database."""
+
+    @property
+    def can_write(self) -> bool:
+        return True
+
+    async def get_secret_values(
+        self,
+        names: set[str],
+        environment: str,
+        *,
+        scope: SecretScope = "workspace",
+        role: Role | None = None,
+    ) -> dict[str, dict[str, str]]:
+        secrets = await self._fetch_secrets(
+            names, environment=environment, scope=scope, role=role
+        )
+        encryption_key = get_db_encryption_key()
+        values: dict[str, dict[str, str]] = {}
+        try:
+            for secret in secrets:
+                keyvalues = decrypt_keyvalues(
+                    secret.encrypted_keys, key=encryption_key
+                )
+                kv_map = values.setdefault(secret.name, {})
+                for kv in keyvalues:
+                    kv_map[kv.key] = kv.value.get_secret_value()
+        except Exception as e:
+            logger.error(f"Error decrypting secrets: {e!r}")
+            raise
+        return values
+
+    async def list_registrations(
+        self,
+        environment: str | None = None,
+        *,
+        scope: SecretScope = "workspace",
+        role: Role | None = None,
+    ) -> list[SecretRegistration]:
+        async with SecretsService.with_session(role=role) as service:
+            if scope == "workspace":
+                secrets: Sequence[BaseSecret] = await service.list_secrets()
+            else:
+                secrets = await service.list_org_secrets()
+        encryption_key = get_db_encryption_key()
+        registrations: list[SecretRegistration] = []
+        for secret in secrets:
+            if environment is not None and secret.environment != environment:
+                continue
+            try:
+                keys = tuple(
+                    kv.key
+                    for kv in decrypt_keyvalues(
+                        secret.encrypted_keys, key=encryption_key
+                    )
+                )
+            except Exception:
+                # Corrupted rows are still listed so operators can spot them.
+                keys = ()
+            registrations.append(
+                SecretRegistration(
+                    name=secret.name,
+                    keys=keys,
+                    type=SecretType(secret.type),
+                    environment=secret.environment,
+                )
+            )
+        return registrations
+
+    async def _fetch_secrets(
+        self,
+        names: set[str],
+        *,
+        environment: str,
+        scope: SecretScope,
+        role: Role | None,
+    ) -> Sequence[BaseSecret]:
+        async with SecretsService.with_session(role=role) as service:
+            if scope == "workspace":
+                return await service.search_secrets(
+                    SecretSearch(names=names, environment=environment)
+                )
+            secrets: list[BaseSecret] = []
+            for name in names:
+                try:
+                    secrets.append(
+                        await service.get_org_secret_by_name(name, environment)
+                    )
+                except TracecatNotFoundError:
+                    continue
+            return secrets

--- a/tracecat/secrets/backends/database.py
+++ b/tracecat/secrets/backends/database.py
@@ -43,6 +43,16 @@ class DatabaseSecretsBackend:
         values: dict[str, dict[str, str]] = {}
         try:
             for secret in secrets:
+                # Registrations owned by an external backend hold no values;
+                # treat them as missing rather than serving empty strings
+                # (e.g. after switching TRACECAT__SECRETS_BACKEND back to db).
+                if getattr(secret, "backend", None) not in (None, "db"):
+                    logger.warning(
+                        "Skipping secret owned by an external backend",
+                        secret_name=secret.name,
+                        secret_backend=secret.backend,
+                    )
+                    continue
                 keyvalues = decrypt_keyvalues(
                     secret.encrypted_keys, key=encryption_key
                 )

--- a/tracecat/secrets/backends/vault.py
+++ b/tracecat/secrets/backends/vault.py
@@ -32,11 +32,11 @@ Security invariants:
 
 from __future__ import annotations
 
-import re
 import threading
 import time
 from collections import OrderedDict
 from pathlib import Path as FilePath
+from urllib.parse import quote
 
 import httpx
 
@@ -46,7 +46,6 @@ from tracecat.exceptions import TracecatException
 from tracecat.logger import logger
 from tracecat.secrets.backend import SecretRegistration, SecretScope
 
-_PATH_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 _REQUEST_TIMEOUT_SECONDS = 10.0
 # Refresh the Vault token well before its lease expires.
 _TOKEN_LEASE_SAFETY_FACTOR = 0.8
@@ -56,14 +55,18 @@ class VaultSecretsError(TracecatException):
     """Raised when the Vault secrets backend cannot resolve secrets."""
 
 
-def _validate_path_segment(value: str, *, label: str) -> str:
-    """Reject path segments that could traverse outside the configured prefix."""
-    if not _PATH_SEGMENT_PATTERN.match(value):
+def _encode_path_segment(value: str, *, label: str) -> str:
+    """Encode one path segment, rejecting values that could traverse the path.
+
+    Tracecat does not constrain secret or environment names, so segments are
+    percent-encoded rather than restricted; only values that would change the
+    path structure ('.', '..', empty, embedded separators/NUL) are rejected.
+    """
+    if not value or value in (".", "..") or any(c in value for c in "/\\\x00"):
         raise VaultSecretsError(
-            f"Invalid {label} {value!r} for Vault secret path. "
-            "Only alphanumerics, '_', '-' and '.' are allowed."
+            f"Invalid {label} {value!r} for Vault secret path."
         )
-    return value
+    return quote(value, safe="")
 
 
 class VaultSecretsBackend:
@@ -160,10 +163,10 @@ class VaultSecretsBackend:
         self, *, scope: SecretScope, owner: str, environment: str, name: str
     ) -> str:
         segments = [
-            _validate_path_segment(scope, label="scope"),
-            _validate_path_segment(owner, label="owner"),
-            _validate_path_segment(environment, label="environment"),
-            _validate_path_segment(name, label="secret name"),
+            _encode_path_segment(scope, label="scope"),
+            _encode_path_segment(owner, label="owner"),
+            _encode_path_segment(environment, label="environment"),
+            _encode_path_segment(name, label="secret name"),
         ]
         if self._path_prefix:
             segments.insert(0, self._path_prefix)
@@ -220,10 +223,9 @@ class VaultSecretsBackend:
             raise VaultSecretsError(
                 f"Vault read failed for path {path!r} (HTTP {response.status_code})."
             )
-        payload = response.json()
         try:
-            data = payload["data"]["data"]
-        except (KeyError, TypeError) as e:
+            data = response.json()["data"]["data"]
+        except (KeyError, TypeError, ValueError) as e:
             raise VaultSecretsError(
                 f"Unexpected Vault KV v2 response shape for path {path!r}."
             ) from e

--- a/tracecat/secrets/backends/vault.py
+++ b/tracecat/secrets/backends/vault.py
@@ -1,0 +1,334 @@
+"""HashiCorp Vault secrets backend (read-only, KV v2).
+
+Secret values live in Vault and are resolved at execution time; the Tracecat
+database only holds value-less registrations. Writes through Tracecat are
+rejected (``can_write`` is ``False``).
+
+Path convention (KV v2, configurable mount and prefix)::
+
+    {mount}/data/{prefix}/{scope}/{owner}/{environment}/{name}
+
+where ``owner`` is the workspace UUID for workspace secrets and the
+organization UUID for organization secrets. Each Vault secret's key/value
+data maps 1:1 to Tracecat secret keys, e.g. an ``ssh_key`` secret stores its
+private key under the ``PRIVATE_KEY`` key.
+
+Auth methods:
+
+- ``jwt`` (default): the pod's projected service-account token is exchanged
+  for a short-lived Vault token via the JWT auth method. This only needs
+  outbound connectivity from Tracecat to Vault, so it works in isolated
+  clusters where Vault cannot call back into the kube-apiserver (configure
+  the JWT auth method with static ``jwt_validation_pubkeys``).
+- ``token``: a static token from ``TRACECAT__VAULT_TOKEN``. Development only.
+
+Security invariants:
+
+- The Vault client, its token, and the value cache live in the executor
+  *service* process only. Action sandboxes receive per-action secret
+  projections and never see Vault credentials.
+- Secret values and Vault tokens are never logged.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import time
+from collections import OrderedDict
+from pathlib import Path as FilePath
+
+import httpx
+
+from tracecat import config
+from tracecat.auth.types import Role
+from tracecat.exceptions import TracecatException
+from tracecat.logger import logger
+from tracecat.secrets.backend import SecretRegistration, SecretScope
+
+_PATH_SEGMENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_REQUEST_TIMEOUT_SECONDS = 10.0
+# Refresh the Vault token well before its lease expires.
+_TOKEN_LEASE_SAFETY_FACTOR = 0.8
+
+
+class VaultSecretsError(TracecatException):
+    """Raised when the Vault secrets backend cannot resolve secrets."""
+
+
+def _validate_path_segment(value: str, *, label: str) -> str:
+    """Reject path segments that could traverse outside the configured prefix."""
+    if not _PATH_SEGMENT_PATTERN.match(value):
+        raise VaultSecretsError(
+            f"Invalid {label} {value!r} for Vault secret path. "
+            "Only alphanumerics, '_', '-' and '.' are allowed."
+        )
+    return value
+
+
+class VaultSecretsBackend:
+    """Resolve secret values from HashiCorp Vault KV v2 (read-only)."""
+
+    def __init__(self) -> None:
+        if not config.TRACECAT__VAULT_ADDR:
+            raise VaultSecretsError(
+                "TRACECAT__VAULT_ADDR must be set when "
+                "TRACECAT__SECRETS_BACKEND=vault."
+            )
+        self._addr = config.TRACECAT__VAULT_ADDR.rstrip("/")
+        self._kv_mount = config.TRACECAT__VAULT_KV_MOUNT
+        self._path_prefix = config.TRACECAT__VAULT_PATH_PREFIX.strip("/")
+        self._auth_method = config.TRACECAT__VAULT_AUTH_METHOD
+        self._namespace = config.TRACECAT__VAULT_NAMESPACE
+        self._cache_ttl = config.TRACECAT__VAULT_CACHE_TTL_SECONDS
+        self._cache_max_size = config.TRACECAT__VAULT_CACHE_MAX_SIZE
+        if self._auth_method not in ("jwt", "token"):
+            raise VaultSecretsError(
+                f"Unsupported TRACECAT__VAULT_AUTH_METHOD {self._auth_method!r}. "
+                "Expected 'jwt' or 'token'."
+            )
+        # The cache and token are shared across event loops (AuthSandbox may
+        # run under transient loops), so guard them with a threading lock
+        # instead of an asyncio lock. A racy double login is harmless.
+        self._lock = threading.Lock()
+        self._cache: OrderedDict[
+            tuple[str, str, str, str], tuple[float, dict[str, str]]
+        ] = OrderedDict()
+        self._client_token: str | None = None
+        self._token_expires_at = 0.0
+
+    @property
+    def can_write(self) -> bool:
+        return False
+
+    async def get_secret_values(
+        self,
+        names: set[str],
+        environment: str,
+        *,
+        scope: SecretScope = "workspace",
+        role: Role | None = None,
+    ) -> dict[str, dict[str, str]]:
+        owner = self._owner_segment(scope, role)
+        results: dict[str, dict[str, str]] = {}
+        async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_SECONDS) as client:
+            for name in sorted(names):
+                values = await self._get_one(
+                    client, scope=scope, owner=owner, environment=environment, name=name
+                )
+                if values is not None:
+                    results[name] = values
+        return results
+
+    async def list_registrations(
+        self,
+        environment: str | None = None,
+        *,
+        scope: SecretScope = "workspace",
+        role: Role | None = None,
+    ) -> list[SecretRegistration]:
+        # Registrations are database-backed in this MVP: the UI registers
+        # which secrets exist (name/keys/type), Vault only serves the values.
+        from tracecat.secrets.backends.database import DatabaseSecretsBackend
+
+        return await DatabaseSecretsBackend().list_registrations(
+            environment, scope=scope, role=role
+        )
+
+    # === Internals ===
+
+    def _owner_segment(self, scope: SecretScope, role: Role | None) -> str:
+        if role is None:
+            raise VaultSecretsError(
+                "A role is required to resolve Vault secrets."
+            )
+        if scope == "workspace":
+            if role.workspace_id is None:
+                raise VaultSecretsError(
+                    "Workspace context is required to resolve workspace secrets "
+                    "from Vault."
+                )
+            return str(role.workspace_id)
+        if role.organization_id is None:
+            raise VaultSecretsError(
+                "Organization context is required to resolve organization "
+                "secrets from Vault."
+            )
+        return str(role.organization_id)
+
+    def _secret_path(
+        self, *, scope: SecretScope, owner: str, environment: str, name: str
+    ) -> str:
+        segments = [
+            _validate_path_segment(scope, label="scope"),
+            _validate_path_segment(owner, label="owner"),
+            _validate_path_segment(environment, label="environment"),
+            _validate_path_segment(name, label="secret name"),
+        ]
+        if self._path_prefix:
+            segments.insert(0, self._path_prefix)
+        return "/".join(segments)
+
+    async def _get_one(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        scope: SecretScope,
+        owner: str,
+        environment: str,
+        name: str,
+    ) -> dict[str, str] | None:
+        cache_key = (scope, owner, environment, name)
+        if (cached := self._cache_get(cache_key)) is not None:
+            return cached
+        path = self._secret_path(
+            scope=scope, owner=owner, environment=environment, name=name
+        )
+        try:
+            data = await self._read_kv2(client, path)
+        except Exception:
+            # Never serve stale data after a failed read.
+            self._cache_evict(cache_key)
+            raise
+        if data is None:
+            logger.debug("Secret not found in Vault", secret_name=name, path=path)
+            return None
+        values = {str(key): str(value) for key, value in data.items()}
+        self._cache_put(cache_key, values)
+        return values
+
+    async def _read_kv2(
+        self, client: httpx.AsyncClient, path: str
+    ) -> dict[str, object] | None:
+        token = await self._get_token(client)
+        url = f"{self._addr}/v1/{self._kv_mount}/data/{path}"
+        response = await client.get(url, headers=self._headers(token))
+        if response.status_code == 404:
+            return None
+        if response.status_code in (401, 403):
+            # Force a re-login on the next call in case the token expired
+            # server-side (e.g. revocation or lease drift).
+            with self._lock:
+                self._client_token = None
+                self._token_expires_at = 0.0
+            raise VaultSecretsError(
+                f"Vault denied access to secret path {path!r} "
+                f"(HTTP {response.status_code}). Check the Vault policy for the "
+                "configured auth role."
+            )
+        if response.status_code >= 400:
+            raise VaultSecretsError(
+                f"Vault read failed for path {path!r} (HTTP {response.status_code})."
+            )
+        payload = response.json()
+        try:
+            data = payload["data"]["data"]
+        except (KeyError, TypeError) as e:
+            raise VaultSecretsError(
+                f"Unexpected Vault KV v2 response shape for path {path!r}."
+            ) from e
+        if not isinstance(data, dict):
+            raise VaultSecretsError(
+                f"Vault secret at path {path!r} is not a key-value mapping."
+            )
+        return data
+
+    def _headers(self, token: str) -> dict[str, str]:
+        headers = {"X-Vault-Token": token}
+        if self._namespace:
+            headers["X-Vault-Namespace"] = self._namespace
+        return headers
+
+    async def _get_token(self, client: httpx.AsyncClient) -> str:
+        if self._auth_method == "token":
+            if not config.TRACECAT__VAULT_TOKEN:
+                raise VaultSecretsError(
+                    "TRACECAT__VAULT_TOKEN must be set when "
+                    "TRACECAT__VAULT_AUTH_METHOD=token."
+                )
+            return config.TRACECAT__VAULT_TOKEN
+        with self._lock:
+            if self._client_token and time.monotonic() < self._token_expires_at:
+                return self._client_token
+        return await self._login_jwt(client)
+
+    async def _login_jwt(self, client: httpx.AsyncClient) -> str:
+        if not config.TRACECAT__VAULT_JWT_ROLE:
+            raise VaultSecretsError(
+                "TRACECAT__VAULT_JWT_ROLE must be set when "
+                "TRACECAT__VAULT_AUTH_METHOD=jwt."
+            )
+        token_path = FilePath(config.TRACECAT__VAULT_JWT_TOKEN_PATH)
+        try:
+            jwt = token_path.read_text(encoding="utf-8").strip()
+        except OSError as e:
+            raise VaultSecretsError(
+                f"Could not read the service account token at {token_path}. "
+                "Ensure the projected token volume is mounted."
+            ) from e
+        if not jwt:
+            raise VaultSecretsError(
+                f"The service account token at {token_path} is empty."
+            )
+        url = f"{self._addr}/v1/auth/{config.TRACECAT__VAULT_JWT_AUTH_MOUNT}/login"
+        headers = (
+            {"X-Vault-Namespace": self._namespace} if self._namespace else None
+        )
+        response = await client.post(
+            url,
+            json={"role": config.TRACECAT__VAULT_JWT_ROLE, "jwt": jwt},
+            headers=headers,
+        )
+        if response.status_code >= 400:
+            raise VaultSecretsError(
+                f"Vault JWT login failed (HTTP {response.status_code}) for role "
+                f"{config.TRACECAT__VAULT_JWT_ROLE!r}."
+            )
+        try:
+            auth = response.json()["auth"]
+            client_token = auth["client_token"]
+            lease_duration = float(auth.get("lease_duration") or 300)
+        except (KeyError, TypeError, ValueError) as e:
+            raise VaultSecretsError(
+                "Unexpected Vault JWT login response shape."
+            ) from e
+        with self._lock:
+            self._client_token = client_token
+            self._token_expires_at = time.monotonic() + max(
+                lease_duration * _TOKEN_LEASE_SAFETY_FACTOR, 10.0
+            )
+        logger.debug(
+            "Authenticated to Vault via JWT",
+            role=config.TRACECAT__VAULT_JWT_ROLE,
+            lease_duration=lease_duration,
+        )
+        return client_token
+
+    def _cache_get(
+        self, key: tuple[str, str, str, str]
+    ) -> dict[str, str] | None:
+        if self._cache_ttl <= 0:
+            return None
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry is None:
+                return None
+            expires_at, values = entry
+            if time.monotonic() >= expires_at:
+                self._cache.pop(key, None)
+                return None
+            self._cache.move_to_end(key)
+            return dict(values)
+
+    def _cache_put(self, key: tuple[str, str, str, str], values: dict[str, str]) -> None:
+        if self._cache_ttl <= 0 or self._cache_max_size <= 0:
+            return
+        with self._lock:
+            self._cache[key] = (time.monotonic() + self._cache_ttl, dict(values))
+            self._cache.move_to_end(key)
+            while len(self._cache) > self._cache_max_size:
+                self._cache.popitem(last=False)
+
+    def _cache_evict(self, key: tuple[str, str, str, str]) -> None:
+        with self._lock:
+            self._cache.pop(key, None)

--- a/tracecat/secrets/schemas.py
+++ b/tracecat/secrets/schemas.py
@@ -234,6 +234,11 @@ class SecretCreate(BaseModel):
 
     @model_validator(mode="after")
     def validate_typed_secret(self) -> SecretCreate:
+        # Value-less payloads register a secret whose values live in an
+        # external secrets backend; there is nothing to validate. The service
+        # re-validates values when the database backend is active.
+        if all(not kv.value.get_secret_value() for kv in self.keys):
+            return self
         if self.type == SecretType.SSH_KEY:
             validate_ssh_key_values(self.keys)
         elif self.type == SecretType.MTLS:
@@ -265,6 +270,12 @@ class SecretUpdate(BaseModel):
 
     @model_validator(mode="after")
     def validate_typed_secret(self) -> SecretUpdate:
+        # Empty values either preserve existing values or describe a
+        # value-less registration; defer validation to the service.
+        if self.keys is not None and all(
+            not kv.value.get_secret_value() for kv in self.keys
+        ):
+            return self
         if self.type == SecretType.SSH_KEY and self.keys is not None:
             validate_ssh_key_values(self.keys)
         elif self.type == SecretType.MTLS and self.keys is not None:

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -20,11 +20,14 @@ from tracecat.exceptions import (
 )
 from tracecat.identifiers import SecretID, WorkspaceID
 from tracecat.logger import logger
+from tracecat import config
 from tracecat.registry.constants import REGISTRY_GIT_SSH_KEY_SECRET_NAME
+from tracecat.secrets.backend import SecretsBackend, get_secrets_backend
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT
 from tracecat.secrets.encryption import decrypt_keyvalues, encrypt_keyvalues
 from tracecat.secrets.enums import SecretType
 from tracecat.secrets.schemas import (
+    SSH_PRIVATE_KEY_NAME,
     SecretCreate,
     SecretKeyValue,
     SecretSearch,
@@ -63,10 +66,24 @@ class SecretsService(BaseOrgService):
         """Encrypt and return the keys for a secret."""
         return encrypt_keyvalues(keys, key=self._encryption_key)
 
+    @staticmethod
+    def _assert_registration_only_keys(keys: list[SecretKeyValue]) -> None:
+        """Reject secret values when the backend does not store values in Tracecat."""
+        if any(kv.value.get_secret_value() for kv in keys):
+            raise ValueError(
+                "Secret values are managed by the "
+                f"{config.TRACECAT__SECRETS_BACKEND!r} secrets backend and cannot "
+                "be stored in Tracecat. Register the secret with empty values and "
+                "store the actual values in the external backend."
+            )
+
     # === Base secrets ===
 
     async def _update_secret(self, secret: BaseSecret, params: SecretUpdate) -> None:
         """Update a base secret."""
+        can_write_values = get_secrets_backend().can_write
+        if not can_write_values and params.keys is not None:
+            self._assert_registration_only_keys(params.keys)
         existing_type = SecretType(secret.type)
         if existing_type == SecretType.SSH_KEY:
             if params.type is not None and SecretType(params.type) != existing_type:
@@ -150,10 +167,11 @@ class SecretsService(BaseOrgService):
                 else:
                     merged_keyvalues.append(SecretKeyValue(**kv))
 
-            if existing_type == SecretType.MTLS:
-                validate_mtls_key_values(merged_keyvalues)
-            elif existing_type == SecretType.CA_CERT:
-                validate_ca_cert_values(merged_keyvalues)
+            if can_write_values:
+                if existing_type == SecretType.MTLS:
+                    validate_mtls_key_values(merged_keyvalues)
+                elif existing_type == SecretType.CA_CERT:
+                    validate_ca_cert_values(merged_keyvalues)
 
             secret.encrypted_keys = encrypt_keyvalues(
                 merged_keyvalues, key=self._encryption_key
@@ -256,12 +274,17 @@ class SecretsService(BaseOrgService):
     async def create_secret(self, params: SecretCreate) -> None:
         """Create a workspace secret."""
         workspace_id = self._require_workspace_id()
-        if params.type == SecretType.SSH_KEY:
-            validate_ssh_key_values(params.keys)
-        elif params.type == SecretType.MTLS:
-            validate_mtls_key_values(params.keys)
-        elif params.type == SecretType.CA_CERT:
-            validate_ca_cert_values(params.keys)
+        if get_secrets_backend().can_write:
+            if params.type == SecretType.SSH_KEY:
+                validate_ssh_key_values(params.keys)
+            elif params.type == SecretType.MTLS:
+                validate_mtls_key_values(params.keys)
+            elif params.type == SecretType.CA_CERT:
+                validate_ca_cert_values(params.keys)
+        else:
+            # Value-less registration: only key names are recorded; values are
+            # served by the external backend at runtime.
+            self._assert_registration_only_keys(params.keys)
         secret = Secret(
             workspace_id=workspace_id,
             name=params.name,
@@ -270,6 +293,7 @@ class SecretsService(BaseOrgService):
             tags=params.tags,
             encrypted_keys=self.encrypt_keys(params.keys),
             environment=params.environment,
+            backend=config.TRACECAT__SECRETS_BACKEND,
         )
         self.session.add(secret)
         await self.session.commit()
@@ -386,12 +410,17 @@ class SecretsService(BaseOrgService):
     @audit_log(resource_type="organization_secret", action="create")
     async def _create_org_secret(self, params: SecretCreate) -> None:
         """Create an organization secret for callers with their own access gate."""
-        if params.type == SecretType.SSH_KEY:
-            validate_ssh_key_values(params.keys)
-        elif params.type == SecretType.MTLS:
-            validate_mtls_key_values(params.keys)
-        elif params.type == SecretType.CA_CERT:
-            validate_ca_cert_values(params.keys)
+        if get_secrets_backend().can_write:
+            if params.type == SecretType.SSH_KEY:
+                validate_ssh_key_values(params.keys)
+            elif params.type == SecretType.MTLS:
+                validate_mtls_key_values(params.keys)
+            elif params.type == SecretType.CA_CERT:
+                validate_ca_cert_values(params.keys)
+        else:
+            # Value-less registration: only key names are recorded; values are
+            # served by the external backend at runtime.
+            self._assert_registration_only_keys(params.keys)
         secret = OrganizationSecret(
             organization_id=self.organization_id,
             name=params.name,
@@ -400,6 +429,7 @@ class SecretsService(BaseOrgService):
             tags=params.tags,
             encrypted_keys=self.encrypt_keys(params.keys),
             environment=params.environment,
+            backend=config.TRACECAT__SECRETS_BACKEND,
         )
         self.session.add(secret)
         await self.session.commit()
@@ -446,8 +476,11 @@ class SecretsService(BaseOrgService):
     async def get_registry_ssh_key(
         self, key_name: str | None = None, environment: str | None = None
     ) -> SecretStr:
+        key_name = key_name or REGISTRY_GIT_SSH_KEY_SECRET_NAME
+        backend = get_secrets_backend()
+        if not backend.can_write:
+            return await self._get_ssh_key_from_backend(backend, key_name, environment)
         try:
-            key_name = key_name or REGISTRY_GIT_SSH_KEY_SECRET_NAME
             secret = await self.get_org_secret_by_name(key_name, environment)
             kv = self.decrypt_keys(secret.encrypted_keys)[0]
             logger.debug("SSH key found", key_name=key_name, key_length=len(kv.value))
@@ -463,3 +496,39 @@ class SecretsService(BaseOrgService):
                 f"SSH key {key_name} not found. Please check whether this key exists.\n\n"
                 " If not, please create a key in your organization's credentials page and try again."
             ) from e
+
+    async def _get_ssh_key_from_backend(
+        self,
+        backend: SecretsBackend,
+        key_name: str,
+        environment: str | None = None,
+    ) -> SecretStr:
+        """Resolve an organization SSH key from an external secrets backend."""
+        values = await backend.get_secret_values(
+            {key_name},
+            environment or DEFAULT_SECRETS_ENVIRONMENT,
+            scope="organization",
+            role=self.role,
+        )
+        keyvalues = values.get(key_name)
+        if not keyvalues:
+            raise TracecatCredentialsNotFoundError(
+                f"SSH key {key_name} not found. Please check whether this key exists.\n\n"
+                " If not, please create a key in your organization's credentials page and try again."
+            )
+        if SSH_PRIVATE_KEY_NAME in keyvalues:
+            raw_value = keyvalues[SSH_PRIVATE_KEY_NAME]
+        elif len(keyvalues) == 1:
+            raw_value = next(iter(keyvalues.values()))
+        else:
+            raise TracecatCredentialsNotFoundError(
+                f"SSH key secret {key_name} must store the private key under the "
+                f"{SSH_PRIVATE_KEY_NAME!r} key."
+            )
+        logger.debug("SSH key found", key_name=key_name, key_length=len(raw_value))
+        # SSH keys must end with a newline char otherwise we run into
+        # load key errors in librcrypto.
+        # https://github.com/openssl/openssl/discussions/21481
+        if not raw_value.endswith("\n"):
+            raw_value += "\n"
+        return SecretStr(raw_value)

--- a/tracecat/secrets/service.py
+++ b/tracecat/secrets/service.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tracecat import config
 from tracecat.audit.logger import audit_log
 from tracecat.auth.secrets import get_db_encryption_key
 from tracecat.auth.types import Role
@@ -20,7 +21,6 @@ from tracecat.exceptions import (
 )
 from tracecat.identifiers import SecretID, WorkspaceID
 from tracecat.logger import logger
-from tracecat import config
 from tracecat.registry.constants import REGISTRY_GIT_SSH_KEY_SECRET_NAME
 from tracecat.secrets.backend import SecretsBackend, get_secrets_backend
 from tracecat.secrets.constants import DEFAULT_SECRETS_ENVIRONMENT

--- a/tracecat/workspace_sync/adapters/secret_metadata.py
+++ b/tracecat/workspace_sync/adapters/secret_metadata.py
@@ -6,6 +6,7 @@ import sqlalchemy as sa
 from pydantic import BaseModel, SecretStr
 from sqlalchemy import select
 
+from tracecat import config
 from tracecat.db.models import Secret
 from tracecat.secrets.enums import SecretType
 from tracecat.secrets.schemas import SecretKeyValue
@@ -210,6 +211,7 @@ class SecretMetadataAdapter(EnvironmentScopedManifestAdapter):
                     environment=spec.environment,
                     tags=tags,
                     description=spec.description,
+                    backend=config.TRACECAT__SECRETS_BACKEND,
                 )
             else:
                 # Matched an existing row: update it in place to the spec.


### PR DESCRIPTION
Follows up on #1214 — a **draft / proof of concept** for a pluggable secrets
layer with a read-only HashiCorp Vault backend. Built for
isolated k8s cluster deployment and shared as-is: adopt it, rework it, or lift the
parts that are useful. I've enabled "Allow edits by maintainers" so you can
push straight to the branch.

### The idea

Resolve workflow secret values from Vault at execution time instead of storing
them (Fernet-encrypted) in Postgres. For teams with a corporate Vault that
kills the second copy of crown-jewel credentials, the single non-rotating
master key, and the DB/backups as an extra attack surface — secrets stay under
Vault's own ACLs, audit, and rotation.

`TRACECAT__SECRETS_BACKEND=db` stays the default and is untouched: the DB
backend is a behavior-preserving extraction of today's
`search_secrets` + `decrypt_keyvalues` flow.

### How it fits

A `SecretsBackend` protocol (`tracecat/secrets/backend.py`) picked by
`TRACECAT__SECRETS_BACKEND` (`db` | `vault`):

- **`DatabaseSecretsBackend`** — today's logic, extracted.
- **`VaultSecretsBackend`** — KV v2 over `httpx` (no new dependency) at
  `{mount}/data/{prefix}/{scope}/{workspace|org uuid}/{environment}/{name}`,
  with a short-TTL, size-bounded in-process cache (default 45s). `can_write`
  is `False`.

Both runtime read paths route through it — `AuthSandbox` for workspace secrets
(the `.secrets` contract and "Missing workspace secrets" error are preserved
byte-for-byte) and `SecretsService.get_registry_ssh_key` for org SSH keys.

In Vault mode the DB rows become **value-less registrations** (name + key names
+ type + environment; requests carrying actual values are rejected). A new
`backend` column (additive migration, default `'db'`) marks ownership. The
workspace "Create credential" dialog picks up a `secrets_backend_readonly` flag
from `/info` and submits a registration, so `custom` secrets work from the UI.

Vault auth defaults to `jwt` — a projected Kubernetes service account token
validated by Vault *offline* via `jwt_validation_pubkeys`, which is the whole
point for isolated clusters where Vault can't call back into the kube-apiserver
(only outbound Tracecat→Vault connectivity needed). A static `token` method is
there for local dev. The Vault client and token stay in the executor service
process and never reach action sandboxes.

### What's covered

- New `tests/unit/test_secrets_backend.py` (23 tests): factory, KV v2 reads,
  cache hit/expiry/disable, JWT login + reuse + invalidation, path safety,
  write blocking. Existing suites still green
  (`test_sandbox`/`test_secrets_service`/`test_secrets`/`api/test_api_secrets`,
  101/101). `ruff` clean; frontend `tsc` + biome clean.
- Alembic migration verified from a clean DB, incl. downgrade/upgrade round-trip.
- Smoke-tested against a live `hashicorp/vault` dev server: a `custom` secret
  resolved straight from KV v2, missing secrets returned the usual error.

### Deliberately out of scope

Writing values to Vault; OAuth integrations (stay in DB); other providers
(AWS/Azure/GCP — the protocol is provider-agnostic); auto-syncing registrations
from Vault; the read-only UI treatment for org-secret dialogs and structured
ssh/mtls/ca types (the API already accepts value-less registrations for those).

Docs live in `docs/self-hosting/secrets-backends.mdx`; `.env.example` is updated.

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a pluggable secrets backend with a read-only HashiCorp Vault option so secret values can be resolved at runtime instead of stored in Postgres. The default behavior remains unchanged (`db`), and the UI now supports value-less registrations when an external backend is active.

- **New Features**
  - Added `SecretsBackend` with `db` (encrypted in DB) and `vault` (KV v2 via `httpx`, read-only) implementations.
  - Vault: JWT or static token auth, optional namespace, short-TTL in-process cache, safe path encoding, and clear 403 handling.
  - Unified resolution: `AuthSandbox` and `SecretsService` read via the selected backend; org SSH keys resolve from the backend in read-only mode.
  - DB: new `backend` column; external-backend rows are registrations (no values). The `db` backend refuses to serve these as values.
  - UI: workspace “Create credential” dialog detects read-only mode from `/info` (`secrets_backend_readonly`) and registers key names only.
  - Docs and `.env.example` updated; extensive unit tests for backend factory, Vault flow, caching, and guards.

- **Migration**
  - Run DB migrations (adds the `backend` column; existing rows default to `db`).
  - To use Vault: set `TRACECAT__SECRETS_BACKEND=vault`, `TRACECAT__VAULT_ADDR`, and configure auth (`TRACECAT__VAULT_AUTH_METHOD=jwt|token`; JWT needs `TRACECAT__VAULT_JWT_ROLE` and a projected token).
  - In Vault mode, create secrets as registrations with empty values; store values in Vault. Keys map 1:1 (SSH uses `PRIVATE_KEY`).

<sup>Written for commit fa2da2609c90098508cedc267b09688b86457821. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

