### PR TITLE
fix(registry): cap slack paginated results at limit

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/integrations/slack_sdk.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/slack_sdk.py
@@ -109,7 +109,9 @@ async def call_paginated_method(
                 )
         else:
             members.append(data)
-    return members
+        if len(members) >= limit:
+            break
+    return members[:limit]
 
 
 ### Other utilities

--- a/packages/tracecat-registry/tracecat_registry/templates/tools/slack/conversations/list_messages.yml
+++ b/packages/tracecat-registry/tracecat_registry/templates/tools/slack/conversations/list_messages.yml
@@ -18,6 +18,10 @@ definition:
       type: str | None
       description: Unix timestamp of the oldest message to return.
       default: null
+    inclusive:
+      type: bool
+      description: Include messages with `latest` or `oldest` timestamps in results. Ignored unless either timestamp is specified.
+      default: false
     limit:
       type: int
       description: Maximum number of messages to return.
@@ -31,6 +35,7 @@ definition:
           channel: ${{ inputs.channel }}
           latest: ${{ inputs.latest }}
           oldest: ${{ inputs.oldest }}
+          inclusive: ${{ inputs.inclusive }}
         key: messages
         limit: ${{ inputs.limit }}
   returns: ${{ steps.list_messages.result }}

--- a/tests/registry/test_slack_sdk.py
+++ b/tests/registry/test_slack_sdk.py
@@ -52,3 +52,121 @@ async def test_call_method_falls_back_to_raw_web_api_method(monkeypatch) -> None
             "status": "is thinking...",
         },
     )
+
+
+class FakePaginator:
+    """Mimics an awaited AsyncSlackResponse that yields one response per page."""
+
+    def __init__(self, pages: list[dict]) -> None:
+        self._pages = pages
+        self.pages_fetched = 0
+
+    def __aiter__(self):
+        return self._iterate()
+
+    async def _iterate(self):
+        for page_data in self._pages:
+            self.pages_fetched += 1
+            yield SimpleNamespace(data=page_data)
+
+
+@pytest.mark.anyio
+async def test_call_paginated_method_stops_at_limit(monkeypatch) -> None:
+    paginator = FakePaginator(
+        [
+            {"messages": [{"ts": "1"}, {"ts": "2"}]},
+            {"messages": [{"ts": "3"}, {"ts": "4"}]},
+            {"messages": [{"ts": "5"}, {"ts": "6"}]},
+        ]
+    )
+    client = SimpleNamespace(
+        conversations_history=AsyncMock(return_value=paginator),
+    )
+
+    monkeypatch.setattr(slack_sdk.secrets, "get", lambda _key: "xoxb-token")
+    monkeypatch.setattr(slack_sdk, "AsyncWebClient", lambda token: client)
+
+    result = await slack_sdk.call_paginated_method(
+        sdk_method="conversations_history",
+        params={"channel": "C123"},
+        key="messages",
+        limit=3,
+    )
+
+    assert result == [{"ts": "1"}, {"ts": "2"}, {"ts": "3"}]
+    # Pagination must stop once the limit is reached, not exhaust all pages.
+    assert paginator.pages_fetched == 2
+    client.conversations_history.assert_awaited_once_with(channel="C123", limit=3)
+
+
+@pytest.mark.anyio
+async def test_call_paginated_method_returns_all_items_below_limit(
+    monkeypatch,
+) -> None:
+    paginator = FakePaginator(
+        [
+            {"members": ["U1", "U2"]},
+            {"members": ["U3"]},
+        ]
+    )
+    client = SimpleNamespace(
+        conversations_members=AsyncMock(return_value=paginator),
+    )
+
+    monkeypatch.setattr(slack_sdk.secrets, "get", lambda _key: "xoxb-token")
+    monkeypatch.setattr(slack_sdk, "AsyncWebClient", lambda token: client)
+
+    result = await slack_sdk.call_paginated_method(
+        sdk_method="conversations_members",
+        params={"channel": "C123"},
+        key="members",
+        limit=10,
+    )
+
+    assert result == ["U1", "U2", "U3"]
+    assert paginator.pages_fetched == 2
+
+
+@pytest.mark.anyio
+async def test_call_paginated_method_without_key_caps_pages(monkeypatch) -> None:
+    paginator = FakePaginator(
+        [
+            {"ok": True, "page": 1},
+            {"ok": True, "page": 2},
+            {"ok": True, "page": 3},
+        ]
+    )
+    client = SimpleNamespace(
+        conversations_history=AsyncMock(return_value=paginator),
+    )
+
+    monkeypatch.setattr(slack_sdk.secrets, "get", lambda _key: "xoxb-token")
+    monkeypatch.setattr(slack_sdk, "AsyncWebClient", lambda token: client)
+
+    result = await slack_sdk.call_paginated_method(
+        sdk_method="conversations_history",
+        params={"channel": "C123"},
+        limit=2,
+    )
+
+    assert result == [{"ok": True, "page": 1}, {"ok": True, "page": 2}]
+    assert paginator.pages_fetched == 2
+
+
+@pytest.mark.anyio
+async def test_call_paginated_method_raises_on_missing_key(monkeypatch) -> None:
+    paginator = FakePaginator([{"members": ["U1"]}])
+    client = SimpleNamespace(
+        conversations_history=AsyncMock(return_value=paginator),
+    )
+
+    monkeypatch.setattr(slack_sdk.secrets, "get", lambda _key: "xoxb-token")
+    monkeypatch.setattr(slack_sdk, "AsyncWebClient", lambda token: client)
+
+    with pytest.raises(ValueError, match="not found in data"):
+        await slack_sdk.call_paginated_method(
+            sdk_method="conversations_history",
+            params={"channel": "C123"},
+            key="messages",
+            limit=10,
+        )


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes `tools.slack_sdk.call_paginated_method` so that `limit` acts as a total item cap instead of only a per-page size.

