### PR TITLE
fix(registry): add caps to cloudflare and google api pagination

### DIFF
--- a/packages/tracecat-registry/tracecat_registry/integrations/cloudflare_sdk.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/cloudflare_sdk.py
@@ -102,6 +102,17 @@ def call_paginated_method(
         dict[str, Any] | None,
         Field(..., description="Parameters for the Cloudflare SDK method."),
     ] = None,
+    limit: Annotated[
+        int | None,
+        Field(
+            ...,
+            ge=1,
+            description=(
+                "Maximum number of items to return across all pages. "
+                "If null, fetches every page."
+            ),
+        ),
+    ] = None,
 ) -> list[Any]:
     params = params or {}
     _validate_public_name(method_name, "Method name")
@@ -112,5 +123,11 @@ def call_paginated_method(
         raise ValueError(
             "Cloudflare paginated methods must return a Cloudflare page object."
         )
-    # Iterating a Cloudflare page auto-paginates across all pages.
-    return [to_jsonable_python(item) for item in result]
+    # Iterating a Cloudflare page auto-paginates across all pages. Pages are
+    # fetched lazily, so stopping at the limit avoids requesting further pages.
+    items: list[Any] = []
+    for item in result:
+        items.append(to_jsonable_python(item))
+        if limit is not None and len(items) >= limit:
+            break
+    return items

--- a/packages/tracecat-registry/tracecat_registry/integrations/google_api.py
+++ b/packages/tracecat-registry/tracecat_registry/integrations/google_api.py
@@ -269,6 +269,14 @@ def call_paginated_api(
             description='Dot-separated response path for the next page token. Defaults to "nextPageToken".',
         ),
     ] = "nextPageToken",
+    max_pages: Annotated[
+        int | None,
+        Field(
+            ...,
+            ge=1,
+            description="Maximum number of pages to fetch. If null, fetches every page.",
+        ),
+    ] = None,
 ) -> list[GoogleAPIResponse]:
     if not page_token_param:
         raise ValueError("Page token request parameter cannot be empty.")
@@ -294,6 +302,8 @@ def call_paginated_api(
             )
         page = cast(GoogleAPIResponse, response)
         pages.append(page)
+        if max_pages is not None and len(pages) >= max_pages:
+            break
         next_page_token = _get_value_by_path(page, next_page_token_path)
         if not next_page_token:
             break

--- a/tests/registry/test_cloudflare_sdk.py
+++ b/tests/registry/test_cloudflare_sdk.py
@@ -17,9 +17,11 @@ class FakeCloudflarePage:
 
     def __init__(self, pages: list[list[Any]]) -> None:
         self.pages = pages
+        self.pages_fetched = 0
 
     def __iter__(self) -> Any:
         for page in self.pages:
+            self.pages_fetched += 1
             yield from page
 
 
@@ -150,3 +152,64 @@ def test_call_paginated_method_flattens_all_page_items(monkeypatch) -> None:
 
     assert result == [{"id": "one"}, {"id": "two"}, {"id": "three"}]
     assert calls == {"params": {"account_id": "account-id"}}
+
+
+def test_call_paginated_method_stops_at_limit(monkeypatch) -> None:
+    page = FakeCloudflarePage(
+        [
+            [FakeCloudflareModel(id="one"), FakeCloudflareModel(id="two")],
+            [FakeCloudflareModel(id="three"), FakeCloudflareModel(id="four")],
+            [FakeCloudflareModel(id="five")],
+        ]
+    )
+
+    monkeypatch.setattr(cloudflare_sdk, "BaseSyncPage", FakeCloudflarePage)
+    monkeypatch.setattr(
+        cloudflare_sdk.secrets,
+        "get",
+        lambda key: "cf-token" if key == "CLOUDFLARE_API_TOKEN" else None,
+    )
+    monkeypatch.setattr(
+        cloudflare_sdk,
+        "Cloudflare",
+        lambda *, api_token: SimpleNamespace(
+            zones=SimpleNamespace(list=lambda **_params: page)
+        ),
+    )
+
+    result = cloudflare_sdk.call_paginated_method(
+        resource="zones",
+        method_name="list",
+        limit=3,
+    )
+
+    assert result == [{"id": "one"}, {"id": "two"}, {"id": "three"}]
+    # Iteration must stop at the limit instead of fetching remaining pages.
+    assert page.pages_fetched == 2
+
+
+def test_call_paginated_method_limit_above_total_returns_all(monkeypatch) -> None:
+    page = FakeCloudflarePage([[FakeCloudflareModel(id="one")], [{"id": "two"}]])
+
+    monkeypatch.setattr(cloudflare_sdk, "BaseSyncPage", FakeCloudflarePage)
+    monkeypatch.setattr(
+        cloudflare_sdk.secrets,
+        "get",
+        lambda key: "cf-token" if key == "CLOUDFLARE_API_TOKEN" else None,
+    )
+    monkeypatch.setattr(
+        cloudflare_sdk,
+        "Cloudflare",
+        lambda *, api_token: SimpleNamespace(
+            zones=SimpleNamespace(list=lambda **_params: page)
+        ),
+    )
+
+    result = cloudflare_sdk.call_paginated_method(
+        resource="zones",
+        method_name="list",
+        limit=10,
+    )
+
+    assert result == [{"id": "one"}, {"id": "two"}]
+    assert page.pages_fetched == 2

