### PR TITLE
fix(agent): size MCP scope token TTL to turn and re-mint on resume

### DIFF
--- a/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
+++ b/packages/tracecat-ee/tracecat_ee/agent/workflows/durable.py
@@ -481,6 +481,7 @@ def _preserved_agents_binding(
 
 
 FINALIZE_TURN_PATCH = "durable-agent-finalize-turn-v1"
+REMINT_SCOPE_TOKENS_PATCH = "durable-agent-remint-scope-tokens-v1"
 
 
 @workflow.defn
@@ -679,6 +680,36 @@ class DurableAgentWorkflow:
             internal_tool_context=internal_tool_context,
             registry_lock=build_result.registry_lock,
         )
+
+    def _remint_scope_tokens(
+        self,
+        compiled_run: CompiledAgentRun,
+        *,
+        internal_tool_context: InternalToolContext | None,
+    ) -> CompiledAgentRun:
+        root = compiled_run.root.model_copy(
+            update={
+                "mcp_auth_token": self._mint_scope_mcp_token(
+                    build_result=compiled_run.root.build_result,
+                    internal_tool_context=internal_tool_context,
+                )
+            }
+        )
+        subagents = [
+            subagent.model_copy(
+                update={
+                    "scope": subagent.scope.model_copy(
+                        update={
+                            "mcp_auth_token": self._mint_scope_mcp_token(
+                                build_result=subagent.scope.build_result,
+                            )
+                        }
+                    )
+                }
+            )
+            for subagent in compiled_run.subagents
+        ]
+        return compiled_run.model_copy(update={"root": root, "subagents": subagents})
 
     async def _compile_agent_run(
         self,
@@ -1329,6 +1360,44 @@ class DurableAgentWorkflow:
                     )
                     return await self._cancelled_turn_output(
                         result, info, emit_cancelled=True
+                    )
+
+                # Approval waits are unbounded. Tokens are turn-scoped, so resumed
+                # user-MCP tool execution and the continuation need fresh tokens.
+                if workflow.patched(REMINT_SCOPE_TOKENS_PATCH):
+                    compiled_run = self._remint_scope_tokens(
+                        compiled_run,
+                        internal_tool_context=internal_tool_context,
+                    )
+                    llm_gateway_auth_token = mint_llm_token(
+                        workspace_id=self.workspace_id,
+                        organization_id=self.organization_id,
+                        session_id=self.session_id,
+                        model=cfg.model_name,
+                        provider=cfg.model_provider,
+                        catalog_id=cfg.catalog_id,
+                        base_url=cfg.base_url,
+                        model_settings=cfg.model_settings,
+                        routes=compiled_run.llm_routes,
+                    )
+
+                # Approval waits are unbounded. Tokens are turn-scoped, so resumed
+                # user-MCP tool execution and the continuation need fresh tokens.
+                if workflow.patched(REMINT_SCOPE_TOKENS_PATCH):
+                    compiled_run = self._remint_scope_tokens(
+                        compiled_run,
+                        internal_tool_context=internal_tool_context,
+                    )
+                    llm_gateway_auth_token = mint_llm_token(
+                        workspace_id=self.workspace_id,
+                        organization_id=self.organization_id,
+                        session_id=self.session_id,
+                        model=cfg.model_name,
+                        provider=cfg.model_provider,
+                        catalog_id=cfg.catalog_id,
+                        base_url=cfg.base_url,
+                        model_settings=cfg.model_settings,
+                        routes=compiled_run.llm_routes,
                     )
 
                 # Execute approved tools and reconcile the SDK transcript.

