### PR TITLE
fix(agent): harden MCP bridge discovery against silent tool loss

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/activities.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/activities.py
@@ -245,6 +245,7 @@ class AgentActivities:
                 discover_user_mcp_tools,
             )
             from tracecat.agent.preset.service import AgentPresetService
+            from tracecat.integrations.mcp_validation import MCPSecretResolutionError
 
             http_servers = [cfg for cfg in args.mcp_servers if is_http_mcp_server(cfg)]
             if not http_servers:
@@ -295,7 +296,7 @@ class AgentActivities:
                             secrets = await svc.resolve_mcp_integration_secrets(
                                 integration_id
                             )
-                        except ValueError:
+                        except (ValueError, MCPSecretResolutionError):
                             secrets = None
                         if secrets:
                             hydrated["headers"] = secrets

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -585,11 +585,13 @@ async def test_user_mcp_discovery_cache_is_scoped_by_claimed_server_name(
         trusted_server._UserMCPDiscoveryCacheKey(
             server_name="Jira",
             url="https://mcp.example.com/v1",
+            transport="http",
             headers_digest=empty_headers_digest,
         ),
         trusted_server._UserMCPDiscoveryCacheKey(
             server_name="Linear",
             url="https://mcp.example.com/v1",
+            transport="http",
             headers_digest=empty_headers_digest,
         ),
     }
