### PR TITLE
fix(ui): show tool limit message in chat tools picker

### DIFF
--- a/frontend/src/components/chat/chat-tools-picker.test.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
 import type { MCPIntegrationRead, RegistryActionReadMinimal } from "@/client"
 import {
   ChatToolsPicker,
@@ -15,6 +15,11 @@ jest.mock("@/components/ui/popover", () => ({
   PopoverTrigger: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
+}))
+
+const mockToast = jest.fn()
+jest.mock("@/components/ui/use-toast", () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
 }))
 
 const runrevealIntegration = {
@@ -121,6 +126,118 @@ describe("DEFAULT_CAPABILITY_GROUPS", () => {
 })
 
 describe("ChatToolsPicker", () => {
+  beforeEach(() => {
+    mockToast.mockClear()
+  })
+
+  it("disables the add toggle for an unselected tool once the limit is reached", () => {
+    const onToolsChange = jest.fn()
+    const selected = Array.from({ length: 50 }, (_, i) => `extra.tool.t${i}`)
+
+    render(
+      <ChatToolsPicker
+        registryActions={[
+          ...selected.map((action) => registryAction(action)),
+          registryAction("extra.tool.brand_new", {
+            default_title: "Brand new tool",
+            display_group: "Extras",
+          }),
+        ]}
+        selectedTools={selected}
+        onToolsChange={onToolsChange}
+        mcpIntegrations={[]}
+        selectedMcpIntegrations={[]}
+        onMcpChange={jest.fn()}
+        surface="regular"
+      />
+    )
+
+    // Footer shows a limit message (no persistent counter).
+    expect(screen.getByText(/reached the 50-tool limit/i)).toBeInTheDocument()
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Search capabilities & tools..."),
+      { target: { value: "brand new" } }
+    )
+
+    // The unselected tool's toggle is disabled, so it can't be added past 50.
+    const addSwitch = screen.getByRole("switch")
+    expect(addSwitch).toBeDisabled()
+    fireEvent.click(addSwitch)
+    expect(onToolsChange).not.toHaveBeenCalled()
+  })
+
+  it("blocks a group toggle that would push past the limit with a message", () => {
+    const onToolsChange = jest.fn()
+    const filler = Array.from({ length: 48 }, (_, i) => `filler.tool.t${i}`)
+    const extras = Array.from({ length: 5 }, (_, i) => `extras.tool.e${i}`)
+
+    render(
+      <ChatToolsPicker
+        registryActions={[
+          ...filler.map((action) =>
+            registryAction(action, { display_group: "Filler" })
+          ),
+          ...extras.map((action) =>
+            registryAction(action, { display_group: "Extras" })
+          ),
+        ]}
+        selectedTools={filler}
+        onToolsChange={onToolsChange}
+        mcpIntegrations={[]}
+        selectedMcpIntegrations={[]}
+        onMcpChange={jest.fn()}
+        surface="regular"
+      />
+    )
+
+    // 48 selected + a 5-tool group would be 53, over the cap: add none, warn.
+    const extrasHeader = screen.getByText("Extras").closest("div")
+    expect(extrasHeader).not.toBeNull()
+    const groupSwitch = within(extrasHeader as HTMLElement).getByRole("switch")
+    fireEvent.click(groupSwitch)
+
+    expect(onToolsChange).not.toHaveBeenCalled()
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Tool limit reached" })
+    )
+  })
+
+  it("still allows removing a selected tool at the limit", () => {
+    const onToolsChange = jest.fn()
+    const selected = Array.from({ length: 50 }, (_, i) => `extra.tool.t${i}`)
+
+    render(
+      <ChatToolsPicker
+        registryActions={[
+          ...selected.map((action, i) =>
+            registryAction(action, {
+              default_title: i === 0 ? "Removable tool" : undefined,
+              display_group: "Extras",
+            })
+          ),
+        ]}
+        selectedTools={selected}
+        onToolsChange={onToolsChange}
+        mcpIntegrations={[]}
+        selectedMcpIntegrations={[]}
+        onMcpChange={jest.fn()}
+        surface="regular"
+      />
+    )
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Search capabilities & tools..."),
+      { target: { value: "removable" } }
+    )
+    fireEvent.click(screen.getByText("Removable tool"))
+
+    expect(onToolsChange).toHaveBeenCalledWith(
+      selected.filter((tool) => tool !== "extra.tool.t0")
+    )
+    expect(mockToast).not.toHaveBeenCalled()
+  })
+
   it("hides MCP integrations when they are not enabled for the chat surface", () => {
     render(
       <ChatToolsPicker

--- a/frontend/src/components/chat/chat-tools-picker.tsx
+++ b/frontend/src/components/chat/chat-tools-picker.tsx
@@ -18,6 +18,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 import { Switch } from "@/components/ui/switch"
+import { toast } from "@/components/ui/use-toast"
 import { cn } from "@/lib/utils"
 import type { ChatSurface } from "@/types/chat-surface"
 
@@ -63,6 +64,16 @@ type CapabilityGroup = {
 }
 
 const TOOL_SEARCH_LIMIT = 24
+
+/**
+ * Maximum number of extra tools (and, separately, MCP integrations) that can be
+ * attached to a single chat session. Mirrors `max_length=50` on
+ * `AgentSessionCreate`/`AgentSessionUpdate` in
+ * `tracecat/agent/session/schemas.py` and the matching `ChatCreate`/`ChatUpdate`
+ * limits in `tracecat/chat/schemas.py`. Keep in sync with the backend so the
+ * picker blocks overflow before the API rejects it with a 422.
+ */
+export const MAX_SELECTABLE_TOOLS = 50
 
 /**
  * Always-on workspace chat capabilities, grouped for display. Mirrors
@@ -183,6 +194,21 @@ export function ChatToolsPicker({
 
   const addedCount =
     selectedTools.length + (mcpEnabled ? selectedMcpIntegrations.length : 0)
+
+  // The backend caps `tools` (and `mcp_integrations`) at MAX_SELECTABLE_TOOLS
+  // each. Track when either list is full so the picker can block additions and
+  // disable the relevant toggles instead of letting the update 422.
+  const toolsAtLimit = selectedTools.length >= MAX_SELECTABLE_TOOLS
+  const mcpAtLimit =
+    mcpEnabled && selectedMcpIntegrations.length >= MAX_SELECTABLE_TOOLS
+
+  // Only surface a limit message when it matters — at the cap — rather than a
+  // persistent counter that duplicates the trigger button and group counts.
+  const limitMessage = toolsAtLimit
+    ? `You've reached the ${MAX_SELECTABLE_TOOLS}-tool limit. Remove a tool to add another.`
+    : mcpAtLimit
+      ? `You've reached the ${MAX_SELECTABLE_TOOLS}-integration limit. Remove one to add another.`
+      : null
 
   const toggleExpanded = (key: string) => {
     setExpanded((prev) => {
@@ -339,6 +365,13 @@ export function ChatToolsPicker({
       onToolsChange(selectedTools.filter((tool) => tool !== value))
       return
     }
+    if (selectedTools.length >= MAX_SELECTABLE_TOOLS) {
+      toast({
+        title: "Tool limit reached",
+        description: `You can add at most ${MAX_SELECTABLE_TOOLS} tools. Remove one before adding another.`,
+      })
+      return
+    }
     onToolsChange([...selectedTools, value])
   }
 
@@ -354,12 +387,29 @@ export function ChatToolsPicker({
     for (const value of values) {
       next.add(value)
     }
+    // Adding a group is all-or-nothing: if it would push past the cap, add none
+    // and tell the user how many they'd need to make room for.
+    if (next.size > MAX_SELECTABLE_TOOLS) {
+      const additional = next.size - selectedTools.length
+      toast({
+        title: "Tool limit reached",
+        description: `Adding these ${additional} tools would exceed the ${MAX_SELECTABLE_TOOLS}-tool limit. Remove some tools first.`,
+      })
+      return
+    }
     onToolsChange(Array.from(next))
   }
 
   const toggleMcp = (id: string) => {
     if (selectedMcpIntegrations.includes(id)) {
       onMcpChange(selectedMcpIntegrations.filter((value) => value !== id))
+      return
+    }
+    if (selectedMcpIntegrations.length >= MAX_SELECTABLE_TOOLS) {
+      toast({
+        title: "MCP integration limit reached",
+        description: `You can add at most ${MAX_SELECTABLE_TOOLS} MCP integrations. Remove one before adding another.`,
+      })
       return
     }
     onMcpChange([...selectedMcpIntegrations, id])
@@ -394,18 +444,22 @@ export function ChatToolsPicker({
             <>
               <GroupLabel>Add tools</GroupLabel>
               {searchResults.length > 0 ? (
-                searchResults.map((tool) => (
-                  <Row
-                    key={tool.value}
-                    dotClassName={
-                      tool.stale ? "bg-muted-foreground" : "bg-amber-500"
-                    }
-                    title={tool.label}
-                    subtitle={tool.group}
-                    checked={selectedTools.includes(tool.value)}
-                    onToggle={() => toggleTool(tool.value)}
-                  />
-                ))
+                searchResults.map((tool) => {
+                  const isSelected = selectedTools.includes(tool.value)
+                  return (
+                    <Row
+                      key={tool.value}
+                      dotClassName={
+                        tool.stale ? "bg-muted-foreground" : "bg-amber-500"
+                      }
+                      title={tool.label}
+                      subtitle={tool.group}
+                      checked={isSelected}
+                      disabled={!isSelected && toolsAtLimit}
+                      onToggle={() => toggleTool(tool.value)}
+                    />
+                  )
+                })
               ) : (
                 <EmptyHint>No tools found.</EmptyHint>
               )}
@@ -431,22 +485,26 @@ export function ChatToolsPicker({
                 <>
                   <GroupLabel>MCP integrations</GroupLabel>
                   {visibleMcpIntegrations.length > 0 ? (
-                    visibleMcpIntegrations.map((integration) => (
-                      <Row
-                        key={integration.id}
-                        dotClassName={
-                          integration.stale
-                            ? "bg-muted-foreground"
-                            : "bg-sky-500"
-                        }
-                        title={integration.name}
-                        subtitle={integration.description}
-                        checked={selectedMcpIntegrations.includes(
-                          integration.id
-                        )}
-                        onToggle={() => toggleMcp(integration.id)}
-                      />
-                    ))
+                    visibleMcpIntegrations.map((integration) => {
+                      const isSelected = selectedMcpIntegrations.includes(
+                        integration.id
+                      )
+                      return (
+                        <Row
+                          key={integration.id}
+                          dotClassName={
+                            integration.stale
+                              ? "bg-muted-foreground"
+                              : "bg-sky-500"
+                          }
+                          title={integration.name}
+                          subtitle={integration.description}
+                          checked={isSelected}
+                          disabled={!isSelected && mcpAtLimit}
+                          onToggle={() => toggleMcp(integration.id)}
+                        />
+                      )
+                    })
                   ) : mcpIntegrationsHref ? (
                     <Link
                       href={mcpIntegrationsHref}
@@ -512,6 +570,7 @@ export function ChatToolsPicker({
                       onToggleGroup={() => toggleGroup(tools)}
                       onToggleTool={toggleTool}
                       selectedTools={selectedTools}
+                      atLimit={toolsAtLimit}
                     />
                   )
                 })
@@ -523,10 +582,15 @@ export function ChatToolsPicker({
           )}
         </div>
 
-        <div className="border-t px-3 py-2 text-[11px] text-muted-foreground">
-          {addedCount} added
-          {isWorkspaceChat ? " · Tracecat defaults always included" : ""}
-        </div>
+        {limitMessage ? (
+          <div className="border-t px-3 py-2 text-[11px] text-muted-foreground">
+            {limitMessage}
+          </div>
+        ) : isWorkspaceChat ? (
+          <div className="border-t px-3 py-2 text-[11px] text-muted-foreground">
+            Tracecat defaults always included
+          </div>
+        ) : null}
       </PopoverContent>
     </Popover>
   )
@@ -578,15 +642,24 @@ function Row({
   subtitle,
   checked,
   onToggle,
+  disabled = false,
 }: {
   dotClassName: string
   title: string
   subtitle?: string
   checked: boolean
   onToggle: () => void
+  disabled?: boolean
 }) {
   return (
-    <label className="flex cursor-pointer items-center gap-2.5 px-3 py-1.5 hover:bg-muted">
+    <label
+      className={cn(
+        "flex items-center gap-2.5 px-3 py-1.5",
+        disabled
+          ? "cursor-not-allowed opacity-50"
+          : "cursor-pointer hover:bg-muted"
+      )}
+    >
       <Dot className={dotClassName} />
       <div className="min-w-0 flex-1">
         <div className="truncate text-[13px] text-foreground/70">{title}</div>
@@ -594,7 +667,11 @@ function Row({
           <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
         ) : null}
       </div>
-      <Switch checked={checked} onCheckedChange={onToggle} />
+      <Switch
+        checked={checked}
+        onCheckedChange={onToggle}
+        disabled={disabled}
+      />
     </label>
   )
 }
@@ -658,6 +735,7 @@ function AddGroupRow({
   onToggleGroup,
   onToggleTool,
   selectedTools,
+  atLimit,
 }: {
   group: string
   tools: ToolOption[]
@@ -668,7 +746,11 @@ function AddGroupRow({
   onToggleGroup: () => void
   onToggleTool: (value: string) => void
   selectedTools: string[]
+  atLimit: boolean
 }) {
+  // At the cap, block adding the whole group (unless it's already fully on, so
+  // it can still be turned off) and any individual unselected tool in it.
+  const groupSwitchDisabled = atLimit && !allSelected
   return (
     <div>
       <div className="flex items-center gap-2.5 px-3 py-1.5 hover:bg-muted">
@@ -688,31 +770,45 @@ function AddGroupRow({
               : toolCountLabel(tools.length)}
           </span>
         </button>
-        <Switch checked={allSelected} onCheckedChange={onToggleGroup} />
+        <Switch
+          checked={allSelected}
+          onCheckedChange={onToggleGroup}
+          disabled={groupSwitchDisabled}
+        />
       </div>
       {open ? (
         <div className="bg-muted/30">
-          {tools.map((tool) => (
-            <label
-              key={tool.value}
-              className="flex cursor-pointer items-center gap-2.5 py-1 pl-9 pr-3 hover:bg-muted"
-            >
-              <div className="min-w-0 flex-1">
-                <div className="truncate text-[13px] text-foreground/70">
-                  {tool.label}
+          {tools.map((tool) => {
+            const isSelected = selectedTools.includes(tool.value)
+            const toolDisabled = atLimit && !isSelected
+            return (
+              <label
+                key={tool.value}
+                className={cn(
+                  "flex items-center gap-2.5 py-1 pl-9 pr-3",
+                  toolDisabled
+                    ? "cursor-not-allowed opacity-50"
+                    : "cursor-pointer hover:bg-muted"
+                )}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] text-foreground/70">
+                    {tool.label}
+                  </div>
+                  {tool.description ? (
+                    <p className="truncate text-[11px] text-muted-foreground">
+                      {tool.description}
+                    </p>
+                  ) : null}
                 </div>
-                {tool.description ? (
-                  <p className="truncate text-[11px] text-muted-foreground">
-                    {tool.description}
-                  </p>
-                ) : null}
-              </div>
-              <Switch
-                checked={selectedTools.includes(tool.value)}
-                onCheckedChange={() => onToggleTool(tool.value)}
-              />
-            </label>
-          ))}
+                <Switch
+                  checked={isSelected}
+                  onCheckedChange={() => onToggleTool(tool.value)}
+                  disabled={toolDisabled}
+                />
+              </label>
+            )
+          })}
         </div>
       ) : null}
     </div>

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -81,9 +81,71 @@ function applyOptimisticChatUpdate<T extends UpdateableChatRecord>(
   }
 }
 
+/**
+ * Extract an actionable message from a FastAPI validation error (HTTP 422).
+ *
+ * These surface as an `ApiError` whose `message` is just "Validation Error",
+ * so we reach into the response body's `detail` to explain what actually
+ * failed. Field limits such as the per-chat tool cap get a friendly message;
+ * everything else falls back to Pydantic's own `msg` text. Returns `null` when
+ * the error isn't a recognizable 422 payload.
+ */
+function parseValidationError(error: unknown): string | null {
+  if (!error || typeof error !== "object") {
+    return null
+  }
+
+  const { status, body } = error as { status?: number; body?: unknown }
+  if (status !== 422 || !body || typeof body !== "object") {
+    return null
+  }
+
+  const detail = (body as { detail?: unknown }).detail
+  if (typeof detail === "string" && detail.trim()) {
+    return detail.trim()
+  }
+  if (!Array.isArray(detail)) {
+    return null
+  }
+
+  const messages: string[] = []
+  for (const item of detail) {
+    if (!item || typeof item !== "object") {
+      continue
+    }
+    const loc = (item as { loc?: unknown }).loc
+    const field = Array.isArray(loc)
+      ? loc.filter((part) => typeof part === "string" && part !== "body").pop()
+      : undefined
+    const maxLength = (item as { ctx?: { max_length?: unknown } }).ctx
+      ?.max_length
+    if (
+      (field === "tools" || field === "mcp_integrations") &&
+      typeof maxLength === "number"
+    ) {
+      const noun = field === "tools" ? "tools" : "MCP integrations"
+      messages.push(
+        `You can add at most ${maxLength} ${noun}. Remove some and try again.`
+      )
+      continue
+    }
+    const msg = (item as { msg?: unknown }).msg
+    if (typeof msg === "string" && msg.trim()) {
+      messages.push(msg.trim())
+    }
+  }
+
+  return messages.length > 0 ? messages.join(" ") : null
+}
+
 export function parseChatError(error: unknown): string {
   if (!error) {
     return DEFAULT_CHAT_ERROR_MESSAGE
+  }
+
+  const validationMessage = parseValidationError(error)
+  if (validationMessage) {
+    return validationMessage
   }
 
   if (typeof error === "string") {


### PR DESCRIPTION
## Problem

In the chat tools picker (Cases/Tables sidebar chat widget), selecting more than 50 tools failed with a raw red toast: **"Failed to update tools — Validation Error"**.

The backend caps a chat session's `tools` (and `mcp_integrations`) at 50 (`max_length=50` on the agent session / chat schemas). When a selection exceeded that, the `PATCH` returned a 422 that the generated client surfaces as the literal string `Validation Error`, which `parseChatError` passed straight into the toast. The user got no idea what went wrong or how to fix it, and nothing stopped them from exceeding the limit in the first place.

## Changes

**Prevent the overflow in the picker** (`chat-tools-picker.tsx`)
- Add `MAX_SELECTABLE_TOOLS = 50`, documented as mirroring the backend `max_length=50`.
- Disable the add-toggle for any unselected tool once the cap is reached (removing selected tools still works).
- Group toggles are all-or-nothing: if adding a whole group would exceed the cap, add none and show a message.
- Replace the redundant footer count with a contextual message shown only at the cap (the count already appears on the trigger button and group rows).

**Friendlier fallback** (`use-chat.ts`)
- `parseChatError` now inspects a 422's response body and turns a tool/MCP `max_length` violation into a clear message ("You can add at most 50 tools. Remove some and try again."), falling back to Pydantic's own `msg` for other validation errors instead of the generic "Validation Error".

## Testing

- `pnpm typecheck` — clean
- `biome check` — clean
- `pnpm jest src/components/chat/chat-tools-picker.test.tsx` — passing, including 3 new tests:
  - add-toggle is disabled at the limit
  - a group toggle that would overflow is blocked with a message
  - removing a selected tool at the limit still works

## Before

<img width="433" height="499" alt="Screenshot 2026-07-05 at 1 42 20 AM" src="https://github.com/user-attachments/assets/1bf48f2b-12ca-4464-81a8-964a6dec9962" />

## After

#### Disable tools selection after 50

<img width="440" height="497" alt="Screenshot 2026-07-05 at 1 45 55 AM" src="https://github.com/user-attachments/assets/8b18a22f-86f3-42d7-8b00-3a689f383794" />

#### Message if they select group that exceed 50 count of selected tools

<img width="446" height="464" alt="Screenshot 2026-07-05 at 1 46 46 AM" src="https://github.com/user-attachments/assets/a4532fea-d869-42ca-a3c9-d6aaaa0f1972" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents selecting more than 50 tools in the chat tools picker and shows clear, helpful messages instead of a generic “Validation Error”. This aligns the UI with backend limits and avoids failed updates.

- Bug Fixes
  - Enforce a 50-item cap for tools and MCP integrations: disable add toggles at the limit, and block group adds that would overflow with a toast.
  - Show a contextual footer message only when at the limit; keep the workspace chat defaults note.
  - Parse FastAPI 422 errors to surface clear max-length messages (e.g., “You can add at most 50 tools”) instead of “Validation Error”.

<sup>Written for commit 8b1312fd97f70d67bc3bd3323519b5447800452a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