--- a/tracecat/agent/tokens.py
+++ b/tracecat/agent/tokens.py
@@ -164,13 +164,14 @@ def mint_mcp_token(
         user_mcp_servers: User-defined MCP server configs for proxying
         allowed_internal_tools: Set of allowed internal tool names
         internal_tool_context: Context for internal tools (preset_id, entity_type)
-        ttl_seconds: Token TTL in seconds (defaults to executor token TTL)
+        ttl_seconds: Token TTL in seconds (defaults to the agent sandbox timeout
+            plus a small buffer so the token outlives one full turn)
 
     Returns:
         Signed JWT string
     """
     now = datetime.now(UTC)
-    ttl = ttl_seconds or config.TRACECAT__EXECUTOR_TOKEN_TTL_SECONDS
+    ttl = ttl_seconds or config.TRACECAT__AGENT_SANDBOX_TIMEOUT + 60
 
     payload: dict[str, Any] = {
         "iss": MCP_TOKEN_ISSUER,
@@ -355,7 +356,8 @@ def mint_llm_token(
         model_settings: Model-specific settings (temperature, max_tokens,
             reasoning_effort, etc.) passed through to LLM provider
         use_workspace_credentials: Legacy credential scope for no-catalog tokens
-        ttl_seconds: Token TTL in seconds (defaults to executor token TTL)
+        ttl_seconds: Token TTL in seconds (defaults to the agent sandbox timeout
+            plus a small buffer so the token outlives one full turn)
 
     Returns:
         Signed JWT string


### PR DESCRIPTION
## Problem

Agent scope MCP tokens are minted with the executor default TTL (`TRACECAT__EXECUTOR_TOKEN_TTL_SECONDS`, 900s), but a single agent turn can run up to `TRACECAT__AGENT_SANDBOX_TIMEOUT` (default 1800s). With default config a token can expire mid-turn. The sibling `mint_llm_token` already sizes its TTL to the turn (`TRACECAT__AGENT_SANDBOX_TIMEOUT + 60`); the MCP token never got the same treatment.

Two concrete failure modes, both silent:

- **Subagents lose their entire toolset.** The root agent connects the trusted MCP bridge at session start with a fresh token, but per-subagent bridge servers (`AgentDefinition.mcpServers`) connect lazily at spawn. A subagent spawned >15 min into a turn presents an expired bearer, `tools/list` is rejected, and the SDK registers zero tools — every call returns "No such tool available" with no error surfaced.
- **Approval resumes reuse stale tokens.** `approvals.wait()` is unbounded. The resume path reused the root MCP token, every subagent MCP token, and the LLM gateway token minted before the pause — all expired after a long wait. Approved registry tools were unaffected (they execute with a service role), but approved user-MCP tool calls failed into error tool results and the resumed turn ran with degraded tool availability.

## Changes

- `mint_mcp_token` default TTL now mirrors `mint_llm_token`: `TRACECAT__AGENT_SANDBOX_TIMEOUT + 60`, derived from config (not hardcoded) so deployments that raise the sandbox timeout keep a valid token for the full turn. Fixed the stale TTL docstrings on both mint functions.
- In the durable agent workflow, after `approvals.handle_decisions()` and before approved-tool execution, re-mint the root scope MCP token, every subagent scope MCP token, and the LLM gateway token. Tokens are rebuilt from the retained per-scope `build_result`s, so claims are identical except `iat`/`exp`. Guarded by a new `durable-agent-remint-scope-tokens-v1` patch marker; the re-mint is pure in-workflow computation (no new activities or awaits), matching the existing inline-mint pattern.

## Verification

- `ruff check` / `ruff format --check`: clean on touched files.
- `basedpyright --warnings` on touched files: 0 errors, 0 warnings.
- `tests/unit/test_agent_tokens.py`: 4 passed.
- `tests/unit/test_durable_agent_workflow_search_attributes.py` + token tests: 15 passed.
- `tests/temporal/test_durable_agent_workflow.py` against a local Temporal dev server: identical results on this branch and on `main` (failures present are pre-existing on `main` and unrelated to this change; details in PR comment if needed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns MCP scope token TTL with the agent turn and re-mints tokens on resume to prevent mid-turn expirations and stale tokens after long approval waits. Prevents subagents losing tools and user-MCP calls failing after long pauses.

- **Bug Fixes**
  - Default `mint_mcp_token` TTL to `TRACECAT__AGENT_SANDBOX_TIMEOUT + 60` (from config); updated docstrings for `mint_mcp_token` and `mint_llm_token`.
  - On approval resume, re-mint root and subagent MCP tokens and the LLM gateway token from preserved scope data before executing approved tools; gated by `durable-agent-remint-scope-tokens-v1`.

<sup>Written for commit baef260689514a31c72710a77e8e8ae511bf749b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

