### PR TITLE
fix(ui): center column type label in table create dialog

### DIFF
--- a/frontend/src/components/data-type/sql-type-display.tsx
+++ b/frontend/src/components/data-type/sql-type-display.tsx
@@ -23,7 +23,7 @@ export function SqlTypeDisplay({
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-2 whitespace-nowrap",
+        "inline-flex items-center gap-2 align-middle whitespace-nowrap",
         className
       )}
     >

--- a/frontend/src/components/tables/table-create-dialog.tsx
+++ b/frontend/src/components/tables/table-create-dialog.tsx
@@ -296,7 +296,7 @@ export function CreateTableDialog({
                                       value={field.value}
                                       onValueChange={field.onChange}
                                     >
-                                      <SelectTrigger>
+                                      <SelectTrigger className="[&>span]:!flex [&>span]:items-center">
                                         <SelectValue placeholder="Select column type" />
                                       </SelectTrigger>
                                       <SelectContent>


### PR DESCRIPTION
## What

Fixes vertical misalignment of the column-type `Select` in the **Create new table** dialog (Workspace → Tables → New table). In two spots the type icon + label sat above the row's vertical center:

- **Trigger** — the selected type (e.g. "Select", "Text") rendered slightly above center, out of line with the adjacent column-name input.
- **Dropdown items** — each option's icon + label rode high within its row (most visible on hover).

## Why

- **Trigger:** `SelectTrigger` styles its value wrapper with `[&>span]:line-clamp-1`, which resolves to `display: -webkit-box`. That's fine for plain text, but the type dropdown renders `SqlTypeDisplay` (icon + label) inside it, and the `-webkit-box` baseline pushes the content upward so it no longer centers against the sibling `Input`.
- **Dropdown items:** `SqlTypeDisplay`'s outer container is `inline-flex`, so inside the option's line-box it is *baseline*-aligned rather than centered, leaving it sitting high in the row.

## Fix

Two minimal, targeted changes:

1. `table-create-dialog.tsx` — force the trigger's value wrapper to flex-center:
   ```tsx
   <SelectTrigger className="[&>span]:!flex [&>span]:items-center">
   ```
   The `!` is deliberate: `tailwind-merge` only drops `display` when a *later* `line-clamp` class appears (one-directional), so a plain `flex` override would leave both `line-clamp-1` and `flex` in the class list and let CSS source order decide non-deterministically. The important flag makes `display: flex` win reliably; the leftover `line-clamp-1` properties are inert once display is no longer `-webkit-box`, and the short fixed type labels never need clamping.

2. `sql-type-display.tsx` — add `align-middle` to the `SqlTypeDisplay` container so it centers within the option's line-box. This is inert in flex contexts (the trigger and `SqlTypeBadge` treat it as a flex item, which ignores `vertical-align`), so only the affected inline dropdown-item case changes.

No change to the shared `select.tsx`, so plain-text selects elsewhere (which rely on `line-clamp-1` for ellipsis truncation) are unaffected.

## Testing

- Verified visually in the Create new table dialog: both the trigger label and the dropdown-item icons/labels now center correctly (before/after screenshots below).
- `pnpm -C frontend exec biome check` — clean.
- `pnpm -C frontend run typecheck` — clean.

_CSS-only alignment fix; no unit-test surface in the current frontend test setup._

## Before
<img width="889" height="763" alt="Screenshot 2026-07-03 at 9 53 38 PM" src="https://github.com/user-attachments/assets/92fd8797-bd34-4182-a934-ede68021e088" />


## After
<img width="887" height="761" alt="Screenshot 2026-07-03 at 9 52 43 PM" src="https://github.com/user-attachments/assets/929e9dff-3a91-496b-a382-401982e3268b" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centered the column-type select icon and label in the Create new table dialog so the trigger and dropdown items align cleanly with adjacent inputs.

- **Bug Fixes**
  - Force `SelectTrigger` value wrapper to center content: `[&>span]:!flex [&>span]:items-center` to override `line-clamp-1`’s `-webkit-box`.
  - Add `align-middle` to `SqlTypeDisplay` so options center within dropdown rows (inert in flex contexts).

<sup>Written for commit e897c7283c068d90d72413142ab136481af07899. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

