### PR TITLE
fix(dsl): resolve top-level action results in subflow trigger_inputs inside scatter

### DIFF
--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -914,6 +914,103 @@ async def test_child_workflow_success(
 
 
 @pytest.mark.anyio
+async def test_child_workflow_in_scatter_resolves_top_level_action(
+    test_role: Role,
+    temporal_client: Client,
+    test_worker_factory: WorkerFactory,
+    test_executor_worker_factory: WorkerFactory,
+):
+    """A child workflow inside a scatter region must resolve top-level action results.
+
+    Regression test for ENG-1492: ``core.workflow.execute`` evaluated its
+    ``trigger_inputs`` against the single scatter stream instead of the
+    stream-aware context, so references to top-level action results (e.g.
+    ``ACTIONS.config.result.*``) resolved to ``null`` inside a scatter region
+    while the scatter item itself resolved correctly.
+    """
+    test_name = f"{test_child_workflow_in_scatter_resolves_top_level_action.__name__}"
+    wf_exec_id = generate_test_exec_id(test_name)
+
+    # Child echoes both the scatter item and the top-level value it received.
+    child_dsl = DSLInput(
+        entrypoint=DSLEntrypoint(expects={}, ref="echo"),
+        actions=[
+            ActionStatement(
+                ref="echo",
+                action="core.transform.reshape",
+                args={
+                    "value": {
+                        "item_id": "${{ TRIGGER.item_id }}",
+                        "flag": "${{ TRIGGER.flag }}",
+                    },
+                },
+                depends_on=[],
+            )
+        ],
+        description="Echo child",
+        returns="${{ ACTIONS.echo.result }}",
+        title="Echo child",
+        triggers=[],
+    )
+    child_workflow = await _create_and_commit_workflow(child_dsl, test_role)
+
+    # Parent: top-level `config` action, then a scatter region that calls the
+    # child, passing both the scatter item and the top-level action result.
+    parent_dsl = DSLInput(
+        title="Parent",
+        description="Child workflow inside scatter resolves top-level action",
+        entrypoint=DSLEntrypoint(ref="config"),
+        actions=[
+            ActionStatement(
+                ref="config",
+                action="core.transform.reshape",
+                args={"value": {"flag": "top_level_value"}},
+                depends_on=[],
+            ),
+            ActionStatement(
+                ref="scatter",
+                action="core.transform.scatter",
+                args=ScatterArgs(collection="${{ [10, 20, 30] }}").model_dump(),
+                depends_on=["config"],
+            ),
+            ActionStatement(
+                ref="call_child",
+                action="core.workflow.execute",
+                args={
+                    "workflow_id": child_workflow.id,
+                    "wait_strategy": WaitStrategy.WAIT.value,
+                    "trigger_inputs": {
+                        "item_id": "${{ ACTIONS.scatter.result }}",
+                        "flag": "${{ ACTIONS.config.result.flag }}",
+                    },
+                },
+                depends_on=["scatter"],
+            ),
+            ActionStatement(
+                ref="gather",
+                action="core.transform.gather",
+                args=GatherArgs(items="${{ ACTIONS.call_child.result }}").model_dump(),
+                depends_on=["call_child"],
+            ),
+        ],
+        returns="${{ ACTIONS.gather.result }}",
+        triggers=[],
+    )
+    run_args = DSLRunArgs(dsl=parent_dsl, role=test_role, wf_id=TEST_WF_ID)
+
+    worker = test_worker_factory(temporal_client)
+    executor_worker = test_executor_worker_factory(temporal_client)
+    result = await _run_workflow(wf_exec_id, run_args, worker, executor_worker)
+
+    gathered = sorted(await to_data(result), key=lambda r: r["item_id"])
+    assert gathered == [
+        {"item_id": 10, "flag": "top_level_value"},
+        {"item_id": 20, "flag": "top_level_value"},
+        {"item_id": 30, "flag": "top_level_value"},
+    ]
+
+
+@pytest.mark.anyio
 async def test_child_workflow_context_passing(
     test_role: Role,
     temporal_client: Client,

--- a/tracecat/dsl/workflow.py
+++ b/tracecat/dsl/workflow.py
@@ -900,7 +900,7 @@ class DSLWorkflow:
                             arg=PrepareSubflowActivityInput(
                                 role=self.role,
                                 task=task,
-                                operand=self.get_context(),
+                                operand=self._build_action_context(task, stream_id),
                                 key=action_collection_prefix(
                                     str(self.workspace_id),
                                     self.wf_exec_id,
@@ -1308,7 +1308,7 @@ class DSLWorkflow:
                 DSLActivities.evaluate_templated_object_activity,
                 arg=EvaluateTemplatedObjectActivityInput(
                     obj=task.args.get("trigger_inputs"),
-                    operand=self.get_context(),
+                    operand=self._build_action_context(task, stream_id),
                     key=key,
                 ),
                 start_to_close_timeout=timedelta(seconds=60),


### PR DESCRIPTION
Resolves https://github.com/TracecatHQ/tracecat/issues/2865

## Summary

Fixes [ENG-1492](https://linear.app/tracecat/issue/ENG-1492). A `core.workflow.execute` action running inside a scatter region (between `core.transform.scatter` and `core.transform.gather`) evaluated its `trigger_inputs` (and subflow args) against the **single current stream** via `get_context()`. Inside a scatter stream that context holds only the scatter item, so any expression referencing a **top-level action result** (e.g. `${{ ACTIONS.config.result.flag }}`) resolved to `null` — because expression evaluation runs with `strict=False`, the miss was silent. References to the scatter item itself (`${{ ACTIONS.<scatter_ref>.result.* }}`) resolved correctly, which is why the bug only surfaced for top-level references. The same expression works when the `core.workflow.execute` is at the top level.

Every other action type builds its context with `_build_action_context` → `scheduler.build_stream_aware_context`, which walks up the stream hierarchy to the root stream. The child-workflow path was the only one using `get_context()` directly.

## Fix

Evaluate child-workflow `trigger_inputs`/args with the stream-aware context on both paths:

- Looped path (`prepare_subflow_activity` operand)
- Single-execution path (`evaluate_templated_object_activity` operand)

This also fixes `TRIGGER` references on this path inside a scatter, which were `null` for the same reason (scatter streams carry `TRIGGER=None`).

## Testing

Added `test_child_workflow_in_scatter_resolves_top_level_action` (a scatter region calling a child workflow that receives both the scatter item and a top-level action result).

Verified locally against a live Temporal cluster:

- **With the fix:** passes — `flag` resolves to the top-level value for every scattered item.
- **Without the fix:** fails with exactly the reported symptom — `flag: null` for all items while `item_id` (the scatter item) resolves correctly.

The rest of the `child_workflow` temporal suite passes (one unrelated pre-existing failure due to secret masking config not disabled in the local run).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ENG-1492: `core.workflow.execute` inside a scatter now resolves `trigger_inputs` with the stream-aware context so top-level action results and `TRIGGER` references no longer return null. This makes subflows inside scatter behave like top-level actions.

- **Bug Fixes**
  - Replaced `get_context()` with `_build_action_context(task, stream_id)` for subflow `trigger_inputs`/args in both the looped (`prepare_subflow_activity`) and single-execution (`evaluate_templated_object_activity`) paths.
  - Added a regression test that runs a child workflow inside scatter and verifies top-level action results are passed through.

<sup>Written for commit 246e42db2f917552898b5248a9e719733da95770. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

