### PR TITLE
fix(ui): align chat composer footer controls

### DIFF
--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -1615,7 +1615,7 @@ function PromptModelIndicator({ modelInfo }: { modelInfo: ModelInfo }) {
   return (
     <Badge
       variant="outline"
-      className="h-7 max-w-[18rem] gap-1.5 px-2.5 text-xs font-normal"
+      className="h-7 min-w-0 max-w-[18rem] gap-1.5 px-2.5 text-xs font-normal"
     >
       <ProviderIcon
         className="size-4 rounded-none bg-transparent p-0"

--- a/frontend/src/components/chat/chat-session-pane.tsx
+++ b/frontend/src/components/chat/chat-session-pane.tsx
@@ -1272,7 +1272,7 @@ export function ChatSessionPane({
           <PromptInputSubmit
             disabled={isInputDisabled || !input.trim()}
             status={status}
-            className="text-muted-foreground/80"
+            className="size-7 text-muted-foreground/80"
           />
         </PromptInputFooter>
       </PromptInput>

--- a/frontend/src/components/chat/chat-tools-picker.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.tsx
@@ -370,7 +370,7 @@ export function ChatToolsPicker({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <PromptInputButton disabled={disabled} className="text-xs">
+        <PromptInputButton disabled={disabled} className="h-7 text-xs">
           <SlidersHorizontalIcon className="size-4" />
           <span>{addedCount > 0 ? `Tools (${addedCount})` : "Tools"}</span>
         </PromptInputButton>


### PR DESCRIPTION
## What

Tidies up the chat copilot composer footer, where the controls were misaligned:

1. The model indicator pill sat flush against the submit (`↵`) button with no gap in a narrow side panel.
2. The **Tools** button and the submit (`↵`) button were taller than the preset selector and the model pill, so the row of controls looked uneven.

## Why

- **Spacing:** `PromptModelIndicator` renders the model pill as a `Badge` with `max-w-[18rem]` and a `truncate` label, but no `min-w-0`. A flex item defaults to `min-width: auto`, so without `min-w-0` the pill can't shrink below its content width and the `truncate` never engages. When the footer row (preset + tools + model pill) exceeds the available width, the pill overflows toward the submit button and collapses the gap between them.
- **Heights:** the preset selector and model pill are `h-7` (28px), but the **Tools** trigger auto-sizes to `sm` (`h-8`, 32px) because it has two children, and the submit button is `icon-sm` (`size-8`, 32px). Those two are 4px taller than their neighbours.

## Fix

- Add `min-w-0` to the model pill so it truncates (the `truncate` class and a `title` tooltip are already in place) when space is tight, restoring the normal footer gap between it and the submit button.
- Pin the **Tools** trigger and the submit button to `h-7` so every control in the footer shares the same 28px height.

Three scoped className changes; no shared primitives touched.

## Testing

- Verified in the copilot composer: the model pill and `↵` submit button now have consistent spacing, and the Tools, preset, model, and submit controls line up at the same height.
- Narrow panel: the model name truncates with an ellipsis (hover shows the full name) instead of crowding the submit button.
- `pnpm -C frontend exec biome check` — clean.
- `pnpm -C frontend run typecheck` — clean.

## Before
<img width="1072" height="153" alt="Screenshot 2026-07-05 at 1 19 26 AM" src="https://github.com/user-attachments/assets/cd2398c0-6613-409e-ae63-74154d51772f" />



## After

<img width="1242" height="158" alt="Screenshot 2026-07-05 at 1 16 20 AM" src="https://github.com/user-attachments/assets/d7b0d0dd-9fe1-4b79-be1b-f55bdc59e976" />