@@ -665,10 +667,9 @@ async def test_user_mcp_discovery_cache_legacy_key_includes_header_digest(
 
     header_digests: list[str] = []
     for key in trusted_server._USER_MCP_DISCOVERY_CACHE:
-        assert len(key) == 3
-        assert key[0] == "Jira"
-        assert key[1] == "https://mcp.example.com/v1"
-        header_digests.append(key[2])
+        assert key.server_name == "Jira"
+        assert key.url == "https://mcp.example.com/v1"
+        header_digests.append(key.headers_digest)
         assert "Bearer token" not in repr(key)
     assert len(header_digests) == 2
     assert len(set(header_digests)) == 2
@@ -699,6 +700,7 @@ def test_user_mcp_discovery_cache_key_tracks_resolved_config() -> None:
     assert key != trusted_server._user_mcp_discovery_cache_key(
         config(headers={"Authorization": "Bearer token-b"})
     )
+    assert key != trusted_server._user_mcp_discovery_cache_key(config(transport="sse"))
     assert "Bearer token-a" not in repr(key)
 
 

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -306,7 +306,12 @@ async def test_token_scoped_fastmcp_get_tool_reuses_token_catalog(
         parameters_json_schema={"type": "object"},
         claims=claims,
     )
-    build_token_scoped_tools = AsyncMock(return_value=[tool])
+    build_token_scoped_tools = AsyncMock(
+        return_value=trusted_server._TokenScopedToolBuild(
+            tools=[tool],
+            failed_user_mcp_servers={},
+        )
+    )
 
     monkeypatch.setattr(
         trusted_server,
@@ -320,7 +325,7 @@ async def test_token_scoped_fastmcp_get_tool_reuses_token_catalog(
     )
     monkeypatch.setattr(
         trusted_server,
-        "build_token_scoped_tools",
+        "_build_token_scoped_tools",
         build_token_scoped_tools,
     )
 
@@ -702,6 +707,89 @@ def test_user_mcp_discovery_cache_key_tracks_resolved_config() -> None:
     )
     assert key != trusted_server._user_mcp_discovery_cache_key(config(transport="sse"))
     assert "Bearer token-a" not in repr(key)
+
+
+@pytest.mark.anyio
+async def test_partial_discovery_failure_is_not_pinned_to_token_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    claims = _build_claims(
+        allowed_actions=["mcp__Alpha__ping", "mcp__Beta__ping"],
+        user_mcp_servers=[
+            UserMCPServerClaim(name="Alpha", url="https://alpha.example.com/mcp"),
+            UserMCPServerClaim(name="Beta", url="https://beta.example.com/mcp"),
+        ],
+    )
+
+    async def fake_fetch_tool_definitions(
+        action_names: list[str],
+    ) -> dict[str, MCPToolDefinition]:
+        assert action_names == []
+        return {}
+
+    beta_failing = [True]
+    client_instantiations: list[list[str]] = []
+
+    class _FakeUserMCPClient:
+        parse_user_mcp_tool_name = staticmethod(UserMCPClient.parse_user_mcp_tool_name)
+
+        def __init__(self, configs: list[dict[str, Any]]) -> None:
+            client_instantiations.append([config["name"] for config in configs])
+            self.configs = configs
+
+        async def discover_tools_detailed(self) -> UserMCPDiscoveryResult:
+            definitions: dict[str, MCPToolDefinition] = {}
+            failed_servers: dict[str, str] = {}
+            for config in self.configs:
+                server_name = config["name"]
+                if server_name == "Beta" and beta_failing[0]:
+                    failed_servers["Beta"] = "TransportError"
+                    continue
+                tool_name = f"mcp__{server_name}__ping"
+                definitions[tool_name] = MCPToolDefinition(
+                    name=tool_name,
+                    description=f"Ping {server_name}",
+                    parameters_json_schema={"type": "object"},
+                )
+            return UserMCPDiscoveryResult(
+                definitions=definitions,
+                failed_servers=failed_servers,
+            )
+
+    monkeypatch.setattr(
+        trusted_server,
+        "fetch_tool_definitions",
+        fake_fetch_tool_definitions,
+    )
+    monkeypatch.setattr(trusted_server, "UserMCPClient", _FakeUserMCPClient)
+    monkeypatch.setattr(
+        trusted_server,
+        "_authorization_header_from_request",
+        lambda: "Bearer test-token",
+    )
+    monkeypatch.setattr(
+        trusted_server,
+        "_claims_from_authorization_header",
+        lambda authorization: claims,
+    )
+
+    server = trusted_server.TokenScopedFastMCP("test")
+
+    partial = await server._tools_from_request()
+    assert [tool.name for tool in partial] == ["mcp__Alpha__ping"]
+
+    beta_failing[0] = False
+    recovered = await server._tools_from_request()
+    assert [tool.name for tool in recovered] == [
+        "mcp__Alpha__ping",
+        "mcp__Beta__ping",
+    ]
+
+    cached = await server._tools_from_request()
+    assert [tool.name for tool in cached] == ["mcp__Alpha__ping", "mcp__Beta__ping"]
+    # The second listing retried only the failed server (Alpha came from the
+    # discovery cache); the third was served from the token cache entirely.
+    assert client_instantiations == [["Alpha", "Beta"], ["Beta"]]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -1,11 +1,11 @@
 import uuid
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
 from fastmcp.exceptions import ToolError
 
-from tracecat.agent.common.types import MCPToolDefinition
+from tracecat.agent.common.types import MCPHttpServerConfig, MCPToolDefinition
 from tracecat.agent.mcp import trusted_server
 from tracecat.agent.mcp.metadata import PROXY_TOOL_CALL_ID_KEY, PROXY_TOOL_METADATA_KEY
 from tracecat.agent.mcp.user_client import UserMCPClient, UserMCPDiscoveryResult
@@ -580,9 +580,18 @@ async def test_user_mcp_discovery_cache_is_scoped_by_claimed_server_name(
     assert [tool.name for tool in jira_tools] == ["mcp__Jira__getIssue"]
     assert [tool.name for tool in linear_tools] == ["mcp__Linear__getIssue"]
     assert discovered_config_names == [["Jira"], ["Linear"]]
+    empty_headers_digest = trusted_server._user_mcp_headers_digest({})
     assert set(trusted_server._USER_MCP_DISCOVERY_CACHE) == {
-        ("Jira", str(integration_id)),
-        ("Linear", str(integration_id)),
+        trusted_server._UserMCPDiscoveryCacheKey(
+            server_name="Jira",
+            url="https://mcp.example.com/v1",
+            headers_digest=empty_headers_digest,
+        ),
+        trusted_server._UserMCPDiscoveryCacheKey(
+            server_name="Linear",
+            url="https://mcp.example.com/v1",
+            headers_digest=empty_headers_digest,
+        ),
     }
 
 
@@ -663,6 +672,34 @@ async def test_user_mcp_discovery_cache_legacy_key_includes_header_digest(
         assert "Bearer token" not in repr(key)
     assert len(header_digests) == 2
     assert len(set(header_digests)) == 2
+
+
+def test_user_mcp_discovery_cache_key_tracks_resolved_config() -> None:
+    def config(**overrides: Any) -> MCPHttpServerConfig:
+        base: dict[str, Any] = {
+            "type": "http",
+            "name": "Jira",
+            "url": "https://mcp.example.com/v1",
+            "transport": "http",
+            "headers": {"Authorization": "Bearer token-a"},
+            "id": "00000000-0000-0000-0000-000000000004",
+        }
+        base.update(overrides)
+        return cast(MCPHttpServerConfig, base)
+
+    key = trusted_server._user_mcp_discovery_cache_key(config())
+    # The integration id is not a cache dimension: editing an integration's
+    # URL or credentials without changing its id must miss the cache.
+    assert key == trusted_server._user_mcp_discovery_cache_key(
+        config(id="00000000-0000-0000-0000-000000000005")
+    )
+    assert key != trusted_server._user_mcp_discovery_cache_key(
+        config(url="https://mcp.example.com/v2")
+    )
+    assert key != trusted_server._user_mcp_discovery_cache_key(
+        config(headers={"Authorization": "Bearer token-b"})
+    )
+    assert "Bearer token-a" not in repr(key)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -591,12 +591,14 @@ async def test_user_mcp_discovery_cache_is_scoped_by_claimed_server_name(
             server_name="Jira",
             url="https://mcp.example.com/v1",
             transport="http",
+            timeout=None,
             headers_digest=empty_headers_digest,
         ),
         trusted_server._UserMCPDiscoveryCacheKey(
             server_name="Linear",
             url="https://mcp.example.com/v1",
             transport="http",
+            timeout=None,
             headers_digest=empty_headers_digest,
         ),
     }
@@ -706,6 +708,7 @@ def test_user_mcp_discovery_cache_key_tracks_resolved_config() -> None:
         config(headers={"Authorization": "Bearer token-b"})
     )
     assert key != trusted_server._user_mcp_discovery_cache_key(config(transport="sse"))
+    assert key != trusted_server._user_mcp_discovery_cache_key(config(timeout=5))
     assert "Bearer token-a" not in repr(key)
 
 

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -779,7 +779,21 @@ async def test_partial_discovery_failure_is_not_pinned_to_token_cache(
     server = trusted_server.TokenScopedFastMCP("test")
 
     partial = await server._tools_from_request()
-    assert [tool.name for tool in partial] == ["mcp__Alpha__ping"]
+    assert [tool.name for tool in partial] == [
+        "mcp__Alpha__ping",
+        "mcp__Beta__ping",
+    ]
+    unavailable = partial[1]
+    assert unavailable.description is not None
+    assert "Unavailable user MCP tool" in unavailable.description
+    with pytest.raises(
+        ToolError,
+        match=(
+            "User MCP tool 'ping' on server 'Beta' is unavailable: "
+            "MCP discovery failed for server 'Beta' \\(TransportError\\)"
+        ),
+    ):
+        await unavailable.run({})
 
     beta_failing[0] = False
     recovered = await server._tools_from_request()
@@ -793,6 +807,91 @@ async def test_partial_discovery_failure_is_not_pinned_to_token_cache(
     # The second listing retried only the failed server (Alpha came from the
     # discovery cache); the third was served from the token cache entirely.
     assert client_instantiations == [["Alpha", "Beta"], ["Beta"]]
+
+
+@pytest.mark.anyio
+async def test_total_discovery_failure_returns_unavailable_tool_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    claims = _build_claims(
+        allowed_actions=["mcp__Jira__getIssue"],
+        user_mcp_servers=[
+            UserMCPServerClaim(name="Jira", url="https://jira.example.com/mcp"),
+        ],
+    )
+
+    async def fake_fetch_tool_definitions(
+        action_names: list[str],
+    ) -> dict[str, MCPToolDefinition]:
+        assert action_names == []
+        return {}
+
+    jira_failing = [True]
+    client_instantiations: list[list[str]] = []
+
+    class _FakeUserMCPClient:
+        parse_user_mcp_tool_name = staticmethod(UserMCPClient.parse_user_mcp_tool_name)
+
+        def __init__(self, configs: list[dict[str, Any]]) -> None:
+            client_instantiations.append([config["name"] for config in configs])
+            self.configs = configs
+
+        async def discover_tools_detailed(self) -> UserMCPDiscoveryResult:
+            if jira_failing[0]:
+                return UserMCPDiscoveryResult(
+                    definitions={},
+                    failed_servers={"Jira": "HTTPStatusError(status_code=503)"},
+                )
+            return UserMCPDiscoveryResult(
+                definitions={
+                    "mcp__Jira__getIssue": MCPToolDefinition(
+                        name="mcp__Jira__getIssue",
+                        description="Get issue",
+                        parameters_json_schema={"type": "object"},
+                    )
+                },
+                failed_servers={},
+            )
+
+    monkeypatch.setattr(
+        trusted_server,
+        "fetch_tool_definitions",
+        fake_fetch_tool_definitions,
+    )
+    monkeypatch.setattr(trusted_server, "UserMCPClient", _FakeUserMCPClient)
+    monkeypatch.setattr(
+        trusted_server,
+        "_authorization_header_from_request",
+        lambda: "Bearer test-token",
+    )
+    monkeypatch.setattr(
+        trusted_server,
+        "_claims_from_authorization_header",
+        lambda authorization: claims,
+    )
+
+    server = trusted_server.TokenScopedFastMCP("test")
+
+    degraded = await server._tools_from_request()
+    assert [tool.name for tool in degraded] == ["mcp__Jira__getIssue"]
+    assert degraded[0].description is not None
+    assert "Unavailable user MCP tool" in degraded[0].description
+    with pytest.raises(
+        ToolError,
+        match=(
+            "User MCP tool 'getIssue' on server 'Jira' is unavailable: "
+            "MCP discovery failed for server 'Jira' "
+            "\\(HTTPStatusError\\(status_code=503\\)\\)"
+        ),
+    ):
+        await degraded[0].run({"issueKey": "ISSUE-1"})
+
+    assert await server.get_tool("mcp__Jira__getIssue") is not None
+
+    jira_failing[0] = False
+    recovered = await server._tools_from_request()
+    assert [tool.description for tool in recovered] == ["Get issue"]
+    assert client_instantiations == [["Jira"], ["Jira"], ["Jira"]]
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -8,11 +8,16 @@ from fastmcp.exceptions import ToolError
 from tracecat.agent.common.types import MCPToolDefinition
 from tracecat.agent.mcp import trusted_server
 from tracecat.agent.mcp.metadata import PROXY_TOOL_CALL_ID_KEY, PROXY_TOOL_METADATA_KEY
-from tracecat.agent.mcp.user_client import UserMCPClient
+from tracecat.agent.mcp.user_client import UserMCPClient, UserMCPDiscoveryResult
 from tracecat.agent.preset.service import AgentPresetService
 from tracecat.agent.tokens import MCPTokenClaims, UserMCPServerClaim
 from tracecat.exceptions import BuiltinRegistryHasNoSelectionError
 from tracecat.registry.lock.types import RegistryLock
+
+
+@pytest.fixture(autouse=True)
+def clear_user_mcp_discovery_cache() -> None:
+    trusted_server._USER_MCP_DISCOVERY_CACHE.clear()
 
 
 def _build_claims(
@@ -149,6 +154,7 @@ async def test_execute_user_mcp_tool_uses_claimed_name_for_resolved_config(
             "url": "https://mcp.atlassian.com/v1/mcp",
             "transport": "http",
             "headers": {"Authorization": "Bearer secret"},
+            "id": str(integration_id),
         }
     ]
     assert call_args == {
@@ -439,23 +445,26 @@ async def test_build_token_scoped_tools_filters_subagent_catalog(
         def __init__(self, configs: list[dict[str, Any]]) -> None:
             self.configs = configs
 
-        async def discover_tools(self) -> dict[str, MCPToolDefinition]:
+        async def discover_tools_detailed(self) -> UserMCPDiscoveryResult:
             assert [config["name"] for config in self.configs] == ["Jira"]
-            return {
-                "mcp__Jira__getIssue": MCPToolDefinition(
-                    name="mcp__Jira__getIssue",
-                    description="Get issue",
-                    parameters_json_schema={
-                        "type": "object",
-                        "properties": {"issueKey": {"type": "string"}},
-                    },
-                ),
-                "mcp__Jira__listProjects": MCPToolDefinition(
-                    name="mcp__Jira__listProjects",
-                    description="List projects",
-                    parameters_json_schema={"type": "object"},
-                ),
-            }
+            return UserMCPDiscoveryResult(
+                definitions={
+                    "mcp__Jira__getIssue": MCPToolDefinition(
+                        name="mcp__Jira__getIssue",
+                        description="Get issue",
+                        parameters_json_schema={
+                            "type": "object",
+                            "properties": {"issueKey": {"type": "string"}},
+                        },
+                    ),
+                    "mcp__Jira__listProjects": MCPToolDefinition(
+                        name="mcp__Jira__listProjects",
+                        description="List projects",
+                        parameters_json_schema={"type": "object"},
+                    ),
+                },
+                failed_servers={},
+            )
 
     monkeypatch.setattr(
         trusted_server,

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -493,6 +493,99 @@ async def test_build_token_scoped_tools_filters_subagent_catalog(
     ]
 
 
+@pytest.mark.anyio
+async def test_user_mcp_discovery_cache_is_scoped_by_claimed_server_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    integration_id = uuid.UUID("00000000-0000-0000-0000-000000000004")
+
+    async def fake_fetch_tool_definitions(
+        action_names: list[str],
+    ) -> dict[str, MCPToolDefinition]:
+        assert action_names == []
+        return {}
+
+    class _PresetServiceContext:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def resolve_mcp_integration_refs(self, integration_ids):
+            assert integration_ids == [str(integration_id)]
+            return [
+                {
+                    "type": "http",
+                    "name": "Stored server name",
+                    "url": "https://mcp.example.com/v1",
+                    "transport": "http",
+                    "id": str(integration_id),
+                }
+            ]
+
+        async def resolve_mcp_integration_secrets(self, resolved_integration_id):
+            assert resolved_integration_id == integration_id
+            return {}
+
+    discovered_config_names: list[list[str]] = []
+
+    class _FakeUserMCPClient:
+        parse_user_mcp_tool_name = staticmethod(UserMCPClient.parse_user_mcp_tool_name)
+
+        def __init__(self, configs: list[dict[str, Any]]) -> None:
+            self.configs = configs
+            discovered_config_names.append([config["name"] for config in configs])
+
+        async def discover_tools_detailed(self) -> UserMCPDiscoveryResult:
+            assert len(self.configs) == 1
+            server_name = self.configs[0]["name"]
+            tool_name = f"mcp__{server_name}__getIssue"
+            return UserMCPDiscoveryResult(
+                definitions={
+                    tool_name: MCPToolDefinition(
+                        name=tool_name,
+                        description=f"Get issue from {server_name}",
+                        parameters_json_schema={"type": "object"},
+                    )
+                },
+                failed_servers={},
+            )
+
+    monkeypatch.setattr(
+        trusted_server,
+        "fetch_tool_definitions",
+        fake_fetch_tool_definitions,
+    )
+    monkeypatch.setattr(
+        AgentPresetService,
+        "with_session",
+        lambda role=None: _PresetServiceContext(),
+    )
+    monkeypatch.setattr(trusted_server, "UserMCPClient", _FakeUserMCPClient)
+
+    def claims_for_server(server_name: str) -> MCPTokenClaims:
+        return _build_claims(
+            allowed_actions=[f"mcp__{server_name}__getIssue"],
+            user_mcp_servers=[UserMCPServerClaim(name=server_name, id=integration_id)],
+        )
+
+    jira_tools = await trusted_server.build_token_scoped_tools(
+        claims_for_server("Jira")
+    )
+    linear_tools = await trusted_server.build_token_scoped_tools(
+        claims_for_server("Linear")
+    )
+
+    assert [tool.name for tool in jira_tools] == ["mcp__Jira__getIssue"]
+    assert [tool.name for tool in linear_tools] == ["mcp__Linear__getIssue"]
+    assert discovered_config_names == [["Jira"], ["Linear"]]
+    assert set(trusted_server._USER_MCP_DISCOVERY_CACHE) == {
+        ("Jira", str(integration_id)),
+        ("Linear", str(integration_id)),
+    }
+
+
 @pytest.mark.parametrize(
     (
         "tool_name",

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -792,6 +792,49 @@ async def test_partial_discovery_failure_is_not_pinned_to_token_cache(
     assert client_instantiations == [["Alpha", "Beta"], ["Beta"]]
 
 
+@pytest.mark.anyio
+async def test_discovery_skips_servers_without_allowed_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    claims = _build_claims(
+        allowed_actions=["mcp__Alpha__ping"],
+        user_mcp_servers=[
+            UserMCPServerClaim(name="Alpha", url="https://alpha.example.com/mcp"),
+            UserMCPServerClaim(name="Bravo", url="https://bravo.example.com/mcp"),
+        ],
+    )
+
+    class _FakeUserMCPClient:
+        parse_user_mcp_tool_name = staticmethod(UserMCPClient.parse_user_mcp_tool_name)
+
+        def __init__(self, configs: list[dict[str, Any]]) -> None:
+            assert [config["name"] for config in configs] == ["Alpha"], (
+                "servers without allowed tools must not be contacted"
+            )
+            self.configs = configs
+
+        async def discover_tools_detailed(self) -> UserMCPDiscoveryResult:
+            return UserMCPDiscoveryResult(
+                definitions={
+                    "mcp__Alpha__ping": MCPToolDefinition(
+                        name="mcp__Alpha__ping",
+                        description="Ping Alpha",
+                        parameters_json_schema={"type": "object"},
+                    )
+                },
+                failed_servers={},
+            )
+
+    monkeypatch.setattr(trusted_server, "UserMCPClient", _FakeUserMCPClient)
+
+    definitions, failed_servers = await trusted_server._discover_allowed_user_mcp_tools(
+        claims
+    )
+
+    assert list(definitions) == ["mcp__Alpha__ping"]
+    assert failed_servers == {}
+
+
 @pytest.mark.parametrize(
     (
         "tool_name",

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -586,6 +586,85 @@ async def test_user_mcp_discovery_cache_is_scoped_by_claimed_server_name(
     }
 
 
+@pytest.mark.anyio
+async def test_user_mcp_discovery_cache_legacy_key_includes_header_digest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch_tool_definitions(
+        action_names: list[str],
+    ) -> dict[str, MCPToolDefinition]:
+        assert action_names == []
+        return {}
+
+    discovered_credentials: list[str] = []
+
+    class _FakeUserMCPClient:
+        parse_user_mcp_tool_name = staticmethod(UserMCPClient.parse_user_mcp_tool_name)
+
+        def __init__(self, configs: list[dict[str, Any]]) -> None:
+            self.configs = configs
+
+        async def discover_tools_detailed(self) -> UserMCPDiscoveryResult:
+            assert len(self.configs) == 1
+            headers = self.configs[0].get("headers", {})
+            assert isinstance(headers, dict)
+            credential_name = {
+                "Bearer token-a": "credential-a",
+                "Bearer token-b": "credential-b",
+            }[headers["Authorization"]]
+            discovered_credentials.append(credential_name)
+            return UserMCPDiscoveryResult(
+                definitions={
+                    "mcp__Jira__getIssue": MCPToolDefinition(
+                        name="mcp__Jira__getIssue",
+                        description=f"Get issue for {credential_name}",
+                        parameters_json_schema={"type": "object"},
+                    )
+                },
+                failed_servers={},
+            )
+
+    monkeypatch.setattr(
+        trusted_server,
+        "fetch_tool_definitions",
+        fake_fetch_tool_definitions,
+    )
+    monkeypatch.setattr(trusted_server, "UserMCPClient", _FakeUserMCPClient)
+
+    def claims_for_header(authorization: str) -> MCPTokenClaims:
+        return _build_claims(
+            allowed_actions=["mcp__Jira__getIssue"],
+            user_mcp_servers=[
+                UserMCPServerClaim(
+                    name="Jira",
+                    url="https://mcp.example.com/v1",
+                    headers={"Authorization": authorization},
+                )
+            ],
+        )
+
+    first_tools = await trusted_server.build_token_scoped_tools(
+        claims_for_header("Bearer token-a")
+    )
+    second_tools = await trusted_server.build_token_scoped_tools(
+        claims_for_header("Bearer token-b")
+    )
+
+    assert [tool.description for tool in first_tools] == ["Get issue for credential-a"]
+    assert [tool.description for tool in second_tools] == ["Get issue for credential-b"]
+    assert discovered_credentials == ["credential-a", "credential-b"]
+
+    header_digests: list[str] = []
+    for key in trusted_server._USER_MCP_DISCOVERY_CACHE:
+        assert len(key) == 3
+        assert key[0] == "Jira"
+        assert key[1] == "https://mcp.example.com/v1"
+        header_digests.append(key[2])
+        assert "Bearer token" not in repr(key)
+    assert len(header_digests) == 2
+    assert len(set(header_digests)) == 2
+
+
 @pytest.mark.parametrize(
     (
         "tool_name",

--- a/tests/unit/test_agent_mcp_trusted_server.py
+++ b/tests/unit/test_agent_mcp_trusted_server.py
@@ -290,7 +290,7 @@ async def test_build_token_scoped_tools_does_not_advertise_internal_from_actions
         allowed_actions=["internal.builder.get_session"],
         allowed_internal_tools=[],
     )
-    tools = await trusted_server.build_token_scoped_tools(claims)
+    tools = (await trusted_server._build_token_scoped_tools(claims)).tools
 
     assert tools == []
 
@@ -363,7 +363,7 @@ async def test_build_token_scoped_tools_filters_root_catalog(
     )
 
     claims = _build_claims(allowed_actions=["core.cases.list_cases"])
-    tools = await trusted_server.build_token_scoped_tools(claims)
+    tools = (await trusted_server._build_token_scoped_tools(claims)).tools
 
     assert [tool.name for tool in tools] == ["core__cases__list_cases"]
     schema = tools[0].parameters
@@ -419,7 +419,7 @@ async def test_build_token_scoped_tools_uses_registry_lock_catalog(
         allowed_actions=["core.cases.list_cases"],
         registry_lock=lock,
     )
-    tools = await trusted_server.build_token_scoped_tools(claims)
+    tools = (await trusted_server._build_token_scoped_tools(claims)).tools
 
     assert [tool.name for tool in tools] == ["core__cases__list_cases"]
     schema = tools[0].parameters
@@ -489,7 +489,7 @@ async def test_build_token_scoped_tools_filters_subagent_catalog(
         ],
     )
 
-    tools = await trusted_server.build_token_scoped_tools(claims)
+    tools = (await trusted_server._build_token_scoped_tools(claims)).tools
 
     assert [tool.name for tool in tools] == [
         "core__cases__list_cases",
@@ -575,12 +575,12 @@ async def test_user_mcp_discovery_cache_is_scoped_by_claimed_server_name(
             user_mcp_servers=[UserMCPServerClaim(name=server_name, id=integration_id)],
         )
 
-    jira_tools = await trusted_server.build_token_scoped_tools(
-        claims_for_server("Jira")
-    )
-    linear_tools = await trusted_server.build_token_scoped_tools(
-        claims_for_server("Linear")
-    )
+    jira_tools = (
+        await trusted_server._build_token_scoped_tools(claims_for_server("Jira"))
+    ).tools
+    linear_tools = (
+        await trusted_server._build_token_scoped_tools(claims_for_server("Linear"))
+    ).tools
 
     assert [tool.name for tool in jira_tools] == ["mcp__Jira__getIssue"]
     assert [tool.name for tool in linear_tools] == ["mcp__Linear__getIssue"]
@@ -661,12 +661,16 @@ async def test_user_mcp_discovery_cache_legacy_key_includes_header_digest(
             ],
         )
 
-    first_tools = await trusted_server.build_token_scoped_tools(
-        claims_for_header("Bearer token-a")
-    )
-    second_tools = await trusted_server.build_token_scoped_tools(
-        claims_for_header("Bearer token-b")
-    )
+    first_tools = (
+        await trusted_server._build_token_scoped_tools(
+            claims_for_header("Bearer token-a")
+        )
+    ).tools
+    second_tools = (
+        await trusted_server._build_token_scoped_tools(
+            claims_for_header("Bearer token-b")
+        )
+    ).tools
 
     assert [tool.description for tool in first_tools] == ["Get issue for credential-a"]
     assert [tool.description for tool in second_tools] == ["Get issue for credential-b"]

--- a/tracecat/agent/executor/activity.py
+++ b/tracecat/agent/executor/activity.py
@@ -68,6 +68,7 @@ from tracecat.config import (
     TRACECAT__AGENT_SKILL_CACHE_MAX_CONCURRENT_DOWNLOADS,
 )
 from tracecat.feature_flags import FeatureFlag, is_feature_enabled
+from tracecat.integrations.mcp_validation import MCPSecretResolutionError
 from tracecat.logger import logger
 from tracecat.registry.lock.types import RegistryLock
 from tracecat.storage import blob
@@ -901,7 +902,7 @@ async def _hydrate_stdio_env(
                     )
                 try:
                     env = await svc.resolve_mcp_integration_secrets(uuid.UUID(cfg_id))
-                except ValueError:
+                except (ValueError, MCPSecretResolutionError):
                     env = None
                 result.append({**cfg, "env": env} if env else cfg)
     return result

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -83,6 +83,7 @@ _USER_MCP_DISCOVERY_CACHE_MAX_SIZE = 512
 class _UserMCPDiscoveryCacheKey(NamedTuple):
     server_name: str
     url: str
+    transport: str
     headers_digest: str
 
 
@@ -194,6 +195,7 @@ def _user_mcp_discovery_cache_key(
     return _UserMCPDiscoveryCacheKey(
         server_name=config["name"],
         url=config["url"],
+        transport=config.get("transport", "http"),
         headers_digest=_user_mcp_headers_digest(config.get("headers")),
     )
 

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -77,6 +77,7 @@ from tracecat.registry.lock.service import RegistryLockService
 _TOKEN_TOOL_CACHE_MAX_SIZE = 256
 _USER_MCP_DISCOVERY_CACHE_TTL_SECONDS = 45.0
 _USER_MCP_DISCOVERY_CACHE_MAX_SIZE = 512
+_UserMCPDiscoveryCacheKey = tuple[str, str]
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,7 +86,10 @@ class _UserMCPDiscoveryCacheEntry:
     definitions: dict[str, MCPToolDefinition]
 
 
-_USER_MCP_DISCOVERY_CACHE: dict[str, _UserMCPDiscoveryCacheEntry] = {}
+_USER_MCP_DISCOVERY_CACHE: dict[
+    _UserMCPDiscoveryCacheKey,
+    _UserMCPDiscoveryCacheEntry,
+] = {}
 _USER_MCP_DISCOVERY_CACHE_LOCK = asyncio.Lock()
 
 
@@ -175,10 +179,12 @@ def _format_failed_user_mcp_servers(failed_servers: dict[str, str]) -> str:
     )
 
 
-def _user_mcp_discovery_cache_key(config: MCPHttpServerConfig) -> str:
+def _user_mcp_discovery_cache_key(
+    config: MCPHttpServerConfig,
+) -> _UserMCPDiscoveryCacheKey:
     if integration_id := config.get("id"):
-        return integration_id
-    return config["url"]
+        return (config["name"], integration_id)
+    return (config["name"], config["url"])
 
 
 def _evict_user_mcp_discovery_cache(now: float) -> None:

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -438,10 +438,21 @@ async def _discover_allowed_user_mcp_tools(
     if not allowed_user_tools or not claims.user_mcp_servers:
         return {}, {}
 
+    # Only contact servers that back at least one allowed tool. A configured
+    # server whose tools were all disabled or filtered out at compile time
+    # must not add latency, retries, or failure noise to this token's listing.
+    expected_server_names = {
+        parsed[0]
+        for tool_name in allowed_user_tools
+        if (parsed := UserMCPClient.parse_user_mcp_tool_name(tool_name)) is not None
+    }
+
     role = _set_role_context(claims)
     configs: list[MCPHttpServerConfig] = []
     failed_servers: dict[str, str] = {}
     for server in claims.user_mcp_servers:
+        if server.name not in expected_server_names:
+            continue
         try:
             configs.append(await _resolve_user_mcp_config(server, role))
         except ToolError as e:

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -479,12 +479,17 @@ def _build_unavailable_user_mcp_tool(
     )
 
 
+class _AllowedUserMCPToolDiscovery(NamedTuple):
+    definitions: dict[str, MCPToolDefinition]
+    failed_servers: dict[str, str]
+
+
 async def _discover_allowed_user_mcp_tools(
     claims: MCPTokenClaims,
-) -> tuple[dict[str, MCPToolDefinition], dict[str, str]]:
+) -> _AllowedUserMCPToolDiscovery:
     allowed_user_tools = _user_mcp_tool_names(claims)
     if not allowed_user_tools or not claims.user_mcp_servers:
-        return {}, {}
+        return _AllowedUserMCPToolDiscovery(definitions={}, failed_servers={})
 
     # Only contact servers that back at least one allowed tool. A configured
     # server whose tools were all disabled or filtered out at compile time
@@ -530,23 +535,20 @@ async def _discover_allowed_user_mcp_tools(
                 _user_mcp_definitions_for_server(discovery.definitions, server_name),
             )
 
-    return {
-        name: definition
-        for name, definition in discovered.items()
-        if name in allowed_user_tools
-    }, failed_servers
+    return _AllowedUserMCPToolDiscovery(
+        definitions={
+            name: definition
+            for name, definition in discovered.items()
+            if name in allowed_user_tools
+        },
+        failed_servers=failed_servers,
+    )
 
 
 class _TokenScopedToolBuild(NamedTuple):
     tools: list[Tool]
     failed_user_mcp_servers: dict[str, str]
     cacheable: bool = True
-
-
-async def build_token_scoped_tools(claims: MCPTokenClaims) -> list[Tool]:
-    """Build the MCP tool catalog visible to one verified token."""
-    build = await _build_token_scoped_tools(claims)
-    return build.tools
 
 
 async def _build_token_scoped_tools(claims: MCPTokenClaims) -> _TokenScopedToolBuild:

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -14,6 +14,7 @@ Docker container with nsjail installed (e.g., the executor image).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import time
 from collections import OrderedDict
@@ -77,7 +78,7 @@ from tracecat.registry.lock.service import RegistryLockService
 _TOKEN_TOOL_CACHE_MAX_SIZE = 256
 _USER_MCP_DISCOVERY_CACHE_TTL_SECONDS = 45.0
 _USER_MCP_DISCOVERY_CACHE_MAX_SIZE = 512
-_UserMCPDiscoveryCacheKey = tuple[str, str]
+_UserMCPDiscoveryCacheKey = tuple[str, str] | tuple[str, str, str]
 
 
 @dataclass(frozen=True, slots=True)
@@ -184,7 +185,23 @@ def _user_mcp_discovery_cache_key(
 ) -> _UserMCPDiscoveryCacheKey:
     if integration_id := config.get("id"):
         return (config["name"], integration_id)
-    return (config["name"], config["url"])
+    return (
+        config["name"],
+        config["url"],
+        _user_mcp_headers_digest(config.get("headers")),
+    )
+
+
+def _user_mcp_headers_digest(headers: dict[str, str] | None) -> str:
+    digest = hashlib.sha256()
+    for name, value in sorted(
+        (name.lower(), value) for name, value in (headers or {}).items()
+    ):
+        digest.update(name.encode())
+        digest.update(b"\0")
+        digest.update(value.encode())
+        digest.update(b"\0")
+    return digest.hexdigest()
 
 
 def _evict_user_mcp_discovery_cache(now: float) -> None:

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -112,6 +112,16 @@ class TracecatScopedTool(Tool):
         return ToolResult(content=result)
 
 
+class UnavailableUserMCPTool(Tool):
+    """A placeholder for an expected user MCP tool that is unavailable now."""
+
+    error_message: SkipJsonSchema[str] = Field(exclude=True)
+
+    async def run(self, arguments: dict[str, Any]) -> ToolResult:
+        del arguments
+        raise ToolError(self.error_message)
+
+
 class TokenScopedFastMCP(FastMCP[None]):
     """FastMCP server whose visible tools are derived from the caller token."""
 
@@ -129,10 +139,10 @@ class TokenScopedFastMCP(FastMCP[None]):
             return self._tool_cache[authorization]
 
         build = await _build_token_scoped_tools(claims)
-        # A partial catalog (some user MCP servers failed discovery) must not
-        # be pinned to the token: the next listing should retry the failed
-        # servers instead of serving the reduced catalog until restart.
-        if not build.failed_user_mcp_servers:
+        # Degraded catalogs must not be pinned to the token: the next listing
+        # should retry unavailable/missing user MCP tools instead of serving
+        # placeholders until restart.
+        if build.cacheable:
             self._tool_cache[authorization] = build.tools
             if len(self._tool_cache) > _TOKEN_TOOL_CACHE_MAX_SIZE:
                 self._tool_cache.popitem(last=False)
@@ -182,13 +192,6 @@ def _safe_user_mcp_error_summary(exc: Exception) -> str:
     if isinstance(exc.__cause__, MCPSecretResolutionError):
         return f"{type(exc).__name__}(cause=MCPSecretResolutionError)"
     return type(exc).__name__
-
-
-def _format_failed_user_mcp_servers(failed_servers: dict[str, str]) -> str:
-    return "; ".join(
-        f"{server_name}: {summary}"
-        for server_name, summary in sorted(failed_servers.items())
-    )
 
 
 def _user_mcp_discovery_cache_key(
@@ -433,6 +436,49 @@ def _build_scoped_tool(
     )
 
 
+def _user_mcp_tool_unavailable_reason(
+    tool_name: str,
+    *,
+    claims: MCPTokenClaims,
+    failed_servers: dict[str, str],
+) -> str:
+    parsed = UserMCPClient.parse_user_mcp_tool_name(tool_name)
+    if parsed is None:
+        return "tool name is not a valid user MCP tool name"
+
+    server_name, _remote_tool_name = parsed
+    if error_summary := failed_servers.get(server_name):
+        return f"MCP discovery failed for server '{server_name}' ({error_summary})"
+
+    if not any(server.name == server_name for server in claims.user_mcp_servers):
+        return f"MCP server '{server_name}' is not present in this token"
+
+    return f"MCP server '{server_name}' did not advertise this tool"
+
+
+def _build_unavailable_user_mcp_tool(
+    tool_name: str,
+    *,
+    reason: str,
+) -> UnavailableUserMCPTool:
+    parsed = UserMCPClient.parse_user_mcp_tool_name(tool_name)
+    remote_tool_name = parsed[1] if parsed is not None else tool_name
+    server_name = parsed[0] if parsed is not None else "unknown"
+    error_message = (
+        f"User MCP tool '{remote_tool_name}' on server '{server_name}' "
+        f"is unavailable: {reason}"
+    )
+    return UnavailableUserMCPTool(
+        name=tool_name,
+        description=(
+            f"Unavailable user MCP tool. {reason}. Continue without this tool, "
+            "or tell the user that the integration is temporarily unavailable."
+        ),
+        parameters={"type": "object", "additionalProperties": True},
+        error_message=error_message,
+    )
+
+
 async def _discover_allowed_user_mcp_tools(
     claims: MCPTokenClaims,
 ) -> tuple[dict[str, MCPToolDefinition], dict[str, str]]:
@@ -494,6 +540,7 @@ async def _discover_allowed_user_mcp_tools(
 class _TokenScopedToolBuild(NamedTuple):
     tools: list[Tool]
     failed_user_mcp_servers: dict[str, str]
+    cacheable: bool = True
 
 
 async def build_token_scoped_tools(claims: MCPTokenClaims) -> list[Tool]:
@@ -551,20 +598,6 @@ async def _build_token_scoped_tools(claims: MCPTokenClaims) -> _TokenScopedToolB
         user_mcp_definitions,
         failed_user_mcp_servers,
     ) = await _discover_allowed_user_mcp_tools(claims)
-    if (
-        expected_user_mcp_tool_names
-        and not user_mcp_definitions
-        and failed_user_mcp_servers
-    ):
-        failed_summary = _format_failed_user_mcp_servers(failed_user_mcp_servers)
-        logger.error(
-            "Failed to resolve any expected user MCP tools",
-            session_id=str(claims.session_id),
-            workspace_id=str(claims.workspace_id),
-            failed_servers=failed_user_mcp_servers,
-        )
-        raise ToolError(f"User MCP discovery failed for all tools: {failed_summary}")
-
     if failed_user_mcp_servers:
         logger.warning(
             "Partially failed to discover token-scoped user MCP tools",
@@ -573,6 +606,9 @@ async def _build_token_scoped_tools(claims: MCPTokenClaims) -> _TokenScopedToolB
             failed_servers=failed_user_mcp_servers,
         )
 
+    unavailable_user_mcp_tool_names = expected_user_mcp_tool_names - set(
+        user_mcp_definitions
+    )
     for tool_name in claims.allowed_actions:
         if definition := user_mcp_definitions.get(tool_name):
             tools.append(
@@ -584,6 +620,18 @@ async def _build_token_scoped_tools(claims: MCPTokenClaims) -> _TokenScopedToolB
                 )
             )
             user_mcp_tool_count += 1
+        elif tool_name in unavailable_user_mcp_tool_names:
+            reason = _user_mcp_tool_unavailable_reason(
+                tool_name,
+                claims=claims,
+                failed_servers=failed_user_mcp_servers,
+            )
+            tools.append(
+                _build_unavailable_user_mcp_tool(
+                    tool_name,
+                    reason=reason,
+                )
+            )
 
     logger.info(
         "Built token-scoped MCP tool listing",
@@ -592,12 +640,14 @@ async def _build_token_scoped_tools(claims: MCPTokenClaims) -> _TokenScopedToolB
         registry_tool_count=registry_tool_count,
         internal_tool_count=internal_tool_count,
         user_mcp_tool_count=user_mcp_tool_count,
+        unavailable_user_mcp_tool_count=len(unavailable_user_mcp_tool_names),
         failed_server_names=list(failed_user_mcp_servers),
     )
 
     return _TokenScopedToolBuild(
         tools=tools,
         failed_user_mcp_servers=failed_user_mcp_servers,
+        cacheable=not unavailable_user_mcp_tool_names and not failed_user_mcp_servers,
     )
 
 

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -127,11 +127,15 @@ class TokenScopedFastMCP(FastMCP[None]):
             self._tool_cache.move_to_end(authorization)
             return self._tool_cache[authorization]
 
-        tools = await build_token_scoped_tools(claims)
-        self._tool_cache[authorization] = tools
-        if len(self._tool_cache) > _TOKEN_TOOL_CACHE_MAX_SIZE:
-            self._tool_cache.popitem(last=False)
-        return tools
+        build = await _build_token_scoped_tools(claims)
+        # A partial catalog (some user MCP servers failed discovery) must not
+        # be pinned to the token: the next listing should retry the failed
+        # servers instead of serving the reduced catalog until restart.
+        if not build.failed_user_mcp_servers:
+            self._tool_cache[authorization] = build.tools
+            if len(self._tool_cache) > _TOKEN_TOOL_CACHE_MAX_SIZE:
+                self._tool_cache.popitem(last=False)
+        return build.tools
 
     async def list_tools(self, *, run_middleware: bool = True) -> Sequence[Tool]:
         del run_middleware
@@ -474,8 +478,19 @@ async def _discover_allowed_user_mcp_tools(
     }, failed_servers
 
 
+class _TokenScopedToolBuild(NamedTuple):
+    tools: list[Tool]
+    failed_user_mcp_servers: dict[str, str]
+
+
 async def build_token_scoped_tools(claims: MCPTokenClaims) -> list[Tool]:
     """Build the MCP tool catalog visible to one verified token."""
+    build = await _build_token_scoped_tools(claims)
+    return build.tools
+
+
+async def _build_token_scoped_tools(claims: MCPTokenClaims) -> _TokenScopedToolBuild:
+    """Build the catalog plus per-server discovery failures for cache policy."""
     _set_role_context(claims)
     tools: list[Tool] = []
     registry_tool_count = 0
@@ -567,7 +582,10 @@ async def build_token_scoped_tools(claims: MCPTokenClaims) -> list[Tool]:
         failed_server_names=list(failed_user_mcp_servers),
     )
 
-    return tools
+    return _TokenScopedToolBuild(
+        tools=tools,
+        failed_user_mcp_servers=failed_user_mcp_servers,
+    )
 
 
 async def _execute_registry_action(

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -13,9 +13,12 @@ Docker container with nsjail installed (e.g., the executor image).
 
 from __future__ import annotations
 
+import asyncio
 import json
+import time
 from collections import OrderedDict
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any
 
 from fastmcp import FastMCP
@@ -67,10 +70,23 @@ from tracecat.exceptions import (
     TracecatNotFoundError,
     TracecatValidationError,
 )
+from tracecat.integrations.mcp_validation import MCPSecretResolutionError
 from tracecat.logger import logger
 from tracecat.registry.lock.service import RegistryLockService
 
 _TOKEN_TOOL_CACHE_MAX_SIZE = 256
+_USER_MCP_DISCOVERY_CACHE_TTL_SECONDS = 45.0
+_USER_MCP_DISCOVERY_CACHE_MAX_SIZE = 512
+
+
+@dataclass(frozen=True, slots=True)
+class _UserMCPDiscoveryCacheEntry:
+    expires_at: float
+    definitions: dict[str, MCPToolDefinition]
+
+
+_USER_MCP_DISCOVERY_CACHE: dict[str, _UserMCPDiscoveryCacheEntry] = {}
+_USER_MCP_DISCOVERY_CACHE_LOCK = asyncio.Lock()
 
 
 class TracecatScopedTool(Tool):
@@ -143,6 +159,81 @@ def _set_role_context(claims: MCPTokenClaims) -> Role:
 def _safe_error_type(exc: Exception) -> str:
     """Return only the exception class name for log-safe reporting."""
     return type(exc).__name__
+
+
+def _safe_user_mcp_error_summary(exc: Exception) -> str:
+    """Summarize user MCP discovery errors without secret-bearing details."""
+    if isinstance(exc.__cause__, MCPSecretResolutionError):
+        return f"{type(exc).__name__}(cause=MCPSecretResolutionError)"
+    return type(exc).__name__
+
+
+def _format_failed_user_mcp_servers(failed_servers: dict[str, str]) -> str:
+    return "; ".join(
+        f"{server_name}: {summary}"
+        for server_name, summary in sorted(failed_servers.items())
+    )
+
+
+def _user_mcp_discovery_cache_key(config: MCPHttpServerConfig) -> str:
+    if integration_id := config.get("id"):
+        return integration_id
+    return config["url"]
+
+
+def _evict_user_mcp_discovery_cache(now: float) -> None:
+    expired_keys = [
+        key
+        for key, entry in _USER_MCP_DISCOVERY_CACHE.items()
+        if entry.expires_at <= now
+    ]
+    for key in expired_keys:
+        _USER_MCP_DISCOVERY_CACHE.pop(key, None)
+
+    overflow_count = len(_USER_MCP_DISCOVERY_CACHE) - _USER_MCP_DISCOVERY_CACHE_MAX_SIZE
+    if overflow_count <= 0:
+        return
+    for key in list(_USER_MCP_DISCOVERY_CACHE)[:overflow_count]:
+        _USER_MCP_DISCOVERY_CACHE.pop(key, None)
+
+
+async def _get_cached_user_mcp_discovery(
+    config: MCPHttpServerConfig,
+) -> dict[str, MCPToolDefinition] | None:
+    now = time.monotonic()
+    cache_key = _user_mcp_discovery_cache_key(config)
+    async with _USER_MCP_DISCOVERY_CACHE_LOCK:
+        _evict_user_mcp_discovery_cache(now)
+        if entry := _USER_MCP_DISCOVERY_CACHE.get(cache_key):
+            return dict(entry.definitions)
+    return None
+
+
+async def _set_cached_user_mcp_discovery(
+    config: MCPHttpServerConfig,
+    definitions: dict[str, MCPToolDefinition],
+) -> None:
+    now = time.monotonic()
+    cache_key = _user_mcp_discovery_cache_key(config)
+    entry = _UserMCPDiscoveryCacheEntry(
+        expires_at=now + _USER_MCP_DISCOVERY_CACHE_TTL_SECONDS,
+        definitions=dict(definitions),
+    )
+    async with _USER_MCP_DISCOVERY_CACHE_LOCK:
+        _evict_user_mcp_discovery_cache(now)
+        _USER_MCP_DISCOVERY_CACHE[cache_key] = entry
+
+
+def _user_mcp_definitions_for_server(
+    definitions: dict[str, MCPToolDefinition],
+    server_name: str,
+) -> dict[str, MCPToolDefinition]:
+    prefix = f"mcp__{server_name}__"
+    return {
+        name: definition
+        for name, definition in definitions.items()
+        if name.startswith(prefix)
+    }
 
 
 def _claims_from_token(token: str) -> MCPTokenClaims:
@@ -253,6 +344,10 @@ async def _resolve_user_mcp_config(
             secrets = await svc.resolve_mcp_integration_secrets(ref.id)
     except ToolError:
         raise
+    except MCPSecretResolutionError as e:
+        raise ToolError(
+            f"Credentials for MCP server '{ref.name}' could not be resolved"
+        ) from e
     except (TracecatValidationError, TracecatNotFoundError) as e:
         raise ToolError(f"MCP integration {ref.id} is unavailable: {e}") from None
     except Exception:
@@ -272,6 +367,7 @@ async def _resolve_user_mcp_config(
         "url": metadata["url"],
         "transport": metadata.get("transport", "http"),
         "headers": secrets or {},
+        "id": str(ref.id),
     }
     timeout = metadata.get("timeout")
     if timeout is not None:
@@ -302,29 +398,58 @@ def _build_scoped_tool(
 
 async def _discover_allowed_user_mcp_tools(
     claims: MCPTokenClaims,
-) -> dict[str, MCPToolDefinition]:
+) -> tuple[dict[str, MCPToolDefinition], dict[str, str]]:
     allowed_user_tools = _user_mcp_tool_names(claims)
     if not allowed_user_tools or not claims.user_mcp_servers:
-        return {}
+        return {}, {}
 
     role = _set_role_context(claims)
-    configs = [
-        await _resolve_user_mcp_config(server, role)
-        for server in claims.user_mcp_servers
-    ]
-    client = UserMCPClient(configs)
-    discovered = await client.discover_tools()
+    configs: list[MCPHttpServerConfig] = []
+    failed_servers: dict[str, str] = {}
+    for server in claims.user_mcp_servers:
+        try:
+            configs.append(await _resolve_user_mcp_config(server, role))
+        except ToolError as e:
+            failed_servers[server.name] = _safe_user_mcp_error_summary(e)
+
+    discovered: dict[str, MCPToolDefinition] = {}
+    uncached_configs: list[MCPHttpServerConfig] = []
+    for config in configs:
+        cached = await _get_cached_user_mcp_discovery(config)
+        if cached is None:
+            uncached_configs.append(config)
+        else:
+            discovered.update(cached)
+
+    if uncached_configs:
+        client = UserMCPClient(uncached_configs)
+        discovery = await client.discover_tools_detailed()
+        failed_servers.update(discovery.failed_servers)
+        discovered.update(discovery.definitions)
+
+        for config in uncached_configs:
+            server_name = config["name"]
+            if server_name in discovery.failed_servers:
+                continue
+            await _set_cached_user_mcp_discovery(
+                config,
+                _user_mcp_definitions_for_server(discovery.definitions, server_name),
+            )
+
     return {
         name: definition
         for name, definition in discovered.items()
         if name in allowed_user_tools
-    }
+    }, failed_servers
 
 
 async def build_token_scoped_tools(claims: MCPTokenClaims) -> list[Tool]:
     """Build the MCP tool catalog visible to one verified token."""
     _set_role_context(claims)
     tools: list[Tool] = []
+    registry_tool_count = 0
+    internal_tool_count = 0
+    user_mcp_tool_count = 0
 
     registry_action_names = _registry_action_names(claims)
     registry_definitions = (
@@ -347,6 +472,7 @@ async def build_token_scoped_tools(claims: MCPTokenClaims) -> list[Tool]:
                     claims=claims,
                 )
             )
+            registry_tool_count += 1
 
     internal_definitions = get_builder_internal_tool_definitions()
     for tool_name in _internal_tool_names(claims):
@@ -359,16 +485,35 @@ async def build_token_scoped_tools(claims: MCPTokenClaims) -> list[Tool]:
                     claims=claims,
                 )
             )
+            internal_tool_count += 1
 
-    try:
-        user_mcp_definitions = await _discover_allowed_user_mcp_tools(claims)
-    except Exception as e:
-        logger.warning(
-            "Failed to discover token-scoped user MCP tools",
-            error_type=_safe_error_type(e),
+    expected_user_mcp_tool_names = _user_mcp_tool_names(claims)
+    (
+        user_mcp_definitions,
+        failed_user_mcp_servers,
+    ) = await _discover_allowed_user_mcp_tools(claims)
+    if (
+        expected_user_mcp_tool_names
+        and not user_mcp_definitions
+        and failed_user_mcp_servers
+    ):
+        failed_summary = _format_failed_user_mcp_servers(failed_user_mcp_servers)
+        logger.error(
+            "Failed to resolve any expected user MCP tools",
+            session_id=str(claims.session_id),
             workspace_id=str(claims.workspace_id),
+            failed_servers=failed_user_mcp_servers,
         )
-        user_mcp_definitions = {}
+        raise ToolError(f"User MCP discovery failed for all tools: {failed_summary}")
+
+    if failed_user_mcp_servers:
+        logger.warning(
+            "Partially failed to discover token-scoped user MCP tools",
+            session_id=str(claims.session_id),
+            workspace_id=str(claims.workspace_id),
+            failed_servers=failed_user_mcp_servers,
+        )
+
     for tool_name in claims.allowed_actions:
         if definition := user_mcp_definitions.get(tool_name):
             tools.append(
@@ -379,6 +524,17 @@ async def build_token_scoped_tools(claims: MCPTokenClaims) -> list[Tool]:
                     claims=claims,
                 )
             )
+            user_mcp_tool_count += 1
+
+    logger.info(
+        "Built token-scoped MCP tool listing",
+        session_id=str(claims.session_id),
+        workspace_id=str(claims.workspace_id),
+        registry_tool_count=registry_tool_count,
+        internal_tool_count=internal_tool_count,
+        user_mcp_tool_count=user_mcp_tool_count,
+        failed_server_names=list(failed_user_mcp_servers),
+    )
 
     return tools
 

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -20,7 +20,7 @@ import time
 from collections import OrderedDict
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, NamedTuple
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
@@ -78,7 +78,12 @@ from tracecat.registry.lock.service import RegistryLockService
 _TOKEN_TOOL_CACHE_MAX_SIZE = 256
 _USER_MCP_DISCOVERY_CACHE_TTL_SECONDS = 45.0
 _USER_MCP_DISCOVERY_CACHE_MAX_SIZE = 512
-_UserMCPDiscoveryCacheKey = tuple[str, str] | tuple[str, str, str]
+
+
+class _UserMCPDiscoveryCacheKey(NamedTuple):
+    server_name: str
+    url: str
+    headers_digest: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -183,12 +188,13 @@ def _format_failed_user_mcp_servers(failed_servers: dict[str, str]) -> str:
 def _user_mcp_discovery_cache_key(
     config: MCPHttpServerConfig,
 ) -> _UserMCPDiscoveryCacheKey:
-    if integration_id := config.get("id"):
-        return (config["name"], integration_id)
-    return (
-        config["name"],
-        config["url"],
-        _user_mcp_headers_digest(config.get("headers")),
+    # Key on the resolved config rather than the integration id: an edit to an
+    # integration's URL or credentials (same id/name) must miss the cache
+    # immediately instead of serving the previous endpoint's tools for a TTL.
+    return _UserMCPDiscoveryCacheKey(
+        server_name=config["name"],
+        url=config["url"],
+        headers_digest=_user_mcp_headers_digest(config.get("headers")),
     )
 
 

--- a/tracecat/agent/mcp/trusted_server.py
+++ b/tracecat/agent/mcp/trusted_server.py
@@ -84,6 +84,7 @@ class _UserMCPDiscoveryCacheKey(NamedTuple):
     server_name: str
     url: str
     transport: str
+    timeout: int | None
     headers_digest: str
 
 
@@ -200,6 +201,7 @@ def _user_mcp_discovery_cache_key(
         server_name=config["name"],
         url=config["url"],
         transport=config.get("transport", "http"),
+        timeout=config.get("timeout"),
         headers_digest=_user_mcp_headers_digest(config.get("headers")),
     )
 

--- a/tracecat/agent/mcp/user_client.py
+++ b/tracecat/agent/mcp/user_client.py
@@ -9,10 +9,19 @@ allowing the sandboxed runtime to access user tools via the Unix socket proxy.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Literal
 
+import httpx
 from fastmcp import Client
 from fastmcp.client.transports import SSETransport, StreamableHttpTransport
+from mcp import McpError
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from tracecat.agent.common.types import MCPHttpServerConfig, MCPToolDefinition
 from tracecat.agent.mcp.utils import (
@@ -21,6 +30,14 @@ from tracecat.agent.mcp.utils import (
 )
 from tracecat.integrations.schemas import MCPToolSummary
 from tracecat.logger import logger
+
+
+@dataclass(frozen=True, slots=True)
+class UserMCPDiscoveryResult:
+    """Detailed user MCP discovery result."""
+
+    definitions: dict[str, MCPToolDefinition]
+    failed_servers: dict[str, str]
 
 
 def _create_transport(
@@ -63,6 +80,48 @@ async def list_remote_mcp_tools(
     ]
 
 
+def _iter_exception_chain(exc: BaseException) -> list[BaseException]:
+    """Return an exception and its explicit cause/context chain."""
+    chain: list[BaseException] = []
+    current: BaseException | None = exc
+    while current is not None and current not in chain:
+        chain.append(current)
+        current = current.__cause__ or current.__context__
+    return chain
+
+
+def _is_retryable_discovery_error_leaf(exc: BaseException) -> bool:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code >= 500
+    if isinstance(exc, httpx.TransportError | httpx.TimeoutException):
+        return True
+    if isinstance(exc, McpError):
+        return exc.error.code == int(httpx.codes.REQUEST_TIMEOUT)
+    return False
+
+
+def _is_retryable_discovery_error(exc: BaseException) -> bool:
+    """Return true for transient connect/list failures only."""
+    return any(
+        _is_retryable_discovery_error_leaf(chained)
+        for chained in _iter_exception_chain(exc)
+    )
+
+
+def _safe_discovery_error_summary(exc: BaseException) -> str:
+    """Summarize a discovery error without response bodies or URLs."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return f"{type(exc).__name__}(status_code={exc.response.status_code})"
+    if isinstance(exc, McpError):
+        return f"{type(exc).__name__}(code={exc.error.code})"
+    if exc.__cause__ is not None:
+        return (
+            f"{type(exc).__name__}"
+            f"(cause={_safe_discovery_error_summary(exc.__cause__)})"
+        )
+    return type(exc).__name__
+
+
 class UserMCPClient:
     """Client for connecting to user-defined MCP servers.
 
@@ -94,18 +153,30 @@ class UserMCPClient:
             Dict mapping tool names (mcp__{server_name}__{tool_name}) to definitions.
 
         """
+        result = await self.discover_tools_detailed(fail_on_error=fail_on_error)
+        return result.definitions
+
+    async def discover_tools_detailed(
+        self,
+        *,
+        fail_on_error: bool = False,
+    ) -> UserMCPDiscoveryResult:
+        """Connect to all configured servers and report per-server failures."""
         tools: dict[str, MCPToolDefinition] = {}
+        failed_servers: dict[str, str] = {}
 
         for server_name, config in self._configs.items():
             try:
                 server_tools = await self._discover_server_tools(server_name, config)
                 tools.update(server_tools)
             except Exception as e:
+                error_summary = _safe_discovery_error_summary(e)
                 logger.error(
                     "Failed to discover tools from user MCP server",
                     server_name=server_name,
-                    error=str(e),
+                    error_summary=error_summary,
                 )
+                failed_servers[server_name] = error_summary
                 if fail_on_error:
                     raise RuntimeError(
                         f"Failed to discover tools from user MCP server '{server_name}'"
@@ -116,9 +187,10 @@ class UserMCPClient:
             server_count=len(self._configs),
             tool_count=len(tools),
             tools=list(tools.keys()),
+            failed_servers=list(failed_servers),
         )
 
-        return tools
+        return UserMCPDiscoveryResult(definitions=tools, failed_servers=failed_servers)
 
     async def _discover_server_tools(
         self,
@@ -135,6 +207,22 @@ class UserMCPClient:
             Dict mapping prefixed tool names to definitions.
 
         """
+        async for attempt in AsyncRetrying(
+            retry=retry_if_exception(_is_retryable_discovery_error),
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=0.5, min=0.5, max=2),
+            reraise=True,
+        ):
+            with attempt:
+                return await self._discover_server_tools_once(server_name, config)
+        raise RuntimeError("MCP server discovery retry loop exited unexpectedly")
+
+    async def _discover_server_tools_once(
+        self,
+        server_name: str,
+        config: MCPHttpServerConfig,
+    ) -> dict[str, MCPToolDefinition]:
+        """Discover tools from a single MCP server without retries."""
         url = config["url"]
         transport_type: Literal["http", "sse"] = config.get("transport", "http")
         headers = config.get("headers")

--- a/tracecat/agent/preset/service.py
+++ b/tracecat/agent/preset/service.py
@@ -56,8 +56,10 @@ from tracecat.dsl.common import create_default_execution_context
 from tracecat.exceptions import TracecatNotFoundError, TracecatValidationError
 from tracecat.executor.service import get_workspace_variables
 from tracecat.expressions.eval import collect_expressions, eval_templated_object
+from tracecat.integrations.enums import MCPAuthType
 from tracecat.integrations.mcp_validation import (
     MCPConfigurationError,
+    MCPSecretResolutionError,
     MCPValidationError,
     validate_mcp_command_config,
 )
@@ -958,10 +960,15 @@ class AgentPresetService(BaseWorkspaceService):
 
         Returns the headers/env dict (depending on server type) freshly
         decrypted, with OAuth tokens refreshed if applicable. Returns
-        ``None`` if the integration cannot be authenticated or is not found.
+        ``None`` only when the integration is not found or has no secrets to
+        resolve.
 
         Call this at the trusted edge per use — never propagate the result
         across a Temporal boundary.
+
+        Raises:
+            MCPSecretResolutionError: If configured credentials/env exist but
+                cannot be resolved.
         """
         integrations_service = IntegrationService(self.session, role=self.role)
         available = await integrations_service.list_mcp_integrations()
@@ -998,7 +1005,12 @@ class AgentPresetService(BaseWorkspaceService):
                         "mcp_integration_id": str(mcp_integration.id),
                     },
                 )
-                return None
+                raise MCPSecretResolutionError(
+                    "Stdio MCP integration env could not be resolved",
+                    mcp_integration_id=mcp_integration.id,
+                    server_name=mcp_integration.name,
+                    server_slug=mcp_integration.slug,
+                ) from e
 
         # HTTP server — resolve headers per auth type.
         try:
@@ -1015,6 +1027,13 @@ class AgentPresetService(BaseWorkspaceService):
                     "mcp_integration_id": str(mcp_integration.id),
                 },
             )
+            if mcp_integration.auth_type in {MCPAuthType.OAUTH2, MCPAuthType.CUSTOM}:
+                raise MCPSecretResolutionError(
+                    "HTTP MCP integration credentials could not be resolved",
+                    mcp_integration_id=mcp_integration.id,
+                    server_name=mcp_integration.name,
+                    server_slug=mcp_integration.slug,
+                ) from e
             return None
         return server_config.get("headers", {})
 

--- a/tracecat/integrations/mcp_validation.py
+++ b/tracecat/integrations/mcp_validation.py
@@ -5,6 +5,7 @@ command injection and other security vulnerabilities.
 """
 
 import re
+import uuid
 
 # Allowlist of commands that can be used for MCP servers
 ALLOWED_MCP_COMMANDS = frozenset({"npx", "uvx", "python", "python3", "node"})
@@ -51,6 +52,23 @@ class MCPConfigurationError(Exception):
     """Raised when an MCP integration cannot be resolved into a usable server config."""
 
     pass
+
+
+class MCPSecretResolutionError(Exception):
+    """Raised when configured MCP integration credentials cannot be resolved."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        mcp_integration_id: uuid.UUID,
+        server_name: str,
+        server_slug: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.mcp_integration_id = mcp_integration_id
+        self.server_name = server_name
+        self.server_slug = server_slug
 
 
 _URL_PATTERN = re.compile(r"\bhttps?://\S+", re.IGNORECASE)


### PR DESCRIPTION
## Problem

The trusted MCP bridge re-discovers user-configured HTTP MCP servers live on every `tools/list`. Any failure in that path was silently swallowed and the affected tools simply vanished from the token-scoped catalog — the agent then got "No such tool available" on every call, with no diagnostics anywhere. This is the signature of a production incident where a subagent lost its entire toolset and the executor logs contained nothing actionable (a successful listing and a listing that never happened were indistinguishable).

Specific silent-drop paths:

- `build_token_scoped_tools` caught **any** discovery exception and continued with zero user-MCP tools.
- One bad server config aborted discovery for **all** servers (config resolution ran in a single list comprehension inside the same try).
- `resolve_mcp_integration_secrets` returned `None` both for "no secrets configured" and "OAuth/header resolution failed"; the bridge turned that into `headers: {}` — a guaranteed upstream 401, then swallowed.
- No retries: a transient upstream blip permanently dropped tools for that listing.

## Changes

- **Typed secret errors.** New `MCPSecretResolutionError` (carries integration id + server name). `resolve_mcp_integration_secrets` raises it when configured credentials (OAuth2/custom headers, stdio env) cannot be resolved; `None` now strictly means not-found/no-secrets. The bridge converts it to a `ToolError` instead of proceeding with empty headers. Compile-time and stdio-hydration callers catch it explicitly and keep their existing soft semantics.
- **Per-server isolation.** `UserMCPClient.discover_tools_detailed()` returns `(definitions, failed_servers)`; each server's config resolution and discovery fail independently.
- **Bounded retries for transient failures only.** Tenacity, 3 attempts, exponential backoff 0.5–2s. Classification is by exception type across the exception chain (fastmcp wraps httpx): `httpx.TransportError`/`TimeoutException`, 5xx `HTTPStatusError`, and timeout-coded `McpError` (408 per MCP SDK convention). 4xx and JSON-RPC application errors are never retried. Error summaries never include response bodies, URLs, or headers.
- **Discovery cache.** 45s in-process async-safe TTL cache of raw per-server discovery results keyed by integration id (URL fallback for legacy inline claims), size-bounded. Only successes are cached; per-token filtering stays per-request. `tools/list` no longer pays one upstream round-trip per server per request.
- **Fail-open visible loss.** User-MCP discovery is best-effort: successful tools stay available, and expected tools that could not be rediscovered are registered as explicit unavailable placeholders. The agent turn can continue, while tool descriptions and call-time ToolErrors explain which MCP server failed and why. Degraded catalogs are not token-cached, so later listings can recover.
- **Success visibility.** Every token-scoped listing logs an INFO with session/workspace ids and registry/internal/user-MCP tool counts plus failed server names — closing the gap where success and never-connected were indistinguishable during incident diagnosis.

## Verification

- `tests/unit/test_agent_mcp_trusted_server.py` + `tests/unit/test_agent_mcp_user_client.py`: 21 passed (existing assertions adapted only to the new return shape; an autouse fixture clears the discovery cache between tests).
- `tests/unit/test_agent_activities.py`: the 4 failures in `TestSandboxedAgentExecutorFilesystemPersistence` are pre-existing — they fail identically on untouched `main`.
- `ruff check` / `ruff format --check`: clean on all touched files.
- `basedpyright --warnings` on touched files: 0 errors, 0 warnings.

## Follow-ups (out of scope here)

- Emit a session-stream warning on partial/total discovery loss (needs a stream-id claim; coordinated with the token-lifetime PR).
- Persist tool input schemas at discovery time and serve `tools/list` from the DB, removing the live round-trip entirely.
- PR #2861 (surface compile-time MCP discovery scope errors) should land after this so soft-failed scopes stay visible at runtime.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens MCP bridge discovery to prevent silent loss of user-MCP tools and improve diagnostics. Adds fail-open placeholders, per-server isolation, safe retries, scoped caching, and skips out-of-scope servers.

- **Bug Fixes**
  - Introduced `MCPSecretResolutionError` for credential/env failures; surfaced as `ToolError` at runtime, while compile-time and stdio hydration keep soft handling.
  - Isolated discovery per server; `UserMCPClient.discover_tools_detailed()` returns definitions and `failed_servers` so one bad server doesn’t hide others.
  - Added bounded retries (3 attempts, exponential backoff 0.5–2s) for transient errors (`httpx` transport/timeouts, 5xx, timeout-coded `McpError`); no retries for 4xx or JSON-RPC app errors; logs use safe summaries.
  - Implemented a 45s in-process TTL discovery cache keyed by resolved config (`server_name`, URL, transport, timeout, headers digest); integration id is not used. Only successes are cached; per-token filtering stays per request.
  - Skips contacting user MCP servers that have no allowed tools for the token.
  - Fail-open on discovery loss: `tools/list` returns “Unavailable user MCP tool” placeholders for expected-but-missing tools (they raise `ToolError` if invoked) instead of failing the listing. Degraded catalogs are not pinned in the token cache; subsequent listings retry only failed servers while using the discovery cache for others.
  - Logging: partial failures log a warning with session/workspace ids and failed server names; every listing logs registry/internal/user-MCP tool counts and unavailable tool counts.

- **Refactors**
  - Standardized discovery output via `UserMCPDiscoveryResult`; `discover_tools_detailed()` now returns a structured result with `definitions` and `failed_servers`.

<sup>Written for commit adcd6e5949f62e672c310a288616301461422947. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