Previously the pagination loop iterated through every available page until the cursor was exhausted, so `limit: 10` on `tools.slack.list_messages` would still fetch the entire channel history (one Slack API call per page) and return everything. The loop now breaks as soon as `limit` items have been collected and the result is truncated to exactly `limit` items, so we stop making Slack API calls once we have enough data.

Notes on the implementation:

- `limit` is still passed through to the SDK method as the page size, so a request under the method's per-page maximum is satisfied in a single API call. Slack caps the page size server-side where needed, and the cursor loop picks up the remainder in that case.
- When `key` is omitted (whole response pages are accumulated), `limit` now caps the number of pages collected, which keeps the previous shape of the result while still preventing unbounded pagination.

Also adds the optional `inclusive` argument to `tools.slack.list_messages` (second part of the linked issue), which is forwarded to `conversations.history` so messages exactly at the `oldest`/`latest` timestamps can be included.

## Related Issues

Fixes #2875

## Screenshots / Recordings

N/A (no UI changes)

## Steps to QA

Unit tests cover the fix:

```
uv run pytest tests/registry/test_slack_sdk.py -v
```

- `test_call_paginated_method_stops_at_limit`: 3 pages of 2 messages with `limit=3` returns exactly 3 items and stops after the second page (no further API calls).
- `test_call_paginated_method_returns_all_items_below_limit`: fewer items than `limit` returns everything.
- `test_call_paginated_method_without_key_caps_pages`: page-mode accumulation is also capped.
- `test_call_paginated_method_raises_on_missing_key`: existing `key` error behaviour is unchanged.

Manual QA (same repro as the issue): run a workflow with `tools.slack.list_messages` and `limit: 10` against a channel with more than 10 messages — the action now returns exactly 10 messages instead of the full history.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap Slack paginated results at the requested limit and stop fetching once reached to avoid extra API calls. Also adds `inclusive` support to `tools.slack.list_messages` to include boundary timestamps.

- **Bug Fixes**
  - `tools.slack_sdk.call_paginated_method` now treats `limit` as a total cap, breaks early, and returns exactly `limit` items.
  - When `key` is omitted, `limit` caps the number of pages collected.

- **New Features**
  - Added `inclusive` to `tools.slack.list_messages`, forwarded to `conversations.history`.

<sup>Written for commit 72b5b1da9852479e3b8f0d91a065f3e9ea5e4d11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

