### PR TITLE
fix(agent): hydrate stdio MCP env secrets for subagent configs

### DIFF
--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -938,11 +938,15 @@ async def run_agent_activity(input: AgentExecutorInput) -> AgentExecutorResult:
 
     # Stdio MCP servers are spawned directly by the runtime; unlike HTTP
     # servers they have no per-call secret resolution hook downstream. The
-    # configs in ``input.config.mcp_servers`` arrive in refs-only shape
-    # (no ``env``) — hydrate from the DB here so the spawned process gets
-    # its credentials.
+    # configs in ``input.config.mcp_servers`` and each subagent's
+    # ``config.mcp_servers`` arrive in refs-only shape (no ``env``) — hydrate
+    # from the DB here so the spawned processes get their credentials.
     config = cast(Any, input.config)
     config.mcp_servers = await _hydrate_stdio_env(config.mcp_servers, role=input.role)
+    for subagent in input.subagents:
+        subagent.config.mcp_servers = await _hydrate_stdio_env(
+            subagent.config.mcp_servers, role=input.role
+        )
 
     executor = SandboxedAgentExecutor(input=input)
     result = await executor.run()


### PR DESCRIPTION
## Summary

`run_agent_activity` hydrates stdio MCP `env` secrets only for the root config (`input.config.mcp_servers`). Subagent configs (`input.subagents[*].config.mcp_servers`) stay in the refs-only shape produced by `resolve_mcp_integration_refs` (no `env`), and the Claude runtime spawns subagent stdio MCP servers directly from those configs (`_build_agent_definitions` → `_stdio_mcp_servers`). Result: any stdio MCP integration that needs env credentials works at the root scope but launches credential-less when attached to a subagent preset.

This applies the same `_hydrate_stdio_env` pass to each subagent config before the executor builds the runtime payload. HTTP MCP servers are unaffected — they route through the trusted MCP bridge, which re-resolves secrets per call from token claims.

## Testing

- `uv run ruff check tracecat/agent/executor/activity.py` and `uv run ruff format --check tracecat/agent/executor/activity.py`
- Pre-commit python type check passed on commit
- Ad-hoc validation with a stubbed `AgentPresetService`: ran the new hydration loop over a `SandboxSubagentConfig` carrying one stdio ref and one HTTP ref — the stdio config gained `env={"API_KEY": ...}` from `resolve_mcp_integration_secrets`, the HTTP config was passed through untouched


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes subagent stdio MCP servers launching without credentials by hydrating `env` secrets in their configs. Previously only the root agent config was hydrated; HTTP MCP servers are unaffected.

- **Bug Fixes**
  - Run `_hydrate_stdio_env` on each `subagent.config.mcp_servers` before building the executor payload.

<sup>Written for commit d9ec5192a1844e5419e0684bae196170e9094eb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

