### PR TITLE
perf(db): add workflow_definition lookup index

### DIFF
--- a/alembic/versions/11d479597e08_add_workflow_definition_lookup_index.py
+++ b/alembic/versions/11d479597e08_add_workflow_definition_lookup_index.py
@@ -1,0 +1,33 @@
+"""add workflow definition lookup index
+
+Revision ID: 11d479597e08
+Revises: e32940d12293
+Create Date: 2026-07-04 22:02:13.128868
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "11d479597e08"
+down_revision: str | None = "e32940d12293"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_workflow_definition_workspace_id_workflow_id_version",
+        "workflow_definition",
+        ["workspace_id", "workflow_id", "version"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_workflow_definition_workspace_id_workflow_id_version",
+        table_name="workflow_definition",
+    )

--- a/tracecat/db/models.py
+++ b/tracecat/db/models.py
@@ -738,6 +738,16 @@ class WorkflowDefinition(WorkspaceModel):
     """
 
     __tablename__ = "workflow_definition"
+    __table_args__ = (
+        # Serves the hot definition lookup (workspace_id, workflow_id) ordered
+        # or filtered by version, plus workspace-scoped scans and RLS predicates.
+        Index(
+            "ix_workflow_definition_workspace_id_workflow_id_version",
+            "workspace_id",
+            "workflow_id",
+            "version",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID,


### PR DESCRIPTION
Follow-up to #2952.

## Problem

`workflow_definition` has no index on `workspace_id` or `workflow_id` — only `id`, `version`, and `alias` are indexed. The hot definition lookup (`WorkflowDefinitionsService.get_definition_by_workflow_id`) filters on `workspace_id = ? AND workflow_id = ?`, so every lookup is a sequential scan. This path runs on webhook triggers, child-workflow resolution (`dsl/action.py`), and the internal execution router, and the table grows with every workflow commit (each row carrying the full JSONB DSL). The RLS policies also apply a `workspace_id` predicate to this table on every query with no index behind it.

## Change

- Add composite index `ix_workflow_definition_workspace_id_workflow_id_version` on `(workspace_id, workflow_id, version)` to the `WorkflowDefinition` model.
- Alembic migration `11d479597e08` (additive/expand-only; real `downgrade()` drops the index).

Leading with `workspace_id` also serves the RLS predicate and workspace-scoped listing; `workflow_id` provides full selectivity for the lookup; trailing `version` covers the exact-version branch.

## Verification

- `alembic upgrade head` → `downgrade -1` → `upgrade head` round-trips cleanly on a dev database.
- `EXPLAIN` (with `enable_seqscan = off` on the near-empty dev table) confirms the lookup uses the new index:

```
Index Scan using ix_workflow_definition_workspace_id_workflow_id_version on workflow_definition
  Index Cond: ((workspace_id = $1) AND (workflow_id = $2))
```

- `ruff check`, `ruff format --check`, and `basedpyright --warnings` pass on the changed files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a composite index on `workflow_definition` for `(workspace_id, workflow_id, version)` to speed up definition lookups and serve RLS predicates. This removes sequential scans on the hot path used by webhook triggers, child-workflow resolution, and the execution router.

- **Migration**
  - `alembic` migration adds `ix_workflow_definition_workspace_id_workflow_id_version`; downgrade drops it.
  - No data changes; online-safe.

<sup>Written for commit c6df83e3a81287792d42c362af58c8d0472212f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

