### PR TITLE
fix(ui): prevent builder panel tabs and content clipping at narrow widths

### DIFF
--- a/frontend/src/components/builder/panel/action-panel.tsx
+++ b/frontend/src/components/builder/panel/action-panel.tsx
@@ -939,9 +939,9 @@ function ActionPanelContent({
               </h3>
             </div>
 
-            <div className="w-full min-w-[30rem]">
-              <div className="flex items-center justify-start">
-                <TabsList className="h-8 justify-start rounded-none bg-transparent p-0">
+            <div className="w-full">
+              <div className="no-scrollbar flex items-center justify-start overflow-x-auto">
+                <TabsList className="h-8 shrink-0 justify-start rounded-none bg-transparent p-0">
                   <TabsTrigger
                     className="flex h-full min-w-24 items-center justify-center rounded-none py-0 text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                     value="inputs"
@@ -977,7 +977,7 @@ function ActionPanelContent({
               <Separator />
             </div>
             <div className="flex-1 overflow-auto">
-              <div className="w-full min-w-[30rem] overflow-x-auto pb-32">
+              <div className="w-full min-w-80 overflow-x-auto pb-32">
                 <TabsContent value="inputs" className="pb-8">
                   <SectionErrorBoundary>
                     <div className="mt-4 flex flex-col space-y-4 px-4 pb-10">

--- a/frontend/src/components/builder/panel/workflow-panel.tsx
+++ b/frontend/src/components/builder/panel/workflow-panel.tsx
@@ -191,9 +191,9 @@ export function WorkflowPanel({
         onValueChange={(value) => setActiveTab(value as WorkflowPanelTab)}
         className="flex h-full w-full flex-col"
       >
-        <div className="w-full min-w-[30rem] shrink-0">
-          <div className="flex items-center justify-start">
-            <TabsList className="h-9 justify-start rounded-none bg-transparent p-0">
+        <div className="w-full shrink-0">
+          <div className="no-scrollbar flex items-center justify-start overflow-x-auto">
+            <TabsList className="h-9 shrink-0 justify-start rounded-none bg-transparent p-0">
               <TabsTrigger
                 className="flex h-full min-w-24 items-center justify-center rounded-none px-5 py text-xs data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                 value="workflow"


### PR DESCRIPTION
## What

Fixes tab strips and form content being clipped in the workflow builder's right side panel at narrow widths.

- **Action panel** (node selected): the last tab (`View template` on template actions) was cut off and unreachable, and the inputs form (including the Form/YAML toggle) extended past the panel edge with no scrollbar.
- **Workflow panel** (no node selected): same issue with the `Versions` tab.

## Why

Both panels force `min-w-[30rem]` (480px) on their tab strip/content while the panel root uses `overflow-hidden`. The side panel's `defaultSize` is 24% of the window, which is ~360px on a typical laptop — under the forced floor — so the clipping shows at the default layout, not just after resizing.

## How

- Tab strips: drop the forced 480px floor and make the row horizontally scrollable with a hidden scrollbar (`no-scrollbar overflow-x-auto`), matching the existing pattern in `agent-presets-builder.tsx`. The trigger panel already uses a plain `w-full` strip, so this aligns the three panels.
- Action panel content: lower the floor from `min-w-[30rem]` to `min-w-80` so the form fields (all `w-full`) fit the actual panel width; below 320px the existing parent `overflow-auto` still provides scrolling.

The `min-w-[30rem]` came from b06d24e93 ("fix(ui): Overflow at mention") — the mechanics of that fix (fixed-position CodeMirror tooltips, `overflow-visible` tab content) are untouched, so mention autocomplete behavior is preserved.

## Testing

- Verified in the local dev stack: with a template action selected, all four tabs and the Form/YAML toggle are visible at default panel width, and the tab row scrolls when the panel is dragged very narrow.
- Verified the workflow panel (`Workflow` / `README` / `Versions`) at narrow widths.
- `pnpm -C frontend check` and `pnpm -C frontend run typecheck` pass.


## Before


https://github.com/user-attachments/assets/ec88f7fc-2b6d-4001-b2bb-3ba7e34ff46f

## After


https://github.com/user-attachments/assets/f14260a8-41fc-4a69-9f9a-dd0bed6d2d07

#### Different screen size check


<img width="1512" height="861" alt="Screenshot 2026-07-05 at 11 54 59 PM" src="https://github.com/user-attachments/assets/41549734-e802-454b-aebf-ee1696b671c2" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes clipping in the builder right panel at narrow widths. Tabs and form content are now fully reachable at the default layout.

- **Bug Fixes**
  - Made Action and Workflow tab strips horizontally scrollable and removed the forced 30rem min-width.
  - Lowered Action panel content floor from 30rem to 20rem (`min-w-80`) so fields fit; mention autocomplete behavior is unchanged.

<sup>Written for commit 2a335d8323de8e3c4152857dca7a12cc18e39b2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

