### PR TITLE
fix(ui): reset table delete confirmation input on close

### DIFF
--- a/frontend/src/components/tables/table-delete-dialog.tsx
+++ b/frontend/src/components/tables/table-delete-dialog.tsx
@@ -35,6 +35,15 @@ export function DeleteTableDialog({
     return null
   }
 
+  // Clear the confirmation input whenever the dialog closes so a value typed
+  // for one table doesn't carry over to the next table's delete dialog.
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setConfirmName("")
+    }
+    onOpenChange(nextOpen)
+  }
+
   const handleDeleteTable = async () => {
     if (confirmName !== table.name) {
       toast({
@@ -48,7 +57,7 @@ export function DeleteTableDialog({
         tableId: table.id,
         workspaceId,
       })
-      onOpenChange(false)
+      handleOpenChange(false)
       router.push(`/workspaces/${workspaceId}/tables`)
     } catch (error) {
       console.error(error)
@@ -56,7 +65,7 @@ export function DeleteTableDialog({
   }
 
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Delete Table</AlertDialogTitle>


### PR DESCRIPTION
## What

Fixes stale state in the **Delete Table** confirmation dialog (Tables tab → table ⋮ → Delete). Text typed into the "type the table name to confirm" field for one table was retained and appeared autofilled when the dialog was later opened for a different table.

## Why

`DeleteTableDialog` is rendered once in `tables-dashboard.tsx` as a single shared instance whose `table` prop swaps as different tables are selected; the component stays mounted across selections (the parent's `selectedTable` isn't cleared on close). Its `confirmName` state was never reset, so it persisted from one open to the next.

The existing `disabled={confirmName !== table.name}` guard prevented an actual wrong-table deletion, but the leftover text was confusing and incorrect.

## Fix

Wrap `onOpenChange` in a `handleOpenChange` that clears `confirmName` whenever the dialog closes — covering Cancel, Escape, overlay click, and the programmatic close after a successful delete. Resetting on close (rather than on open) avoids a flash of stale text when the dialog reopens. Each open now starts with an empty confirmation field.

## Testing

- Type text in table A's delete confirmation → Cancel → open table B's delete dialog → field is empty (previously autofilled with A's text).
- Delete button remains disabled until the exact current table name is typed.
- `pnpm -C frontend exec biome check` — clean.
- `pnpm -C frontend run typecheck` — clean.

_UI state fix; no unit-test surface in the current frontend test setup._


## Before
<img width="905" height="475" alt="Screenshot 2026-07-03 at 11 04 40 PM" src="https://github.com/user-attachments/assets/152596a1-d674-4d23-a235-b96578724867" />

## After
<img width="738" height="404" alt="Screenshot 2026-07-03 at 11 07 18 PM" src="https://github.com/user-attachments/assets/08218163-4f71-42e9-a09f-ab59ad4bf78c" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset the Delete Table confirmation input on dialog close so text typed for one table doesn’t carry over to another. Prevents confusing autofill while keeping the delete guard intact.

- **Bug Fixes**
  - Wrap `onOpenChange` with `handleOpenChange` to clear `confirmName` when the dialog closes (Cancel, Escape, overlay click, or after a successful delete).
  - Call `handleOpenChange(false)` on delete and pass it to `AlertDialog` so each open starts with an empty field.

<sup>Written for commit 1b0f60b00fd2dca21c29b895c8d92f9b42247a54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

