### PR TITLE
fix(ui): make CSV import preview header opaque

### DIFF
--- a/frontend/src/components/tables/table-import-csv-dialog.tsx
+++ b/frontend/src/components/tables/table-import-csv-dialog.tsx
@@ -400,13 +400,13 @@ export function CsvPreview({ csvData }: CsvPreviewProps) {
         <table className="w-full min-w-max table-auto border-separate border-spacing-0 text-xs">
           <thead>
             <tr>
-              <th className="sticky left-0 top-0 z-20 min-w-[40px] border-b border-r border-border/30 bg-muted/30 px-3 py-2 text-left font-medium text-muted-foreground">
+              <th className="sticky left-0 top-0 z-20 min-w-[40px] border-b border-r border-border/30 bg-muted px-3 py-2 text-left font-medium text-muted-foreground">
                 #
               </th>
               {csvData.headers.map((header) => (
                 <th
                   key={header}
-                  className="sticky top-0 z-10 min-w-[120px] max-w-[200px] whitespace-nowrap border-b border-border/30 bg-muted/30 px-3 py-2 text-left font-medium"
+                  className="sticky top-0 z-10 min-w-[120px] max-w-[200px] whitespace-nowrap border-b border-border/30 bg-muted px-3 py-2 text-left font-medium"
                 >
                   <div className="truncate" title={header}>
                     {header}


### PR DESCRIPTION
## What

Fixes a visual bug in the **Import table from CSV** dialog's preview: when scrolling the preview horizontally, column headers bled through the sticky `#` (row-index) corner in the header row.

## Why

The preview's sticky header cells — the `#` corner and the column headers — used `bg-muted/30`. With `--muted` at `96.1%` lightness over the white dialog background, a 30% opacity composites to roughly `98.8%` — effectively transparent. So as the table scrolled horizontally, the column header cells slid *behind* the higher-z sticky `#` corner and showed through it (e.g. "Category" overlapping the corner).

The body's sticky index column already used opaque `bg-background`, which is why only the header row bled.

## Fix

Use opaque `bg-muted` (the same tint at full opacity) on both preview header cells. This blocks scrolled content behind the sticky header, keeps the subtle gray header look, and makes the `#` corner match its neighboring header cells (no seam).

## Testing

- Verified visually: scrolling the CSV preview horizontally no longer bleeds column headers through the sticky corner.
- `pnpm -C frontend exec biome check` — clean.

_CSS-only fix; no unit-test surface in the current frontend test setup._

## Before
<img width="754" height="711" alt="Screenshot 2026-07-03 at 10 21 20 PM" src="https://github.com/user-attachments/assets/52fcc095-a09d-4931-aff0-bab7e5871f44" />

## After
<img width="752" height="708" alt="Screenshot 2026-07-03 at 10 18 04 PM" src="https://github.com/user-attachments/assets/112582b9-c482-4ae8-87ce-d0e951ef6598" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix bleed-through in the CSV import preview: make the sticky header cells opaque so column headers no longer show under the '#' corner while scrolling. Replace `bg-muted/30` with `bg-muted` on the header cells.

<sup>Written for commit a9e185d75ad198572d547a6fdc68ef20f7c211f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

