### PR TITLE
fix(api): scope workflow execution definitions

### DIFF
--- a/tests/unit/api/test_api_workflow_execution_path_ids.py
+++ b/tests/unit/api/test_api_workflow_execution_path_ids.py
@@ -11,9 +11,23 @@ from temporalio.client import WorkflowExecutionStatus
 
 from tracecat.auth.types import Role
 from tracecat.dsl.common import DSLInput
+from tracecat.identifiers.workflow import WorkflowUUID
 from tracecat.validation.schemas import ValidationResult, ValidationResultType
 from tracecat.workflow.executions import internal_router as internal_executions_router
 from tracecat.workflow.executions import router as executions_router
+
+
+def _workflow_definition_content(title: str = "Test Workflow") -> dict:
+    return DSLInput(
+        **{
+            "title": title,
+            "description": "Test workflow",
+            "entrypoint": {"ref": "start"},
+            "actions": [{"ref": "start", "action": "core.noop"}],
+            "config": {"enable_runtime_tests": False},
+        }
+    ).model_dump()
+
 
 # --- Internal Router: GET /executions/{execution_id} ---
 
@@ -486,6 +500,95 @@ async def test_get_workflow_execution_compact_accepts_slash_id(
     assert payload["status"] == "RUNNING"
     mock_svc.get_execution.assert_awaited_once_with(wf_exec_id)
     mock_svc.list_workflow_execution_events_compact.assert_awaited_once_with(wf_exec_id)
+
+
+@pytest.mark.anyio
+async def test_create_workflow_execution_uses_workspace_scoped_definition(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    workflow_id = "wf_4itKqkgCZrLhgYiq5L211X"
+    wf_exec_id = f"{workflow_id}/exec_abc"
+
+    mock_defn = Mock()
+    mock_defn.content = _workflow_definition_content()
+    mock_defn.registry_lock = None
+
+    mock_get_definition = AsyncMock(return_value=mock_defn)
+    mock_exec_service = AsyncMock()
+    mock_exec_service.create_workflow_execution_nowait = Mock(
+        return_value={
+            "wf_id": workflow_id,
+            "wf_exec_id": wf_exec_id,
+            "message": "Workflow execution started",
+        }
+    )
+
+    with (
+        patch.object(
+            executions_router.WorkflowDefinitionsService,
+            "__init__",
+            lambda self, session, role: None,
+        ),
+        patch.object(
+            executions_router.WorkflowDefinitionsService,
+            "get_definition_by_workflow_id",
+            mock_get_definition,
+        ),
+        patch.object(
+            executions_router.WorkflowExecutionsService,
+            "connect",
+            AsyncMock(return_value=mock_exec_service),
+        ),
+    ):
+        response = client.post(
+            "/workflow-executions",
+            json={"workflow_id": workflow_id, "inputs": {"key": "value"}},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["wf_exec_id"] == wf_exec_id
+    mock_get_definition.assert_awaited_once_with(WorkflowUUID.new(workflow_id))
+    mock_exec_service.create_workflow_execution_nowait.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_create_workflow_execution_returns_404_for_unscoped_definition(
+    client: TestClient,
+    test_admin_role: Role,
+) -> None:
+    """Cross-workspace workflow IDs are rejected by the scoped definition lookup."""
+    workflow_id = "wf_4itKqkgCZrLhgYiq5L211X"
+
+    mock_get_definition = AsyncMock(return_value=None)
+    mock_connect = AsyncMock()
+
+    with (
+        patch.object(
+            executions_router.WorkflowDefinitionsService,
+            "__init__",
+            lambda self, session, role: None,
+        ),
+        patch.object(
+            executions_router.WorkflowDefinitionsService,
+            "get_definition_by_workflow_id",
+            mock_get_definition,
+        ),
+        patch.object(
+            executions_router.WorkflowExecutionsService,
+            "connect",
+            mock_connect,
+        ),
+    ):
+        response = client.post(
+            "/workflow-executions",
+            json={"workflow_id": workflow_id, "inputs": {"key": "value"}},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "Invalid workflow ID"
+    mock_get_definition.assert_awaited_once_with(WorkflowUUID.new(workflow_id))
+    mock_connect.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/unit/api/test_api_workflow_execution_path_ids.py
+++ b/tests/unit/api/test_api_workflow_execution_path_ids.py
@@ -548,7 +548,9 @@ async def test_create_workflow_execution_uses_workspace_scoped_definition(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["wf_exec_id"] == wf_exec_id
-    mock_get_definition.assert_awaited_once_with(WorkflowUUID.new(workflow_id))
+    mock_get_definition.assert_awaited_once_with(
+        WorkflowUUID.new(workflow_id), load_relationships=False
+    )
     mock_exec_service.create_workflow_execution_nowait.assert_called_once()
 
 
@@ -587,7 +589,9 @@ async def test_create_workflow_execution_returns_404_for_unscoped_definition(
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["detail"] == "Invalid workflow ID"
-    mock_get_definition.assert_awaited_once_with(WorkflowUUID.new(workflow_id))
+    mock_get_definition.assert_awaited_once_with(
+        WorkflowUUID.new(workflow_id), load_relationships=False
+    )
     mock_connect.assert_not_awaited()
 
 

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -6,7 +6,6 @@ import temporalio.service
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import ValidationError
 from sqlalchemy import or_, select
-from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 from temporalio.client import WorkflowExecution
 
@@ -21,7 +20,7 @@ from tracecat.auth.dependencies import (
 from tracecat.auth.types import Role
 from tracecat.authz.controls import require_scope
 from tracecat.db.dependencies import AsyncDBSession
-from tracecat.db.models import Workflow, WorkflowDefinition
+from tracecat.db.models import Workflow
 from tracecat.dsl.common import (
     DSLInput,
     get_execution_type_from_search_attr,
@@ -93,6 +92,7 @@ from tracecat.workflow.executions.service import (
     WorkflowExecutionResultNotFoundError,
     WorkflowExecutionsService,
 )
+from tracecat.workflow.management.definitions import WorkflowDefinitionsService
 from tracecat.workflow.management.management import WorkflowsManagementService
 
 router = APIRouter(prefix="/workflow-executions", tags=["workflow-executions"])
@@ -1001,26 +1001,20 @@ async def create_workflow_execution(
     session: AsyncDBSession,
 ) -> WorkflowExecutionCreateResponse:
     """Create and schedule a workflow execution."""
-    service = await WorkflowExecutionsService.connect(role=role)
-    # Get the dslinput from the workflow definition
+    # Get the dslinput from the workflow definition scoped to the caller's
+    # workspace. The request body workflow_id is user-controlled, so a raw lookup
+    # by workflow_id would allow one workspace to execute another's workflow.
     wf_id = WorkflowUUID.new(params.workflow_id)
-    try:
-        result = await session.execute(
-            select(WorkflowDefinition)
-            .where(WorkflowDefinition.workflow_id == wf_id)
-            .order_by(WorkflowDefinition.version.desc())
-        )
-        defn = result.scalars().first()
-        if not defn:
-            raise NoResultFound("No workflow definition found for workflow ID")
-    except NoResultFound as e:
-        # No workflow associated with the webhook
-        logger.opt(exception=e).error("Invalid workflow ID", error=e)
+    defn_service = WorkflowDefinitionsService(session, role=role)
+    defn = await defn_service.get_definition_by_workflow_id(wf_id)
+    if not defn:
+        logger.error("Invalid workflow ID", workflow_id=wf_id)
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Invalid workflow ID"
-        ) from e
+        )
     dsl_input = DSLInput(**defn.content)
     try:
+        service = await WorkflowExecutionsService.connect(role=role)
         response = service.create_workflow_execution_nowait(
             dsl=dsl_input,
             wf_id=wf_id,

--- a/tracecat/workflow/executions/router.py
+++ b/tracecat/workflow/executions/router.py
@@ -1006,7 +1006,9 @@ async def create_workflow_execution(
     # by workflow_id would allow one workspace to execute another's workflow.
     wf_id = WorkflowUUID.new(params.workflow_id)
     defn_service = WorkflowDefinitionsService(session, role=role)
-    defn = await defn_service.get_definition_by_workflow_id(wf_id)
+    defn = await defn_service.get_definition_by_workflow_id(
+        wf_id, load_relationships=False
+    )
     if not defn:
         logger.error("Invalid workflow ID", workflow_id=wf_id)
         raise HTTPException(

--- a/tracecat/workflow/management/definitions.py
+++ b/tracecat/workflow/management/definitions.py
@@ -29,21 +29,23 @@ class WorkflowDefinitionsService(BaseWorkspaceService):
     service_name = "workflow_definitions"
 
     async def get_definition_by_workflow_id(
-        self, workflow_id: WorkflowID, *, version: int | None = None
+        self,
+        workflow_id: WorkflowID,
+        *,
+        version: int | None = None,
+        load_relationships: bool = True,
     ) -> WorkflowDefinition | None:
-        statement = (
-            select(WorkflowDefinition)
-            .where(
-                WorkflowDefinition.workspace_id == self.workspace_id,
-                WorkflowDefinition.workflow_id == workflow_id,
-            )
-            .options(
+        statement = select(WorkflowDefinition).where(
+            WorkflowDefinition.workspace_id == self.workspace_id,
+            WorkflowDefinition.workflow_id == workflow_id,
+        )
+        if load_relationships:
+            statement = statement.options(
                 selectinload(WorkflowDefinition.workflow).options(
                     selectinload(Workflow.case_trigger),
                     selectinload(Workflow.actions),
                 )
             )
-        )
         if version is not None:
             statement = statement.where(WorkflowDefinition.version == version)
         else:


### PR DESCRIPTION
## Summary

- Resolve committed workflow definitions through the workspace-scoped definitions service before starting public workflow executions.
- Return `404` without dispatching when the submitted workflow ID is not visible in the caller's workspace.
- Add endpoint coverage for successful scoped execution lookup and the rejected cross-workspace lookup path.

## Root Cause

The public committed execution route accepted a user-controlled workflow ID and loaded the latest committed definition by workflow ID alone. That skipped the tenant filter already used by the draft and internal execution paths.

## Impact

The public execution path now enforces the same workspace boundary as the rest of workflow definition access, preventing a caller from dispatching a committed workflow definition that belongs to another workspace.

## Validation

- `uv run pytest tests/unit/api/test_api_workflow_execution_path_ids.py -q`
- `uv run ruff check tracecat/workflow/executions/router.py tests/unit/api/test_api_workflow_execution_path_ids.py`
- `uv run ruff format --check tracecat/workflow/executions/router.py tests/unit/api/test_api_workflow_execution_path_ids.py`
- `uv run basedpyright tracecat/workflow/executions/router.py tests/unit/api/test_api_workflow_execution_path_ids.py`
- commit hooks via `PATH="/Users/daryllim/.nvm/versions/node/v22.15.0/bin:$PATH" CI=true uv run git commit -m "fix(api): scope workflow execution definitions"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes workflow execution to the caller’s workspace and returns 404 for cross-workspace workflow IDs. Also skips loading unused relationships when resolving definitions to speed up execution start.

- Bug Fixes
  - Resolve definitions via `WorkflowDefinitionsService` scoped to the caller’s workspace (replaces raw DB lookup).
  - Return 404 and do not connect/dispatch when the workflow ID is not visible in the workspace.
  - Added unit tests for scoped lookup success and cross-workspace rejection.

- Performance
  - Use `WorkflowDefinitionsService.get_definition_by_workflow_id(..., load_relationships=False)` to avoid loading `Workflow` relationships during execution creation.

<sup>Written for commit 94fd0c6f02003ba85578ef0d2886b27ec4f6b24e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