--- a/tests/registry/test_google_api.py
+++ b/tests/registry/test_google_api.py
@@ -325,6 +325,45 @@ def test_call_paginated_api_returns_pages(monkeypatch: pytest.MonkeyPatch) -> No
     assert calls == [{"pageSize": 1}, {"pageSize": 1, "pageToken": "next-token"}]
 
 
+def test_call_paginated_api_stops_at_max_pages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def build(*_args: Any, **_kwargs: Any) -> FakeService:
+        return FakeService(
+            calls,
+            [
+                {"files": [{"id": "1"}], "nextPageToken": "token-1"},
+                {"files": [{"id": "2"}], "nextPageToken": "token-2"},
+                {"files": [{"id": "3"}]},
+            ],
+        )
+
+    monkeypatch.setattr(
+        google_api.secrets,
+        "get_or_default",
+        lambda key: "service-token" if key == "GOOGLE_SERVICE_TOKEN" else None,
+    )
+    monkeypatch.setattr(google_api, "build", build)
+
+    result = google_api.call_paginated_api(
+        service_name="drive",
+        version="v3",
+        resource="files",
+        method_name="list",
+        params={"pageSize": 1},
+        max_pages=2,
+    )
+
+    assert result == [
+        {"files": [{"id": "1"}], "nextPageToken": "token-1"},
+        {"files": [{"id": "2"}], "nextPageToken": "token-2"},
+    ]
+    # No third request is made once max_pages is reached.
+    assert calls == [{"pageSize": 1}, {"pageSize": 1, "pageToken": "token-1"}]
+
+
 def test_call_paginated_api_supports_custom_token_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/TracecatHQ/tracecat/blob/main/CONTRIBUTING.md).
- [x] PR title is short and non-generic (see previously [merged PRs](https://github.com/TracecatHQ/tracecat/pulls?q=is%3Apr+is%3Aclosed) for examples).
- [x] PR only implements a single feature or fixes a single bug.
- [x] Tests passing (`uv run pytest tests`)?
- [x] [Lint](https://docs.astral.sh/ruff/) / [pre-commits](https://pre-commit.com/) passing (`pre-commit run --all-files`)?

## Description

This PR fixes the unbounded pagination in `tools.cloudflare_sdk.call_paginated_method` and `tools.google_api.call_paginated_api` — the same class of problem as the Slack fix in #2948, except here the caller had **no way at all** to bound the fetch.

- **Cloudflare**: iterating the SDK's page object auto-paginates across every page; passing `per_page` in `params` only changes the page size. Added an optional `limit` (total item cap) — pages are fetched lazily by the SDK, so stopping at the limit also stops further API requests.
- **Google API**: the `while True` loop followed `nextPageToken` until exhaustion. Added an optional `max_pages` cap (this action returns whole response pages rather than flattened items, so a page cap fits its shape better than an item cap).

Both new arguments default to `null`, so existing workflows keep the current fetch-everything behavior — no breaking change.

## Related Issues

Fixes #2949

## Screenshots / Recordings

N/A (no UI changes)

## Steps to QA

Unit tests cover both fixes with mocked SDK clients:

```
uv run pytest tests/registry/test_cloudflare_sdk.py tests/registry/test_google_api.py
```

- `test_call_paginated_method_stops_at_limit` (Cloudflare): 3 pages with `limit=3` returns exactly 3 items and never fetches the third page.
- `test_call_paginated_method_limit_above_total_returns_all` (Cloudflare): a limit above the total returns everything.
- `test_call_paginated_api_stops_at_max_pages` (Google): `max_pages=2` with 3 pages available returns 2 pages and makes exactly 2 API calls.
- Existing tests for both actions pass unchanged, confirming the default (`null`) behavior is untouched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added caps to Cloudflare and Google API pagination to prevent unbounded fetches. Introduces an item `limit` for Cloudflare and a `max_pages` cap for Google; defaults keep current behavior.

- **Bug Fixes**
  - Cloudflare: `cloudflare_sdk.call_paginated_method` accepts `limit` to cap total items and stop further page requests.
  - Google: `google_api.call_paginated_api` accepts `max_pages` to cap the number of pages fetched.
  - Backward-compatible: both args are optional and default to null.

<sup>Written for commit 7b7e71886499c49bc6bef726495bd276199a7b58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

