### PR TITLE
docs: consolidate TLS and certificate guidance for self-hosting

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -147,6 +147,7 @@
             "pages": [
               "self-hosting/architecture",
               "self-hosting/docker-compose",
+              "self-hosting/tls",
               "self-hosting/aws-fargate",
               "self-hosting/kubernetes",
               "self-hosting/environment-variables",

--- a/docs/self-hosting/architecture.mdx
+++ b/docs/self-hosting/architecture.mdx
@@ -99,7 +99,7 @@ See [SAML configuration](/authentication/saml) for provider-specific setup instr
   <Accordion title="How do I enable production TLS?">
     Caddy auto-provisions TLS certificates from Let's Encrypt when `BASE_DOMAIN` is set to a real domain. Set `PUBLIC_APP_URL` to use `https://` and expose ports 80 and 443 on the Caddy container.
 
-    See [Configure SSL for production](/self-hosting/docker-compose#how-do-i-configure-ssl-for-production) for step-by-step instructions.
+    See [TLS and certificates](/self-hosting/tls) for step-by-step instructions.
   </Accordion>
 
   <Accordion title="Can I use any S3-compatible bucket?">

--- a/docs/self-hosting/docker-compose.mdx
+++ b/docs/self-hosting/docker-compose.mdx
@@ -332,5 +332,8 @@ For an overview of all services and networking, see [Architecture](/self-hosting
       # ... existing reverse_proxy configuration ...
     }
     ```
+
+    If you deploy into a cloud VM (for example an EC2 instance), we recommend placing a managed load balancer such as an AWS Application Load Balancer in front of Caddy.
+    Terminate TLS at the load balancer with an ACM certificate and forward traffic to Caddy, so certificates and public HTTPS are handled by managed infrastructure instead of the VM.
   </Accordion>
 </AccordionGroup>

--- a/docs/self-hosting/docker-compose.mdx
+++ b/docs/self-hosting/docker-compose.mdx
@@ -75,7 +75,7 @@ Once deployed, access your instance at:
 <Warning>
   Plain HTTP is fine for local development on `localhost`, but do not expose an HTTP-only deployment to a public domain.
   Modern browsers upgrade requests to a public hostname to HTTPS, so the UI fails with `ERR_CONNECTION_REFUSED` even while `curl` over HTTP still works.
-  Enable TLS before going to production. See [How do I configure SSL for production?](#how-do-i-configure-ssl-for-production).
+  Enable TLS before going to production. See [TLS and certificates](/self-hosting/tls).
 </Warning>
 
 ## Updating Tracecat
@@ -271,69 +271,11 @@ For an overview of all services and networking, see [Architecture](/self-hosting
   </Accordion>
 
   <Accordion title="My browser shows ERR_CONNECTION_REFUSED but curl over HTTP works">
-    Your deployment is serving plain HTTP, but the browser is trying to reach it over HTTPS.
-    This is expected browser behavior, not a Tracecat or Caddy error: modern browsers automatically upgrade requests to a public hostname to HTTPS (through HSTS, the "Always use secure connections" setting, or a prior HTTPS visit).
-    Because the default stack exposes only port 80 with no TLS, the HTTPS request is refused.
-
-    The Caddy logs confirm HTTP-only mode:
-
-    ```text
-    server is listening only on the HTTP port, so no automatic HTTPS will be applied to this server
-    ```
-
-    Serving a public deployment over plain HTTP is not supported. Enable TLS as described in the next FAQ.
+    Your deployment is serving plain HTTP, but the browser is upgrading the request to HTTPS.
+    See [Browsers force HTTPS](/self-hosting/tls#browsers-force-https).
   </Accordion>
 
   <Accordion title="How do I configure SSL for production?">
-    Tracecat ships with [Caddy](https://caddyserver.com/) as a reverse proxy.
-    Caddy automatically provisions and renews TLS certificates from Let's Encrypt when configured with a domain name.
-
-    <Steps>
-      <Step title="Update environment variables">
-        In your `.env` file, set `BASE_DOMAIN` to your domain and switch every public URL and the allowed origins to HTTPS:
-
-        ```bash
-        BASE_DOMAIN=tracecat.example.com
-        PUBLIC_APP_URL=https://tracecat.example.com
-        PUBLIC_API_URL=https://tracecat.example.com/api
-        TRACECAT__ALLOW_ORIGINS=https://tracecat.example.com
-        ```
-
-        Mixing HTTP and HTTPS across these values causes CORS failures. Keep the scheme consistent everywhere.
-      </Step>
-      <Step title="Expose ports 80 and 443">
-        Update the `caddy` service ports in your `docker-compose.yml`:
-
-        ```yaml
-        services:
-          caddy:
-            ports:
-              - "80:80"
-              - "443:443"
-        ```
-
-        Port 80 must remain open for the ACME HTTP-01 challenge. Port 443 serves HTTPS traffic.
-      </Step>
-      <Step title="Restart the stack">
-        ```bash
-        docker compose up -d
-        ```
-
-        Caddy will automatically obtain and renew certificates on startup.
-      </Step>
-    </Steps>
-
-    If your domain is internal or cannot use Let's Encrypt, supply your own certificate and private key with Caddy's [`tls` directive](https://caddyserver.com/docs/caddyfile/directives/tls).
-    Mount the files into the `caddy` service and reference them in your `Caddyfile`:
-
-    ```caddyfile
-    {$BASE_DOMAIN} {
-      tls /etc/caddy/certs/tls.crt /etc/caddy/certs/tls.key
-      # ... existing reverse_proxy configuration ...
-    }
-    ```
-
-    If you deploy into a cloud VM (for example an EC2 instance), we recommend placing a managed load balancer such as an AWS Application Load Balancer in front of Caddy.
-    Terminate TLS at the load balancer with an ACM certificate and forward traffic to Caddy, so certificates and public HTTPS are handled by managed infrastructure instead of the VM.
+    See [TLS and certificates](/self-hosting/tls) for automatic Let's Encrypt setup with Caddy, custom certificates, and trusting internal CAs for outbound connections.
   </Accordion>
 </AccordionGroup>

--- a/docs/self-hosting/docker-compose.mdx
+++ b/docs/self-hosting/docker-compose.mdx
@@ -72,6 +72,12 @@ Once deployed, access your instance at:
 - API docs: `http://localhost:${PUBLIC_APP_PORT}/api/docs`
 - MCP: `http://localhost:${PUBLIC_APP_PORT}/mcp`
 
+<Warning>
+  Plain HTTP is fine for local development on `localhost`, but do not expose an HTTP-only deployment to a public domain.
+  Modern browsers upgrade requests to a public hostname to HTTPS, so the UI fails with `ERR_CONNECTION_REFUSED` even while `curl` over HTTP still works.
+  Enable TLS before going to production. See [How do I configure SSL for production?](#how-do-i-configure-ssl-for-production).
+</Warning>
+
 ## Updating Tracecat
 
 <Warning>
@@ -264,19 +270,36 @@ For an overview of all services and networking, see [Architecture](/self-hosting
     For production workloads, use a managed PostgreSQL instance (e.g., Amazon Aurora Serverless) for better QPS and reliability.
   </Accordion>
 
+  <Accordion title="My browser shows ERR_CONNECTION_REFUSED but curl over HTTP works">
+    Your deployment is serving plain HTTP, but the browser is trying to reach it over HTTPS.
+    This is expected browser behavior, not a Tracecat or Caddy error: modern browsers automatically upgrade requests to a public hostname to HTTPS (through HSTS, the "Always use secure connections" setting, or a prior HTTPS visit).
+    Because the default stack exposes only port 80 with no TLS, the HTTPS request is refused.
+
+    The Caddy logs confirm HTTP-only mode:
+
+    ```text
+    server is listening only on the HTTP port, so no automatic HTTPS will be applied to this server
+    ```
+
+    Serving a public deployment over plain HTTP is not supported. Enable TLS as described in the next FAQ.
+  </Accordion>
+
   <Accordion title="How do I configure SSL for production?">
     Tracecat ships with [Caddy](https://caddyserver.com/) as a reverse proxy.
     Caddy automatically provisions and renews TLS certificates from Let's Encrypt when configured with a domain name.
 
     <Steps>
       <Step title="Update environment variables">
-        In your `.env` file, set `BASE_DOMAIN` to your domain and update the public URLs to use HTTPS:
+        In your `.env` file, set `BASE_DOMAIN` to your domain and switch every public URL and the allowed origins to HTTPS:
 
         ```bash
         BASE_DOMAIN=tracecat.example.com
         PUBLIC_APP_URL=https://tracecat.example.com
         PUBLIC_API_URL=https://tracecat.example.com/api
+        TRACECAT__ALLOW_ORIGINS=https://tracecat.example.com
         ```
+
+        Mixing HTTP and HTTPS across these values causes CORS failures. Keep the scheme consistent everywhere.
       </Step>
       <Step title="Expose ports 80 and 443">
         Update the `caddy` service ports in your `docker-compose.yml`:
@@ -299,5 +322,15 @@ For an overview of all services and networking, see [Architecture](/self-hosting
         Caddy will automatically obtain and renew certificates on startup.
       </Step>
     </Steps>
+
+    If your domain is internal or cannot use Let's Encrypt, supply your own certificate and private key with Caddy's [`tls` directive](https://caddyserver.com/docs/caddyfile/directives/tls).
+    Mount the files into the `caddy` service and reference them in your `Caddyfile`:
+
+    ```caddyfile
+    {$BASE_DOMAIN} {
+      tls /etc/caddy/certs/tls.crt /etc/caddy/certs/tls.key
+      # ... existing reverse_proxy configuration ...
+    }
+    ```
   </Accordion>
 </AccordionGroup>

--- a/docs/self-hosting/security.mdx
+++ b/docs/self-hosting/security.mdx
@@ -85,4 +85,4 @@ Docker Compose deployments default to basic email/password authentication. For p
 
 ## TLS
 
-Never run production traffic over plain HTTP. See [How do I configure SSL for production?](/self-hosting/docker-compose#how-do-i-configure-ssl-for-production) for Caddy-based automatic TLS setup.
+Never run production traffic over plain HTTP. See [TLS and certificates](/self-hosting/tls) for Caddy-based automatic TLS setup, custom certificates, and trusting internal CAs.

--- a/docs/self-hosting/tls.mdx
+++ b/docs/self-hosting/tls.mdx
@@ -1,0 +1,159 @@
+---
+title: TLS and certificates
+description: "Configure HTTPS for self-hosted Tracecat: automatic Let's Encrypt certificates with Caddy, custom certificates, and trusting internal CAs for outbound connections."
+---
+
+This page covers Docker Compose deployments.
+On [Kubernetes](/self-hosting/kubernetes) and [AWS Fargate](/self-hosting/aws-fargate), terminate TLS at your ingress controller or load balancer instead.
+
+## Inbound HTTPS with Caddy
+
+Tracecat ships with [Caddy](https://caddyserver.com/) as a reverse proxy.
+Caddy automatically provisions and renews TLS certificates from Let's Encrypt when configured with a domain name.
+
+<Steps>
+  <Step title="Update environment variables">
+    In your `.env` file, set `BASE_DOMAIN` to your domain and switch every public URL and the allowed origins to HTTPS:
+
+    ```bash
+    BASE_DOMAIN=tracecat.example.com
+    PUBLIC_APP_URL=https://tracecat.example.com
+    PUBLIC_API_URL=https://tracecat.example.com/api
+    TRACECAT__ALLOW_ORIGINS=https://tracecat.example.com
+    ```
+
+    Mixing HTTP and HTTPS across these values causes CORS failures. Keep the scheme consistent everywhere.
+  </Step>
+  <Step title="Expose ports 80 and 443">
+    Update the `caddy` service ports in your `docker-compose.yml`:
+
+    ```yaml
+    services:
+      caddy:
+        ports:
+          - "80:80"
+          - "443:443"
+    ```
+
+    Port 80 must remain open for the ACME HTTP-01 challenge. Port 443 serves HTTPS traffic.
+  </Step>
+  <Step title="Restart the stack">
+    ```bash
+    docker compose up -d
+    ```
+
+    Caddy will automatically obtain and renew certificates on startup.
+  </Step>
+</Steps>
+
+### Bring your own certificate
+
+If your domain is internal or cannot use Let's Encrypt, supply your own certificate and private key with Caddy's [`tls` directive](https://caddyserver.com/docs/caddyfile/directives/tls).
+Mount the files into the `caddy` service and reference them in your `Caddyfile`:
+
+```caddyfile
+{$BASE_DOMAIN} {
+  tls /etc/caddy/certs/tls.crt /etc/caddy/certs/tls.key
+  # ... existing reverse_proxy configuration ...
+}
+```
+
+### Cloud VMs
+
+If you deploy into a cloud VM (for example an EC2 instance), we recommend placing a managed load balancer such as an AWS Application Load Balancer in front of Caddy.
+Terminate TLS at the load balancer with an ACM certificate and forward traffic to Caddy, so certificates and public HTTPS are handled by managed infrastructure instead of the VM.
+
+## Browsers force HTTPS
+
+If the browser fails with `ERR_CONNECTION_REFUSED` while `curl` over HTTP works, your deployment is serving plain HTTP but the browser is trying to reach it over HTTPS.
+This is expected browser behavior, not a Tracecat or Caddy error: modern browsers automatically upgrade requests to a public hostname to HTTPS (through HSTS, the "Always use secure connections" setting, or a prior HTTPS visit).
+Because the default stack exposes only port 80 with no TLS, the HTTPS request is refused.
+
+The Caddy logs confirm HTTP-only mode:
+
+```text
+server is listening only on the HTTP port, so no automatic HTTPS will be applied to this server
+```
+
+Serving a public deployment over plain HTTP is not supported.
+Configure [inbound HTTPS](#inbound-https-with-caddy) instead.
+
+## Trust an internal CA for outbound connections
+
+Tracecat containers do not inherit the host's trust store.
+If Tracecat calls services with certificates signed by an internal CA — a custom LLM provider, an internal Jira, an on-prem API — those connections fail TLS verification even when `curl` on the host succeeds.
+
+### Per-action: CA certificate secret
+
+For HTTP actions, create a workspace secret named `ca_cert` with the key `CA_CERTIFICATE` set to your CA certificate as PEM text.
+`core.http` picks it up automatically and verifies servers against it without any deployment changes.
+HTTP actions also accept `verify_ssl: false`, but only use this as a temporary workaround — it disables certificate verification entirely.
+See [HTTP actions](/automations/core-actions/request-actions/http).
+
+### Deployment-wide: inject the CA into service trust stores
+
+To make every service trust your CA — including custom LLM providers and Python integrations — append it to the certifi bundle with a one-shot init container.
+
+<Steps>
+  <Step title="Add your CA certificates">
+    Create a `certs/` directory next to your `docker-compose.yml` and place your CA certificates in it as `.crt` files in PEM format (not DER).
+    Include the full chain: root and any intermediate CAs.
+  </Step>
+  <Step title="Create a Compose override">
+    Create `docker-compose.override.yml` next to your `docker-compose.yml`:
+
+    ```yaml
+    x-custom-ca: &custom-ca
+      environment:
+        SSL_CERT_FILE: /custom-ca/bundle.crt
+        REQUESTS_CA_BUNDLE: /custom-ca/bundle.crt
+        CURL_CA_BUNDLE: /custom-ca/bundle.crt
+      volumes:
+        - custom-ca:/custom-ca:ro
+      depends_on:
+        cert-init:
+          condition: service_completed_successfully
+
+    services:
+      cert-init:
+        image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-latest}
+        restart: "no"
+        user: root
+        volumes:
+          - ./certs:/certs:ro
+          - custom-ca:/custom-ca
+        command:
+          - python
+          - -c
+          - |
+            import certifi, shutil
+            from pathlib import Path
+            shutil.copy(certifi.where(), '/custom-ca/bundle.crt')
+            with open('/custom-ca/bundle.crt', 'a') as bundle:
+                for cert in sorted(Path('/certs').rglob('*.crt')):
+                    bundle.write(cert.read_text())
+                    print(f'Appended {cert}')
+
+      api: *custom-ca
+      executor: *custom-ca
+      agent-executor: *custom-ca
+      agent-worker: *custom-ca
+      litellm: *custom-ca
+
+    volumes:
+      custom-ca:
+    ```
+
+    The `cert-init` service copies the default certifi bundle into a shared volume and appends your CA certificates.
+    Docker Compose merges the override with each service's existing configuration.
+    Apply the same `*custom-ca` block to any other service that makes outbound HTTPS calls.
+  </Step>
+  <Step title="Restart the stack">
+    ```bash
+    docker compose up -d
+    ```
+
+    Compose picks up `docker-compose.override.yml` automatically.
+    Check the init container output with `docker compose logs cert-init`.
+  </Step>
+</Steps>

--- a/docs/self-hosting/tls.mdx
+++ b/docs/self-hosting/tls.mdx
@@ -116,7 +116,7 @@ To make every service trust your CA — including custom LLM providers and Pytho
 
     services:
       cert-init:
-        image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-latest}
+        image: ghcr.io/tracecathq/tracecat:${TRACECAT__IMAGE_TAG:-1.0.0-beta.50}
         restart: "no"
         user: root
         volumes:
@@ -157,3 +157,9 @@ To make every service trust your CA — including custom LLM providers and Pytho
     Check the init container output with `docker compose logs cert-init`.
   </Step>
 </Steps>
+
+<Note>
+  The injected bundle does not reach actions running inside the [nsjail sandbox](/self-hosting/security#execution-sandboxing) (`TRACECAT__EXECUTOR_SANDBOX_ENABLED=true`).
+  The sandbox strips these environment variables and does not mount `/custom-ca`.
+  For sandboxed HTTP actions, use the per-action `ca_cert` secret instead.
+</Note>

--- a/docs/self-hosting/tls.mdx
+++ b/docs/self-hosting/tls.mdx
@@ -63,6 +63,19 @@ Mount the files into the `caddy` service and reference them in your `Caddyfile`:
 If you deploy into a cloud VM (for example an EC2 instance), we recommend placing a managed load balancer such as an AWS Application Load Balancer in front of Caddy.
 Terminate TLS at the load balancer with an ACM certificate and forward traffic to Caddy, so certificates and public HTTPS are handled by managed infrastructure instead of the VM.
 
+With TLS terminated at the load balancer, keep Caddy in HTTP-only mode.
+Do not set `BASE_DOMAIN` to a bare domain as in the Let's Encrypt setup above — that enables Caddy's automatic HTTPS, which redirects the load balancer's forwarded HTTP requests back to HTTPS and creates a redirect loop.
+Keep the default port-only `BASE_DOMAIN` and set only the public URLs to HTTPS:
+
+```bash
+BASE_DOMAIN=:80
+PUBLIC_APP_URL=https://tracecat.example.com
+PUBLIC_API_URL=https://tracecat.example.com/api
+TRACECAT__ALLOW_ORIGINS=https://tracecat.example.com
+```
+
+Point the load balancer's HTTPS listener at Caddy's HTTP port (80), and redirect HTTP to HTTPS at the load balancer.
+
 ## Browsers force HTTPS
 
 If the browser fails with `ERR_CONNECTION_REFUSED` while `curl` over HTTP works, your deployment is serving plain HTTP but the browser is trying to reach it over HTTPS.


### PR DESCRIPTION
## Summary

Closes #2857.

A fresh self-hosted Docker Compose deployment serves plain HTTP on port 80. When it is exposed on a public domain, modern browsers upgrade the request to HTTPS (HSTS, "Always use secure connections", or a prior HTTPS visit) and fail with `ERR_CONNECTION_REFUSED`, even though `curl` over HTTP still works. The docs did not surface this symptom or the fix clearly.

## Changes

- Add a warning in the "Access Tracecat" section: plain HTTP is fine on `localhost`, but enable TLS before exposing a public domain.
- Add a symptom-based FAQ: "My browser shows ERR_CONNECTION_REFUSED but curl over HTTP works", explaining the browser HTTPS upgrade and pointing to the SSL setup.
- Expand the existing SSL FAQ to include `TRACECAT__ALLOW_ORIGINS`, note that mixing HTTP/HTTPS schemes causes CORS failures, and add a bring-your-own-certificate example using Caddy's `tls` directive for internal domains that cannot use Let's Encrypt.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates HTTPS/TLS docs into a new self-hosting TLS page and warns against exposing HTTP-only Docker Compose on public domains; adds a symptom-based fix for browser HTTPS upgrades causing ERR_CONNECTION_REFUSED.

Covers Caddy + Let's Encrypt, custom certs, CORS with `TRACECAT__ALLOW_ORIGINS`, load balancers (e.g., ALB/ACM) with Caddy kept HTTP-only and `BASE_DOMAIN=:80` to avoid redirect loops, and trusting internal CAs via per-action `ca_cert` or a deployment-wide `cert-init` override (pinned image); notes the `nsjail` sandbox limit, updates links, and trims the Docker Compose FAQ.

<sup>Written for commit d2e646d97d8541931c816eaa7b8eec9713487a8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

