### PR TITLE
test(ui): polyfill ResizeObserver in jsdom setup

### DIFF
--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -18,6 +18,15 @@ global.WritableStream = WritableStream
 // jsdom does not implement scrollIntoView (used by cmdk selection)
 Element.prototype.scrollIntoView = jest.fn()
 
+// jsdom does not implement ResizeObserver (used by useOverflowBadges and other
+// layout-measuring hooks). Provide a no-op stub so components that observe
+// element size can mount under jsdom.
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
 // Mock next-runtime-env
 jest.mock("next-runtime-env", () => ({
   env: jest.fn((key) => process.env[key] || ""),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a no‑op ResizeObserver polyfill in the Jest jsdom setup so UI tests don’t crash when components observe element size. This lets hooks like useOverflowBadges mount in jsdom by stubbing observe, unobserve, and disconnect.

<sup>Written for commit 32c177a1dd2c7b01dcb568987697db5179778096. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TracecatHQ/tracecat/pull/2961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

